### PR TITLE
Flink: Fix IcebergSource tableloader lifecycle management in batch mode

### DIFF
--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
@@ -56,9 +56,9 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
    */
   public ContinuousSplitPlannerImpl(
       TableLoader tableLoader, ScanContext scanContext, String threadName) {
-    this.tableLoader = tableLoader;
+    this.tableLoader = tableLoader.clone();
     this.tableLoader.open();
-    this.table = tableLoader.loadTable();
+    this.table = this.tableLoader.loadTable();
     this.scanContext = scanContext;
     this.isSharedPool = threadName == null;
     this.workerPool =


### PR DESCRIPTION
This is to fix a connection pool issue that prevents IcebergSource to startup in batch mode. The root cause is that the FileIO is closed when the tableLoader is closed via the try-with-resources statements. We need multiple copies of the user tableLoader parameter to retrieve the table name and do split planning and to close the loader after each use. The fix is to utilize clone the table loader to that it can be opened/closed by the batch split planning mechanism. This patch has been manually verified.