### PR TITLE
Spark 3.5: Fix Migrate procedure renaming issue for custom catalog

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
@@ -60,6 +60,15 @@ public interface MigrateTable extends Action<MigrateTable, MigrateTable.Result> 
     throw new UnsupportedOperationException("Backup table name cannot be specified");
   }
 
+  /**
+   * Sets a destination catalog name to use the catalog for renaming a backup table
+   * @param catalogName - the destination catalog name for backup table rename
+   * @return this for method chaining
+   */
+  default MigrateTable destCatalogName(String catalogName) {
+    throw new UnsupportedOperationException("Destination catalog name cannot be specified");
+  }
+
   /** The action result that contains a summary of the execution. */
   interface Result {
     /** Returns the number of migrated data files. */

--- a/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
@@ -62,6 +62,7 @@ public interface MigrateTable extends Action<MigrateTable, MigrateTable.Result> 
 
   /**
    * Sets a destination catalog name to use the catalog for renaming a backup table
+   *
    * @param catalogName - the destination catalog name for backup table rename
    * @return this for method chaining
    */

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -174,14 +174,15 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
         tableName, location);
-    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
 
-    Object result =
-        scalarSql(
-            "CALL %s.system.migrate(table => '%s', drop_backup => false, dest_catalog_name => '%s')",
-            catalogName, tableName, destCatalogName);
-    Assertions.assertThat(result).isEqualTo(1L);
-    Assertions.assertThat(spark.catalog().tableExists(tableName + "_BACKUP_")).isTrue();
+    Assertions.assertThatThrownBy(
+            () -> {
+              sql(
+                  "CALL %s.system.migrate(table => '%s', dest_catalog_name => '%s')",
+                  catalogName, tableName, destCatalogName);
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("The destination catalog %s doesn't exist in SparkSession.", destCatalogName);
   }
 
   @Test

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -146,18 +146,20 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
   public void testMigrateWithDestCatalogName() throws IOException {
     Assume.assumeTrue(catalogName.equals("spark_catalog"));
 
-    spark.conf().set("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog");
+    spark
+        .conf()
+        .set("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog");
 
     String location = temp.newFolder().toString();
     sql(
-            "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
-            tableName, location);
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        tableName, location);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
 
     Object result =
-            scalarSql(
-                    "CALL %s.system.migrate(table => '%s', drop_backup => false, dest_catalog_name => '%s')",
-                    catalogName, tableName, catalogName);
+        scalarSql(
+            "CALL %s.system.migrate(table => '%s', drop_backup => false, dest_catalog_name => '%s')",
+            catalogName, tableName, catalogName);
     Assertions.assertThat(result).isEqualTo(1L);
     Assertions.assertThat(spark.catalog().tableExists(tableName + "_BACKUP_")).isTrue();
   }
@@ -170,14 +172,14 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
 
     String location = temp.newFolder().toString();
     sql(
-            "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
-            tableName, location);
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        tableName, location);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
 
     Object result =
-            scalarSql(
-                    "CALL %s.system.migrate(table => '%s', drop_backup => false, dest_catalog_name => '%s')",
-                    catalogName, tableName, destCatalogName);
+        scalarSql(
+            "CALL %s.system.migrate(table => '%s', drop_backup => false, dest_catalog_name => '%s')",
+            catalogName, tableName, destCatalogName);
     Assertions.assertThat(result).isEqualTo(1L);
     Assertions.assertThat(spark.catalog().tableExists(tableName + "_BACKUP_")).isTrue();
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
@@ -117,10 +117,8 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
     if (catalogManager.isCatalogRegistered(catalogName)) {
       catalogPlugin = catalogManager.catalog(catalogName);
     } else {
-      LOG.warn(
-          "{} doesn't exist in SparkSession. " + "Fallback to current SparkSession catalog.",
-          catalogName);
-      catalogPlugin = catalogManager.currentCatalog();
+      throw new IllegalArgumentException(
+          String.format("The destination catalog %s doesn't exist in SparkSession.", catalogName));
     }
     this.destCatalog = checkDestinationCatalog(catalogPlugin);
     return this;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
@@ -117,8 +117,9 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
     if (catalogManager.isCatalogRegistered(catalogName)) {
       catalogPlugin = catalogManager.catalog(catalogName);
     } else {
-      LOG.warn("{} doesn't exist in SparkSession. " +
-              "Fallback to current SparkSession catalog.", catalogName);
+      LOG.warn(
+          "{} doesn't exist in SparkSession. " + "Fallback to current SparkSession catalog.",
+          catalogName);
       catalogPlugin = catalogManager.currentCatalog();
     }
     this.destCatalog = checkDestinationCatalog(catalogPlugin);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
@@ -40,7 +40,8 @@ class MigrateTableProcedure extends BaseProcedure {
         ProcedureParameter.required("table", DataTypes.StringType),
         ProcedureParameter.optional("properties", STRING_MAP),
         ProcedureParameter.optional("drop_backup", DataTypes.BooleanType),
-        ProcedureParameter.optional("backup_table_name", DataTypes.StringType)
+        ProcedureParameter.optional("backup_table_name", DataTypes.StringType),
+        ProcedureParameter.optional("dest_catalog_name", DataTypes.StringType),
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -93,6 +94,7 @@ class MigrateTableProcedure extends BaseProcedure {
 
     boolean dropBackup = args.isNullAt(2) ? false : args.getBoolean(2);
     String backupTableName = args.isNullAt(3) ? null : args.getString(3);
+    String destCatalogName = args.isNullAt(4) ? null : args.getString(4);
 
     MigrateTableSparkAction migrateTableSparkAction =
         SparkActions.get().migrateTable(tableName).tableProperties(properties);
@@ -103,6 +105,10 @@ class MigrateTableProcedure extends BaseProcedure {
 
     if (backupTableName != null) {
       migrateTableSparkAction = migrateTableSparkAction.backupTableName(backupTableName);
+    }
+
+    if (destCatalogName != null) {
+      migrateTableSparkAction = migrateTableSparkAction.destCatalogName(destCatalogName);
     }
 
     MigrateTable.Result result = migrateTableSparkAction.execute();


### PR DESCRIPTION
For the fix of https://github.com/apache/iceberg/issues/7317. The issue is related to the non-supporting migrate query for Glue Data Catalog. To support the migrate query for custom catalog impl, this commit makes it possible to specify the destination catalog name. 

I also think adding support renaming GlueCatalogHiveClient tables is another way to support this. If there's a better way to resolve the issue, please let me know.

---
The following partial script is an example to run the migrate query with Glue Data Catalog:

```scala
// SparkSession init
        val spark: SparkSession = SparkSession.builder
          .config(s"spark.sql.catalog.glue_catalog", "org.apache.iceberg.spark.SparkCatalog")
          .config(s"spark.sql.catalog.glue_catalog.catalog-impl", "org.apache.iceberg.aws.glue.GlueCatalog")
          .config(s"spark.sql.catalog.glue_catalog.warehouse", warehouse)
          .config("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
          .config("spark.sql.catalog.spark_catalog.catalog-impl", "org.apache.iceberg.aws.glue.GlueCatalog")
          .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
          .getOrCreate()

// Migrate procedure
        spark.sql(
            s"""
                CALL glue_catalog.system.migrate (
                    table => 'db.table,
                    drop_backup => true,
                    backup_table_name => 'backup_table',
                    dest_catalog_name => 'glue_catalog'
               )
        """)
```