### PR TITLE
Add Description on Using a Separate Authorization Server

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2873,7 +2873,7 @@ components:
         403 response. Implementations must not return altered success (200)
         responses when a request is unauthenticated or unauthorized.
 
-        If a separate authorization server is used, subtitute the tokenUrl with 
+        If a separate authorization server is used, substitute the tokenUrl with 
         the full token path of the external authorization server, and use the 
         resulting token to access the resources defined in the spec.
       flows:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2872,6 +2872,10 @@ components:
         For unauthorized requests, services should return an appropriate 401 or
         403 response. Implementations must not return altered success (200)
         responses when a request is unauthenticated or unauthorized.
+
+        If a separate authorization server is used, subtitute the tokenUrl with 
+        the full token path of the external authorization server, and use the 
+        resulting token to access the resources defined in the spec.
       flows:
         clientCredentials:
           tokenUrl: /v1/oauth/tokens


### PR DESCRIPTION
Updates the Rest Catalog Open API Spec to address: https://github.com/apache/iceberg/issues/8869

Slack discussion thread where the agreement has been reached regarding the required Spec update: https://apache-iceberg.slack.com/archives/C03LG1D563F/p1698767745835999