### PR TITLE
Docs: Update default format version to 2

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,7 @@ The value of these properties are not persisted as a part of the table metadata.
 
 | Property       | Default  | Description                                                   |
 | -------------- | -------- | ------------------------------------------------------------- |
-| format-version | 1        | Table's format version (can be 1 or 2) as defined in the [Spec](../../../spec/#format-versioning). |
+| format-version | 2        | Table's format version (can be 1 or 2) as defined in the [Spec](../../../spec/#format-versioning). Defaults to 2 since version 1.4.0. |
 
 ### Compatibility flags
 


### PR DESCRIPTION
Correct the default format version in documentation, we already switched to V2 by default since #8381.