### PR TITLE
[spark 3.5] Support specifying spec_id in RewriteManifestProcedure

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -335,25 +335,29 @@ public class TestRewriteManifestsProcedure extends SparkExtensionsTestBase {
   @Test
   public void testWriteManifestWithSpecId() {
     sql(
-            "CREATE TABLE %s (id int, dt string, hr string) USING iceberg PARTITIONED BY (dt)", tableName);
+        "CREATE TABLE %s (id int, dt string, hr string) USING iceberg PARTITIONED BY (dt)",
+        tableName);
 
     sql("INSERT INTO %s VALUES (1, '2024-01-01', '00')", tableName);
     sql("INSERT INTO %s VALUES (2, '2024-01-01', '00')", tableName);
     assertEquals(
-            "Should have 2 manifests",
-            ImmutableList.of(row(2L)),
-            sql("SELECT count(*) FROM %s.manifests", tableName));
+        "Should have 2 manifests",
+        ImmutableList.of(row(2L)),
+        sql("SELECT count(*) FROM %s.manifests", tableName));
 
     sql("ALTER TABLE %s ADD PARTITION FIELD hr", tableName);
     assertEquals(
-            "Should still have 2 manifests",
-            ImmutableList.of(row(2L)),
-            sql("SELECT count(*) FROM %s.manifests", tableName));
+        "Should still have 2 manifests",
+        ImmutableList.of(row(2L)),
+        sql("SELECT count(*) FROM %s.manifests", tableName));
 
     List<Object[]> output = sql("CALL %s.system.rewrite_manifests('%s')", catalogName, tableIdent);
     assertEquals("Procedure output must match", ImmutableList.of(row(0, 0)), output);
 
-    output = sql("CALL %s.system.rewrite_manifests(table => '%s', spec_id => 0)", catalogName, tableIdent);
+    output =
+        sql(
+            "CALL %s.system.rewrite_manifests(table => '%s', spec_id => 0)",
+            catalogName, tableIdent);
     assertEquals("Procedure output must match", ImmutableList.of(row(2, 1)), output);
   }
 }

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -331,4 +331,29 @@ public class TestRewriteManifestsProcedure extends SparkExtensionsTestBase {
             row(1, Timestamp.valueOf("2022-01-01 10:00:00"), Date.valueOf("2022-01-01"))),
         sql("SELECT * FROM %s WHERE ts < current_timestamp()", tableName));
   }
+
+  @Test
+  public void testWriteManifestWithSpecId() {
+    sql(
+            "CREATE TABLE %s (id int, dt string, hr string) USING iceberg PARTITIONED BY (dt)", tableName);
+
+    sql("INSERT INTO %s VALUES (1, '2024-01-01', '00')", tableName);
+    sql("INSERT INTO %s VALUES (2, '2024-01-01', '00')", tableName);
+    assertEquals(
+            "Should have 2 manifests",
+            ImmutableList.of(row(2L)),
+            sql("SELECT count(*) FROM %s.manifests", tableName));
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD hr", tableName);
+    assertEquals(
+            "Should still have 2 manifests",
+            ImmutableList.of(row(2L)),
+            sql("SELECT count(*) FROM %s.manifests", tableName));
+
+    List<Object[]> output = sql("CALL %s.system.rewrite_manifests('%s')", catalogName, tableIdent);
+    assertEquals("Procedure output must match", ImmutableList.of(row(0, 0)), output);
+
+    output = sql("CALL %s.system.rewrite_manifests(table => '%s', spec_id => 0)", catalogName, tableIdent);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2, 1)), output);
+  }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -46,7 +46,8 @@ class RewriteManifestsProcedure extends BaseProcedure {
   private static final ProcedureParameter[] PARAMETERS =
       new ProcedureParameter[] {
         ProcedureParameter.required("table", DataTypes.StringType),
-        ProcedureParameter.optional("use_caching", DataTypes.BooleanType)
+        ProcedureParameter.optional("use_caching", DataTypes.BooleanType),
+        ProcedureParameter.optional("spec_id", DataTypes.IntegerType)
       };
 
   // counts are not nullable since the action result is never null
@@ -85,6 +86,7 @@ class RewriteManifestsProcedure extends BaseProcedure {
   public InternalRow[] call(InternalRow args) {
     Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
     Boolean useCaching = args.isNullAt(1) ? null : args.getBoolean(1);
+    Integer specId = args.isNullAt(2) ? null : args.getInt(2);
 
     return modifyIcebergTable(
         tableIdent,
@@ -93,6 +95,10 @@ class RewriteManifestsProcedure extends BaseProcedure {
 
           if (useCaching != null) {
             action.option(RewriteManifestsSparkAction.USE_CACHING, useCaching.toString());
+          }
+
+          if (specId != null) {
+            action.specId(specId);
           }
 
           RewriteManifests.Result result = action.execute();


### PR DESCRIPTION
As title. Current manifest rewrite in spark procedure only can be performed on manifests with current spec id. This PR allows user to specify rewrite on manifests with old spec ids. 