### PR TITLE
Core: Optimize manifest evaluation for super wide tables

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/NamedReference.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/NamedReference.java
@@ -38,7 +38,8 @@ public class NamedReference<T> implements UnboundTerm<T>, Reference<T> {
 
   @Override
   public BoundReference<T> bind(Types.StructType struct, boolean caseSensitive) {
-    Schema schema = struct.asSchema(); 
+    Schema schema = struct.asSchema();
+
     Types.NestedField field =
         caseSensitive ? schema.findField(name) : schema.caseInsensitiveFindField(name);
 

--- a/api/src/main/java/org/apache/iceberg/expressions/NamedReference.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/NamedReference.java
@@ -39,7 +39,6 @@ public class NamedReference<T> implements UnboundTerm<T>, Reference<T> {
   @Override
   public BoundReference<T> bind(Types.StructType struct, boolean caseSensitive) {
     Schema schema = struct.asSchema();
-
     Types.NestedField field =
         caseSensitive ? schema.findField(name) : schema.caseInsensitiveFindField(name);
 

--- a/api/src/main/java/org/apache/iceberg/expressions/NamedReference.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/NamedReference.java
@@ -38,7 +38,7 @@ public class NamedReference<T> implements UnboundTerm<T>, Reference<T> {
 
   @Override
   public BoundReference<T> bind(Types.StructType struct, boolean caseSensitive) {
-    Schema schema = new Schema(struct.fields());
+    Schema schema = struct.asSchema(); 
     Types.NestedField field =
         caseSensitive ? schema.findField(name) : schema.caseInsensitiveFindField(name);
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -594,6 +594,13 @@ public class Types {
       return this;
     }
 
+    /**
+     * Returns a schema which contains the columns inside struct type.
+     * This method can be used to avoid expensive conversion of StructType 
+     * to Schema during manifest evaluation. 
+     * 
+     * @return the schema containing columns of struct type.
+     */
     public Schema asSchema() {
       if (this.schema == null) {
         this.schema = new Schema(Arrays.asList(this.fields));

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -537,6 +537,7 @@ public class Types {
     private final NestedField[] fields;
 
     // lazy values
+    private transient Schema schema = null;
     private transient List<NestedField> fieldList = null;
     private transient Map<String, NestedField> fieldsByName = null;
     private transient Map<String, NestedField> fieldsByLowerCaseName = null;
@@ -591,6 +592,18 @@ public class Types {
     public Types.StructType asStructType() {
       return this;
     }
+
+    public Schema asSchema() {
+      if (this.schema == null) {
+        synchronized (this) {
+          if (this.schema == null) {
+            this.schema = Arrays.asList(this.fields);
+          }
+        }
+      }
+      return this.schema;
+    }
+
 
     @Override
     public String toString() {

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -595,15 +596,10 @@ public class Types {
 
     public Schema asSchema() {
       if (this.schema == null) {
-        synchronized (this) {
-          if (this.schema == null) {
-            this.schema = Arrays.asList(this.fields);
-          }
-        }
+        this.schema = new Schema(Arrays.asList(this.fields));
       }
       return this.schema;
     }
-
 
     @Override
     public String toString() {

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -595,10 +595,10 @@ public class Types {
     }
 
     /**
-     * Returns a schema which contains the columns inside struct type.
-     * This method can be used to avoid expensive conversion of StructType 
-     * to Schema during manifest evaluation. 
-     * 
+     * Returns a schema which contains the columns inside struct type. This method can be used to
+     * avoid expensive conversion of StructType containing large number of columns to Schema during
+     * manifest evaluation.
+     *
      * @return the schema containing columns of struct type.
      */
     public Schema asSchema() {


### PR DESCRIPTION
During the snapshot commit process of MergingSnapshotProducer, Iceberg tries to merge the manifest files to increase the planning performance. During operations like overwrite, MergingSnapshotProducer finds the matching manifest files by deleteExpression and rewrites the manifests by filtering out the deleted manifest entries.

https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java#L330

While finding the matching manifests by deleteExpression, we found that the Schema is created every time the expression needs to be bound. This has proven very expensive when there are large number of manifest files (~25,000 manifest files) for a super wide table (~35,000 columns).

https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/expressions/NamedReference.java#L41

For optimising the manifest evaluation, we can add a method called asSchema() in the StructType class to avoid creating the new Schema every time the filter needs to be bound.
