### PR TITLE
Override useCommitCoordinator to false in BaseStreamingWriter

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -507,6 +507,11 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     }
 
     @Override
+    public boolean useCommitCoordinator() {
+      return false;
+    }
+
+    @Override
     public final void commit(long epochId, WriterCommitMessage[] messages) {
       LOG.info("Committing epoch {} for query {} in {} mode", epochId, queryId, mode());
 


### PR DESCRIPTION
Followup PR for https://github.com/apache/iceberg/pull/9017: overriding `useCommitCoordinator` to false in `BaseStreamingWriter`