### PR TITLE
Core: Use properties while initializing default HadoopFileIO for Hadoop catalog.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -112,11 +112,11 @@ public class HadoopCatalog extends BaseMetastoreCatalog
     this.warehouseLocation = LocationUtil.stripTrailingSlash(inputWarehouseLocation);
     this.fs = Util.getFs(new Path(warehouseLocation), conf);
 
-    String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
-    this.fileIO =
-        fileIOImpl == null
-            ? new HadoopFileIO(conf)
-            : CatalogUtil.loadFileIO(fileIOImpl, properties, conf);
+    String fileIOImpl =
+        properties.getOrDefault(
+            CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.hadoop.HadoopFileIO");
+
+    this.fileIO = CatalogUtil.loadFileIO(fileIOImpl, properties, conf);
 
     this.lockManager = LockManagers.from(properties);
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -222,6 +222,23 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
   }
 
   @Test
+  public void testHadoopFileIOProperties() {
+    TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    ImmutableMap<String, String> catalogProps =
+        ImmutableMap.of(
+            "warehouse", "/hive/testwarehouse",
+            "io.manifest.cache-enabled", "true");
+
+    HadoopCatalog catalog = new HadoopCatalog();
+    catalog.setConf(new Configuration());
+    catalog.initialize("hadoop", catalogProps);
+    FileIO fileIO = catalog.newTableOps(tableIdent).io();
+
+    Assertions.assertThat(fileIO.properties()).containsEntry("warehouse", "/hive/testwarehouse");
+    Assertions.assertThat(fileIO.properties()).containsEntry("io.manifest.cache-enabled", "true");
+  }
+
+  @Test
   public void testCreateAndDropTableWithoutNamespace() throws Exception {
     HadoopCatalog catalog = hadoopCatalog();
 


### PR DESCRIPTION
Make HadoopFileIO as default for Hadoop Catalog to initialize HadoopFileIO catalog configs similar to [NessieCatalog](https://github.com/apache/iceberg/blob/main/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java#L123) 
