### PR TITLE
Core: Add EnvironmentContext to commit summary

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -352,6 +352,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         SnapshotSummary.ADDED_EQ_DELETES_PROP,
         SnapshotSummary.REMOVED_EQ_DELETES_PROP);
 
+    builder.putAll(EnvironmentContext.get());
     return builder.build();
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
@@ -90,4 +90,11 @@ public class TestSnapshotSummary extends TestBase {
         .containsEntry(SnapshotSummary.ADD_EQ_DELETE_FILES_PROP, "1")
         .containsEntry(SnapshotSummary.ADD_POS_DELETE_FILES_PROP, "1");
   }
+
+  @TestTemplate
+  public void testIcebergVersionInSummary() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Map<String, String> summary = table.currentSnapshot().summary();
+    assertThat(summary).containsKey("iceberg-version");
+  }
 }


### PR DESCRIPTION
Currently, it's not easy to find the Spark application that has run rewrite files actions. This patch adds application id to commit summary via `EnviromentContext`