### PR TITLE
Docs: Document reading in Spark using branch and tag identifiers

### DIFF
--- a/docs/spark-queries.md
+++ b/docs/spark-queries.md
@@ -120,6 +120,17 @@ SELECT * FROM prod.db.table TIMESTAMP AS OF 499162860;
 SELECT * FROM prod.db.table FOR SYSTEM_TIME AS OF 499162860;
 ```
 
+The branch or tag may also be specified using a similar syntax to metadata tables, with `branch_<branchname>` or `tag_<tagname>`:
+
+```sql
+SELECT * FROM prod.db.table.`branch_audit-branch`;
+SELECT * FROM prod.db.table.`tag_historical-snapshot`;
+```
+
+(Identifiers with "-" are not valid, and so must be escaped using back quotes.)
+
+Note that the identifier with branch or tag may not be used in combination with `VERSION AS OF`.
+
 #### DataFrame
 
 To select a specific table snapshot or the snapshot at some time in the DataFrame API, Iceberg supports four Spark read options:


### PR DESCRIPTION
Writing to a branch or tag is supported in Spark using a table identifier with `branch_<branchname>` or `tag_<tagname>`. Reading from the branch or tag is supported using the same kind of identifier, in addition to the `VERSION AS OF` syntax, but this is not documented. For consistency, users may prefer to read and write using the same syntax. We should document that they can.

Note: When loading a table using identifiers with `snapshot_id_` and `at_timestamp_` was implemented, this was considered an implementation detail and we did not expose it publicly (i.e., document it). However, since the `branch_` and `tag_` identifiers are used for writes and documented, we should expose them for reads as well.