### PR TITLE
Hive: Make HiveMetastoreExtension configurable

### DIFF
--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveCreateReplaceTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveCreateReplaceTableTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.CatalogProperties;
@@ -68,7 +67,7 @@ public class HiveCreateReplaceTableTest {
 
   @RegisterExtension
   private static final HiveMetastoreExtension HIVE_METASTORE_EXTENSION =
-      new HiveMetastoreExtension(DB_NAME, Collections.emptyMap());
+      HiveMetastoreExtension.builder().withDatabase(DB_NAME).build();
 
   private static HiveCatalog catalog;
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreExtension.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreExtension.java
@@ -33,7 +33,7 @@ public class HiveMetastoreExtension implements BeforeAllCallback, AfterAllCallba
   private final Map<String, String> hiveConfOverride;
   private final String databaseName;
 
-  public HiveMetastoreExtension(String databaseName, Map<String, String> hiveConfOverride) {
+  private HiveMetastoreExtension(String databaseName, Map<String, String> hiveConfOverride) {
     this.databaseName = databaseName;
     this.hiveConfOverride = hiveConfOverride;
   }
@@ -50,9 +50,11 @@ public class HiveMetastoreExtension implements BeforeAllCallback, AfterAllCallba
 
     metastore.start(hiveConfWithOverrides);
     metastoreClient = new HiveMetaStoreClient(hiveConfWithOverrides);
-    String dbPath = metastore.getDatabasePath(databaseName);
-    Database db = new Database(databaseName, "description", dbPath, Maps.newHashMap());
-    metastoreClient.createDatabase(db);
+    if (null != databaseName) {
+      String dbPath = metastore.getDatabasePath(databaseName);
+      Database db = new Database(databaseName, "description", dbPath, Maps.newHashMap());
+      metastoreClient.createDatabase(db);
+    }
   }
 
   @Override
@@ -79,5 +81,30 @@ public class HiveMetastoreExtension implements BeforeAllCallback, AfterAllCallba
 
   public TestHiveMetastore metastore() {
     return metastore;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String databaseName;
+    private Map<String, String> config;
+
+    public Builder() {}
+
+    public Builder withDatabase(String databaseToCreate) {
+      this.databaseName = databaseToCreate;
+      return this;
+    }
+
+    public Builder withConfig(Map<String, String> configToSet) {
+      this.config = configToSet;
+      return this;
+    }
+
+    public HiveMetastoreExtension build() {
+      return new HiveMetastoreExtension(databaseName, config);
+    }
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableBaseTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableBaseTest.java
@@ -26,7 +26,6 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -52,7 +51,7 @@ public class HiveTableBaseTest {
 
   @RegisterExtension
   protected static final HiveMetastoreExtension HIVE_METASTORE_EXTENSION =
-      new HiveMetastoreExtension(DB_NAME, Collections.emptyMap());
+      HiveMetastoreExtension.builder().withDatabase(DB_NAME).build();
 
   protected static HiveCatalog catalog;
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestCachedClientPool.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestCachedClientPool.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.security.PrivilegedAction;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
@@ -44,7 +43,7 @@ public class TestCachedClientPool {
 
   @RegisterExtension
   private static final HiveMetastoreExtension HIVE_METASTORE_EXTENSION =
-      new HiveMetastoreExtension(DB_NAME, Collections.emptyMap());
+      HiveMetastoreExtension.builder().withDatabase(DB_NAME).build();
 
   @Test
   public void testClientPoolCleaner() throws InterruptedException {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -105,7 +104,7 @@ public class TestHiveCatalog {
 
   @RegisterExtension
   private static final HiveMetastoreExtension HIVE_METASTORE_EXTENSION =
-      new HiveMetastoreExtension(DB_NAME, Collections.emptyMap());
+      HiveMetastoreExtension.builder().withDatabase(DB_NAME).build();
 
   @BeforeEach
   public void before() {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
@@ -107,8 +107,10 @@ public class TestHiveCommitLocks {
 
   @RegisterExtension
   private static final HiveMetastoreExtension HIVE_METASTORE_EXTENSION =
-      new HiveMetastoreExtension(
-          DB_NAME, ImmutableMap.of(HiveConf.ConfVars.HIVE_TXN_TIMEOUT.varname, "1s"));
+      HiveMetastoreExtension.builder()
+          .withDatabase(DB_NAME)
+          .withConfig(ImmutableMap.of(HiveConf.ConfVars.HIVE_TXN_TIMEOUT.varname, "1s"))
+          .build();
 
   private static HiveCatalog catalog;
   private Path tableLocation;


### PR DESCRIPTION
This is mainly required for https://github.com/apache/iceberg/pull/8918 so that the extension doesn't always create the database and gives the test more control over when to create the database