### PR TITLE
API, Core: Optimize CharSequenceMap for file paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ spark/v3.4/spark/benchmark/*
 spark/v3.4/spark-extensions/benchmark/*
 spark/v3.5/spark/benchmark/*
 spark/v3.5/spark-extensions/benchmark/*
-data/benchmark/*
+*/benchmark/*
 
 __pycache__/
 *.py[cod]

--- a/api/src/main/java/org/apache/iceberg/types/JavaHashes.java
+++ b/api/src/main/java/org/apache/iceberg/types/JavaHashes.java
@@ -34,6 +34,27 @@ public class JavaHashes {
     return result;
   }
 
+  /**
+   * Computes a hash code for a given file path.
+   *
+   * <p>This method takes into account only the file name at the end of the path. The hash code is
+   * computed by processing characters in reverse order, starting from the end of the sequence until
+   * a slash ('/') is encountered, which indicates the start of the file name. This approach is
+   * beneficial for computing hash codes of Iceberg file paths as those have common prefixes but
+   * unique file names.
+   */
+  public static int filePathHashCode(CharSequence filePath) {
+    int result = 177;
+    for (int i = filePath.length() - 1; i >= 0; i--) {
+      char ch = filePath.charAt(i);
+      if (ch == '/') {
+        break;
+      }
+      result = 31 * result + (int) ch;
+    }
+    return result;
+  }
+
   static JavaHash<Object> strings() {
     return CharSequenceHash.INSTANCE;
   }

