### PR TITLE
Spark: Add spark.sql.iceberg.locality.enabled to control whether fetch locali…

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -71,7 +71,12 @@ public class SparkReadConf {
 
   public boolean localityEnabled() {
     boolean defaultValue = Util.mayHaveBlockLocations(table.io(), table.location());
-    return PropertyUtil.propertyAsBoolean(readOptions, SparkReadOptions.LOCALITY, defaultValue);
+    return confParser
+        .booleanConf()
+        .option(SparkReadOptions.LOCALITY)
+        .sessionConf(SparkSQLProperties.LOCALITY)
+        .defaultValue(defaultValue)
+        .parse();
   }
 
   public Long snapshotId() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -63,4 +63,7 @@ public class SparkSQLProperties {
   // Controls the WAP branch used for write-audit-publish workflow.
   // When set, new snapshots will be committed to this branch.
   public static final String WAP_BRANCH = "spark.wap.branch";
+
+  // Controls whether to report locality information to Spark while allocating input partitions
+  public static final String LOCALITY = "spark.sql.iceberg.locality";
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -65,5 +65,5 @@ public class SparkSQLProperties {
   public static final String WAP_BRANCH = "spark.wap.branch";
 
   // Controls whether to report locality information to Spark while allocating input partitions
-  public static final String LOCALITY = "spark.sql.iceberg.locality";
+  public static final String LOCALITY = "spark.sql.iceberg.locality.enabled";
 }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -81,7 +81,12 @@ public class SparkReadConf {
 
   public boolean localityEnabled() {
     boolean defaultValue = Util.mayHaveBlockLocations(table.io(), table.location());
-    return PropertyUtil.propertyAsBoolean(readOptions, SparkReadOptions.LOCALITY, defaultValue);
+    return confParser
+        .booleanConf()
+        .option(SparkReadOptions.LOCALITY)
+        .sessionConf(SparkSQLProperties.LOCALITY)
+        .defaultValue(defaultValue)
+        .parse();
   }
 
   public Long snapshotId() {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -76,5 +76,5 @@ public class SparkSQLProperties {
   public static final String DELETE_PLANNING_MODE = "spark.sql.iceberg.delete-planning-mode";
 
   // Controls whether to report locality information to Spark while allocating input partitions
-  public static final String LOCALITY = "spark.sql.iceberg.locality";
+  public static final String LOCALITY = "spark.sql.iceberg.locality.enabled";
 }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -74,4 +74,7 @@ public class SparkSQLProperties {
 
   // Overrides the delete planning mode
   public static final String DELETE_PLANNING_MODE = "spark.sql.iceberg.delete-planning-mode";
+
+  // Controls whether to report locality information to Spark while allocating input partitions
+  public static final String LOCALITY = "spark.sql.iceberg.locality";
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -79,7 +79,12 @@ public class SparkReadConf {
 
   public boolean localityEnabled() {
     boolean defaultValue = Util.mayHaveBlockLocations(table.io(), table.location());
-    return PropertyUtil.propertyAsBoolean(readOptions, SparkReadOptions.LOCALITY, defaultValue);
+    return confParser
+        .booleanConf()
+        .option(SparkReadOptions.LOCALITY)
+        .sessionConf(SparkSQLProperties.LOCALITY)
+        .defaultValue(defaultValue)
+        .parse();
   }
 
   public Long snapshotId() {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -69,5 +69,5 @@ public class SparkSQLProperties {
   public static final String ADVISORY_PARTITION_SIZE = "spark.sql.iceberg.advisory-partition-size";
 
   // Controls whether to report locality information to Spark while allocating input partitions
-  public static final String LOCALITY = "spark.sql.iceberg.locality";
+  public static final String LOCALITY = "spark.sql.iceberg.locality.enabled";
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -67,4 +67,7 @@ public class SparkSQLProperties {
 
   // Overrides the advisory partition size
   public static final String ADVISORY_PARTITION_SIZE = "spark.sql.iceberg.advisory-partition-size";
+
+  // Controls whether to report locality information to Spark while allocating input partitions
+  public static final String LOCALITY = "spark.sql.iceberg.locality";
 }


### PR DESCRIPTION
…ty information while planing.

We have a computing cluster which is seperate from our HDFS cluster, jobs running on this cluster will never be able to take advantage of the HDFS locality information, so we want to save the process of requesting locality information.
For other data sources, we can use `spark.sql.sources.ignoreDataLocality`,  but Iceberg doesn't use Spark's config, instead I found that Iceberg has a [read option](https://github.com/apache/iceberg/blob/ad6d21a3d9bb1a57fe398656ef73d108e18157d1/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java#L78) `locality` to control this behavior in the Spark connector, but the corresponding Spark SQL property is missing.

@RussellSpitzer @aokolnychyi can you help take a look at this? Thanks!
