### PR TITLE
Spark: Use Awaitility instead of Thread.sleep

### DIFF
--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -160,6 +160,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
     testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
 
     testImplementation libs.avro.avro
+    testImplementation libs.awaitility
     testImplementation libs.parquet.hadoop
 
     // Required because we remove antlr plugin dependencies from the compile configuration, see note above

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -92,9 +92,13 @@ public class TestCopyOnWriteDelete extends TestDelete {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", tableName);
 
@@ -111,9 +115,14 @@ public class TestCopyOnWriteDelete extends TestDelete {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -123,8 +123,8 @@ public class TestCopyOnWriteDelete extends TestDelete {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -41,6 +43,7 @@ import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecut
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.spark.sql.Encoders;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.MERGE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -41,6 +43,7 @@ import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecut
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.spark.sql.Encoders;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -128,8 +128,8 @@ public class TestCopyOnWriteMerge extends TestMerge {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -89,9 +89,13 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("UPDATE %s SET id = -1 WHERE id = 1", tableName);
 
@@ -108,9 +112,14 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -39,6 +41,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.spark.Spark3Util;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -120,8 +120,8 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -25,7 +25,9 @@ import static org.apache.iceberg.TableProperties.DELETE_MODE_DEFAULT;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -66,6 +68,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.v2.OptimizeMetadataOnlyDeleteFromTable;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -852,8 +852,8 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {
@@ -945,8 +945,8 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -818,9 +818,13 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", tableName);
 
@@ -840,9 +844,14 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;
@@ -902,9 +911,13 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", tableName);
 
@@ -924,9 +937,14 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -1006,9 +1006,13 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql(
                     "MERGE INTO %s t USING source s "
@@ -1033,9 +1037,14 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;
@@ -1095,9 +1104,13 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql(
                     "MERGE INTO %s t USING source s "
@@ -1122,9 +1135,14 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -23,7 +23,9 @@ import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -56,6 +58,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -1045,8 +1045,8 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {
@@ -1143,8 +1143,8 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -29,7 +29,9 @@ import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.UPDATE_MODE;
 import static org.apache.iceberg.TableProperties.UPDATE_MODE_DEFAULT;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +66,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -455,9 +455,13 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("UPDATE %s SET id = -1 WHERE id = 1", tableName);
 
@@ -477,9 +481,14 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;
@@ -538,9 +547,13 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("UPDATE %s SET id = -1 WHERE id = 1", tableName);
 
@@ -560,9 +573,14 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -489,8 +489,8 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {
@@ -581,8 +581,8 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -809,7 +809,6 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .collect(Collectors.toList());
     Assert.assertEquals("Should be 1 invalid file", 1, invalidFiles.size());
 
-    // sleep for 1 second to ensure files will be old enough
     waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -163,6 +163,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
     testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
 
     testImplementation libs.avro.avro
+    testImplementation libs.awaitility
     testImplementation libs.parquet.hadoop
 
     // Required because we remove antlr plugin dependencies from the compile configuration, see note above

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -132,8 +132,8 @@ public class TestCopyOnWriteDelete extends TestDelete {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -101,9 +101,13 @@ public class TestCopyOnWriteDelete extends TestDelete {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", commitTarget());
 
@@ -120,9 +124,14 @@ public class TestCopyOnWriteDelete extends TestDelete {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -48,6 +50,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -135,8 +135,8 @@ public class TestCopyOnWriteMerge extends TestMerge {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -99,9 +99,13 @@ public class TestCopyOnWriteMerge extends TestMerge {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql(
                     "MERGE INTO %s t USING source s "
@@ -123,9 +127,14 @@ public class TestCopyOnWriteMerge extends TestMerge {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.MERGE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -46,6 +48,7 @@ import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -128,8 +128,8 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -45,6 +47,7 @@ import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -868,9 +868,13 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", commitTarget());
 
@@ -890,9 +894,14 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;
@@ -958,9 +967,13 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", commitTarget());
 
@@ -980,9 +993,14 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -25,8 +25,10 @@ import static org.apache.iceberg.TableProperties.DELETE_MODE_DEFAULT;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -72,6 +74,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.v2.OptimizeMetadataOnlyDeleteFromIcebergTable;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -902,8 +902,8 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {
@@ -1001,8 +1001,8 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -1166,8 +1166,8 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {
@@ -1269,8 +1269,8 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -1127,9 +1127,13 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql(
                     "MERGE INTO %s t USING source s "
@@ -1154,9 +1158,14 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;
@@ -1221,9 +1230,13 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql(
                     "MERGE INTO %s t USING source s "
@@ -1248,9 +1261,14 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -26,7 +26,9 @@ import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -65,6 +67,7 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -482,9 +482,13 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("UPDATE %s SET id = -1 WHERE id = 1", commitTarget());
 
@@ -504,9 +508,14 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;
@@ -571,9 +580,13 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("UPDATE %s SET id = -1 WHERE id = 1", tableName);
 
@@ -593,9 +606,14 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -29,7 +29,9 @@ import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.UPDATE_MODE;
 import static org.apache.iceberg.TableProperties.UPDATE_MODE_DEFAULT;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +69,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -516,8 +516,8 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {
@@ -614,8 +614,8 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -810,7 +810,6 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .collect(Collectors.toList());
     Assert.assertEquals("Should be 1 invalid file", 1, invalidFiles.size());
 
-    // sleep for 1 second to ensure files will be old enough
     waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();

--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -162,6 +162,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
     testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
 
     testImplementation libs.avro.avro
+    testImplementation libs.awaitility
     testImplementation libs.parquet.hadoop
 
     // Required because we remove antlr plugin dependencies from the compile configuration, see note above

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -49,6 +51,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -144,8 +144,8 @@ public class TestCopyOnWriteDelete extends TestDelete {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -111,9 +111,13 @@ public class TestCopyOnWriteMerge extends TestMerge {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql(
                     "MERGE INTO %s t USING source s "
@@ -135,9 +139,14 @@ public class TestCopyOnWriteMerge extends TestMerge {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.MERGE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -47,6 +49,7 @@ import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -147,8 +147,8 @@ public class TestCopyOnWriteMerge extends TestMerge {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -109,9 +109,13 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("UPDATE %s SET id = -1 WHERE id = 1", commitTarget());
 
@@ -128,9 +132,14 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -140,8 +140,8 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -46,6 +48,7 @@ import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -27,8 +27,10 @@ import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.SPLIT_OPEN_FILE_COST;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -77,6 +79,7 @@ import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.execution.datasources.v2.OptimizeMetadataOnlyDeleteFromTable;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -1038,9 +1038,13 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", commitTarget());
 
@@ -1060,9 +1064,14 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;
@@ -1129,9 +1138,13 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", commitTarget());
 
@@ -1151,9 +1164,14 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -1072,8 +1072,8 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {
@@ -1172,8 +1172,8 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -28,8 +28,10 @@ import static org.apache.iceberg.TableProperties.SPLIT_OPEN_FILE_COST;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -68,6 +70,7 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -1364,9 +1364,13 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql(
                     "MERGE INTO %s t USING source s "
@@ -1391,9 +1395,14 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;
@@ -1459,9 +1468,13 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql(
                     "MERGE INTO %s t USING source s "
@@ -1486,9 +1499,14 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -1403,8 +1403,8 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {
@@ -1507,8 +1507,8 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -681,8 +681,8 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {
@@ -780,8 +780,8 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -647,9 +647,13 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("UPDATE %s SET id = -1 WHERE id = 1", commitTarget());
 
@@ -669,9 +673,14 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;
@@ -737,9 +746,13 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("UPDATE %s SET id = -1 WHERE id = 1", tableName);
 
@@ -759,9 +772,14 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -31,8 +31,10 @@ import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.UPDATE_MODE;
 import static org.apache.iceberg.TableProperties.UPDATE_MODE_DEFAULT;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +73,7 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -804,7 +804,6 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .collect(Collectors.toList());
     Assert.assertEquals("Should be 1 invalid file", 1, invalidFiles.size());
 
-    // sleep for 1 second to ensure files will be old enough
     waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -162,6 +162,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
     testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
 
     testImplementation libs.avro.avro
+    testImplementation libs.awaitility
     testImplementation libs.parquet.hadoop
 
     // Required because we remove antlr plugin dependencies from the compile configuration, see note above

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -144,8 +144,8 @@ public class TestCopyOnWriteDelete extends TestDelete {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -49,6 +51,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -113,9 +116,10 @@ public class TestCopyOnWriteDelete extends TestDelete {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await().pollInterval(Duration.ofMillis(10))
+                        .untilAsserted(() -> assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2));
+
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", commitTarget());
 
@@ -132,9 +136,15 @@ public class TestCopyOnWriteDelete extends TestDelete {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .atMost(Duration.ofSeconds(20))
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -117,9 +117,12 @@ public class TestCopyOnWriteDelete extends TestDelete {
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
                 final int finalNumOperations = numOperations;
-                Awaitility.await().pollInterval(Duration.ofMillis(10))
-                        .untilAsserted(() -> assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2));
-
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", commitTarget());
 
@@ -138,7 +141,6 @@ public class TestCopyOnWriteDelete extends TestDelete {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
                 final int finalNumOperations = numOperations;
                 Awaitility.await()
-                    .atMost(Duration.ofSeconds(20))
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -147,8 +147,8 @@ public class TestCopyOnWriteMerge extends TestMerge {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -140,8 +140,8 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -46,6 +48,7 @@ import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -109,9 +112,13 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () ->
+                            assertThat(barrier.get())
+                                .isGreaterThanOrEqualTo(finalNumOperations * 2));
 
                 sql("UPDATE %s SET id = -1 WHERE id = 1", commitTarget());
 
@@ -128,9 +135,14 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                final int finalNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(Duration.ofMillis(10))
+                    .untilAsserted(
+                        () -> {
+                          assertThat(shouldAppend.get()).isFalse();
+                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                        });
 
                 if (!shouldAppend.get()) {
                   return;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -1086,8 +1086,8 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {
@@ -1186,8 +1186,8 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -1520,8 +1520,8 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {
@@ -1624,8 +1624,8 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -670,8 +670,8 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 sql("UPDATE %s SET id = -1 WHERE id = 1", commitTarget());
@@ -794,8 +794,8 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                     .pollInterval(Duration.ofMillis(10))
                     .untilAsserted(
                         () -> {
-                          assertThat(shouldAppend.get()).isFalse();
-                          assertThat(barrier.get()).isGreaterThanOrEqualTo(finalNumOperations * 2);
+                          assertThat(
+                              !shouldAppend.get() || barrier.get() >= finalNumOperations * 2);
                         });
 
                 if (!shouldAppend.get()) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -804,7 +804,6 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .collect(Collectors.toList());
     Assert.assertEquals("Should be 1 invalid file", 1, invalidFiles.size());
 
-    // sleep for 1 second to ensure files will be old enough
     waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();


### PR DESCRIPTION
From the comment, https://github.com/apache/iceberg/issues/7154#issuecomment-1785003366
There're some places can be replaced with Awaitlity.
Here I only change TestCopyOnWriteDelete.java, because I don't know whether I'm in the correct path.
After reviewing, I can inspect other places.
Part of #7154 
:)