### PR TITLE
API, Core, Spark: Change behavior of fastForward/replace to create the from branch if it does not exist

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ManageSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ManageSnapshots.java
@@ -164,7 +164,8 @@ public interface ManageSnapshots extends PendingUpdate<Snapshot> {
 
   /**
    * Replaces the {@code from} branch to point to the {@code to} snapshot. The {@code to} will
-   * remain unchanged, and {@code from} branch will retain its retention properties.
+   * remain unchanged, and {@code from} branch will retain its retention properties. If the {@code
+   * from} branch does not exist, it will be created with default retention properties.
    *
    * @param from Branch to replace
    * @param to The branch {@code from} should be replaced with
@@ -175,7 +176,8 @@ public interface ManageSnapshots extends PendingUpdate<Snapshot> {
   /**
    * Performs a fast-forward of {@code from} up to the {@code to} snapshot if {@code from} is an
    * ancestor of {@code to}. The {@code to} will remain unchanged, and {@code from} will retain its
-   * retention properties.
+   * retention properties. If the {@code from} branch does not exist, it will be created with
+   * default retention properties.
    *
    * @param from Branch to fast-forward
    * @param to Ref for the {@code from} branch to be fast forwarded to

--- a/core/src/main/java/org/apache/iceberg/UpdateSnapshotReferencesOperation.java
+++ b/core/src/main/java/org/apache/iceberg/UpdateSnapshotReferencesOperation.java
@@ -120,9 +120,11 @@ class UpdateSnapshotReferencesOperation implements PendingUpdate<Map<String, Sna
     Preconditions.checkNotNull(to, "Destination ref cannot be null");
     SnapshotRef branchToUpdate = updatedRefs.get(from);
     SnapshotRef toRef = updatedRefs.get(to);
-    Preconditions.checkArgument(
-        branchToUpdate != null, "Branch to update does not exist: %s", from);
     Preconditions.checkArgument(toRef != null, "Ref does not exist: %s", to);
+    if (branchToUpdate == null) {
+      return createBranch(from, toRef.snapshotId());
+    }
+
     Preconditions.checkArgument(branchToUpdate.isBranch(), "Ref %s is a tag not a branch", from);
 
     // Nothing to replace

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
@@ -190,21 +190,8 @@ public class TestFastForwardBranchProcedure extends SparkExtensionsTestBase {
   }
 
   @Test
-  public void testFastForwardNonExistingBranchCases() {
+  public void testFastForwardNonExistingToRefFails() {
     sql("CREATE TABLE %s (id int NOT NULL, data string) USING iceberg", tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-    table.refresh();
-
-    assertThatThrownBy(
-            () ->
-                sql(
-                    "CALL %s.system.fast_forward(table => '%s', branch => '%s', to => '%s')",
-                    catalogName, tableIdent, "non_existing_branch", SnapshotRef.MAIN_BRANCH))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Branch to fast-forward does not exist: non_existing_branch");
-
-    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
     assertThatThrownBy(
             () ->
                 sql(
@@ -237,14 +224,37 @@ public class TestFastForwardBranchProcedure extends SparkExtensionsTestBase {
     sql("INSERT INTO TABLE %s VALUES (3, 'c')", tableNameWithBranch2);
     table.refresh();
     Snapshot branch2Snapshot = table.snapshot(branch2);
+    assertThat(
+            sql(
+                "CALL %s.system.fast_forward('%s', '%s', '%s')",
+                catalogName, tableIdent, branch1, branch2))
+        .containsExactly(row(branch1, branch1Snapshot.snapshotId(), branch2Snapshot.snapshotId()));
+  }
 
-    List<Object[]> output =
-        sql(
-            "CALL %s.system.fast_forward('%s', '%s', '%s')",
-            catalogName, tableIdent, branch1, branch2);
-    List<Object> outputRow = Arrays.stream(output.get(0)).collect(Collectors.toList());
-    assertThat(outputRow.get(0)).isEqualTo(branch1);
-    assertThat(outputRow.get(1)).isEqualTo(branch1Snapshot.snapshotId());
-    assertThat(outputRow.get(2)).isEqualTo(branch2Snapshot.snapshotId());
+  @Test
+  public void testFastForwardNonExistingFromMainCreatesBranch() {
+    sql("CREATE TABLE %s (id int NOT NULL, data string) USING iceberg", tableName);
+    String branch1 = "branch1";
+    sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branch1);
+    String branchIdentifier = String.format("%s.branch_%s", tableName, branch1);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", branchIdentifier);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", branchIdentifier);
+    Table table = validationCatalog.loadTable(tableIdent);
+    table.refresh();
+    Snapshot branch1Snapshot = table.snapshot(branch1);
+
+    assertThat(
+            sql(
+                "CALL %s.system.fast_forward('%s', '%s', '%s')",
+                catalogName, tableIdent, SnapshotRef.MAIN_BRANCH, branch1))
+        .containsExactly(row(SnapshotRef.MAIN_BRANCH, null, branch1Snapshot.snapshotId()));
+
+    // Ensure the same behavior for non-main branches
+    String branch2 = "branch2";
+    assertThat(
+            sql(
+                "CALL %s.system.fast_forward('%s', '%s', '%s')",
+                catalogName, tableIdent, branch2, branch1))
+        .containsExactly(row(branch2, null, branch1Snapshot.snapshotId()));
   }
 }


### PR DESCRIPTION
Fixes #8849 

This change adds a `fastForwardOrCreate` API which will perform a fast forward of the `from` branch if it exists; otherwise `from` will be created and pointing towards what `to` references.

This change also integrates the API with the Spark fast forward procedure by default. Technically this is a behavior change but I think it is arguable that the  previous behavior was  a bug/incorrect behavior so we should change that.

Alternatives to this include:

1.) no new API, do a try/catch of fast forward and in case it fails attempt to do a creation. I think the issue there beyond being a little messy is that it forces clients/integrations to have to do that everywhere. 

2.) No new API, Change the `fastForward` API behavior to do a creation by default. I can see the merit because ultimately I think it would be quite common for users to frequently fast forward a branch which does not exist before. But I ultimately don't want to set a precedent on API behavior changes. 

I concluded on a new API because at this point, users who would be using the fast forward API would've already had to create the branch anyways; a new API allows existing users to simplify their code, and new users to just use the new API. 