### PR TITLE
Core: Look up targeted position deletes by path

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceMap.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceMap.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -148,6 +149,10 @@ public class CharSequenceMap<V> implements Map<CharSequence, V>, Serializable {
     }
 
     return entrySet;
+  }
+
+  public V computeIfAbsent(CharSequence key, Supplier<V> valueSupplier) {
+    return computeIfAbsent(key, ignored -> valueSupplier.get());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
@@ -320,4 +320,31 @@ public class ArrayUtil {
 
     return true;
   }
+
+  @SuppressWarnings("unchecked")
+  public static <T> T[] concat(Class<T> type, T[]... arrays) {
+    T[] result = (T[]) Array.newInstance(type, totalLength(arrays));
+
+    int currentLength = 0;
+
+    for (T[] array : arrays) {
+      int length = array.length;
+      if (length > 0) {
+        System.arraycopy(array, 0, result, currentLength, length);
+        currentLength += length;
+      }
+    }
+
+    return result;
+  }
+
+  private static int totalLength(Object[][] arrays) {
+    int totalLength = 0;
+
+    for (Object[] array : arrays) {
+      totalLength += array.length;
+    }
+
+    return totalLength;
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestArrayUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestArrayUtil.java
@@ -41,4 +41,36 @@ public class TestArrayUtil {
     long[] ascendingArray = new long[] {1, 2, 2, 3};
     assertThat(ArrayUtil.isStrictlyAscending(ascendingArray)).isFalse();
   }
+
+  @Test
+  public void testConcatWithDifferentLengthArrays() {
+    Integer[] array1 = {1, 2, 3};
+    Integer[] array2 = {4, 5};
+    Integer[] array3 = {6, 7, 8, 9};
+
+    Integer[] result = ArrayUtil.concat(Integer.class, array1, array2, array3);
+    assertThat(result).isEqualTo(new Integer[] {1, 2, 3, 4, 5, 6, 7, 8, 9});
+  }
+
+  @Test
+  public void testConcatWithEmptyArrays() {
+    String[] array1 = {};
+    String[] array2 = {"a", "b"};
+
+    String[] result = ArrayUtil.concat(String.class, array1, array2);
+    assertThat(result).isEqualTo(new String[] {"a", "b"});
+  }
+
+  @Test
+  public void testConcatWithSingleArray() {
+    Boolean[] array = {true, false};
+    Boolean[] result = ArrayUtil.concat(Boolean.class, array);
+    assertThat(result).isEqualTo(new Boolean[] {true, false});
+  }
+
+  @Test
+  public void testConcatWithNoArray() {
+    Character[] result = ArrayUtil.concat(Character.class);
+    assertThat(result).isEqualTo(new Character[] {});
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestPartitionMap.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestPartitionMap.java
@@ -293,4 +293,18 @@ public class TestPartitionMap {
     assertThat(map.get("some-string")).isNull();
     assertThat(map.remove("some-string")).isNull();
   }
+
+  @Test
+  public void testComputeIfAbsent() {
+    PartitionMap<String> map = PartitionMap.create(SPECS);
+
+    String result1 = map.computeIfAbsent(BY_DATA_SPEC.specId(), Row.of("a"), () -> "v1");
+    assertThat(result1).isEqualTo("v1");
+    assertThat(map.get(BY_DATA_SPEC.specId(), CustomRow.of("a"))).isEqualTo("v1");
+
+    // verify existing key is not affected
+    String result2 = map.computeIfAbsent(BY_DATA_SPEC.specId(), CustomRow.of("a"), () -> "v2");
+    assertThat(result2).isEqualTo("v1");
+    assertThat(map.get(BY_DATA_SPEC.specId(), CustomRow.of("a"))).isEqualTo("v1");
+  }
 }

--- a/data/src/test/java/org/apache/iceberg/data/TestDataFileIndexStatsFilters.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestDataFileIndexStatsFilters.java
@@ -18,19 +18,28 @@
  */
 package org.apache.iceberg.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.TestTables;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
@@ -53,6 +62,8 @@ public class TestDataFileIndexStatsFilters {
 
   private Table table;
   private List<Record> records = null;
+  private List<Record> oddRecords = null;
+  private List<Record> evenRecords = null;
   private DataFile dataFile = null;
   private DataFile dataFileWithoutNulls = null;
   private DataFile dataFileOnlyNulls = null;
@@ -73,6 +84,15 @@ public class TestDataFileIndexStatsFilters {
     records.add(record.copy("id", 6, "data", "f", "category", "even"));
     records.add(record.copy("id", 7, "data", "g", "category", "odd"));
     records.add(record.copy("id", 8, "data", null, "category", "even"));
+
+    this.oddRecords =
+        records.stream()
+            .filter(rec -> rec.getField("category").equals("odd"))
+            .collect(Collectors.toList());
+    this.evenRecords =
+        records.stream()
+            .filter(rec -> rec.getField("category").equals("even"))
+            .collect(Collectors.toList());
 
     this.dataFile = FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), records);
     this.dataFileWithoutNulls =
@@ -317,5 +337,150 @@ public class TestDataFileIndexStatsFilters {
     FileScanTask task = tasks.get(0);
     Assert.assertEquals(
         "Should have one delete file, data and deletes have null values", 1, task.deletes().size());
+  }
+
+  @Test
+  public void testDifferentDeleteTypes() throws IOException {
+    // init the table with an unpartitioned data file
+    table.newAppend().appendFile(dataFile).commit();
+
+    // add a matching global equality delete
+    DeleteFile globalEqDeleteFile1 = writeEqDeletes("id", 7, 8);
+    table.newRowDelta().addDeletes(globalEqDeleteFile1).commit();
+
+    // evolve the spec to partition by category
+    table.updateSpec().addField("category").commit();
+
+    StructLike evenPartition = Row.of("even");
+    StructLike oddPartition = Row.of("odd");
+
+    // add 2 data files to "even" and "odd" partitions
+    DataFile dataFileWithEvenRecords = writeData(evenPartition, evenRecords);
+    DataFile dataFileWithOddRecords = writeData(oddPartition, oddRecords);
+    table
+        .newFastAppend()
+        .appendFile(dataFileWithEvenRecords)
+        .appendFile(dataFileWithOddRecords)
+        .commit();
+
+    // add 2 matching and 1 filterable partition-scoped equality delete files for "even" partition
+    DeleteFile partitionEqDeleteFile1 = writeEqDeletes(evenPartition, "id", 2);
+    DeleteFile partitionEqDeleteFile2 = writeEqDeletes(evenPartition, "id", 4);
+    DeleteFile partitionEqDeleteFile3 = writeEqDeletes(evenPartition, "id", 25);
+    table
+        .newRowDelta()
+        .addDeletes(partitionEqDeleteFile1)
+        .addDeletes(partitionEqDeleteFile2)
+        .addDeletes(partitionEqDeleteFile3)
+        .commit();
+
+    // add 1 matching partition-scoped position delete file for "even" partition
+    Pair<DeleteFile, CharSequenceSet> partitionPosDeletes =
+        writePosDeletes(
+            evenPartition,
+            ImmutableList.of(
+                Pair.of(dataFileWithEvenRecords.path(), 0L),
+                Pair.of("some-other-file.parquet", 0L)));
+    table
+        .newRowDelta()
+        .addDeletes(partitionPosDeletes.first())
+        .validateDataFilesExist(partitionPosDeletes.second())
+        .commit();
+
+    // add 1 path-scoped position delete file for dataFileWithEvenRecords
+    Pair<DeleteFile, CharSequenceSet> pathPosDeletes =
+        writePosDeletes(
+            evenPartition,
+            ImmutableList.of(
+                Pair.of(dataFileWithEvenRecords.path(), 1L),
+                Pair.of(dataFileWithEvenRecords.path(), 2L)));
+    table
+        .newRowDelta()
+        .addDeletes(pathPosDeletes.first())
+        .validateDataFilesExist(pathPosDeletes.second())
+        .commit();
+
+    // switch back to the unpartitioned spec
+    table.updateSpec().removeField("category").commit();
+
+    // add another global equality delete file that can be filtered using stats
+    DeleteFile globalEqDeleteFile2 = writeEqDeletes("id", 20, 21);
+    table.newRowDelta().addDeletes(globalEqDeleteFile2);
+
+    List<FileScanTask> tasks = planTasks();
+
+    assertThat(tasks).hasSize(3);
+
+    for (FileScanTask task : tasks) {
+      if (coversDataFile(task, dataFile)) {
+        assertDeletes(task, globalEqDeleteFile1);
+
+      } else if (coversDataFile(task, dataFileWithEvenRecords)) {
+        assertDeletes(
+            task,
+            partitionEqDeleteFile1,
+            partitionEqDeleteFile2,
+            pathPosDeletes.first(),
+            partitionPosDeletes.first());
+
+      } else if (coversDataFile(task, dataFileWithOddRecords)) {
+        assertThat(task.deletes()).isEmpty();
+
+      } else {
+        fail("Unexpected task: " + task);
+      }
+    }
+  }
+
+  private boolean coversDataFile(FileScanTask task, DataFile file) {
+    return task.file().path().toString().equals(file.path().toString());
+  }
+
+  private void assertDeletes(FileScanTask task, DeleteFile... expectedDeleteFiles) {
+    CharSequenceSet actualDeletePaths = deletePaths(task);
+
+    assertThat(actualDeletePaths.size()).isEqualTo(expectedDeleteFiles.length);
+
+    for (DeleteFile expectedDeleteFile : expectedDeleteFiles) {
+      assertThat(actualDeletePaths.contains(expectedDeleteFile.path())).isTrue();
+    }
+  }
+
+  private CharSequenceSet deletePaths(FileScanTask task) {
+    return CharSequenceSet.of(Iterables.transform(task.deletes(), ContentFile::path));
+  }
+
+  private List<FileScanTask> planTasks() throws IOException {
+    try (CloseableIterable<FileScanTask> tasksIterable = table.newScan().planFiles()) {
+      return Lists.newArrayList(tasksIterable);
+    }
+  }
+
+  private DataFile writeData(StructLike partition, List<Record> data) throws IOException {
+    return FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), partition, data);
+  }
+
+  private DeleteFile writeEqDeletes(String col, Object... values) throws IOException {
+    return writeEqDeletes(null /* unpartitioned */, col, values);
+  }
+
+  private DeleteFile writeEqDeletes(StructLike partition, String col, Object... values)
+      throws IOException {
+    Schema deleteSchema = SCHEMA.select(col);
+
+    Record delete = GenericRecord.create(deleteSchema);
+    List<Record> deletes = Lists.newArrayList();
+    for (Object value : values) {
+      deletes.add(delete.copy(col, value));
+    }
+
+    OutputFile out = Files.localOutput(temp.newFile());
+    return FileHelpers.writeDeleteFile(table, out, partition, deletes, deleteSchema);
+  }
+
+  private Pair<DeleteFile, CharSequenceSet> writePosDeletes(
+      StructLike partition, List<Pair<CharSequence, Long>> deletes) throws IOException {
+    OutputFile out = Files.localOutput(temp.newFile());
+    return FileHelpers.writeDeleteFile(table, out, partition, deletes);
   }
 }


### PR DESCRIPTION
This PR optimizes our `DeleteFileIndex` to look up deletes by path if they are targeting a single data file. This change is one in the set of properly supporting an optional 1-1 mapping for data files and position deletes. This PR relies on stored boundaries. If they are the same, it means the full path was persisted. In the future, we may optimize this part by persisting extra metadata.

This PR adds a few new tests and relies on other existing tests. It also comes with a benchmark that did not complete in 5 minutes before.

```
Benchmark                                           (oneToOneMapping)  Mode  Cnt            Score            Error   Units
DeleteFileIndexBenchmark.buildIndexAndLookup                     true    ss   10            9.670 ±          0.251    s/op
DeleteFileIndexBenchmark.buildIndexAndLookup                    false    ss   10            0.514 ±          0.026    s/op

```