### PR TITLE
Fixed certain operations failing to add new data files during retries

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -188,7 +188,7 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
         }
       }
 
-      this.newManifests = committedNewManifests;
+      this.newManifests = null;
     }
 
     // clean up only rewrittenAppendManifests as they are always owned by the table

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -895,7 +895,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         }
       }
 
-      this.cachedNewDataManifests = committedNewDataManifests;
+      this.cachedNewDataManifests = null;
     }
 
     ListIterator<ManifestFile> deleteManifestsIterator = cachedNewDeleteManifests.listIterator();


### PR DESCRIPTION
Since the following PR: https://github.com/apache/iceberg/pull/6335 FastAppend and subclasses of MergingSnapshotProducer will skip newly added data files during retries. 

This happens because the cached value is set to an empty list instead of null and then during retry when `newDataFilesAsManifests` is called the logic is skipped and no data files are returned. 

I think it's important to have unit tests that cover retries to avoid this bug recurring in the future, however, this PR only focuses on fixing the present issue since it appears to be a critical data loss issue. 