### PR TITLE
Remove redundant error propagation check. 

### DIFF
--- a/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
@@ -58,7 +58,6 @@ public class DynConstructors {
         throw e;
       } catch (InvocationTargetException e) {
         Throwables.propagateIfInstanceOf(e.getCause(), Exception.class);
-        Throwables.propagateIfInstanceOf(e.getCause(), RuntimeException.class);
         throw Throwables.propagate(e.getCause());
       }
     }

--- a/common/src/main/java/org/apache/iceberg/common/DynMethods.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynMethods.java
@@ -62,7 +62,6 @@ public class DynMethods {
 
       } catch (InvocationTargetException e) {
         Throwables.propagateIfInstanceOf(e.getCause(), Exception.class);
-        Throwables.propagateIfInstanceOf(e.getCause(), RuntimeException.class);
         throw Throwables.propagate(e.getCause());
       }
     }


### PR DESCRIPTION
[Throwables.propagate](https://github.com/google/guava/blob/e5cc39c9e0bcca1347a937cb090321fb96de0e5c/guava/src/com/google/common/base/Throwables.java#L229) always translate to `RuntimeException`
Adding another check as `Throwables.propagateIfInstanceOf(e.getCause(), RuntimeException.class);` is redundant. 