### PR TITLE
Switch to junit5 for mr

### DIFF
--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -23,6 +23,9 @@ project(':iceberg-mr') {
       exclude group: 'org.apache.parquet', module: 'parquet-hadoop-bundle'
     }
   }
+  test {
+    useJUnitPlatform()
+  }
 
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')

--- a/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.mr;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -40,7 +41,6 @@ import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -53,7 +53,7 @@ public class TestCatalogs {
 
   private Configuration conf;
 
-  @TempDir public Path temp;
+  @TempDir private Path temp;
 
   @BeforeEach
   public void before() {
@@ -64,7 +64,7 @@ public class TestCatalogs {
   public void testLoadTableFromLocation() throws IOException {
     conf.set(CatalogUtil.ICEBERG_CATALOG_TYPE, Catalogs.LOCATION);
 
-    Assertions.assertThatThrownBy(() -> Catalogs.loadTable(conf))
+    assertThatThrownBy(() -> Catalogs.loadTable(conf))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Table location not set");
 
@@ -73,7 +73,7 @@ public class TestCatalogs {
 
     conf.set(InputFormatConfig.TABLE_LOCATION, hadoopTable.location());
 
-    Assertions.assertThat(Catalogs.loadTable(conf).location()).isEqualTo(hadoopTable.location());
+    assertThat(Catalogs.loadTable(conf).location()).isEqualTo(hadoopTable.location());
   }
 
   @Test
@@ -82,7 +82,7 @@ public class TestCatalogs {
     String warehouseLocation = temp.resolve("hadoop").resolve("warehouse").toString();
     setCustomCatalogProperties(defaultCatalogName, warehouseLocation);
 
-    Assertions.assertThatThrownBy(() -> Catalogs.loadTable(conf))
+    assertThatThrownBy(() -> Catalogs.loadTable(conf))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Table identifier not set");
 
@@ -91,8 +91,7 @@ public class TestCatalogs {
 
     conf.set(InputFormatConfig.TABLE_IDENTIFIER, "table");
 
-    Assertions.assertThat(Catalogs.loadTable(conf).location())
-        .isEqualTo(hadoopCatalogTable.location());
+    assertThat(Catalogs.loadTable(conf).location()).isEqualTo(hadoopCatalogTable.location());
   }
 
   @Test
@@ -100,7 +99,7 @@ public class TestCatalogs {
     Properties missingSchema = new Properties();
     missingSchema.put("location", temp.resolve("hadoop_tables").toString());
 
-    Assertions.assertThatThrownBy(() -> Catalogs.createTable(conf, missingSchema))
+    assertThatThrownBy(() -> Catalogs.createTable(conf, missingSchema))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("Table schema not set");
 
@@ -108,7 +107,7 @@ public class TestCatalogs {
     Properties missingLocation = new Properties();
     missingLocation.put(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(SCHEMA));
 
-    Assertions.assertThatThrownBy(() -> Catalogs.createTable(conf, missingLocation))
+    assertThatThrownBy(() -> Catalogs.createTable(conf, missingLocation))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("Table location not set");
 
@@ -123,14 +122,13 @@ public class TestCatalogs {
     HadoopTables tables = new HadoopTables();
     Table table = tables.load(properties.getProperty("location"));
 
-    Assertions.assertThat(table.location()).isEqualTo(properties.getProperty("location"));
-    Assertions.assertThat(SchemaParser.toJson(table.schema()))
-        .isEqualTo(SchemaParser.toJson(SCHEMA));
-    Assertions.assertThat(PartitionSpecParser.toJson(table.spec()))
+    assertThat(table.location()).isEqualTo(properties.getProperty("location"));
+    assertThat(SchemaParser.toJson(table.schema())).isEqualTo(SchemaParser.toJson(SCHEMA));
+    assertThat(PartitionSpecParser.toJson(table.spec()))
         .isEqualTo(PartitionSpecParser.toJson(SPEC));
     assertThat(table.properties()).containsEntry("dummy", "test");
 
-    Assertions.assertThatThrownBy(() -> Catalogs.dropTable(conf, new Properties()))
+    assertThatThrownBy(() -> Catalogs.dropTable(conf, new Properties()))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("Table location not set");
 
@@ -138,7 +136,7 @@ public class TestCatalogs {
     dropProperties.put("location", temp.toFile() + "/hadoop_tables");
     Catalogs.dropTable(conf, dropProperties);
 
-    Assertions.assertThatThrownBy(() -> Catalogs.loadTable(conf, dropProperties))
+    assertThatThrownBy(() -> Catalogs.loadTable(conf, dropProperties))
         .isInstanceOf(NoSuchTableException.class)
         .hasMessage("Table does not exist at location: " + properties.getProperty("location"));
   }
@@ -155,14 +153,14 @@ public class TestCatalogs {
     missingSchema.put("name", identifier.toString());
     missingSchema.put(InputFormatConfig.CATALOG_NAME, defaultCatalogName);
 
-    Assertions.assertThatThrownBy(() -> Catalogs.createTable(conf, missingSchema))
+    assertThatThrownBy(() -> Catalogs.createTable(conf, missingSchema))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("Table schema not set");
 
     Properties missingIdentifier = new Properties();
     missingIdentifier.put(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(SCHEMA));
     missingIdentifier.put(InputFormatConfig.CATALOG_NAME, defaultCatalogName);
-    Assertions.assertThatThrownBy(() -> Catalogs.createTable(conf, missingIdentifier))
+    assertThatThrownBy(() -> Catalogs.createTable(conf, missingIdentifier))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("Table identifier not set");
 
@@ -178,13 +176,12 @@ public class TestCatalogs {
     HadoopCatalog catalog = new CustomHadoopCatalog(conf, warehouseLocation);
     Table table = catalog.loadTable(identifier);
 
-    Assertions.assertThat(SchemaParser.toJson(table.schema()))
-        .isEqualTo(SchemaParser.toJson(SCHEMA));
-    Assertions.assertThat(PartitionSpecParser.toJson(table.spec()))
+    assertThat(SchemaParser.toJson(table.schema())).isEqualTo(SchemaParser.toJson(SCHEMA));
+    assertThat(PartitionSpecParser.toJson(table.spec()))
         .isEqualTo(PartitionSpecParser.toJson(SPEC));
     assertThat(table.properties()).containsEntry("dummy", "test");
 
-    Assertions.assertThatThrownBy(() -> Catalogs.dropTable(conf, new Properties()))
+    assertThatThrownBy(() -> Catalogs.dropTable(conf, new Properties()))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("Table identifier not set");
 
@@ -193,7 +190,7 @@ public class TestCatalogs {
     dropProperties.put(InputFormatConfig.CATALOG_NAME, defaultCatalogName);
     Catalogs.dropTable(conf, dropProperties);
 
-    Assertions.assertThatThrownBy(() -> Catalogs.loadTable(conf, dropProperties))
+    assertThatThrownBy(() -> Catalogs.loadTable(conf, dropProperties))
         .isInstanceOf(NoSuchTableException.class)
         .hasMessage("Table does not exist: test.table");
   }
@@ -202,11 +199,11 @@ public class TestCatalogs {
   public void testLoadCatalogDefault() {
     String catalogName = "barCatalog";
     Optional<Catalog> defaultCatalog = Catalogs.loadCatalog(conf, catalogName);
-    Assertions.assertThat(defaultCatalog.isPresent()).isTrue();
-    Assertions.assertThat(defaultCatalog.get()).isInstanceOf(HiveCatalog.class);
+    assertThat(defaultCatalog).isPresent();
+    assertThat(defaultCatalog.get()).isInstanceOf(HiveCatalog.class);
     Properties properties = new Properties();
     properties.put(InputFormatConfig.CATALOG_NAME, catalogName);
-    Assertions.assertThat(Catalogs.hiveCatalog(conf, properties)).isTrue();
+    assertThat(Catalogs.hiveCatalog(conf, properties)).isTrue();
   }
 
   @Test
@@ -216,11 +213,11 @@ public class TestCatalogs {
         InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogUtil.ICEBERG_CATALOG_TYPE),
         CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE);
     Optional<Catalog> hiveCatalog = Catalogs.loadCatalog(conf, catalogName);
-    Assertions.assertThat(hiveCatalog.isPresent()).isTrue();
-    Assertions.assertThat(hiveCatalog.get()).isInstanceOf(HiveCatalog.class);
+    assertThat(hiveCatalog).isPresent();
+    assertThat(hiveCatalog.get()).isInstanceOf(HiveCatalog.class);
     Properties properties = new Properties();
     properties.put(InputFormatConfig.CATALOG_NAME, catalogName);
-    Assertions.assertThat(Catalogs.hiveCatalog(conf, properties)).isTrue();
+    assertThat(Catalogs.hiveCatalog(conf, properties)).isTrue();
   }
 
   @Test
@@ -234,13 +231,13 @@ public class TestCatalogs {
             catalogName, CatalogProperties.WAREHOUSE_LOCATION),
         "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
-    Assertions.assertThat(hadoopCatalog.isPresent()).isTrue();
-    Assertions.assertThat(hadoopCatalog.get()).isInstanceOf(HadoopCatalog.class);
-    Assertions.assertThat(hadoopCatalog.get().toString())
+    assertThat(hadoopCatalog).isPresent();
+    assertThat(hadoopCatalog.get()).isInstanceOf(HadoopCatalog.class);
+    assertThat(hadoopCatalog.get().toString())
         .isEqualTo("HadoopCatalog{name=barCatalog, location=/tmp/mylocation}");
     Properties properties = new Properties();
     properties.put(InputFormatConfig.CATALOG_NAME, catalogName);
-    Assertions.assertThat(Catalogs.hiveCatalog(conf, properties)).isFalse();
+    assertThat(Catalogs.hiveCatalog(conf, properties)).isFalse();
   }
 
   @Test
@@ -254,18 +251,16 @@ public class TestCatalogs {
             catalogName, CatalogProperties.WAREHOUSE_LOCATION),
         "/tmp/mylocation");
     Optional<Catalog> customHadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
-    Assertions.assertThat(customHadoopCatalog.isPresent()).isTrue();
-    Assertions.assertThat(customHadoopCatalog.get()).isInstanceOf(CustomHadoopCatalog.class);
+    assertThat(customHadoopCatalog).isPresent();
+    assertThat(customHadoopCatalog.get()).isInstanceOf(CustomHadoopCatalog.class);
     Properties properties = new Properties();
     properties.put(InputFormatConfig.CATALOG_NAME, catalogName);
-    Assertions.assertThat(Catalogs.hiveCatalog(conf, properties)).isFalse();
+    assertThat(Catalogs.hiveCatalog(conf, properties)).isFalse();
   }
 
   @Test
   public void testLoadCatalogLocation() {
-    Assertions.assertThat(
-            Catalogs.loadCatalog(conf, Catalogs.ICEBERG_HADOOP_TABLE_NAME).isPresent())
-        .isFalse();
+    assertThat(Catalogs.loadCatalog(conf, Catalogs.ICEBERG_HADOOP_TABLE_NAME)).isNotPresent();
   }
 
   @Test
@@ -275,7 +270,7 @@ public class TestCatalogs {
         InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogUtil.ICEBERG_CATALOG_TYPE),
         "fooType");
 
-    Assertions.assertThatThrownBy(() -> Catalogs.loadCatalog(conf, catalogName))
+    assertThatThrownBy(() -> Catalogs.loadCatalog(conf, catalogName))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("Unknown catalog type: fooType");
   }

--- a/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
@@ -53,8 +53,7 @@ public class TestCatalogs {
 
   private Configuration conf;
 
-  @TempDir
-  public Path temp;
+  @TempDir public Path temp;
 
   @BeforeEach
   public void before() {
@@ -92,7 +91,8 @@ public class TestCatalogs {
 
     conf.set(InputFormatConfig.TABLE_IDENTIFIER, "table");
 
-    Assertions.assertThat(Catalogs.loadTable(conf).location()).isEqualTo(hadoopCatalogTable.location());
+    Assertions.assertThat(Catalogs.loadTable(conf).location())
+        .isEqualTo(hadoopCatalogTable.location());
   }
 
   @Test
@@ -124,8 +124,10 @@ public class TestCatalogs {
     Table table = tables.load(properties.getProperty("location"));
 
     Assertions.assertThat(table.location()).isEqualTo(properties.getProperty("location"));
-    Assertions.assertThat(SchemaParser.toJson(table.schema())).isEqualTo(SchemaParser.toJson(SCHEMA));
-    Assertions.assertThat(PartitionSpecParser.toJson(table.spec())).isEqualTo(PartitionSpecParser.toJson(SPEC));
+    Assertions.assertThat(SchemaParser.toJson(table.schema()))
+        .isEqualTo(SchemaParser.toJson(SCHEMA));
+    Assertions.assertThat(PartitionSpecParser.toJson(table.spec()))
+        .isEqualTo(PartitionSpecParser.toJson(SPEC));
     assertThat(table.properties()).containsEntry("dummy", "test");
 
     Assertions.assertThatThrownBy(() -> Catalogs.dropTable(conf, new Properties()))
@@ -176,8 +178,10 @@ public class TestCatalogs {
     HadoopCatalog catalog = new CustomHadoopCatalog(conf, warehouseLocation);
     Table table = catalog.loadTable(identifier);
 
-    Assertions.assertThat(SchemaParser.toJson(table.schema())).isEqualTo(SchemaParser.toJson(SCHEMA));
-    Assertions.assertThat(PartitionSpecParser.toJson(table.spec())).isEqualTo(PartitionSpecParser.toJson(SPEC));
+    Assertions.assertThat(SchemaParser.toJson(table.schema()))
+        .isEqualTo(SchemaParser.toJson(SCHEMA));
+    Assertions.assertThat(PartitionSpecParser.toJson(table.spec()))
+        .isEqualTo(PartitionSpecParser.toJson(SPEC));
     assertThat(table.properties()).containsEntry("dummy", "test");
 
     Assertions.assertThatThrownBy(() -> Catalogs.dropTable(conf, new Properties()))
@@ -233,7 +237,7 @@ public class TestCatalogs {
     Assertions.assertThat(hadoopCatalog.isPresent()).isTrue();
     Assertions.assertThat(hadoopCatalog.get()).isInstanceOf(HadoopCatalog.class);
     Assertions.assertThat(hadoopCatalog.get().toString())
-            .isEqualTo("HadoopCatalog{name=barCatalog, location=/tmp/mylocation}");
+        .isEqualTo("HadoopCatalog{name=barCatalog, location=/tmp/mylocation}");
     Properties properties = new Properties();
     properties.put(InputFormatConfig.CATALOG_NAME, catalogName);
     Assertions.assertThat(Catalogs.hiveCatalog(conf, properties)).isFalse();
@@ -259,7 +263,9 @@ public class TestCatalogs {
 
   @Test
   public void testLoadCatalogLocation() {
-    Assertions.assertThat(Catalogs.loadCatalog(conf, Catalogs.ICEBERG_HADOOP_TABLE_NAME).isPresent()).isFalse();
+    Assertions.assertThat(
+            Catalogs.loadCatalog(conf, Catalogs.ICEBERG_HADOOP_TABLE_NAME).isPresent())
+        .isFalse();
   }
 
   @Test

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -286,7 +286,8 @@ public class HiveIcebergTestUtils {
             .collect(Collectors.toList());
 
     assertThat(dataFiles).hasSize(dataFileNum);
-    assertThat(new File(HiveIcebergOutputCommitter.generateJobLocation(table.location(), conf, jobId)))
+    assertThat(
+            new File(HiveIcebergOutputCommitter.generateJobLocation(table.location(), conf, jobId)))
         .doesNotExist();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -63,7 +63,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
-import org.junit.Assert;
+import org.assertj.core.api.Assertions;
 
 public class HiveIcebergTestUtils {
   // TODO: Can this be a constant all around the Iceberg tests?
@@ -218,13 +218,12 @@ public class HiveIcebergTestUtils {
     for (int i = 0; i < expected.size(); ++i) {
       if (expected.get(i) instanceof OffsetDateTime) {
         // For OffsetDateTime we just compare the actual instant
-        Assert.assertEquals(
-            ((OffsetDateTime) expected.get(i)).toInstant(),
-            ((OffsetDateTime) actual.get(i)).toInstant());
+        Assertions.assertThat(((OffsetDateTime) actual.get(i)).toInstant())
+                .isEqualTo(((OffsetDateTime) expected.get(i)).toInstant());
       } else if (expected.get(i) instanceof byte[]) {
-        Assert.assertArrayEquals((byte[]) expected.get(i), (byte[]) actual.get(i));
+        Assertions.assertThat((byte[]) actual.get(i)).isEqualTo((byte[]) expected.get(i));
       } else {
-        Assert.assertEquals(expected.get(i), actual.get(i));
+        Assertions.assertThat(actual.get(i)).isEqualTo(expected.get(i));
       }
     }
   }
@@ -265,7 +264,7 @@ public class HiveIcebergTestUtils {
     sortedExpected.sort(Comparator.comparingLong(record -> (Long) record.get(sortBy)));
     sortedActual.sort(Comparator.comparingLong(record -> (Long) record.get(sortBy)));
 
-    Assert.assertEquals(sortedExpected.size(), sortedActual.size());
+    Assertions.assertThat(sortedActual.size()).isEqualTo(sortedExpected.size());
     for (int i = 0; i < sortedExpected.size(); ++i) {
       assertEquals(sortedExpected.get(i), sortedActual.get(i));
     }
@@ -288,9 +287,9 @@ public class HiveIcebergTestUtils {
             .filter(path -> !path.getFileName().toString().startsWith("."))
             .collect(Collectors.toList());
 
-    Assert.assertEquals(dataFileNum, dataFiles.size());
-    Assert.assertFalse(
+    Assertions.assertThat(dataFiles.size()).isEqualTo(dataFileNum);
+    Assertions.assertThat(
         new File(HiveIcebergOutputCommitter.generateJobLocation(table.location(), conf, jobId))
-            .exists());
+            .exists()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -262,7 +262,7 @@ public class HiveIcebergTestUtils {
     sortedExpected.sort(Comparator.comparingLong(record -> (Long) record.get(sortBy)));
     sortedActual.sort(Comparator.comparingLong(record -> (Long) record.get(sortBy)));
 
-    assertThat(sortedActual).hasSize(sortedExpected.size());
+    assertThat(sortedActual).hasSameSizeAs(sortedExpected);
     for (int i = 0; i < sortedExpected.size(); ++i) {
       assertEquals(sortedExpected.get(i), sortedActual.get(i));
     }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -219,7 +219,7 @@ public class HiveIcebergTestUtils {
       if (expected.get(i) instanceof OffsetDateTime) {
         // For OffsetDateTime we just compare the actual instant
         Assertions.assertThat(((OffsetDateTime) actual.get(i)).toInstant())
-                .isEqualTo(((OffsetDateTime) expected.get(i)).toInstant());
+            .isEqualTo(((OffsetDateTime) expected.get(i)).toInstant());
       } else if (expected.get(i) instanceof byte[]) {
         Assertions.assertThat((byte[]) actual.get(i)).isEqualTo((byte[]) expected.get(i));
       } else {
@@ -289,7 +289,8 @@ public class HiveIcebergTestUtils {
 
     Assertions.assertThat(dataFiles.size()).isEqualTo(dataFileNum);
     Assertions.assertThat(
-        new File(HiveIcebergOutputCommitter.generateJobLocation(table.location(), conf, jobId))
-            .exists()).isFalse();
+            new File(HiveIcebergOutputCommitter.generateJobLocation(table.location(), conf, jobId))
+                .exists())
+        .isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.mr.hive;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,7 +64,6 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
-import org.assertj.core.api.Assertions;
 
 public class HiveIcebergTestUtils {
   // TODO: Can this be a constant all around the Iceberg tests?
@@ -218,12 +218,10 @@ public class HiveIcebergTestUtils {
     for (int i = 0; i < expected.size(); ++i) {
       if (expected.get(i) instanceof OffsetDateTime) {
         // For OffsetDateTime we just compare the actual instant
-        Assertions.assertThat(((OffsetDateTime) actual.get(i)).toInstant())
+        assertThat(((OffsetDateTime) actual.get(i)).toInstant())
             .isEqualTo(((OffsetDateTime) expected.get(i)).toInstant());
-      } else if (expected.get(i) instanceof byte[]) {
-        Assertions.assertThat((byte[]) actual.get(i)).isEqualTo((byte[]) expected.get(i));
       } else {
-        Assertions.assertThat(actual.get(i)).isEqualTo(expected.get(i));
+        assertThat(actual.get(i)).isEqualTo(expected.get(i));
       }
     }
   }
@@ -264,7 +262,7 @@ public class HiveIcebergTestUtils {
     sortedExpected.sort(Comparator.comparingLong(record -> (Long) record.get(sortBy)));
     sortedActual.sort(Comparator.comparingLong(record -> (Long) record.get(sortBy)));
 
-    Assertions.assertThat(sortedActual.size()).isEqualTo(sortedExpected.size());
+    assertThat(sortedActual).hasSize(sortedExpected.size());
     for (int i = 0; i < sortedExpected.size(); ++i) {
       assertEquals(sortedExpected.get(i), sortedActual.get(i));
     }
@@ -287,10 +285,8 @@ public class HiveIcebergTestUtils {
             .filter(path -> !path.getFileName().toString().startsWith("."))
             .collect(Collectors.toList());
 
-    Assertions.assertThat(dataFiles.size()).isEqualTo(dataFileNum);
-    Assertions.assertThat(
-            new File(HiveIcebergOutputCommitter.generateJobLocation(table.location(), conf, jobId))
-                .exists())
-        .isFalse();
+    assertThat(dataFiles).hasSize(dataFileNum);
+    assertThat(new File(HiveIcebergOutputCommitter.generateJobLocation(table.location(), conf, jobId)))
+        .doesNotExist();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestDeserializer.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestDeserializer.java
@@ -161,7 +161,8 @@ public class TestDeserializer {
   @Test
   public void testDeserializeEverySupportedType() {
     assumeThat(HiveVersion.min(HiveVersion.HIVE_3))
-        .as("No test yet for Hive3 (Date/Timestamp creation)");
+        .as("No test yet for Hive3 (Date/Timestamp creation)")
+        .isFalse();
 
     Deserializer deserializer =
         new Deserializer.Builder()

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestDeserializer.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestDeserializer.java
@@ -35,9 +35,9 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.hive.HiveVersion;
 import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 public class TestDeserializer {
   private static final Schema CUSTOMER_SCHEMA =
@@ -74,7 +74,7 @@ public class TestDeserializer {
 
     Record actual = deserializer.deserialize(new Object[] {new LongWritable(1L), new Text("Bob")});
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -92,7 +92,7 @@ public class TestDeserializer {
 
     Record actual = deserializer.deserialize(new Object[] {new LongWritable(1L), new Text("Bob")});
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -127,7 +127,7 @@ public class TestDeserializer {
     Object[] data = new Object[] {map};
     Record actual = deserializer.deserialize(data);
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -155,13 +155,13 @@ public class TestDeserializer {
     Object[] data = new Object[] {new Object[] {new LongWritable(1L)}};
     Record actual = deserializer.deserialize(data);
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertThat(actual).isEqualTo(expected);
   }
 
   @Test
   public void testDeserializeEverySupportedType() {
-    Assume.assumeFalse(
-        "No test yet for Hive3 (Date/Timestamp creation)", HiveVersion.min(HiveVersion.HIVE_3));
+    Assumptions.assumeFalse(HiveVersion.min(HiveVersion.HIVE_3),
+        "No test yet for Hive3 (Date/Timestamp creation)");
 
     Deserializer deserializer =
         new Deserializer.Builder()
@@ -196,9 +196,9 @@ public class TestDeserializer {
 
     Record actual = deserializer.deserialize(nulls);
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertThat(actual).isEqualTo(expected);
 
     // Check null record as well
-    Assert.assertNull(deserializer.deserialize(null));
+    Assertions.assertThat(deserializer.deserialize(null)).isNull();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestDeserializer.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestDeserializer.java
@@ -160,8 +160,8 @@ public class TestDeserializer {
 
   @Test
   public void testDeserializeEverySupportedType() {
-    Assumptions.assumeFalse(HiveVersion.min(HiveVersion.HIVE_3),
-        "No test yet for Hive3 (Date/Timestamp creation)");
+    Assumptions.assumeFalse(
+        HiveVersion.min(HiveVersion.HIVE_3), "No test yet for Hive3 (Date/Timestamp creation)");
 
     Deserializer deserializer =
         new Deserializer.Builder()

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestDeserializer.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestDeserializer.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.mr.hive;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,8 +37,6 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.hive.HiveVersion;
 import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 public class TestDeserializer {
@@ -74,7 +74,7 @@ public class TestDeserializer {
 
     Record actual = deserializer.deserialize(new Object[] {new LongWritable(1L), new Text("Bob")});
 
-    Assertions.assertThat(actual).isEqualTo(expected);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -92,7 +92,7 @@ public class TestDeserializer {
 
     Record actual = deserializer.deserialize(new Object[] {new LongWritable(1L), new Text("Bob")});
 
-    Assertions.assertThat(actual).isEqualTo(expected);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -127,7 +127,7 @@ public class TestDeserializer {
     Object[] data = new Object[] {map};
     Record actual = deserializer.deserialize(data);
 
-    Assertions.assertThat(actual).isEqualTo(expected);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -155,13 +155,13 @@ public class TestDeserializer {
     Object[] data = new Object[] {new Object[] {new LongWritable(1L)}};
     Record actual = deserializer.deserialize(data);
 
-    Assertions.assertThat(actual).isEqualTo(expected);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
   public void testDeserializeEverySupportedType() {
-    Assumptions.assumeFalse(
-        HiveVersion.min(HiveVersion.HIVE_3), "No test yet for Hive3 (Date/Timestamp creation)");
+    assumeThat(HiveVersion.min(HiveVersion.HIVE_3))
+        .as("No test yet for Hive3 (Date/Timestamp creation)");
 
     Deserializer deserializer =
         new Deserializer.Builder()
@@ -196,9 +196,9 @@ public class TestDeserializer {
 
     Record actual = deserializer.deserialize(nulls);
 
-    Assertions.assertThat(actual).isEqualTo(expected);
+    assertThat(actual).isEqualTo(expected);
 
     // Check null record as well
-    Assertions.assertThat(deserializer.deserialize(null)).isNull();
+    assertThat(deserializer.deserialize(null)).isNull();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergFilterFactory.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergFilterFactory.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg.mr.hive;
 
-import static org.junit.Assert.assertEquals;
-
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
@@ -40,7 +38,7 @@ import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestHiveIcebergFilterFactory {
 
@@ -82,10 +80,10 @@ public class TestHiveIcebergFilterFactory {
     UnboundPredicate childExpressionActual = (UnboundPredicate) actual.child();
     UnboundPredicate childExpressionExpected = Expressions.equal("salary", 3000L);
 
-    assertEquals(actual.op(), expected.op());
-    assertEquals(actual.child().op(), expected.child().op());
-    assertEquals(childExpressionActual.ref().name(), childExpressionExpected.ref().name());
-    assertEquals(childExpressionActual.literal(), childExpressionExpected.literal());
+    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
+    Assertions.assertThat(expected.child().op()).isEqualTo(actual.child().op());
+    Assertions.assertThat(childExpressionExpected.ref().name()).isEqualTo(childExpressionActual.ref().name());
+    Assertions.assertThat(childExpressionExpected.literal()).isEqualTo(childExpressionActual.literal());
   }
 
   @Test
@@ -98,9 +96,9 @@ public class TestHiveIcebergFilterFactory {
     UnboundPredicate actual =
         (UnboundPredicate) HiveIcebergFilterFactory.generateFilterExpression(arg);
 
-    assertEquals(actual.op(), expected.op());
-    assertEquals(actual.literal(), expected.literal());
-    assertEquals(actual.ref().name(), expected.ref().name());
+    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
+    Assertions.assertThat(expected.literal()).isEqualTo(actual.literal());
+    Assertions.assertThat(expected.ref().name()).isEqualTo(actual.ref().name());
   }
 
   @Test
@@ -126,9 +124,9 @@ public class TestHiveIcebergFilterFactory {
     UnboundPredicate actual =
         (UnboundPredicate) HiveIcebergFilterFactory.generateFilterExpression(arg);
 
-    assertEquals(actual.op(), expected.op());
-    assertEquals(actual.literals(), expected.literals());
-    assertEquals(actual.ref().name(), expected.ref().name());
+    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
+    Assertions.assertThat(expected.literals()).isEqualTo(actual.literals());
+    Assertions.assertThat(expected.ref().name()).isEqualTo(actual.ref().name());
   }
 
   @Test
@@ -144,9 +142,9 @@ public class TestHiveIcebergFilterFactory {
                 Expressions.lessThanOrEqual("salary", 3000L));
     And actual = (And) HiveIcebergFilterFactory.generateFilterExpression(arg);
 
-    assertEquals(actual.op(), expected.op());
-    assertEquals(actual.left().op(), expected.left().op());
-    assertEquals(actual.right().op(), expected.right().op());
+    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
+    Assertions.assertThat(expected.left().op()).isEqualTo(actual.left().op());
+    Assertions.assertThat(expected.right().op()).isEqualTo(actual.right().op());
   }
 
   @Test
@@ -173,8 +171,8 @@ public class TestHiveIcebergFilterFactory {
     UnboundPredicate actual =
         (UnboundPredicate) HiveIcebergFilterFactory.generateFilterExpression(arg);
 
-    assertEquals(actual.op(), expected.op());
-    assertEquals(actual.ref().name(), expected.ref().name());
+    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
+    Assertions.assertThat(expected.ref().name()).isEqualTo(actual.ref().name());
   }
 
   @Test
@@ -193,9 +191,9 @@ public class TestHiveIcebergFilterFactory {
             Expressions.and(Expressions.equal("salary", 3000L), Expressions.equal("salary", 4000L));
     And actual = (And) HiveIcebergFilterFactory.generateFilterExpression(arg);
 
-    assertEquals(actual.op(), expected.op());
-    assertEquals(actual.left().op(), expected.left().op());
-    assertEquals(actual.right().op(), expected.right().op());
+    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
+    Assertions.assertThat(expected.left().op()).isEqualTo(actual.left().op());
+    Assertions.assertThat(expected.right().op()).isEqualTo(actual.right().op());
   }
 
   @Test
@@ -213,9 +211,9 @@ public class TestHiveIcebergFilterFactory {
         (Or) Expressions.or(Expressions.equal("salary", 3000L), Expressions.equal("salary", 4000L));
     Or actual = (Or) HiveIcebergFilterFactory.generateFilterExpression(arg);
 
-    assertEquals(actual.op(), expected.op());
-    assertEquals(actual.left().op(), expected.left().op());
-    assertEquals(actual.right().op(), expected.right().op());
+    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
+    Assertions.assertThat(expected.left().op()).isEqualTo(actual.left().op());
+    Assertions.assertThat(expected.right().op()).isEqualTo(actual.right().op());
   }
 
   @Test
@@ -308,9 +306,9 @@ public class TestHiveIcebergFilterFactory {
   }
 
   private void assertPredicatesMatch(UnboundPredicate expected, UnboundPredicate actual) {
-    assertEquals(expected.op(), actual.op());
-    assertEquals(expected.literal(), actual.literal());
-    assertEquals(expected.ref().name(), actual.ref().name());
+    Assertions.assertThat(actual.op()).isEqualTo(expected.op());
+    Assertions.assertThat(actual.literal()).isEqualTo(expected.literal());
+    Assertions.assertThat(actual.ref().name()).isEqualTo(expected.ref().name());
   }
 
   private static class MockSearchArgument implements SearchArgument {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergFilterFactory.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergFilterFactory.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.mr.hive;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
@@ -80,12 +82,10 @@ public class TestHiveIcebergFilterFactory {
     UnboundPredicate childExpressionActual = (UnboundPredicate) actual.child();
     UnboundPredicate childExpressionExpected = Expressions.equal("salary", 3000L);
 
-    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
-    Assertions.assertThat(expected.child().op()).isEqualTo(actual.child().op());
-    Assertions.assertThat(childExpressionExpected.ref().name())
-        .isEqualTo(childExpressionActual.ref().name());
-    Assertions.assertThat(childExpressionExpected.literal())
-        .isEqualTo(childExpressionActual.literal());
+    assertThat(expected.op()).isEqualTo(actual.op());
+    assertThat(expected.child().op()).isEqualTo(actual.child().op());
+    assertThat(childExpressionExpected.ref().name()).isEqualTo(childExpressionActual.ref().name());
+    assertThat(childExpressionExpected.literal()).isEqualTo(childExpressionActual.literal());
   }
 
   @Test
@@ -98,9 +98,9 @@ public class TestHiveIcebergFilterFactory {
     UnboundPredicate actual =
         (UnboundPredicate) HiveIcebergFilterFactory.generateFilterExpression(arg);
 
-    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
-    Assertions.assertThat(expected.literal()).isEqualTo(actual.literal());
-    Assertions.assertThat(expected.ref().name()).isEqualTo(actual.ref().name());
+    assertThat(expected.op()).isEqualTo(actual.op());
+    assertThat(expected.literal()).isEqualTo(actual.literal());
+    assertThat(expected.ref().name()).isEqualTo(actual.ref().name());
   }
 
   @Test
@@ -126,9 +126,9 @@ public class TestHiveIcebergFilterFactory {
     UnboundPredicate actual =
         (UnboundPredicate) HiveIcebergFilterFactory.generateFilterExpression(arg);
 
-    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
-    Assertions.assertThat(expected.literals()).isEqualTo(actual.literals());
-    Assertions.assertThat(expected.ref().name()).isEqualTo(actual.ref().name());
+    assertThat(expected.op()).isEqualTo(actual.op());
+    assertThat(expected.literals()).isEqualTo(actual.literals());
+    assertThat(expected.ref().name()).isEqualTo(actual.ref().name());
   }
 
   @Test
@@ -144,9 +144,9 @@ public class TestHiveIcebergFilterFactory {
                 Expressions.lessThanOrEqual("salary", 3000L));
     And actual = (And) HiveIcebergFilterFactory.generateFilterExpression(arg);
 
-    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
-    Assertions.assertThat(expected.left().op()).isEqualTo(actual.left().op());
-    Assertions.assertThat(expected.right().op()).isEqualTo(actual.right().op());
+    assertThat(expected.op()).isEqualTo(actual.op());
+    assertThat(expected.left().op()).isEqualTo(actual.left().op());
+    assertThat(expected.right().op()).isEqualTo(actual.right().op());
   }
 
   @Test
@@ -173,8 +173,8 @@ public class TestHiveIcebergFilterFactory {
     UnboundPredicate actual =
         (UnboundPredicate) HiveIcebergFilterFactory.generateFilterExpression(arg);
 
-    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
-    Assertions.assertThat(expected.ref().name()).isEqualTo(actual.ref().name());
+    assertThat(expected.op()).isEqualTo(actual.op());
+    assertThat(expected.ref().name()).isEqualTo(actual.ref().name());
   }
 
   @Test
@@ -193,9 +193,9 @@ public class TestHiveIcebergFilterFactory {
             Expressions.and(Expressions.equal("salary", 3000L), Expressions.equal("salary", 4000L));
     And actual = (And) HiveIcebergFilterFactory.generateFilterExpression(arg);
 
-    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
-    Assertions.assertThat(expected.left().op()).isEqualTo(actual.left().op());
-    Assertions.assertThat(expected.right().op()).isEqualTo(actual.right().op());
+    assertThat(expected.op()).isEqualTo(actual.op());
+    assertThat(expected.left().op()).isEqualTo(actual.left().op());
+    assertThat(expected.right().op()).isEqualTo(actual.right().op());
   }
 
   @Test
@@ -213,9 +213,9 @@ public class TestHiveIcebergFilterFactory {
         (Or) Expressions.or(Expressions.equal("salary", 3000L), Expressions.equal("salary", 4000L));
     Or actual = (Or) HiveIcebergFilterFactory.generateFilterExpression(arg);
 
-    Assertions.assertThat(expected.op()).isEqualTo(actual.op());
-    Assertions.assertThat(expected.left().op()).isEqualTo(actual.left().op());
-    Assertions.assertThat(expected.right().op()).isEqualTo(actual.right().op());
+    assertThat(expected.op()).isEqualTo(actual.op());
+    assertThat(expected.left().op()).isEqualTo(actual.left().op());
+    assertThat(expected.right().op()).isEqualTo(actual.right().op());
   }
 
   @Test
@@ -308,9 +308,9 @@ public class TestHiveIcebergFilterFactory {
   }
 
   private void assertPredicatesMatch(UnboundPredicate expected, UnboundPredicate actual) {
-    Assertions.assertThat(actual.op()).isEqualTo(expected.op());
-    Assertions.assertThat(actual.literal()).isEqualTo(expected.literal());
-    Assertions.assertThat(actual.ref().name()).isEqualTo(expected.ref().name());
+    assertThat(actual.op()).isEqualTo(expected.op());
+    assertThat(actual.literal()).isEqualTo(expected.literal());
+    assertThat(actual.ref().name()).isEqualTo(expected.ref().name());
   }
 
   private static class MockSearchArgument implements SearchArgument {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergFilterFactory.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergFilterFactory.java
@@ -82,8 +82,10 @@ public class TestHiveIcebergFilterFactory {
 
     Assertions.assertThat(expected.op()).isEqualTo(actual.op());
     Assertions.assertThat(expected.child().op()).isEqualTo(actual.child().op());
-    Assertions.assertThat(childExpressionExpected.ref().name()).isEqualTo(childExpressionActual.ref().name());
-    Assertions.assertThat(childExpressionExpected.literal()).isEqualTo(childExpressionActual.literal());
+    Assertions.assertThat(childExpressionExpected.ref().name())
+        .isEqualTo(childExpressionActual.ref().name());
+    Assertions.assertThat(childExpressionExpected.literal())
+        .isEqualTo(childExpressionActual.literal());
   }
 
   @Test

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
@@ -79,8 +79,7 @@ public class TestHiveIcebergOutputCommitter {
   private static final PartitionSpec PARTITIONED_SPEC =
       PartitionSpec.builderFor(CUSTOMER_SCHEMA).bucket("customer_id", 3).build();
 
-  @TempDir
-  public Path temp;
+  @TempDir public Path temp;
 
   @Test
   public void testNeedsTaskCommit() {
@@ -92,7 +91,8 @@ public class TestHiveIcebergOutputCommitter {
 
     // Map only job should commit map tasks
     Assertions.assertThat(
-        committer.needsTaskCommit(new TaskAttemptContextImpl(mapOnlyJobConf, MAP_TASK_ID))).isTrue();
+            committer.needsTaskCommit(new TaskAttemptContextImpl(mapOnlyJobConf, MAP_TASK_ID)))
+        .isTrue();
 
     JobConf mapReduceJobConf = new JobConf();
     mapReduceJobConf.setNumMapTasks(10);
@@ -100,9 +100,11 @@ public class TestHiveIcebergOutputCommitter {
 
     // MapReduce job should not commit map tasks, but should commit reduce tasks
     Assertions.assertThat(
-        committer.needsTaskCommit(new TaskAttemptContextImpl(mapReduceJobConf, MAP_TASK_ID))).isFalse();
+            committer.needsTaskCommit(new TaskAttemptContextImpl(mapReduceJobConf, MAP_TASK_ID)))
+        .isFalse();
     Assertions.assertThat(
-        committer.needsTaskCommit(new TaskAttemptContextImpl(mapReduceJobConf, REDUCE_TASK_ID))).isTrue();
+            committer.needsTaskCommit(new TaskAttemptContextImpl(mapReduceJobConf, REDUCE_TASK_ID)))
+        .isTrue();
   }
 
   @Test

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDe.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDe.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.mr.hive;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +36,6 @@ import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
 import org.apache.iceberg.mr.mapred.Container;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -44,12 +44,12 @@ public class TestHiveIcebergSerDe {
   private static final Schema schema =
       new Schema(required(1, "string_field", Types.StringType.get()));
 
-  @TempDir public Path tmp;
+  @TempDir private Path tmp;
 
   @Test
   public void testInitialize() throws IOException, SerDeException {
     File location = tmp.toFile();
-    Assertions.assertThat(location.delete()).isTrue();
+    assertThat(location.delete()).isTrue();
 
     Configuration conf = new Configuration();
 
@@ -63,8 +63,7 @@ public class TestHiveIcebergSerDe {
     HiveIcebergSerDe serDe = new HiveIcebergSerDe();
     serDe.initialize(conf, properties);
 
-    Assertions.assertThat(serDe.getObjectInspector())
-        .isEqualTo(IcebergObjectInspector.create(schema));
+    assertThat(serDe.getObjectInspector()).isEqualTo(IcebergObjectInspector.create(schema));
   }
 
   @Test
@@ -75,6 +74,6 @@ public class TestHiveIcebergSerDe {
     Container<Record> container = new Container<>();
     container.set(record);
 
-    Assertions.assertThat(serDe.deserialize(container)).isEqualTo(record);
+    assertThat(serDe.deserialize(container)).isEqualTo(record);
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDe.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDe.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.serde2.SerDeException;
@@ -34,22 +35,22 @@ import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
 import org.apache.iceberg.mr.mapred.Container;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestHiveIcebergSerDe {
 
   private static final Schema schema =
       new Schema(required(1, "string_field", Types.StringType.get()));
 
-  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+  @TempDir
+  public Path tmp;
 
   @Test
   public void testInitialize() throws IOException, SerDeException {
-    File location = tmp.newFolder();
-    Assert.assertTrue(location.delete());
+    File location = tmp.toFile();
+    Assertions.assertThat(location.delete()).isTrue();
 
     Configuration conf = new Configuration();
 
@@ -63,7 +64,7 @@ public class TestHiveIcebergSerDe {
     HiveIcebergSerDe serDe = new HiveIcebergSerDe();
     serDe.initialize(conf, properties);
 
-    Assert.assertEquals(IcebergObjectInspector.create(schema), serDe.getObjectInspector());
+    Assertions.assertThat(serDe.getObjectInspector()).isEqualTo(IcebergObjectInspector.create(schema));
   }
 
   @Test
@@ -74,6 +75,6 @@ public class TestHiveIcebergSerDe {
     Container<Record> container = new Container<>();
     container.set(record);
 
-    Assert.assertEquals(record, serDe.deserialize(container));
+    Assertions.assertThat(serDe.deserialize(container)).isEqualTo(record);
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDe.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDe.java
@@ -44,8 +44,7 @@ public class TestHiveIcebergSerDe {
   private static final Schema schema =
       new Schema(required(1, "string_field", Types.StringType.get()));
 
-  @TempDir
-  public Path tmp;
+  @TempDir public Path tmp;
 
   @Test
   public void testInitialize() throws IOException, SerDeException {
@@ -64,7 +63,8 @@ public class TestHiveIcebergSerDe {
     HiveIcebergSerDe serDe = new HiveIcebergSerDe();
     serDe.initialize(conf, properties);
 
-    Assertions.assertThat(serDe.getObjectInspector()).isEqualTo(IcebergObjectInspector.create(schema));
+    Assertions.assertThat(serDe.getObjectInspector())
+        .isEqualTo(IcebergObjectInspector.create(schema));
   }
 
   @Test

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergBinaryObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergBinaryObjectInspector.java
@@ -18,13 +18,14 @@
  */
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.ByteBuffer;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.BytesWritable;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergBinaryObjectInspector {
@@ -33,42 +34,40 @@ public class TestIcebergBinaryObjectInspector {
   public void testIcebergByteBufferObjectInspector() {
     BinaryObjectInspector oi = IcebergBinaryObjectInspector.get();
 
-    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
-    Assertions.assertThat(oi.getPrimitiveCategory())
+    assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    assertThat(oi.getPrimitiveCategory())
         .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.BINARY);
 
-    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.binaryTypeInfo);
-    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.binaryTypeInfo.getTypeName());
+    assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.binaryTypeInfo);
+    assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.binaryTypeInfo.getTypeName());
 
-    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(byte[].class);
-    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(BytesWritable.class);
+    assertThat(oi.getJavaPrimitiveClass()).isEqualTo(byte[].class);
+    assertThat(oi.getPrimitiveWritableClass()).isEqualTo(BytesWritable.class);
 
-    Assertions.assertThat(oi.copyObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    assertThat(oi.copyObject(null)).isNull();
+    assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    assertThat(oi.getPrimitiveWritableObject(null)).isNull();
 
     byte[] bytes = new byte[] {0, 1, 2, 3};
 
     ByteBuffer buffer = ByteBuffer.wrap(bytes);
-    Assertions.assertThat(oi.getPrimitiveJavaObject(buffer)).isEqualTo(bytes);
-    Assertions.assertThat(oi.getPrimitiveWritableObject(buffer))
-        .isEqualTo(new BytesWritable(bytes));
+    assertThat(oi.getPrimitiveJavaObject(buffer)).isEqualTo(bytes);
+    assertThat(oi.getPrimitiveWritableObject(buffer)).isEqualTo(new BytesWritable(bytes));
 
     ByteBuffer slice = ByteBuffer.wrap(bytes, 1, 2).slice();
-    Assertions.assertThat(oi.getPrimitiveJavaObject(slice)).isEqualTo(new byte[] {1, 2});
-    Assertions.assertThat(oi.getPrimitiveWritableObject(slice))
+    assertThat(oi.getPrimitiveJavaObject(slice)).isEqualTo(new byte[] {1, 2});
+    assertThat(oi.getPrimitiveWritableObject(slice))
         .isEqualTo(new BytesWritable(new byte[] {1, 2}));
 
     slice.position(1);
-    Assertions.assertThat(oi.getPrimitiveJavaObject(slice)).isEqualTo(new byte[] {2});
-    Assertions.assertThat(oi.getPrimitiveWritableObject(slice))
-        .isEqualTo(new BytesWritable(new byte[] {2}));
+    assertThat(oi.getPrimitiveJavaObject(slice)).isEqualTo(new byte[] {2});
+    assertThat(oi.getPrimitiveWritableObject(slice)).isEqualTo(new BytesWritable(new byte[] {2}));
 
     byte[] copy = (byte[]) oi.copyObject(bytes);
 
-    Assertions.assertThat(copy).isEqualTo(bytes);
-    Assertions.assertThat(copy).isNotSameAs(bytes);
+    assertThat(copy).isEqualTo(bytes);
+    assertThat(copy).isNotSameAs(bytes);
 
-    Assertions.assertThat(oi.preferWritable()).isFalse();
+    assertThat(oi.preferWritable()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergBinaryObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergBinaryObjectInspector.java
@@ -35,7 +35,7 @@ public class TestIcebergBinaryObjectInspector {
 
     Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
     Assertions.assertThat(oi.getPrimitiveCategory())
-            .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.BINARY);
+        .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.BINARY);
 
     Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.binaryTypeInfo);
     Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.binaryTypeInfo.getTypeName());
@@ -51,15 +51,18 @@ public class TestIcebergBinaryObjectInspector {
 
     ByteBuffer buffer = ByteBuffer.wrap(bytes);
     Assertions.assertThat(oi.getPrimitiveJavaObject(buffer)).isEqualTo(bytes);
-    Assertions.assertThat(oi.getPrimitiveWritableObject(buffer)).isEqualTo(new BytesWritable(bytes));
+    Assertions.assertThat(oi.getPrimitiveWritableObject(buffer))
+        .isEqualTo(new BytesWritable(bytes));
 
     ByteBuffer slice = ByteBuffer.wrap(bytes, 1, 2).slice();
     Assertions.assertThat(oi.getPrimitiveJavaObject(slice)).isEqualTo(new byte[] {1, 2});
-    Assertions.assertThat(oi.getPrimitiveWritableObject(slice)).isEqualTo(new BytesWritable(new byte[] {1, 2}));
+    Assertions.assertThat(oi.getPrimitiveWritableObject(slice))
+        .isEqualTo(new BytesWritable(new byte[] {1, 2}));
 
     slice.position(1);
     Assertions.assertThat(oi.getPrimitiveJavaObject(slice)).isEqualTo(new byte[] {2});
-    Assertions.assertThat(oi.getPrimitiveWritableObject(slice)).isEqualTo(new BytesWritable(new byte[] {2}));
+    Assertions.assertThat(oi.getPrimitiveWritableObject(slice))
+        .isEqualTo(new BytesWritable(new byte[] {2}));
 
     byte[] copy = (byte[]) oi.copyObject(bytes);
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergBinaryObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergBinaryObjectInspector.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.BytesWritable;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestIcebergBinaryObjectInspector {
 
@@ -33,39 +33,39 @@ public class TestIcebergBinaryObjectInspector {
   public void testIcebergByteBufferObjectInspector() {
     BinaryObjectInspector oi = IcebergBinaryObjectInspector.get();
 
-    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-    Assert.assertEquals(
-        PrimitiveObjectInspector.PrimitiveCategory.BINARY, oi.getPrimitiveCategory());
+    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    Assertions.assertThat(oi.getPrimitiveCategory())
+            .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.BINARY);
 
-    Assert.assertEquals(TypeInfoFactory.binaryTypeInfo, oi.getTypeInfo());
-    Assert.assertEquals(TypeInfoFactory.binaryTypeInfo.getTypeName(), oi.getTypeName());
+    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.binaryTypeInfo);
+    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.binaryTypeInfo.getTypeName());
 
-    Assert.assertEquals(byte[].class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(BytesWritable.class, oi.getPrimitiveWritableClass());
+    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(byte[].class);
+    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(BytesWritable.class);
 
-    Assert.assertNull(oi.copyObject(null));
-    Assert.assertNull(oi.getPrimitiveJavaObject(null));
-    Assert.assertNull(oi.getPrimitiveWritableObject(null));
+    Assertions.assertThat(oi.copyObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
 
     byte[] bytes = new byte[] {0, 1, 2, 3};
 
     ByteBuffer buffer = ByteBuffer.wrap(bytes);
-    Assert.assertArrayEquals(bytes, oi.getPrimitiveJavaObject(buffer));
-    Assert.assertEquals(new BytesWritable(bytes), oi.getPrimitiveWritableObject(buffer));
+    Assertions.assertThat(oi.getPrimitiveJavaObject(buffer)).isEqualTo(bytes);
+    Assertions.assertThat(oi.getPrimitiveWritableObject(buffer)).isEqualTo(new BytesWritable(bytes));
 
     ByteBuffer slice = ByteBuffer.wrap(bytes, 1, 2).slice();
-    Assert.assertArrayEquals(new byte[] {1, 2}, oi.getPrimitiveJavaObject(slice));
-    Assert.assertEquals(new BytesWritable(new byte[] {1, 2}), oi.getPrimitiveWritableObject(slice));
+    Assertions.assertThat(oi.getPrimitiveJavaObject(slice)).isEqualTo(new byte[] {1, 2});
+    Assertions.assertThat(oi.getPrimitiveWritableObject(slice)).isEqualTo(new BytesWritable(new byte[] {1, 2}));
 
     slice.position(1);
-    Assert.assertArrayEquals(new byte[] {2}, oi.getPrimitiveJavaObject(slice));
-    Assert.assertEquals(new BytesWritable(new byte[] {2}), oi.getPrimitiveWritableObject(slice));
+    Assertions.assertThat(oi.getPrimitiveJavaObject(slice)).isEqualTo(new byte[] {2});
+    Assertions.assertThat(oi.getPrimitiveWritableObject(slice)).isEqualTo(new BytesWritable(new byte[] {2}));
 
     byte[] copy = (byte[]) oi.copyObject(bytes);
 
-    Assert.assertArrayEquals(bytes, copy);
-    Assert.assertNotSame(bytes, copy);
+    Assertions.assertThat(copy).isEqualTo(bytes);
+    Assertions.assertThat(copy).isNotSameAs(bytes);
 
-    Assert.assertFalse(oi.preferWritable());
+    Assertions.assertThat(oi.preferWritable()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDateObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDateObjectInspector.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestIcebergDateObjectInspector {
 
@@ -34,30 +34,30 @@ public class TestIcebergDateObjectInspector {
   public void testIcebergDateObjectInspector() {
     DateObjectInspector oi = IcebergDateObjectInspector.get();
 
-    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-    Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.DATE, oi.getPrimitiveCategory());
+    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    Assertions.assertThat(oi.getPrimitiveCategory()).isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.DATE);
 
-    Assert.assertEquals(TypeInfoFactory.dateTypeInfo, oi.getTypeInfo());
-    Assert.assertEquals(TypeInfoFactory.dateTypeInfo.getTypeName(), oi.getTypeName());
+    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.dateTypeInfo);
+    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.dateTypeInfo.getTypeName());
 
-    Assert.assertEquals(Date.class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(DateWritable.class, oi.getPrimitiveWritableClass());
+    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(Date.class);
+    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(DateWritable.class);
 
-    Assert.assertNull(oi.copyObject(null));
-    Assert.assertNull(oi.getPrimitiveJavaObject(null));
-    Assert.assertNull(oi.getPrimitiveWritableObject(null));
+    Assertions.assertThat(oi.copyObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
 
     LocalDate local = LocalDate.of(2020, 1, 1);
     Date date = Date.valueOf("2020-01-01");
 
-    Assert.assertEquals(date, oi.getPrimitiveJavaObject(local));
-    Assert.assertEquals(new DateWritable(date), oi.getPrimitiveWritableObject(local));
+    Assertions.assertThat(oi.getPrimitiveJavaObject(local)).isEqualTo(date);
+    Assertions.assertThat(oi.getPrimitiveWritableObject(local)).isEqualTo(new DateWritable(date));
 
     Date copy = (Date) oi.copyObject(date);
 
-    Assert.assertEquals(date, copy);
-    Assert.assertNotSame(date, copy);
+    Assertions.assertThat(copy).isEqualTo(date);
+    Assertions.assertThat(copy).isNotSameAs(date);
 
-    Assert.assertFalse(oi.preferWritable());
+    Assertions.assertThat(oi.preferWritable()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDateObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDateObjectInspector.java
@@ -35,7 +35,8 @@ public class TestIcebergDateObjectInspector {
     DateObjectInspector oi = IcebergDateObjectInspector.get();
 
     Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
-    Assertions.assertThat(oi.getPrimitiveCategory()).isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.DATE);
+    Assertions.assertThat(oi.getPrimitiveCategory())
+        .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.DATE);
 
     Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.dateTypeInfo);
     Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.dateTypeInfo.getTypeName());

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDateObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDateObjectInspector.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.sql.Date;
 import java.time.LocalDate;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
@@ -25,7 +27,6 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergDateObjectInspector {
@@ -34,31 +35,31 @@ public class TestIcebergDateObjectInspector {
   public void testIcebergDateObjectInspector() {
     DateObjectInspector oi = IcebergDateObjectInspector.get();
 
-    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
-    Assertions.assertThat(oi.getPrimitiveCategory())
+    assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    assertThat(oi.getPrimitiveCategory())
         .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.DATE);
 
-    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.dateTypeInfo);
-    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.dateTypeInfo.getTypeName());
+    assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.dateTypeInfo);
+    assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.dateTypeInfo.getTypeName());
 
-    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(Date.class);
-    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(DateWritable.class);
+    assertThat(oi.getJavaPrimitiveClass()).isEqualTo(Date.class);
+    assertThat(oi.getPrimitiveWritableClass()).isEqualTo(DateWritable.class);
 
-    Assertions.assertThat(oi.copyObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    assertThat(oi.copyObject(null)).isNull();
+    assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    assertThat(oi.getPrimitiveWritableObject(null)).isNull();
 
     LocalDate local = LocalDate.of(2020, 1, 1);
     Date date = Date.valueOf("2020-01-01");
 
-    Assertions.assertThat(oi.getPrimitiveJavaObject(local)).isEqualTo(date);
-    Assertions.assertThat(oi.getPrimitiveWritableObject(local)).isEqualTo(new DateWritable(date));
+    assertThat(oi.getPrimitiveJavaObject(local)).isEqualTo(date);
+    assertThat(oi.getPrimitiveWritableObject(local)).isEqualTo(new DateWritable(date));
 
     Date copy = (Date) oi.copyObject(date);
 
-    Assertions.assertThat(copy).isEqualTo(date);
-    Assertions.assertThat(copy).isNotSameAs(date);
+    assertThat(copy).isEqualTo(date);
+    assertThat(copy).isNotSameAs(date);
 
-    Assertions.assertThat(oi.preferWritable()).isFalse();
+    assertThat(oi.preferWritable()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDecimalObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDecimalObjectInspector.java
@@ -45,10 +45,12 @@ public class TestIcebergDecimalObjectInspector {
     HiveDecimalObjectInspector oi = IcebergDecimalObjectInspector.get(38, 18);
 
     Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
-    Assertions.assertThat(oi.getPrimitiveCategory()).isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.DECIMAL);
+    Assertions.assertThat(oi.getPrimitiveCategory())
+        .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.DECIMAL);
 
     Assertions.assertThat(oi.getTypeInfo()).isEqualTo(new DecimalTypeInfo(38, 18));
-    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.decimalTypeInfo.getTypeName(), oi.getTypeName());
+    Assertions.assertThat(oi.getTypeName())
+        .isEqualTo(TypeInfoFactory.decimalTypeInfo.getTypeName(), oi.getTypeName());
 
     Assertions.assertThat(oi.precision()).isEqualTo(38);
     Assertions.assertThat(oi.scale()).isEqualTo(18);
@@ -64,7 +66,7 @@ public class TestIcebergDecimalObjectInspector {
 
     Assertions.assertThat(oi.getPrimitiveJavaObject(BigDecimal.ONE)).isEqualTo(one);
     Assertions.assertThat(oi.getPrimitiveWritableObject(BigDecimal.ONE))
-            .isEqualTo(new HiveDecimalWritable(one));
+        .isEqualTo(new HiveDecimalWritable(one));
 
     HiveDecimal copy = (HiveDecimal) oi.copyObject(one);
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDecimalObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDecimalObjectInspector.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.math.BigDecimal;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
@@ -26,7 +28,6 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergDecimalObjectInspector {
@@ -35,44 +36,44 @@ public class TestIcebergDecimalObjectInspector {
   public void testCache() {
     HiveDecimalObjectInspector oi = IcebergDecimalObjectInspector.get(38, 18);
 
-    Assertions.assertThat(IcebergDecimalObjectInspector.get(38, 18)).isSameAs(oi);
-    Assertions.assertThat(IcebergDecimalObjectInspector.get(28, 18)).isNotSameAs(oi);
-    Assertions.assertThat(IcebergDecimalObjectInspector.get(38, 28)).isNotSameAs(oi);
+    assertThat(IcebergDecimalObjectInspector.get(38, 18)).isSameAs(oi);
+    assertThat(IcebergDecimalObjectInspector.get(28, 18)).isNotSameAs(oi);
+    assertThat(IcebergDecimalObjectInspector.get(38, 28)).isNotSameAs(oi);
   }
 
   @Test
   public void testIcebergDecimalObjectInspector() {
     HiveDecimalObjectInspector oi = IcebergDecimalObjectInspector.get(38, 18);
 
-    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
-    Assertions.assertThat(oi.getPrimitiveCategory())
+    assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    assertThat(oi.getPrimitiveCategory())
         .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.DECIMAL);
 
-    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(new DecimalTypeInfo(38, 18));
-    Assertions.assertThat(oi.getTypeName())
+    assertThat(oi.getTypeInfo()).isEqualTo(new DecimalTypeInfo(38, 18));
+    assertThat(oi.getTypeName())
         .isEqualTo(TypeInfoFactory.decimalTypeInfo.getTypeName(), oi.getTypeName());
 
-    Assertions.assertThat(oi.precision()).isEqualTo(38);
-    Assertions.assertThat(oi.scale()).isEqualTo(18);
+    assertThat(oi.precision()).isEqualTo(38);
+    assertThat(oi.scale()).isEqualTo(18);
 
-    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(HiveDecimal.class);
-    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(HiveDecimalWritable.class);
+    assertThat(oi.getJavaPrimitiveClass()).isEqualTo(HiveDecimal.class);
+    assertThat(oi.getPrimitiveWritableClass()).isEqualTo(HiveDecimalWritable.class);
 
-    Assertions.assertThat(oi.copyObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    assertThat(oi.copyObject(null)).isNull();
+    assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    assertThat(oi.getPrimitiveWritableObject(null)).isNull();
 
     HiveDecimal one = HiveDecimal.create(BigDecimal.ONE);
 
-    Assertions.assertThat(oi.getPrimitiveJavaObject(BigDecimal.ONE)).isEqualTo(one);
-    Assertions.assertThat(oi.getPrimitiveWritableObject(BigDecimal.ONE))
+    assertThat(oi.getPrimitiveJavaObject(BigDecimal.ONE)).isEqualTo(one);
+    assertThat(oi.getPrimitiveWritableObject(BigDecimal.ONE))
         .isEqualTo(new HiveDecimalWritable(one));
 
     HiveDecimal copy = (HiveDecimal) oi.copyObject(one);
 
-    Assertions.assertThat(copy).isEqualTo(one);
-    Assertions.assertThat(copy).isNotSameAs(one);
+    assertThat(copy).isEqualTo(one);
+    assertThat(copy).isNotSameAs(one);
 
-    Assertions.assertThat(oi.preferWritable()).isFalse();
+    assertThat(oi.preferWritable()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDecimalObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDecimalObjectInspector.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestIcebergDecimalObjectInspector {
 
@@ -35,43 +35,42 @@ public class TestIcebergDecimalObjectInspector {
   public void testCache() {
     HiveDecimalObjectInspector oi = IcebergDecimalObjectInspector.get(38, 18);
 
-    Assert.assertSame(oi, IcebergDecimalObjectInspector.get(38, 18));
-    Assert.assertNotSame(oi, IcebergDecimalObjectInspector.get(28, 18));
-    Assert.assertNotSame(oi, IcebergDecimalObjectInspector.get(38, 28));
+    Assertions.assertThat(IcebergDecimalObjectInspector.get(38, 18)).isSameAs(oi);
+    Assertions.assertThat(IcebergDecimalObjectInspector.get(28, 18)).isNotSameAs(oi);
+    Assertions.assertThat(IcebergDecimalObjectInspector.get(38, 28)).isNotSameAs(oi);
   }
 
   @Test
   public void testIcebergDecimalObjectInspector() {
     HiveDecimalObjectInspector oi = IcebergDecimalObjectInspector.get(38, 18);
 
-    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-    Assert.assertEquals(
-        PrimitiveObjectInspector.PrimitiveCategory.DECIMAL, oi.getPrimitiveCategory());
+    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    Assertions.assertThat(oi.getPrimitiveCategory()).isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.DECIMAL);
 
-    Assert.assertEquals(new DecimalTypeInfo(38, 18), oi.getTypeInfo());
-    Assert.assertEquals(TypeInfoFactory.decimalTypeInfo.getTypeName(), oi.getTypeName());
+    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(new DecimalTypeInfo(38, 18));
+    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.decimalTypeInfo.getTypeName(), oi.getTypeName());
 
-    Assert.assertEquals(38, oi.precision());
-    Assert.assertEquals(18, oi.scale());
+    Assertions.assertThat(oi.precision()).isEqualTo(38);
+    Assertions.assertThat(oi.scale()).isEqualTo(18);
 
-    Assert.assertEquals(HiveDecimal.class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(HiveDecimalWritable.class, oi.getPrimitiveWritableClass());
+    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(HiveDecimal.class);
+    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(HiveDecimalWritable.class);
 
-    Assert.assertNull(oi.copyObject(null));
-    Assert.assertNull(oi.getPrimitiveJavaObject(null));
-    Assert.assertNull(oi.getPrimitiveWritableObject(null));
+    Assertions.assertThat(oi.copyObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
 
     HiveDecimal one = HiveDecimal.create(BigDecimal.ONE);
 
-    Assert.assertEquals(one, oi.getPrimitiveJavaObject(BigDecimal.ONE));
-    Assert.assertEquals(
-        new HiveDecimalWritable(one), oi.getPrimitiveWritableObject(BigDecimal.ONE));
+    Assertions.assertThat(oi.getPrimitiveJavaObject(BigDecimal.ONE)).isEqualTo(one);
+    Assertions.assertThat(oi.getPrimitiveWritableObject(BigDecimal.ONE))
+            .isEqualTo(new HiveDecimalWritable(one));
 
     HiveDecimal copy = (HiveDecimal) oi.copyObject(one);
 
-    Assert.assertEquals(one, copy);
-    Assert.assertNotSame(one, copy);
+    Assertions.assertThat(copy).isEqualTo(one);
+    Assertions.assertThat(copy).isNotSameAs(one);
 
-    Assert.assertFalse(oi.preferWritable());
+    Assertions.assertThat(oi.preferWritable()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergFixedObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergFixedObjectInspector.java
@@ -33,7 +33,7 @@ public class TestIcebergFixedObjectInspector {
 
     Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
     Assertions.assertThat(oi.getPrimitiveCategory())
-            .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.BINARY);
+        .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.BINARY);
 
     Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.binaryTypeInfo);
     Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.binaryTypeInfo.getTypeName());

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergFixedObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergFixedObjectInspector.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.BytesWritable;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestIcebergFixedObjectInspector {
 
@@ -31,33 +31,33 @@ public class TestIcebergFixedObjectInspector {
   public void testIcebergFixedObjectInspector() {
     IcebergFixedObjectInspector oi = IcebergFixedObjectInspector.get();
 
-    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-    Assert.assertEquals(
-        PrimitiveObjectInspector.PrimitiveCategory.BINARY, oi.getPrimitiveCategory());
+    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    Assertions.assertThat(oi.getPrimitiveCategory())
+            .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.BINARY);
 
-    Assert.assertEquals(TypeInfoFactory.binaryTypeInfo, oi.getTypeInfo());
-    Assert.assertEquals(TypeInfoFactory.binaryTypeInfo.getTypeName(), oi.getTypeName());
+    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.binaryTypeInfo);
+    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.binaryTypeInfo.getTypeName());
 
-    Assert.assertEquals(byte[].class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(BytesWritable.class, oi.getPrimitiveWritableClass());
+    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(byte[].class);
+    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(BytesWritable.class);
 
-    Assert.assertNull(oi.copyObject(null));
-    Assert.assertNull(oi.getPrimitiveJavaObject(null));
-    Assert.assertNull(oi.getPrimitiveWritableObject(null));
-    Assert.assertNull(oi.convert(null));
+    Assertions.assertThat(oi.copyObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    Assertions.assertThat(oi.convert(null)).isNull();
 
     byte[] bytes = new byte[] {0, 1};
     BytesWritable bytesWritable = new BytesWritable(bytes);
 
-    Assert.assertArrayEquals(bytes, oi.getPrimitiveJavaObject(bytes));
-    Assert.assertEquals(bytesWritable, oi.getPrimitiveWritableObject(bytes));
-    Assert.assertEquals(bytes, oi.convert(bytes));
+    Assertions.assertThat(oi.getPrimitiveJavaObject(bytes)).isEqualTo(bytes);
+    Assertions.assertThat(oi.getPrimitiveWritableObject(bytes)).isEqualTo(bytesWritable);
+    Assertions.assertThat(oi.convert(bytes)).isEqualTo(bytes);
 
     byte[] copy = (byte[]) oi.copyObject(bytes);
 
-    Assert.assertArrayEquals(bytes, copy);
-    Assert.assertNotSame(bytes, copy);
+    Assertions.assertThat(copy).isEqualTo(bytes);
+    Assertions.assertThat(copy).isNotSameAs(bytes);
 
-    Assert.assertFalse(oi.preferWritable());
+    Assertions.assertThat(oi.preferWritable()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergFixedObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergFixedObjectInspector.java
@@ -18,11 +18,12 @@
  */
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.BytesWritable;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergFixedObjectInspector {
@@ -31,33 +32,33 @@ public class TestIcebergFixedObjectInspector {
   public void testIcebergFixedObjectInspector() {
     IcebergFixedObjectInspector oi = IcebergFixedObjectInspector.get();
 
-    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
-    Assertions.assertThat(oi.getPrimitiveCategory())
+    assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    assertThat(oi.getPrimitiveCategory())
         .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.BINARY);
 
-    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.binaryTypeInfo);
-    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.binaryTypeInfo.getTypeName());
+    assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.binaryTypeInfo);
+    assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.binaryTypeInfo.getTypeName());
 
-    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(byte[].class);
-    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(BytesWritable.class);
+    assertThat(oi.getJavaPrimitiveClass()).isEqualTo(byte[].class);
+    assertThat(oi.getPrimitiveWritableClass()).isEqualTo(BytesWritable.class);
 
-    Assertions.assertThat(oi.copyObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
-    Assertions.assertThat(oi.convert(null)).isNull();
+    assertThat(oi.copyObject(null)).isNull();
+    assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    assertThat(oi.convert(null)).isNull();
 
     byte[] bytes = new byte[] {0, 1};
     BytesWritable bytesWritable = new BytesWritable(bytes);
 
-    Assertions.assertThat(oi.getPrimitiveJavaObject(bytes)).isEqualTo(bytes);
-    Assertions.assertThat(oi.getPrimitiveWritableObject(bytes)).isEqualTo(bytesWritable);
-    Assertions.assertThat(oi.convert(bytes)).isEqualTo(bytes);
+    assertThat(oi.getPrimitiveJavaObject(bytes)).isEqualTo(bytes);
+    assertThat(oi.getPrimitiveWritableObject(bytes)).isEqualTo(bytesWritable);
+    assertThat(oi.convert(bytes)).isEqualTo(bytes);
 
     byte[] copy = (byte[]) oi.copyObject(bytes);
 
-    Assertions.assertThat(copy).isEqualTo(bytes);
-    Assertions.assertThat(copy).isNotSameAs(bytes);
+    assertThat(copy).isEqualTo(bytes);
+    assertThat(copy).isNotSameAs(bytes);
 
-    Assertions.assertThat(oi.preferWritable()).isFalse();
+    assertThat(oi.preferWritable()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
@@ -31,7 +32,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.hive.HiveVersion;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergObjectInspector {
@@ -74,166 +74,161 @@ public class TestIcebergObjectInspector {
   @Test
   public void testIcebergObjectInspector() {
     ObjectInspector oi = IcebergObjectInspector.create(schema);
-    Assertions.assertThat(oi).isNotNull();
-    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.STRUCT);
+    assertThat(oi).isNotNull();
+    assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.STRUCT);
 
     StructObjectInspector soi = (StructObjectInspector) oi;
 
     // binary
     StructField binaryField = soi.getStructFieldRef("binary_field");
-    Assertions.assertThat(binaryField.getFieldID()).isEqualTo(1);
-    Assertions.assertThat(binaryField.getFieldName()).isEqualTo("binary_field");
-    Assertions.assertThat(binaryField.getFieldComment()).isEqualTo("binary comment");
-    Assertions.assertThat(binaryField.getFieldObjectInspector())
-        .isEqualTo(IcebergBinaryObjectInspector.get());
+    assertThat(binaryField.getFieldID()).isEqualTo(1);
+    assertThat(binaryField.getFieldName()).isEqualTo("binary_field");
+    assertThat(binaryField.getFieldComment()).isEqualTo("binary comment");
+    assertThat(binaryField.getFieldObjectInspector()).isEqualTo(IcebergBinaryObjectInspector.get());
 
     // boolean
     StructField booleanField = soi.getStructFieldRef("boolean_field");
-    Assertions.assertThat(booleanField.getFieldID()).isEqualTo(2);
-    Assertions.assertThat(booleanField.getFieldName()).isEqualTo("boolean_field");
-    Assertions.assertThat(booleanField.getFieldComment()).isEqualTo("boolean comment");
-    Assertions.assertThat(booleanField.getFieldObjectInspector())
+    assertThat(booleanField.getFieldID()).isEqualTo(2);
+    assertThat(booleanField.getFieldName()).isEqualTo("boolean_field");
+    assertThat(booleanField.getFieldComment()).isEqualTo("boolean comment");
+    assertThat(booleanField.getFieldObjectInspector())
         .isEqualTo(getPrimitiveObjectInspector(boolean.class));
 
     // date
     StructField dateField = soi.getStructFieldRef("date_field");
-    Assertions.assertThat(dateField.getFieldID()).isEqualTo(3);
-    Assertions.assertThat(dateField.getFieldName()).isEqualTo("date_field");
-    Assertions.assertThat(dateField.getFieldComment()).isEqualTo("date comment");
+    assertThat(dateField.getFieldID()).isEqualTo(3);
+    assertThat(dateField.getFieldName()).isEqualTo("date_field");
+    assertThat(dateField.getFieldComment()).isEqualTo("date comment");
     if (HiveVersion.min(HiveVersion.HIVE_3)) {
-      Assertions.assertThat(dateField.getFieldObjectInspector().getClass().getName())
+      assertThat(dateField.getFieldObjectInspector().getClass().getName())
           .isEqualTo(
               "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspectorHive3");
     } else {
-      Assertions.assertThat(dateField.getFieldObjectInspector().getClass().getName())
+      assertThat(dateField.getFieldObjectInspector().getClass().getName())
           .isEqualTo("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspector");
     }
 
     // decimal
     StructField decimalField = soi.getStructFieldRef("decimal_field");
-    Assertions.assertThat(decimalField.getFieldID()).isEqualTo(4);
-    Assertions.assertThat(decimalField.getFieldName()).isEqualTo("decimal_field");
-    Assertions.assertThat(decimalField.getFieldComment()).isEqualTo("decimal comment");
-    Assertions.assertThat(decimalField.getFieldObjectInspector())
+    assertThat(decimalField.getFieldID()).isEqualTo(4);
+    assertThat(decimalField.getFieldName()).isEqualTo("decimal_field");
+    assertThat(decimalField.getFieldComment()).isEqualTo("decimal comment");
+    assertThat(decimalField.getFieldObjectInspector())
         .isEqualTo(IcebergDecimalObjectInspector.get(38, 18));
 
     // double
     StructField doubleField = soi.getStructFieldRef("double_field");
-    Assertions.assertThat(doubleField.getFieldID()).isEqualTo(5);
-    Assertions.assertThat(doubleField.getFieldName()).isEqualTo("double_field");
-    Assertions.assertThat(doubleField.getFieldComment()).isEqualTo("double comment");
-    Assertions.assertThat(doubleField.getFieldObjectInspector())
+    assertThat(doubleField.getFieldID()).isEqualTo(5);
+    assertThat(doubleField.getFieldName()).isEqualTo("double_field");
+    assertThat(doubleField.getFieldComment()).isEqualTo("double comment");
+    assertThat(doubleField.getFieldObjectInspector())
         .isEqualTo(getPrimitiveObjectInspector(double.class));
 
     // fixed
     StructField fixedField = soi.getStructFieldRef("fixed_field");
-    Assertions.assertThat(fixedField.getFieldID()).isEqualTo(6);
-    Assertions.assertThat(fixedField.getFieldName()).isEqualTo("fixed_field");
-    Assertions.assertThat(fixedField.getFieldComment()).isEqualTo("fixed comment");
-    Assertions.assertThat(fixedField.getFieldObjectInspector())
-        .isEqualTo(IcebergFixedObjectInspector.get());
+    assertThat(fixedField.getFieldID()).isEqualTo(6);
+    assertThat(fixedField.getFieldName()).isEqualTo("fixed_field");
+    assertThat(fixedField.getFieldComment()).isEqualTo("fixed comment");
+    assertThat(fixedField.getFieldObjectInspector()).isEqualTo(IcebergFixedObjectInspector.get());
 
     // float
     StructField floatField = soi.getStructFieldRef("float_field");
-    Assertions.assertThat(floatField.getFieldID()).isEqualTo(7);
-    Assertions.assertThat(floatField.getFieldName()).isEqualTo("float_field");
-    Assertions.assertThat(floatField.getFieldComment()).isEqualTo("float comment");
-    Assertions.assertThat(floatField.getFieldObjectInspector())
+    assertThat(floatField.getFieldID()).isEqualTo(7);
+    assertThat(floatField.getFieldName()).isEqualTo("float_field");
+    assertThat(floatField.getFieldComment()).isEqualTo("float comment");
+    assertThat(floatField.getFieldObjectInspector())
         .isEqualTo(getPrimitiveObjectInspector(float.class));
 
     // integer
     StructField integerField = soi.getStructFieldRef("integer_field");
-    Assertions.assertThat(integerField.getFieldID()).isEqualTo(8);
-    Assertions.assertThat(integerField.getFieldName()).isEqualTo("integer_field");
-    Assertions.assertThat(integerField.getFieldComment()).isEqualTo("integer comment");
-    Assertions.assertThat(integerField.getFieldObjectInspector())
+    assertThat(integerField.getFieldID()).isEqualTo(8);
+    assertThat(integerField.getFieldName()).isEqualTo("integer_field");
+    assertThat(integerField.getFieldComment()).isEqualTo("integer comment");
+    assertThat(integerField.getFieldObjectInspector())
         .isEqualTo(getPrimitiveObjectInspector(int.class));
 
     // long
     StructField longField = soi.getStructFieldRef("long_field");
-    Assertions.assertThat(longField.getFieldID()).isEqualTo(9);
-    Assertions.assertThat(longField.getFieldName()).isEqualTo("long_field");
-    Assertions.assertThat(longField.getFieldComment()).isEqualTo("long comment");
-    Assertions.assertThat(longField.getFieldObjectInspector())
+    assertThat(longField.getFieldID()).isEqualTo(9);
+    assertThat(longField.getFieldName()).isEqualTo("long_field");
+    assertThat(longField.getFieldComment()).isEqualTo("long comment");
+    assertThat(longField.getFieldObjectInspector())
         .isEqualTo(getPrimitiveObjectInspector(long.class));
 
     // string
     StructField stringField = soi.getStructFieldRef("string_field");
-    Assertions.assertThat(stringField.getFieldID()).isEqualTo(10);
-    Assertions.assertThat(stringField.getFieldName()).isEqualTo("string_field");
-    Assertions.assertThat(stringField.getFieldComment()).isEqualTo("string comment");
-    Assertions.assertThat(stringField.getFieldObjectInspector())
+    assertThat(stringField.getFieldID()).isEqualTo(10);
+    assertThat(stringField.getFieldName()).isEqualTo("string_field");
+    assertThat(stringField.getFieldComment()).isEqualTo("string comment");
+    assertThat(stringField.getFieldObjectInspector())
         .isEqualTo(getPrimitiveObjectInspector(String.class));
 
     // timestamp without tz
     StructField timestampField = soi.getStructFieldRef("timestamp_field");
-    Assertions.assertThat(timestampField.getFieldID()).isEqualTo(11);
-    Assertions.assertThat(timestampField.getFieldName()).isEqualTo("timestamp_field");
-    Assertions.assertThat(timestampField.getFieldComment()).isEqualTo("timestamp comment");
+    assertThat(timestampField.getFieldID()).isEqualTo(11);
+    assertThat(timestampField.getFieldName()).isEqualTo("timestamp_field");
+    assertThat(timestampField.getFieldComment()).isEqualTo("timestamp comment");
     if (HiveVersion.min(HiveVersion.HIVE_3)) {
-      Assertions.assertThat(timestampField.getFieldObjectInspector().getClass().getSimpleName())
+      assertThat(timestampField.getFieldObjectInspector().getClass().getSimpleName())
           .isEqualTo("IcebergTimestampObjectInspectorHive3");
     } else {
-      Assertions.assertThat(timestampField.getFieldObjectInspector())
+      assertThat(timestampField.getFieldObjectInspector())
           .isEqualTo(IcebergTimestampObjectInspector.get());
     }
 
     // timestamp with tz
     StructField timestampTzField = soi.getStructFieldRef("timestamptz_field");
-    Assertions.assertThat(timestampTzField.getFieldID()).isEqualTo(12);
-    Assertions.assertThat(timestampTzField.getFieldName()).isEqualTo("timestamptz_field");
-    Assertions.assertThat(timestampTzField.getFieldComment()).isEqualTo("timestamptz comment");
+    assertThat(timestampTzField.getFieldID()).isEqualTo(12);
+    assertThat(timestampTzField.getFieldName()).isEqualTo("timestamptz_field");
+    assertThat(timestampTzField.getFieldComment()).isEqualTo("timestamptz comment");
     if (HiveVersion.min(HiveVersion.HIVE_3)) {
-      Assertions.assertThat(timestampTzField.getFieldObjectInspector().getClass().getSimpleName())
+      assertThat(timestampTzField.getFieldObjectInspector().getClass().getSimpleName())
           .isEqualTo("IcebergTimestampWithZoneObjectInspectorHive3");
     } else {
-      Assertions.assertThat(timestampTzField.getFieldObjectInspector())
+      assertThat(timestampTzField.getFieldObjectInspector())
           .isEqualTo(IcebergTimestampWithZoneObjectInspector.get());
     }
 
     // UUID
     StructField uuidField = soi.getStructFieldRef("uuid_field");
-    Assertions.assertThat(uuidField.getFieldID()).isEqualTo(13);
-    Assertions.assertThat(uuidField.getFieldName()).isEqualTo("uuid_field");
-    Assertions.assertThat(uuidField.getFieldComment()).isEqualTo("uuid comment");
-    Assertions.assertThat(uuidField.getFieldObjectInspector())
-        .isEqualTo(IcebergUUIDObjectInspector.get());
+    assertThat(uuidField.getFieldID()).isEqualTo(13);
+    assertThat(uuidField.getFieldName()).isEqualTo("uuid_field");
+    assertThat(uuidField.getFieldComment()).isEqualTo("uuid comment");
+    assertThat(uuidField.getFieldObjectInspector()).isEqualTo(IcebergUUIDObjectInspector.get());
 
     // list
     StructField listField = soi.getStructFieldRef("list_field");
-    Assertions.assertThat(listField.getFieldID()).isEqualTo(14);
-    Assertions.assertThat(listField.getFieldName()).isEqualTo("list_field");
-    Assertions.assertThat(listField.getFieldComment()).isEqualTo("list comment");
-    Assertions.assertThat(listField.getFieldObjectInspector())
-        .isEqualTo(getListObjectInspector(String.class));
+    assertThat(listField.getFieldID()).isEqualTo(14);
+    assertThat(listField.getFieldName()).isEqualTo("list_field");
+    assertThat(listField.getFieldComment()).isEqualTo("list comment");
+    assertThat(listField.getFieldObjectInspector()).isEqualTo(getListObjectInspector(String.class));
 
     // map
     StructField mapField = soi.getStructFieldRef("map_field");
-    Assertions.assertThat(mapField.getFieldID()).isEqualTo(16);
-    Assertions.assertThat(mapField.getFieldName()).isEqualTo("map_field");
-    Assertions.assertThat(mapField.getFieldComment()).isEqualTo("map comment");
-    Assertions.assertThat(mapField.getFieldObjectInspector())
+    assertThat(mapField.getFieldID()).isEqualTo(16);
+    assertThat(mapField.getFieldName()).isEqualTo("map_field");
+    assertThat(mapField.getFieldComment()).isEqualTo("map comment");
+    assertThat(mapField.getFieldObjectInspector())
         .isEqualTo(getMapObjectInspector(String.class, int.class));
 
     // struct
     StructField structField = soi.getStructFieldRef("struct_field");
-    Assertions.assertThat(structField.getFieldID()).isEqualTo(19);
-    Assertions.assertThat(structField.getFieldName()).isEqualTo("struct_field");
-    Assertions.assertThat(structField.getFieldComment()).isEqualTo("struct comment");
+    assertThat(structField.getFieldID()).isEqualTo(19);
+    assertThat(structField.getFieldName()).isEqualTo("struct_field");
+    assertThat(structField.getFieldComment()).isEqualTo("struct comment");
 
     ObjectInspector expectedObjectInspector =
         new IcebergRecordObjectInspector(
             (Types.StructType) schema.findType(19),
             ImmutableList.of(getPrimitiveObjectInspector(String.class)));
-    Assertions.assertThat(structField.getFieldObjectInspector()).isEqualTo(expectedObjectInspector);
+    assertThat(structField.getFieldObjectInspector()).isEqualTo(expectedObjectInspector);
 
     // time
     StructField timeField = soi.getStructFieldRef("time_field");
-    Assertions.assertThat(timeField.getFieldID()).isEqualTo(21);
-    Assertions.assertThat(timeField.getFieldName()).isEqualTo("time_field");
-    Assertions.assertThat(timeField.getFieldComment()).isEqualTo("time comment");
-    Assertions.assertThat(timeField.getFieldObjectInspector())
-        .isEqualTo(IcebergTimeObjectInspector.get());
+    assertThat(timeField.getFieldID()).isEqualTo(21);
+    assertThat(timeField.getFieldName()).isEqualTo("time_field");
+    assertThat(timeField.getFieldComment()).isEqualTo("time comment");
+    assertThat(timeField.getFieldObjectInspector()).isEqualTo(IcebergTimeObjectInspector.get());
   }
 
   private static ObjectInspector getPrimitiveObjectInspector(Class<?> clazz) {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
@@ -31,8 +31,8 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.hive.HiveVersion;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestIcebergObjectInspector {
 
@@ -74,165 +74,160 @@ public class TestIcebergObjectInspector {
   @Test
   public void testIcebergObjectInspector() {
     ObjectInspector oi = IcebergObjectInspector.create(schema);
-    Assert.assertNotNull(oi);
-    Assert.assertEquals(ObjectInspector.Category.STRUCT, oi.getCategory());
+    Assertions.assertThat(oi).isNotNull();
+    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.STRUCT);
 
     StructObjectInspector soi = (StructObjectInspector) oi;
 
     // binary
     StructField binaryField = soi.getStructFieldRef("binary_field");
-    Assert.assertEquals(1, binaryField.getFieldID());
-    Assert.assertEquals("binary_field", binaryField.getFieldName());
-    Assert.assertEquals("binary comment", binaryField.getFieldComment());
-    Assert.assertEquals(IcebergBinaryObjectInspector.get(), binaryField.getFieldObjectInspector());
+    Assertions.assertThat(binaryField.getFieldID()).isEqualTo(1);
+    Assertions.assertThat(binaryField.getFieldName()).isEqualTo("binary_field");
+    Assertions.assertThat(binaryField.getFieldComment()).isEqualTo("binary comment");
+    Assertions.assertThat(binaryField.getFieldObjectInspector()).isEqualTo(IcebergBinaryObjectInspector.get());
 
     // boolean
     StructField booleanField = soi.getStructFieldRef("boolean_field");
-    Assert.assertEquals(2, booleanField.getFieldID());
-    Assert.assertEquals("boolean_field", booleanField.getFieldName());
-    Assert.assertEquals("boolean comment", booleanField.getFieldComment());
-    Assert.assertEquals(
-        getPrimitiveObjectInspector(boolean.class), booleanField.getFieldObjectInspector());
+    Assertions.assertThat(booleanField.getFieldID()).isEqualTo(2);
+    Assertions.assertThat(booleanField.getFieldName()).isEqualTo("boolean_field");
+    Assertions.assertThat(booleanField.getFieldComment()).isEqualTo("boolean comment");
+    Assertions.assertThat(booleanField.getFieldObjectInspector())
+                    .isEqualTo(getPrimitiveObjectInspector(boolean.class));
 
     // date
     StructField dateField = soi.getStructFieldRef("date_field");
-    Assert.assertEquals(3, dateField.getFieldID());
-    Assert.assertEquals("date_field", dateField.getFieldName());
-    Assert.assertEquals("date comment", dateField.getFieldComment());
+    Assertions.assertThat(dateField.getFieldID()).isEqualTo(3);
+    Assertions.assertThat(dateField.getFieldName()).isEqualTo("date_field");
+    Assertions.assertThat(dateField.getFieldComment()).isEqualTo("date comment");
     if (HiveVersion.min(HiveVersion.HIVE_3)) {
-      Assert.assertEquals(
-          "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspectorHive3",
-          dateField.getFieldObjectInspector().getClass().getName());
+      Assertions.assertThat(dateField.getFieldObjectInspector().getClass().getName())
+              .isEqualTo("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspectorHive3");
     } else {
-      Assert.assertEquals(
-          "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspector",
-          dateField.getFieldObjectInspector().getClass().getName());
+      Assertions.assertThat(dateField.getFieldObjectInspector().getClass().getName())
+              .isEqualTo("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspector");
     }
 
     // decimal
     StructField decimalField = soi.getStructFieldRef("decimal_field");
-    Assert.assertEquals(4, decimalField.getFieldID());
-    Assert.assertEquals("decimal_field", decimalField.getFieldName());
-    Assert.assertEquals("decimal comment", decimalField.getFieldComment());
-    Assert.assertEquals(
-        IcebergDecimalObjectInspector.get(38, 18), decimalField.getFieldObjectInspector());
+    Assertions.assertThat(decimalField.getFieldID()).isEqualTo(4);
+    Assertions.assertThat(decimalField.getFieldName()).isEqualTo("decimal_field");
+    Assertions.assertThat(decimalField.getFieldComment()).isEqualTo("decimal comment");
+    Assertions.assertThat(decimalField.getFieldObjectInspector())
+            .isEqualTo(IcebergDecimalObjectInspector.get(38, 18));
 
     // double
     StructField doubleField = soi.getStructFieldRef("double_field");
-    Assert.assertEquals(5, doubleField.getFieldID());
-    Assert.assertEquals("double_field", doubleField.getFieldName());
-    Assert.assertEquals("double comment", doubleField.getFieldComment());
-    Assert.assertEquals(
-        getPrimitiveObjectInspector(double.class), doubleField.getFieldObjectInspector());
+    Assertions.assertThat(doubleField.getFieldID()).isEqualTo(5);
+    Assertions.assertThat(doubleField.getFieldName()).isEqualTo("double_field");
+    Assertions.assertThat(doubleField.getFieldComment()).isEqualTo("double comment");
+    Assertions.assertThat(doubleField.getFieldObjectInspector())
+                    .isEqualTo(getPrimitiveObjectInspector(double.class));
 
     // fixed
     StructField fixedField = soi.getStructFieldRef("fixed_field");
-    Assert.assertEquals(6, fixedField.getFieldID());
-    Assert.assertEquals("fixed_field", fixedField.getFieldName());
-    Assert.assertEquals("fixed comment", fixedField.getFieldComment());
-    Assert.assertEquals(IcebergFixedObjectInspector.get(), fixedField.getFieldObjectInspector());
+    Assertions.assertThat(fixedField.getFieldID()).isEqualTo(6);
+    Assertions.assertThat(fixedField.getFieldName()).isEqualTo("fixed_field");
+    Assertions.assertThat(fixedField.getFieldComment()).isEqualTo("fixed comment");
+    Assertions.assertThat(fixedField.getFieldObjectInspector()).isEqualTo(IcebergFixedObjectInspector.get());
 
     // float
     StructField floatField = soi.getStructFieldRef("float_field");
-    Assert.assertEquals(7, floatField.getFieldID());
-    Assert.assertEquals("float_field", floatField.getFieldName());
-    Assert.assertEquals("float comment", floatField.getFieldComment());
-    Assert.assertEquals(
-        getPrimitiveObjectInspector(float.class), floatField.getFieldObjectInspector());
+    Assertions.assertThat(floatField.getFieldID()).isEqualTo(7);
+    Assertions.assertThat(floatField.getFieldName()).isEqualTo("float_field");
+    Assertions.assertThat(floatField.getFieldComment()).isEqualTo("float comment");
+    Assertions.assertThat(floatField.getFieldObjectInspector())
+                    .isEqualTo(getPrimitiveObjectInspector(float.class));
 
     // integer
     StructField integerField = soi.getStructFieldRef("integer_field");
-    Assert.assertEquals(8, integerField.getFieldID());
-    Assert.assertEquals("integer_field", integerField.getFieldName());
-    Assert.assertEquals("integer comment", integerField.getFieldComment());
-    Assert.assertEquals(
-        getPrimitiveObjectInspector(int.class), integerField.getFieldObjectInspector());
+    Assertions.assertThat(integerField.getFieldID()).isEqualTo(8);
+    Assertions.assertThat(integerField.getFieldName()).isEqualTo("integer_field");
+    Assertions.assertThat(integerField.getFieldComment()).isEqualTo("integer comment");
+    Assertions.assertThat(integerField.getFieldObjectInspector())
+                    .isEqualTo(getPrimitiveObjectInspector(int.class));
 
     // long
     StructField longField = soi.getStructFieldRef("long_field");
-    Assert.assertEquals(9, longField.getFieldID());
-    Assert.assertEquals("long_field", longField.getFieldName());
-    Assert.assertEquals("long comment", longField.getFieldComment());
-    Assert.assertEquals(
-        getPrimitiveObjectInspector(long.class), longField.getFieldObjectInspector());
+    Assertions.assertThat(longField.getFieldID()).isEqualTo(9);
+    Assertions.assertThat(longField.getFieldName()).isEqualTo("long_field");
+    Assertions.assertThat(longField.getFieldComment()).isEqualTo("long comment");
+    Assertions.assertThat(longField.getFieldObjectInspector())
+                    .isEqualTo(getPrimitiveObjectInspector(long.class));
 
     // string
     StructField stringField = soi.getStructFieldRef("string_field");
-    Assert.assertEquals(10, stringField.getFieldID());
-    Assert.assertEquals("string_field", stringField.getFieldName());
-    Assert.assertEquals("string comment", stringField.getFieldComment());
-    Assert.assertEquals(
-        getPrimitiveObjectInspector(String.class), stringField.getFieldObjectInspector());
+    Assertions.assertThat(stringField.getFieldID()).isEqualTo(10);
+    Assertions.assertThat(stringField.getFieldName()).isEqualTo("string_field");
+    Assertions.assertThat(stringField.getFieldComment()).isEqualTo("string comment");
+    Assertions.assertThat(stringField.getFieldObjectInspector())
+            .isEqualTo(getPrimitiveObjectInspector(String.class));
 
     // timestamp without tz
     StructField timestampField = soi.getStructFieldRef("timestamp_field");
-    Assert.assertEquals(11, timestampField.getFieldID());
-    Assert.assertEquals("timestamp_field", timestampField.getFieldName());
-    Assert.assertEquals("timestamp comment", timestampField.getFieldComment());
+    Assertions.assertThat(timestampField.getFieldID()).isEqualTo(11);
+    Assertions.assertThat(timestampField.getFieldName()).isEqualTo("timestamp_field");
+    Assertions.assertThat(timestampField.getFieldComment()).isEqualTo("timestamp comment");
     if (HiveVersion.min(HiveVersion.HIVE_3)) {
-      Assert.assertEquals(
-          "IcebergTimestampObjectInspectorHive3",
-          timestampField.getFieldObjectInspector().getClass().getSimpleName());
+      Assertions.assertThat(timestampField.getFieldObjectInspector().getClass().getSimpleName())
+              .isEqualTo("IcebergTimestampObjectInspectorHive3");
     } else {
-      Assert.assertEquals(
-          IcebergTimestampObjectInspector.get(), timestampField.getFieldObjectInspector());
+      Assertions.assertThat(timestampField.getFieldObjectInspector())
+              .isEqualTo(IcebergTimestampObjectInspector.get());
     }
 
     // timestamp with tz
     StructField timestampTzField = soi.getStructFieldRef("timestamptz_field");
-    Assert.assertEquals(12, timestampTzField.getFieldID());
-    Assert.assertEquals("timestamptz_field", timestampTzField.getFieldName());
-    Assert.assertEquals("timestamptz comment", timestampTzField.getFieldComment());
+    Assertions.assertThat(timestampTzField.getFieldID()).isEqualTo(12);
+    Assertions.assertThat(timestampTzField.getFieldName()).isEqualTo("timestamptz_field");
+    Assertions.assertThat(timestampTzField.getFieldComment()).isEqualTo("timestamptz comment");
     if (HiveVersion.min(HiveVersion.HIVE_3)) {
-      Assert.assertEquals(
-          "IcebergTimestampWithZoneObjectInspectorHive3",
-          timestampTzField.getFieldObjectInspector().getClass().getSimpleName());
+      Assertions.assertThat(timestampTzField.getFieldObjectInspector().getClass().getSimpleName())
+              .isEqualTo("IcebergTimestampWithZoneObjectInspectorHive3");
     } else {
-      Assert.assertEquals(
-          IcebergTimestampWithZoneObjectInspector.get(),
-          timestampTzField.getFieldObjectInspector());
+      Assertions.assertThat(timestampTzField.getFieldObjectInspector())
+              .isEqualTo(IcebergTimestampWithZoneObjectInspector.get());
     }
 
     // UUID
     StructField uuidField = soi.getStructFieldRef("uuid_field");
-    Assert.assertEquals(13, uuidField.getFieldID());
-    Assert.assertEquals("uuid_field", uuidField.getFieldName());
-    Assert.assertEquals("uuid comment", uuidField.getFieldComment());
-    Assert.assertEquals(IcebergUUIDObjectInspector.get(), uuidField.getFieldObjectInspector());
+    Assertions.assertThat(uuidField.getFieldID()).isEqualTo(13);
+    Assertions.assertThat(uuidField.getFieldName()).isEqualTo("uuid_field");
+    Assertions.assertThat(uuidField.getFieldComment()).isEqualTo("uuid comment");
+    Assertions.assertThat(uuidField.getFieldObjectInspector()).isEqualTo(IcebergUUIDObjectInspector.get());
 
     // list
     StructField listField = soi.getStructFieldRef("list_field");
-    Assert.assertEquals(14, listField.getFieldID());
-    Assert.assertEquals("list_field", listField.getFieldName());
-    Assert.assertEquals("list comment", listField.getFieldComment());
-    Assert.assertEquals(getListObjectInspector(String.class), listField.getFieldObjectInspector());
+    Assertions.assertThat(listField.getFieldID()).isEqualTo(14);
+    Assertions.assertThat(listField.getFieldName()).isEqualTo("list_field");
+    Assertions.assertThat(listField.getFieldComment()).isEqualTo("list comment");
+    Assertions.assertThat(listField.getFieldObjectInspector()).isEqualTo(getListObjectInspector(String.class));
 
     // map
     StructField mapField = soi.getStructFieldRef("map_field");
-    Assert.assertEquals(16, mapField.getFieldID());
-    Assert.assertEquals("map_field", mapField.getFieldName());
-    Assert.assertEquals("map comment", mapField.getFieldComment());
-    Assert.assertEquals(
-        getMapObjectInspector(String.class, int.class), mapField.getFieldObjectInspector());
+    Assertions.assertThat(mapField.getFieldID()).isEqualTo(16);
+    Assertions.assertThat(mapField.getFieldName()).isEqualTo("map_field");
+    Assertions.assertThat(mapField.getFieldComment()).isEqualTo("map comment");
+    Assertions.assertThat(mapField.getFieldObjectInspector())
+            .isEqualTo(getMapObjectInspector(String.class, int.class));
 
     // struct
     StructField structField = soi.getStructFieldRef("struct_field");
-    Assert.assertEquals(19, structField.getFieldID());
-    Assert.assertEquals("struct_field", structField.getFieldName());
-    Assert.assertEquals("struct comment", structField.getFieldComment());
+    Assertions.assertThat(structField.getFieldID()).isEqualTo(19);
+    Assertions.assertThat(structField.getFieldName()).isEqualTo("struct_field");
+    Assertions.assertThat(structField.getFieldComment()).isEqualTo("struct comment");
 
     ObjectInspector expectedObjectInspector =
         new IcebergRecordObjectInspector(
             (Types.StructType) schema.findType(19),
             ImmutableList.of(getPrimitiveObjectInspector(String.class)));
-    Assert.assertEquals(expectedObjectInspector, structField.getFieldObjectInspector());
+    Assertions.assertThat(structField.getFieldObjectInspector()).isEqualTo(expectedObjectInspector);
 
     // time
     StructField timeField = soi.getStructFieldRef("time_field");
-    Assert.assertEquals(21, timeField.getFieldID());
-    Assert.assertEquals("time_field", timeField.getFieldName());
-    Assert.assertEquals("time comment", timeField.getFieldComment());
-    Assert.assertEquals(IcebergTimeObjectInspector.get(), timeField.getFieldObjectInspector());
+    Assertions.assertThat(timeField.getFieldID()).isEqualTo(21);
+    Assertions.assertThat(timeField.getFieldName()).isEqualTo("time_field");
+    Assertions.assertThat(timeField.getFieldComment()).isEqualTo("time comment");
+    Assertions.assertThat(timeField.getFieldObjectInspector()).isEqualTo(IcebergTimeObjectInspector.get());
   }
 
   private static ObjectInspector getPrimitiveObjectInspector(Class<?> clazz) {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
@@ -84,7 +84,8 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(binaryField.getFieldID()).isEqualTo(1);
     Assertions.assertThat(binaryField.getFieldName()).isEqualTo("binary_field");
     Assertions.assertThat(binaryField.getFieldComment()).isEqualTo("binary comment");
-    Assertions.assertThat(binaryField.getFieldObjectInspector()).isEqualTo(IcebergBinaryObjectInspector.get());
+    Assertions.assertThat(binaryField.getFieldObjectInspector())
+        .isEqualTo(IcebergBinaryObjectInspector.get());
 
     // boolean
     StructField booleanField = soi.getStructFieldRef("boolean_field");
@@ -92,7 +93,7 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(booleanField.getFieldName()).isEqualTo("boolean_field");
     Assertions.assertThat(booleanField.getFieldComment()).isEqualTo("boolean comment");
     Assertions.assertThat(booleanField.getFieldObjectInspector())
-                    .isEqualTo(getPrimitiveObjectInspector(boolean.class));
+        .isEqualTo(getPrimitiveObjectInspector(boolean.class));
 
     // date
     StructField dateField = soi.getStructFieldRef("date_field");
@@ -101,10 +102,11 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(dateField.getFieldComment()).isEqualTo("date comment");
     if (HiveVersion.min(HiveVersion.HIVE_3)) {
       Assertions.assertThat(dateField.getFieldObjectInspector().getClass().getName())
-              .isEqualTo("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspectorHive3");
+          .isEqualTo(
+              "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspectorHive3");
     } else {
       Assertions.assertThat(dateField.getFieldObjectInspector().getClass().getName())
-              .isEqualTo("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspector");
+          .isEqualTo("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspector");
     }
 
     // decimal
@@ -113,7 +115,7 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(decimalField.getFieldName()).isEqualTo("decimal_field");
     Assertions.assertThat(decimalField.getFieldComment()).isEqualTo("decimal comment");
     Assertions.assertThat(decimalField.getFieldObjectInspector())
-            .isEqualTo(IcebergDecimalObjectInspector.get(38, 18));
+        .isEqualTo(IcebergDecimalObjectInspector.get(38, 18));
 
     // double
     StructField doubleField = soi.getStructFieldRef("double_field");
@@ -121,14 +123,15 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(doubleField.getFieldName()).isEqualTo("double_field");
     Assertions.assertThat(doubleField.getFieldComment()).isEqualTo("double comment");
     Assertions.assertThat(doubleField.getFieldObjectInspector())
-                    .isEqualTo(getPrimitiveObjectInspector(double.class));
+        .isEqualTo(getPrimitiveObjectInspector(double.class));
 
     // fixed
     StructField fixedField = soi.getStructFieldRef("fixed_field");
     Assertions.assertThat(fixedField.getFieldID()).isEqualTo(6);
     Assertions.assertThat(fixedField.getFieldName()).isEqualTo("fixed_field");
     Assertions.assertThat(fixedField.getFieldComment()).isEqualTo("fixed comment");
-    Assertions.assertThat(fixedField.getFieldObjectInspector()).isEqualTo(IcebergFixedObjectInspector.get());
+    Assertions.assertThat(fixedField.getFieldObjectInspector())
+        .isEqualTo(IcebergFixedObjectInspector.get());
 
     // float
     StructField floatField = soi.getStructFieldRef("float_field");
@@ -136,7 +139,7 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(floatField.getFieldName()).isEqualTo("float_field");
     Assertions.assertThat(floatField.getFieldComment()).isEqualTo("float comment");
     Assertions.assertThat(floatField.getFieldObjectInspector())
-                    .isEqualTo(getPrimitiveObjectInspector(float.class));
+        .isEqualTo(getPrimitiveObjectInspector(float.class));
 
     // integer
     StructField integerField = soi.getStructFieldRef("integer_field");
@@ -144,7 +147,7 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(integerField.getFieldName()).isEqualTo("integer_field");
     Assertions.assertThat(integerField.getFieldComment()).isEqualTo("integer comment");
     Assertions.assertThat(integerField.getFieldObjectInspector())
-                    .isEqualTo(getPrimitiveObjectInspector(int.class));
+        .isEqualTo(getPrimitiveObjectInspector(int.class));
 
     // long
     StructField longField = soi.getStructFieldRef("long_field");
@@ -152,7 +155,7 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(longField.getFieldName()).isEqualTo("long_field");
     Assertions.assertThat(longField.getFieldComment()).isEqualTo("long comment");
     Assertions.assertThat(longField.getFieldObjectInspector())
-                    .isEqualTo(getPrimitiveObjectInspector(long.class));
+        .isEqualTo(getPrimitiveObjectInspector(long.class));
 
     // string
     StructField stringField = soi.getStructFieldRef("string_field");
@@ -160,7 +163,7 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(stringField.getFieldName()).isEqualTo("string_field");
     Assertions.assertThat(stringField.getFieldComment()).isEqualTo("string comment");
     Assertions.assertThat(stringField.getFieldObjectInspector())
-            .isEqualTo(getPrimitiveObjectInspector(String.class));
+        .isEqualTo(getPrimitiveObjectInspector(String.class));
 
     // timestamp without tz
     StructField timestampField = soi.getStructFieldRef("timestamp_field");
@@ -169,10 +172,10 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(timestampField.getFieldComment()).isEqualTo("timestamp comment");
     if (HiveVersion.min(HiveVersion.HIVE_3)) {
       Assertions.assertThat(timestampField.getFieldObjectInspector().getClass().getSimpleName())
-              .isEqualTo("IcebergTimestampObjectInspectorHive3");
+          .isEqualTo("IcebergTimestampObjectInspectorHive3");
     } else {
       Assertions.assertThat(timestampField.getFieldObjectInspector())
-              .isEqualTo(IcebergTimestampObjectInspector.get());
+          .isEqualTo(IcebergTimestampObjectInspector.get());
     }
 
     // timestamp with tz
@@ -182,10 +185,10 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(timestampTzField.getFieldComment()).isEqualTo("timestamptz comment");
     if (HiveVersion.min(HiveVersion.HIVE_3)) {
       Assertions.assertThat(timestampTzField.getFieldObjectInspector().getClass().getSimpleName())
-              .isEqualTo("IcebergTimestampWithZoneObjectInspectorHive3");
+          .isEqualTo("IcebergTimestampWithZoneObjectInspectorHive3");
     } else {
       Assertions.assertThat(timestampTzField.getFieldObjectInspector())
-              .isEqualTo(IcebergTimestampWithZoneObjectInspector.get());
+          .isEqualTo(IcebergTimestampWithZoneObjectInspector.get());
     }
 
     // UUID
@@ -193,14 +196,16 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(uuidField.getFieldID()).isEqualTo(13);
     Assertions.assertThat(uuidField.getFieldName()).isEqualTo("uuid_field");
     Assertions.assertThat(uuidField.getFieldComment()).isEqualTo("uuid comment");
-    Assertions.assertThat(uuidField.getFieldObjectInspector()).isEqualTo(IcebergUUIDObjectInspector.get());
+    Assertions.assertThat(uuidField.getFieldObjectInspector())
+        .isEqualTo(IcebergUUIDObjectInspector.get());
 
     // list
     StructField listField = soi.getStructFieldRef("list_field");
     Assertions.assertThat(listField.getFieldID()).isEqualTo(14);
     Assertions.assertThat(listField.getFieldName()).isEqualTo("list_field");
     Assertions.assertThat(listField.getFieldComment()).isEqualTo("list comment");
-    Assertions.assertThat(listField.getFieldObjectInspector()).isEqualTo(getListObjectInspector(String.class));
+    Assertions.assertThat(listField.getFieldObjectInspector())
+        .isEqualTo(getListObjectInspector(String.class));
 
     // map
     StructField mapField = soi.getStructFieldRef("map_field");
@@ -208,7 +213,7 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(mapField.getFieldName()).isEqualTo("map_field");
     Assertions.assertThat(mapField.getFieldComment()).isEqualTo("map comment");
     Assertions.assertThat(mapField.getFieldObjectInspector())
-            .isEqualTo(getMapObjectInspector(String.class, int.class));
+        .isEqualTo(getMapObjectInspector(String.class, int.class));
 
     // struct
     StructField structField = soi.getStructFieldRef("struct_field");
@@ -227,7 +232,8 @@ public class TestIcebergObjectInspector {
     Assertions.assertThat(timeField.getFieldID()).isEqualTo(21);
     Assertions.assertThat(timeField.getFieldName()).isEqualTo("time_field");
     Assertions.assertThat(timeField.getFieldComment()).isEqualTo("time comment");
-    Assertions.assertThat(timeField.getFieldObjectInspector()).isEqualTo(IcebergTimeObjectInspector.get());
+    Assertions.assertThat(timeField.getFieldObjectInspector())
+        .isEqualTo(IcebergTimeObjectInspector.get());
   }
 
   private static ObjectInspector getPrimitiveObjectInspector(Class<?> clazz) {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergRecordObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergRecordObjectInspector.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
@@ -27,7 +28,6 @@ import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergRecordObjectInspector {
@@ -47,23 +47,22 @@ public class TestIcebergRecordObjectInspector {
     Record innerRecord = record.get(1, Record.class);
 
     StructObjectInspector soi = (StructObjectInspector) IcebergObjectInspector.create(schema);
-    Assertions.assertThat(soi.getStructFieldsDataAsList(record))
+    assertThat(soi.getStructFieldsDataAsList(record))
         .isEqualTo(ImmutableList.of(record.get(0), record.get(1)));
 
     StructField integerField = soi.getStructFieldRef("integer_field");
-    Assertions.assertThat(soi.getStructFieldData(record, integerField)).isEqualTo(record.get(0));
+    assertThat(soi.getStructFieldData(record, integerField)).isEqualTo(record.get(0));
 
     StructField structField = soi.getStructFieldRef("struct_field");
     Object innerData = soi.getStructFieldData(record, structField);
-    Assertions.assertThat(innerData).isEqualTo(innerRecord);
+    assertThat(innerData).isEqualTo(innerRecord);
 
     StructObjectInspector innerSoi = (StructObjectInspector) structField.getFieldObjectInspector();
     StructField stringField = innerSoi.getStructFieldRef("string_field");
 
-    Assertions.assertThat(innerSoi.getStructFieldsDataAsList(innerRecord))
+    assertThat(innerSoi.getStructFieldsDataAsList(innerRecord))
         .isEqualTo(ImmutableList.of(innerRecord.get(0)));
-    Assertions.assertThat(innerSoi.getStructFieldData(innerData, stringField))
-        .isEqualTo(innerRecord.get(0));
+    assertThat(innerSoi.getStructFieldData(innerData, stringField)).isEqualTo(innerRecord.get(0));
   }
 
   @Test
@@ -77,8 +76,8 @@ public class TestIcebergRecordObjectInspector {
                 Types.StructType.of(
                     Types.NestedField.required(3, "string_field", Types.StringType.get()))));
     StructObjectInspector soi = (StructObjectInspector) IcebergObjectInspector.create(schema);
-    Assertions.assertThat(soi.getStructFieldsDataAsList(null)).isNull();
+    assertThat(soi.getStructFieldsDataAsList(null)).isNull();
     StructField integerField = soi.getStructFieldRef("integer_field");
-    Assertions.assertThat(soi.getStructFieldData(null, integerField)).isNull();
+    assertThat(soi.getStructFieldData(null, integerField)).isNull();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergRecordObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergRecordObjectInspector.java
@@ -48,7 +48,7 @@ public class TestIcebergRecordObjectInspector {
 
     StructObjectInspector soi = (StructObjectInspector) IcebergObjectInspector.create(schema);
     Assertions.assertThat(soi.getStructFieldsDataAsList(record))
-                    .isEqualTo(ImmutableList.of(record.get(0), record.get(1)));
+        .isEqualTo(ImmutableList.of(record.get(0), record.get(1)));
 
     StructField integerField = soi.getStructFieldRef("integer_field");
     Assertions.assertThat(soi.getStructFieldData(record, integerField)).isEqualTo(record.get(0));
@@ -61,8 +61,9 @@ public class TestIcebergRecordObjectInspector {
     StructField stringField = innerSoi.getStructFieldRef("string_field");
 
     Assertions.assertThat(innerSoi.getStructFieldsDataAsList(innerRecord))
-            .isEqualTo(ImmutableList.of(innerRecord.get(0)));
-    Assertions.assertThat(innerSoi.getStructFieldData(innerData, stringField)).isEqualTo(innerRecord.get(0));
+        .isEqualTo(ImmutableList.of(innerRecord.get(0)));
+    Assertions.assertThat(innerSoi.getStructFieldData(innerData, stringField))
+        .isEqualTo(innerRecord.get(0));
   }
 
   @Test

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergRecordObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergRecordObjectInspector.java
@@ -27,8 +27,8 @@ import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestIcebergRecordObjectInspector {
 
@@ -47,22 +47,22 @@ public class TestIcebergRecordObjectInspector {
     Record innerRecord = record.get(1, Record.class);
 
     StructObjectInspector soi = (StructObjectInspector) IcebergObjectInspector.create(schema);
-    Assert.assertEquals(
-        ImmutableList.of(record.get(0), record.get(1)), soi.getStructFieldsDataAsList(record));
+    Assertions.assertThat(soi.getStructFieldsDataAsList(record))
+                    .isEqualTo(ImmutableList.of(record.get(0), record.get(1)));
 
     StructField integerField = soi.getStructFieldRef("integer_field");
-    Assert.assertEquals(record.get(0), soi.getStructFieldData(record, integerField));
+    Assertions.assertThat(soi.getStructFieldData(record, integerField)).isEqualTo(record.get(0));
 
     StructField structField = soi.getStructFieldRef("struct_field");
     Object innerData = soi.getStructFieldData(record, structField);
-    Assert.assertEquals(innerRecord, innerData);
+    Assertions.assertThat(innerData).isEqualTo(innerRecord);
 
     StructObjectInspector innerSoi = (StructObjectInspector) structField.getFieldObjectInspector();
     StructField stringField = innerSoi.getStructFieldRef("string_field");
 
-    Assert.assertEquals(
-        ImmutableList.of(innerRecord.get(0)), innerSoi.getStructFieldsDataAsList(innerRecord));
-    Assert.assertEquals(innerRecord.get(0), innerSoi.getStructFieldData(innerData, stringField));
+    Assertions.assertThat(innerSoi.getStructFieldsDataAsList(innerRecord))
+            .isEqualTo(ImmutableList.of(innerRecord.get(0)));
+    Assertions.assertThat(innerSoi.getStructFieldData(innerData, stringField)).isEqualTo(innerRecord.get(0));
   }
 
   @Test
@@ -76,8 +76,8 @@ public class TestIcebergRecordObjectInspector {
                 Types.StructType.of(
                     Types.NestedField.required(3, "string_field", Types.StringType.get()))));
     StructObjectInspector soi = (StructObjectInspector) IcebergObjectInspector.create(schema);
-    Assert.assertNull(soi.getStructFieldsDataAsList(null));
+    Assertions.assertThat(soi.getStructFieldsDataAsList(null)).isNull();
     StructField integerField = soi.getStructFieldRef("integer_field");
-    Assert.assertNull(soi.getStructFieldData(null, integerField));
+    Assertions.assertThat(soi.getStructFieldData(null, integerField)).isNull();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimeObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimeObjectInspector.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.Text;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestIcebergTimeObjectInspector {
 
@@ -33,34 +33,34 @@ public class TestIcebergTimeObjectInspector {
 
     IcebergTimeObjectInspector oi = IcebergTimeObjectInspector.get();
 
-    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-    Assert.assertEquals(
-        PrimitiveObjectInspector.PrimitiveCategory.STRING, oi.getPrimitiveCategory());
+    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    Assertions.assertThat(oi.getPrimitiveCategory())
+            .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.STRING);
 
-    Assert.assertEquals(TypeInfoFactory.stringTypeInfo, oi.getTypeInfo());
-    Assert.assertEquals(TypeInfoFactory.stringTypeInfo.getTypeName(), oi.getTypeName());
+    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.stringTypeInfo);
+    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.stringTypeInfo.getTypeName());
 
-    Assert.assertEquals(String.class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(Text.class, oi.getPrimitiveWritableClass());
+    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(String.class);
+    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(Text.class);
 
-    Assert.assertNull(oi.copyObject(null));
-    Assert.assertNull(oi.getPrimitiveJavaObject(null));
-    Assert.assertNull(oi.getPrimitiveWritableObject(null));
-    Assert.assertNull(oi.convert(null));
+    Assertions.assertThat(oi.copyObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    Assertions.assertThat(oi.convert(null)).isNull();
 
     LocalTime localTime = LocalTime.now();
     String time = localTime.toString();
     Text text = new Text(time);
 
-    Assert.assertEquals(time, oi.getPrimitiveJavaObject(text));
-    Assert.assertEquals(text, oi.getPrimitiveWritableObject(time));
-    Assert.assertEquals(localTime, oi.convert(time));
+    Assertions.assertThat(oi.getPrimitiveJavaObject(text)).isEqualTo(time);
+    Assertions.assertThat(oi.getPrimitiveWritableObject(time)).isEqualTo(text);
+    Assertions.assertThat(oi.convert(time)).isEqualTo(localTime);
 
     Text copy = (Text) oi.copyObject(text);
 
-    Assert.assertEquals(text, copy);
-    Assert.assertNotSame(text, copy);
+    Assertions.assertThat(copy).isEqualTo(text);
+    Assertions.assertThat(copy).isNotSameAs(text);
 
-    Assert.assertFalse(oi.preferWritable());
+    Assertions.assertThat(oi.preferWritable()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimeObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimeObjectInspector.java
@@ -35,7 +35,7 @@ public class TestIcebergTimeObjectInspector {
 
     Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
     Assertions.assertThat(oi.getPrimitiveCategory())
-            .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.STRING);
+        .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.STRING);
 
     Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.stringTypeInfo);
     Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.stringTypeInfo.getTypeName());

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimeObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimeObjectInspector.java
@@ -18,12 +18,13 @@
  */
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.LocalTime;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.Text;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergTimeObjectInspector {
@@ -33,34 +34,34 @@ public class TestIcebergTimeObjectInspector {
 
     IcebergTimeObjectInspector oi = IcebergTimeObjectInspector.get();
 
-    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
-    Assertions.assertThat(oi.getPrimitiveCategory())
+    assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    assertThat(oi.getPrimitiveCategory())
         .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.STRING);
 
-    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.stringTypeInfo);
-    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.stringTypeInfo.getTypeName());
+    assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.stringTypeInfo);
+    assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.stringTypeInfo.getTypeName());
 
-    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(String.class);
-    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(Text.class);
+    assertThat(oi.getJavaPrimitiveClass()).isEqualTo(String.class);
+    assertThat(oi.getPrimitiveWritableClass()).isEqualTo(Text.class);
 
-    Assertions.assertThat(oi.copyObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
-    Assertions.assertThat(oi.convert(null)).isNull();
+    assertThat(oi.copyObject(null)).isNull();
+    assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    assertThat(oi.convert(null)).isNull();
 
     LocalTime localTime = LocalTime.now();
     String time = localTime.toString();
     Text text = new Text(time);
 
-    Assertions.assertThat(oi.getPrimitiveJavaObject(text)).isEqualTo(time);
-    Assertions.assertThat(oi.getPrimitiveWritableObject(time)).isEqualTo(text);
-    Assertions.assertThat(oi.convert(time)).isEqualTo(localTime);
+    assertThat(oi.getPrimitiveJavaObject(text)).isEqualTo(time);
+    assertThat(oi.getPrimitiveWritableObject(time)).isEqualTo(text);
+    assertThat(oi.convert(time)).isEqualTo(localTime);
 
     Text copy = (Text) oi.copyObject(text);
 
-    Assertions.assertThat(copy).isEqualTo(text);
-    Assertions.assertThat(copy).isNotSameAs(text);
+    assertThat(copy).isEqualTo(text);
+    assertThat(copy).isNotSameAs(text);
 
-    Assertions.assertThat(oi.preferWritable()).isFalse();
+    assertThat(oi.preferWritable()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
@@ -18,13 +18,14 @@
  */
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergTimestampObjectInspector {
@@ -33,36 +34,34 @@ public class TestIcebergTimestampObjectInspector {
   public void testIcebergTimestampObjectInspector() {
     IcebergTimestampObjectInspector oi = IcebergTimestampObjectInspector.get();
 
-    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
-    Assertions.assertThat(oi.getPrimitiveCategory())
+    assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    assertThat(oi.getPrimitiveCategory())
         .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP);
 
-    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.timestampTypeInfo);
-    Assertions.assertThat(oi.getTypeName())
-        .isEqualTo(TypeInfoFactory.timestampTypeInfo.getTypeName());
+    assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.timestampTypeInfo);
+    assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.timestampTypeInfo.getTypeName());
 
-    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(Timestamp.class);
-    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(TimestampWritable.class);
+    assertThat(oi.getJavaPrimitiveClass()).isEqualTo(Timestamp.class);
+    assertThat(oi.getPrimitiveWritableClass()).isEqualTo(TimestampWritable.class);
 
-    Assertions.assertThat(oi.copyObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
-    Assertions.assertThat(oi.convert(null)).isNull();
+    assertThat(oi.copyObject(null)).isNull();
+    assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    assertThat(oi.convert(null)).isNull();
 
     LocalDateTime local = LocalDateTime.of(2020, 1, 1, 12, 55, 30, 5560000);
     Timestamp ts = Timestamp.valueOf(local);
 
-    Assertions.assertThat(oi.getPrimitiveJavaObject(local)).isEqualTo(ts);
-    Assertions.assertThat(oi.getPrimitiveWritableObject(local))
-        .isEqualTo(new TimestampWritable(ts));
+    assertThat(oi.getPrimitiveJavaObject(local)).isEqualTo(ts);
+    assertThat(oi.getPrimitiveWritableObject(local)).isEqualTo(new TimestampWritable(ts));
 
     Timestamp copy = (Timestamp) oi.copyObject(ts);
 
-    Assertions.assertThat(copy).isEqualTo(ts);
-    Assertions.assertThat(copy).isNotSameAs(ts);
+    assertThat(copy).isEqualTo(ts);
+    assertThat(copy).isNotSameAs(ts);
 
-    Assertions.assertThat(oi.preferWritable()).isFalse();
+    assertThat(oi.preferWritable()).isFalse();
 
-    Assertions.assertThat(oi.convert(ts)).isEqualTo(local);
+    assertThat(oi.convert(ts)).isEqualTo(local);
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
@@ -35,10 +35,11 @@ public class TestIcebergTimestampObjectInspector {
 
     Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
     Assertions.assertThat(oi.getPrimitiveCategory())
-            .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP);
+        .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP);
 
     Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.timestampTypeInfo);
-    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.timestampTypeInfo.getTypeName());
+    Assertions.assertThat(oi.getTypeName())
+        .isEqualTo(TypeInfoFactory.timestampTypeInfo.getTypeName());
 
     Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(Timestamp.class);
     Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(TimestampWritable.class);
@@ -52,7 +53,8 @@ public class TestIcebergTimestampObjectInspector {
     Timestamp ts = Timestamp.valueOf(local);
 
     Assertions.assertThat(oi.getPrimitiveJavaObject(local)).isEqualTo(ts);
-    Assertions.assertThat(oi.getPrimitiveWritableObject(local)).isEqualTo(new TimestampWritable(ts));
+    Assertions.assertThat(oi.getPrimitiveWritableObject(local))
+        .isEqualTo(new TimestampWritable(ts));
 
     Timestamp copy = (Timestamp) oi.copyObject(ts);
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestIcebergTimestampObjectInspector {
 
@@ -33,34 +33,34 @@ public class TestIcebergTimestampObjectInspector {
   public void testIcebergTimestampObjectInspector() {
     IcebergTimestampObjectInspector oi = IcebergTimestampObjectInspector.get();
 
-    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-    Assert.assertEquals(
-        PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());
+    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    Assertions.assertThat(oi.getPrimitiveCategory())
+            .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP);
 
-    Assert.assertEquals(TypeInfoFactory.timestampTypeInfo, oi.getTypeInfo());
-    Assert.assertEquals(TypeInfoFactory.timestampTypeInfo.getTypeName(), oi.getTypeName());
+    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.timestampTypeInfo);
+    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.timestampTypeInfo.getTypeName());
 
-    Assert.assertEquals(Timestamp.class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(TimestampWritable.class, oi.getPrimitiveWritableClass());
+    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(Timestamp.class);
+    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(TimestampWritable.class);
 
-    Assert.assertNull(oi.copyObject(null));
-    Assert.assertNull(oi.getPrimitiveJavaObject(null));
-    Assert.assertNull(oi.getPrimitiveWritableObject(null));
-    Assert.assertNull(oi.convert(null));
+    Assertions.assertThat(oi.copyObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    Assertions.assertThat(oi.convert(null)).isNull();
 
     LocalDateTime local = LocalDateTime.of(2020, 1, 1, 12, 55, 30, 5560000);
     Timestamp ts = Timestamp.valueOf(local);
 
-    Assert.assertEquals(ts, oi.getPrimitiveJavaObject(local));
-    Assert.assertEquals(new TimestampWritable(ts), oi.getPrimitiveWritableObject(local));
+    Assertions.assertThat(oi.getPrimitiveJavaObject(local)).isEqualTo(ts);
+    Assertions.assertThat(oi.getPrimitiveWritableObject(local)).isEqualTo(new TimestampWritable(ts));
 
     Timestamp copy = (Timestamp) oi.copyObject(ts);
 
-    Assert.assertEquals(ts, copy);
-    Assert.assertNotSame(ts, copy);
+    Assertions.assertThat(copy).isEqualTo(ts);
+    Assertions.assertThat(copy).isNotSameAs(ts);
 
-    Assert.assertFalse(oi.preferWritable());
+    Assertions.assertThat(oi.preferWritable()).isFalse();
 
-    Assert.assertEquals(local, oi.convert(ts));
+    Assertions.assertThat(oi.convert(ts)).isEqualTo(local);
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
@@ -37,10 +37,11 @@ public class TestIcebergTimestampWithZoneObjectInspector {
 
     Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
     Assertions.assertThat(oi.getPrimitiveCategory())
-            .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP);
+        .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP);
 
     Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.timestampTypeInfo);
-    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.timestampTypeInfo.getTypeName());
+    Assertions.assertThat(oi.getTypeName())
+        .isEqualTo(TypeInfoFactory.timestampTypeInfo.getTypeName());
 
     Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(Timestamp.class);
     Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(TimestampWritable.class);
@@ -55,7 +56,8 @@ public class TestIcebergTimestampWithZoneObjectInspector {
     Timestamp ts = Timestamp.from(offsetDateTime.toInstant());
 
     Assertions.assertThat(oi.getPrimitiveJavaObject(offsetDateTime)).isEqualTo(ts);
-    Assertions.assertThat(oi.getPrimitiveWritableObject(offsetDateTime)).isEqualTo(new TimestampWritable(ts));
+    Assertions.assertThat(oi.getPrimitiveWritableObject(offsetDateTime))
+        .isEqualTo(new TimestampWritable(ts));
 
     Timestamp copy = (Timestamp) oi.copyObject(ts);
 
@@ -65,10 +67,10 @@ public class TestIcebergTimestampWithZoneObjectInspector {
     Assertions.assertThat(oi.preferWritable()).isFalse();
 
     Assertions.assertThat(oi.convert(ts))
-            .isEqualTo(OffsetDateTime.ofInstant(local.toInstant(ZoneOffset.ofHours(-5)), ZoneOffset.UTC));
+        .isEqualTo(
+            OffsetDateTime.ofInstant(local.toInstant(ZoneOffset.ofHours(-5)), ZoneOffset.UTC));
 
-    Assertions.assertThat(
-        offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC))
-                    .isEqualTo(oi.convert(Timestamp.from(offsetDateTime.toInstant())));
+    Assertions.assertThat(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC))
+        .isEqualTo(oi.convert(Timestamp.from(offsetDateTime.toInstant())));
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestIcebergTimestampWithZoneObjectInspector {
 
@@ -35,41 +35,40 @@ public class TestIcebergTimestampWithZoneObjectInspector {
   public void testIcebergTimestampObjectInspectorWithUTCAdjustment() {
     IcebergTimestampWithZoneObjectInspector oi = IcebergTimestampWithZoneObjectInspector.get();
 
-    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-    Assert.assertEquals(
-        PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());
+    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    Assertions.assertThat(oi.getPrimitiveCategory())
+            .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP);
 
-    Assert.assertEquals(TypeInfoFactory.timestampTypeInfo, oi.getTypeInfo());
-    Assert.assertEquals(TypeInfoFactory.timestampTypeInfo.getTypeName(), oi.getTypeName());
+    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.timestampTypeInfo);
+    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.timestampTypeInfo.getTypeName());
 
-    Assert.assertEquals(Timestamp.class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(TimestampWritable.class, oi.getPrimitiveWritableClass());
+    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(Timestamp.class);
+    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(TimestampWritable.class);
 
-    Assert.assertNull(oi.copyObject(null));
-    Assert.assertNull(oi.getPrimitiveJavaObject(null));
-    Assert.assertNull(oi.getPrimitiveWritableObject(null));
-    Assert.assertNull(oi.convert(null));
+    Assertions.assertThat(oi.copyObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    Assertions.assertThat(oi.convert(null)).isNull();
 
     LocalDateTime local = LocalDateTime.of(2020, 1, 1, 16, 45, 33, 456000);
     OffsetDateTime offsetDateTime = OffsetDateTime.of(local, ZoneOffset.ofHours(-5));
     Timestamp ts = Timestamp.from(offsetDateTime.toInstant());
 
-    Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
-    Assert.assertEquals(new TimestampWritable(ts), oi.getPrimitiveWritableObject(offsetDateTime));
+    Assertions.assertThat(oi.getPrimitiveJavaObject(offsetDateTime)).isEqualTo(ts);
+    Assertions.assertThat(oi.getPrimitiveWritableObject(offsetDateTime)).isEqualTo(new TimestampWritable(ts));
 
     Timestamp copy = (Timestamp) oi.copyObject(ts);
 
-    Assert.assertEquals(ts, copy);
-    Assert.assertNotSame(ts, copy);
+    Assertions.assertThat(copy).isEqualTo(ts);
+    Assertions.assertThat(copy).isNotSameAs(ts);
 
-    Assert.assertFalse(oi.preferWritable());
+    Assertions.assertThat(oi.preferWritable()).isFalse();
 
-    Assert.assertEquals(
-        OffsetDateTime.ofInstant(local.toInstant(ZoneOffset.ofHours(-5)), ZoneOffset.UTC),
-        oi.convert(ts));
+    Assertions.assertThat(oi.convert(ts))
+            .isEqualTo(OffsetDateTime.ofInstant(local.toInstant(ZoneOffset.ofHours(-5)), ZoneOffset.UTC));
 
-    Assert.assertEquals(
-        offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC),
-        oi.convert(Timestamp.from(offsetDateTime.toInstant())));
+    Assertions.assertThat(
+        offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC))
+                    .isEqualTo(oi.convert(Timestamp.from(offsetDateTime.toInstant())));
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -26,7 +28,6 @@ import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergTimestampWithZoneObjectInspector {
@@ -35,42 +36,40 @@ public class TestIcebergTimestampWithZoneObjectInspector {
   public void testIcebergTimestampObjectInspectorWithUTCAdjustment() {
     IcebergTimestampWithZoneObjectInspector oi = IcebergTimestampWithZoneObjectInspector.get();
 
-    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
-    Assertions.assertThat(oi.getPrimitiveCategory())
+    assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    assertThat(oi.getPrimitiveCategory())
         .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP);
 
-    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.timestampTypeInfo);
-    Assertions.assertThat(oi.getTypeName())
-        .isEqualTo(TypeInfoFactory.timestampTypeInfo.getTypeName());
+    assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.timestampTypeInfo);
+    assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.timestampTypeInfo.getTypeName());
 
-    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(Timestamp.class);
-    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(TimestampWritable.class);
+    assertThat(oi.getJavaPrimitiveClass()).isEqualTo(Timestamp.class);
+    assertThat(oi.getPrimitiveWritableClass()).isEqualTo(TimestampWritable.class);
 
-    Assertions.assertThat(oi.copyObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
-    Assertions.assertThat(oi.convert(null)).isNull();
+    assertThat(oi.copyObject(null)).isNull();
+    assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    assertThat(oi.convert(null)).isNull();
 
     LocalDateTime local = LocalDateTime.of(2020, 1, 1, 16, 45, 33, 456000);
     OffsetDateTime offsetDateTime = OffsetDateTime.of(local, ZoneOffset.ofHours(-5));
     Timestamp ts = Timestamp.from(offsetDateTime.toInstant());
 
-    Assertions.assertThat(oi.getPrimitiveJavaObject(offsetDateTime)).isEqualTo(ts);
-    Assertions.assertThat(oi.getPrimitiveWritableObject(offsetDateTime))
-        .isEqualTo(new TimestampWritable(ts));
+    assertThat(oi.getPrimitiveJavaObject(offsetDateTime)).isEqualTo(ts);
+    assertThat(oi.getPrimitiveWritableObject(offsetDateTime)).isEqualTo(new TimestampWritable(ts));
 
     Timestamp copy = (Timestamp) oi.copyObject(ts);
 
-    Assertions.assertThat(copy).isEqualTo(ts);
-    Assertions.assertThat(copy).isNotSameAs(ts);
+    assertThat(copy).isEqualTo(ts);
+    assertThat(copy).isNotSameAs(ts);
 
-    Assertions.assertThat(oi.preferWritable()).isFalse();
+    assertThat(oi.preferWritable()).isFalse();
 
-    Assertions.assertThat(oi.convert(ts))
+    assertThat(oi.convert(ts))
         .isEqualTo(
             OffsetDateTime.ofInstant(local.toInstant(ZoneOffset.ofHours(-5)), ZoneOffset.UTC));
 
-    Assertions.assertThat(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC))
+    assertThat(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC))
         .isEqualTo(oi.convert(Timestamp.from(offsetDateTime.toInstant())));
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergUUIDObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergUUIDObjectInspector.java
@@ -18,12 +18,13 @@
  */
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.UUID;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.Text;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergUUIDObjectInspector {
@@ -32,34 +33,34 @@ public class TestIcebergUUIDObjectInspector {
   public void testIcebergUUIDObjectInspector() {
     IcebergUUIDObjectInspector oi = IcebergUUIDObjectInspector.get();
 
-    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
-    Assertions.assertThat(oi.getPrimitiveCategory())
+    assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    assertThat(oi.getPrimitiveCategory())
         .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.STRING);
 
-    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.stringTypeInfo);
-    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.stringTypeInfo.getTypeName());
+    assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.stringTypeInfo);
+    assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.stringTypeInfo.getTypeName());
 
-    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(String.class);
-    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(Text.class);
+    assertThat(oi.getJavaPrimitiveClass()).isEqualTo(String.class);
+    assertThat(oi.getPrimitiveWritableClass()).isEqualTo(Text.class);
 
-    Assertions.assertThat(oi.copyObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
-    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
-    Assertions.assertThat(oi.convert(null)).isNull();
+    assertThat(oi.copyObject(null)).isNull();
+    assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    assertThat(oi.convert(null)).isNull();
 
     UUID uuid = UUID.randomUUID();
     String uuidStr = uuid.toString();
     Text text = new Text(uuidStr);
 
-    Assertions.assertThat(oi.getPrimitiveJavaObject(text)).isEqualTo(uuidStr);
-    Assertions.assertThat(oi.getPrimitiveWritableObject(uuidStr)).isEqualTo(text);
-    Assertions.assertThat(oi.convert(uuidStr)).isEqualTo(uuid);
+    assertThat(oi.getPrimitiveJavaObject(text)).isEqualTo(uuidStr);
+    assertThat(oi.getPrimitiveWritableObject(uuidStr)).isEqualTo(text);
+    assertThat(oi.convert(uuidStr)).isEqualTo(uuid);
 
     Text copy = (Text) oi.copyObject(text);
 
-    Assertions.assertThat(copy).isEqualTo(text);
-    Assertions.assertThat(copy).isNotSameAs(text);
+    assertThat(copy).isEqualTo(text);
+    assertThat(copy).isNotSameAs(text);
 
-    Assertions.assertThat(oi.preferWritable()).isFalse();
+    assertThat(oi.preferWritable()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergUUIDObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergUUIDObjectInspector.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.Text;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestIcebergUUIDObjectInspector {
 
@@ -32,34 +32,34 @@ public class TestIcebergUUIDObjectInspector {
   public void testIcebergUUIDObjectInspector() {
     IcebergUUIDObjectInspector oi = IcebergUUIDObjectInspector.get();
 
-    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-    Assert.assertEquals(
-        PrimitiveObjectInspector.PrimitiveCategory.STRING, oi.getPrimitiveCategory());
+    Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
+    Assertions.assertThat(oi.getPrimitiveCategory())
+            .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.STRING);
 
-    Assert.assertEquals(TypeInfoFactory.stringTypeInfo, oi.getTypeInfo());
-    Assert.assertEquals(TypeInfoFactory.stringTypeInfo.getTypeName(), oi.getTypeName());
+    Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.stringTypeInfo);
+    Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.stringTypeInfo.getTypeName());
 
-    Assert.assertEquals(String.class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(Text.class, oi.getPrimitiveWritableClass());
+    Assertions.assertThat(oi.getJavaPrimitiveClass()).isEqualTo(String.class);
+    Assertions.assertThat(oi.getPrimitiveWritableClass()).isEqualTo(Text.class);
 
-    Assert.assertNull(oi.copyObject(null));
-    Assert.assertNull(oi.getPrimitiveJavaObject(null));
-    Assert.assertNull(oi.getPrimitiveWritableObject(null));
-    Assert.assertNull(oi.convert(null));
+    Assertions.assertThat(oi.copyObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    Assertions.assertThat(oi.getPrimitiveWritableObject(null)).isNull();
+    Assertions.assertThat(oi.convert(null)).isNull();
 
     UUID uuid = UUID.randomUUID();
     String uuidStr = uuid.toString();
     Text text = new Text(uuidStr);
 
-    Assert.assertEquals(uuidStr, oi.getPrimitiveJavaObject(text));
-    Assert.assertEquals(text, oi.getPrimitiveWritableObject(uuidStr));
-    Assert.assertEquals(uuid, oi.convert(uuidStr));
+    Assertions.assertThat(oi.getPrimitiveJavaObject(text)).isEqualTo(uuidStr);
+    Assertions.assertThat(oi.getPrimitiveWritableObject(uuidStr)).isEqualTo(text);
+    Assertions.assertThat(oi.convert(uuidStr)).isEqualTo(uuid);
 
     Text copy = (Text) oi.copyObject(text);
 
-    Assert.assertEquals(text, copy);
-    Assert.assertNotSame(text, copy);
+    Assertions.assertThat(copy).isEqualTo(text);
+    Assertions.assertThat(copy).isNotSameAs(text);
 
-    Assert.assertFalse(oi.preferWritable());
+    Assertions.assertThat(oi.preferWritable()).isFalse();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergUUIDObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergUUIDObjectInspector.java
@@ -34,7 +34,7 @@ public class TestIcebergUUIDObjectInspector {
 
     Assertions.assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.PRIMITIVE);
     Assertions.assertThat(oi.getPrimitiveCategory())
-            .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.STRING);
+        .isEqualTo(PrimitiveObjectInspector.PrimitiveCategory.STRING);
 
     Assertions.assertThat(oi.getTypeInfo()).isEqualTo(TypeInfoFactory.stringTypeInfo);
     Assertions.assertThat(oi.getTypeName()).isEqualTo(TypeInfoFactory.stringTypeInfo.getTypeName());


### PR DESCRIPTION
Closes #9083 

The goal here is to switch all imports to Junit5 and to use AssertJ-style assertions.

All test cases except the ones using parameterized tests have been migrated. Once https://github.com/apache/iceberg/pull/9161 gets merged, I will make the necessary changes to migrate Parameterized test as well. 

