### PR TITLE
Core: Add PartitionMap

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/PartitionMap.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionMap.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+
+/**
+ * A map that uses a pair of spec ID and partition tuple as keys.
+ *
+ * <p>This implementation internally stores provided partition tuples in {@link StructLikeMap} for
+ * consistent hashing and equals behavior. This ensures that objects of different types that
+ * represent the same structs are treated as equal keys in the map.
+ *
+ * <p>Note: This map is not designed for concurrent modification by multiple threads. However, it
+ * supports safe concurrent reads, assuming there are no concurrent writes.
+ *
+ * <p>Note: This map does not support null pairs but supports null as partition tuples.
+ *
+ * @param <V> the type of values
+ */
+public class PartitionMap<V> extends AbstractMap<Pair<Integer, StructLike>, V> {
+
+  private final Map<Integer, PartitionSpec> specs;
+  private final Map<Integer, Map<StructLike, V>> partitionMaps;
+
+  private PartitionMap(Map<Integer, PartitionSpec> specs) {
+    this.specs = specs;
+    this.partitionMaps = Maps.newHashMap();
+  }
+
+  public static <T> PartitionMap<T> create(Map<Integer, PartitionSpec> specs) {
+    return new PartitionMap<>(specs);
+  }
+
+  @Override
+  public int size() {
+    return partitionMaps.values().stream().mapToInt(Map::size).sum();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return partitionMaps.values().stream().allMatch(Map::isEmpty);
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return execute(key, this::containsKey, false /* default value */);
+  }
+
+  public boolean containsKey(int specId, StructLike struct) {
+    Map<StructLike, V> partitionMap = partitionMaps.get(specId);
+    return partitionMap != null && partitionMap.containsKey(struct);
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return partitionMaps.values().stream().anyMatch(map -> map.containsValue(value));
+  }
+
+  @Override
+  public V get(Object key) {
+    return execute(key, this::get, null /* default value */);
+  }
+
+  public V get(int specId, StructLike struct) {
+    Map<StructLike, V> partitionMap = partitionMaps.get(specId);
+    return partitionMap != null ? partitionMap.get(struct) : null;
+  }
+
+  @Override
+  public V put(Pair<Integer, StructLike> key, V value) {
+    return put(key.first(), key.second(), value);
+  }
+
+  public V put(int specId, StructLike struct, V value) {
+    Map<StructLike, V> partitionMap = partitionMaps.computeIfAbsent(specId, this::newPartitionMap);
+    return partitionMap.put(struct, value);
+  }
+
+  @Override
+  public void putAll(Map<? extends Pair<Integer, StructLike>, ? extends V> otherMap) {
+    otherMap.forEach(this::put);
+  }
+
+  @Override
+  public V remove(Object key) {
+    return execute(key, this::removeKey, null /* default value */);
+  }
+
+  public V removeKey(int specId, StructLike struct) {
+    Map<StructLike, V> partitionMap = partitionMaps.get(specId);
+    return partitionMap != null ? partitionMap.remove(struct) : null;
+  }
+
+  @Override
+  public void clear() {
+    partitionMaps.clear();
+  }
+
+  @Override
+  public Set<Pair<Integer, StructLike>> keySet() {
+    PartitionSet keySet = PartitionSet.create(specs);
+
+    for (Entry<Integer, Map<StructLike, V>> specIdAndPartitionMap : partitionMaps.entrySet()) {
+      int specId = specIdAndPartitionMap.getKey();
+      Map<StructLike, V> partitionMap = specIdAndPartitionMap.getValue();
+      for (StructLike partition : partitionMap.keySet()) {
+        keySet.add(specId, partition);
+      }
+    }
+
+    return Collections.unmodifiableSet(keySet);
+  }
+
+  @Override
+  public Collection<V> values() {
+    List<V> values = Lists.newArrayList();
+
+    for (Map<StructLike, V> partitionMap : partitionMaps.values()) {
+      values.addAll(partitionMap.values());
+    }
+
+    return Collections.unmodifiableCollection(values);
+  }
+
+  @Override
+  public Set<Entry<Pair<Integer, StructLike>, V>> entrySet() {
+    Set<Entry<Pair<Integer, StructLike>, V>> entrySet = Sets.newHashSet();
+
+    for (Entry<Integer, Map<StructLike, V>> specIdAndPartitionMap : partitionMaps.entrySet()) {
+      int specId = specIdAndPartitionMap.getKey();
+      Map<StructLike, V> partitionMap = specIdAndPartitionMap.getValue();
+      for (Entry<StructLike, V> structAndValue : partitionMap.entrySet()) {
+        entrySet.add(new PartitionEntry<>(specId, structAndValue));
+      }
+    }
+
+    return Collections.unmodifiableSet(entrySet);
+  }
+
+  public V computeIfAbsent(int specId, StructLike struct, Supplier<V> valueSupplier) {
+    Map<StructLike, V> partitionMap = partitionMaps.computeIfAbsent(specId, this::newPartitionMap);
+    return partitionMap.computeIfAbsent(struct, key -> valueSupplier.get());
+  }
+
+  private Map<StructLike, V> newPartitionMap(int specId) {
+    PartitionSpec spec = specs.get(specId);
+    Preconditions.checkNotNull(spec, "Cannot find spec with ID %s: %s", specId, specs);
+    return StructLikeMap.create(spec.partitionType());
+  }
+
+  @Override
+  public String toString() {
+    return partitionMaps.entrySet().stream()
+        .flatMap(this::toStrings)
+        .collect(Collectors.joining(", ", "{", "}"));
+  }
+
+  private Stream<String> toStrings(Entry<Integer, Map<StructLike, V>> entry) {
+    PartitionSpec spec = specs.get(entry.getKey());
+    return entry.getValue().entrySet().stream().map(innerEntry -> toString(spec, innerEntry));
+  }
+
+  private String toString(PartitionSpec spec, Entry<StructLike, V> entry) {
+    StructLike struct = entry.getKey();
+    V value = entry.getValue();
+    return spec.partitionToPath(struct) + " -> " + (value == this ? "(this Map)" : value);
+  }
+
+  private <R> R execute(Object key, BiFunction<Integer, StructLike, R> action, R defaultValue) {
+    if (key instanceof Pair) {
+      Object first = ((Pair<?, ?>) key).first();
+      Object second = ((Pair<?, ?>) key).second();
+      if (first instanceof Integer && (second == null || second instanceof StructLike)) {
+        return action.apply((Integer) first, (StructLike) second);
+      }
+    } else if (key == null) {
+      throw new NullPointerException(getClass().getName() + " does not support null keys");
+    }
+
+    return defaultValue;
+  }
+
+  private static class PartitionEntry<V> implements Entry<Pair<Integer, StructLike>, V> {
+    private final int specId;
+    private final Entry<StructLike, V> structAndValue;
+
+    private PartitionEntry(int specId, Entry<StructLike, V> structAndValue) {
+      this.specId = specId;
+      this.structAndValue = structAndValue;
+    }
+
+    @Override
+    public Pair<Integer, StructLike> getKey() {
+      return Pair.of(specId, structAndValue.getKey());
+    }
+
+    @Override
+    public V getValue() {
+      return structAndValue.getValue();
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(specId, structAndValue);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      } else if (other == null || getClass() != other.getClass()) {
+        return false;
+      }
+
+      PartitionEntry<?> that = (PartitionEntry<?>) other;
+      return specId == that.specId && Objects.equals(structAndValue, that.structAndValue);
+    }
+
+    @Override
+    public V setValue(V newValue) {
+      throw new UnsupportedOperationException("Cannot set value");
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.util;
 
+import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -32,7 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 
-public class PartitionSet implements Set<Pair<Integer, StructLike>> {
+public class PartitionSet extends AbstractSet<Pair<Integer, StructLike>> {
   public static PartitionSet create(Map<Integer, PartitionSpec> specsById) {
     return new PartitionSet(specsById);
   }

--- a/core/src/test/java/org/apache/iceberg/util/TestPartitionMap.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestPartitionMap.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.TestHelpers.CustomRow;
+import org.apache.iceberg.TestHelpers.Row;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestPartitionMap {
+
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "id", Types.IntegerType.get()),
+          required(2, "data", Types.StringType.get()),
+          required(3, "category", Types.StringType.get()));
+  private static final PartitionSpec UNPARTITIONED_SPEC = PartitionSpec.unpartitioned();
+  private static final PartitionSpec BY_DATA_SPEC =
+      PartitionSpec.builderFor(SCHEMA).identity("data").withSpecId(1).build();
+  private static final PartitionSpec BY_DATA_CATEGORY_BUCKET_SPEC =
+      PartitionSpec.builderFor(SCHEMA).identity("data").bucket("category", 8).withSpecId(3).build();
+  private static final Map<Integer, PartitionSpec> SPECS =
+      ImmutableMap.of(
+          UNPARTITIONED_SPEC.specId(),
+          UNPARTITIONED_SPEC,
+          BY_DATA_SPEC.specId(),
+          BY_DATA_SPEC,
+          BY_DATA_CATEGORY_BUCKET_SPEC.specId(),
+          BY_DATA_CATEGORY_BUCKET_SPEC);
+
+  @Test
+  public void testEmptyMap() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+    assertThat(map).isEmpty();
+    assertThat(map).hasSize(0);
+    assertThat(map).doesNotContainKey(Pair.of(1, Row.of(1))).doesNotContainValue("value");
+    assertThat(map.values()).isEmpty();
+    assertThat(map.keySet()).isEmpty();
+    assertThat(map.entrySet()).isEmpty();
+  }
+
+  @Test
+  public void testSize() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+    map.put(UNPARTITIONED_SPEC.specId(), null, "v1");
+    map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v2");
+    map.put(BY_DATA_SPEC.specId(), Row.of("bbb"), "v3");
+    map.put(BY_DATA_CATEGORY_BUCKET_SPEC.specId(), Row.of("ccc", 2), "v4");
+    assertThat(map).isNotEmpty();
+    assertThat(map).hasSize(4);
+  }
+
+  @Test
+  public void testDifferentStructLikeImplementations() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+    map.put(BY_DATA_SPEC.specId(), CustomRow.of("aaa"), "value");
+    map.put(UNPARTITIONED_SPEC.specId(), null, "value");
+    assertThat(map)
+        .containsEntry(Pair.of(BY_DATA_SPEC.specId(), CustomRow.of("aaa")), "value")
+        .containsEntry(Pair.of(BY_DATA_SPEC.specId(), Row.of("aaa")), "value")
+        .containsEntry(Pair.of(UNPARTITIONED_SPEC.specId(), null), "value");
+  }
+
+  @Test
+  public void testPutAndGet() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+    map.put(UNPARTITIONED_SPEC.specId(), null, "v1");
+    map.put(BY_DATA_CATEGORY_BUCKET_SPEC.specId(), Row.of("aaa", 1), "v2");
+    assertThat(map.get(UNPARTITIONED_SPEC.specId(), null)).isEqualTo("v1");
+    assertThat(map.get(BY_DATA_CATEGORY_BUCKET_SPEC.specId(), Row.of("aaa", 1))).isEqualTo("v2");
+  }
+
+  @Test
+  public void testRemove() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+
+    map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
+    map.put(BY_DATA_SPEC.specId(), Row.of("bbb"), "v2");
+
+    map.removeKey(BY_DATA_SPEC.specId(), Row.of("aaa"));
+
+    assertThat(map).doesNotContainKey(Pair.of(BY_DATA_SPEC.specId(), Row.of("aaa")));
+    assertThat(map.get(BY_DATA_SPEC.specId(), Row.of("aaa"))).isNull();
+    assertThat(map).containsKey(Pair.of(BY_DATA_SPEC.specId(), Row.of("bbb")));
+    assertThat(map.get(BY_DATA_SPEC.specId(), Row.of("bbb"))).isEqualTo("v2");
+  }
+
+  @Test
+  public void putAll() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+
+    Map<Pair<Integer, StructLike>, String> otherMap = Maps.newHashMap();
+    otherMap.put(Pair.of(BY_DATA_SPEC.specId(), Row.of("aaa")), "v1");
+    otherMap.put(Pair.of(BY_DATA_SPEC.specId(), Row.of("bbb")), "v2");
+    map.putAll(otherMap);
+
+    assertThat(map)
+        .containsEntry(Pair.of(BY_DATA_SPEC.specId(), Row.of("aaa")), "v1")
+        .containsEntry(Pair.of(BY_DATA_SPEC.specId(), Row.of("bbb")), "v2");
+  }
+
+  @Test
+  public void testClear() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+    map.put(UNPARTITIONED_SPEC.specId(), null, "v1");
+    map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v2");
+    assertThat(map).hasSize(2);
+    map.clear();
+    assertThat(map).isEmpty();
+  }
+
+  @Test
+  public void testValues() {
+    PartitionMap<Integer> map = PartitionMap.create(SPECS);
+    map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), 1);
+    map.put(BY_DATA_CATEGORY_BUCKET_SPEC.specId(), Row.of("aaa", 2), 2);
+    map.put(BY_DATA_SPEC.specId(), Row.of("bbb"), 3);
+    assertThat(map.values()).containsAll(ImmutableList.of(1, 2, 3));
+  }
+
+  @Test
+  public void testEntrySet() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+    map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
+    map.put(BY_DATA_CATEGORY_BUCKET_SPEC.specId(), Row.of("bbb", 2), "v2");
+    map.put(BY_DATA_SPEC.specId(), CustomRow.of("ccc"), "v3");
+    assertThat(map.entrySet()).hasSize(3);
+  }
+
+  @Test
+  public void testKeySet() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+    map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
+    map.put(BY_DATA_SPEC.specId(), CustomRow.of("ccc"), "v2");
+    assertThat(map.get(BY_DATA_SPEC.specId(), CustomRow.of("aaa"))).isEqualTo("v1");
+    assertThat(map.get(BY_DATA_SPEC.specId(), Row.of("ccc"))).isEqualTo("v2");
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    PartitionMap<String> map1 = PartitionMap.create(SPECS);
+    PartitionMap<String> map2 = PartitionMap.create(SPECS);
+
+    assertThat(map1).isEqualTo(map2);
+    assertThat(map1.hashCode()).isEqualTo(map2.hashCode());
+
+    map1.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
+    map1.put(BY_DATA_SPEC.specId(), Row.of("bbb"), "v2");
+
+    map2.put(BY_DATA_SPEC.specId(), CustomRow.of("aaa"), "v1");
+    map2.put(BY_DATA_SPEC.specId(), CustomRow.of("bbb"), "v2");
+
+    assertThat(map1).isEqualTo(map2);
+    assertThat(map1.hashCode()).isEqualTo(map2.hashCode());
+  }
+
+  @Test
+  public void testToString() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+
+    // empty map
+    assertThat(map.toString()).isEqualTo("{}");
+
+    // single entry
+    map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
+    assertThat(map.toString()).isEqualTo("{data=aaa -> v1}");
+
+    // multiple entries
+    map.put(BY_DATA_SPEC.specId(), CustomRow.of("bbb"), "v2");
+    map.put(BY_DATA_CATEGORY_BUCKET_SPEC.specId(), Row.of("ccc", 2), "v3");
+    assertThat(map.toString())
+        .contains("data=aaa -> v1")
+        .contains("data=bbb -> v2")
+        .contains("data=ccc/category_bucket=2 -> v3");
+  }
+
+  @Test
+  public void testConcurrentReadAccess() throws InterruptedException {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+    map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
+    map.put(BY_DATA_SPEC.specId(), Row.of("bbb"), "v2");
+    map.put(UNPARTITIONED_SPEC.specId(), null, "v3");
+    map.put(BY_DATA_SPEC.specId(), CustomRow.of("ccc"), "v4");
+
+    int numThreads = 10;
+    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+
+    // read the map from multiple threads to ensure thread-local wrappers are used
+    for (int i = 0; i < numThreads; i++) {
+      executorService.submit(
+          () -> {
+            assertThat(map.get(BY_DATA_SPEC.specId(), Row.of("aaa"))).isEqualTo("v1");
+            assertThat(map.get(BY_DATA_SPEC.specId(), Row.of("bbb"))).isEqualTo("v2");
+            assertThat(map.get(UNPARTITIONED_SPEC.specId(), null)).isEqualTo("v3");
+            assertThat(map.get(BY_DATA_SPEC.specId(), Row.of("ccc"))).isEqualTo("v4");
+          });
+    }
+
+    executorService.shutdown();
+    assertThat(executorService.awaitTermination(1, TimeUnit.MINUTES)).isTrue();
+  }
+
+  @Test
+  public void testNullKey() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+    assertThatThrownBy(() -> map.put(null, "value")).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> map.get(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> map.remove(null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void testUnknownSpecId() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+    assertThatThrownBy(() -> map.put(Integer.MAX_VALUE, null, "value"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Cannot find spec with ID");
+  }
+
+  @Test
+  public void testUnmodifiableViews() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+    map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
+    map.put(BY_DATA_SPEC.specId(), Row.of("bbb"), "v2");
+
+    assertThatThrownBy(() -> map.keySet().add(Pair.of(1, null)))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.values().add("other"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.entrySet().add(null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.entrySet().iterator().next().setValue("other"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.entrySet().iterator().remove())
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void testKeyAndEntrySetEquality() {
+    PartitionMap<String> map1 = PartitionMap.create(SPECS);
+    PartitionMap<String> map2 = PartitionMap.create(SPECS);
+
+    assertThat(map1.keySet()).isEqualTo(map2.keySet());
+    assertThat(map1.entrySet()).isEqualTo(map2.entrySet());
+
+    map1.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
+    map1.put(BY_DATA_SPEC.specId(), Row.of("bbb"), "v2");
+
+    map2.put(BY_DATA_SPEC.specId(), CustomRow.of("aaa"), "v1");
+    map2.put(BY_DATA_SPEC.specId(), CustomRow.of("bbb"), "v2");
+
+    assertThat(map1.keySet()).isEqualTo(map2.keySet());
+    assertThat(map1.entrySet()).isEqualTo(map2.entrySet());
+  }
+
+  @Test
+  public void testLookupArbitraryKeyTypes() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+    map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
+    map.put(UNPARTITIONED_SPEC.specId(), null, "v2");
+    assertThat(map.containsKey("some-string")).isFalse();
+    assertThat(map.get("some-string")).isNull();
+    assertThat(map.remove("some-string")).isNull();
+  }
+}


### PR DESCRIPTION
This PR adds `PartitionMap`, a map that uses a pair of spec ID and partition tuple as keys. It is similar to `PartitionSet`.

The class will simplify places like `DeleteFileIndex` that uses the following code not related to the main logic.

```
private final Map<Integer, Types.StructType> partitionTypeById;
private final Map<Integer, ThreadLocal<StructLikeWrapper>> wrapperById;
private final Map<Pair<Integer, StructLikeWrapper>, DeleteFileGroup> deletesByPartition;

// use HashMap with precomputed values instead of thread-safe collections loaded on demand
// as the cache is being accessed for each data file and the lookup speed is critical
private Map<Integer, ThreadLocal<StructLikeWrapper>> wrappers(Map<Integer, PartitionSpec> specs) {
  Map<Integer, ThreadLocal<StructLikeWrapper>> wrappers = Maps.newHashMap();
  specs.forEach((specId, spec) -> wrappers.put(specId, newWrapper(specId)));
  return wrappers;
}

private ThreadLocal<StructLikeWrapper> newWrapper(int specId) {
  return ThreadLocal.withInitial(() -> StructLikeWrapper.forType(partitionTypeById.get(specId)));
}

private Pair<Integer, StructLikeWrapper> partition(int specId, StructLike struct) {
  ThreadLocal<StructLikeWrapper> wrapper = wrapperById.get(specId);
  return Pair.of(specId, wrapper.get().set(struct));
}
```