### PR TITLE
Core: Remove synchronization from BitmapPositionDeleteIndex

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -28,7 +28,7 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
   }
 
   @Override
-  public synchronized void delete(long position) {
+  public void delete(long position) {
     roaring64Bitmap.add(position);
   }
 


### PR DESCRIPTION
This PR removes synchronization from `BitmapPositionDeleteIndex` added in PR #8805.

We switched to `ParallelIterable` to parallelize reading of deletes in the original change. However, marking the `delete` method in `BitmapPositionDeleteIndex` synchronized was redundant because `ParallelIterable` outputs elements synchronously. That class internally uses a thread-safe queue to process the input iterables concurrently but does not require extra synchronization in consumers. In other words, there will be only one thread consuming from the iterable that will be populated by multiple threads internally.

I verified this manually and we also have `TestPositionFilter`.