### PR TITLE
Revert "Build: Bump actions/labeler from 4 to 5 (#9264)"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,7 +28,7 @@ jobs:
   triage:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
This reverts commit 1b80537e821b7bf901a5b221fc3bfe53c8d87794.

V5 has some issues (breaking changes). We might have to adopt the config file as per new requirements.
To unblock the PRs. We can revert the fix and analyze later. 
More info: https://github.com/actions/labeler/issues/710