### PR TITLE
Core:  Add manifest file filtering when filtering partitions.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
@@ -79,6 +79,10 @@ public class PartitionSet implements Set<Pair<Integer, StructLike>> {
     return false;
   }
 
+  public Set<StructLike> get(int specId) {
+    return partitionSetById.get(specId);
+  }
+
   @Override
   public boolean add(Pair<Integer, StructLike> pair) {
     Preconditions.checkArgument(pair.first() != null, "Cannot track partition with null spec id");


### PR DESCRIPTION
If the user utilizes PartitionSet to filter files for scanning, we can construct a corresponding filter based on the PartitionSet to filter Manifest files.