### PR TITLE
Core: Implement equals/hashCode method for RESTResponse

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -19,13 +19,7 @@
 package org.apache.iceberg;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Deque;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -506,5 +500,22 @@ public class Schema implements Serializable {
             struct.fields().stream()
                 .map(this::identifierFieldToString)
                 .collect(Collectors.toList())));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Schema schema = (Schema) o;
+    return schemaId == schema.schemaId
+        && Objects.equals(struct, schema.struct)
+        && Arrays.equals(identifierFieldIds, schema.identifierFieldIds);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(struct, schemaId);
+    result = 31 * result + Arrays.hashCode(identifierFieldIds);
+    return result;
   }
 }

--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -19,7 +19,14 @@
 package org.apache.iceberg;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -504,8 +511,12 @@ public class Schema implements Serializable {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     Schema schema = (Schema) o;
     return schemaId == schema.schemaId
         && Objects.equals(struct, schema.struct)

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -114,6 +114,7 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   }
 
   @Override
+  @SuppressWarnings("ReferenceEquality")
   public void commit(TableMetadata base, TableMetadata metadata) {
     // if the metadata is already out of date, reject it
     if (base != current()) {

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -337,6 +337,7 @@ public class BaseTransaction implements Transaction {
     }
   }
 
+  @SuppressWarnings("ReferenceEquality")
   private void commitReplaceTransaction(boolean orCreate) {
     Map<String, String> props = base != null ? base.properties() : current.properties();
 
@@ -393,6 +394,7 @@ public class BaseTransaction implements Transaction {
     }
   }
 
+  @SuppressWarnings("ReferenceEquality")
   private void commitSimpleTransaction() {
     // if there were no changes, don't try to commit
     if (base == current) {
@@ -488,6 +490,7 @@ public class BaseTransaction implements Transaction {
             });
   }
 
+  @SuppressWarnings("ReferenceEquality")
   private void applyUpdates(TableOperations underlyingOps) {
     if (base != underlyingOps.refresh()) {
       // use refreshed the metadata
@@ -540,7 +543,7 @@ public class BaseTransaction implements Transaction {
     }
 
     @Override
-    @SuppressWarnings("ConsistentOverrides")
+    @SuppressWarnings({"ConsistentOverrides", "ReferenceEquality"})
     public void commit(TableMetadata underlyingBase, TableMetadata metadata) {
       if (underlyingBase != current) {
         // trigger a refresh and retry

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -19,7 +19,12 @@
 package org.apache.iceberg;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
@@ -27,7 +32,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -176,7 +180,7 @@ public class TableMetadata implements Serializable {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(timestampMillis, snapshotId);
+      return Objects.hash(timestampMillis, snapshotId);
     }
 
     @Override
@@ -213,12 +217,12 @@ public class TableMetadata implements Serializable {
         return false;
       }
       MetadataLogEntry that = (MetadataLogEntry) other;
-      return timestampMillis == that.timestampMillis && java.util.Objects.equals(file, that.file);
+      return timestampMillis == that.timestampMillis && Objects.equals(file, that.file);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(timestampMillis, file);
+      return Objects.hash(timestampMillis, file);
     }
 
     @Override
@@ -843,9 +847,14 @@ public class TableMetadata implements Serializable {
   }
 
   @Override
+  @SuppressWarnings("CyclomaticComplexity")
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     TableMetadata that = (TableMetadata) o;
     return formatVersion == that.formatVersion
         && lastSequenceNumber == that.lastSequenceNumber
@@ -856,23 +865,23 @@ public class TableMetadata implements Serializable {
         && lastAssignedPartitionId == that.lastAssignedPartitionId
         && defaultSortOrderId == that.defaultSortOrderId
         && currentSnapshotId == that.currentSnapshotId
-        && Objects.equal(metadataFileLocation, that.metadataFileLocation)
-        && Objects.equal(uuid, that.uuid)
-        && Objects.equal(location, that.location)
-        && Objects.equal(properties, that.properties)
-        && Objects.equal(schemasById, that.schemasById)
-        && Objects.equal(specsById, that.specsById)
-        && Objects.equal(sortOrdersById, that.sortOrdersById)
-        && Objects.equal(snapshotLog, that.snapshotLog)
-        && Objects.equal(previousFiles, that.previousFiles)
-        && Objects.equal(statisticsFiles, that.statisticsFiles)
-        && Objects.equal(snapshotsById, that.snapshotsById)
-        && Objects.equal(refs, that.refs);
+        && Objects.equals(metadataFileLocation, that.metadataFileLocation)
+        && Objects.equals(uuid, that.uuid)
+        && Objects.equals(location, that.location)
+        && Objects.equals(properties, that.properties)
+        && Objects.equals(schemasById, that.schemasById)
+        && Objects.equals(specsById, that.specsById)
+        && Objects.equals(sortOrdersById, that.sortOrdersById)
+        && Objects.equals(snapshotLog, that.snapshotLog)
+        && Objects.equals(previousFiles, that.previousFiles)
+        && Objects.equals(statisticsFiles, that.statisticsFiles)
+        && Objects.equals(snapshotsById, that.snapshotsById)
+        && Objects.equals(refs, that.refs);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(
+    return Objects.hash(
         metadataFileLocation,
         formatVersion,
         uuid,
@@ -898,29 +907,29 @@ public class TableMetadata implements Serializable {
 
   @Override
   public String toString() {
-    return "TableMetadata{" +
-            "metadataFileLocation='" + metadataFileLocation + '\'' +
-            ", formatVersion=" + formatVersion +
-            ", uuid='" + uuid + '\'' +
-            ", location='" + location + '\'' +
-            ", lastSequenceNumber=" + lastSequenceNumber +
-            ", lastUpdatedMillis=" + lastUpdatedMillis +
-            ", lastColumnId=" + lastColumnId +
-            ", currentSchemaId=" + currentSchemaId +
-            ", defaultSpecId=" + defaultSpecId +
-            ", lastAssignedPartitionId=" + lastAssignedPartitionId +
-            ", defaultSortOrderId=" + defaultSortOrderId +
-            ", properties=" + properties +
-            ", currentSnapshotId=" + currentSnapshotId +
-            ", schemasById=" + schemasById +
-            ", specsById=" + specsById +
-            ", sortOrdersById=" + sortOrdersById +
-            ", snapshotLog=" + snapshotLog +
-            ", previousFiles=" + previousFiles +
-            ", statisticsFiles=" + statisticsFiles +
-            ", snapshotsById=" + snapshotsById +
-            ", refs=" + refs +
-            '}';
+    return MoreObjects.toStringHelper(this)
+        .add("metadataFileLocation", metadataFileLocation)
+        .add("formatVersion", formatVersion)
+        .add("uuid", uuid)
+        .add("location", location)
+        .add("lastSequenceNumber", lastSequenceNumber)
+        .add("lastUpdatedMillis", lastUpdatedMillis)
+        .add("lastColumnId", lastColumnId)
+        .add("currentSchemaId", currentSchemaId)
+        .add("defaultSpecId", defaultSpecId)
+        .add("lastAssignedPartitionId", lastAssignedPartitionId)
+        .add("defaultSortOrderId", defaultSortOrderId)
+        .add("properties", properties)
+        .add("currentSnapshotId", currentSnapshotId)
+        .add("schemasById", schemasById)
+        .add("specsById", specsById)
+        .add("sortOrdersById", sortOrdersById)
+        .add("snapshotLog", snapshotLog)
+        .add("previousFiles", previousFiles)
+        .add("statisticsFiles", statisticsFiles)
+        .add("snapshotsById", snapshotsById)
+        .add("refs", refs)
+        .toString();
   }
 
   public static Builder buildFrom(TableMetadata base) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -19,11 +19,7 @@
 package org.apache.iceberg;
 
 import java.io.Serializable;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
@@ -844,6 +840,87 @@ public class TableMetadata implements Serializable {
     }
 
     return inputRefs;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TableMetadata that = (TableMetadata) o;
+    return formatVersion == that.formatVersion
+        && lastSequenceNumber == that.lastSequenceNumber
+        && lastUpdatedMillis == that.lastUpdatedMillis
+        && lastColumnId == that.lastColumnId
+        && currentSchemaId == that.currentSchemaId
+        && defaultSpecId == that.defaultSpecId
+        && lastAssignedPartitionId == that.lastAssignedPartitionId
+        && defaultSortOrderId == that.defaultSortOrderId
+        && currentSnapshotId == that.currentSnapshotId
+        && Objects.equal(metadataFileLocation, that.metadataFileLocation)
+        && Objects.equal(uuid, that.uuid)
+        && Objects.equal(location, that.location)
+        && Objects.equal(properties, that.properties)
+        && Objects.equal(schemasById, that.schemasById)
+        && Objects.equal(specsById, that.specsById)
+        && Objects.equal(sortOrdersById, that.sortOrdersById)
+        && Objects.equal(snapshotLog, that.snapshotLog)
+        && Objects.equal(previousFiles, that.previousFiles)
+        && Objects.equal(statisticsFiles, that.statisticsFiles)
+        && Objects.equal(snapshotsById, that.snapshotsById)
+        && Objects.equal(refs, that.refs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        metadataFileLocation,
+        formatVersion,
+        uuid,
+        location,
+        lastSequenceNumber,
+        lastUpdatedMillis,
+        lastColumnId,
+        currentSchemaId,
+        defaultSpecId,
+        lastAssignedPartitionId,
+        defaultSortOrderId,
+        properties,
+        currentSnapshotId,
+        schemasById,
+        specsById,
+        sortOrdersById,
+        snapshotLog,
+        previousFiles,
+        statisticsFiles,
+        snapshotsById,
+        refs);
+  }
+
+  @Override
+  public String toString() {
+    return "TableMetadata{" +
+            "metadataFileLocation='" + metadataFileLocation + '\'' +
+            ", formatVersion=" + formatVersion +
+            ", uuid='" + uuid + '\'' +
+            ", location='" + location + '\'' +
+            ", lastSequenceNumber=" + lastSequenceNumber +
+            ", lastUpdatedMillis=" + lastUpdatedMillis +
+            ", lastColumnId=" + lastColumnId +
+            ", currentSchemaId=" + currentSchemaId +
+            ", defaultSpecId=" + defaultSpecId +
+            ", lastAssignedPartitionId=" + lastAssignedPartitionId +
+            ", defaultSortOrderId=" + defaultSortOrderId +
+            ", properties=" + properties +
+            ", currentSnapshotId=" + currentSnapshotId +
+            ", schemasById=" + schemasById +
+            ", specsById=" + specsById +
+            ", sortOrdersById=" + sortOrdersById +
+            ", snapshotLog=" + snapshotLog +
+            ", previousFiles=" + previousFiles +
+            ", statisticsFiles=" + statisticsFiles +
+            ", snapshotsById=" + snapshotsById +
+            ", refs=" + refs +
+            '}';
   }
 
   public static Builder buildFrom(TableMetadata base) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -128,6 +128,7 @@ public class HadoopTableOperations implements TableOperations {
   }
 
   @Override
+  @SuppressWarnings("ReferenceEquality")
   public void commit(TableMetadata base, TableMetadata metadata) {
     Pair<Integer, TableMetadata> current = versionAndMetadata();
     if (base != current.second()) {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ConfigResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ConfigResponse.java
@@ -110,6 +110,19 @@ public class ConfigResponse implements RESTResponse {
         .toString();
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ConfigResponse that = (ConfigResponse) o;
+    return Objects.equals(defaults, that.defaults) && Objects.equals(overrides, that.overrides);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(defaults, overrides);
+  }
+
   public static Builder builder() {
     return new Builder();
   }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ConfigResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ConfigResponse.java
@@ -112,8 +112,12 @@ public class ConfigResponse implements RESTResponse {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     ConfigResponse that = (ConfigResponse) o;
     return Objects.equals(defaults, that.defaults) && Objects.equals(overrides, that.overrides);
   }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/CreateNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/CreateNamespaceResponse.java
@@ -66,8 +66,12 @@ public class CreateNamespaceResponse implements RESTResponse {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     CreateNamespaceResponse that = (CreateNamespaceResponse) o;
     return Objects.equals(namespace, that.namespace) && Objects.equals(properties, that.properties);
   }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/CreateNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/CreateNamespaceResponse.java
@@ -64,6 +64,19 @@ public class CreateNamespaceResponse implements RESTResponse {
         .toString();
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CreateNamespaceResponse that = (CreateNamespaceResponse) o;
+    return Objects.equals(namespace, that.namespace) && Objects.equals(properties, that.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, properties);
+  }
+
   public static Builder builder() {
     return new Builder();
   }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
@@ -22,6 +22,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.rest.RESTResponse;
 
@@ -81,6 +82,22 @@ public class ErrorResponse implements RESTResponse {
     }
 
     return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ErrorResponse that = (ErrorResponse) o;
+    return code == that.code
+        && Objects.equals(message, that.message)
+        && Objects.equals(type, that.type)
+        && Objects.equals(stack, that.stack);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(message, type, code, stack);
   }
 
   public static Builder builder() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
@@ -86,8 +86,12 @@ public class ErrorResponse implements RESTResponse {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     ErrorResponse that = (ErrorResponse) o;
     return code == that.code
         && Objects.equals(message, that.message)

--- a/core/src/main/java/org/apache/iceberg/rest/responses/GetNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/GetNamespaceResponse.java
@@ -66,8 +66,12 @@ public class GetNamespaceResponse implements RESTResponse {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     GetNamespaceResponse that = (GetNamespaceResponse) o;
     return Objects.equals(namespace, that.namespace) && Objects.equals(properties, that.properties);
   }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/GetNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/GetNamespaceResponse.java
@@ -64,6 +64,19 @@ public class GetNamespaceResponse implements RESTResponse {
         .toString();
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GetNamespaceResponse that = (GetNamespaceResponse) o;
+    return Objects.equals(namespace, that.namespace) && Objects.equals(properties, that.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, properties);
+  }
+
   public static Builder builder() {
     return new Builder();
   }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ListNamespacesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ListNamespacesResponse.java
@@ -56,8 +56,12 @@ public class ListNamespacesResponse implements RESTResponse {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     ListNamespacesResponse that = (ListNamespacesResponse) o;
     return Objects.equals(namespaces, that.namespaces);
   }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ListNamespacesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ListNamespacesResponse.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.rest.responses;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -51,6 +52,19 @@ public class ListNamespacesResponse implements RESTResponse {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("namespaces", namespaces()).toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ListNamespacesResponse that = (ListNamespacesResponse) o;
+    return Objects.equals(namespaces, that.namespaces);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(namespaces);
   }
 
   public static Builder builder() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ListTablesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ListTablesResponse.java
@@ -57,8 +57,12 @@ public class ListTablesResponse implements RESTResponse {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     ListTablesResponse that = (ListTablesResponse) o;
     return Objects.equals(identifiers, that.identifiers);
   }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ListTablesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ListTablesResponse.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.rest.responses;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -52,6 +53,19 @@ public class ListTablesResponse implements RESTResponse {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("identifiers", identifiers).toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ListTablesResponse that = (ListTablesResponse) o;
+    return Objects.equals(identifiers, that.identifiers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(identifiers);
   }
 
   public static Builder builder() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
@@ -80,8 +80,12 @@ public class LoadTableResponse implements RESTResponse {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     LoadTableResponse that = (LoadTableResponse) o;
     return Objects.equals(metadataLocation, that.metadataLocation)
         && Objects.equals(metadata, that.metadata)

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.rest.responses;
 
 import java.util.Map;
+import java.util.Objects;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -75,6 +76,21 @@ public class LoadTableResponse implements RESTResponse {
         .add("metadata", metadata)
         .add("config", config)
         .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LoadTableResponse that = (LoadTableResponse) o;
+    return Objects.equals(metadataLocation, that.metadataLocation)
+        && Objects.equals(metadata, that.metadata)
+        && Objects.equals(config, that.config);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(metadataLocation, metadata, config);
   }
 
   public static Builder builder() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.rest.responses;
 
 import java.util.List;
+import java.util.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -76,6 +77,23 @@ public class OAuthTokenResponse implements RESTResponse {
 
   public static Builder builder() {
     return new Builder();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    OAuthTokenResponse that = (OAuthTokenResponse) o;
+    return Objects.equals(accessToken, that.accessToken)
+        && Objects.equals(issuedTokenType, that.issuedTokenType)
+        && Objects.equals(tokenType, that.tokenType)
+        && Objects.equals(expiresIn, that.expiresIn)
+        && Objects.equals(scope, that.scope);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(accessToken, issuedTokenType, tokenType, expiresIn, scope);
   }
 
   public static class Builder {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java
@@ -81,8 +81,12 @@ public class OAuthTokenResponse implements RESTResponse {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     OAuthTokenResponse that = (OAuthTokenResponse) o;
     return Objects.equals(accessToken, that.accessToken)
         && Objects.equals(issuedTokenType, that.issuedTokenType)

--- a/core/src/main/java/org/apache/iceberg/rest/responses/UpdateNamespacePropertiesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/UpdateNamespacePropertiesResponse.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.rest.responses;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -71,6 +72,21 @@ public class UpdateNamespacePropertiesResponse implements RESTResponse {
         .add("updates", updated)
         .add("missing", missing)
         .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    UpdateNamespacePropertiesResponse that = (UpdateNamespacePropertiesResponse) o;
+    return Objects.equals(removed, that.removed)
+        && Objects.equals(updated, that.updated)
+        && Objects.equals(missing, that.missing);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(removed, updated, missing);
   }
 
   public static Builder builder() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/UpdateNamespacePropertiesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/UpdateNamespacePropertiesResponse.java
@@ -76,8 +76,12 @@ public class UpdateNamespacePropertiesResponse implements RESTResponse {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     UpdateNamespacePropertiesResponse that = (UpdateNamespacePropertiesResponse) o;
     return Objects.equals(removed, that.removed)
         && Objects.equals(updated, that.updated)

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestCatalogErrorResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestCatalogErrorResponseParser.java
@@ -121,9 +121,6 @@ public class TestCatalogErrorResponseParser {
   }
 
   public void assertEquals(ErrorResponse expected, ErrorResponse actual) {
-    Assertions.assertThat(actual.message()).isEqualTo(expected.message());
-    Assertions.assertThat(actual.type()).isEqualTo(expected.type());
-    Assertions.assertThat(actual.code()).isEqualTo(expected.code());
-    Assertions.assertThat(actual.stack()).isEqualTo(expected.stack());
+    Assertions.assertThat(actual).isEqualTo(expected);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestConfigResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestConfigResponse.java
@@ -222,6 +222,30 @@ public class TestConfigResponse extends RequestResponseTestBase<ConfigResponse> 
         .doesNotContainValue(null);
   }
 
+  @Test
+  public void testEqualsCheck() {
+    ConfigResponse resp =
+        ConfigResponse.builder().withDefaults(DEFAULTS).withOverrides(OVERRIDES).build();
+    ConfigResponse resp2 =
+        ConfigResponse.builder().withDefaults(DEFAULTS).withOverrides(OVERRIDES).build();
+
+    Assertions.assertThat(resp).isEqualTo(resp2);
+
+    Assertions.assertThat(resp.hashCode()).isEqualTo(resp2.hashCode());
+  }
+
+  @Test
+  public void testUnEqualsCheck() {
+    ConfigResponse resp =
+        ConfigResponse.builder().withDefaults(OVERRIDES).withOverrides(DEFAULTS).build();
+    ConfigResponse resp2 =
+        ConfigResponse.builder().withDefaults(DEFAULTS).withOverrides(OVERRIDES).build();
+
+    Assertions.assertThat(resp).isNotEqualTo(resp2);
+
+    Assertions.assertThat(resp.hashCode()).isNotEqualTo(resp2.hashCode());
+  }
+
   @Override
   public String[] allFieldsFromSpec() {
     return new String[] {"defaults", "overrides"};

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestCreateNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestCreateNamespaceResponse.java
@@ -164,4 +164,26 @@ public class TestCreateNamespaceResponse extends RequestResponseTestBase<CreateN
     response.validate();
     return response;
   }
+
+  @Test
+  public void testEqualsCheck() {
+    CreateNamespaceResponse resp1 = createExampleInstance();
+    CreateNamespaceResponse resp2 = createExampleInstance();
+
+    Assertions.assertThat(resp1).isEqualTo(resp2);
+    Assertions.assertThat(resp1.hashCode()).isEqualTo(resp2.hashCode());
+  }
+
+  @Test
+  public void testUnEqualsCheck() {
+    CreateNamespaceResponse resp1 = createExampleInstance();
+    CreateNamespaceResponse resp2 =
+        CreateNamespaceResponse.builder()
+            .withNamespace(Namespace.of("ns1", "test1"))
+            .setProperties(PROPERTIES)
+            .build();
+
+    Assertions.assertThat(resp1).isNotEqualTo(resp2);
+    Assertions.assertThat(resp1.hashCode()).isNotEqualTo(resp2.hashCode());
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestGetNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestGetNamespaceResponse.java
@@ -146,4 +146,26 @@ public class TestGetNamespaceResponse extends RequestResponseTestBase<GetNamespa
     resp.validate();
     return resp;
   }
+
+  @Test
+  public void testEqualsCheck() {
+    GetNamespaceResponse resp1 = createExampleInstance();
+    GetNamespaceResponse resp2 = createExampleInstance();
+
+    Assertions.assertThat(resp1).isEqualTo(resp2);
+    Assertions.assertThat(resp1.hashCode()).isEqualTo(resp2.hashCode());
+  }
+
+  @Test
+  public void testUnEqualsCheck() {
+    GetNamespaceResponse resp1 = createExampleInstance();
+    GetNamespaceResponse resp2 =
+        GetNamespaceResponse.builder()
+            .withNamespace(Namespace.of("ns1", "ts1"))
+            .setProperties(PROPERTIES)
+            .build();
+
+    Assertions.assertThat(resp1).isNotEqualTo(resp2);
+    Assertions.assertThat(resp1.hashCode()).isNotEqualTo(resp2.hashCode());
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestListNamespacesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestListNamespacesResponse.java
@@ -107,4 +107,23 @@ public class TestListNamespacesResponse extends RequestResponseTestBase<ListName
     resp.validate();
     return resp;
   }
+
+  @Test
+  public void testEqualsCheck() {
+    ListNamespacesResponse resp1 = createExampleInstance();
+    ListNamespacesResponse resp2 = createExampleInstance();
+
+    Assertions.assertThat(resp1).isEqualTo(resp2);
+    Assertions.assertThat(resp1.hashCode()).isEqualTo(resp2.hashCode());
+  }
+
+  @Test
+  public void testUnEqualsCheck() {
+    ListNamespacesResponse resp1 = createExampleInstance();
+    ListNamespacesResponse resp2 =
+        ListNamespacesResponse.builder().add(Namespace.of("ns1", "ts1")).build();
+
+    Assertions.assertThat(resp1).isNotEqualTo(resp2);
+    Assertions.assertThat(resp1.hashCode()).isNotEqualTo(resp2.hashCode());
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestListTablesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestListTablesResponse.java
@@ -129,4 +129,23 @@ public class TestListTablesResponse extends RequestResponseTestBase<ListTablesRe
     resp.validate();
     return resp;
   }
+
+  @Test
+  public void testEqualsCheck() {
+    ListTablesResponse resp1 = createExampleInstance();
+    ListTablesResponse resp2 = createExampleInstance();
+
+    Assertions.assertThat(resp1).isEqualTo(resp2);
+    Assertions.assertThat(resp1.hashCode()).isEqualTo(resp2.hashCode());
+  }
+
+  @Test
+  public void testUnEqualsCheck() {
+    ListTablesResponse resp1 = createExampleInstance();
+    ListTablesResponse resp2 =
+        ListTablesResponse.builder().add(TableIdentifier.of("ns1", "t1")).build();
+
+    Assertions.assertThat(resp1).isNotEqualTo(resp2);
+    Assertions.assertThat(resp1.hashCode()).isNotEqualTo(resp2.hashCode());
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponse.java
@@ -267,18 +267,20 @@ public class TestLoadTableResponse extends RequestResponseTestBase<LoadTableResp
   @Test
   public void testEqualsCheck() {
     String uuid = UUID.randomUUID().toString();
-    TableMetadata metadata1 = TableMetadata.buildFrom(
-                    TableMetadata.newTableMetadata(
-                            SCHEMA_7, SPEC_5, SORT_ORDER_3, TEST_TABLE_LOCATION, TABLE_PROPS))
+    TableMetadata metadata1 =
+        TableMetadata.buildFrom(
+                TableMetadata.newTableMetadata(
+                    SCHEMA_7, SPEC_5, SORT_ORDER_3, TEST_TABLE_LOCATION, TABLE_PROPS))
             .discardChanges()
             .withMetadataLocation(TEST_METADATA_LOCATION)
             .assignUUID(uuid)
             .build();
     LoadTableResponse resp1 = LoadTableResponse.builder().withTableMetadata(metadata1).build();
 
-    TableMetadata metadata2 = TableMetadata.buildFrom(
-                    TableMetadata.newTableMetadata(
-                            SCHEMA_7, SPEC_5, SORT_ORDER_3, TEST_TABLE_LOCATION, TABLE_PROPS))
+    TableMetadata metadata2 =
+        TableMetadata.buildFrom(
+                TableMetadata.newTableMetadata(
+                    SCHEMA_7, SPEC_5, SORT_ORDER_3, TEST_TABLE_LOCATION, TABLE_PROPS))
             .discardChanges()
             .withMetadataLocation(TEST_METADATA_LOCATION)
             .assignUUID(uuid)

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthErrorResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthErrorResponseParser.java
@@ -62,8 +62,7 @@ public class TestOAuthErrorResponseParser {
   }
 
   public void assertEquals(ErrorResponse expected, ErrorResponse actual) {
-    Assertions.assertThat(actual.code()).isEqualTo(expected.code());
-    Assertions.assertThat(actual.type()).isEqualTo(expected.type());
-    Assertions.assertThat(actual.message()).isEqualTo(expected.message());
+    Assertions.assertThat(actual).isEqualTo(expected);
+    Assertions.assertThat(actual.hashCode()).isEqualTo(expected.hashCode());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java
@@ -132,4 +132,29 @@ public class TestOAuthTokenResponse extends RequestResponseTestBase<OAuthTokenRe
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Cannot parse to a string value: token_type: 34");
   }
+
+  @Test
+  public void testEqualsCheck() {
+    OAuthTokenResponse resp1 = createExampleInstance();
+    OAuthTokenResponse resp2 = createExampleInstance();
+
+    Assertions.assertThat(resp1).isEqualTo(resp2);
+    Assertions.assertThat(resp1.hashCode()).isEqualTo(resp2.hashCode());
+  }
+
+  @Test
+  public void testUnequalsCheck() {
+    OAuthTokenResponse resp1 = createExampleInstance();
+    OAuthTokenResponse resp2 =
+        OAuthTokenResponse.builder()
+            .setExpirationInSeconds(600)
+            .withToken("test-token2")
+            .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
+            .withTokenType("Bearer")
+            .addScope("catalog")
+            .build();
+
+    Assertions.assertThat(resp1).isNotEqualTo(resp2);
+    Assertions.assertThat(resp1.hashCode()).isNotEqualTo(resp2.hashCode());
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestUpdateNamespacePropertiesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestUpdateNamespacePropertiesResponse.java
@@ -260,4 +260,27 @@ public class TestUpdateNamespacePropertiesResponse
     resp.validate();
     return resp;
   }
+
+  @Test
+  public void testEqualsCheck() {
+    UpdateNamespacePropertiesResponse resp1 = createExampleInstance();
+    UpdateNamespacePropertiesResponse resp2 = createExampleInstance();
+
+    Assertions.assertThat(resp1).isEqualTo(resp2);
+    Assertions.assertThat(resp1.hashCode()).isEqualTo(resp2.hashCode());
+  }
+
+  @Test
+  public void testUnEqualsCheck() {
+    UpdateNamespacePropertiesResponse resp1 = createExampleInstance();
+    UpdateNamespacePropertiesResponse resp2 =
+        UpdateNamespacePropertiesResponse.builder()
+            .addUpdated(REMOVED)
+            .addMissing(UPDATED)
+            .addRemoved(MISSING)
+            .build();
+
+    Assertions.assertThat(resp1).isNotEqualTo(resp2);
+    Assertions.assertThat(resp1.hashCode()).isNotEqualTo(resp2.hashCode());
+  }
 }


### PR DESCRIPTION
Close #9003 

Implement equals method so that it would be easier to check the equality of rest responses.