### PR TITLE
API, Core: Add sqlFor API to views to handle basic resolution of dialect

### DIFF
--- a/api/src/main/java/org/apache/iceberg/view/View.java
+++ b/api/src/main/java/org/apache/iceberg/view/View.java
@@ -121,4 +121,15 @@ public interface View {
   default UUID uuid() {
     throw new UnsupportedOperationException("Retrieving a view's uuid is not supported");
   }
+
+  /**
+   * Returns the view representation for the given SQL dialect
+   *
+   * @return the view representation for the given SQL dialect, or null if no representation could
+   *     be resolved
+   */
+  default SQLViewRepresentation sqlFor(String dialect) {
+    throw new UnsupportedOperationException(
+        "Resolving a sql with a given dialect is not supported");
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/view/BaseView.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseView.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.UpdateLocation;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 public class BaseView implements View, Serializable {
 
@@ -102,5 +103,29 @@ public class BaseView implements View, Serializable {
   @Override
   public UUID uuid() {
     return UUID.fromString(ops.current().uuid());
+  }
+
+  /**
+   * This implementation of sqlFor will resolve what is considered the "closest" dialect. If an
+   * exact match is found, then that is returned. Otherwise, the first representation would be
+   * returned. If no SQL representation is found, null is returned.
+   */
+  @Override
+  public SQLViewRepresentation sqlFor(String dialect) {
+    Preconditions.checkArgument(dialect != null, "Invalid dialect: null");
+    Preconditions.checkArgument(!dialect.isEmpty(), "Invalid dialect: (empty string)");
+    SQLViewRepresentation closest = null;
+    for (ViewRepresentation representation : currentVersion().representations()) {
+      if (representation instanceof SQLViewRepresentation) {
+        SQLViewRepresentation sqlViewRepresentation = (SQLViewRepresentation) representation;
+        if (sqlViewRepresentation.dialect().equals(dialect)) {
+          return sqlViewRepresentation;
+        } else if (closest == null) {
+          closest = sqlViewRepresentation;
+        }
+      }
+    }
+
+    return closest;
   }
 }


### PR DESCRIPTION
This change adds a `ViewRepresentation sqlFor(String dialect)` API which will resolve a representation based on the give dialect. The current implementation just aims for an exact search with a fallback to the first added representation in case an exact match does not exist.  If no SQL dialect exists, null is returned.

The intention of this API is so that engine integrations don't have to implement this same logic. If an engine wants to use a different dialect than what this API returns then they can still implement that.