### PR TITLE
API, Spark: Fix aggregation pushdown on struct fields

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/ValueAggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ValueAggregate.java
@@ -30,13 +30,16 @@ class ValueAggregate<T> extends BoundAggregate<T, T> {
 
   @Override
   public T eval(StructLike struct) {
-    return term().eval(struct);
+    if (struct.size() > 1) {
+      throw new UnsupportedOperationException("Expected struct like of size 1");
+    }
+
+    return (T) struct.get(0, term().type().typeId().javaClass());
   }
 
   @Override
   public T eval(DataFile file) {
-    valueStruct.setValue(evaluateRef(file));
-    return term().eval(valueStruct);
+    return (T) evaluateRef(file);
   }
 
   protected Object evaluateRef(DataFile file) {

--- a/api/src/main/java/org/apache/iceberg/expressions/ValueAggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ValueAggregate.java
@@ -30,16 +30,13 @@ class ValueAggregate<T> extends BoundAggregate<T, T> {
 
   @Override
   public T eval(StructLike struct) {
-    if (struct.size() > 1) {
-      throw new UnsupportedOperationException("Expected struct like of size 1");
-    }
-
-    return (T) struct.get(0, term().type().typeId().javaClass());
+    return term().eval(struct);
   }
 
   @Override
   public T eval(DataFile file) {
-    return (T) evaluateRef(file);
+    valueStruct.setValue(evaluateRef(file));
+    return term().eval(valueStruct);
   }
 
   protected Object evaluateRef(DataFile file) {
@@ -63,7 +60,11 @@ class ValueAggregate<T> extends BoundAggregate<T, T> {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T get(int pos, Class<T> javaClass) {
-      return (T) value;
+      if (javaClass.isAssignableFrom(StructLike.class)) {
+        return (T) this;
+      } else {
+        return (T) value;
+      }
     }
 
     @Override

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import org.apache.iceberg.CatalogUtil;
@@ -36,17 +37,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.TestBase;
 import org.apache.spark.sql.SparkSession;
-<<<<<<< HEAD
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
-=======
-import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
->>>>>>> a7f9c6000 (Fix agg pushodwn on struct)
 
 public class TestAggregatePushDown extends CatalogTestBase {
 
@@ -253,78 +247,6 @@ public class TestAggregatePushDown extends CatalogTestBase {
     List<Object[]> expected = Lists.newArrayList();
     expected.add(new Object[] {6L, 23331.0});
     assertEquals("expected and actual should equal", expected, actual);
-  }
-
-  @TestTemplate
-  public void testAggregationPushdownStructInteger() {
-    testAggregationPushdownStruct(
-        2L,
-        3L,
-        2L,
-        "(id BIGINT, struct_with_int STRUCT<c1:BIGINT>)",
-        "struct_with_int.c1",
-        "(1, named_struct(\"c1\", NULL))",
-        "(2, named_struct(\"c1\", 2))",
-        "(3, named_struct(\"c1\", 3))");
-  }
-
-  @TestTemplate
-  public void testAggregationPushdownNestedStruct() {
-    testAggregationPushdownStruct(
-        2L,
-        3L,
-        2L,
-        "(id BIGINT, struct_with_int STRUCT<c1:STRUCT<c2:STRUCT<c3:STRUCT<c4:BIGINT>>>>)",
-        "struct_with_int.c1.c2.c3.c4",
-        "(1, named_struct(\"c1\", named_struct(\"c2\", named_struct(\"c3\", named_struct(\"c4\", NULL)))))",
-        "(2, named_struct(\"c1\", named_struct(\"c2\", named_struct(\"c3\", named_struct(\"c4\", 2)))))",
-        "(3, named_struct(\"c1\", named_struct(\"c2\", named_struct(\"c3\", named_struct(\"c4\", 3)))))");
-  }
-
-  @TestTemplate
-  public void testAggregationPushdownStructTimestamp() {
-    long timestamp = System.currentTimeMillis();
-    long futureTimestamp = timestamp + 5000;
-    Timestamp expectedMax = new Timestamp(futureTimestamp / 1000 * 1000);
-    Timestamp expectedMin = new Timestamp(1000 * (timestamp / 1000));
-    testAggregationPushdownStruct(
-        2L,
-        expectedMax,
-        expectedMin,
-        "(id BIGINT, struct_with_ts STRUCT<c1:TIMESTAMP>)",
-        "struct_with_ts.c1",
-        "(1, named_struct(\"c1\", NULL))",
-        String.format(
-            "(2, named_struct(\"c1\", CAST(from_unixtime(%d/1000) AS TIMESTAMP)))", timestamp),
-        String.format(
-            "(3, named_struct(\"c1\", CAST(from_unixtime(%d/1000) AS TIMESTAMP)))",
-            timestamp + 5000));
-  }
-
-  private void testAggregationPushdownStruct(
-      Object expectedCount,
-      Object expectedMax,
-      Object expectedMin,
-      String schema,
-      String aggField,
-      String... rows) {
-    sql("CREATE TABLE %s %s USING iceberg", tableName, schema);
-    sql("INSERT INTO TABLE %s VALUES %s", tableName, String.join(",", rows));
-    List<Object[]> actual =
-        sql("SELECT COUNT(%s), MAX(%s), MIN(%s) FROM %s", aggField, aggField, aggField, tableName);
-    Object actualCount = actual.get(0)[0];
-    Object actualMax = actual.get(0)[1];
-    Object actualMin = actual.get(0)[2];
-    Assertions.assertThat(actualCount)
-        .withFailMessage("Expected and actual count should equal")
-        .isEqualTo(expectedCount);
-    Assertions.assertThat(actualMax)
-        .withFailMessage("Expected and actual max should equal")
-        .isEqualTo(expectedMax);
-    Assertions.assertThat(actualMin)
-        .withFailMessage("Expected and actual min should equal")
-        .isEqualTo(expectedMin);
-    sql("DROP TABLE %s", tableName);
   }
 
   @TestTemplate
@@ -556,6 +478,126 @@ public class TestAggregatePushDown extends CatalogTestBase {
     assertThat(explainContainsPushDownAggregates)
         .as("max not pushed down for complex types")
         .isFalse();
+  }
+
+  @TestTemplate
+  public void testAggregationPushdownStructInteger() {
+    sql("CREATE TABLE %s (id BIGINT, struct_with_int STRUCT<c1:BIGINT>) USING iceberg", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, named_struct(\"c1\", NULL))", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, named_struct(\"c1\", 2))", tableName);
+    sql("INSERT INTO TABLE %s VALUES (3, named_struct(\"c1\", 3))", tableName);
+
+    String query = "SELECT COUNT(%s), MAX(%s), MIN(%s) FROM %s";
+    String aggField = "struct_with_int.c1";
+    assertAggregates(sql(query, aggField, aggField, aggField, tableName), 2L, 3L, 2L);
+    assertExplainContains(
+        sql("EXPLAIN " + query, aggField, aggField, aggField, tableName),
+        "count(struct_with_int.c1)",
+        "max(struct_with_int.c1)",
+        "min(struct_with_int.c1)");
+  }
+
+  @TestTemplate
+  public void testAggregationPushdownNestedStruct() {
+    sql(
+        "CREATE TABLE %s (id BIGINT, struct_with_int STRUCT<c1:STRUCT<c2:STRUCT<c3:STRUCT<c4:BIGINT>>>>) USING iceberg",
+        tableName);
+    sql(
+        "INSERT INTO TABLE %s VALUES (1, named_struct(\"c1\", named_struct(\"c2\", named_struct(\"c3\", named_struct(\"c4\", NULL)))))",
+        tableName);
+    sql(
+        "INSERT INTO TABLE %s VALUES (2, named_struct(\"c1\", named_struct(\"c2\", named_struct(\"c3\", named_struct(\"c4\", 2)))))",
+        tableName);
+    sql(
+        "INSERT INTO TABLE %s VALUES (3, named_struct(\"c1\", named_struct(\"c2\", named_struct(\"c3\", named_struct(\"c4\", 3)))))",
+        tableName);
+
+    String query = "SELECT COUNT(%s), MAX(%s), MIN(%s) FROM %s";
+    String aggField = "struct_with_int.c1.c2.c3.c4";
+
+    assertAggregates(sql(query, aggField, aggField, aggField, tableName), 2L, 3L, 2L);
+
+    assertExplainContains(
+        sql("EXPLAIN " + query, aggField, aggField, aggField, tableName),
+        "count(struct_with_int.c1.c2.c3.c4)",
+        "max(struct_with_int.c1.c2.c3.c4)",
+        "min(struct_with_int.c1.c2.c3.c4)");
+  }
+
+  @TestTemplate
+  public void testAggregationPushdownStructTimestamp() {
+    sql(
+        "CREATE TABLE %s (id BIGINT, struct_with_ts STRUCT<c1:TIMESTAMP>) USING iceberg",
+        tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, named_struct(\"c1\", NULL))", tableName);
+    sql(
+        "INSERT INTO TABLE %s VALUES (2, named_struct(\"c1\", timestamp('2023-01-30T22:22:22Z')))",
+        tableName);
+    sql(
+        "INSERT INTO TABLE %s VALUES (3, named_struct(\"c1\", timestamp('2023-01-30T22:23:23Z')))",
+        tableName);
+
+    String query = "SELECT COUNT(%s), MAX(%s), MIN(%s) FROM %s";
+    String aggField = "struct_with_ts.c1";
+
+    assertAggregates(
+        sql(query, aggField, aggField, aggField, tableName),
+        2L,
+        new Timestamp(1675117403000L),
+        new Timestamp(1675117342000L));
+
+    assertExplainContains(
+        sql("EXPLAIN " + query, aggField, aggField, aggField, tableName),
+        "count(struct_with_ts.c1)",
+        "max(struct_with_ts.c1)",
+        "min(struct_with_ts.c1)");
+  }
+
+  @TestTemplate
+  public void testAggregationPushdownOnBucketedColumn() {
+    sql(
+        "CREATE TABLE %s (id BIGINT, struct_with_int STRUCT<c1:INT>) USING iceberg PARTITIONED BY (bucket(8, id))",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, named_struct(\"c1\", NULL))", tableName);
+    sql("INSERT INTO TABLE %s VALUES (null, named_struct(\"c1\", 2))", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, named_struct(\"c1\", 3))", tableName);
+
+    String query = "SELECT COUNT(%s), MAX(%s), MIN(%s) FROM %s";
+    String aggField = "id";
+    assertAggregates(sql(query, aggField, aggField, aggField, tableName), 2L, 2L, 1L);
+    assertExplainContains(
+        sql("EXPLAIN " + query, aggField, aggField, aggField, tableName),
+        "count(id)",
+        "max(id)",
+        "min(id)");
+  }
+
+  private void assertAggregates(
+      List<Object[]> actual, Object expectedCount, Object expectedMax, Object expectedMin) {
+    Object actualCount = actual.get(0)[0];
+    Object actualMax = actual.get(0)[1];
+    Object actualMin = actual.get(0)[2];
+
+    Assertions.assertThat(actualCount)
+        .as("Expected and actual count should equal")
+        .isEqualTo(expectedCount);
+    Assertions.assertThat(actualMax)
+        .as("Expected and actual max should equal")
+        .isEqualTo(expectedMax);
+    Assertions.assertThat(actualMin)
+        .as("Expected and actual min should equal")
+        .isEqualTo(expectedMin);
+  }
+
+  private void assertExplainContains(List<Object[]> explain, String... expectedFragments) {
+    String explainString = explain.get(0)[0].toString().toLowerCase(Locale.ROOT);
+    Arrays.stream(expectedFragments)
+        .forEach(
+            fragment ->
+                Assertions.assertThat(explainString.contains(fragment))
+                    .isTrue()
+                    .as("Expected to find plan fragment in explain plan"));
   }
 
   @TestTemplate


### PR DESCRIPTION
Currently, aggregation pushdowns on struct fields fail due to casting errors because in certain cases (e.g. optional field in struct) the accessor visitor construct a WrappedPositionAccessor when visiting the field. This WrappedPositionAccessor has an expectation that the element it's accessing is a `StructLike` but for aggregation pushdown this does not apply (the top level element is a Java type). 

Since there's always a single value I think we should be able to just read the evaluated value without actually performing any term evaluation. 