### PR TITLE
API: Add CharSequenceMap

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceMap.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceMap.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+
+/**
+ * A map that uses char sequences as keys.
+ *
+ * <p>This implementation wraps provided keys into {@link CharSequenceWrapper} for consistent
+ * hashing and equals behavior. This ensures that objects of different types that represent the same
+ * sequence of characters are treated as equal keys in the map.
+ *
+ * <p>Note: This map is not designed for concurrent modification by multiple threads. However, it
+ * supports safe concurrent reads, assuming there are no concurrent writes.
+ *
+ * <p>Note: This map does not support null keys.
+ *
+ * @param <V> the type of values
+ */
+public class CharSequenceMap<V> implements Map<CharSequence, V>, Serializable {
+
+  private static final long serialVersionUID = 1L;
+  private static final ThreadLocal<CharSequenceWrapper> WRAPPERS =
+      ThreadLocal.withInitial(() -> CharSequenceWrapper.wrap(null));
+
+  private final Map<CharSequenceWrapper, V> wrapperMap;
+
+  private CharSequenceMap() {
+    this.wrapperMap = Maps.newHashMap();
+  }
+
+  public static <T> CharSequenceMap<T> create() {
+    return new CharSequenceMap<>();
+  }
+
+  @Override
+  public int size() {
+    return wrapperMap.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return wrapperMap.isEmpty();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    if (key instanceof CharSequence) {
+      CharSequenceWrapper wrapper = WRAPPERS.get();
+      boolean result = wrapperMap.containsKey(wrapper.set((CharSequence) key));
+      wrapper.set(null); // don't hold a reference to the key
+      return result;
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return wrapperMap.containsValue(value);
+  }
+
+  @Override
+  public V get(Object key) {
+    if (key instanceof CharSequence) {
+      CharSequenceWrapper wrapper = WRAPPERS.get();
+      V result = wrapperMap.get(wrapper.set((CharSequence) key));
+      wrapper.set(null); // don't hold a reference to the value
+      return result;
+    }
+
+    return null;
+  }
+
+  @Override
+  public V put(CharSequence key, V value) {
+    return wrapperMap.put(CharSequenceWrapper.wrap(key), value);
+  }
+
+  @Override
+  public V remove(Object key) {
+    if (key instanceof CharSequence) {
+      CharSequenceWrapper wrapper = WRAPPERS.get();
+      V result = wrapperMap.remove(wrapper.set((CharSequence) key));
+      wrapper.set(null); // don't hold a reference to the value
+      return result;
+    }
+
+    return null;
+  }
+
+  @Override
+  public void putAll(Map<? extends CharSequence, ? extends V> otherMap) {
+    otherMap.forEach(this::put);
+  }
+
+  @Override
+  public void clear() {
+    wrapperMap.clear();
+  }
+
+  @Override
+  public Set<CharSequence> keySet() {
+    CharSequenceSet keySet = CharSequenceSet.empty();
+
+    for (CharSequenceWrapper wrapper : wrapperMap.keySet()) {
+      keySet.add(wrapper.get());
+    }
+
+    return keySet;
+  }
+
+  @Override
+  public Collection<V> values() {
+    return wrapperMap.values();
+  }
+
+  @Override
+  public Set<Entry<CharSequence, V>> entrySet() {
+    Set<Entry<CharSequence, V>> entrySet = Sets.newHashSet();
+
+    for (Entry<CharSequenceWrapper, V> entry : wrapperMap.entrySet()) {
+      entrySet.add(new CharSequenceEntry<>(entry));
+    }
+
+    return entrySet;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    CharSequenceMap<?> that = (CharSequenceMap<?>) other;
+    return Objects.equals(wrapperMap, that.wrapperMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(wrapperMap);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+
+    builder.append('{');
+
+    for (Entry<CharSequence, V> entry : entrySet()) {
+      if (builder.length() > 1) { // comma and space are not needed before the first entry
+        builder.append(", ");
+      }
+      CharSequence key = entry.getKey();
+      V value = entry.getValue();
+      builder.append(key);
+      builder.append('=');
+      builder.append(value == this ? "(this Map)" : value);
+    }
+
+    builder.append('}');
+
+    return builder.toString();
+  }
+
+  private static class CharSequenceEntry<V> implements Entry<CharSequence, V> {
+    private final Entry<CharSequenceWrapper, V> inner;
+
+    private CharSequenceEntry(Entry<CharSequenceWrapper, V> inner) {
+      this.inner = inner;
+    }
+
+    @Override
+    public CharSequence getKey() {
+      return inner.getKey().get();
+    }
+
+    @Override
+    public V getValue() {
+      return inner.getValue();
+    }
+
+    @Override
+    public int hashCode() {
+      return inner.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      } else if (other == null || getClass() != other.getClass()) {
+        return false;
+      }
+
+      CharSequenceEntry<?> that = (CharSequenceEntry<?>) other;
+      return inner.equals(that.inner);
+    }
+
+    @Override
+    public V setValue(V value) {
+      throw new UnsupportedOperationException("Cannot set value");
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceMap.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceMap.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
@@ -168,24 +169,13 @@ public class CharSequenceMap<V> implements Map<CharSequence, V>, Serializable {
 
   @Override
   public String toString() {
-    StringBuilder builder = new StringBuilder();
+    return entrySet().stream().map(this::toString).collect(Collectors.joining(", ", "{", "}"));
+  }
 
-    builder.append('{');
-
-    for (Entry<CharSequence, V> entry : entrySet()) {
-      if (builder.length() > 1) { // comma and space are not needed before the first entry
-        builder.append(", ");
-      }
-      CharSequence key = entry.getKey();
-      V value = entry.getValue();
-      builder.append(key);
-      builder.append('=');
-      builder.append(value == this ? "(this Map)" : value);
-    }
-
-    builder.append('}');
-
-    return builder.toString();
+  private String toString(Entry<CharSequence, V> entry) {
+    CharSequence key = entry.getKey();
+    V value = entry.getValue();
+    return key + "=" + (value == this ? "(this Map)" : value);
   }
 
   private static class CharSequenceEntry<V> implements Entry<CharSequence, V> {

--- a/api/src/test/java/org/apache/iceberg/util/TestCharSequenceMap.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestCharSequenceMap.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+public class TestCharSequenceMap {
+
+  @Test
+  public void testEmptyMap() {
+    CharSequenceMap<String> map = CharSequenceMap.create();
+    assertThat(map).isEmpty();
+    assertThat(map).hasSize(0);
+    assertThat(map).doesNotContainKey("key");
+    assertThat(map).doesNotContainValue("value");
+    assertThat(map.values()).isEmpty();
+    assertThat(map.keySet()).isEmpty();
+    assertThat(map.entrySet()).isEmpty();
+  }
+
+  @Test
+  public void testDifferentCharSequenceImplementations() {
+    CharSequenceMap<String> map = CharSequenceMap.create();
+    map.put("abc", "value1");
+    map.put(new StringBuffer("def"), "value2");
+    assertThat(map).containsEntry(new StringBuilder("abc"), "value1");
+    assertThat(map).containsEntry("def", "value2");
+  }
+
+  @Test
+  public void testPutAndGet() {
+    CharSequenceMap<String> map = CharSequenceMap.create();
+    map.put("key1", "value1");
+    assertThat(map).containsEntry("key1", "value1");
+  }
+
+  @Test
+  public void testRemove() {
+    CharSequenceMap<String> map = CharSequenceMap.create();
+    map.put("key1", "value1");
+    map.remove(new StringBuilder("key1"));
+    assertThat(map).doesNotContainKey("key1");
+    assertThat(map).isEmpty();
+  }
+
+  @Test
+  public void testPutAll() {
+    CharSequenceMap<String> map = CharSequenceMap.create();
+    map.putAll(ImmutableMap.of("key1", "value1", "key2", "value2"));
+    assertThat(map).containsEntry("key1", "value1");
+    assertThat(map).containsEntry("key2", "value2");
+  }
+
+  @Test
+  public void testClear() {
+    CharSequenceMap<String> map = CharSequenceMap.create();
+    map.put("key1", "value1");
+    map.clear();
+    assertThat(map).isEmpty();
+  }
+
+  @Test
+  public void testValues() {
+    CharSequenceMap<String> map = CharSequenceMap.create();
+    map.put("key1", "value1");
+    map.put("key2", "value2");
+    assertThat(map.values()).containsAll(ImmutableList.of("value1", "value2"));
+  }
+
+  @Test
+  public void testEntrySet() {
+    CharSequenceMap<String> map = CharSequenceMap.create();
+    map.put("key1", "value1");
+    map.put(new StringBuilder("key2"), "value2");
+    assertThat(map.entrySet()).hasSize(2);
+  }
+
+  @Test
+  public void testEquals() {
+    CharSequenceMap<String> map1 = CharSequenceMap.create();
+    map1.put(new StringBuilder("key"), "value");
+
+    CharSequenceMap<String> map2 = CharSequenceMap.create();
+    map2.put("key", "value");
+
+    assertThat(map1).isEqualTo(map2);
+  }
+
+  @Test
+  public void testHashCode() {
+    CharSequenceMap<String> map1 = CharSequenceMap.create();
+    map1.put(new StringBuilder("key"), "value");
+
+    CharSequenceMap<String> map2 = CharSequenceMap.create();
+    map2.put("key", "value");
+
+    assertThat(map1.hashCode()).isEqualTo(map2.hashCode());
+  }
+
+  @Test
+  public void testToString() {
+    CharSequenceMap<String> map = CharSequenceMap.create();
+
+    // empty map
+    assertThat(map.toString()).isEqualTo("{}");
+
+    // single entry
+    map.put("key1", "value1");
+    assertThat(map.toString()).isEqualTo("{key1=value1}");
+
+    // multiple entries
+    map.put("key2", "value2");
+    map.put("key3", "value3");
+    String toStringResult = map.toString();
+    assertThat(toStringResult).contains("key1=value1", "key2=value2", "key3=value3");
+  }
+
+  @Test
+  public void testComputeIfAbsent() {
+    CharSequenceMap<String> map = CharSequenceMap.create();
+
+    String result1 = map.computeIfAbsent("key1", key -> "computedValue1");
+    assertThat(result1).isEqualTo("computedValue1");
+    assertThat(map).containsEntry("key1", "computedValue1");
+
+    // verify existing key is not affected
+    String result2 = map.computeIfAbsent("key1", key -> "newValue");
+    assertThat(result2).isEqualTo("computedValue1");
+    assertThat(map).containsEntry("key1", "computedValue1");
+  }
+
+  @Test
+  public void testMerge() {
+    CharSequenceMap<String> map = CharSequenceMap.create();
+    map.put("key1", "value1");
+    map.put("key2", "value2");
+
+    // merge with an existing key
+    map.merge(new StringBuilder("key1"), "newValue", (oldVal, newVal) -> oldVal + newVal);
+    assertThat(map).containsEntry("key1", "value1newValue");
+
+    // merge with a non-existing key
+    map.merge(new StringBuffer("key3"), "value3", (oldVal, newVal) -> oldVal + newVal);
+    assertThat(map).containsEntry("key3", "value3");
+
+    // merge with null BiFunction should replace the value
+    map.merge("key2", "replacedValue", (oldVal, newVal) -> null);
+    assertThat(map).doesNotContainKey("key2");
+
+    // merge when old value is null (should add new value)
+    map.remove("key1");
+    map.merge("key1", "reAddedValue", (oldVal, newVal) -> oldVal + newVal);
+    assertThat(map).containsEntry("key1", "reAddedValue");
+  }
+
+  @Test
+  public void testConcurrentReadAccess() throws InterruptedException {
+    CharSequenceMap<String> map = CharSequenceMap.create();
+    map.put("key1", "value1");
+    map.put("key2", "value2");
+    map.put("key3", "value3");
+
+    int numThreads = 10;
+    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+
+    // read the map from multiple threads to ensure thread-local wrappers are used
+    for (int i = 0; i < numThreads; i++) {
+      executorService.submit(
+          () -> {
+            assertThat(map.get("key1")).isEqualTo("value1");
+            assertThat(map.get("key2")).isEqualTo("value2");
+            assertThat(map.get("key3")).isEqualTo("value3");
+          });
+    }
+
+    executorService.shutdown();
+    assertThat(executorService.awaitTermination(1, TimeUnit.MINUTES)).isTrue();
+  }
+}


### PR DESCRIPTION
This PR adds `CharSequenceMap`, a map implementation that uses arbitrary char sequences as keys. The implementation is similar to `CharSequenceSet`. This class will be used in writers, delete file index, Spark executor-level content file cache.