### PR TITLE
Hive: Improve performance of HiveCatalog#listTables

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -72,9 +72,10 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
   static final String HIVE_CONF_CATALOG = "metastore.catalog.default";
 
   static final String ICEBERG_TYPE_FILTER =
-          String.format("%s = \"%s\"",
-                  BaseMetastoreTableOperations.TABLE_TYPE_PROP,
-                  BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE);
+      String.format(
+          "%s = \"%s\"",
+          BaseMetastoreTableOperations.TABLE_TYPE_PROP,
+          BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE);
 
   private static final Logger LOG = LoggerFactory.getLogger(HiveCatalog.class);
 
@@ -135,12 +136,8 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
                 .collect(Collectors.toList());
       } else {
         List<String> tableObjects =
-                clients.run(
-                        client ->
-                                client.listTableNamesByFilter(
-                                        database,
-                                        ICEBERG_TYPE_FILTER,
-                                        (short) -1));
+            clients.run(
+                client -> client.listTableNamesByFilter(database, ICEBERG_TYPE_FILTER, (short) -1));
         tableIdentifiers =
             tableObjects.stream()
                 .map(t -> TableIdentifier.of(namespace, t))

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg.hive;
 
-import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,6 +33,7 @@ import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogProperties;
@@ -76,7 +75,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
   static final String ICEBERG_TYPE_FILTER =
       String.format(
           "%s%s = \"%s\"",
-          HIVE_FILTER_FIELD_PARAMS,
+          hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS,
           BaseMetastoreTableOperations.TABLE_TYPE_PROP,
           BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE);
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.hive;
 
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -73,7 +75,8 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
 
   static final String ICEBERG_TYPE_FILTER =
       String.format(
-          "%s = \"%s\"",
+          "%s%s = \"%s\"",
+          HIVE_FILTER_FIELD_PARAMS,
           BaseMetastoreTableOperations.TABLE_TYPE_PROP,
           BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE);
 


### PR DESCRIPTION
Currently, HiveCatalog gets the list of Iceberg tables in 2 steps:

1. list all table names
2. get all table metas with these names and filter them by the table property table_type

In fact, we could push down the table property filter to the HMS, and get the Iceberg tables with one request.

Closes #9031.