### PR TITLE
Core: Fix logic in BaseTransaction for determining set of committed files when there are no new snapshots

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.metrics.LoggingMetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
@@ -446,16 +447,20 @@ public class BaseTransaction implements Transaction {
       }
 
       Set<String> committedFiles = committedFiles(ops, newSnapshots);
-      // delete all of the files that were deleted in the most recent set of operation commits
-      Tasks.foreach(deletedFiles)
-          .suppressFailureWhenFinished()
-          .onFailure((file, exc) -> LOG.warn("Failed to delete uncommitted file: {}", file, exc))
-          .run(
-              path -> {
-                if (committedFiles == null || !committedFiles.contains(path)) {
-                  ops.io().deleteFile(path);
-                }
-              });
+      if (committedFiles != null) {
+        // delete all of the files that were deleted in the most recent set of operation commits
+        Tasks.foreach(deletedFiles)
+            .suppressFailureWhenFinished()
+            .onFailure((file, exc) -> LOG.warn("Failed to delete uncommitted file: {}", file, exc))
+            .run(
+                path -> {
+                  if (!committedFiles.contains(path)) {
+                    ops.io().deleteFile(path);
+                  }
+                });
+      } else {
+        LOG.warn("Failed to load metadata for a committed snapshot, skipping clean-up");
+      }
 
     } catch (RuntimeException e) {
       LOG.warn("Failed to load committed metadata, skipping clean-up", e);
@@ -502,9 +507,11 @@ public class BaseTransaction implements Transaction {
     }
   }
 
+  // committedFiles returns null whenever the set of committed files
+  // cannot be determined from the provided snapshots
   private static Set<String> committedFiles(TableOperations ops, Set<Long> snapshotIds) {
     if (snapshotIds.isEmpty()) {
-      return null;
+      return ImmutableSet.of();
     }
 
     Set<String> committedFiles = Sets.newHashSet();


### PR DESCRIPTION
This is a follow up to https://github.com/apache/iceberg/pull/9183. Null gets returned from `committedFiles` in 2 cases:

1.)  The snapshot ID list is empty (e.g. ExpireSnapshots in a transaction). This snapshot ID is the set of snapshots produced as a result of the transaction

2.).The set of committed files could not exactly be determined (e.g. missing any snapshot metadata).

In the first case, the logic should perform file deletion in case there were no new snapshots (e.g. ExpireSnapshots) which #9183 pointed out and addressed.

In the second case, we do want to signal to callers that it's a unique situation and file deletions should not be performed.

What this change does is return an empty set in case 1 and null in case 2 to prevent deleting files when we could not determine the full set of committed files.