### PR TITLE
Core: Make the default partition name consistent when creating tables and update PartitionSpec

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -548,7 +548,6 @@ public class PartitionSpec implements Serializable {
       return new PartitionSpec(schema, specId, fields, lastAssignedFieldId.get());
     }
 
-
     static String defaultIdentityPartitionName(String sourceName) {
       return sourceName;
     }

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -426,7 +426,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder identity(String sourceName) {
-      return identity(sourceName, sourceName);
+      return identity(sourceName, defaultIdentityPartitionName(sourceName));
     }
 
     public Builder year(String sourceName, String targetName) {
@@ -440,7 +440,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder year(String sourceName) {
-      return year(sourceName, sourceName + "_year");
+      return year(sourceName, defaultYearPartitionName(sourceName));
     }
 
     public Builder month(String sourceName, String targetName) {
@@ -454,7 +454,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder month(String sourceName) {
-      return month(sourceName, sourceName + "_month");
+      return month(sourceName, defaultMonthPartitionName(sourceName));
     }
 
     public Builder day(String sourceName, String targetName) {
@@ -468,7 +468,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder day(String sourceName) {
-      return day(sourceName, sourceName + "_day");
+      return day(sourceName, defaultDayPartitionName(sourceName));
     }
 
     public Builder hour(String sourceName, String targetName) {
@@ -482,7 +482,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder hour(String sourceName) {
-      return hour(sourceName, sourceName + "_hour");
+      return hour(sourceName, defaultHourPartitionName(sourceName));
     }
 
     public Builder bucket(String sourceName, int numBuckets, String targetName) {
@@ -495,7 +495,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder bucket(String sourceName, int numBuckets) {
-      return bucket(sourceName, numBuckets, sourceName + "_bucket");
+      return bucket(sourceName, numBuckets, defaultBucketPartitionName(sourceName, numBuckets));
     }
 
     public Builder truncate(String sourceName, int width, String targetName) {
@@ -508,7 +508,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder truncate(String sourceName, int width) {
-      return truncate(sourceName, width, sourceName + "_trunc");
+      return truncate(sourceName, width, defaultTruncatePartitionName(sourceName, width));
     }
 
     public Builder alwaysNull(String sourceName, String targetName) {
@@ -522,7 +522,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder alwaysNull(String sourceName) {
-      return alwaysNull(sourceName, sourceName + "_null");
+      return alwaysNull(sourceName, defaultAlwaysNullPartitionName(sourceName));
     }
 
     // add a partition field with an auto-increment partition field id starting from
@@ -546,6 +546,39 @@ public class PartitionSpec implements Serializable {
 
     PartitionSpec buildUnchecked() {
       return new PartitionSpec(schema, specId, fields, lastAssignedFieldId.get());
+    }
+
+
+    static String defaultIdentityPartitionName(String sourceName) {
+      return sourceName;
+    }
+
+    static String defaultBucketPartitionName(String sourceName, int numBuckets) {
+      return sourceName + "_bucket_" + numBuckets;
+    }
+
+    static String defaultTruncatePartitionName(String sourceName, int width) {
+      return sourceName + "_trunc_" + width;
+    }
+
+    static String defaultYearPartitionName(String sourceName) {
+      return sourceName + "_year";
+    }
+
+    static String defaultMonthPartitionName(String sourceName) {
+      return sourceName + "_month";
+    }
+
+    static String defaultDayPartitionName(String sourceName) {
+      return sourceName + "_day";
+    }
+
+    static String defaultHourPartitionName(String sourceName) {
+      return sourceName + "_hour";
+    }
+
+    static String defaultAlwaysNullPartitionName(String sourceName) {
+      return sourceName + "_null";
     }
   }
 

--- a/api/src/test/java/org/apache/iceberg/TestPartitionPaths.java
+++ b/api/src/test/java/org/apache/iceberg/TestPartitionPaths.java
@@ -50,7 +50,7 @@ public class TestPartitionPaths {
 
     assertThat(spec.partitionToPath(partition))
         .as("Should produce expected partition key")
-        .isEqualTo("ts_hour=2017-12-01-10/id_bucket=" + idBucket);
+        .isEqualTo("ts_hour=2017-12-01-10/id_bucket_10=" + idBucket);
   }
 
   @Test
@@ -60,6 +60,6 @@ public class TestPartitionPaths {
 
     assertThat(spec.partitionToPath(Row.of("a/b/c/d", "a/b/c/d")))
         .as("Should escape / as %2F")
-        .isEqualTo("data=a%2Fb%2Fc%2Fd/data_trunc=a%2Fb%2Fc%2Fd");
+        .isEqualTo("data=a%2Fb%2Fc%2Fd/data_trunc_10=a%2Fb%2Fc%2Fd");
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
@@ -358,19 +358,19 @@ public class TestProjection {
     predicate =
         (UnboundPredicate<Integer>)
             Projections.strict(partitionSpec).project(equal(bucket("long", 10), 20));
-    assertThat(predicate.ref().name()).isEqualTo("long_bucket");
+    assertThat(predicate.ref().name()).isEqualTo("long_bucket_10");
     predicate =
         (UnboundPredicate<Integer>)
             Projections.inclusive(partitionSpec).project(equal(bucket("long", 10), 20));
-    assertThat(predicate.ref().name()).isEqualTo("long_bucket");
+    assertThat(predicate.ref().name()).isEqualTo("long_bucket_10");
 
     predicate =
         (UnboundPredicate<Integer>)
             Projections.strict(partitionSpec).project(equal(truncate("string", 10), "abc"));
-    assertThat(predicate.ref().name()).isEqualTo("string_trunc");
+    assertThat(predicate.ref().name()).isEqualTo("string_trunc_10");
     predicate =
         (UnboundPredicate<Integer>)
             Projections.inclusive(partitionSpec).project(equal(truncate("string", 10), "abc"));
-    assertThat(predicate.ref().name()).isEqualTo("string_trunc");
+    assertThat(predicate.ref().name()).isEqualTo("string_trunc_10");
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg;
 
+import static org.apache.iceberg.PartitionSpec.Builder.*;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,8 +42,6 @@ import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.transforms.UnknownTransform;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.Pair;
-
-import static org.apache.iceberg.PartitionSpec.Builder.*;
 
 class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
   private final TableOperations ops;

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -41,6 +41,8 @@ import org.apache.iceberg.transforms.UnknownTransform;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.Pair;
 
+import static org.apache.iceberg.PartitionSpec.Builder.*;
+
 class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
   private final TableOperations ops;
   private final TableMetadata base;
@@ -509,42 +511,42 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
 
     @Override
     public String identity(int fieldId, String sourceName, int sourceId) {
-      return sourceName;
+      return defaultIdentityPartitionName(sourceName);
     }
 
     @Override
     public String bucket(int fieldId, String sourceName, int sourceId, int numBuckets) {
-      return sourceName + "_bucket_" + numBuckets;
+      return defaultBucketPartitionName(sourceName, numBuckets);
     }
 
     @Override
     public String truncate(int fieldId, String sourceName, int sourceId, int width) {
-      return sourceName + "_trunc_" + width;
+      return defaultTruncatePartitionName(sourceName, width);
     }
 
     @Override
     public String year(int fieldId, String sourceName, int sourceId) {
-      return sourceName + "_year";
+      return defaultYearPartitionName(sourceName);
     }
 
     @Override
     public String month(int fieldId, String sourceName, int sourceId) {
-      return sourceName + "_month";
+      return defaultMonthPartitionName(sourceName);
     }
 
     @Override
     public String day(int fieldId, String sourceName, int sourceId) {
-      return sourceName + "_day";
+      return defaultDayPartitionName(sourceName);
     }
 
     @Override
     public String hour(int fieldId, String sourceName, int sourceId) {
-      return sourceName + "_hour";
+      return defaultHourPartitionName(sourceName);
     }
 
     @Override
     public String alwaysNull(int fieldId, String sourceName, int sourceId) {
-      return sourceName + "_null";
+      return defaultAlwaysNullPartitionName(sourceName);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -58,7 +58,7 @@ public class TableTestBase {
 
   // Partition spec used to create tables
   public static final PartitionSpec SPEC =
-      PartitionSpec.builderFor(SCHEMA).bucket("data", BUCKETS_NUMBER).build();
+      PartitionSpec.builderFor(SCHEMA).bucket("data", BUCKETS_NUMBER, "data_bucket").build();
 
   static final DataFile FILE_A =
       DataFiles.builder(SPEC)

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -358,7 +358,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
   public void testRename() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
-            .renameField("shard", "id_bucket") // rename back to default
+            .renameField("shard", "id_bucket_16") // rename back to default
             .apply();
 
     PartitionSpec expected =
@@ -371,7 +371,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
   public void testMultipleChanges() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
-            .renameField("shard", "id_bucket") // rename back to default
+            .renameField("shard", "id_bucket_16") // rename back to default
             .removeField(day("ts"))
             .addField("prefix", truncate("data", 4))
             .apply();
@@ -389,7 +389,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     PartitionSpec v2Expected =
         PartitionSpec.builderFor(SCHEMA)
             .add(id("category"), 1000, "category", Transforms.identity())
-            .add(id("id"), 1002, "id_bucket", Transforms.bucket(16))
+            .add(id("id"), 1002, "id_bucket_16", Transforms.bucket(16))
             .add(id("data"), 1003, "prefix", Transforms.truncate(4))
             .build();
 


### PR DESCRIPTION
When I creating Table Using
```
PartitionSpec.builderFor(schema)
                .bucket("data", 16)
                .build();
```
The default partition name is 'data_bucket'

When I add PartitionSpec using
```
 table.updateSpec()
        .addField(Expressions.bucket("data", 16))
        .commit();
```
The default partition name is 'data_bucket_16'

We should make the default partition name consistent in both cases.