### PR TITLE
Parquet: Add a table property to control the Parquet row-group size of position delete files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -126,6 +126,11 @@ public class TableProperties {
       "write.delete.parquet.row-group-size-bytes";
   public static final int PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT = 128 * 1024 * 1024; // 128 MB
 
+  public static final String PATH_POS_DELETE_PARQUET_ROW_GROUP_SIZE_BYTES =
+      "write.delete.path-pos-delete.parquet.row-group-size-bytes";
+  public static final int DEFAULT_PATH_POS_DELETE_PARQUET_ROW_GROUP_SIZE_BYTES =
+      2 * 1024 * 1024; // 2 MB
+
   public static final String PARQUET_PAGE_SIZE_BYTES = "write.parquet.page-size-bytes";
   public static final String DELETE_PARQUET_PAGE_SIZE_BYTES =
       "write.delete.parquet.page-size-bytes";

--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceParquetPosDeleteRowGroupFilterBenchmark.java
+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceParquetPosDeleteRowGroupFilterBenchmark.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetReaders;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A benchmark that evaluates the non-vectorized read and vectorized read with pos-delete in the
+ * Spark data source for Iceberg.
+ *
+ * <p>This class uses a dataset with a flat schema. To run this benchmark for spark-3.5: <code>
+ *   ./gradlew -DsparkVersions=3.5 :iceberg-spark:iceberg-spark-3.5:jmh
+ *       -PjmhIncludeRegex=IcebergSourceParquetPosDeleteRowGroupFilterBenchmark.readIcebergVectorized
+ *       -PjmhOutputPath=benchmark/iceberg-source-parquet-pos-delete-row-group-filter-benchmark-result.txt
+ * </code>
+ */
+public class IcebergSourceParquetPosDeleteRowGroupFilterBenchmark
+    extends IcebergSourceDeleteBenchmark {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(IcebergSourceParquetPosDeleteRowGroupFilterBenchmark.class);
+
+  private static final Schema DELETE_SCHEMA =
+      new Schema(MetadataColumns.DELETE_FILE_PATH, MetadataColumns.DELETE_FILE_POS);
+
+  @Param({"2", "4", "128" /* default size */})
+  private int rowGroupSizeMB;
+
+  @Param({"3", "5"})
+  private int numDataFiles;
+
+  private DeleteFile posDeleteFile;
+
+  @Override
+  protected void appendData() throws IOException {
+    for (int fileNum = 1; fileNum <= numDataFiles; fileNum++) {
+      writeData(fileNum);
+    }
+
+    table()
+        .updateProperties()
+        .set(
+            TableProperties.PATH_POS_DELETE_PARQUET_ROW_GROUP_SIZE_BYTES,
+            String.valueOf(rowGroupSizeMB * 1024 * 1024))
+        .commit();
+
+    // add pos-deletes
+    table().refresh();
+    List<CharSequence> filePaths =
+        Streams.stream(table().newScan().planFiles())
+            .map(task -> task.file().path())
+            .collect(Collectors.toList());
+
+    writePosDeletes(filePaths, NUM_ROWS, 0.10);
+
+    table().refresh();
+    posDeleteFile =
+        Iterables.getOnlyElement(table().currentSnapshot().addedDeleteFiles(table().io()));
+    List<Long> offsets = posDeleteFile.splitOffsets();
+
+    LOG.info(
+        "row-group-size-MB: {}, position delete file size in bytes: {}, number row-groups: {}",
+        rowGroupSizeMB,
+        posDeleteFile.fileSizeInBytes(),
+        offsets.size());
+  }
+
+  // Benchmarking the performance of reading position delete files with different number of
+  // row-groups
+  @Benchmark
+  @Threads(1)
+  public void readPositionDelete(Blackhole blackhole) {
+    CloseableIterable<Record> reader =
+        Parquet.read(Files.localInput(posDeleteFile.path().toString()))
+            .project(DELETE_SCHEMA)
+            .reuseContainers()
+            .createReaderFunc(
+                fileSchema -> GenericParquetReaders.buildReader(DELETE_SCHEMA, fileSchema))
+            .build();
+
+    for (Record record : reader) {
+      blackhole.consume(record);
+    }
+  }
+
+  @Override
+  protected FileFormat fileFormat() {
+    return FileFormat.PARQUET;
+  }
+}


### PR DESCRIPTION
This add a table property `write.delete.path-pos-delete.parquet.row-group-size-bytes` to control the Parquet row-group size of position delete files.

When the position delete file has only `file_path` and `pos` columns, even one million position delete records will only occupy 1~2MB of storage space (assuming they have the same `file_path`):
```text 
data-file-row-count: 100000000, pos-delete-row-count : 10000, delete-file-size-bytes: 24617
data-file-row-count: 100000000, pos-delete-row-count : 100000, delete-file-size-bytes: 209195
data-file-row-count: 100000000, pos-delete-row-count : 500000, delete-file-size-bytes: 922813
data-file-row-count: 100000000, pos-delete-row-count : 1000000, delete-file-size-bytes: 1625049
```
However, currently the default value of Parquet row-group size of position delete is 128MB, which is too big, position delete records belonging to different data files will be written to the same row-group. The reader must read all pos delete to find the relevant position deletes because all delete records are written to one row-group.

So this adds a property to control the row-group size of position delete file, it will be used when position deletes has only `file_path` and `pos` colunmns. The default is set to 2MB to separate position deletes that should be applied to different data files into different row-groups as much as possible, so that we can take advantage of the row-group filter to filter out unreleated position delete records when reading. 

closes #9149 