### PR TITLE
Add support for CreateScan and GetScanTasks in RESTCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FileScanTaskParser.java
+++ b/core/src/main/java/org/apache/iceberg/FileScanTaskParser.java
@@ -131,6 +131,13 @@ public class FileScanTaskParser {
     ResidualEvaluator residualEvaluator = ResidualEvaluator.of(spec, filter, caseSensitive);
     BaseFileScanTask baseFileScanTask =
         new BaseFileScanTask(dataFile, deleteFiles, schemaString, specString, residualEvaluator);
+
+    if (start == 0 && length == dataFile.fileSizeInBytes()) {
+      // TODO
+      // When rest scans are enabled we require this check
+      // As fileScanTasks returned from external service are not split
+      return baseFileScanTask;
+    }
     return new BaseFileScanTask.SplitScanTask(start, length, baseFileScanTask);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/RESTTable.java
+++ b/core/src/main/java/org/apache/iceberg/RESTTable.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.apache.iceberg.rest.ResourcePaths;
+
+public class RESTTable extends BaseTable {
+  private final RESTClient client;
+  private final String path;
+  private final Supplier<Map<String, String>> headers;
+  private final boolean tableScanViaRestEnabled;
+  private final MetricsReporter reporter;
+
+  private final ResourcePaths resourcePaths;
+  private final TableIdentifier tableIdentifier;
+
+  public RESTTable(
+      TableOperations ops,
+      String name,
+      MetricsReporter reporter,
+      RESTClient client,
+      String path,
+      Supplier<Map<String, String>> headers,
+      boolean tableScanViaRestEnabled,
+      TableIdentifier tableIdentifier,
+      ResourcePaths resourcePaths) {
+    super(ops, name, reporter);
+    this.reporter = reporter;
+    this.client = client;
+    this.headers = headers;
+    this.path = path;
+    this.tableScanViaRestEnabled = tableScanViaRestEnabled;
+    this.tableIdentifier = tableIdentifier;
+    this.resourcePaths = resourcePaths;
+  }
+
+  @Override
+  public TableScan newScan() {
+
+    if (tableScanViaRestEnabled
+        && Boolean.parseBoolean(
+            this.properties().get(RESTSessionCatalog.REST_TABLE_SCAN_ENABLED))) {
+      return new RESTTableScan(
+          this,
+          schema(),
+          ImmutableTableScanContext.builder().metricsReporter(reporter).build(),
+          client,
+          path,
+          headers,
+          operations(),
+          tableIdentifier,
+          resourcePaths);
+    }
+    return super.newScan();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/RESTTableScan.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.expressions.ExpressionParser;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.ErrorHandlers;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.ResourcePaths;
+import org.apache.iceberg.rest.requests.CreateScanRequest;
+import org.apache.iceberg.rest.responses.CreateScanResponse;
+import org.apache.iceberg.rest.responses.GetScanTasksResponse;
+import org.apache.iceberg.types.Types;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RESTTableScan extends DataTableScan {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RESTTableScan.class);
+  private final RESTClient client;
+  private final String path;
+  private final Supplier<Map<String, String>> headers;
+  private final TableOperations operations;
+  private final Table table;
+  private final Schema schema;
+  private final TableScanContext context;
+  private final ResourcePaths resourcePaths;
+  private final TableIdentifier tableIdentifier;
+
+  public RESTTableScan(
+      Table table,
+      Schema schema,
+      TableScanContext context,
+      RESTClient client,
+      String path,
+      Supplier<Map<String, String>> headers,
+      TableOperations operations,
+      TableIdentifier tableIdentifier,
+      ResourcePaths resourcePaths) {
+    super(table, schema, context);
+    this.context = context;
+    this.table = table;
+    this.schema = schema;
+    this.client = client;
+    this.headers = headers;
+    this.path = path;
+    this.operations = operations;
+    this.tableIdentifier = tableIdentifier;
+    this.resourcePaths = resourcePaths;
+  }
+
+  @Override
+  public CloseableIterable<FileScanTask> planFiles() {
+    String filterString = ExpressionParser.toJson(filter());
+
+    CreateScanRequest request =
+        CreateScanRequest.builder().withSelect(columnNames()).withFilter(filterString).build();
+
+    CreateScanResponse createScanResponse =
+        client.post(
+            resourcePaths.createScan(tableIdentifier),
+            request,
+            CreateScanResponse.class,
+            headers,
+            ErrorHandlers.defaultErrorHandler());
+
+    return new RESTScanTasks(createScanResponse.scan(), createScanResponse.shards());
+  }
+
+  @Override
+  protected TableScan newRefinedScan(
+      Table refinedTable, Schema refinedSchema, TableScanContext refinedContext) {
+    return new RESTTableScan(
+        refinedTable,
+        refinedSchema,
+        refinedContext,
+        client,
+        path,
+        headers,
+        operations,
+        tableIdentifier,
+        resourcePaths);
+  }
+
+  private List<String> columnNames() {
+    List<String> columnNames =
+        schema.columns().stream().map(Types.NestedField::name).collect(Collectors.toList());
+    return columnNames;
+  }
+
+  public class RESTScanTasks implements CloseableIterable<FileScanTask> {
+    private String scanID;
+    private List<String> shardsList;
+    private List<FileScanTask> fileScanTaskList;
+
+    private String currentShard;
+    private String nextToken;
+    private Map<String, String> queryParams;
+
+    public RESTScanTasks(String scanID, List<String> shards) {
+      this.scanID = scanID;
+      this.shardsList = Lists.newArrayList(shards);
+      this.fileScanTaskList = Lists.newArrayList();
+      this.currentShard = null;
+      this.nextToken = null;
+      this.queryParams = Maps.newHashMap();
+    }
+
+    @Override
+    public CloseableIterator<FileScanTask> iterator() {
+
+      return new CloseableIterator<FileScanTask>() {
+
+        @Override
+        public void close() {}
+
+        @Override
+        public boolean hasNext() {
+          if (fileScanTaskList.isEmpty()) {
+            if (shardsList.isEmpty()) {
+              // we have no fileScanTasks in our scan tasks list
+              // and we have no shards to get more fileScanTasks so done
+              return false;
+            }
+            if (currentShard == null) {
+              // get a shard so we can start consuming fileScanTasks
+              currentShard = shardsList.remove(0);
+            }
+            // retrive fileScanTasks for this shard
+            getNextFileScanTasks();
+          }
+          return true;
+        }
+
+        @Override
+        public FileScanTask next() {
+          return fileScanTaskList.remove(0);
+        }
+      };
+    }
+
+    public void getNextFileScanTasks() {
+      queryParams.put("shard", currentShard);
+      if (nextToken != null) {
+        queryParams.put("next", nextToken);
+      }
+      GetScanTasksResponse getScanTasksResponse =
+          client.get(
+              resourcePaths.getScanTasks(tableIdentifier, scanID),
+              queryParams,
+              GetScanTasksResponse.class,
+              headers,
+              ErrorHandlers.defaultErrorHandler());
+
+      if (!getScanTasksResponse.fileScanTasks().isEmpty()) {
+        fileScanTaskList.addAll(getScanTasksResponse.fileScanTasks());
+      }
+
+      nextToken = getScanTasksResponse.nextToken();
+      if (nextToken == null) {
+        // this means that we have consumed all fileScanTasks for this shard
+        // so set currentShard to null
+        // this allows us to get the next shard in hasNext
+        currentShard = null;
+      }
+    }
+
+    @Override
+    public void close() throws IOException {}
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -59,6 +59,8 @@ import org.apache.iceberg.rest.requests.UpdateTableRequest.UpdateRequirement;
 import org.apache.iceberg.rest.requests.UpdateTableRequestParser;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
+import org.apache.iceberg.rest.responses.GetScanTasksResponse;
+import org.apache.iceberg.rest.responses.GetScanTasksResponseParser;
 import org.apache.iceberg.rest.responses.ImmutableLoadViewResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponseParser;
@@ -115,7 +117,9 @@ public class RESTSerializers {
         .addSerializer(LoadViewResponse.class, new LoadViewResponseSerializer<>())
         .addSerializer(ImmutableLoadViewResponse.class, new LoadViewResponseSerializer<>())
         .addDeserializer(LoadViewResponse.class, new LoadViewResponseDeserializer<>())
-        .addDeserializer(ImmutableLoadViewResponse.class, new LoadViewResponseDeserializer<>());
+        .addDeserializer(ImmutableLoadViewResponse.class, new LoadViewResponseDeserializer<>())
+        .addSerializer(GetScanTasksResponse.class, new GetScanTasksResponseSerializer<>())
+        .addDeserializer(GetScanTasksResponse.class, new GetScanTasksResponseDeserializer<>());
 
     mapper.registerModule(module);
   }
@@ -426,6 +430,24 @@ public class RESTSerializers {
     public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
       JsonNode jsonNode = p.getCodec().readTree(p);
       return (T) LoadViewResponseParser.fromJson(jsonNode);
+    }
+  }
+
+  static class GetScanTasksResponseSerializer<T extends GetScanTasksResponse>
+      extends JsonSerializer<T> {
+    @Override
+    public void serialize(T request, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      GetScanTasksResponseParser.toJson(request, gen);
+    }
+  }
+
+  static class GetScanTasksResponseDeserializer<T extends GetScanTasksResponse>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) GetScanTasksResponseParser.fromJson(jsonNode);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -111,4 +111,27 @@ public class ResourcePaths {
   public String renameView() {
     return SLASH.join("v1", prefix, "views", "rename");
   }
+
+  public String createScan(TableIdentifier ident) {
+    return SLASH.join(
+        "v1",
+        prefix,
+        "namespaces",
+        RESTUtil.encodeNamespace(ident.namespace()),
+        "tables",
+        RESTUtil.encodeString(ident.name()),
+        "scans");
+  }
+
+  public String getScanTasks(TableIdentifier ident, String scanID) {
+    return SLASH.join(
+        "v1",
+        prefix,
+        "namespaces",
+        RESTUtil.encodeNamespace(ident.namespace()),
+        "tables",
+        RESTUtil.encodeString(ident.name()),
+        "scans",
+        RESTUtil.encodeString(scanID));
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/requests/CreateScanRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/CreateScanRequest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.RESTRequest;
+
+public class CreateScanRequest implements RESTRequest {
+  private List<String> select;
+  private String filter;
+  private Map<String, String> options = Maps.newHashMap();
+
+  public CreateScanRequest() {}
+
+  private CreateScanRequest(List<String> select, String filter) {
+    this.select = select;
+    this.filter = filter;
+    validate();
+  }
+
+  @Override
+  public void validate() {
+    Preconditions.checkArgument(
+        select != null && !select.isEmpty(), "Invalid select: should not be null or empty");
+    Preconditions.checkArgument(filter != null, "Invalid filter: null");
+    Preconditions.checkArgument(
+        options != null && !options.isEmpty(), "Invalid options: should not be null or empty");
+  }
+
+  public List<String> select() {
+    return select;
+  }
+
+  public String filter() {
+    return filter;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("select", select)
+        .add("filter", filter)
+        .add("options", options)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> select;
+    private String filter;
+
+    private Builder() {}
+
+    public Builder withSelect(List<String> newSelect) {
+      Preconditions.checkNotNull(newSelect, "Invalid select: null");
+      this.select = newSelect;
+      return this;
+    }
+
+    public Builder withFilter(String newFilter) {
+      this.filter = newFilter;
+      return this;
+    }
+
+    public CreateScanRequest build() {
+      return new CreateScanRequest(select, filter);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/GetScanTasksRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/GetScanTasksRequest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.RESTRequest;
+
+public class GetScanTasksRequest implements RESTRequest {
+
+  private String scanID;
+
+  private String shard;
+
+  public GetScanTasksRequest() {}
+
+  public GetScanTasksRequest(String scanID, String shard) {
+    this.scanID = scanID;
+    this.shard = shard;
+    validate();
+  }
+
+  @Override
+  public void validate() {
+    Preconditions.checkArgument(scanID != null, "Invalid scanID: null");
+    Preconditions.checkArgument(shard != null, "Invalid shard: null");
+  }
+
+  public String scanID() {
+    return scanID;
+  }
+
+  public String shard() {
+    return shard;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("scanID", scanID).add("shard", shard).toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String scanID;
+
+    private String shard;
+
+    private Builder() {}
+
+    public Builder withScanID(String newScanID) {
+      Preconditions.checkNotNull(newScanID, "Invalid selections: null");
+      this.scanID = newScanID;
+      return this;
+    }
+
+    public Builder withShard(String newShard) {
+      this.shard = newShard;
+      return this;
+    }
+
+    public GetScanTasksRequest build() {
+      return new GetScanTasksRequest(scanID, shard);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/CreateScanResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/CreateScanResponse.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.RESTResponse;
+
+public class CreateScanResponse implements RESTResponse {
+
+  private String scan;
+  private List<String> shards;
+
+  public CreateScanResponse() {}
+
+  private CreateScanResponse(String scan, List<String> shards) {
+    this.scan = scan;
+    this.shards = shards;
+    validate();
+  }
+
+  @Override
+  public void validate() {
+    Preconditions.checkArgument(scan != null, "Invalid scan: null");
+    Preconditions.checkArgument(shards != null, "Invalid shards: null");
+  }
+
+  public String scan() {
+    return scan;
+  }
+
+  public List<String> shards() {
+    return shards;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("scan", scan).add("shards", shards).toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String scan;
+
+    private List<String> shards;
+
+    private Builder() {}
+
+    public Builder withScan(String newScan) {
+      Preconditions.checkNotNull(newScan, "Invalid scan: null");
+      this.scan = newScan;
+      return this;
+    }
+
+    public Builder withShards(List<String> newShards) {
+      Preconditions.checkNotNull(newShards, "Invalid shards: null");
+      this.shards = newShards;
+      return this;
+    }
+
+    public CreateScanResponse build() {
+      return new CreateScanResponse(scan, shards);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/GetScanTasksResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/GetScanTasksResponse.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import java.util.List;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.RESTResponse;
+
+public class GetScanTasksResponse implements RESTResponse {
+
+  private List<FileScanTask> fileScanTasks;
+
+  private String next;
+
+  public GetScanTasksResponse() {}
+
+  private GetScanTasksResponse(List<FileScanTask> fileScanTasks, String nextToken) {
+    this.fileScanTasks = fileScanTasks;
+    this.next = nextToken;
+  }
+
+  public List<FileScanTask> fileScanTasks() {
+    return fileScanTasks;
+  }
+
+  public String nextToken() {
+    return next;
+  }
+
+  @Override
+  public void validate() {
+    Preconditions.checkArgument(fileScanTasks != null, "Invalid fileScanTasks: null");
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("fileScanTasks", fileScanTasks)
+        .add("next", next)
+        .toString();
+  }
+
+  public static GetScanTasksResponse.Builder builder() {
+    return new GetScanTasksResponse.Builder();
+  }
+
+  public static class Builder {
+
+    private List<FileScanTask> fileScanTasks;
+    private String next;
+
+    private Builder() {}
+
+    public GetScanTasksResponse.Builder withFileScanTasks(List<FileScanTask> fileScanTaskList) {
+      Preconditions.checkNotNull(fileScanTaskList, "Invalid fileScanTasks: null");
+      this.fileScanTasks = fileScanTaskList;
+      return this;
+    }
+
+    public GetScanTasksResponse.Builder withNextToken(String nextToken) {
+      this.next = nextToken;
+      return this;
+    }
+
+    public GetScanTasksResponse build() {
+      return new GetScanTasksResponse(fileScanTasks, next);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/GetScanTasksResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/GetScanTasksResponseParser.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.FileScanTaskParser;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.JsonUtil;
+
+public class GetScanTasksResponseParser {
+  static final String FILE_SCAN_TASKS = "file-scan-tasks";
+  static final String NEXT_TOKEN = "next";
+
+  private GetScanTasksResponseParser() {}
+
+  public static String toJson(GetScanTasksResponse response) {
+    return toJson(response, false);
+  }
+
+  public static String toJson(GetScanTasksResponse response, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(response, gen), pretty);
+  }
+
+  public static void toJson(GetScanTasksResponse response, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != response, "Invalid get scan task response : null");
+
+    gen.writeStartObject();
+    gen.writeArrayFieldStart(FILE_SCAN_TASKS);
+    for (FileScanTask fileScanTask : response.fileScanTasks()) {
+      FileScanTaskParser.toJson(fileScanTask);
+    }
+    gen.writeEndArray();
+    gen.writeEndObject();
+  }
+
+  public static GetScanTasksResponse fromJson(String json) {
+    Preconditions.checkArgument(
+        json != null, "Cannot parse get scan tasks metadata from null string");
+    return JsonUtil.parse(json, GetScanTasksResponseParser::fromJson);
+  }
+
+  public static GetScanTasksResponse fromJson(JsonNode json) {
+    Preconditions.checkArgument(json != null, "Cannot parse get scan tasks from null object");
+    Preconditions.checkArgument(
+        json.isObject(), "Cannot parse get scan tasks metadata from non-object: %s", json);
+
+    JsonNode fileScanTasksJson = JsonUtil.get("file-scan-tasks", json);
+    List<FileScanTask> fileScanTaskList = Lists.newArrayList();
+    for (JsonNode fileScanTaskNode : fileScanTasksJson) {
+      fileScanTaskList.add(FileScanTaskParser.fromJson(fileScanTaskNode.toString(), false));
+    }
+    String nextToken = null;
+    if (json.get(NEXT_TOKEN) != null) {
+      nextToken = String.valueOf(JsonUtil.getString(NEXT_TOKEN, json));
+    }
+    return GetScanTasksResponse.builder()
+        .withFileScanTasks(fileScanTaskList)
+        .withNextToken(nextToken)
+        .build();
+  }
+}

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -209,6 +209,40 @@ class MetadataLog(BaseModel):
     __root__: List[MetadataLogItem]
 
 
+class ColumnSizes(BaseModel):
+    keys: Optional[int] = None
+    values: Optional[float] = None
+
+
+class ValueCounts(BaseModel):
+    keys: Optional[int] = None
+    values: Optional[float] = None
+
+
+class NullValueCounts(BaseModel):
+    keys: Optional[int] = None
+    values: Optional[float] = None
+
+
+class NanValueCounts(BaseModel):
+    keys: Optional[int] = None
+    values: Optional[float] = None
+
+
+class LowerBounds(BaseModel):
+    keys: Optional[int] = None
+    values: Optional[bytes] = None
+
+
+class UpperBounds(BaseModel):
+    keys: Optional[int] = None
+    values: Optional[bytes] = None
+
+
+class FileContent(BaseModel):
+    __root__: Literal['DATA', 'POSITION_DELETES', 'EQUALITY_DELETES']
+
+
 class SQLViewRepresentation(BaseModel):
     type: str
     sql: str
@@ -420,6 +454,21 @@ class AssertDefaultSortOrderId(TableRequirement):
     default_sort_order_id: int = Field(..., alias='default-sort-order-id')
 
 
+class CreateScanResult(BaseModel):
+    """
+    create scan response
+    """
+
+    scan: str
+    shards: List[str]
+
+
+class CreateScanRequest(BaseModel):
+    select: List[str]
+    filter: Optional[str] = None
+    options: Dict[str, str]
+
+
 class RegisterTableRequest(BaseModel):
     name: str
     metadata_location: str = Field(..., alias='metadata-location')
@@ -614,6 +663,32 @@ class TransformTerm(BaseModel):
     term: Reference
 
 
+class ContentFile(BaseModel):
+    spec_id: Optional[str] = Field(None, alias='spec-id')
+    content: Optional[FileContent] = None
+    file_path: str = Field(..., alias='file-path')
+    file_format: Optional[str] = Field(None, alias='file-format')
+    partition: Optional[Dict[str, str]] = None
+    record_count: Optional[float] = Field(None, alias='record-count')
+    file_size_in_bytes: Optional[float] = Field(None, alias='file-size-in-bytes')
+    column_sizes: Optional[Dict[str, ColumnSizes]] = Field(None, alias='column-sizes')
+    value_counts: Optional[Dict[str, ValueCounts]] = Field(None, alias='value-counts')
+    null_value_counts: Optional[Dict[str, NullValueCounts]] = Field(
+        None, alias='null-value-counts'
+    )
+    nan_value_counts: Optional[Dict[str, NanValueCounts]] = Field(
+        None, alias='nan-value-counts'
+    )
+    lower_bounds: Optional[Dict[str, LowerBounds]] = Field(None, alias='lower-bounds')
+    upper_bounds: Optional[Dict[str, UpperBounds]] = Field(None, alias='upper-bounds')
+    key_metadata: Optional[bytes] = Field(None, alias='key-metadata')
+    split_offsets: Optional[List[float]] = Field(None, alias='split-offsets')
+    equality_ids: Optional[List[int]] = Field(None, alias='equality-ids')
+    sort_order_id: Optional[int] = Field(None, alias='sort-order-id')
+    data_sequence_number: Optional[float] = Field(None, alias='data-sequence-number')
+    file_sequence_number: Optional[float] = Field(None, alias='file-sequence-number')
+
+
 class ReportMetricsRequest2(CommitReport):
     report_type: str = Field(..., alias='report-type')
 
@@ -718,6 +793,19 @@ class TableMetadata(BaseModel):
     metadata_log: Optional[MetadataLog] = Field(None, alias='metadata-log')
 
 
+class FileScanTask(BaseModel):
+    data_file: ContentFile = Field(..., alias='data-file')
+    partition: Optional[Dict[str, str]] = None
+    size_bytes: Optional[float] = Field(None, alias='size-bytes')
+    start: Optional[float] = None
+    length: Optional[float] = None
+    estimated_rows_count: Optional[float] = Field(None, alias='estimated-rows-count')
+    delete_files: Optional[List[ContentFile]] = Field(None, alias='delete-files')
+    schema_: Optional[Schema] = Field(None, alias='schema')
+    spec: Optional[PartitionSpec] = None
+    residual_filter: Optional[Expression] = Field(None, alias='residual-filter')
+
+
 class ViewMetadata(BaseModel):
     view_uuid: str = Field(..., alias='view-uuid')
     format_version: int = Field(..., alias='format-version', ge=1, le=1)
@@ -807,6 +895,15 @@ class LoadTableResult(BaseModel):
     )
     metadata: TableMetadata
     config: Optional[Dict[str, str]] = None
+
+
+class GetScanTasksResult(BaseModel):
+    """
+    Result of when attempting to get file scan tasks from a scan.
+    """
+
+    file_scan_tasks: List[FileScanTask] = Field(..., alias='file-scan-tasks')
+    next: Optional[str] = None
 
 
 class CommitTableRequest(BaseModel):
@@ -910,6 +1007,7 @@ ListType.update_forward_refs()
 MapType.update_forward_refs()
 Expression.update_forward_refs()
 TableMetadata.update_forward_refs()
+FileScanTask.update_forward_refs()
 ViewMetadata.update_forward_refs()
 AddSchemaUpdate.update_forward_refs()
 CreateTableRequest.update_forward_refs()

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -530,6 +530,111 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
+  /v1/{prefix}/namespaces/{namespace}/tables/{table}/scans:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/table'
+    post:
+      tags:
+        - Catalog API
+      summary: Create a table scan for the table
+      description:
+        Creates a table scan for the table.
+      operationId: createScan
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateScanRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/CreateScanResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description:
+            Not Found
+            - NoSuchTableException, the table does not exist
+            - NoSuchNamespaceException, the namespace does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+              examples:
+                TableDoesNotExist:
+                  $ref: '#/components/examples/NoSuchTableError'
+                NamespaceDoesNotExist:
+                  $ref: '#/components/examples/NoSuchNamespaceError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
+
+
+  /v1/{prefix}/namespaces/{namespace}/tables/{table}/scans/{scan}:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/table'
+      - $ref: '#/components/parameters/scan'
+    get:
+      tags:
+        - Catalog API
+      summary: Gets a list of FileScanTasks
+      operationId: getScanTasks
+      description:
+        Gets a list of FileScanTasks
+      parameters:
+        - in: query
+          name: shard
+          description:
+            Reads a single or multiple shards in parallel, to obtain a list of file scan tasks.
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: next
+          description:
+            Used for obtaining the next batch of fileScanTasks
+          required: false
+          allowEmptyValue: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/GetScanTasksResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description:
+            Not Found - NoSuchTableException, table to load does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                TableToLoadDoesNotExist:
+                  $ref: '#/components/examples/NoSuchTableError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
+
   /v1/{prefix}/namespaces/{namespace}/register:
     parameters:
       - $ref: '#/components/parameters/prefix'
@@ -1444,6 +1549,15 @@ components:
         type: string
       example: "sales"
 
+    scan:
+      name: scan
+      in: path
+      description: a scan id
+      required: true
+      schema:
+        type: string
+      example: "scan123"
+
     view:
       name: view
       in: path
@@ -2030,6 +2144,138 @@ components:
         metadata-log:
           $ref: '#/components/schemas/MetadataLog'
 
+    FileScanTask:
+      type: object
+      required:
+        - data-file
+      properties:
+        data-file:
+          $ref: '#/components/schemas/ContentFile'
+        partition:
+            type: object
+            additionalProperties:
+              type: string
+        size-bytes:
+          type: number
+        start:
+          type: number
+        length:
+          type: number
+        estimated-rows-count:
+          type: number
+        delete-files:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContentFile'
+        schema:
+          $ref: '#/components/schemas/Schema'
+        spec:
+          $ref: '#/components/schemas/PartitionSpec'
+        residual-filter:
+          $ref: '#/components/schemas/Expression'
+
+    ContentFile:
+      type: object
+      required:
+        - file-path
+      properties:
+        spec-id:
+          type: string
+        content:
+          $ref: '#/components/schemas/FileContent'
+        file-path:
+          type: string
+        file-format:
+          type: string
+        partition:
+          type: object
+          additionalProperties:
+            type: string
+        record-count:
+          type: number
+        file-size-in-bytes:
+          type: number
+        column-sizes:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              keys:
+                type: integer
+              values:
+                type: number
+        value-counts:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              keys:
+                type: integer
+              values:
+                type: number
+        null-value-counts:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              keys:
+                type: integer
+              values:
+                type: number
+        nan-value-counts:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              keys:
+                type: integer
+              values:
+                type: number
+        lower-bounds:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              keys:
+                type: integer
+              values:
+                type: string
+                format: binary
+        upper-bounds:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              keys:
+                type: integer
+              values:
+                type: string
+                format: binary
+        key-metadata:
+          type: string
+          format: binary
+        split-offsets:
+          type: array
+          items:
+            type: number
+        equality-ids:
+          type: array
+          items:
+            type: integer
+        sort-order-id:
+          type: integer
+        data-sequence-number:
+          type: number
+        file-sequence-number:
+          type: number
+
+    FileContent:
+      type: string
+      enum:
+        - DATA
+        - POSITION_DELETES
+        - EQUALITY_DELETES
+
     SQLViewRepresentation:
       type: object
       required:
@@ -2550,6 +2796,33 @@ components:
           additionalProperties:
             type: string
 
+    CreateScanResult:
+      type: object
+      description: create scan response
+      required:
+        - scan
+        - shards
+      properties:
+        scan:
+          type: string
+        shards:
+          type: array
+          items:
+            type: string
+
+    GetScanTasksResult:
+      description: Result of when attempting to get file scan tasks from a scan.
+      type: object
+      required:
+        - file-scan-tasks
+      properties:
+        file-scan-tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileScanTask'
+        next:
+          type: string
+
     CommitTableRequest:
       type: object
       required:
@@ -2611,6 +2884,23 @@ components:
         stage-create:
           type: boolean
         properties:
+          type: object
+          additionalProperties:
+            type: string
+
+    CreateScanRequest:
+      type: object
+      required:
+        - select
+        - options
+      properties:
+        select:
+          type: array
+          items:
+            type: string
+        filter:
+          type: string
+        options:
           type: object
           additionalProperties:
             type: string
@@ -3291,6 +3581,20 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/LoadTableResult'
+
+    CreateScanResponse:
+      description: Create Scan Response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateScanResult'
+
+    GetScanTasksResponse:
+      description: get scan tasks response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GetScanTasksResult'
 
     LoadTableResponse:
       description: Table metadata result when loading a table

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -530,7 +530,7 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
-  /v1/{prefix}/namespaces/{namespace}/tables/{table}/scans:
+  /v1/{prefix}/namespaces/{namespace}/tables/{table}/preplan:
     parameters:
       - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
@@ -538,18 +538,20 @@ paths:
     post:
       tags:
         - Catalog API
-      summary: Create a table scan for the table
+      summary: Intiate a preplanning process on the table to find plan-tasks relevant to a specific query.
       description:
-        Creates a table scan for the table.
-      operationId: createScan
+        When a user submits a query, we can do a "preplan" to find the relevant plan-tasks 
+        based on the user's selected columns, and filters. The plan-tasks can then be used during "plan" 
+        for distributed planning for performance gain.
+      operationId: prePlan
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateScanRequest'
+              $ref: '#/components/schemas/PrePlanTableRequest'
       responses:
         200:
-          $ref: '#/components/responses/CreateScanResponse'
+          $ref: '#/components/responses/PrePlanTableResponse'
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'
         401:
@@ -579,38 +581,28 @@ paths:
 
 
 
-  /v1/{prefix}/namespaces/{namespace}/tables/{table}/scans/{scan}:
+  /v1/{prefix}/namespaces/{namespace}/tables/{table}/plan/:
     parameters:
       - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
       - $ref: '#/components/parameters/table'
-      - $ref: '#/components/parameters/scan'
-    get:
+    post:
       tags:
         - Catalog API
-      summary: Gets a list of FileScanTasks
-      operationId: getScanTasks
+      summary: Initiate plan on table to find relevant file scan tasks for a specific query.
+      operationId: planTable
       description:
-        Gets a list of FileScanTasks
-      parameters:
-        - in: query
-          name: shard
-          description:
-            Reads a single or multiple shards in parallel, to obtain a list of file scan tasks.
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: next
-          description:
-            Used for obtaining the next batch of fileScanTasks
-          required: false
-          allowEmptyValue: true
-          schema:
-            type: string
+        When a user submits a query, we can do a "plan" to find the relevant file scan tasks
+        based on the user's selected columns, and filters. Passing the param plan-tasks can be used 
+        for enhanced query performance, by distributing the planning work.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlanTableRequest'
       responses:
         200:
-          $ref: '#/components/responses/GetScanTasksResponse'
+          $ref: '#/components/responses/PlanTableResponse'
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'
         401:
@@ -2144,6 +2136,13 @@ components:
         metadata-log:
           $ref: '#/components/schemas/MetadataLog'
 
+    PlanTask:
+      description:
+        A flexible JSON object that contains information provided by the server, 
+        to be utilized by clients for distributed planning. However it is recommended that servers 
+        provide a plan-task-id, as well as a location to a manifest.
+      type: object
+
     FileScanTask:
       type: object
       required:
@@ -2272,9 +2271,9 @@ components:
     FileContent:
       type: string
       enum:
-        - DATA
-        - POSITION_DELETES
-        - EQUALITY_DELETES
+        - data
+        - position-deletes
+        - equality-deletes
 
     SQLViewRepresentation:
       type: object
@@ -2796,22 +2795,23 @@ components:
           additionalProperties:
             type: string
 
-    CreateScanResult:
+    PrePlanTableResult:
+      description:
+        When doing prePlan the result is a list of plan-tasks.
       type: object
-      description: create scan response
       required:
-        - scan
-        - shards
+        - plan-tasks
       properties:
-        scan:
-          type: string
-        shards:
+        expiration-time-ms:
+          type: integer
+          format: int64
+        plan-tasks:
           type: array
           items:
-            type: string
+            $ref: '#/components/schemas/PlanTask'
 
-    GetScanTasksResult:
-      description: Result of when attempting to get file scan tasks from a scan.
+    PlanTableResult:
+      description: Result of getting file-scan-tasks from a plan operation.
       type: object
       required:
         - file-scan-tasks
@@ -2820,8 +2820,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileScanTask'
-        next:
-          type: string
 
     CommitTableRequest:
       type: object
@@ -2888,22 +2886,57 @@ components:
           additionalProperties:
             type: string
 
-    CreateScanRequest:
+    PrePlanTableRequest:
       type: object
       required:
         - select
         - options
       properties:
         select:
+          description: A list of the selected columns that user specifies during a query.
           type: array
           items:
             type: string
         filter:
-          type: string
+          $ref: '#/components/schemas/Expression'
         options:
           type: object
           additionalProperties:
             type: string
+        snapshot-id:
+          type: integer
+          format: int64
+        timestamp-ms:
+          type: integer
+          format: int64
+
+    PlanTableRequest:
+      type: object
+      required:
+        - select
+        - options
+      properties:
+        select:
+          description: A list of the selected columns that user specifies during a query.
+          type: array
+          items:
+            type: string
+        filter:
+          $ref: '#/components/schemas/Expression'
+        options:
+          type: object
+          additionalProperties:
+            type: string
+        plan-tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlanTask'
+        snapshot-id:
+          type: integer
+          format: int64
+        timestamp-ms:
+          type: integer
+          format: int64
 
     RegisterTableRequest:
       type: object
@@ -3582,19 +3615,19 @@ components:
           schema:
             $ref: '#/components/schemas/LoadTableResult'
 
-    CreateScanResponse:
-      description: Create Scan Response
+    PrePlanTableResponse:
+      description: PrePlanTable Response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/CreateScanResult'
+            $ref: '#/components/schemas/PrePlanTableResult'
 
-    GetScanTasksResponse:
-      description: get scan tasks response
+    PlanTableResponse:
+      description: PlanTable Response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/GetScanTasksResult'
+            $ref: '#/components/schemas/PlanTableResult'
 
     LoadTableResponse:
       description: Table metadata result when loading a table

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.MetricsModes;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RESTTable;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SparkDistributedDataScan;
@@ -719,7 +720,10 @@ public class SparkScanBuilder
   }
 
   private BatchScan newBatchScan() {
-    if (table instanceof BaseTable && readConf.distributedPlanningEnabled()) {
+    if (table instanceof BaseTable
+        && !(table
+            instanceof RESTTable) // TODO added this to use restTable scan, however will revisit.
+        && readConf.distributedPlanningEnabled()) {
       return new SparkDistributedDataScan(spark, table, readConf);
     } else {
       return table.newBatchScan();


### PR DESCRIPTION
Hi all, 
 
Im reaching out to share a proposal for a new Scan API that will be utilized by the RESTCatalog. The process for table scan planning is currently done within client engines such as Apache Spark. By moving scan functionality to the RESTCatalog, we can integrate Iceberg table scans with external services, which can lead to several benefits. This all can be found in the detailed proposal [here](https://docs.google.com/document/d/1FdjCnFZM1fNtgyb9-v9fU4FwOX4An-pqEwSaJe8RgUg/edit#heading=h.cftjlkb2wh4h). Feel free to comment, and add your suggestions.

@jackye1995 @rdblue @danielcweeks @amogh-jahagirdar 