### PR TITLE
Docs: Document UNORDERED for spark write

### DIFF
--- a/docs/spark-ddl.md
+++ b/docs/spark-ddl.md
@@ -435,6 +435,12 @@ To order within each task, not across tasks, use `LOCALLY ORDERED BY`:
 ALTER TABLE prod.db.sample WRITE LOCALLY ORDERED BY category, id
 ```
 
+To unset the sort order of the table, use `UNORDERED`:
+
+```sql
+ALTER TABLE prod.db.sample WRITE UNORDERED
+```
+
 ### `ALTER TABLE ... WRITE DISTRIBUTED BY PARTITION`
 
 `WRITE DISTRIBUTED BY PARTITION` will request that each partition is handled by one writer, the default implementation is hash distribution.


### PR DESCRIPTION
We have testcase in https://github.com/apache/iceberg/blob/b9a4478b0f8f5eeae553eb3900b08a7a08dbdb40/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetWriteDistributionAndOrdering.java#L183

But it is not documented causing confusion to users.
Ref: https://github.com/apache/iceberg/issues/5071