### PR TITLE
API: Optimize equals in CharSequenceWrapper

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
@@ -52,6 +52,15 @@ public class CharSequenceWrapper implements CharSequence, Serializable {
     }
 
     CharSequenceWrapper that = (CharSequenceWrapper) other;
+
+    if (wrapped instanceof String && that.wrapped instanceof String) {
+      return wrapped.equals(that.wrapped);
+    }
+
+    if (length() != that.length()) {
+      return false;
+    }
+
     return Comparators.charSequences().compare(wrapped, that.wrapped) == 0;
   }
 


### PR DESCRIPTION
While profiling #8755, I noticed that `equals` in `CharSequenceWrapper` is quite slow. 


This PR contains 2 optimizations:
- Check if both wrapped objects are `String`. If so, call `equals()` on them. This comparison will be much more efficient because bytes will be compared directly.
- Return early if char sequences have different lengths.
