### PR TITLE
Add dependabot to automatically update the site

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,4 +30,10 @@ updates:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 50
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 5
 


### PR DESCRIPTION
Since we're moving the site back into the main repository, it would be great to have Dependabot update `site/requirements.txt`