### PR TITLE
Core: Add comment property to ViewProperties

### DIFF
--- a/core/src/main/java/org/apache/iceberg/view/ViewProperties.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewProperties.java
@@ -25,6 +25,7 @@ public class ViewProperties {
 
   public static final String METADATA_COMPRESSION = "write.metadata.compression-codec";
   public static final String METADATA_COMPRESSION_DEFAULT = "gzip";
+  public static final String COMMENT = "comment";
 
   private ViewProperties() {}
 }

--- a/core/src/test/java/org/apache/iceberg/view/TestViewMetadataParser.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestViewMetadataParser.java
@@ -107,7 +107,8 @@ public class TestViewMetadataParser {
             .addVersion(version1)
             .addVersion(version2)
             .setLocation("s3://bucket/test/location")
-            .setProperties(ImmutableMap.of("some-key", "some-value"))
+            .setProperties(
+                ImmutableMap.of("some-key", "some-value", ViewProperties.COMMENT, "some-comment"))
             .setCurrentVersionId(2)
             .upgradeFormatVersion(1)
             .build();
@@ -218,7 +219,9 @@ public class TestViewMetadataParser {
                     .addVersion(version1)
                     .addVersion(version2)
                     .setLocation("s3://bucket/test/location")
-                    .setProperties(ImmutableMap.of("some-key", "some-value"))
+                    .setProperties(
+                        ImmutableMap.of(
+                            "some-key", "some-value", ViewProperties.COMMENT, "some-comment"))
                     .setCurrentVersionId(2)
                     .upgradeFormatVersion(1)
                     .build())

--- a/core/src/test/resources/org/apache/iceberg/view/ValidViewMetadata.json
+++ b/core/src/test/resources/org/apache/iceberg/view/ValidViewMetadata.json
@@ -2,7 +2,7 @@
   "view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",
   "format-version": 1,
   "location": "s3://bucket/test/location",
-  "properties": {"some-key": "some-value"},
+  "properties": {"some-key": "some-value", "comment":  "some-comment"},
   "current-schema-id": 0,
   "schemas": [
     {


### PR DESCRIPTION
We reference using "comment" as a property in the view spec, but it looks like we don't have a constant defined in the library. See https://github.com/trinodb/trino/pull/19818#discussion_r1408354022 for more details but I think "comment" should be defined in the Iceberg library as it is not engine specific. 