### PR TITLE
Spark: Don't allow branch_ usage with VERSION AS OF

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -171,7 +171,7 @@ public class SparkCatalog extends BaseCatalog {
       SparkTable sparkTable = (SparkTable) table;
 
       Preconditions.checkArgument(
-          sparkTable.snapshotId() == null,
+          sparkTable.snapshotId() == null && sparkTable.branch() == null,
           "Cannot do time-travel based on both table identifier and AS OF");
 
       try {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -173,6 +173,10 @@ public class SparkTable
     return snapshotId;
   }
 
+  public String branch() {
+    return branch;
+  }
+
   public SparkTable copyWithSnapshotId(long newSnapshotId) {
     return new SparkTable(icebergTable, newSnapshotId, refreshEagerly);
   }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -427,6 +427,21 @@ public class TestSelect extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testInvalidTimeTravelAgainstBranchIdentifierWithAsOf() {
+    long snapshotId = validationCatalog.loadTable(tableIdent).currentSnapshot().snapshotId();
+    validationCatalog.loadTable(tableIdent).manageSnapshots().createBranch("b1").commit();
+
+    // create a second snapshot
+    sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0)", tableName);
+
+    // using branch_b1 in the table identifier and VERSION AS OF
+    Assertions.assertThatThrownBy(
+            () -> sql("SELECT * FROM %s.branch_b1 VERSION AS OF %s", tableName, snapshotId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot do time-travel based on both table identifier and AS OF");
+  }
+
+  @Test
   public void testSpecifySnapshotAndTimestamp() {
     // get the snapshot ID of the last write
     long snapshotId = validationCatalog.loadTable(tableIdent).currentSnapshot().snapshotId();

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -170,7 +170,7 @@ public class SparkCatalog extends BaseCatalog {
       SparkTable sparkTable = (SparkTable) table;
 
       Preconditions.checkArgument(
-          sparkTable.snapshotId() == null,
+          sparkTable.snapshotId() == null && sparkTable.branch() == null,
           "Cannot do time-travel based on both table identifier and AS OF");
 
       try {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -173,6 +173,10 @@ public class SparkTable
     return snapshotId;
   }
 
+  public String branch() {
+    return branch;
+  }
+
   public SparkTable copyWithSnapshotId(long newSnapshotId) {
     return new SparkTable(icebergTable, newSnapshotId, refreshEagerly);
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -170,7 +170,7 @@ public class SparkCatalog extends BaseCatalog {
       SparkTable sparkTable = (SparkTable) table;
 
       Preconditions.checkArgument(
-          sparkTable.snapshotId() == null,
+          sparkTable.snapshotId() == null && sparkTable.branch() == null,
           "Cannot do time-travel based on both table identifier and AS OF");
 
       try {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -173,6 +173,10 @@ public class SparkTable
     return snapshotId;
   }
 
+  public String branch() {
+    return branch;
+  }
+
   public SparkTable copyWithSnapshotId(long newSnapshotId) {
     return new SparkTable(icebergTable, newSnapshotId, refreshEagerly);
   }


### PR DESCRIPTION
In the context of https://github.com/apache/iceberg/pull/9131 we talked in the Iceberg sync about making sure that queries like `SELECT * from ns.table.branch_x VERSION AS OF ...` shouldn't be supported and should throw an error