--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
@@ -25,12 +25,18 @@ import org.apache.iceberg.types.JavaHashes;
 /** Wrapper class to adapt CharSequence for use in maps and sets. */
 public class CharSequenceWrapper implements CharSequence, Serializable {
   public static CharSequenceWrapper wrap(CharSequence seq) {
-    return new CharSequenceWrapper(seq);
+    return new CharSequenceWrapper(false, seq);
   }
 
+  public static CharSequenceWrapper wrapFilePath(CharSequence filePath) {
+    return new CharSequenceWrapper(true, filePath);
+  }
+
+  private final boolean isFilePath;
   private CharSequence wrapped;
 
-  private CharSequenceWrapper(CharSequence wrapped) {
+  private CharSequenceWrapper(boolean isFilePath, CharSequence wrapped) {
+    this.isFilePath = isFilePath;
     this.wrapped = wrapped;
   }
 
@@ -66,7 +72,7 @@ public class CharSequenceWrapper implements CharSequence, Serializable {
 
   @Override
   public int hashCode() {
-    return JavaHashes.hashCode(wrapped);
+    return isFilePath ? JavaHashes.filePathHashCode(wrapped) : JavaHashes.hashCode(wrapped);
   }
 
   @Override

--- a/api/src/test/java/org/apache/iceberg/util/TestCharSequenceMap.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestCharSequenceMap.java
@@ -29,6 +29,9 @@ import org.junit.jupiter.api.Test;
 
 public class TestCharSequenceMap {
 
+  private static final String FILE_PATH_A = "s3://bucket/key/fileA.parquet";
+  private static final String FILE_PATH_B = "s3://bucket/key/fileB.parquet";
+
   @Test
   public void testEmptyMap() {
     CharSequenceMap<String> map = CharSequenceMap.create();
@@ -198,5 +201,47 @@ public class TestCharSequenceMap {
 
     executorService.shutdown();
     assertThat(executorService.awaitTermination(1, TimeUnit.MINUTES)).isTrue();
+  }
+
+  @Test
+  public void testDifferentCharSequenceImplementationsFilePaths() {
+    CharSequenceMap<String> map = CharSequenceMap.createForFilePaths();
+    map.put(FILE_PATH_A, "value1");
+    map.put(new StringBuffer(FILE_PATH_B), "value2");
+    assertThat(map)
+        .containsEntry(new StringBuilder(FILE_PATH_A), "value1")
+        .containsEntry(FILE_PATH_B, "value2");
+  }
+
+  @Test
+  public void testFileNamesOnly() {
+    CharSequenceMap<String> map = CharSequenceMap.createForFilePaths();
+    map.put("fileA.parquet", "value1");
+    map.put("fileB.parquet", "value2");
+    assertThat(map)
+        .containsEntry("fileA.parquet", "value1")
+        .containsEntry("fileB.parquet", "value2");
+  }
+
+  @Test
+  public void testEqualsFilePaths() {
+    CharSequenceMap<String> map1 = CharSequenceMap.createForFilePaths();
+    map1.put(new StringBuilder(FILE_PATH_A), "value");
+
+    CharSequenceMap<String> map2 = CharSequenceMap.createForFilePaths();
+    map2.put(FILE_PATH_A, "value");
+
+    assertThat(map1).isEqualTo(map2);
+  }
+
+  @Test
+  public void testHashCodeFilePaths() {
+    CharSequenceMap<String> map1 = CharSequenceMap.createForFilePaths();
+    map1.put(new StringBuilder(FILE_PATH_A), "value");
+
+    CharSequenceMap<String> map2 = CharSequenceMap.createForFilePaths();
+    map2.put(FILE_PATH_A, "value");
+
+    assertThat(map1.hashCode()).isEqualTo(map2.hashCode());
   }
 }

--- a/core/src/jmh/java/org/apache/iceberg/util/CharSequenceMapBenchmark.java
+++ b/core/src/jmh/java/org/apache/iceberg/util/CharSequenceMapBenchmark.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.LocationProviders;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Fork(1)
+@State(Scope.Benchmark)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.SingleShotTime)
+@Timeout(time = 10, timeUnit = TimeUnit.MINUTES)
+public class CharSequenceMapBenchmark {
+
+  private static final Random RANDOM = ThreadLocalRandom.current();
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "col1", Types.IntegerType.get()),
+          required(2, "col2", Types.IntegerType.get()),
+          required(3, "data", Types.StringType.get()));
+  private static final PartitionSpec SPEC =
+      PartitionSpec.builderFor(SCHEMA).identity("col1").identity("col2").build();
+  private static final String TABLE_LOCATION =
+      "s3:/secure-organization-bucket-name/database-name/specific_table_name/data";
+  private static final Map<String, String> TABLE_PROPERTIES =
+      ImmutableMap.of(TableProperties.OBJECT_STORE_ENABLED, "true");
+  private static final LocationProvider LOCATIONS =
+      LocationProviders.locationsFor(TABLE_LOCATION, TABLE_PROPERTIES);
+  private static final int NUM_FILE_PATHS = 1_000_000;
+  private static final Object VALUE = new Object();
+
+  private List<CharSequence> filePaths;
+
+  @Setup
+  public void setup() {
+    List<CharSequence> randomFilePaths = Lists.newArrayList();
+    for (int i = 0; i < NUM_FILE_PATHS; i++) {
+      randomFilePaths.add(generateFilePath());
+    }
+    this.filePaths = randomFilePaths;
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void defaultCharSequenceMap(Blackhole blackhole) {
+    CharSequenceMap<Object> map = CharSequenceMap.create();
+    for (int i = 0; i < 10; i++) {
+      for (CharSequence filePath : filePaths) {
+        map.putIfAbsent(filePath, VALUE);
+      }
+    }
+    blackhole.consume(map);
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void filePathCharSequenceMap(Blackhole blackhole) {
+    CharSequenceMap<Object> map = CharSequenceMap.createForFilePaths();
+    for (int i = 0; i < 10; i++) {
+      for (CharSequence filePath : filePaths) {
+        map.putIfAbsent(filePath, VALUE);
+      }
+    }
+    blackhole.consume(map);
+  }
+
+  private String generateFilePath() {
+    int col1Value = RANDOM.nextInt(1000);
+    int col2Value = RANDOM.nextInt(5000);
+    String fileName = generateFileName();
+    return LOCATIONS.newDataLocation(SPEC, TestHelpers.Row.of(col1Value, col2Value), fileName);
+  }
+
+  private String generateFileName() {
+    int partitionId = RANDOM.nextInt(100000);
+    int taskId = RANDOM.nextInt(100);
+    UUID operationId = UUID.randomUUID();
+    int fileCount = RANDOM.nextInt(1000);
+    return String.format("%d-%d-%s-%d", partitionId, taskId, operationId, fileCount);
+  }
+}


### PR DESCRIPTION
I am using `CharSequenceMap` in #8755 to build a map of position delete indexes for a delete file. While profiling that change, I noticed we spend quite a bit of time computing hash codes for file paths compared to what `String` would do. This is because our logic in `CharSequenceWrapper` is generic while `String` can compute a hash code for latin only chars faster by iterating over bytes directly. This PR optimizes the hash code computation for file paths by only taking into account file names. This speeds up the computation without increasing the chance of collisions.

This PR comes with tests and a benchmark.

```
Benchmark                                                Mode  Cnt  Score   Error  Units
CharSequenceMapBenchmark.defaultCharSequenceMap            ss   10  2.742 ± 0.499   s/op
CharSequenceMapBenchmark.filePathCharSequenceMap           ss   10  1.420 ± 0.234   s/op
```

I am planning to use `CharSequenceMap` in `DeleteFileIndex` so this will be a common pattern.