### PR TITLE
Core: Add a constructor to StaticTableOperations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
@@ -34,11 +34,21 @@ public class StaticTableOperations implements TableOperations {
 
   /** Creates a StaticTableOperations tied to a specific static version of the TableMetadata */
   public StaticTableOperations(String metadataFileLocation, FileIO io) {
-    this(metadataFileLocation, io, null);
+    this(null, metadataFileLocation, io, null);
+  }
+
+  public StaticTableOperations(TableMetadata staticMetadata, FileIO io) {
+    this(staticMetadata, staticMetadata.metadataFileLocation(), io, null);
   }
 
   public StaticTableOperations(
-      String metadataFileLocation, FileIO io, LocationProvider locationProvider) {
+          String metadataFileLocation, FileIO io, LocationProvider locationProvider) {
+    this(null, metadataFileLocation, io, locationProvider);
+  }
+
+  public StaticTableOperations(
+          TableMetadata staticMetadata, String metadataFileLocation, FileIO io, LocationProvider locationProvider) {
+    this.staticMetadata = staticMetadata;
     this.io = io;
     this.metadataFileLocation = metadataFileLocation;
     this.locationProvider = locationProvider;

--- a/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
@@ -34,26 +34,25 @@ public class StaticTableOperations implements TableOperations {
 
   /** Creates a StaticTableOperations tied to a specific static version of the TableMetadata */
   public StaticTableOperations(String metadataFileLocation, FileIO io) {
-    this(null, metadataFileLocation, io, null);
-  }
-
-  public StaticTableOperations(TableMetadata staticMetadata, FileIO io) {
-    this(staticMetadata, staticMetadata.metadataFileLocation(), io, null);
+    this(metadataFileLocation, io, null);
   }
 
   public StaticTableOperations(
       String metadataFileLocation, FileIO io, LocationProvider locationProvider) {
-    this(null, metadataFileLocation, io, locationProvider);
+    this.io = io;
+    this.metadataFileLocation = metadataFileLocation;
+    this.locationProvider = locationProvider;
+  }
+
+  public StaticTableOperations(TableMetadata staticMetadata, FileIO io) {
+    this(staticMetadata, io, null);
   }
 
   public StaticTableOperations(
-      TableMetadata staticMetadata,
-      String metadataFileLocation,
-      FileIO io,
-      LocationProvider locationProvider) {
+      TableMetadata staticMetadata, FileIO io, LocationProvider locationProvider) {
     this.staticMetadata = staticMetadata;
+    this.metadataFileLocation = staticMetadata.metadataFileLocation();
     this.io = io;
-    this.metadataFileLocation = metadataFileLocation;
     this.locationProvider = locationProvider;
   }
 

--- a/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
@@ -42,12 +42,15 @@ public class StaticTableOperations implements TableOperations {
   }
 
   public StaticTableOperations(
-          String metadataFileLocation, FileIO io, LocationProvider locationProvider) {
+      String metadataFileLocation, FileIO io, LocationProvider locationProvider) {
     this(null, metadataFileLocation, io, locationProvider);
   }
 
   public StaticTableOperations(
-          TableMetadata staticMetadata, String metadataFileLocation, FileIO io, LocationProvider locationProvider) {
+      TableMetadata staticMetadata,
+      String metadataFileLocation,
+      FileIO io,
+      LocationProvider locationProvider) {
     this.staticMetadata = staticMetadata;
     this.io = io;
     this.metadataFileLocation = metadataFileLocation;

--- a/core/src/test/java/org/apache/iceberg/util/TestReachableFileUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestReachableFileUtil.java
@@ -124,7 +124,7 @@ public class TestReachableFileUtil {
     TableMetadata metadata = ops.current();
     String metadataFileLocation = metadata.metadataFileLocation();
 
-    StaticTableOperations staticOps = new StaticTableOperations(metadataFileLocation, table.io());
+    StaticTableOperations staticOps = new StaticTableOperations(metadata, table.io());
     Table staticTable = new BaseTable(staticOps, metadataFileLocation);
 
     String reportedVersionHintLocation = ReachableFileUtil.versionHintLocation(staticTable);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -137,9 +137,8 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Table newStaticTable(TableMetadata metadata, FileIO io) {
-    String metadataFileLocation = metadata.metadataFileLocation();
-    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
-    return new BaseTable(ops, metadataFileLocation);
+    StaticTableOperations ops = new StaticTableOperations(metadata, io);
+    return new BaseTable(ops, metadata.metadataFileLocation());
   }
 
   protected Dataset<FileInfo> contentFileDS(Table table) {


### PR DESCRIPTION
If the table is already having table metadata object, no need to do an extra IO to read from the table metadata location. So, we need a constructor that accepts table metadata object directly. 