### PR TITLE
Spark 3.5: Fix rewriting manifests for evolved unpartitioned V1 tables

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -179,7 +179,7 @@ public class RewriteManifestsSparkAction
     Dataset<Row> manifestEntryDF = buildManifestEntryDF(matchingManifests);
 
     List<ManifestFile> newManifests;
-    if (spec.fields().size() < 1) {
+    if (spec.isUnpartitioned()) {
       newManifests = writeManifestsForUnpartitionedTable(manifestEntryDF, targetNumManifests);
     } else {
       newManifests = writeManifestsForPartitionedTable(manifestEntryDF, targetNumManifests);


### PR DESCRIPTION
This PR fixes our action for rewriting manifests for evolved unpartitioned V1 tables. There is no need to repartition by range and locally order manifest entries if the spec contains only void transforms. Such tables should be treated as unpartitioned.