### PR TITLE
Docs: Add note that snapshot expiration and cleanup orphan files could corrupt Flink job state

### DIFF
--- a/docs/flink-writes.md
+++ b/docs/flink-writes.md
@@ -271,3 +271,12 @@ INSERT INTO tableName /*+ OPTIONS('upsert-enabled'='true') */
 ```
 
 Check out all the options here: [write-options](/flink-configuration#write-options) 
+
+## Notes
+
+Flink streaming write jobs rely on snapshot summary to keep the last committed checkpoint ID, and
+store uncommitted data as temporary files. Therefore, [expiring snapshots](../tables/maintenance#expire-snapshots)
+and [deleting orphan files](../tables/maintenance#delete-orphan-files) could possibly corrupt
+the state of the Flink job. To avoid that, make sure to keep the last snapshot created by the Flink
+job (which can be identified by the `flink.job-id` property in the summary), and only delete
+orphan files that are old enough.


### PR DESCRIPTION
Update the doc per the discussions in #5846