### PR TITLE
GCS: Allow no-auth for testing purposes

### DIFF
--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -26,7 +26,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
 
 public class GCPProperties implements Serializable {
-
   // Service Options
   public static final String GCS_PROJECT_ID = "gcs.project-id";
   public static final String GCS_CLIENT_LIB_TOKEN = "gcs.client-lib-token";

--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -45,9 +45,7 @@ public class GCPProperties implements Serializable {
   // Boolean to explicitly configure "no authentication" for testing purposes using a GCS emulator
   public static final String GCS_NO_AUTH = "gcs.no-auth";
 
-  /**
-   * Configure the batch size used when deleting multiple files from a given GCS bucket
-   */
+  /** Configure the batch size used when deleting multiple files from a given GCS bucket */
   public static final String GCS_DELETE_BATCH_SIZE = "gcs.delete.batch-size";
   /**
    * Max possible batch size for deletion. Currently, a max of 100 keys is advised, so we default to
@@ -72,8 +70,7 @@ public class GCPProperties implements Serializable {
 
   private int gcsDeleteBatchSize = GCS_DELETE_BATCH_SIZE_DEFAULT;
 
-  public GCPProperties() {
-  }
+  public GCPProperties() {}
 
   @SuppressWarnings("JavaUtilDate") // GCP API uses java.util.Date
   public GCPProperties(Map<String, String> properties) {
@@ -101,7 +98,9 @@ public class GCPProperties implements Serializable {
     gcsNoAuth = Boolean.parseBoolean(properties.getOrDefault(GCS_NO_AUTH, "false"));
     Preconditions.checkState(
         !(gcsOAuth2Token != null && gcsNoAuth),
-        "Invalid auth settings: must not configure %s and %s", GCS_NO_AUTH, GCS_OAUTH2_TOKEN);
+        "Invalid auth settings: must not configure %s and %s",
+        GCS_NO_AUTH,
+        GCS_OAUTH2_TOKEN);
 
     gcsDeleteBatchSize =
         PropertyUtil.propertyAsInt(

--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.gcp;
 
+import com.google.api.client.util.Preconditions;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
@@ -25,6 +26,7 @@ import java.util.Optional;
 import org.apache.iceberg.util.PropertyUtil;
 
 public class GCPProperties implements Serializable {
+
   // Service Options
   public static final String GCS_PROJECT_ID = "gcs.project-id";
   public static final String GCS_CLIENT_LIB_TOKEN = "gcs.client-lib-token";
@@ -40,6 +42,8 @@ public class GCPProperties implements Serializable {
 
   public static final String GCS_OAUTH2_TOKEN = "gcs.oauth2.token";
   public static final String GCS_OAUTH2_TOKEN_EXPIRES_AT = "gcs.oauth2.token-expires-at";
+  // Boolean to explicitly configure "no authentication" for testing purposes using a GCS emulator
+  public static final String GCS_NO_AUTH = "gcs.no-auth";
 
   /** Configure the batch size used when deleting multiple files from a given GCS bucket */
   public static final String GCS_DELETE_BATCH_SIZE = "gcs.delete.batch-size";
@@ -60,6 +64,7 @@ public class GCPProperties implements Serializable {
   private Integer gcsChannelReadChunkSize;
   private Integer gcsChannelWriteChunkSize;
 
+  private boolean gcsNoAuth;
   private String gcsOAuth2Token;
   private Date gcsOAuth2TokenExpiresAt;
 
@@ -90,6 +95,10 @@ public class GCPProperties implements Serializable {
       gcsOAuth2TokenExpiresAt =
           new Date(Long.parseLong(properties.get(GCS_OAUTH2_TOKEN_EXPIRES_AT)));
     }
+    gcsNoAuth = Boolean.parseBoolean(properties.getOrDefault(GCS_NO_AUTH, "false"));
+    Preconditions.checkState(
+        !(gcsOAuth2Token != null && gcsNoAuth),
+        "Must not configure " + GCS_NO_AUTH + " and " + GCS_OAUTH2_TOKEN);
 
     gcsDeleteBatchSize =
         PropertyUtil.propertyAsInt(
@@ -130,6 +139,10 @@ public class GCPProperties implements Serializable {
 
   public Optional<String> oauth2Token() {
     return Optional.ofNullable(gcsOAuth2Token);
+  }
+
+  public boolean noAuth() {
+    return gcsNoAuth;
   }
 
   public Optional<Date> oauth2TokenExpiresAt() {

--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -18,11 +18,11 @@
  */
 package org.apache.iceberg.gcp;
 
-import com.google.api.client.util.Preconditions;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
 
 public class GCPProperties implements Serializable {
@@ -45,7 +45,9 @@ public class GCPProperties implements Serializable {
   // Boolean to explicitly configure "no authentication" for testing purposes using a GCS emulator
   public static final String GCS_NO_AUTH = "gcs.no-auth";
 
-  /** Configure the batch size used when deleting multiple files from a given GCS bucket */
+  /**
+   * Configure the batch size used when deleting multiple files from a given GCS bucket
+   */
   public static final String GCS_DELETE_BATCH_SIZE = "gcs.delete.batch-size";
   /**
    * Max possible batch size for deletion. Currently, a max of 100 keys is advised, so we default to
@@ -70,7 +72,8 @@ public class GCPProperties implements Serializable {
 
   private int gcsDeleteBatchSize = GCS_DELETE_BATCH_SIZE_DEFAULT;
 
-  public GCPProperties() {}
+  public GCPProperties() {
+  }
 
   @SuppressWarnings("JavaUtilDate") // GCP API uses java.util.Date
   public GCPProperties(Map<String, String> properties) {
@@ -98,7 +101,7 @@ public class GCPProperties implements Serializable {
     gcsNoAuth = Boolean.parseBoolean(properties.getOrDefault(GCS_NO_AUTH, "false"));
     Preconditions.checkState(
         !(gcsOAuth2Token != null && gcsNoAuth),
-        "Must not configure " + GCS_NO_AUTH + " and " + GCS_OAUTH2_TOKEN);
+        "Invalid auth settings: must not configure %s and %s", GCS_NO_AUTH, GCS_OAUTH2_TOKEN);
 
     gcsDeleteBatchSize =
         PropertyUtil.propertyAsInt(

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
@@ -56,7 +56,6 @@ import org.slf4j.LoggerFactory;
  * Overview</a>
  */
 public class GCSFileIO implements DelegateFileIO {
-
   private static final Logger LOG = LoggerFactory.getLogger(GCSFileIO.class);
   private static final String DEFAULT_METRICS_IMPL =
       "org.apache.iceberg.hadoop.HadoopMetricsContext";

--- a/gcp/src/test/java/org/apache/iceberg/gcp/GCPPropertiesTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/GCPPropertiesTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp;
+
+import static org.apache.iceberg.gcp.GCPProperties.GCS_NO_AUTH;
+import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_TOKEN;
+
+import com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class GCPPropertiesTest {
+
+  @Test
+  public void testOAuthWithNoAuth() {
+    Assertions.assertThatIllegalStateException().isThrownBy(() -> new GCPProperties(ImmutableMap.of(
+        GCS_OAUTH2_TOKEN, "oauth", GCS_NO_AUTH, "true"))).withMessage(
+        String.format("Invalid auth settings: must not configure %s and %s", GCS_NO_AUTH,
+            GCS_OAUTH2_TOKEN));
+    Assertions.assertThatNoException().isThrownBy(() -> new GCPProperties(ImmutableMap.of(
+        GCS_OAUTH2_TOKEN, "oauth", GCS_NO_AUTH, "false")));
+    Assertions.assertThatNoException().isThrownBy(() -> new GCPProperties(ImmutableMap.of(
+        GCS_NO_AUTH, "true")));
+  }
+}

--- a/gcp/src/test/java/org/apache/iceberg/gcp/GCPPropertiesTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/GCPPropertiesTest.java
@@ -29,13 +29,20 @@ public class GCPPropertiesTest {
 
   @Test
   public void testOAuthWithNoAuth() {
-    Assertions.assertThatIllegalStateException().isThrownBy(() -> new GCPProperties(ImmutableMap.of(
-        GCS_OAUTH2_TOKEN, "oauth", GCS_NO_AUTH, "true"))).withMessage(
-        String.format("Invalid auth settings: must not configure %s and %s", GCS_NO_AUTH,
-            GCS_OAUTH2_TOKEN));
-    Assertions.assertThatNoException().isThrownBy(() -> new GCPProperties(ImmutableMap.of(
-        GCS_OAUTH2_TOKEN, "oauth", GCS_NO_AUTH, "false")));
-    Assertions.assertThatNoException().isThrownBy(() -> new GCPProperties(ImmutableMap.of(
-        GCS_NO_AUTH, "true")));
+    Assertions.assertThatIllegalStateException()
+        .isThrownBy(
+            () ->
+                new GCPProperties(ImmutableMap.of(GCS_OAUTH2_TOKEN, "oauth", GCS_NO_AUTH, "true")))
+        .withMessage(
+            String.format(
+                "Invalid auth settings: must not configure %s and %s",
+                GCS_NO_AUTH, GCS_OAUTH2_TOKEN));
+    Assertions.assertThatNoException()
+        .isThrownBy(
+            () ->
+                new GCPProperties(
+                    ImmutableMap.of(GCS_OAUTH2_TOKEN, "oauth", GCS_NO_AUTH, "false")));
+    Assertions.assertThatNoException()
+        .isThrownBy(() -> new GCPProperties(ImmutableMap.of(GCS_NO_AUTH, "true")));
   }
 }

--- a/gcp/src/test/java/org/apache/iceberg/gcp/GCPPropertiesTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/GCPPropertiesTest.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.gcp;
 
 import static org.apache.iceberg.gcp.GCPProperties.GCS_NO_AUTH;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.assertj.core.api.Assertions;
@@ -37,12 +38,13 @@ public class GCPPropertiesTest {
             String.format(
                 "Invalid auth settings: must not configure %s and %s",
                 GCS_NO_AUTH, GCS_OAUTH2_TOKEN));
-    Assertions.assertThatNoException()
-        .isThrownBy(
-            () ->
-                new GCPProperties(
-                    ImmutableMap.of(GCS_OAUTH2_TOKEN, "oauth", GCS_NO_AUTH, "false")));
-    Assertions.assertThatNoException()
-        .isThrownBy(() -> new GCPProperties(ImmutableMap.of(GCS_NO_AUTH, "true")));
+
+    GCPProperties gcpProperties =
+        new GCPProperties(ImmutableMap.of(GCS_OAUTH2_TOKEN, "oauth", GCS_NO_AUTH, "false"));
+    assertThat(gcpProperties.noAuth()).isFalse();
+    assertThat(gcpProperties.oauth2Token()).get().isEqualTo("oauth");
+    gcpProperties = new GCPProperties(ImmutableMap.of(GCS_NO_AUTH, "true"));
+    assertThat(gcpProperties.noAuth()).isTrue();
+    assertThat(gcpProperties.oauth2Token()).isNotPresent();
   }
 }

--- a/gcp/src/test/java/org/apache/iceberg/gcp/GCPPropertiesTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/GCPPropertiesTest.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.gcp;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_NO_AUTH;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_TOKEN;
 
-import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Although there is no "official" Google Cloud Storage emulator available yet, there is [one available](https://github.com/oittaa/gcp-storage-emulator) that allows at least some basic testing. To use an emulator, the client needs to be configured to use no authentication, otherwise it will fallback to "automatic credential detection".