### PR TITLE
Core: Properly suppress historical snapshots when building TableMetadata with suppressHistoricalSnapshots()

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -886,6 +886,7 @@ public class TableMetadata implements Serializable {
     private final Map<String, SnapshotRef> refs;
     private final Map<Long, List<StatisticsFile>> statisticsFiles;
     private final Map<Long, List<PartitionStatisticsFile>> partitionStatisticsFiles;
+    private boolean suppressHistoricalSnapshots = false;
 
     // change tracking
     private final List<MetadataUpdate> changes;
@@ -1288,6 +1289,7 @@ public class TableMetadata implements Serializable {
      * @return this for method chaining
      */
     public Builder suppressHistoricalSnapshots() {
+      this.suppressHistoricalSnapshots = true;
       Set<Long> refSnapshotIds =
           refs.values().stream().map(SnapshotRef::snapshotId).collect(Collectors.toSet());
       Set<Long> suppressedSnapshotIds = Sets.difference(snapshotsById.keySet(), refSnapshotIds);
@@ -1408,7 +1410,9 @@ public class TableMetadata implements Serializable {
     private boolean hasChanges() {
       return changes.size() != startingChangeCount
           || (discardChanges && !changes.isEmpty())
-          || metadataLocation != null;
+          || metadataLocation != null
+          || suppressHistoricalSnapshots
+          || null != snapshotsSupplier;
     }
 
     public TableMetadata build() {

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -814,7 +814,6 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
           LoadTableResponse originalResponse = (LoadTableResponse) invocation.callRealMethod();
           TableMetadata refsMetadata =
               TableMetadata.buildFrom(originalResponse.tableMetadata())
-                  .withMetadataLocation(originalResponse.metadataLocation())
                   .suppressHistoricalSnapshots()
                   .build();
 
@@ -941,7 +940,6 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
           LoadTableResponse originalResponse = (LoadTableResponse) invocation.callRealMethod();
           TableMetadata refsMetadata =
               TableMetadata.buildFrom(originalResponse.tableMetadata())
-                  .withMetadataLocation(originalResponse.metadataLocation())
                   .suppressHistoricalSnapshots()
                   .build();
 
@@ -1059,7 +1057,6 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
           LoadTableResponse originalResponse = (LoadTableResponse) invocation.callRealMethod();
           TableMetadata refsMetadata =
               TableMetadata.buildFrom(originalResponse.tableMetadata())
-                  .withMetadataLocation(originalResponse.metadataLocation())
                   .suppressHistoricalSnapshots()
                   .build();
 


### PR DESCRIPTION
While using
```
TableMetadata.buildFrom(originalResponse.tableMetadata())
    .suppressHistoricalSnapshots()
```
already suppresses historical snapshots correctly, we still end up with all snapshots when calling `build()`.
This is because `build()` exists early when there are no changes in https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/TableMetadata.java#L1391-L1393:

```
if (!hasChanges()) {
    return base;
}
```

This then causes to return all snapshots from `base` metadata.