### PR TITLE
Spark: Add tests for select using tag and branch identifier

### DIFF
--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -253,8 +253,7 @@ public class TestSelect extends SparkCatalogTestBase {
 
     // Spark session catalog does not support extended table names
     if (!"spark_catalog".equals(catalogName)) {
-      // read the table at the tag
-      // tag in table name
+      // read the table using the "tag_" prefix in the table name
       List<Object[]> actual3 = sql("SELECT * FROM %s.tag_test_tag", tableName);
       assertEquals("Snapshot at specific tag reference name, prefix", expected, actual3);
     }
@@ -311,8 +310,7 @@ public class TestSelect extends SparkCatalogTestBase {
 
     // Spark session catalog does not support extended table names
     if (!"spark_catalog".equals(catalogName)) {
-      // read the table at the branch
-      // branch in table name
+      // read the table using the "branch_" prefix in the table name
       List<Object[]> actual3 = sql("SELECT * FROM %s.branch_test_branch", tableName);
       assertEquals("Snapshot at specific branch reference name, prefix", expected, actual3);
     }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -235,23 +235,31 @@ public class TestSelect extends SparkCatalogTestBase {
   }
 
   @Test
-  public void testTagReferenceAsOf() {
+  public void testTagReference() {
     Table table = validationCatalog.loadTable(tableIdent);
     long snapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().createTag("test_tag", snapshotId).commit();
-
-    // create a second snapshot, read the table at the snapshot
     List<Object[]> expected = sql("SELECT * FROM %s", tableName);
+
+    // create a second snapshot, read the table at the tag
     sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0)", tableName);
     List<Object[]> actual1 = sql("SELECT * FROM %s VERSION AS OF 'test_tag'", tableName);
     assertEquals("Snapshot at specific tag reference name", expected, actual1);
 
-    // read the table at the snapshot
+    // read the table at the tag
     // HIVE time travel syntax
     List<Object[]> actual2 = sql("SELECT * FROM %s FOR SYSTEM_VERSION AS OF 'test_tag'", tableName);
     assertEquals("Snapshot at specific tag reference name", expected, actual2);
 
-    // read the table using DataFrameReader option: branch
+    // Spark session catalog does not support extended table names
+    if (!"spark_catalog".equals(catalogName)) {
+      // read the table at the tag
+      // tag in table name
+      List<Object[]> actual3 = sql("SELECT * FROM %s.tag_test_tag", tableName);
+      assertEquals("Snapshot at specific tag reference name, prefix", expected, actual3);
+    }
+
+    // read the table using DataFrameReader option: tag
     Dataset<Row> df =
         spark.read().format("iceberg").option(SparkReadOptions.TAG, "test_tag").load(tableName);
     List<Object[]> fromDF = rowsToJava(df.collectAsList());
@@ -284,22 +292,30 @@ public class TestSelect extends SparkCatalogTestBase {
   }
 
   @Test
-  public void testBranchReferenceAsOf() {
+  public void testBranchReference() {
     Table table = validationCatalog.loadTable(tableIdent);
     long snapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().createBranch("test_branch", snapshotId).commit();
-
-    // create a second snapshot, read the table at the snapshot
     List<Object[]> expected = sql("SELECT * FROM %s", tableName);
+
+    // create a second snapshot, read the table at the branch
     sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0)", tableName);
     List<Object[]> actual1 = sql("SELECT * FROM %s VERSION AS OF 'test_branch'", tableName);
     assertEquals("Snapshot at specific branch reference name", expected, actual1);
 
-    // read the table at the snapshot
+    // read the table at the branch
     // HIVE time travel syntax
     List<Object[]> actual2 =
         sql("SELECT * FROM %s FOR SYSTEM_VERSION AS OF 'test_branch'", tableName);
     assertEquals("Snapshot at specific branch reference name", expected, actual2);
+
+    // Spark session catalog does not support extended table names
+    if (!"spark_catalog".equals(catalogName)) {
+      // read the table at the branch
+      // branch in table name
+      List<Object[]> actual3 = sql("SELECT * FROM %s.branch_test_branch", tableName);
+      assertEquals("Snapshot at specific branch reference name, prefix", expected, actual3);
+    }
 
     // read the table using DataFrameReader option: branch
     Dataset<Row> df =

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -252,8 +252,7 @@ public class TestSelect extends SparkCatalogTestBase {
 
     // Spark session catalog does not support extended table names
     if (!"spark_catalog".equals(catalogName)) {
-      // read the table at the tag
-      // tag in table name
+      // read the table using the "tag_" prefix in the table name
       List<Object[]> actual3 = sql("SELECT * FROM %s.tag_test_tag", tableName);
       assertEquals("Snapshot at specific tag reference name, prefix", expected, actual3);
     }
@@ -310,8 +309,7 @@ public class TestSelect extends SparkCatalogTestBase {
 
     // Spark session catalog does not support extended table names
     if (!"spark_catalog".equals(catalogName)) {
-      // read the table at the branch
-      // branch in table name
+      // read the table using the "branch_" prefix in the table name
       List<Object[]> actual3 = sql("SELECT * FROM %s.branch_test_branch", tableName);
       assertEquals("Snapshot at specific branch reference name, prefix", expected, actual3);
     }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -234,23 +234,31 @@ public class TestSelect extends SparkCatalogTestBase {
   }
 
   @Test
-  public void testTagReferenceAsOf() {
+  public void testTagReference() {
     Table table = validationCatalog.loadTable(tableIdent);
     long snapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().createTag("test_tag", snapshotId).commit();
-
-    // create a second snapshot, read the table at the snapshot
     List<Object[]> expected = sql("SELECT * FROM %s", tableName);
+
+    // create a second snapshot, read the table at the tag
     sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0)", tableName);
     List<Object[]> actual1 = sql("SELECT * FROM %s VERSION AS OF 'test_tag'", tableName);
     assertEquals("Snapshot at specific tag reference name", expected, actual1);
 
-    // read the table at the snapshot
+    // read the table at the tag
     // HIVE time travel syntax
     List<Object[]> actual2 = sql("SELECT * FROM %s FOR SYSTEM_VERSION AS OF 'test_tag'", tableName);
     assertEquals("Snapshot at specific tag reference name", expected, actual2);
 
-    // read the table using DataFrameReader option: branch
+    // Spark session catalog does not support extended table names
+    if (!"spark_catalog".equals(catalogName)) {
+      // read the table at the tag
+      // tag in table name
+      List<Object[]> actual3 = sql("SELECT * FROM %s.tag_test_tag", tableName);
+      assertEquals("Snapshot at specific tag reference name, prefix", expected, actual3);
+    }
+
+    // read the table using DataFrameReader option: tag
     Dataset<Row> df =
         spark.read().format("iceberg").option(SparkReadOptions.TAG, "test_tag").load(tableName);
     List<Object[]> fromDF = rowsToJava(df.collectAsList());
@@ -283,22 +291,30 @@ public class TestSelect extends SparkCatalogTestBase {
   }
 
   @Test
-  public void testBranchReferenceAsOf() {
+  public void testBranchReference() {
     Table table = validationCatalog.loadTable(tableIdent);
     long snapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().createBranch("test_branch", snapshotId).commit();
-
-    // create a second snapshot, read the table at the snapshot
     List<Object[]> expected = sql("SELECT * FROM %s", tableName);
+
+    // create a second snapshot, read the table at the branch
     sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0)", tableName);
     List<Object[]> actual1 = sql("SELECT * FROM %s VERSION AS OF 'test_branch'", tableName);
     assertEquals("Snapshot at specific branch reference name", expected, actual1);
 
-    // read the table at the snapshot
+    // read the table at the branch
     // HIVE time travel syntax
     List<Object[]> actual2 =
         sql("SELECT * FROM %s FOR SYSTEM_VERSION AS OF 'test_branch'", tableName);
     assertEquals("Snapshot at specific branch reference name", expected, actual2);
+
+    // Spark session catalog does not support extended table names
+    if (!"spark_catalog".equals(catalogName)) {
+      // read the table at the branch
+      // branch in table name
+      List<Object[]> actual3 = sql("SELECT * FROM %s.branch_test_branch", tableName);
+      assertEquals("Snapshot at specific branch reference name, prefix", expected, actual3);
+    }
 
     // read the table using DataFrameReader option: branch
     Dataset<Row> df =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -252,8 +252,7 @@ public class TestSelect extends SparkCatalogTestBase {
 
     // Spark session catalog does not support extended table names
     if (!"spark_catalog".equals(catalogName)) {
-      // read the table at the tag
-      // tag in table name
+      // read the table using the "tag_" prefix in the table name
       List<Object[]> actual3 = sql("SELECT * FROM %s.tag_test_tag", tableName);
       assertEquals("Snapshot at specific tag reference name, prefix", expected, actual3);
     }
@@ -310,8 +309,7 @@ public class TestSelect extends SparkCatalogTestBase {
 
     // Spark session catalog does not support extended table names
     if (!"spark_catalog".equals(catalogName)) {
-      // read the table at the branch
-      // branch in table name
+      // read the table using the "branch_" prefix in the table name
       List<Object[]> actual3 = sql("SELECT * FROM %s.branch_test_branch", tableName);
       assertEquals("Snapshot at specific branch reference name, prefix", expected, actual3);
     }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -234,23 +234,31 @@ public class TestSelect extends SparkCatalogTestBase {
   }
 
   @Test
-  public void testTagReferenceAsOf() {
+  public void testTagReference() {
     Table table = validationCatalog.loadTable(tableIdent);
     long snapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().createTag("test_tag", snapshotId).commit();
-
-    // create a second snapshot, read the table at the snapshot
     List<Object[]> expected = sql("SELECT * FROM %s", tableName);
+
+    // create a second snapshot, read the table at the tag
     sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0)", tableName);
     List<Object[]> actual1 = sql("SELECT * FROM %s VERSION AS OF 'test_tag'", tableName);
     assertEquals("Snapshot at specific tag reference name", expected, actual1);
 
-    // read the table at the snapshot
+    // read the table at the tag
     // HIVE time travel syntax
     List<Object[]> actual2 = sql("SELECT * FROM %s FOR SYSTEM_VERSION AS OF 'test_tag'", tableName);
     assertEquals("Snapshot at specific tag reference name", expected, actual2);
 
-    // read the table using DataFrameReader option: branch
+    // Spark session catalog does not support extended table names
+    if (!"spark_catalog".equals(catalogName)) {
+      // read the table at the tag
+      // tag in table name
+      List<Object[]> actual3 = sql("SELECT * FROM %s.tag_test_tag", tableName);
+      assertEquals("Snapshot at specific tag reference name, prefix", expected, actual3);
+    }
+
+    // read the table using DataFrameReader option: tag
     Dataset<Row> df =
         spark.read().format("iceberg").option(SparkReadOptions.TAG, "test_tag").load(tableName);
     List<Object[]> fromDF = rowsToJava(df.collectAsList());
@@ -283,22 +291,30 @@ public class TestSelect extends SparkCatalogTestBase {
   }
 
   @Test
-  public void testBranchReferenceAsOf() {
+  public void testBranchReference() {
     Table table = validationCatalog.loadTable(tableIdent);
     long snapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().createBranch("test_branch", snapshotId).commit();
-
-    // create a second snapshot, read the table at the snapshot
     List<Object[]> expected = sql("SELECT * FROM %s", tableName);
+
+    // create a second snapshot, read the table at the branch
     sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0)", tableName);
     List<Object[]> actual1 = sql("SELECT * FROM %s VERSION AS OF 'test_branch'", tableName);
     assertEquals("Snapshot at specific branch reference name", expected, actual1);
 
-    // read the table at the snapshot
+    // read the table at the branch
     // HIVE time travel syntax
     List<Object[]> actual2 =
         sql("SELECT * FROM %s FOR SYSTEM_VERSION AS OF 'test_branch'", tableName);
     assertEquals("Snapshot at specific branch reference name", expected, actual2);
+
+    // Spark session catalog does not support extended table names
+    if (!"spark_catalog".equals(catalogName)) {
+      // read the table at the branch
+      // branch in table name
+      List<Object[]> actual3 = sql("SELECT * FROM %s.branch_test_branch", tableName);
+      assertEquals("Snapshot at specific branch reference name, prefix", expected, actual3);
+    }
 
     // read the table using DataFrameReader option: branch
     Dataset<Row> df =


### PR DESCRIPTION
Follow up to https://github.com/apache/iceberg/pull/9238. Add tests for reading using the `tag_` and `branch_` identifiers.