### PR TITLE
Spark: Fix metadata delete condition check when there are branches

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -135,7 +135,7 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
         true,
         WRITE_DISTRIBUTION_MODE_NONE,
         false,
-        null,
+        "test",
         DISTRIBUTED
       },
       {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -326,9 +326,8 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
   public void testDeleteFileThenMetadataDelete() throws Exception {
     Assume.assumeFalse("Avro does not support metadata delete", fileFormat.equals("avro"));
     createAndInitUnpartitionedTable();
-
-    sql("INSERT INTO TABLE %s VALUES (1, 'hr'), (2, 'hardware'), (null, 'hr')", tableName);
     createBranchIfNeeded();
+    sql("INSERT INTO TABLE %s VALUES (1, 'hr'), (2, 'hardware'), (null, 'hr')", commitTarget());
 
     // MOR mode: writes a delete file as null cannot be deleted by metadata
     sql("DELETE FROM %s AS t WHERE t.id IS NULL", commitTarget());

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -330,7 +330,7 @@ public class SparkTable
             .ignoreResiduals();
 
     if (branch != null) {
-      scan.useRef(branch);
+      scan = scan.useRef(branch);
     }
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -806,7 +806,7 @@ public class TestHelpers {
   public static List<DataFile> dataFiles(Table table, String branch) {
     TableScan scan = table.newScan();
     if (branch != null) {
-      scan.useRef(branch);
+      scan = scan.useRef(branch);
     }
 
     CloseableIterable<FileScanTask> tasks = scan.includeColumnStats().planFiles();


### PR DESCRIPTION
Fix #7635 .

The Iceberg Spark integration has logic to surface to the Spark Optimizer whether a metadata delete (deleting a data file) should be performed or not (the alternative is row level deletes). When there are branches, this logic incorrectly reads the main branch's metadata and surfaces to the optimizer that metadata deletes are possible even though they are not possible on the actual branch being deleted.

This leads to expected failure at the time of the commit validation since there are residual rows in the file that don't match the deletion criteria. 

This fixes the problem by making sure the scan gets built correctly. Also this change also makes sure the metadata delete tests actually exercise branches. Previously the tests weren't exercising metadata deletes on branches because all the branch tests were using Avro and Avro doesn't support metadata deletes so those tests would get skipped.

