### PR TITLE
Spark: IN clause on system function is not pushed down

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSystemFunctionPushDownDQL.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSystemFunctionPushDownDQL.java
@@ -24,6 +24,7 @@ import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.hour;
+import static org.apache.iceberg.expressions.Expressions.in;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.month;
@@ -40,6 +41,8 @@ import static org.apache.iceberg.spark.SystemFunctionPushDownHelper.timestampStr
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.expressions.ExpressionUtil;
@@ -212,15 +215,72 @@ public class TestSystemFunctionPushDownDQL extends ExtensionsTestBase {
     String query =
         String.format(
             "SELECT * FROM %s WHERE system.bucket(5, id) <= %s ORDER BY id", tableName, target);
+    checkQueryExecution(query, partitioned, lessThanOrEqual(bucket("id", 5), target));
+  }
 
+  @TestTemplate
+  public void testBucketLongFunctionInClauseOnUnpartitionedTable() {
+    createUnpartitionedTable(spark, tableName);
+    testBucketLongFunctionInClause(false);
+  }
+
+  @TestTemplate
+  public void testBucketLongFunctionInClauseOnPartitionedTable() {
+    createPartitionedTable(spark, tableName, "bucket(5, id)");
+    testBucketLongFunctionInClause(true);
+  }
+
+  private void testBucketLongFunctionInClause(boolean partitioned) {
+    List<Integer> inValues = IntStream.range(0, 3).boxed().collect(Collectors.toList());
+    String inValuesAsSql =
+        inValues.stream().map(x -> Integer.toString(x)).collect(Collectors.joining(", "));
+    String query =
+        String.format(
+            "SELECT * FROM %s WHERE system.bucket(5, id) IN (%s) ORDER BY id",
+            tableName, inValuesAsSql);
+
+    checkQueryExecution(query, partitioned, in(bucket("id", 5), inValues.toArray()));
+  }
+
+  private void checkQueryExecution(
+      String query, boolean partitioned, org.apache.iceberg.expressions.Expression expression) {
     Dataset<Row> df = spark.sql(query);
     LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
 
     checkExpressions(optimizedPlan, partitioned, "bucket");
-    checkPushedFilters(optimizedPlan, lessThanOrEqual(bucket("id", 5), target));
+    checkPushedFilters(optimizedPlan, expression);
 
     List<Object[]> actual = rowsToJava(df.collectAsList());
     assertThat(actual).hasSize(5);
+  }
+
+  @TestTemplate
+  public void testBucketLongFunctionIsNotReplacedWhenArgumentsAreNotLiteralsOnPartitionedTable() {
+    createPartitionedTable(spark, tableName, "bucket(5, id)");
+    testBucketLongFunctionIsNotReplacedWhenArgumentsAreNotLiterals();
+  }
+
+  @TestTemplate
+  public void testBucketLongFunctionIsNotReplacedWhenArgumentsAreNotLiteralsOnUnpartitionedTable() {
+    createUnpartitionedTable(spark, tableName);
+    testBucketLongFunctionIsNotReplacedWhenArgumentsAreNotLiterals();
+  }
+
+  private void testBucketLongFunctionIsNotReplacedWhenArgumentsAreNotLiterals() {
+    String query =
+        String.format(
+            "SELECT * FROM %s WHERE system.bucket(5, id) IN (system.bucket(5, id), 1) ORDER BY id",
+            tableName);
+
+    Dataset<Row> df = spark.sql(query);
+    LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
+
+    checkExpressionsNotReplaced(
+        optimizedPlan, "org.apache.iceberg.spark.functions.BucketFunction$BucketLong", 2);
+    checkNotPushedFilters(optimizedPlan);
+
+    List<Object[]> actual = rowsToJava(df.collectAsList());
+    assertThat(actual.size()).isEqualTo(10);
   }
 
   @TestTemplate
@@ -309,5 +369,25 @@ public class TestSystemFunctionPushDownDQL extends ExtensionsTestBase {
     assertThat(ExpressionUtil.equivalent(expected, actual, STRUCT, true))
         .as("Pushed filter should match")
         .isTrue();
+  }
+
+  private void checkExpressionsNotReplaced(
+      LogicalPlan optimizedPlan, String expectedFunctionName, int expectedFunctionCount) {
+    List<StaticInvoke> staticInvokes =
+        PlanUtils.collectSparkExpressions(
+                optimizedPlan, expression -> expression instanceof StaticInvoke)
+            .stream()
+            .map(x -> (StaticInvoke) x)
+            .collect(Collectors.toList());
+
+    assertThat(staticInvokes.size()).isEqualTo(expectedFunctionCount);
+    assertThat(staticInvokes)
+        .allSatisfy(e -> assertThat(e.staticObject().getName()).isEqualTo(expectedFunctionName));
+  }
+
+  private void checkNotPushedFilters(LogicalPlan optimizedPlan) {
+    List<org.apache.iceberg.expressions.Expression> pushedFilters =
+        PlanUtils.collectPushDownFilters(optimizedPlan);
+    assertThat(pushedFilters.size()).isEqualTo(0);
   }
 }


### PR DESCRIPTION
PR to verify bug reported in issue #9191.

With some guidance I'm open to work on the fix too.