### PR TITLE
Docs: Remove UNIQUE keyword as it is not supported in Flink

### DIFF
--- a/docs/flink-writes.md
+++ b/docs/flink-writes.md
@@ -69,7 +69,7 @@ Iceberg supports `UPSERT` based on the primary key when writing data into v2 tab
 
 ```sql
 CREATE TABLE `hive_catalog`.`default`.`sample` (
-    `id`  INT COMMENT 'unique id',
+    `id` INT COMMENT 'unique id',
     `data` STRING NOT NULL,
     PRIMARY KEY(`id`) NOT ENFORCED
 ) with ('format-version'='2', 'write.upsert.enabled'='true');

--- a/docs/flink-writes.md
+++ b/docs/flink-writes.md
@@ -69,7 +69,7 @@ Iceberg supports `UPSERT` based on the primary key when writing data into v2 tab
 
 ```sql
 CREATE TABLE `hive_catalog`.`default`.`sample` (
-    `id`  INT UNIQUE COMMENT 'unique id',
+    `id`  INT COMMENT 'unique id',
     `data` STRING NOT NULL,
     PRIMARY KEY(`id`) NOT ENFORCED
 ) with ('format-version'='2', 'write.upsert.enabled'='true');


### PR DESCRIPTION
Remove UNIQUE keyword as it is not supported in Flink. 