### PR TITLE
Rest Catalog: Add RESTful data operations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -19,9 +19,11 @@
 package org.apache.iceberg;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.view.ViewMetadata;
 import org.apache.iceberg.view.ViewVersion;
@@ -450,6 +452,120 @@ public interface MetadataUpdate extends Serializable {
     @Override
     public void applyTo(ViewMetadata.Builder viewMetadataBuilder) {
       viewMetadataBuilder.setCurrentVersionId(versionId);
+    }
+  }
+
+  class AppendFilesUpdate implements MetadataUpdate {
+    private final List<String> addedManifests;
+
+    public AppendFilesUpdate(List<String> addedManifests) {
+      this.addedManifests = addedManifests;
+    }
+
+    public List<String> getAddedManifests() {
+      return addedManifests;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder tableMetadataBuilder) {
+      tableMetadataBuilder.appendFiles(addedManifests);
+    }
+  }
+
+  class DeleteFilesUpdate implements MetadataUpdate {
+    private List<String> deletedManifests;
+    private Expression deleteExpression;
+    private boolean caseSensitive;
+
+    public DeleteFilesUpdate() {}
+
+    public void setDeletedManifests(List<String> deletedManifests) {
+      this.deletedManifests = deletedManifests;
+    }
+
+    public List<String> getDeletedManifests() {
+      return deletedManifests;
+    }
+
+    public void setDeleteExpression(Expression expression) {
+      this.deleteExpression = expression;
+    }
+
+    public Expression getDeleteExpression() {
+      return deleteExpression;
+    }
+
+    public void setCaseSensitive(boolean caseSensitive) {
+      this.caseSensitive = caseSensitive;
+    }
+
+    public boolean isCaseSensitive() {
+      return caseSensitive;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder tableMetadataBuilder) {
+      tableMetadataBuilder.deleteFiles(deletedManifests, deleteExpression, caseSensitive);
+    }
+  }
+
+  class OverwriteFilesUpdate implements MetadataUpdate {
+    private List<String> addedManifests;
+    private List<String> deletedManifests;
+    private Expression overwriteByRowFilterExpression;
+    private Expression conflictExpression;
+    private boolean caseSensitive;
+
+    public OverwriteFilesUpdate() {}
+
+    public void setAddedManifests(List<String> addedManifests) {
+      this.addedManifests = addedManifests;
+    }
+
+    public List<String> getAddedManifests() {
+      return addedManifests;
+    }
+
+    public void setDeletedManifests(List<String> deletedManifests) {
+      this.deletedManifests = deletedManifests;
+    }
+
+    public List<String> getDeletedManifests() {
+      return deletedManifests;
+    }
+
+    public void setOverwriteByRowFilterExpression(Expression overwriteByRowFilterExpression) {
+      this.overwriteByRowFilterExpression = overwriteByRowFilterExpression;
+    }
+
+    public Expression getOverwriteByRowFilterExpression() {
+      return overwriteByRowFilterExpression;
+    }
+
+    public void setConflictExpression(Expression conflictExpression) {
+      this.conflictExpression = conflictExpression;
+    }
+
+    public Expression getConflictExpression() {
+      return conflictExpression;
+    }
+
+    public void setCaseSensitive(boolean caseSensitive) {
+      this.caseSensitive = caseSensitive;
+    }
+
+    public boolean isCaseSensitive() {
+      return caseSensitive;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder tableMetadataBuilder) {
+      tableMetadataBuilder.overwriteFiles(
+          addedManifests,
+          deletedManifests,
+          overwriteByRowFilterExpression,
+          conflictExpression,
+          caseSensitive);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -30,6 +30,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -1742,6 +1743,37 @@ public class TableMetadata implements Serializable {
 
     private <U extends MetadataUpdate> Stream<U> changes(Class<U> updateClass) {
       return changes.stream().filter(updateClass::isInstance).map(updateClass::cast);
+    }
+
+    public Builder appendFiles(List<String> files) {
+      changes.add(new MetadataUpdate.AppendFilesUpdate(files));
+      return this;
+    }
+
+    public Builder deleteFiles(
+        List<String> manifests, Expression deleteExpression, boolean caseSensitive) {
+      MetadataUpdate.DeleteFilesUpdate update = new MetadataUpdate.DeleteFilesUpdate();
+      update.setDeletedManifests(manifests);
+      update.setDeleteExpression(deleteExpression);
+      update.setCaseSensitive(caseSensitive);
+      changes.add(update);
+      return this;
+    }
+
+    public Builder overwriteFiles(
+        List<String> addedManifests,
+        List<String> deletedManifests,
+        Expression overwriteByRowFilterExpression,
+        Expression conflictExpression,
+        boolean caseSensitive) {
+      MetadataUpdate.OverwriteFilesUpdate update = new MetadataUpdate.OverwriteFilesUpdate();
+      update.setAddedManifests(addedManifests);
+      update.setDeletedManifests(deletedManifests);
+      update.setOverwriteByRowFilterExpression(overwriteByRowFilterExpression);
+      update.setConflictExpression(conflictExpression);
+      update.setCaseSensitive(caseSensitive);
+      changes.add(update);
+      return this;
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTable.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTable.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DeleteFiles;
+import org.apache.iceberg.OverwriteFiles;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.rest.operations.RestAppendFiles;
+import org.apache.iceberg.rest.operations.RestDeleteFiles;
+import org.apache.iceberg.rest.operations.RestOverwriteFiles;
+
+public class RESTTable extends BaseTable {
+  private final RESTClient client;
+  private final String path;
+  private final Supplier<Map<String, String>> headers;
+  private final boolean dataCommitViaRestEnabled;
+
+  public RESTTable(
+      TableOperations ops,
+      String name,
+      MetricsReporter reporter,
+      RESTClient client,
+      String path,
+      Supplier<Map<String, String>> headers,
+      boolean dataCommitViaRestEnabled) {
+    super(ops, name, reporter);
+    this.client = client;
+    this.headers = headers;
+    this.path = path;
+    this.dataCommitViaRestEnabled = dataCommitViaRestEnabled;
+  }
+
+  @Override
+  public AppendFiles newAppend() {
+    if (dataCommitViaRestEnabled) {
+      return new RestAppendFiles(client, path, headers, operations());
+    }
+    return super.newAppend();
+  }
+
+  @Override
+  public DeleteFiles newDelete() {
+    if (dataCommitViaRestEnabled) {
+      return new RestDeleteFiles(client, path, headers, operations());
+    }
+    return super.newDelete();
+  }
+
+  @Override
+  public OverwriteFiles newOverwrite() {
+    if (dataCommitViaRestEnabled) {
+      return new RestOverwriteFiles(client, path, headers, operations());
+    }
+    return super.newOverwrite();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/operations/RestAppendFiles.java
+++ b/core/src/main/java/org/apache/iceberg/rest/operations/RestAppendFiles.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.operations;
+
+import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES;
+import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFAULT;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RollingManifestWriter;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.UpdateRequirement;
+import org.apache.iceberg.UpdateRequirements;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.rest.ErrorHandlers;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+
+public class RestAppendFiles implements AppendFiles {
+  private final RESTClient client;
+  private final String path;
+  private final Supplier<Map<String, String>> headers;
+  private final TableOperations ops;
+  private final PartitionSpec spec;
+  private final long targetManifestSizeBytes;
+  private final String commitUUID = UUID.randomUUID().toString();
+  private final AtomicInteger manifestCount = new AtomicInteger(0);
+  private volatile Long snapshotId = null;
+  private final List<DataFile> newDataFiles = Lists.newArrayList();
+
+  public RestAppendFiles(
+      RESTClient client, String path, Supplier<Map<String, String>> headers, TableOperations ops) {
+    this.client = client;
+    this.path = path;
+    this.headers = headers;
+    this.ops = ops;
+    this.spec = ops.current().spec();
+    this.targetManifestSizeBytes =
+        ops.current()
+            .propertyAsLong(MANIFEST_TARGET_SIZE_BYTES, MANIFEST_TARGET_SIZE_BYTES_DEFAULT);
+  }
+
+  @Override
+  public void commit() {
+    MetadataUpdate.AppendFilesUpdate appendFilesUpdate = constructMetadataUpdate();
+    List<UpdateRequirement> requirements =
+        UpdateRequirements.forUpdateTable(ops.current(), ImmutableList.of(appendFilesUpdate));
+    UpdateTableRequest request =
+        new UpdateTableRequest(requirements, ImmutableList.of(appendFilesUpdate));
+    client.post(
+        path, request, LoadTableResponse.class, headers, ErrorHandlers.tableCommitHandler());
+  }
+
+  private MetadataUpdate.AppendFilesUpdate constructMetadataUpdate() {
+    List<String> addedManifests = constructManifests();
+    return new MetadataUpdate.AppendFilesUpdate(addedManifests);
+  }
+
+  @Override
+  public AppendFiles appendFile(DataFile file) {
+    newDataFiles.add(file);
+    return this;
+  }
+
+  @Override
+  public RestAppendFiles appendManifest(ManifestFile manifest) {
+    Preconditions.checkArgument(
+        !manifest.hasExistingFiles(), "Cannot append manifest with existing files");
+    Preconditions.checkArgument(
+        !manifest.hasDeletedFiles(), "Cannot append manifest with deleted files");
+    Preconditions.checkArgument(
+        manifest.snapshotId() == null || manifest.snapshotId() == -1,
+        "Snapshot id must be assigned during commit");
+    Preconditions.checkArgument(
+        manifest.sequenceNumber() == -1, "Sequence number must be assigned during commit");
+
+    // append data files from the manifest
+    ManifestReader<DataFile> reader = ManifestFiles.read(manifest, ops.io());
+    reader.forEach(this::appendFile);
+    return this;
+  }
+
+  private List<String> constructManifests() {
+    List<ManifestFile> manifests = Lists.newArrayList();
+    try {
+      RollingManifestWriter<DataFile> writer = newRollingManifestWriter();
+      try {
+        newDataFiles.forEach(writer::add);
+      } finally {
+        writer.close();
+      }
+      manifests.addAll(writer.toManifestFiles());
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to write manifest");
+    }
+    return manifests.stream().map(ManifestFile::path).collect(Collectors.toList());
+  }
+
+  protected RollingManifestWriter<DataFile> newRollingManifestWriter() {
+    return new RollingManifestWriter<>(this::newManifestWriter, targetManifestSizeBytes);
+  }
+
+  protected ManifestWriter<DataFile> newManifestWriter() {
+    return ManifestFiles.write(
+        ops.current().formatVersion(), spec, newManifestOutput(), snapshotId());
+  }
+
+  protected OutputFile newManifestOutput() {
+    return ops.io()
+        .newOutputFile(
+            ops.metadataFileLocation(
+                FileFormat.AVRO.addExtension(commitUUID + "-m" + manifestCount.getAndIncrement())));
+  }
+
+  protected long snapshotId() {
+    if (snapshotId == null) {
+      synchronized (this) {
+        while (snapshotId == null || ops.current().snapshot(snapshotId) != null) {
+          this.snapshotId = ops.newSnapshotId();
+        }
+      }
+    }
+    return snapshotId;
+  }
+
+  @Override
+  public AppendFiles set(String property, String value) {
+    return this;
+  }
+
+  @Override
+  public AppendFiles deleteWith(Consumer<String> deleteFunc) {
+    return null;
+  }
+
+  @Override
+  public AppendFiles stageOnly() {
+    return null;
+  }
+
+  @Override
+  public AppendFiles scanManifestsWith(ExecutorService executorService) {
+    return null;
+  }
+
+  @Override
+  public Snapshot apply() {
+    return null;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/operations/RestDeleteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/rest/operations/RestDeleteFiles.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.operations;
+
+import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES;
+import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFAULT;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RollingManifestWriter;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.UpdateRequirement;
+import org.apache.iceberg.UpdateRequirements;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.rest.ErrorHandlers;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+
+public class RestDeleteFiles implements DeleteFiles {
+  private final RESTClient client;
+  private final String path;
+  private final Supplier<Map<String, String>> headers;
+  private final TableOperations ops;
+  private final PartitionSpec spec;
+  private final long targetManifestSizeBytes;
+  private final String commitUUID = UUID.randomUUID().toString();
+  private final AtomicInteger manifestCount = new AtomicInteger(0);
+  private volatile Long snapshotId = null;
+  private Expression deleteExpression;
+  private List<DataFile> deletedDataFiles = Lists.newArrayList();
+  private boolean caseSensitive = true;
+
+  public RestDeleteFiles(
+      RESTClient client, String path, Supplier<Map<String, String>> headers, TableOperations ops) {
+    this.client = client;
+    this.path = path;
+    this.headers = headers;
+    this.ops = ops;
+    this.spec = ops.current().spec();
+    this.targetManifestSizeBytes =
+        ops.current()
+            .propertyAsLong(MANIFEST_TARGET_SIZE_BYTES, MANIFEST_TARGET_SIZE_BYTES_DEFAULT);
+  }
+
+  @Override
+  public void commit() {
+    MetadataUpdate deleteFilesUpdate = constructMetadataUpdate();
+    List<UpdateRequirement> requirements =
+        UpdateRequirements.forUpdateTable(ops.current(), ImmutableList.of(deleteFilesUpdate));
+    UpdateTableRequest request =
+        new UpdateTableRequest(requirements, ImmutableList.of(deleteFilesUpdate));
+    client.post(
+        path, request, LoadTableResponse.class, headers, ErrorHandlers.tableCommitHandler());
+  }
+
+  private MetadataUpdate constructMetadataUpdate() {
+    MetadataUpdate.DeleteFilesUpdate deleteFilesUpdate = new MetadataUpdate.DeleteFilesUpdate();
+    if (!deletedDataFiles.isEmpty()) {
+      List<String> manifestLocations = constructManifests();
+      deleteFilesUpdate.setDeletedManifests(manifestLocations);
+    } else {
+      deleteFilesUpdate.setDeleteExpression(deleteExpression);
+      deleteFilesUpdate.setCaseSensitive(caseSensitive);
+    }
+    return deleteFilesUpdate;
+  }
+
+  private List<String> constructManifests() {
+    List<ManifestFile> manifests = Lists.newArrayList();
+    try {
+      RollingManifestWriter<DataFile> writer = newRollingManifestWriter();
+      try {
+        deletedDataFiles.forEach(writer::add);
+      } finally {
+        writer.close();
+      }
+      manifests.addAll(writer.toManifestFiles());
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to write manifest");
+    }
+    return manifests.stream().map(ManifestFile::path).collect(Collectors.toList());
+  }
+
+  protected RollingManifestWriter<DataFile> newRollingManifestWriter() {
+    return new RollingManifestWriter<>(this::newManifestWriter, targetManifestSizeBytes);
+  }
+
+  protected ManifestWriter<DataFile> newManifestWriter() {
+    return ManifestFiles.write(
+        ops.current().formatVersion(), spec, newManifestOutput(), snapshotId());
+  }
+
+  protected OutputFile newManifestOutput() {
+    return ops.io()
+        .newOutputFile(
+            ops.metadataFileLocation(
+                FileFormat.AVRO.addExtension(commitUUID + "-m" + manifestCount.getAndIncrement())));
+  }
+
+  protected long snapshotId() {
+    if (snapshotId == null) {
+      synchronized (this) {
+        while (snapshotId == null || ops.current().snapshot(snapshotId) != null) {
+          this.snapshotId = ops.newSnapshotId();
+        }
+      }
+    }
+    return snapshotId;
+  }
+
+  @Override
+  public DeleteFiles deleteFile(CharSequence filePath) {
+    DataFile file = (DataFile) ops.io().newInputFile(filePath.toString());
+    deletedDataFiles.add(file);
+    return this;
+  }
+
+  @Override
+  public DeleteFiles deleteFile(DataFile file) {
+    deletedDataFiles.add(file);
+    return this;
+  }
+
+  @Override
+  public DeleteFiles deleteFromRowFilter(Expression expr) {
+    this.deleteExpression = expr;
+    return this;
+  }
+
+  @Override
+  public DeleteFiles caseSensitive(boolean isCaseSensitive) {
+    this.caseSensitive = isCaseSensitive;
+    return this;
+  }
+
+  @Override
+  public DeleteFiles set(String property, String value) {
+    return this;
+  }
+
+  @Override
+  public DeleteFiles deleteWith(Consumer<String> deleteFunc) {
+    return this;
+  }
+
+  @Override
+  public DeleteFiles stageOnly() {
+    return this;
+  }
+
+  @Override
+  public DeleteFiles scanManifestsWith(ExecutorService executorService) {
+    return this;
+  }
+
+  @Override
+  public Snapshot apply() {
+    return null;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/operations/RestOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/rest/operations/RestOverwriteFiles.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.operations;
+
+import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES;
+import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFAULT;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.OverwriteFiles;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RollingManifestWriter;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.UpdateRequirement;
+import org.apache.iceberg.UpdateRequirements;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.rest.ErrorHandlers;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+
+public class RestOverwriteFiles implements OverwriteFiles {
+  private final RESTClient client;
+  private final String path;
+  private final Supplier<Map<String, String>> headers;
+  private final TableOperations ops;
+  private final PartitionSpec spec;
+  private final long targetManifestSizeBytes;
+  private final String commitUUID = UUID.randomUUID().toString();
+  private final AtomicInteger manifestCount = new AtomicInteger(0);
+  private volatile Long snapshotId = null;
+  private Expression overwriteByRowFilterExpression;
+  private Expression conflictDetectionFilter;
+  private final List<DataFile> deletedDataFiles = Lists.newArrayList();
+  private final List<DataFile> newDataFiles = Lists.newArrayList();
+  private boolean caseSensitive = true;
+
+  public RestOverwriteFiles(
+      RESTClient client, String path, Supplier<Map<String, String>> headers, TableOperations ops) {
+    this.client = client;
+    this.path = path;
+    this.headers = headers;
+    this.ops = ops;
+    this.spec = ops.current().spec();
+    this.targetManifestSizeBytes =
+        ops.current()
+            .propertyAsLong(MANIFEST_TARGET_SIZE_BYTES, MANIFEST_TARGET_SIZE_BYTES_DEFAULT);
+  }
+
+  @Override
+  public void commit() {
+    MetadataUpdate.OverwriteFilesUpdate overwriteFilesUpdate = constructMetadataUpdate();
+    List<UpdateRequirement> requirements =
+        UpdateRequirements.forUpdateTable(ops.current(), ImmutableList.of(overwriteFilesUpdate));
+    UpdateTableRequest request =
+        new UpdateTableRequest(requirements, ImmutableList.of(overwriteFilesUpdate));
+    client.post(
+        path, request, LoadTableResponse.class, headers, ErrorHandlers.tableCommitHandler());
+  }
+
+  private MetadataUpdate.OverwriteFilesUpdate constructMetadataUpdate() {
+    MetadataUpdate.OverwriteFilesUpdate update = new MetadataUpdate.OverwriteFilesUpdate();
+    update.setAddedManifests(constructManifests(newDataFiles));
+    update.setDeletedManifests(constructManifests(deletedDataFiles));
+    update.setOverwriteByRowFilterExpression(overwriteByRowFilterExpression);
+    update.setConflictExpression(conflictDetectionFilter);
+    update.setCaseSensitive(caseSensitive);
+    return update;
+  }
+
+  private List<String> constructManifests(List<DataFile> files) {
+    List<ManifestFile> manifests = Lists.newArrayList();
+    try {
+      RollingManifestWriter<DataFile> writer = newRollingManifestWriter();
+      try {
+        files.forEach(writer::add);
+      } finally {
+        writer.close();
+      }
+      manifests.addAll(writer.toManifestFiles());
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to write manifest");
+    }
+    return manifests.stream().map(ManifestFile::path).collect(Collectors.toList());
+  }
+
+  protected RollingManifestWriter<DataFile> newRollingManifestWriter() {
+    return new RollingManifestWriter<>(this::newManifestWriter, targetManifestSizeBytes);
+  }
+
+  protected ManifestWriter<DataFile> newManifestWriter() {
+    return ManifestFiles.write(
+        ops.current().formatVersion(), spec, newManifestOutput(), snapshotId());
+  }
+
+  protected OutputFile newManifestOutput() {
+    return ops.io()
+        .newOutputFile(
+            ops.metadataFileLocation(
+                FileFormat.AVRO.addExtension(commitUUID + "-m" + manifestCount.getAndIncrement())));
+  }
+
+  protected long snapshotId() {
+    if (snapshotId == null) {
+      synchronized (this) {
+        while (snapshotId == null || ops.current().snapshot(snapshotId) != null) {
+          this.snapshotId = ops.newSnapshotId();
+        }
+      }
+    }
+    return snapshotId;
+  }
+
+  @Override
+  public OverwriteFiles overwriteByRowFilter(Expression expression) {
+    this.overwriteByRowFilterExpression = expression;
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles addFile(DataFile file) {
+    newDataFiles.add(file);
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles deleteFile(DataFile file) {
+    deletedDataFiles.add(file);
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles validateAddedFilesMatchOverwriteFilter() {
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles validateFromSnapshot(long newSnapshotId) {
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles caseSensitive(boolean isCaseSensitive) {
+    this.caseSensitive = isCaseSensitive;
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles conflictDetectionFilter(Expression expression) {
+    this.conflictDetectionFilter = expression;
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles validateNoConflictingData() {
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles validateNoConflictingDeletes() {
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles set(String property, String value) {
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles deleteWith(Consumer<String> deleteFunc) {
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles stageOnly() {
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles scanManifestsWith(ExecutorService executorService) {
+    return this;
+  }
+
+  @Override
+  public Snapshot apply() {
+    return null;
+  }
+}

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -344,6 +344,30 @@ class SetCurrentViewVersionUpdate(BaseUpdate):
     )
 
 
+class AppendFilesUpdate(BaseUpdate):
+    appended_manifests: List[str] = Field(
+        ...,
+        alias='appended-manifests',
+        description='Manifest files of DataFiles appended to a table',
+    )
+
+
+class DeleteFilesUpdateItem(BaseModel):
+    deleted_manifests: List[str] = Field(
+        ...,
+        alias='deleted-manifests',
+        description='Manifest files of DataFiles deleted from a table',
+    )
+
+
+class DeleteFilesUpdate1(BaseUpdate):
+    case_sensitive: Optional[bool] = Field(None, alias='case-sensitive')
+
+
+class DeleteFilesUpdate2(DeleteFilesUpdateItem, DeleteFilesUpdate1):
+    pass
+
+
 class TableRequirement(BaseModel):
     type: str
 
@@ -618,7 +642,7 @@ class TransformTerm(BaseModel):
     term: Reference
 
 
-class ReportMetricsRequest2(CommitReport):
+class ReportMetricsRequest1(CommitReport):
     report_type: str = Field(..., alias='report-type')
 
 
@@ -742,6 +766,32 @@ class AddSchemaUpdate(BaseUpdate):
     )
 
 
+class DeleteFilesUpdateItem1(BaseModel):
+    delete_expression: Expression = Field(..., alias='delete-expression')
+
+
+class DeleteFilesUpdate(BaseModel):
+    __root__: Union[DeleteFilesUpdate2, DeleteFilesUpdate3]
+
+
+class OverwriteFilesUpdate(BaseUpdate):
+    appended_manifests: Optional[List[str]] = Field(
+        None,
+        alias='appended-manifests',
+        description='Manifest files of DataFiles appended to a table',
+    )
+    deleted_manifests: Optional[List[str]] = Field(
+        None,
+        alias='deleted-manifests',
+        description='Manifest files of DataFiles deleted from a table',
+    )
+    overwrite_by_row_filter_expression: Optional[Expression] = Field(
+        None, alias='overwrite-by-row-filter-expression'
+    )
+    conflict_filter: Optional[Expression] = Field(None, alias='conflict-filter')
+    case_sensitive: Optional[bool] = Field(None, alias='case-sensitive')
+
+
 class TableUpdate(BaseModel):
     __root__: Union[
         AssignUUIDUpdate,
@@ -759,6 +809,9 @@ class TableUpdate(BaseModel):
         SetLocationUpdate,
         SetPropertiesUpdate,
         RemovePropertiesUpdate,
+        AppendFilesUpdate,
+        DeleteFilesUpdate,
+        OverwriteFilesUpdate,
     ]
 
 
@@ -879,8 +932,8 @@ class LoadViewResult(BaseModel):
     config: Optional[Dict[str, str]] = None
 
 
-class ReportMetricsRequest(BaseModel):
-    __root__: Union[ReportMetricsRequest1, ReportMetricsRequest2]
+class ReportMetricsRequest2(BaseModel):
+    __root__: Union[ReportMetricsRequest, ReportMetricsRequest1]
 
 
 class ScanReport(BaseModel):
@@ -906,7 +959,11 @@ class Schema(StructType):
     )
 
 
-class ReportMetricsRequest1(ScanReport):
+class DeleteFilesUpdate3(DeleteFilesUpdateItem1, DeleteFilesUpdate1):
+    pass
+
+
+class ReportMetricsRequest(ScanReport):
     report_type: str = Field(..., alias='report-type')
 
 
@@ -917,6 +974,7 @@ Expression.update_forward_refs()
 TableMetadata.update_forward_refs()
 ViewMetadata.update_forward_refs()
 AddSchemaUpdate.update_forward_refs()
+DeleteFilesUpdate.update_forward_refs()
 CreateTableRequest.update_forward_refs()
 CreateViewRequest.update_forward_refs()
-ReportMetricsRequest.update_forward_refs()
+ReportMetricsRequest2.update_forward_refs()

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2341,6 +2341,63 @@ components:
               type: integer
               description: The view version id to set as current, or -1 to set last added view version id
 
+    AppendFilesUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          required:
+            - appended-manifests
+          properties:
+            appended-manifests:
+              type: array
+              items:
+                type: string
+              description: Manifest files of DataFiles appended to a table
+
+    DeleteFilesUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - oneOf:
+            - required:
+                - deleted-manifests
+              properties:
+                deleted-manifests:
+                  type: array
+                  items:
+                    type: string
+                  description: Manifest files of DataFiles deleted from a table
+            - required:
+                - delete-expression
+              properties:
+                delete-expression:
+                  $ref: '#/components/schemas/Expression'
+        - type: object
+          properties:
+            case-sensitive:
+              type: boolean
+
+    OverwriteFilesUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            appended-manifests:
+              type: array
+              items:
+                type: string
+              description: Manifest files of DataFiles appended to a table
+            deleted-manifests:
+              type: array
+              items:
+                type: string
+              description: Manifest files of DataFiles deleted from a table
+            overwrite-by-row-filter-expression:
+              $ref: '#/components/schemas/Expression'
+            conflict-filter:
+              $ref: '#/components/schemas/Expression'
+            case-sensitive:
+              type: boolean
+
     TableUpdate:
       anyOf:
         - $ref: '#/components/schemas/AssignUUIDUpdate'
@@ -2358,6 +2415,9 @@ components:
         - $ref: '#/components/schemas/SetLocationUpdate'
         - $ref: '#/components/schemas/SetPropertiesUpdate'
         - $ref: '#/components/schemas/RemovePropertiesUpdate'
+        - $ref: '#/components/schemas/AppendFilesUpdate'
+        - $ref: '#/components/schemas/DeleteFilesUpdate'
+        - $ref: '#/components/schemas/OverwriteFilesUpdate'
 
     ViewUpdate:
       anyOf:


### PR DESCRIPTION
Hi All, 

I have a proposal that can be found [here](https://docs.google.com/document/d/1OG68EtPxLWvNBJACQwcMrRYuGJCnQas8_LSruTRcHG8). This proposal aims to allow for data commits to be a part of the REST catalog. Empowering the catalog with more control of the data committing process. In hindsight, the catalog will be able to enable support through a configuration: `rest-data-commit-enabled`.  the client will become responsible for constructing the information necessary for the server commit the changes against Iceberg tables. 

@jackye1995 @amogh-jahagirdar @rdblue 