### PR TITLE
API: Fix equals and hashCode in CharSequenceSet

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.util;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -168,22 +167,29 @@ public class CharSequenceSet implements Set<CharSequence>, Serializable {
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (this == o) {
+  public boolean equals(Object other) {
+    if (this == other) {
       return true;
-    }
-
-    if (o == null || getClass() != o.getClass()) {
+    } else if (!(other instanceof Set)) {
       return false;
     }
 
-    CharSequenceSet that = (CharSequenceSet) o;
-    return wrapperSet.equals(that.wrapperSet);
+    Set<?> that = (Set<?>) other;
+
+    if (size() != that.size()) {
+      return false;
+    }
+
+    try {
+      return containsAll(that);
+    } catch (ClassCastException | NullPointerException unused) {
+      return false;
+    }
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(wrapperSet);
+    return wrapperSet.stream().mapToInt(CharSequenceWrapper::hashCode).sum();
   }
 
   @Override

--- a/api/src/test/java/org/apache/iceberg/util/TestCharSequenceSet.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestCharSequenceSet.java
@@ -19,8 +19,10 @@
 package org.apache.iceberg.util;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -78,5 +80,36 @@ public class TestCharSequenceSet {
         .isTrue();
 
     Assertions.assertThat(set).isEmpty();
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    CharSequenceSet set1 = CharSequenceSet.empty();
+    CharSequenceSet set2 = CharSequenceSet.empty();
+
+    Assertions.assertThat(set1).isEqualTo(set2);
+    Assertions.assertThat(set1.hashCode()).isEqualTo(set2.hashCode());
+
+    set1.add("v1");
+    set1.add("v2");
+    set1.add("v3");
+
+    set2.add(new StringBuilder("v1"));
+    set2.add(new StringBuffer("v2"));
+    set2.add("v3");
+
+    Set<CharSequence> set3 = Collections.unmodifiableSet(set2);
+
+    Set<CharSequenceWrapper> set4 =
+        ImmutableSet.of(
+            CharSequenceWrapper.wrap("v1"),
+            CharSequenceWrapper.wrap(new StringBuffer("v2")),
+            CharSequenceWrapper.wrap(new StringBuffer("v3")));
+
+    Assertions.assertThat(set1).isEqualTo(set2).isEqualTo(set3).isEqualTo(set4);
+    Assertions.assertThat(set1.hashCode())
+        .isEqualTo(set2.hashCode())
+        .isEqualTo(set3.hashCode())
+        .isEqualTo(set4.hashCode());
   }
 }


### PR DESCRIPTION
The `equals` and `hashCode` behaviors in `CharSequenceSet` contradict the `Set` API, which prohibits wrapping these sets into unmodifiable wrappers in `CharSequenceMap#keySet`.

```
/**
 * Compares the specified object with this set for equality.  Returns
 * {@code true} if the specified object is also a set, the two sets
 * have the same size, and every member of the specified set is
 * contained in this set (or equivalently, every member of this set is
 * contained in the specified set).  This definition ensures that the
 * equals method works properly across different implementations of the
 * set interface.
 *
 * @param o object to be compared for equality with this set
 * @return {@code true} if the specified object is equal to this set
 */
boolean equals(Object o);

/**
 * Returns the hash code value for this set.  The hash code of a set is
 * defined to be the sum of the hash codes of the elements in the set,
 * where the hash code of a {@code null} element is defined to be zero.
 * This ensures that {@code s1.equals(s2)} implies that
 * {@code s1.hashCode()==s2.hashCode()} for any two sets {@code s1}
 * and {@code s2}, as required by the general contract of
 * {@link Object#hashCode}.
 *
 * @return the hash code value for this set
 * @see Object#equals(Object)
 * @see Set#equals(Object)
 */
int hashCode();
```
