### PR TITLE
Spark Streaming: Fix clobbering of files across streaming epochs

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -673,11 +673,11 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       Table table = tableBroadcast.value();
       PartitionSpec spec = table.specs().get(outputSpecId);
       FileIO io = table.io();
-
+      String operationId = queryId + "-" + epochId;
       OutputFileFactory fileFactory =
           OutputFileFactory.builderFor(table, partitionId, taskId)
               .format(format)
-              .operationId(queryId)
+              .operationId(operationId)
               .build();
       SparkFileWriterFactory writerFactory =
           SparkFileWriterFactory.builderFor(table)


### PR DESCRIPTION
Fixes #9172 
Fixes #8953 

Leaving in draft as I figure out how to repro this in our tests just so we're really confident this is the issue and the right fix.

Currently the output file path in Spark Streaming has the following components (excluding the partition component):
1.) The Spark queryID as a "operation key"
2.) The task ID of the writing task
3.) The partitionID
4.) a suffix, used for delete files.

The Spark Streaming DSV2 writer SPI passes in the partitionID, taskID, and the epochID. Currently, we ignore the epochID when constructing the writer.
Prior to #6569 this was not an issue because we had a random UUID per file so files wouldn't clobber over each other. 
After #6569 we intentionally replaced the random UUID with a queryID so we can track which query wrote the file. However, it seems like tasks can be re-used across epochs based on one of the descriptions of the problem in #9172:

" I also tested with latest version, iceberg-spark-runtime-3.4_2.12-1.4.2.jar as well, I could see that the second number, part of the file name, is continuously increasing 00001-3200-11773075-523f-4667-936b-88702fe9860c-00001.parquet, however after around 200 execution of stream, the file name got reset 00001-3166-11773075-523f-4667-936b-88702fe9860c-00001.parquet and files were started getting overwritten."

The second part is the taskID, so it seems as though task ID 3166 was re-used in a later epoch. 

So what this fix does is just add the epochID to  ensure uniquness. Alternatively, to be really safe we could always just add a random UUID to the end (so there's a random UUID per writer in addition to the queryID). 
