### PR TITLE
Aliyun: Switch iceberg-aliyun's tests to Junit5

### DIFF
--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/TestAliyunClientFactories.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/TestAliyunClientFactories.java
@@ -35,7 +35,6 @@ public class TestAliyunClientFactories {
         .isEqualTo(AliyunClientFactories.defaultFactory());
 
     AliyunClientFactory defaultFactory = AliyunClientFactories.from(Maps.newHashMap());
-
     Assertions.assertThat(defaultFactory)
         .as("Should load default when factory impl not configured")
         .isInstanceOf(AliyunClientFactories.DefaultAliyunClientFactory.class);
@@ -46,7 +45,6 @@ public class TestAliyunClientFactories {
 
     AliyunClientFactory defaultFactoryWithConfig =
         AliyunClientFactories.from(ImmutableMap.of(AliyunProperties.CLIENT_ACCESS_KEY_ID, "key"));
-
     Assertions.assertThat(defaultFactoryWithConfig)
         .as("Should load default when factory impl not configured")
         .isInstanceOf(AliyunClientFactories.DefaultAliyunClientFactory.class);
@@ -60,7 +58,6 @@ public class TestAliyunClientFactories {
   public void testLoadCustom() {
     Map<String, String> properties = Maps.newHashMap();
     properties.put(AliyunProperties.CLIENT_FACTORY, CustomFactory.class.getName());
-
     Assertions.assertThat(AliyunClientFactories.from(properties))
         .as("Should load custom class")
         .isInstanceOf(CustomFactory.class);

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/TestAliyunClientFactories.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/TestAliyunClientFactories.java
@@ -29,7 +29,6 @@ public class TestAliyunClientFactories {
 
   @Test
   public void testLoadDefault() {
-
     Assertions.assertThat(AliyunClientFactories.defaultFactory())
         .as("Default client should be singleton")
         .isEqualTo(AliyunClientFactories.defaultFactory());

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/TestAliyunClientFactories.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/TestAliyunClientFactories.java
@@ -22,43 +22,48 @@ import com.aliyun.oss.OSS;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestAliyunClientFactories {
 
   @Test
   public void testLoadDefault() {
-    Assert.assertEquals(
-        "Default client should be singleton",
-        AliyunClientFactories.defaultFactory(),
-        AliyunClientFactories.defaultFactory());
+
+    Assertions.assertThat(AliyunClientFactories.defaultFactory())
+        .as("Default client should be singleton")
+        .isEqualTo(AliyunClientFactories.defaultFactory());
 
     AliyunClientFactory defaultFactory = AliyunClientFactories.from(Maps.newHashMap());
-    Assert.assertTrue(
-        "Should load default when factory impl not configured",
-        defaultFactory instanceof AliyunClientFactories.DefaultAliyunClientFactory);
-    Assert.assertNull(
-        "Should have no Aliyun properties set", defaultFactory.aliyunProperties().accessKeyId());
+
+    Assertions.assertThat(defaultFactory)
+        .as("Should load default when factory impl not configured")
+        .isInstanceOf(AliyunClientFactories.DefaultAliyunClientFactory.class);
+
+    Assertions.assertThat(defaultFactory.aliyunProperties().accessKeyId())
+        .as("Should have no Aliyun properties set")
+        .isNull();
 
     AliyunClientFactory defaultFactoryWithConfig =
         AliyunClientFactories.from(ImmutableMap.of(AliyunProperties.CLIENT_ACCESS_KEY_ID, "key"));
-    Assert.assertTrue(
-        "Should load default when factory impl not configured",
-        defaultFactoryWithConfig instanceof AliyunClientFactories.DefaultAliyunClientFactory);
-    Assert.assertEquals(
-        "Should have access key set",
-        "key",
-        defaultFactoryWithConfig.aliyunProperties().accessKeyId());
+
+    Assertions.assertThat(defaultFactoryWithConfig)
+        .as("Should load default when factory impl not configured")
+        .isInstanceOf(AliyunClientFactories.DefaultAliyunClientFactory.class);
+
+    Assertions.assertThat(defaultFactoryWithConfig.aliyunProperties().accessKeyId())
+        .as("Should have access key set")
+        .isEqualTo("key");
   }
 
   @Test
   public void testLoadCustom() {
     Map<String, String> properties = Maps.newHashMap();
     properties.put(AliyunProperties.CLIENT_FACTORY, CustomFactory.class.getName());
-    Assert.assertTrue(
-        "Should load custom class",
-        AliyunClientFactories.from(properties) instanceof CustomFactory);
+
+    Assertions.assertThat(AliyunClientFactories.from(properties))
+        .as("Should load custom class")
+        .isInstanceOf(CustomFactory.class);
   }
 
   public static class CustomFactory implements AliyunClientFactory {

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/TestUtility.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/TestUtility.java
@@ -18,9 +18,9 @@
  */
 package org.apache.iceberg.aliyun;
 
-import org.apache.iceberg.aliyun.oss.AliyunOSSTestRule;
+import org.apache.iceberg.aliyun.oss.AliyunOSSExtension;
 import org.apache.iceberg.aliyun.oss.OSSURI;
-import org.apache.iceberg.aliyun.oss.mock.AliyunOSSMockRule;
+import org.apache.iceberg.aliyun.oss.mock.AliyunOSSMockExtension;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
@@ -41,33 +41,34 @@ public class TestUtility {
 
   private TestUtility() {}
 
-  public static AliyunOSSTestRule initialize() {
-    AliyunOSSTestRule testRule;
+  public static AliyunOSSExtension initialize() {
+    AliyunOSSExtension extension;
 
     String implClass = System.getenv(ALIYUN_TEST_OSS_RULE_CLASS);
     if (!Strings.isNullOrEmpty(implClass)) {
-      LOG.info("The initializing AliyunOSSTestRule implementation is: {}", implClass);
+      LOG.info("The initializing AliyunOSSExtension implementation is: {}", implClass);
       try {
-        DynConstructors.Ctor<AliyunOSSTestRule> ctor =
-            DynConstructors.builder(AliyunOSSTestRule.class).impl(implClass).buildChecked();
-        testRule = ctor.newInstance();
+        DynConstructors.Ctor<AliyunOSSExtension> ctor =
+            DynConstructors.builder(AliyunOSSExtension.class).impl(implClass).buildChecked();
+        extension = ctor.newInstance();
       } catch (NoSuchMethodException e) {
         throw new IllegalArgumentException(
             String.format(
-                "Cannot initialize AliyunOSSTestRule, missing no-arg constructor: %s", implClass),
+                "Cannot initialize AliyunOSSExtension, missing no-arg constructor: %s", implClass),
             e);
       } catch (ClassCastException e) {
         throw new IllegalArgumentException(
             String.format(
-                "Cannot initialize AliyunOSSTestRule, %s does not implement it.", implClass),
+                "Cannot initialize AliyunOSSExtension, %s does not implement it.", implClass),
             e);
       }
     } else {
-      LOG.info("Initializing AliyunOSSTestRule implementation with default AliyunOSSMockRule");
-      testRule = AliyunOSSMockRule.builder().silent().build();
+      LOG.info(
+          "Initializing AliyunOSSExtension implementation with default AliyunOSSMockExtension");
+      extension = AliyunOSSMockExtension.builder().silent().build();
     }
 
-    return testRule;
+    return extension;
   }
 
   public static String accessKeyId() {

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/AliyunOSSExtension.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/AliyunOSSExtension.java
@@ -20,9 +20,9 @@ package org.apache.iceberg.aliyun.oss;
 
 import com.aliyun.oss.OSS;
 import java.util.UUID;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * API for test Aliyun Object Storage Service (OSS) which is either local mock http server or remote
@@ -30,7 +30,7 @@ import org.junit.runners.model.Statement;
  *
  * <p>This API includes start,stop OSS service, create OSS client, setup bucket and teardown bucket.
  */
-public interface AliyunOSSTestRule extends TestRule {
+public interface AliyunOSSExtension extends BeforeAllCallback, AfterAllCallback {
   UUID RANDOM_UUID = java.util.UUID.randomUUID();
 
   /** Returns a specific bucket name for testing purpose. */
@@ -39,18 +39,13 @@ public interface AliyunOSSTestRule extends TestRule {
   }
 
   @Override
-  default Statement apply(Statement base, Description description) {
-    return new Statement() {
-      @Override
-      public void evaluate() throws Throwable {
-        start();
-        try {
-          base.evaluate();
-        } finally {
-          stop();
-        }
-      }
-    };
+  default void afterAll(ExtensionContext context) throws Exception {
+    stop();
+  }
+
+  @Override
+  default void beforeAll(ExtensionContext context) throws Exception {
+    start();
   }
 
   /**

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/AliyunOSSTestBase.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/AliyunOSSTestBase.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 public abstract class AliyunOSSTestBase {
   @RegisterExtension
-  public static final AliyunOSSExtension OSS_TEST_EXTENSION = TestUtility.initialize();
+  private static final AliyunOSSExtension OSS_TEST_EXTENSION = TestUtility.initialize();
 
   private final SerializableSupplier<OSS> ossClient = OSS_TEST_EXTENSION::createOSSClient;
   private final String bucketName = OSS_TEST_EXTENSION.testBucketName();

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/AliyunOSSTestBase.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/AliyunOSSTestBase.java
@@ -21,25 +21,26 @@ package org.apache.iceberg.aliyun.oss;
 import com.aliyun.oss.OSS;
 import org.apache.iceberg.aliyun.TestUtility;
 import org.apache.iceberg.util.SerializableSupplier;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public abstract class AliyunOSSTestBase {
-  @ClassRule public static final AliyunOSSTestRule OSS_TEST_RULE = TestUtility.initialize();
+  @RegisterExtension
+  public static final AliyunOSSExtension OSS_TEST_EXTENSION = TestUtility.initialize();
 
-  private final SerializableSupplier<OSS> ossClient = OSS_TEST_RULE::createOSSClient;
-  private final String bucketName = OSS_TEST_RULE.testBucketName();
-  private final String keyPrefix = OSS_TEST_RULE.keyPrefix();
+  private final SerializableSupplier<OSS> ossClient = OSS_TEST_EXTENSION::createOSSClient;
+  private final String bucketName = OSS_TEST_EXTENSION.testBucketName();
+  private final String keyPrefix = OSS_TEST_EXTENSION.keyPrefix();
 
-  @Before
+  @BeforeEach
   public void before() {
-    OSS_TEST_RULE.setUpBucket(bucketName);
+    OSS_TEST_EXTENSION.setUpBucket(bucketName);
   }
 
-  @After
+  @AfterEach
   public void after() {
-    OSS_TEST_RULE.tearDownBucket(bucketName);
+    OSS_TEST_EXTENSION.tearDownBucket(bucketName);
   }
 
   protected String location(String key) {

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/OSSIntegrationExtension.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/OSSIntegrationExtension.java
@@ -26,7 +26,7 @@ import com.aliyun.oss.model.OSSObjectSummary;
 import org.apache.iceberg.aliyun.TestUtility;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-public class OSSIntegrationTestRule implements AliyunOSSTestRule {
+public class OSSIntegrationExtension implements AliyunOSSExtension {
   // Aliyun access key pair.
   private String accessKeyId;
   private String accessKeySecret;
@@ -106,7 +106,7 @@ public class OSSIntegrationTestRule implements AliyunOSSTestRule {
 
   private OSS ossClient() {
     if (lazyClient == null) {
-      synchronized (OSSIntegrationTestRule.class) {
+      synchronized (OSSIntegrationExtension.class) {
         if (lazyClient == null) {
           lazyClient = createOSSClient();
         }

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSFileIO.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSFileIO.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TestOSSFileIO extends AliyunOSSTestBase {
-
   private static final String OSS_IMPL_CLASS = OSSFileIO.class.getName();
   private final Configuration conf = new Configuration();
   private final Random random = ThreadLocalRandom.current();
@@ -74,7 +73,6 @@ public class TestOSSFileIO extends AliyunOSSTestBase {
     writeOSSData(out, data);
 
     OSSURI uri = new OSSURI(location);
-
     Assertions.assertThat(ossClient().get().doesObjectExist(uri.bucket(), uri.key()))
         .as("OSS file should exist")
         .isTrue();

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSFileIO.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSFileIO.java
@@ -39,24 +39,25 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.apache.iceberg.util.SerializableSupplier;
 import org.apache.iceberg.util.SerializationUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestOSSFileIO extends AliyunOSSTestBase {
+
   private static final String OSS_IMPL_CLASS = OSSFileIO.class.getName();
   private final Configuration conf = new Configuration();
   private final Random random = ThreadLocalRandom.current();
 
   private FileIO fileIO;
 
-  @Before
+  @BeforeEach
   public void beforeFile() {
     fileIO = new OSSFileIO(ossClient());
   }
 
-  @After
+  @AfterEach
   public void afterFile() {
     if (fileIO != null) {
       fileIO.close();
@@ -73,28 +74,34 @@ public class TestOSSFileIO extends AliyunOSSTestBase {
     writeOSSData(out, data);
 
     OSSURI uri = new OSSURI(location);
-    Assert.assertTrue(
-        "OSS file should exist", ossClient().get().doesObjectExist(uri.bucket(), uri.key()));
-    Assert.assertEquals("Should have expected location", location, out.location());
-    Assert.assertEquals("Should have expected length", dataSize, ossDataLength(uri));
-    Assert.assertArrayEquals("Should have expected content", data, ossDataContent(uri, dataSize));
+
+    Assertions.assertThat(ossClient().get().doesObjectExist(uri.bucket(), uri.key()))
+        .as("OSS file should exist")
+        .isTrue();
+    Assertions.assertThat(out.location()).as("Should have expected location").isEqualTo(location);
+    Assertions.assertThat(ossDataLength(uri)).as("Should have expected length").isEqualTo(dataSize);
+    Assertions.assertThat(ossDataContent(uri, dataSize))
+        .as("Should have expected content")
+        .isEqualTo(data);
   }
 
   @Test
   public void testInputFile() throws IOException {
     String location = randomLocation();
     InputFile in = fileIO().newInputFile(location);
-    Assert.assertFalse("OSS file should not exist", in.exists());
+    Assertions.assertThat(in.exists()).as("OSS file should not exist").isFalse();
 
     int dataSize = 1024 * 10;
     byte[] data = randomData(dataSize);
     OutputFile out = fileIO().newOutputFile(location);
     writeOSSData(out, data);
 
-    Assert.assertTrue("OSS file should exist", in.exists());
-    Assert.assertEquals("Should have expected location", location, in.location());
-    Assert.assertEquals("Should have expected length", dataSize, in.getLength());
-    Assert.assertArrayEquals("Should have expected content", data, inFileContent(in, dataSize));
+    Assertions.assertThat(in.exists()).as("OSS file should exist").isTrue();
+    Assertions.assertThat(in.location()).as("Should have expected location").isEqualTo(location);
+    Assertions.assertThat(in.getLength()).as("Should have expected length").isEqualTo(dataSize);
+    Assertions.assertThat(inFileContent(in, dataSize))
+        .as("Should have expected content")
+        .isEqualTo(data);
   }
 
   @Test
@@ -106,20 +113,24 @@ public class TestOSSFileIO extends AliyunOSSTestBase {
     writeOSSData(out, data);
 
     InputFile in = fileIO().newInputFile(location);
-    Assert.assertTrue("OSS file should exist", in.exists());
+    Assertions.assertThat(in.exists()).as("OSS file should exist").isTrue();
+
     fileIO().deleteFile(in);
-    Assert.assertFalse("OSS file should not exist", fileIO().newInputFile(location).exists());
+    Assertions.assertThat(fileIO().newInputFile(location).exists())
+        .as("OSS file should not exist")
+        .isFalse();
   }
 
   @Test
   public void testLoadFileIO() {
     FileIO file = CatalogUtil.loadFileIO(OSS_IMPL_CLASS, ImmutableMap.of(), conf);
-    Assert.assertTrue("Should be OSSFileIO", file instanceof OSSFileIO);
+    Assertions.assertThat(file).as("Should be OSSFileIO").isInstanceOf(OSSFileIO.class);
 
     byte[] data = SerializationUtil.serializeToBytes(file);
     FileIO expectedFileIO = SerializationUtil.deserializeFromBytes(data);
-    Assert.assertTrue(
-        "The deserialized FileIO should be OSSFileIO", expectedFileIO instanceof OSSFileIO);
+    Assertions.assertThat(expectedFileIO)
+        .as("The deserialized FileIO should be OSSFileIO")
+        .isInstanceOf(OSSFileIO.class);
   }
 
   @Test
@@ -134,19 +145,21 @@ public class TestOSSFileIO extends AliyunOSSTestBase {
     SerializableSupplier<OSS> post = SerializationUtil.deserializeFromBytes(data);
 
     OSS client = post.get();
-    Assert.assertTrue("Should be instance of oss client", client instanceof OSSClient);
+    Assertions.assertThat(client)
+        .as("Should be instance of oss client")
+        .isInstanceOf(OSSClient.class);
 
     OSSClient oss = (OSSClient) client;
-    Assert.assertEquals(
-        "Should have expected endpoint", new URI("http://" + endpoint), oss.getEndpoint());
-    Assert.assertEquals(
-        "Should have expected access key",
-        accessKeyId,
-        oss.getCredentialsProvider().getCredentials().getAccessKeyId());
-    Assert.assertEquals(
-        "Should have expected secret key",
-        accessSecret,
-        oss.getCredentialsProvider().getCredentials().getSecretAccessKey());
+    Assertions.assertThat(oss.getEndpoint())
+        .as("Should have expected endpoint")
+        .isEqualTo(new URI("http://" + endpoint));
+
+    Assertions.assertThat(oss.getCredentialsProvider().getCredentials().getAccessKeyId())
+        .as("Should have expected access key")
+        .isEqualTo(accessKeyId);
+    Assertions.assertThat(oss.getCredentialsProvider().getCredentials().getSecretAccessKey())
+        .as("Should have expected secret key")
+        .isEqualTo(accessSecret);
   }
 
   private FileIO fileIO() {

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputFile.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputFile.java
@@ -37,8 +37,7 @@ import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestOSSInputFile extends AliyunOSSTestBase {
   private final OSS ossClient = ossClient().get();
@@ -75,7 +74,7 @@ public class TestOSSInputFile extends AliyunOSSTestBase {
 
     InputFile inputFile =
         new OSSInputFile(ossMock, uri, aliyunProperties, MetricsContext.nullMetrics());
-    Assert.assertFalse("OSS file should not exist", inputFile.exists());
+    Assertions.assertThat(inputFile.exists()).as("OSS file should not exist").isFalse();
     verify(ossMock, times(1)).getSimplifiedObjectMeta(uri.bucket(), uri.key());
     reset(ossMock);
 
@@ -83,7 +82,7 @@ public class TestOSSInputFile extends AliyunOSSTestBase {
     byte[] data = randomData(dataSize);
     writeOSSData(uri, data);
 
-    Assert.assertTrue("OSS file should exist", inputFile.exists());
+    Assertions.assertThat(inputFile.exists()).as("OSS file should  exist").isTrue();
     inputFile.exists();
     verify(ossMock, times(1)).getSimplifiedObjectMeta(uri.bucket(), uri.key());
     reset(ossMock);
@@ -109,14 +108,17 @@ public class TestOSSInputFile extends AliyunOSSTestBase {
   private void readAndVerify(OSSURI uri, byte[] data) throws IOException {
     InputFile inputFile =
         new OSSInputFile(ossClient().get(), uri, aliyunProperties, MetricsContext.nullMetrics());
-    Assert.assertTrue("OSS file should exist", inputFile.exists());
-    Assert.assertEquals("Should have expected file length", data.length, inputFile.getLength());
+    Assertions.assertThat(inputFile.exists()).as("OSS file should exist").isTrue();
+    Assertions.assertThat(inputFile.getLength())
+        .as("Should have expected file length")
+        .isEqualTo(data.length);
 
     byte[] actual = new byte[data.length];
     try (SeekableInputStream in = inputFile.newStream()) {
       ByteStreams.readFully(in, actual);
     }
-    Assert.assertArrayEquals("Should have same object content", data, actual);
+
+    Assertions.assertThat(actual).as("Should have same object content").isEqualTo(data);
   }
 
   private void verifyLength(OSS ossClientMock, OSSURI uri, byte[] data, boolean isCache) {
@@ -130,7 +132,9 @@ public class TestOSSInputFile extends AliyunOSSTestBase {
           new OSSInputFile(ossClientMock, uri, aliyunProperties, MetricsContext.nullMetrics());
     }
     inputFile.getLength();
-    Assert.assertEquals("Should have expected file length", data.length, inputFile.getLength());
+    Assertions.assertThat(inputFile.getLength())
+        .as("Should have expected file length")
+        .isEqualTo(data.length);
   }
 
   private OSSURI randomURI() {

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
@@ -18,9 +18,6 @@
  */
 package org.apache.iceberg.aliyun.oss;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
@@ -29,7 +26,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestOSSInputStream extends AliyunOSSTestBase {
   private final Random random = ThreadLocalRandom.current();
@@ -72,7 +69,7 @@ public class TestOSSInputStream extends AliyunOSSTestBase {
       SeekableInputStream in, long rangeStart, int size, byte[] original, boolean buffered)
       throws IOException {
     in.seek(rangeStart);
-    assertEquals("Should have the correct position", rangeStart, in.getPos());
+    Assertions.assertThat(in.getPos()).as("Should have the correct position").isEqualTo(rangeStart);
 
     long rangeEnd = rangeStart + size;
     byte[] actual = new byte[size];
@@ -86,12 +83,11 @@ public class TestOSSInputStream extends AliyunOSSTestBase {
       }
     }
 
-    assertEquals("Should have the correct position", rangeEnd, in.getPos());
+    Assertions.assertThat(in.getPos()).as("Should have the correct position").isEqualTo(rangeEnd);
 
-    assertArrayEquals(
-        "Should have expected range data",
-        Arrays.copyOfRange(original, (int) rangeStart, (int) rangeEnd),
-        actual);
+    Assertions.assertThat(actual)
+        .as("Should have expected range data")
+        .isEqualTo(Arrays.copyOfRange(original, (int) rangeStart, (int) rangeEnd));
   }
 
   @Test
@@ -115,10 +111,9 @@ public class TestOSSInputStream extends AliyunOSSTestBase {
       in.seek(expected.length / 2);
       byte[] actual = new byte[expected.length / 2];
       ByteStreams.readFully(in, actual);
-      assertArrayEquals(
-          "Should have expected seeking stream",
-          Arrays.copyOfRange(expected, expected.length / 2, expected.length),
-          actual);
+      Assertions.assertThat(actual)
+          .as("Should have expected seeking stream")
+          .isEqualTo(Arrays.copyOfRange(expected, expected.length / 2, expected.length));
     }
   }
 

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSOutputFile.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSOutputFile.java
@@ -33,8 +33,7 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestOSSOutputFile extends AliyunOSSTestBase {
 
@@ -54,11 +53,15 @@ public class TestOSSOutputFile extends AliyunOSSTestBase {
       ByteStreams.copy(is, os);
     }
 
-    Assert.assertTrue("OSS file should exist", ossClient.doesObjectExist(uri.bucket(), uri.key()));
-    Assert.assertEquals("Object length should match", ossDataLength(uri), dataSize);
+    Assertions.assertThat(ossClient.doesObjectExist(uri.bucket(), uri.key()))
+        .as("OSS file should exist")
+        .isTrue();
+
+    Assertions.assertThat(ossDataLength(uri)).as("Object length should match").isEqualTo(dataSize);
 
     byte[] actual = ossDataContent(uri, dataSize);
-    Assert.assertArrayEquals("Object content should match", data, actual);
+
+    Assertions.assertThat(actual).as("Object content should match").isEqualTo(data);
   }
 
   @Test
@@ -100,14 +103,12 @@ public class TestOSSOutputFile extends AliyunOSSTestBase {
         InputStream is = new ByteArrayInputStream(expect)) {
       ByteStreams.copy(is, os);
     }
-
-    Assert.assertEquals(
-        String.format("Should overwrite object length from %d to %d", dataSize, expectSize),
-        expectSize,
-        ossDataLength(uri));
+    Assertions.assertThat(ossDataLength(uri))
+        .as(String.format("Should overwrite object length from %d to %d", dataSize, expectSize))
+        .isEqualTo(expectSize);
 
     byte[] actual = ossDataContent(uri, expectSize);
-    Assert.assertArrayEquals("Should overwrite object content", expect, actual);
+    Assertions.assertThat(actual).as("Should overwrite object content").isEqualTo(expect);
   }
 
   @Test
@@ -115,7 +116,7 @@ public class TestOSSOutputFile extends AliyunOSSTestBase {
     OSSURI uri = randomURI();
     OutputFile out =
         new OSSOutputFile(ossClient, uri, aliyunProperties, MetricsContext.nullMetrics());
-    Assert.assertEquals("Location should match", uri.location(), out.location());
+    Assertions.assertThat(out.location()).as("Location should match").isEqualTo(uri.location());
   }
 
   @Test
@@ -131,16 +132,21 @@ public class TestOSSOutputFile extends AliyunOSSTestBase {
     }
 
     InputFile in = out.toInputFile();
-    Assert.assertTrue("Should be an instance of OSSInputFile", in instanceof OSSInputFile);
-    Assert.assertTrue("OSS file should exist", in.exists());
-    Assert.assertEquals("Should have expected location", out.location(), in.location());
-    Assert.assertEquals("Should have expected length", dataSize, in.getLength());
+
+    Assertions.assertThat(in)
+        .as("Should be an instance of OSSInputFile")
+        .isInstanceOf(OSSInputFile.class);
+    Assertions.assertThat(in.exists()).as("OSS file should exist").isTrue();
+    Assertions.assertThat(in.location())
+        .as("Should have expected location")
+        .isEqualTo(out.location());
+    Assertions.assertThat(in.getLength()).as("Should have expected length").isEqualTo(dataSize);
 
     byte[] actual = new byte[dataSize];
     try (InputStream as = in.newStream()) {
       ByteStreams.readFully(as, actual);
     }
-    Assert.assertArrayEquals("Should have expected content", data, actual);
+    Assertions.assertThat(actual).as("Should have expected content").isEqualTo(data);
   }
 
   private OSSURI randomURI() {

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSOutputFile.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSOutputFile.java
@@ -60,7 +60,6 @@ public class TestOSSOutputFile extends AliyunOSSTestBase {
     Assertions.assertThat(ossDataLength(uri)).as("Object length should match").isEqualTo(dataSize);
 
     byte[] actual = ossDataContent(uri, dataSize);
-
     Assertions.assertThat(actual).as("Object content should match").isEqualTo(data);
   }
 
@@ -132,7 +131,6 @@ public class TestOSSOutputFile extends AliyunOSSTestBase {
     }
 
     InputFile in = out.toInputFile();
-
     Assertions.assertThat(in)
         .as("Should be an instance of OSSInputFile")
         .isInstanceOf(OSSInputFile.class);

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSOutputStream.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSOutputStream.java
@@ -38,8 +38,8 @@ import org.apache.iceberg.aliyun.AliyunProperties;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,30 +88,30 @@ public class TestOSSOutputStream extends AliyunOSSTestBase {
         new OSSOutputStream(mock, uri, props, MetricsContext.nullMetrics())) {
       if (arrayWrite) {
         out.write(data);
-        Assert.assertEquals("OSSOutputStream position", data.length, out.getPos());
+        Assertions.assertThat(out.getPos()).as("OSSOutputStream position").isEqualTo(data.length);
       } else {
         for (int i = 0; i < data.length; i++) {
           out.write(data[i]);
-          Assert.assertEquals("OSSOutputStream position", i + 1, out.getPos());
+          Assertions.assertThat(out.getPos()).as("OSSOutputStream position").isEqualTo(i + 1);
         }
       }
     }
 
-    Assert.assertTrue(
-        "OSS object should exist", ossClient.doesObjectExist(uri.bucket(), uri.key()));
-    Assert.assertEquals(
-        "Object length",
-        ossClient.getObject(uri.bucket(), uri.key()).getObjectMetadata().getContentLength(),
-        data.length);
+    Assertions.assertThat(ossClient.doesObjectExist(uri.bucket(), uri.key()))
+        .as("OSS object should exist")
+        .isTrue();
+    Assertions.assertThat(
+            ossClient.getObject(uri.bucket(), uri.key()).getObjectMetadata().getContentLength())
+        .as("Object length")
+        .isEqualTo(data.length);
 
     byte[] actual = ossDataContent(uri, data.length);
-    Assert.assertArrayEquals("Object content", data, actual);
+    Assertions.assertThat(actual).as("Object content").isEqualTo(data);
 
     // Verify all staging files are cleaned up.
-    Assert.assertEquals(
-        "Staging files should clean up",
-        0,
-        Files.list(Paths.get(props.ossStagingDirectory())).count());
+    Assertions.assertThat(Files.list(Paths.get(props.ossStagingDirectory())).count())
+        .as("Staging files should clean up")
+        .isEqualTo(0);
   }
 
   private OSSURI randomURI() {

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSURI.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSURI.java
@@ -26,7 +26,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestOSSURI {
-
   @Test
   public void testUrlParsing() {
     String location = "oss://bucket/path/to/file";

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSURI.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSURI.java
@@ -23,18 +23,18 @@ import static com.aliyun.oss.internal.OSSUtils.OSS_RESOURCE_MANAGER;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestOSSURI {
+
   @Test
   public void testUrlParsing() {
     String location = "oss://bucket/path/to/file";
     OSSURI uri = new OSSURI(location);
 
-    Assert.assertEquals("bucket", uri.bucket());
-    Assert.assertEquals("path/to/file", uri.key());
-    Assert.assertEquals(location, uri.toString());
+    Assertions.assertThat(uri.bucket()).isEqualTo("bucket");
+    Assertions.assertThat(uri.key()).isEqualTo("path/to/file");
+    Assertions.assertThat(uri.toString()).isEqualTo(location);
   }
 
   @Test
@@ -42,9 +42,9 @@ public class TestOSSURI {
     String location = "oss://bucket/path%20to%20file";
     OSSURI uri = new OSSURI(location);
 
-    Assert.assertEquals("bucket", uri.bucket());
-    Assert.assertEquals("path%20to%20file", uri.key());
-    Assert.assertEquals(location, uri.toString());
+    Assertions.assertThat(uri.bucket()).isEqualTo("bucket");
+    Assertions.assertThat(uri.key()).isEqualTo("path%20to%20file");
+    Assertions.assertThat(uri.toString()).isEqualTo(location);
   }
 
   @Test
@@ -93,9 +93,9 @@ public class TestOSSURI {
     String location = "oss://bucket/path/to/file#print";
     OSSURI uri = new OSSURI(location);
 
-    Assert.assertEquals("bucket", uri.bucket());
-    Assert.assertEquals("path/to/file", uri.key());
-    Assert.assertEquals(location, uri.toString());
+    Assertions.assertThat(uri.bucket()).isEqualTo("bucket");
+    Assertions.assertThat(uri.key()).isEqualTo("path/to/file");
+    Assertions.assertThat(uri.toString()).isEqualTo(location);
   }
 
   @Test
@@ -103,17 +103,17 @@ public class TestOSSURI {
     String location = "oss://bucket/path/to/file?query=foo#bar";
     OSSURI uri = new OSSURI(location);
 
-    Assert.assertEquals("bucket", uri.bucket());
-    Assert.assertEquals("path/to/file", uri.key());
-    Assert.assertEquals(location, uri.toString());
+    Assertions.assertThat(uri.bucket()).isEqualTo("bucket");
+    Assertions.assertThat(uri.key()).isEqualTo("path/to/file");
+    Assertions.assertThat(uri.toString()).isEqualTo(location);
   }
 
   @Test
   public void testValidSchemes() {
     for (String scheme : Lists.newArrayList("https", "oss")) {
       OSSURI uri = new OSSURI(scheme + "://bucket/path/to/file");
-      Assert.assertEquals("bucket", uri.bucket());
-      Assert.assertEquals("path/to/file", uri.key());
+      Assertions.assertThat(uri.bucket()).isEqualTo("bucket");
+      Assertions.assertThat(uri.key()).isEqualTo("path/to/file");
     }
   }
 }

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/AliyunOSSMockExtension.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/AliyunOSSMockExtension.java
@@ -25,18 +25,18 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.Map;
-import org.apache.iceberg.aliyun.oss.AliyunOSSTestRule;
+import org.apache.iceberg.aliyun.oss.AliyunOSSExtension;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
-public class AliyunOSSMockRule implements AliyunOSSTestRule {
+public class AliyunOSSMockExtension implements AliyunOSSExtension {
 
   private final Map<String, Object> properties;
 
   private AliyunOSSMockApp ossMockApp;
 
-  private AliyunOSSMockRule(Map<String, Object> properties) {
+  private AliyunOSSMockExtension(Map<String, Object> properties) {
     this.properties = properties;
   }
 
@@ -108,7 +108,7 @@ public class AliyunOSSMockRule implements AliyunOSSTestRule {
       return this;
     }
 
-    public AliyunOSSTestRule build() {
+    public AliyunOSSExtension build() {
       String rootDir = (String) props.get(AliyunOSSMockApp.PROP_ROOT_DIR);
       if (Strings.isNullOrEmpty(rootDir)) {
         File dir =
@@ -121,7 +121,7 @@ public class AliyunOSSMockRule implements AliyunOSSTestRule {
       File root = new File(rootDir);
       root.deleteOnExit();
       root.mkdir();
-      return new AliyunOSSMockRule(props);
+      return new AliyunOSSMockExtension(props);
     }
   }
 }

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/TestLocalAliyunOSS.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/TestLocalAliyunOSS.java
@@ -31,23 +31,22 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
 import org.apache.iceberg.aliyun.TestUtility;
-import org.apache.iceberg.aliyun.oss.AliyunOSSTestRule;
+import org.apache.iceberg.aliyun.oss.AliyunOSSExtension;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class TestLocalAliyunOSS {
 
-  @ClassRule public static final AliyunOSSTestRule OSS_TEST_RULE = TestUtility.initialize();
+  @RegisterExtension
+  public static final AliyunOSSExtension OSS_TEST_EXTENSION = TestUtility.initialize();
 
-  private final OSS oss = OSS_TEST_RULE.createOSSClient();
-  private final String bucketName = OSS_TEST_RULE.testBucketName();
+  private final OSS oss = OSS_TEST_EXTENSION.createOSSClient();
+  private final String bucketName = OSS_TEST_EXTENSION.testBucketName();
   private final Random random = new Random(1);
 
   private static void assertThrows(Runnable runnable, String expectedErrorCode) {
@@ -58,37 +57,38 @@ public class TestLocalAliyunOSS {
         .isEqualTo(expectedErrorCode);
   }
 
-  @Before
+  @BeforeEach
   public void before() {
-    OSS_TEST_RULE.setUpBucket(bucketName);
+    OSS_TEST_EXTENSION.setUpBucket(bucketName);
   }
 
-  @After
+  @AfterEach
   public void after() {
-    OSS_TEST_RULE.tearDownBucket(bucketName);
+    OSS_TEST_EXTENSION.tearDownBucket(bucketName);
   }
 
   @Test
   public void testBuckets() {
-    Assume.assumeTrue(
-        "Aliyun integration test cannot delete existing bucket from test environment.",
-        OSS_TEST_RULE.getClass() == AliyunOSSMockRule.class);
+    Assertions.assertThat(OSS_TEST_EXTENSION)
+        .as("Aliyun integration test cannot delete existing bucket from test environment.")
+        .isInstanceOf(AliyunOSSMockExtension.class);
 
-    Assert.assertTrue(doesBucketExist(bucketName));
+    Assertions.assertThat(doesBucketExist(bucketName)).isTrue();
+
     assertThrows(() -> oss.createBucket(bucketName), OSSErrorCode.BUCKET_ALREADY_EXISTS);
 
     oss.deleteBucket(bucketName);
-    Assert.assertFalse(doesBucketExist(bucketName));
+    Assertions.assertThat(doesBucketExist(bucketName)).isFalse();
 
     oss.createBucket(bucketName);
-    Assert.assertTrue(doesBucketExist(bucketName));
+    Assertions.assertThat(doesBucketExist(bucketName)).isTrue();
   }
 
   @Test
   public void testDeleteBucket() {
-    Assume.assumeTrue(
-        "Aliyun integration test cannot delete existing bucket from test environment.",
-        OSS_TEST_RULE.getClass() == AliyunOSSMockRule.class);
+    Assertions.assertThat(OSS_TEST_EXTENSION)
+        .as("Aliyun integration test cannot delete existing bucket from test environment.")
+        .isInstanceOf(AliyunOSSMockExtension.class);
 
     String bucketNotExist = String.format("bucket-not-existing-%s", UUID.randomUUID());
     assertThrows(() -> oss.deleteBucket(bucketNotExist), OSSErrorCode.NO_SUCH_BUCKET);
@@ -107,7 +107,7 @@ public class TestLocalAliyunOSS {
 
     oss.deleteObject(bucketName, "object2");
     oss.deleteBucket(bucketName);
-    Assert.assertFalse(doesBucketExist(bucketName));
+    Assertions.assertThat(doesBucketExist(bucketName)).isFalse();
 
     oss.createBucket(bucketName);
   }
@@ -122,18 +122,18 @@ public class TestLocalAliyunOSS {
         () -> oss.putObject(bucketNotExist, "object", wrap(bytes)), OSSErrorCode.NO_SUCH_BUCKET);
 
     PutObjectResult result = oss.putObject(bucketName, "object", wrap(bytes));
-    Assert.assertEquals(AliyunOSSMockLocalStore.md5sum(wrap(bytes)), result.getETag());
+    Assertions.assertThat(result.getETag()).isEqualTo(AliyunOSSMockLocalStore.md5sum(wrap(bytes)));
   }
 
   @Test
   public void testDoesObjectExist() {
-    Assert.assertFalse(oss.doesObjectExist(bucketName, "key"));
+    Assertions.assertThat(oss.doesObjectExist(bucketName, "key")).isFalse();
 
     byte[] bytes = new byte[4 * 1024];
     random.nextBytes(bytes);
     oss.putObject(bucketName, "key", wrap(bytes));
 
-    Assert.assertTrue(oss.doesObjectExist(bucketName, "key"));
+    Assertions.assertThat(oss.doesObjectExist(bucketName, "key")).isTrue();
     oss.deleteObject(bucketName, "key");
   }
 
@@ -153,7 +153,7 @@ public class TestLocalAliyunOSS {
     try (InputStream is = oss.getObject(bucketName, "key").getObjectContent()) {
       ByteStreams.readFully(is, actual);
     }
-    Assert.assertArrayEquals(bytes, actual);
+    Assertions.assertThat(actual).isEqualTo(bytes);
     oss.deleteObject(bucketName, "key");
   }
 
@@ -229,7 +229,7 @@ public class TestLocalAliyunOSS {
     try (InputStream is = oss.getObject(getObjectRequest).getObjectContent()) {
       ByteStreams.readFully(is, actual);
     }
-    Assert.assertArrayEquals(testBytes, actual);
+    Assertions.assertThat(actual).isEqualTo(testBytes);
   }
 
   private InputStream wrap(byte[] data) {

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/TestLocalAliyunOSS.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/TestLocalAliyunOSS.java
@@ -34,9 +34,9 @@ import org.apache.iceberg.aliyun.TestUtility;
 import org.apache.iceberg.aliyun.oss.AliyunOSSExtension;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Assumptions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -70,9 +70,9 @@ public class TestLocalAliyunOSS {
 
   @Test
   public void testBuckets() {
-    Assumptions.assumeTrue(
-        OSS_TEST_EXTENSION.getClass() == AliyunOSSMockExtension.class,
-        "Aliyun integration test cannot delete existing bucket from test environment.");
+    Assumptions.assumeThat(OSS_TEST_EXTENSION.getClass())
+        .as("Aliyun integration test cannot delete existing bucket from test environment.")
+        .isEqualTo(AliyunOSSMockExtension.class);
 
     Assertions.assertThat(doesBucketExist(bucketName)).isTrue();
 
@@ -87,9 +87,9 @@ public class TestLocalAliyunOSS {
 
   @Test
   public void testDeleteBucket() {
-    Assumptions.assumeTrue(
-        OSS_TEST_EXTENSION.getClass() == AliyunOSSMockExtension.class,
-        "Aliyun integration test cannot delete existing bucket from test environment.");
+    Assumptions.assumeThat(OSS_TEST_EXTENSION.getClass())
+        .as("Aliyun integration test cannot delete existing bucket from test environment.")
+        .isEqualTo(AliyunOSSMockExtension.class);
 
     String bucketNotExist = String.format("bucket-not-existing-%s", UUID.randomUUID());
     assertThrows(() -> oss.deleteBucket(bucketNotExist), OSSErrorCode.NO_SUCH_BUCKET);

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/TestLocalAliyunOSS.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/TestLocalAliyunOSS.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class TestLocalAliyunOSS {
 
   @RegisterExtension
-  public static final AliyunOSSExtension OSS_TEST_EXTENSION = TestUtility.initialize();
+  private static final AliyunOSSExtension OSS_TEST_EXTENSION = TestUtility.initialize();
 
   private final OSS oss = OSS_TEST_EXTENSION.createOSSClient();
   private final String bucketName = OSS_TEST_EXTENSION.testBucketName();

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/TestLocalAliyunOSS.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/TestLocalAliyunOSS.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -69,9 +70,9 @@ public class TestLocalAliyunOSS {
 
   @Test
   public void testBuckets() {
-    Assertions.assertThat(OSS_TEST_EXTENSION)
-        .as("Aliyun integration test cannot delete existing bucket from test environment.")
-        .isInstanceOf(AliyunOSSMockExtension.class);
+    Assumptions.assumeTrue(
+        OSS_TEST_EXTENSION.getClass() == AliyunOSSMockExtension.class,
+        "Aliyun integration test cannot delete existing bucket from test environment.");
 
     Assertions.assertThat(doesBucketExist(bucketName)).isTrue();
 
@@ -86,9 +87,9 @@ public class TestLocalAliyunOSS {
 
   @Test
   public void testDeleteBucket() {
-    Assertions.assertThat(OSS_TEST_EXTENSION)
-        .as("Aliyun integration test cannot delete existing bucket from test environment.")
-        .isInstanceOf(AliyunOSSMockExtension.class);
+    Assumptions.assumeTrue(
+        OSS_TEST_EXTENSION.getClass() == AliyunOSSMockExtension.class,
+        "Aliyun integration test cannot delete existing bucket from test environment.");
 
     String bucketNotExist = String.format("bucket-not-existing-%s", UUID.randomUUID());
     assertThrows(() -> oss.deleteBucket(bucketNotExist), OSSErrorCode.NO_SUCH_BUCKET);

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,9 @@
  * under the License.
  */
 
+
 import groovy.transform.Memoized
+
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
@@ -413,6 +415,9 @@ project(':iceberg-data') {
 }
 
 project(':iceberg-aliyun') {
+  test {
+    useJUnitPlatform()
+  }
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     api project(':iceberg-api')

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-
 import groovy.transform.Memoized
-
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 


### PR DESCRIPTION
Switch iceberg-aliyun's tests to Junit5
Fix: #9081 
@nastra Hi, I have changed all of the junit4 code to junit5 with AssertJ, but I have a question here: To fit the Extension class of Junit5, I changed most of the term 'Rule' to 'Extension', but there is a system env variable in `org/apache/iceberg/aliyun/TestUtility.java` called `ALIYUN_TEST_OSS_TEST_RULE_CLASS`.
I don't know where the CI system runs, and how the variable is set. So I'm not sure if I should change this.