### PR TITLE
Open-API: Bump dependencies

### DIFF
--- a/open-api/requirements.txt
+++ b/open-api/requirements.txt
@@ -15,7 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-openapi-spec-validator==0.5.2
 datamodel-code-generator==0.23.0
-# Add the Pydantic constraint since 2.4.0 has a bug
-pydantic<2.4.0


### PR DESCRIPTION
The other dependencies can go, since they are pulled in by `datamodel-code-generator`.