### PR TITLE
Spec: Fix view example

### DIFF
--- a/format/view-spec.md
+++ b/format/view-spec.md
@@ -239,12 +239,14 @@ s3://bucket/warehouse/default.db/event_agg/metadata/00001-(uuid).metadata.json
 ```
 
 Each change creates a new metadata JSON file.
+For example, SQL is modified with identifier having catalog name and namespace as below.
 
 ```sql
 USE prod.other_db;
 CREATE OR REPLACE VIEW default.event_agg (
-    event_count,
+    event_count COMMENT 'Count of events',
     event_date)
+COMMENT 'Daily event counts'
 AS
 SELECT
     COUNT(1), CAST(event_ts AS DATE)

--- a/format/view-spec.md
+++ b/format/view-spec.md
@@ -239,7 +239,7 @@ s3://bucket/warehouse/default.db/event_agg/metadata/00001-(uuid).metadata.json
 ```
 
 Each change creates a new metadata JSON file.
-For example, SQL is modified with identifier having catalog name and namespace as below.
+In the below example, the underlying SQL is modified by specifying the fully-qualified table name.
 
 ```sql
 USE prod.other_db;


### PR DESCRIPTION
When compared 244-249 lines to 175-177 lines,
column comment and view comment were missing. But this change was not reflected back in the new metadata file.

So, added back the comments, else we need to update the view metadata Json to reflect without comments. 