### PR TITLE
Override useCommitCoordinator to false

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeletesRewrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeletesRewrite.java
@@ -137,6 +137,11 @@ public class SparkPositionDeletesRewrite implements Write {
     }
 
     @Override
+    public boolean useCommitCoordinator() {
+      return false;
+    }
+
+    @Override
     public void commit(WriterCommitMessage[] messages) {
       PositionDeletesRewriteCoordinator coordinator = PositionDeletesRewriteCoordinator.get();
       coordinator.stageRewrite(table, fileSetId, ImmutableSet.copyOf(files(messages)));

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -172,6 +172,11 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     }
 
     @Override
+    public boolean useCommitCoordinator() {
+      return false;
+    }
+
+    @Override
     public void commit(WriterCommitMessage[] messages) {
       RowDelta rowDelta = table.newRowDelta();
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -272,6 +272,11 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     }
 
     @Override
+    public boolean useCommitCoordinator() {
+      return false;
+    }
+
+    @Override
     public void abort(WriterCommitMessage[] messages) {
       SparkWrite.this.abort(messages);
     }


### PR DESCRIPTION
In Spark `BatchWrite.java`, `useCommitCoordinator` is default to true. This PR overrides `useCommitCoordinator` to false, so we can rewrite a task after it fails. Here is the [issue](https://github.com/apache/iceberg/issues/8904)