### PR TITLE
Flink: Backport PR #9212 - switching to SortKey for data statistics

### DIFF
--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatistics.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatistics.java
@@ -19,7 +19,7 @@
 package org.apache.iceberg.flink.sink.shuffle;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.SortKey;
 
 /**
  * DataStatistics defines the interface to collect data distribution information.
@@ -29,7 +29,7 @@ import org.apache.flink.table.data.RowData;
  * (sketching) can be used.
  */
 @Internal
-interface DataStatistics<D extends DataStatistics, S> {
+interface DataStatistics<D extends DataStatistics<D, S>, S> {
 
   /**
    * Check if data statistics contains any statistics information.
@@ -38,12 +38,8 @@ interface DataStatistics<D extends DataStatistics, S> {
    */
   boolean isEmpty();
 
-  /**
-   * Add data key to data statistics.
-   *
-   * @param key generate from data by applying key selector
-   */
-  void add(RowData key);
+  /** Add row sortKey to data statistics. */
+  void add(SortKey sortKey);
 
   /**
    * Merge current statistics with other statistics.

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
@@ -172,6 +172,7 @@ class DataStatisticsCoordinator<D extends DataStatistics<D, S>, S> implements Op
     }
   }
 
+  @SuppressWarnings("FutureReturnValueIgnored")
   private void sendDataStatisticsToSubtasks(
       long checkpointId, DataStatistics<D, S> globalDataStatistics) {
     callInCoordinatorThread(
@@ -339,7 +340,7 @@ class DataStatisticsCoordinator<D extends DataStatistics<D, S>, S> implements Op
 
     private OperatorCoordinator.SubtaskGateway getSubtaskGateway(int subtaskIndex) {
       Preconditions.checkState(
-          gateways[subtaskIndex].size() > 0,
+          !gateways[subtaskIndex].isEmpty(),
           "Coordinator of %s subtask %d is not ready yet to receive events",
           operatorName,
           subtaskIndex);

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsUtil.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsUtil.java
@@ -76,7 +76,6 @@ class DataStatisticsUtil {
     return bytes.toByteArray();
   }
 
-  @SuppressWarnings("unchecked")
   static <D extends DataStatistics<D, S>, S>
       AggregatedStatistics<D, S> deserializeAggregatedStatistics(
           byte[] bytes, TypeSerializer<DataStatistics<D, S>> statisticsSerializer)

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeySerializer.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeySerializer.java
@@ -1,0 +1,353 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.shuffle;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.SortField;
+import org.apache.iceberg.SortKey;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.SortOrderParser;
+import org.apache.iceberg.types.CheckCompatibility;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+class SortKeySerializer extends TypeSerializer<SortKey> {
+  private final Schema schema;
+  private final SortOrder sortOrder;
+  private final int size;
+  private final Types.NestedField[] transformedFields;
+
+  private transient SortKey sortKey;
+
+  SortKeySerializer(Schema schema, SortOrder sortOrder) {
+    this.schema = schema;
+    this.sortOrder = sortOrder;
+    this.size = sortOrder.fields().size();
+
+    this.transformedFields = new Types.NestedField[size];
+    for (int i = 0; i < size; ++i) {
+      SortField sortField = sortOrder.fields().get(i);
+      Types.NestedField sourceField = schema.findField(sortField.sourceId());
+      Type resultType = sortField.transform().getResultType(sourceField.type());
+      Types.NestedField transformedField =
+          Types.NestedField.of(
+              sourceField.fieldId(),
+              sourceField.isOptional(),
+              sourceField.name(),
+              resultType,
+              sourceField.doc());
+      transformedFields[i] = transformedField;
+    }
+  }
+
+  private SortKey lazySortKey() {
+    if (sortKey == null) {
+      this.sortKey = new SortKey(schema, sortOrder);
+    }
+
+    return sortKey;
+  }
+
+  @Override
+  public boolean isImmutableType() {
+    return false;
+  }
+
+  @Override
+  public TypeSerializer<SortKey> duplicate() {
+    return new SortKeySerializer(schema, sortOrder);
+  }
+
+  @Override
+  public SortKey createInstance() {
+    return new SortKey(schema, sortOrder);
+  }
+
+  @Override
+  public SortKey copy(SortKey from) {
+    return from.copy();
+  }
+
+  @Override
+  public SortKey copy(SortKey from, SortKey reuse) {
+    // no benefit of reuse
+    return copy(from);
+  }
+
+  @Override
+  public int getLength() {
+    return -1;
+  }
+
+  @Override
+  public void serialize(SortKey record, DataOutputView target) throws IOException {
+    Preconditions.checkArgument(
+        record.size() == size,
+        "Invalid size of the sort key object: %s. Expected %s",
+        record.size(),
+        size);
+    for (int i = 0; i < size; ++i) {
+      int fieldId = transformedFields[i].fieldId();
+      Type.TypeID typeId = transformedFields[i].type().typeId();
+      switch (typeId) {
+        case BOOLEAN:
+          target.writeBoolean(record.get(i, Boolean.class));
+          break;
+        case INTEGER:
+        case DATE:
+          target.writeInt(record.get(i, Integer.class));
+          break;
+        case LONG:
+        case TIME:
+        case TIMESTAMP:
+          target.writeLong(record.get(i, Long.class));
+          break;
+        case FLOAT:
+          target.writeFloat(record.get(i, Float.class));
+          break;
+        case DOUBLE:
+          target.writeDouble(record.get(i, Double.class));
+          break;
+        case STRING:
+          target.writeUTF(record.get(i, CharSequence.class).toString());
+          break;
+        case UUID:
+          UUID uuid = record.get(i, UUID.class);
+          target.writeLong(uuid.getMostSignificantBits());
+          target.writeLong(uuid.getLeastSignificantBits());
+          break;
+        case FIXED:
+        case BINARY:
+          byte[] bytes = record.get(i, ByteBuffer.class).array();
+          target.writeInt(bytes.length);
+          target.write(bytes);
+          break;
+        case DECIMAL:
+          BigDecimal decimal = record.get(i, BigDecimal.class);
+          byte[] decimalBytes = decimal.unscaledValue().toByteArray();
+          target.writeInt(decimalBytes.length);
+          target.write(decimalBytes);
+          target.writeInt(decimal.scale());
+          break;
+        case STRUCT:
+        case MAP:
+        case LIST:
+        default:
+          // SortKey transformation is a flattened struct without list and map
+          throw new UnsupportedOperationException(
+              String.format("Field %d has unsupported field type: %s", fieldId, typeId));
+      }
+    }
+  }
+
+  @Override
+  public SortKey deserialize(DataInputView source) throws IOException {
+    // copying is a little faster than constructing a new SortKey object
+    SortKey deserialized = lazySortKey().copy();
+    deserialize(deserialized, source);
+    return deserialized;
+  }
+
+  @Override
+  public SortKey deserialize(SortKey reuse, DataInputView source) throws IOException {
+    Preconditions.checkArgument(
+        reuse.size() == size,
+        "Invalid size of the sort key object: %s. Expected %s",
+        reuse.size(),
+        size);
+    for (int i = 0; i < size; ++i) {
+      int fieldId = transformedFields[i].fieldId();
+      Type.TypeID typeId = transformedFields[i].type().typeId();
+      switch (typeId) {
+        case BOOLEAN:
+          reuse.set(i, source.readBoolean());
+          break;
+        case INTEGER:
+        case DATE:
+          reuse.set(i, source.readInt());
+          break;
+        case LONG:
+        case TIME:
+        case TIMESTAMP:
+          reuse.set(i, source.readLong());
+          break;
+        case FLOAT:
+          reuse.set(i, source.readFloat());
+          break;
+        case DOUBLE:
+          reuse.set(i, source.readDouble());
+          break;
+        case STRING:
+          reuse.set(i, source.readUTF());
+          break;
+        case UUID:
+          long mostSignificantBits = source.readLong();
+          long leastSignificantBits = source.readLong();
+          reuse.set(i, new UUID(mostSignificantBits, leastSignificantBits));
+          break;
+        case FIXED:
+        case BINARY:
+          byte[] bytes = new byte[source.readInt()];
+          source.read(bytes);
+          reuse.set(i, ByteBuffer.wrap(bytes));
+          break;
+        case DECIMAL:
+          byte[] unscaledBytes = new byte[source.readInt()];
+          source.read(unscaledBytes);
+          int scale = source.readInt();
+          BigDecimal decimal = new BigDecimal(new BigInteger(unscaledBytes), scale);
+          reuse.set(i, decimal);
+          break;
+        case STRUCT:
+        case MAP:
+        case LIST:
+        default:
+          // SortKey transformation is a flattened struct without list and map
+          throw new UnsupportedOperationException(
+              String.format("Field %d has unsupported field type: %s", fieldId, typeId));
+      }
+    }
+
+    return reuse;
+  }
+
+  @Override
+  public void copy(DataInputView source, DataOutputView target) throws IOException {
+    // no optimization here
+    serialize(deserialize(source), target);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof SortKeySerializer)) {
+      return false;
+    }
+
+    SortKeySerializer other = (SortKeySerializer) obj;
+    return Objects.equals(schema.asStruct(), other.schema.asStruct())
+        && Objects.equals(sortOrder, other.sortOrder);
+  }
+
+  @Override
+  public int hashCode() {
+    return schema.asStruct().hashCode() * 31 + sortOrder.hashCode();
+  }
+
+  @Override
+  public TypeSerializerSnapshot<SortKey> snapshotConfiguration() {
+    return new SortKeySerializerSnapshot(schema, sortOrder);
+  }
+
+  public static class SortKeySerializerSnapshot implements TypeSerializerSnapshot<SortKey> {
+    private static final int CURRENT_VERSION = 1;
+
+    private Schema schema;
+    private SortOrder sortOrder;
+
+    @SuppressWarnings({"checkstyle:RedundantModifier", "WeakerAccess"})
+    public SortKeySerializerSnapshot() {
+      // this constructor is used when restoring from a checkpoint.
+    }
+
+    // constructors need to public. Otherwise, Flink state restore would complain
+    // "The class has no (implicit) public nullary constructor".
+    @SuppressWarnings("checkstyle:RedundantModifier")
+    public SortKeySerializerSnapshot(Schema schema, SortOrder sortOrder) {
+      this.schema = schema;
+      this.sortOrder = sortOrder;
+    }
+
+    @Override
+    public int getCurrentVersion() {
+      return CURRENT_VERSION;
+    }
+
+    @Override
+    public void writeSnapshot(DataOutputView out) throws IOException {
+      Preconditions.checkState(schema != null, "Invalid schema: null");
+      Preconditions.checkState(sortOrder != null, "Invalid sort order: null");
+
+      StringUtils.writeString(SchemaParser.toJson(schema), out);
+      StringUtils.writeString(SortOrderParser.toJson(sortOrder), out);
+    }
+
+    @Override
+    public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader)
+        throws IOException {
+      if (readVersion == 1) {
+        readV1(in);
+      } else {
+        throw new IllegalArgumentException("Unknown read version: " + readVersion);
+      }
+    }
+
+    @Override
+    public TypeSerializerSchemaCompatibility<SortKey> resolveSchemaCompatibility(
+        TypeSerializer<SortKey> newSerializer) {
+      if (!(newSerializer instanceof SortKeySerializer)) {
+        return TypeSerializerSchemaCompatibility.incompatible();
+      }
+
+      SortKeySerializer newAvroSerializer = (SortKeySerializer) newSerializer;
+      return resolveSchemaCompatibility(newAvroSerializer.schema, schema);
+    }
+
+    @Override
+    public TypeSerializer<SortKey> restoreSerializer() {
+      Preconditions.checkState(schema != null, "Invalid schema: null");
+      Preconditions.checkState(sortOrder != null, "Invalid sort order: null");
+      return new SortKeySerializer(schema, sortOrder);
+    }
+
+    private void readV1(DataInputView in) throws IOException {
+      String schemaJson = StringUtils.readString(in);
+      String sortOrderJson = StringUtils.readString(in);
+      this.schema = SchemaParser.fromJson(schemaJson);
+      this.sortOrder = SortOrderParser.fromJson(sortOrderJson).bind(schema);
+    }
+
+    @VisibleForTesting
+    static <T> TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(
+        Schema readSchema, Schema writeSchema) {
+      List<String> compatibilityErrors =
+          CheckCompatibility.writeCompatibilityErrors(readSchema, writeSchema);
+      if (compatibilityErrors.isEmpty()) {
+        return TypeSerializerSchemaCompatibility.compatibleAsIs();
+      }
+
+      return TypeSerializerSchemaCompatibility.incompatible();
+    }
+  }
+}

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestDataStatisticsOperator.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestDataStatisticsOperator.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -50,33 +49,37 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
-import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortKey;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestDataStatisticsOperator {
-  private final RowType rowType = RowType.of(new VarCharType());
+  private final Schema schema =
+      new Schema(
+          Types.NestedField.optional(1, "id", Types.StringType.get()),
+          Types.NestedField.optional(2, "number", Types.IntegerType.get()));
+  private final SortOrder sortOrder = SortOrder.builderFor(schema).asc("id").build();
+  private final SortKey sortKey = new SortKey(schema, sortOrder);
+  private final RowType rowType = RowType.of(new VarCharType(), new IntType());
   private final TypeSerializer<RowData> rowSerializer = new RowDataSerializer(rowType);
-  private final GenericRowData genericRowDataA = GenericRowData.of(StringData.fromString("a"));
-  private final GenericRowData genericRowDataB = GenericRowData.of(StringData.fromString("b"));
-  // When operator hands events from coordinator, DataStatisticsUtil#deserializeDataStatistics
-  // deserializes bytes into BinaryRowData
-  private final BinaryRowData binaryRowDataA =
-      new RowDataSerializer(rowType).toBinaryRow(GenericRowData.of(StringData.fromString("a")));
-  private final BinaryRowData binaryRowDataB =
-      new RowDataSerializer(rowType).toBinaryRow(GenericRowData.of(StringData.fromString("b")));
-  private final BinaryRowData binaryRowDataC =
-      new RowDataSerializer(rowType).toBinaryRow(GenericRowData.of(StringData.fromString("c")));
-  private final TypeSerializer<DataStatistics<MapDataStatistics, Map<RowData, Long>>>
-      statisticsSerializer = MapDataStatisticsSerializer.fromKeySerializer(rowSerializer);
-  private DataStatisticsOperator<MapDataStatistics, Map<RowData, Long>> operator;
+  private final TypeSerializer<DataStatistics<MapDataStatistics, Map<SortKey, Long>>>
+      statisticsSerializer =
+          MapDataStatisticsSerializer.fromSortKeySerializer(
+              new SortKeySerializer(schema, sortOrder));
+
+  private DataStatisticsOperator<MapDataStatistics, Map<SortKey, Long>> operator;
 
   private Environment getTestingEnvironment() {
     return new StreamMockEnvironment(
@@ -99,20 +102,10 @@ public class TestDataStatisticsOperator {
         new MockOutput<>(Lists.newArrayList()));
   }
 
-  private DataStatisticsOperator<MapDataStatistics, Map<RowData, Long>> createOperator() {
+  private DataStatisticsOperator<MapDataStatistics, Map<SortKey, Long>> createOperator() {
     MockOperatorEventGateway mockGateway = new MockOperatorEventGateway();
-    KeySelector<RowData, RowData> keySelector =
-        new KeySelector<RowData, RowData>() {
-          private static final long serialVersionUID = 7662520075515707428L;
-
-          @Override
-          public RowData getKey(RowData value) {
-            return value;
-          }
-        };
-
     return new DataStatisticsOperator<>(
-        "testOperator", keySelector, mockGateway, statisticsSerializer);
+        "testOperator", schema, sortOrder, mockGateway, statisticsSerializer);
   }
 
   @After
@@ -123,20 +116,26 @@ public class TestDataStatisticsOperator {
   @Test
   public void testProcessElement() throws Exception {
     try (OneInputStreamOperatorTestHarness<
-            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<RowData, Long>>>
+            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<SortKey, Long>>>
         testHarness = createHarness(this.operator)) {
       StateInitializationContext stateContext = getStateContext();
       operator.initializeState(stateContext);
-      operator.processElement(new StreamRecord<>(genericRowDataA));
-      operator.processElement(new StreamRecord<>(genericRowDataA));
-      operator.processElement(new StreamRecord<>(genericRowDataB));
+      operator.processElement(new StreamRecord<>(GenericRowData.of(StringData.fromString("a"), 5)));
+      operator.processElement(new StreamRecord<>(GenericRowData.of(StringData.fromString("a"), 3)));
+      operator.processElement(new StreamRecord<>(GenericRowData.of(StringData.fromString("b"), 1)));
       assertThat(operator.localDataStatistics()).isInstanceOf(MapDataStatistics.class);
+
+      SortKey keyA = sortKey.copy();
+      keyA.set(0, "a");
+      SortKey keyB = sortKey.copy();
+      keyB.set(0, "b");
+      Map<SortKey, Long> expectedMap = ImmutableMap.of(keyA, 2L, keyB, 1L);
+
       MapDataStatistics mapDataStatistics = (MapDataStatistics) operator.localDataStatistics();
-      Map<RowData, Long> statsMap = mapDataStatistics.statistics();
+      Map<SortKey, Long> statsMap = mapDataStatistics.statistics();
       assertThat(statsMap).hasSize(2);
-      assertThat(statsMap)
-          .containsExactlyInAnyOrderEntriesOf(
-              ImmutableMap.of(genericRowDataA, 2L, genericRowDataB, 1L));
+      assertThat(statsMap).containsExactlyInAnyOrderEntriesOf(expectedMap);
+
       testHarness.endInput();
     }
   }
@@ -144,11 +143,14 @@ public class TestDataStatisticsOperator {
   @Test
   public void testOperatorOutput() throws Exception {
     try (OneInputStreamOperatorTestHarness<
-            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<RowData, Long>>>
+            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<SortKey, Long>>>
         testHarness = createHarness(this.operator)) {
-      testHarness.processElement(new StreamRecord<>(genericRowDataA));
-      testHarness.processElement(new StreamRecord<>(genericRowDataB));
-      testHarness.processElement(new StreamRecord<>(genericRowDataB));
+      testHarness.processElement(
+          new StreamRecord<>(GenericRowData.of(StringData.fromString("a"), 2)));
+      testHarness.processElement(
+          new StreamRecord<>(GenericRowData.of(StringData.fromString("b"), 3)));
+      testHarness.processElement(
+          new StreamRecord<>(GenericRowData.of(StringData.fromString("b"), 1)));
 
       List<RowData> recordsOutput =
           testHarness.extractOutputValues().stream()
@@ -157,7 +159,10 @@ public class TestDataStatisticsOperator {
               .collect(Collectors.toList());
       assertThat(recordsOutput)
           .containsExactlyInAnyOrderElementsOf(
-              ImmutableList.of(genericRowDataA, genericRowDataB, genericRowDataB));
+              ImmutableList.of(
+                  GenericRowData.of(StringData.fromString("a"), 2),
+                  GenericRowData.of(StringData.fromString("b"), 3),
+                  GenericRowData.of(StringData.fromString("b"), 1)));
     }
   }
 
@@ -165,36 +170,61 @@ public class TestDataStatisticsOperator {
   public void testRestoreState() throws Exception {
     OperatorSubtaskState snapshot;
     try (OneInputStreamOperatorTestHarness<
-            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<RowData, Long>>>
+            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<SortKey, Long>>>
         testHarness1 = createHarness(this.operator)) {
-      DataStatistics<MapDataStatistics, Map<RowData, Long>> mapDataStatistics =
-          new MapDataStatistics();
-      mapDataStatistics.add(binaryRowDataA);
-      mapDataStatistics.add(binaryRowDataA);
-      mapDataStatistics.add(binaryRowDataB);
-      mapDataStatistics.add(binaryRowDataC);
-      operator.handleOperatorEvent(
-          DataStatisticsEvent.create(0, mapDataStatistics, statisticsSerializer));
+      MapDataStatistics mapDataStatistics = new MapDataStatistics();
+
+      SortKey key = sortKey.copy();
+      key.set(0, "a");
+      mapDataStatistics.add(key);
+      key.set(0, "a");
+      mapDataStatistics.add(key);
+      key.set(0, "b");
+      mapDataStatistics.add(key);
+      key.set(0, "c");
+      mapDataStatistics.add(key);
+
+      SortKey keyA = sortKey.copy();
+      keyA.set(0, "a");
+      SortKey keyB = sortKey.copy();
+      keyB.set(0, "b");
+      SortKey keyC = sortKey.copy();
+      keyC.set(0, "c");
+      Map<SortKey, Long> expectedMap = ImmutableMap.of(keyA, 2L, keyB, 1L, keyC, 1L);
+
+      DataStatisticsEvent<MapDataStatistics, Map<SortKey, Long>> event =
+          DataStatisticsEvent.create(0, mapDataStatistics, statisticsSerializer);
+      operator.handleOperatorEvent(event);
       assertThat(operator.globalDataStatistics()).isInstanceOf(MapDataStatistics.class);
       assertThat(operator.globalDataStatistics().statistics())
-          .containsExactlyInAnyOrderEntriesOf(
-              ImmutableMap.of(binaryRowDataA, 2L, binaryRowDataB, 1L, binaryRowDataC, 1L));
+          .containsExactlyInAnyOrderEntriesOf(expectedMap);
       snapshot = testHarness1.snapshot(1L, 0);
     }
 
     // Use the snapshot to initialize state for another new operator and then verify that the global
     // statistics for the new operator is same as before
-    DataStatisticsOperator<MapDataStatistics, Map<RowData, Long>> restoredOperator =
+    DataStatisticsOperator<MapDataStatistics, Map<SortKey, Long>> restoredOperator =
         createOperator();
     try (OneInputStreamOperatorTestHarness<
-            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<RowData, Long>>>
+            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<SortKey, Long>>>
         testHarness2 = new OneInputStreamOperatorTestHarness<>(restoredOperator, 2, 2, 1)) {
       testHarness2.setup();
       testHarness2.initializeState(snapshot);
       assertThat(restoredOperator.globalDataStatistics()).isInstanceOf(MapDataStatistics.class);
-      assertThat(restoredOperator.globalDataStatistics().statistics())
-          .containsExactlyInAnyOrderEntriesOf(
-              ImmutableMap.of(binaryRowDataA, 2L, binaryRowDataB, 1L, binaryRowDataC, 1L));
+
+      // restored RowData is BinaryRowData. convert to GenericRowData for comparison
+      Map<SortKey, Long> restoredStatistics = Maps.newHashMap();
+      restoredStatistics.putAll(restoredOperator.globalDataStatistics().statistics());
+
+      SortKey keyA = sortKey.copy();
+      keyA.set(0, "a");
+      SortKey keyB = sortKey.copy();
+      keyB.set(0, "b");
+      SortKey keyC = sortKey.copy();
+      keyC.set(0, "c");
+      Map<SortKey, Long> expectedMap = ImmutableMap.of(keyA, 2L, keyB, 1L, keyC, 1L);
+
+      assertThat(restoredStatistics).containsExactlyInAnyOrderEntriesOf(expectedMap);
     }
   }
 
@@ -209,18 +239,16 @@ public class TestDataStatisticsOperator {
   }
 
   private OneInputStreamOperatorTestHarness<
-          RowData, DataStatisticsOrRecord<MapDataStatistics, Map<RowData, Long>>>
+          RowData, DataStatisticsOrRecord<MapDataStatistics, Map<SortKey, Long>>>
       createHarness(
-          final DataStatisticsOperator<MapDataStatistics, Map<RowData, Long>>
+          final DataStatisticsOperator<MapDataStatistics, Map<SortKey, Long>>
               dataStatisticsOperator)
           throws Exception {
 
     OneInputStreamOperatorTestHarness<
-            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<RowData, Long>>>
+            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<SortKey, Long>>>
         harness = new OneInputStreamOperatorTestHarness<>(dataStatisticsOperator, 1, 1, 0);
-    harness.setup(
-        new DataStatisticsOrRecordSerializer<>(
-            MapDataStatisticsSerializer.fromKeySerializer(rowSerializer), rowSerializer));
+    harness.setup(new DataStatisticsOrRecordSerializer<>(statisticsSerializer, rowSerializer));
     harness.open();
     return harness;
   }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestMapDataStatistics.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestMapDataStatistics.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.shuffle;
+
+import java.util.Map;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.SortKey;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.RowDataWrapper;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestMapDataStatistics {
+  private final SortOrder sortOrder = SortOrder.builderFor(TestFixtures.SCHEMA).asc("data").build();
+  private final SortKey sortKey = new SortKey(TestFixtures.SCHEMA, sortOrder);
+  private final RowType rowType = FlinkSchemaUtil.convert(TestFixtures.SCHEMA);
+  private final RowDataWrapper rowWrapper =
+      new RowDataWrapper(rowType, TestFixtures.SCHEMA.asStruct());
+
+  @Test
+  public void testAddsAndGet() {
+    MapDataStatistics dataStatistics = new MapDataStatistics();
+
+    GenericRowData reusedRow =
+        GenericRowData.of(StringData.fromString("a"), 1, StringData.fromString("2023-06-20"));
+    sortKey.wrap(rowWrapper.wrap(reusedRow));
+    dataStatistics.add(sortKey);
+
+    reusedRow.setField(0, StringData.fromString("b"));
+    sortKey.wrap(rowWrapper.wrap(reusedRow));
+    dataStatistics.add(sortKey);
+
+    reusedRow.setField(0, StringData.fromString("c"));
+    sortKey.wrap(rowWrapper.wrap(reusedRow));
+    dataStatistics.add(sortKey);
+
+    reusedRow.setField(0, StringData.fromString("b"));
+    sortKey.wrap(rowWrapper.wrap(reusedRow));
+    dataStatistics.add(sortKey);
+
+    reusedRow.setField(0, StringData.fromString("a"));
+    sortKey.wrap(rowWrapper.wrap(reusedRow));
+    dataStatistics.add(sortKey);
+
+    reusedRow.setField(0, StringData.fromString("b"));
+    sortKey.wrap(rowWrapper.wrap(reusedRow));
+    dataStatistics.add(sortKey);
+
+    Map<SortKey, Long> actual = dataStatistics.statistics();
+
+    rowWrapper.wrap(
+        GenericRowData.of(StringData.fromString("a"), 1, StringData.fromString("2023-06-20")));
+    sortKey.wrap(rowWrapper);
+    SortKey keyA = sortKey.copy();
+
+    rowWrapper.wrap(
+        GenericRowData.of(StringData.fromString("b"), 1, StringData.fromString("2023-06-20")));
+    sortKey.wrap(rowWrapper);
+    SortKey keyB = sortKey.copy();
+
+    rowWrapper.wrap(
+        GenericRowData.of(StringData.fromString("c"), 1, StringData.fromString("2023-06-20")));
+    sortKey.wrap(rowWrapper);
+    SortKey keyC = sortKey.copy();
+
+    Map<SortKey, Long> expected = ImmutableMap.of(keyA, 2L, keyB, 3L, keyC, 1L);
+    Assertions.assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSortKeySerializerBase.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSortKeySerializerBase.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.shuffle;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortKey;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.RowDataWrapper;
+
+public abstract class TestSortKeySerializerBase extends SerializerTestBase<SortKey> {
+
+  protected abstract Schema schema();
+
+  protected abstract SortOrder sortOrder();
+
+  protected abstract GenericRowData rowData();
+
+  @Override
+  protected TypeSerializer<SortKey> createSerializer() {
+    return new SortKeySerializer(schema(), sortOrder());
+  }
+
+  @Override
+  protected int getLength() {
+    return -1;
+  }
+
+  @Override
+  protected Class<SortKey> getTypeClass() {
+    return SortKey.class;
+  }
+
+  @Override
+  protected SortKey[] getTestData() {
+    return new SortKey[] {sortKey()};
+  }
+
+  private SortKey sortKey() {
+    RowDataWrapper rowDataWrapper =
+        new RowDataWrapper(FlinkSchemaUtil.convert(schema()), schema().asStruct());
+    SortKey sortKey = new SortKey(schema(), sortOrder());
+    sortKey.wrap(rowDataWrapper.wrap(rowData()));
+    return sortKey;
+  }
+}

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSortKeySerializerNestedStruct.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSortKeySerializerNestedStruct.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.shuffle;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.flink.DataGenerator;
+import org.apache.iceberg.flink.DataGenerators;
+
+public class TestSortKeySerializerNestedStruct extends TestSortKeySerializerBase {
+  private final DataGenerator generator = new DataGenerators.StructOfStruct();
+
+  @Override
+  protected Schema schema() {
+    return generator.icebergSchema();
+  }
+
+  @Override
+  protected SortOrder sortOrder() {
+    return SortOrder.builderFor(schema())
+        .asc("row_id")
+        .sortBy(
+            Expressions.bucket("struct_of_struct.id", 4), SortDirection.DESC, NullOrder.NULLS_LAST)
+        .sortBy(
+            Expressions.truncate("struct_of_struct.person_struct.name", 16),
+            SortDirection.ASC,
+            NullOrder.NULLS_FIRST)
+        .build();
+  }
+
+  @Override
+  protected GenericRowData rowData() {
+    return generator.generateFlinkRowData();
+  }
+}

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSortKeySerializerPrimitives.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSortKeySerializerPrimitives.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.shuffle;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.flink.DataGenerator;
+import org.apache.iceberg.flink.DataGenerators;
+
+public class TestSortKeySerializerPrimitives extends TestSortKeySerializerBase {
+  private final DataGenerator generator = new DataGenerators.Primitives();
+
+  @Override
+  protected Schema schema() {
+    return generator.icebergSchema();
+  }
+
+  @Override
+  protected SortOrder sortOrder() {
+    return SortOrder.builderFor(schema())
+        .asc("boolean_field")
+        .sortBy(Expressions.bucket("int_field", 4), SortDirection.DESC, NullOrder.NULLS_LAST)
+        .sortBy(Expressions.truncate("string_field", 2), SortDirection.ASC, NullOrder.NULLS_FIRST)
+        .sortBy(Expressions.bucket("uuid_field", 16), SortDirection.ASC, NullOrder.NULLS_FIRST)
+        .sortBy(Expressions.hour("ts_with_zone_field"), SortDirection.ASC, NullOrder.NULLS_FIRST)
+        .sortBy(Expressions.day("ts_without_zone_field"), SortDirection.ASC, NullOrder.NULLS_FIRST)
+        // can not test HeapByteBuffer due to equality test inside SerializerTestBase
+        // .sortBy(Expressions.truncate("binary_field", 2), SortDirection.ASC,
+        // NullOrder.NULLS_FIRST)
+        .build();
+  }
+
+  @Override
+  protected GenericRowData rowData() {
+    return generator.generateFlinkRowData();
+  }
+}

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatistics.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatistics.java
@@ -19,7 +19,7 @@
 package org.apache.iceberg.flink.sink.shuffle;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.SortKey;
 
 /**
  * DataStatistics defines the interface to collect data distribution information.
@@ -29,7 +29,7 @@ import org.apache.flink.table.data.RowData;
  * (sketching) can be used.
  */
 @Internal
-interface DataStatistics<D extends DataStatistics, S> {
+interface DataStatistics<D extends DataStatistics<D, S>, S> {
 
   /**
    * Check if data statistics contains any statistics information.
@@ -38,12 +38,8 @@ interface DataStatistics<D extends DataStatistics, S> {
    */
   boolean isEmpty();
 
-  /**
-   * Add data key to data statistics.
-   *
-   * @param key generate from data by applying key selector
-   */
-  void add(RowData key);
+  /** Add row sortKey to data statistics. */
+  void add(SortKey sortKey);
 
   /**
    * Merge current statistics with other statistics.

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsUtil.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsUtil.java
@@ -76,7 +76,6 @@ class DataStatisticsUtil {
     return bytes.toByteArray();
   }
 
-  @SuppressWarnings("unchecked")
   static <D extends DataStatistics<D, S>, S>
       AggregatedStatistics<D, S> deserializeAggregatedStatistics(
           byte[] bytes, TypeSerializer<DataStatistics<D, S>> statisticsSerializer)

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeySerializer.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeySerializer.java
@@ -1,0 +1,353 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.shuffle;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.SortField;
+import org.apache.iceberg.SortKey;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.SortOrderParser;
+import org.apache.iceberg.types.CheckCompatibility;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+class SortKeySerializer extends TypeSerializer<SortKey> {
+  private final Schema schema;
+  private final SortOrder sortOrder;
+  private final int size;
+  private final Types.NestedField[] transformedFields;
+
+  private transient SortKey sortKey;
+
+  SortKeySerializer(Schema schema, SortOrder sortOrder) {
+    this.schema = schema;
+    this.sortOrder = sortOrder;
+    this.size = sortOrder.fields().size();
+
+    this.transformedFields = new Types.NestedField[size];
+    for (int i = 0; i < size; ++i) {
+      SortField sortField = sortOrder.fields().get(i);
+      Types.NestedField sourceField = schema.findField(sortField.sourceId());
+      Type resultType = sortField.transform().getResultType(sourceField.type());
+      Types.NestedField transformedField =
+          Types.NestedField.of(
+              sourceField.fieldId(),
+              sourceField.isOptional(),
+              sourceField.name(),
+              resultType,
+              sourceField.doc());
+      transformedFields[i] = transformedField;
+    }
+  }
+
+  private SortKey lazySortKey() {
+    if (sortKey == null) {
+      this.sortKey = new SortKey(schema, sortOrder);
+    }
+
+    return sortKey;
+  }
+
+  @Override
+  public boolean isImmutableType() {
+    return false;
+  }
+
+  @Override
+  public TypeSerializer<SortKey> duplicate() {
+    return new SortKeySerializer(schema, sortOrder);
+  }
+
+  @Override
+  public SortKey createInstance() {
+    return new SortKey(schema, sortOrder);
+  }
+
+  @Override
+  public SortKey copy(SortKey from) {
+    return from.copy();
+  }
+
+  @Override
+  public SortKey copy(SortKey from, SortKey reuse) {
+    // no benefit of reuse
+    return copy(from);
+  }
+
+  @Override
+  public int getLength() {
+    return -1;
+  }
+
+  @Override
+  public void serialize(SortKey record, DataOutputView target) throws IOException {
+    Preconditions.checkArgument(
+        record.size() == size,
+        "Invalid size of the sort key object: %s. Expected %s",
+        record.size(),
+        size);
+    for (int i = 0; i < size; ++i) {
+      int fieldId = transformedFields[i].fieldId();
+      Type.TypeID typeId = transformedFields[i].type().typeId();
+      switch (typeId) {
+        case BOOLEAN:
+          target.writeBoolean(record.get(i, Boolean.class));
+          break;
+        case INTEGER:
+        case DATE:
+          target.writeInt(record.get(i, Integer.class));
+          break;
+        case LONG:
+        case TIME:
+        case TIMESTAMP:
+          target.writeLong(record.get(i, Long.class));
+          break;
+        case FLOAT:
+          target.writeFloat(record.get(i, Float.class));
+          break;
+        case DOUBLE:
+          target.writeDouble(record.get(i, Double.class));
+          break;
+        case STRING:
+          target.writeUTF(record.get(i, CharSequence.class).toString());
+          break;
+        case UUID:
+          UUID uuid = record.get(i, UUID.class);
+          target.writeLong(uuid.getMostSignificantBits());
+          target.writeLong(uuid.getLeastSignificantBits());
+          break;
+        case FIXED:
+        case BINARY:
+          byte[] bytes = record.get(i, ByteBuffer.class).array();
+          target.writeInt(bytes.length);
+          target.write(bytes);
+          break;
+        case DECIMAL:
+          BigDecimal decimal = record.get(i, BigDecimal.class);
+          byte[] decimalBytes = decimal.unscaledValue().toByteArray();
+          target.writeInt(decimalBytes.length);
+          target.write(decimalBytes);
+          target.writeInt(decimal.scale());
+          break;
+        case STRUCT:
+        case MAP:
+        case LIST:
+        default:
+          // SortKey transformation is a flattened struct without list and map
+          throw new UnsupportedOperationException(
+              String.format("Field %d has unsupported field type: %s", fieldId, typeId));
+      }
+    }
+  }
+
+  @Override
+  public SortKey deserialize(DataInputView source) throws IOException {
+    // copying is a little faster than constructing a new SortKey object
+    SortKey deserialized = lazySortKey().copy();
+    deserialize(deserialized, source);
+    return deserialized;
+  }
+
+  @Override
+  public SortKey deserialize(SortKey reuse, DataInputView source) throws IOException {
+    Preconditions.checkArgument(
+        reuse.size() == size,
+        "Invalid size of the sort key object: %s. Expected %s",
+        reuse.size(),
+        size);
+    for (int i = 0; i < size; ++i) {
+      int fieldId = transformedFields[i].fieldId();
+      Type.TypeID typeId = transformedFields[i].type().typeId();
+      switch (typeId) {
+        case BOOLEAN:
+          reuse.set(i, source.readBoolean());
+          break;
+        case INTEGER:
+        case DATE:
+          reuse.set(i, source.readInt());
+          break;
+        case LONG:
+        case TIME:
+        case TIMESTAMP:
+          reuse.set(i, source.readLong());
+          break;
+        case FLOAT:
+          reuse.set(i, source.readFloat());
+          break;
+        case DOUBLE:
+          reuse.set(i, source.readDouble());
+          break;
+        case STRING:
+          reuse.set(i, source.readUTF());
+          break;
+        case UUID:
+          long mostSignificantBits = source.readLong();
+          long leastSignificantBits = source.readLong();
+          reuse.set(i, new UUID(mostSignificantBits, leastSignificantBits));
+          break;
+        case FIXED:
+        case BINARY:
+          byte[] bytes = new byte[source.readInt()];
+          source.read(bytes);
+          reuse.set(i, ByteBuffer.wrap(bytes));
+          break;
+        case DECIMAL:
+          byte[] unscaledBytes = new byte[source.readInt()];
+          source.read(unscaledBytes);
+          int scale = source.readInt();
+          BigDecimal decimal = new BigDecimal(new BigInteger(unscaledBytes), scale);
+          reuse.set(i, decimal);
+          break;
+        case STRUCT:
+        case MAP:
+        case LIST:
+        default:
+          // SortKey transformation is a flattened struct without list and map
+          throw new UnsupportedOperationException(
+              String.format("Field %d has unsupported field type: %s", fieldId, typeId));
+      }
+    }
+
+    return reuse;
+  }
+
+  @Override
+  public void copy(DataInputView source, DataOutputView target) throws IOException {
+    // no optimization here
+    serialize(deserialize(source), target);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof SortKeySerializer)) {
+      return false;
+    }
+
+    SortKeySerializer other = (SortKeySerializer) obj;
+    return Objects.equals(schema.asStruct(), other.schema.asStruct())
+        && Objects.equals(sortOrder, other.sortOrder);
+  }
+
+  @Override
+  public int hashCode() {
+    return schema.asStruct().hashCode() * 31 + sortOrder.hashCode();
+  }
+
+  @Override
+  public TypeSerializerSnapshot<SortKey> snapshotConfiguration() {
+    return new SortKeySerializerSnapshot(schema, sortOrder);
+  }
+
+  public static class SortKeySerializerSnapshot implements TypeSerializerSnapshot<SortKey> {
+    private static final int CURRENT_VERSION = 1;
+
+    private Schema schema;
+    private SortOrder sortOrder;
+
+    @SuppressWarnings({"checkstyle:RedundantModifier", "WeakerAccess"})
+    public SortKeySerializerSnapshot() {
+      // this constructor is used when restoring from a checkpoint.
+    }
+
+    // constructors need to public. Otherwise, Flink state restore would complain
+    // "The class has no (implicit) public nullary constructor".
+    @SuppressWarnings("checkstyle:RedundantModifier")
+    public SortKeySerializerSnapshot(Schema schema, SortOrder sortOrder) {
+      this.schema = schema;
+      this.sortOrder = sortOrder;
+    }
+
+    @Override
+    public int getCurrentVersion() {
+      return CURRENT_VERSION;
+    }
+
+    @Override
+    public void writeSnapshot(DataOutputView out) throws IOException {
+      Preconditions.checkState(schema != null, "Invalid schema: null");
+      Preconditions.checkState(sortOrder != null, "Invalid sort order: null");
+
+      StringUtils.writeString(SchemaParser.toJson(schema), out);
+      StringUtils.writeString(SortOrderParser.toJson(sortOrder), out);
+    }
+
+    @Override
+    public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader)
+        throws IOException {
+      if (readVersion == 1) {
+        readV1(in);
+      } else {
+        throw new IllegalArgumentException("Unknown read version: " + readVersion);
+      }
+    }
+
+    @Override
+    public TypeSerializerSchemaCompatibility<SortKey> resolveSchemaCompatibility(
+        TypeSerializer<SortKey> newSerializer) {
+      if (!(newSerializer instanceof SortKeySerializer)) {
+        return TypeSerializerSchemaCompatibility.incompatible();
+      }
+
+      SortKeySerializer newAvroSerializer = (SortKeySerializer) newSerializer;
+      return resolveSchemaCompatibility(newAvroSerializer.schema, schema);
+    }
+
+    @Override
+    public TypeSerializer<SortKey> restoreSerializer() {
+      Preconditions.checkState(schema != null, "Invalid schema: null");
+      Preconditions.checkState(sortOrder != null, "Invalid sort order: null");
+      return new SortKeySerializer(schema, sortOrder);
+    }
+
+    private void readV1(DataInputView in) throws IOException {
+      String schemaJson = StringUtils.readString(in);
+      String sortOrderJson = StringUtils.readString(in);
+      this.schema = SchemaParser.fromJson(schemaJson);
+      this.sortOrder = SortOrderParser.fromJson(sortOrderJson).bind(schema);
+    }
+
+    @VisibleForTesting
+    static <T> TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(
+        Schema readSchema, Schema writeSchema) {
+      List<String> compatibilityErrors =
+          CheckCompatibility.writeCompatibilityErrors(readSchema, writeSchema);
+      if (compatibilityErrors.isEmpty()) {
+        return TypeSerializerSchemaCompatibility.compatibleAsIs();
+      }
+
+      return TypeSerializerSchemaCompatibility.incompatible();
+    }
+  }
+}

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestDataStatisticsOperator.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestDataStatisticsOperator.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -50,33 +49,37 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
-import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortKey;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestDataStatisticsOperator {
-  private final RowType rowType = RowType.of(new VarCharType());
+  private final Schema schema =
+      new Schema(
+          Types.NestedField.optional(1, "id", Types.StringType.get()),
+          Types.NestedField.optional(2, "number", Types.IntegerType.get()));
+  private final SortOrder sortOrder = SortOrder.builderFor(schema).asc("id").build();
+  private final SortKey sortKey = new SortKey(schema, sortOrder);
+  private final RowType rowType = RowType.of(new VarCharType(), new IntType());
   private final TypeSerializer<RowData> rowSerializer = new RowDataSerializer(rowType);
-  private final GenericRowData genericRowDataA = GenericRowData.of(StringData.fromString("a"));
-  private final GenericRowData genericRowDataB = GenericRowData.of(StringData.fromString("b"));
-  // When operator hands events from coordinator, DataStatisticsUtil#deserializeDataStatistics
-  // deserializes bytes into BinaryRowData
-  private final BinaryRowData binaryRowDataA =
-      new RowDataSerializer(rowType).toBinaryRow(GenericRowData.of(StringData.fromString("a")));
-  private final BinaryRowData binaryRowDataB =
-      new RowDataSerializer(rowType).toBinaryRow(GenericRowData.of(StringData.fromString("b")));
-  private final BinaryRowData binaryRowDataC =
-      new RowDataSerializer(rowType).toBinaryRow(GenericRowData.of(StringData.fromString("c")));
-  private final TypeSerializer<DataStatistics<MapDataStatistics, Map<RowData, Long>>>
-      statisticsSerializer = MapDataStatisticsSerializer.fromKeySerializer(rowSerializer);
-  private DataStatisticsOperator<MapDataStatistics, Map<RowData, Long>> operator;
+  private final TypeSerializer<DataStatistics<MapDataStatistics, Map<SortKey, Long>>>
+      statisticsSerializer =
+          MapDataStatisticsSerializer.fromSortKeySerializer(
+              new SortKeySerializer(schema, sortOrder));
+
+  private DataStatisticsOperator<MapDataStatistics, Map<SortKey, Long>> operator;
 
   private Environment getTestingEnvironment() {
     return new StreamMockEnvironment(
@@ -99,20 +102,10 @@ public class TestDataStatisticsOperator {
         new MockOutput<>(Lists.newArrayList()));
   }
 
-  private DataStatisticsOperator<MapDataStatistics, Map<RowData, Long>> createOperator() {
+  private DataStatisticsOperator<MapDataStatistics, Map<SortKey, Long>> createOperator() {
     MockOperatorEventGateway mockGateway = new MockOperatorEventGateway();
-    KeySelector<RowData, RowData> keySelector =
-        new KeySelector<RowData, RowData>() {
-          private static final long serialVersionUID = 7662520075515707428L;
-
-          @Override
-          public RowData getKey(RowData value) {
-            return value;
-          }
-        };
-
     return new DataStatisticsOperator<>(
-        "testOperator", keySelector, mockGateway, statisticsSerializer);
+        "testOperator", schema, sortOrder, mockGateway, statisticsSerializer);
   }
 
   @After
@@ -123,20 +116,26 @@ public class TestDataStatisticsOperator {
   @Test
   public void testProcessElement() throws Exception {
     try (OneInputStreamOperatorTestHarness<
-            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<RowData, Long>>>
+            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<SortKey, Long>>>
         testHarness = createHarness(this.operator)) {
       StateInitializationContext stateContext = getStateContext();
       operator.initializeState(stateContext);
-      operator.processElement(new StreamRecord<>(genericRowDataA));
-      operator.processElement(new StreamRecord<>(genericRowDataA));
-      operator.processElement(new StreamRecord<>(genericRowDataB));
+      operator.processElement(new StreamRecord<>(GenericRowData.of(StringData.fromString("a"), 5)));
+      operator.processElement(new StreamRecord<>(GenericRowData.of(StringData.fromString("a"), 3)));
+      operator.processElement(new StreamRecord<>(GenericRowData.of(StringData.fromString("b"), 1)));
       assertThat(operator.localDataStatistics()).isInstanceOf(MapDataStatistics.class);
+
+      SortKey keyA = sortKey.copy();
+      keyA.set(0, "a");
+      SortKey keyB = sortKey.copy();
+      keyB.set(0, "b");
+      Map<SortKey, Long> expectedMap = ImmutableMap.of(keyA, 2L, keyB, 1L);
+
       MapDataStatistics mapDataStatistics = (MapDataStatistics) operator.localDataStatistics();
-      Map<RowData, Long> statsMap = mapDataStatistics.statistics();
+      Map<SortKey, Long> statsMap = mapDataStatistics.statistics();
       assertThat(statsMap).hasSize(2);
-      assertThat(statsMap)
-          .containsExactlyInAnyOrderEntriesOf(
-              ImmutableMap.of(genericRowDataA, 2L, genericRowDataB, 1L));
+      assertThat(statsMap).containsExactlyInAnyOrderEntriesOf(expectedMap);
+
       testHarness.endInput();
     }
   }
@@ -144,11 +143,14 @@ public class TestDataStatisticsOperator {
   @Test
   public void testOperatorOutput() throws Exception {
     try (OneInputStreamOperatorTestHarness<
-            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<RowData, Long>>>
+            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<SortKey, Long>>>
         testHarness = createHarness(this.operator)) {
-      testHarness.processElement(new StreamRecord<>(genericRowDataA));
-      testHarness.processElement(new StreamRecord<>(genericRowDataB));
-      testHarness.processElement(new StreamRecord<>(genericRowDataB));
+      testHarness.processElement(
+          new StreamRecord<>(GenericRowData.of(StringData.fromString("a"), 2)));
+      testHarness.processElement(
+          new StreamRecord<>(GenericRowData.of(StringData.fromString("b"), 3)));
+      testHarness.processElement(
+          new StreamRecord<>(GenericRowData.of(StringData.fromString("b"), 1)));
 
       List<RowData> recordsOutput =
           testHarness.extractOutputValues().stream()
@@ -157,7 +159,10 @@ public class TestDataStatisticsOperator {
               .collect(Collectors.toList());
       assertThat(recordsOutput)
           .containsExactlyInAnyOrderElementsOf(
-              ImmutableList.of(genericRowDataA, genericRowDataB, genericRowDataB));
+              ImmutableList.of(
+                  GenericRowData.of(StringData.fromString("a"), 2),
+                  GenericRowData.of(StringData.fromString("b"), 3),
+                  GenericRowData.of(StringData.fromString("b"), 1)));
     }
   }
 
@@ -165,36 +170,61 @@ public class TestDataStatisticsOperator {
   public void testRestoreState() throws Exception {
     OperatorSubtaskState snapshot;
     try (OneInputStreamOperatorTestHarness<
-            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<RowData, Long>>>
+            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<SortKey, Long>>>
         testHarness1 = createHarness(this.operator)) {
-      DataStatistics<MapDataStatistics, Map<RowData, Long>> mapDataStatistics =
-          new MapDataStatistics();
-      mapDataStatistics.add(binaryRowDataA);
-      mapDataStatistics.add(binaryRowDataA);
-      mapDataStatistics.add(binaryRowDataB);
-      mapDataStatistics.add(binaryRowDataC);
-      operator.handleOperatorEvent(
-          DataStatisticsEvent.create(0, mapDataStatistics, statisticsSerializer));
+      MapDataStatistics mapDataStatistics = new MapDataStatistics();
+
+      SortKey key = sortKey.copy();
+      key.set(0, "a");
+      mapDataStatistics.add(key);
+      key.set(0, "a");
+      mapDataStatistics.add(key);
+      key.set(0, "b");
+      mapDataStatistics.add(key);
+      key.set(0, "c");
+      mapDataStatistics.add(key);
+
+      SortKey keyA = sortKey.copy();
+      keyA.set(0, "a");
+      SortKey keyB = sortKey.copy();
+      keyB.set(0, "b");
+      SortKey keyC = sortKey.copy();
+      keyC.set(0, "c");
+      Map<SortKey, Long> expectedMap = ImmutableMap.of(keyA, 2L, keyB, 1L, keyC, 1L);
+
+      DataStatisticsEvent<MapDataStatistics, Map<SortKey, Long>> event =
+          DataStatisticsEvent.create(0, mapDataStatistics, statisticsSerializer);
+      operator.handleOperatorEvent(event);
       assertThat(operator.globalDataStatistics()).isInstanceOf(MapDataStatistics.class);
       assertThat(operator.globalDataStatistics().statistics())
-          .containsExactlyInAnyOrderEntriesOf(
-              ImmutableMap.of(binaryRowDataA, 2L, binaryRowDataB, 1L, binaryRowDataC, 1L));
+          .containsExactlyInAnyOrderEntriesOf(expectedMap);
       snapshot = testHarness1.snapshot(1L, 0);
     }
 
     // Use the snapshot to initialize state for another new operator and then verify that the global
     // statistics for the new operator is same as before
-    DataStatisticsOperator<MapDataStatistics, Map<RowData, Long>> restoredOperator =
+    DataStatisticsOperator<MapDataStatistics, Map<SortKey, Long>> restoredOperator =
         createOperator();
     try (OneInputStreamOperatorTestHarness<
-            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<RowData, Long>>>
+            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<SortKey, Long>>>
         testHarness2 = new OneInputStreamOperatorTestHarness<>(restoredOperator, 2, 2, 1)) {
       testHarness2.setup();
       testHarness2.initializeState(snapshot);
       assertThat(restoredOperator.globalDataStatistics()).isInstanceOf(MapDataStatistics.class);
-      assertThat(restoredOperator.globalDataStatistics().statistics())
-          .containsExactlyInAnyOrderEntriesOf(
-              ImmutableMap.of(binaryRowDataA, 2L, binaryRowDataB, 1L, binaryRowDataC, 1L));
+
+      // restored RowData is BinaryRowData. convert to GenericRowData for comparison
+      Map<SortKey, Long> restoredStatistics = Maps.newHashMap();
+      restoredStatistics.putAll(restoredOperator.globalDataStatistics().statistics());
+
+      SortKey keyA = sortKey.copy();
+      keyA.set(0, "a");
+      SortKey keyB = sortKey.copy();
+      keyB.set(0, "b");
+      SortKey keyC = sortKey.copy();
+      keyC.set(0, "c");
+      Map<SortKey, Long> expectedMap = ImmutableMap.of(keyA, 2L, keyB, 1L, keyC, 1L);
+
+      assertThat(restoredStatistics).containsExactlyInAnyOrderEntriesOf(expectedMap);
     }
   }
 
@@ -209,18 +239,16 @@ public class TestDataStatisticsOperator {
   }
 
   private OneInputStreamOperatorTestHarness<
-          RowData, DataStatisticsOrRecord<MapDataStatistics, Map<RowData, Long>>>
+          RowData, DataStatisticsOrRecord<MapDataStatistics, Map<SortKey, Long>>>
       createHarness(
-          final DataStatisticsOperator<MapDataStatistics, Map<RowData, Long>>
+          final DataStatisticsOperator<MapDataStatistics, Map<SortKey, Long>>
               dataStatisticsOperator)
           throws Exception {
 
     OneInputStreamOperatorTestHarness<
-            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<RowData, Long>>>
+            RowData, DataStatisticsOrRecord<MapDataStatistics, Map<SortKey, Long>>>
         harness = new OneInputStreamOperatorTestHarness<>(dataStatisticsOperator, 1, 1, 0);
-    harness.setup(
-        new DataStatisticsOrRecordSerializer<>(
-            MapDataStatisticsSerializer.fromKeySerializer(rowSerializer), rowSerializer));
+    harness.setup(new DataStatisticsOrRecordSerializer<>(statisticsSerializer, rowSerializer));
     harness.open();
     return harness;
   }

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestMapDataStatistics.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestMapDataStatistics.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.shuffle;
+
+import java.util.Map;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.SortKey;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.RowDataWrapper;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestMapDataStatistics {
+  private final SortOrder sortOrder = SortOrder.builderFor(TestFixtures.SCHEMA).asc("data").build();
+  private final SortKey sortKey = new SortKey(TestFixtures.SCHEMA, sortOrder);
+  private final RowType rowType = FlinkSchemaUtil.convert(TestFixtures.SCHEMA);
+  private final RowDataWrapper rowWrapper =
+      new RowDataWrapper(rowType, TestFixtures.SCHEMA.asStruct());
+
+  @Test
+  public void testAddsAndGet() {
+    MapDataStatistics dataStatistics = new MapDataStatistics();
+
+    GenericRowData reusedRow =
+        GenericRowData.of(StringData.fromString("a"), 1, StringData.fromString("2023-06-20"));
+    sortKey.wrap(rowWrapper.wrap(reusedRow));
+    dataStatistics.add(sortKey);
+
+    reusedRow.setField(0, StringData.fromString("b"));
+    sortKey.wrap(rowWrapper.wrap(reusedRow));
+    dataStatistics.add(sortKey);
+
+    reusedRow.setField(0, StringData.fromString("c"));
+    sortKey.wrap(rowWrapper.wrap(reusedRow));
+    dataStatistics.add(sortKey);
+
+    reusedRow.setField(0, StringData.fromString("b"));
+    sortKey.wrap(rowWrapper.wrap(reusedRow));
+    dataStatistics.add(sortKey);
+
+    reusedRow.setField(0, StringData.fromString("a"));
+    sortKey.wrap(rowWrapper.wrap(reusedRow));
+    dataStatistics.add(sortKey);
+
+    reusedRow.setField(0, StringData.fromString("b"));
+    sortKey.wrap(rowWrapper.wrap(reusedRow));
+    dataStatistics.add(sortKey);
+
+    Map<SortKey, Long> actual = dataStatistics.statistics();
+
+    rowWrapper.wrap(
+        GenericRowData.of(StringData.fromString("a"), 1, StringData.fromString("2023-06-20")));
+    sortKey.wrap(rowWrapper);
+    SortKey keyA = sortKey.copy();
+
+    rowWrapper.wrap(
+        GenericRowData.of(StringData.fromString("b"), 1, StringData.fromString("2023-06-20")));
+    sortKey.wrap(rowWrapper);
+    SortKey keyB = sortKey.copy();
+
+    rowWrapper.wrap(
+        GenericRowData.of(StringData.fromString("c"), 1, StringData.fromString("2023-06-20")));
+    sortKey.wrap(rowWrapper);
+    SortKey keyC = sortKey.copy();
+
+    Map<SortKey, Long> expected = ImmutableMap.of(keyA, 2L, keyB, 3L, keyC, 1L);
+    Assertions.assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSortKeySerializerBase.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSortKeySerializerBase.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.shuffle;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortKey;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.RowDataWrapper;
+
+public abstract class TestSortKeySerializerBase extends SerializerTestBase<SortKey> {
+
+  protected abstract Schema schema();
+
+  protected abstract SortOrder sortOrder();
+
+  protected abstract GenericRowData rowData();
+
+  @Override
+  protected TypeSerializer<SortKey> createSerializer() {
+    return new SortKeySerializer(schema(), sortOrder());
+  }
+
+  @Override
+  protected int getLength() {
+    return -1;
+  }
+
+  @Override
+  protected Class<SortKey> getTypeClass() {
+    return SortKey.class;
+  }
+
+  @Override
+  protected SortKey[] getTestData() {
+    return new SortKey[] {sortKey()};
+  }
+
+  private SortKey sortKey() {
+    RowDataWrapper rowDataWrapper =
+        new RowDataWrapper(FlinkSchemaUtil.convert(schema()), schema().asStruct());
+    SortKey sortKey = new SortKey(schema(), sortOrder());
+    sortKey.wrap(rowDataWrapper.wrap(rowData()));
+    return sortKey;
+  }
+}

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSortKeySerializerNestedStruct.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSortKeySerializerNestedStruct.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.shuffle;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.flink.DataGenerator;
+import org.apache.iceberg.flink.DataGenerators;
+
+public class TestSortKeySerializerNestedStruct extends TestSortKeySerializerBase {
+  private final DataGenerator generator = new DataGenerators.StructOfStruct();
+
+  @Override
+  protected Schema schema() {
+    return generator.icebergSchema();
+  }
+
+  @Override
+  protected SortOrder sortOrder() {
+    return SortOrder.builderFor(schema())
+        .asc("row_id")
+        .sortBy(
+            Expressions.bucket("struct_of_struct.id", 4), SortDirection.DESC, NullOrder.NULLS_LAST)
+        .sortBy(
+            Expressions.truncate("struct_of_struct.person_struct.name", 16),
+            SortDirection.ASC,
+            NullOrder.NULLS_FIRST)
+        .build();
+  }
+
+  @Override
+  protected GenericRowData rowData() {
+    return generator.generateFlinkRowData();
+  }
+}

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSortKeySerializerPrimitives.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSortKeySerializerPrimitives.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.shuffle;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.flink.DataGenerator;
+import org.apache.iceberg.flink.DataGenerators;
+
+public class TestSortKeySerializerPrimitives extends TestSortKeySerializerBase {
+  private final DataGenerator generator = new DataGenerators.Primitives();
+
+  @Override
+  protected Schema schema() {
+    return generator.icebergSchema();
+  }
+
+  @Override
+  protected SortOrder sortOrder() {
+    return SortOrder.builderFor(schema())
+        .asc("boolean_field")
+        .sortBy(Expressions.bucket("int_field", 4), SortDirection.DESC, NullOrder.NULLS_LAST)
+        .sortBy(Expressions.truncate("string_field", 2), SortDirection.ASC, NullOrder.NULLS_FIRST)
+        .sortBy(Expressions.bucket("uuid_field", 16), SortDirection.ASC, NullOrder.NULLS_FIRST)
+        .sortBy(Expressions.hour("ts_with_zone_field"), SortDirection.ASC, NullOrder.NULLS_FIRST)
+        .sortBy(Expressions.day("ts_without_zone_field"), SortDirection.ASC, NullOrder.NULLS_FIRST)
+        // can not test HeapByteBuffer due to equality test inside SerializerTestBase
+        // .sortBy(Expressions.truncate("binary_field", 2), SortDirection.ASC,
+        // NullOrder.NULLS_FIRST)
+        .build();
+  }
+
+  @Override
+  protected GenericRowData rowData() {
+    return generator.generateFlinkRowData();
+  }
+}


### PR DESCRIPTION
It is a clean back port

```
cp -r flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/
cp -r flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/

cp -r flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/
cp -r flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/
```