### PR TITLE
Test: Fix flaky tests which concurrently modify HashSet

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -795,7 +795,7 @@ public class TestRemoveSnapshots extends TableTestBase {
     rewriteManifests.addManifest(newManifest);
     rewriteManifests.commit();
 
-    Set<String> deletedFiles = Sets.newHashSet();
+    Set<String> deletedFiles = ConcurrentHashMap.newKeySet();
     Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
     AtomicInteger deleteThreadsIndex = new AtomicInteger(0);
     AtomicInteger planThreadsIndex = new AtomicInteger(0);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -207,7 +207,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     long t4 = rightAfterSnapshot();
 
-    Set<String> deletedFiles = Sets.newHashSet();
+    Set<String> deletedFiles = ConcurrentHashMap.newKeySet();
     Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
     AtomicInteger deleteThreadsIndex = new AtomicInteger(0);
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -271,7 +271,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     waitUntilAfter(System.currentTimeMillis());
 
-    Set<String> deletedFiles = Sets.newHashSet();
+    Set<String> deletedFiles = ConcurrentHashMap.newKeySet();
     Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
     AtomicInteger deleteThreadsIndex = new AtomicInteger(0);
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -207,7 +207,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     long t4 = rightAfterSnapshot();
 
-    Set<String> deletedFiles = Sets.newHashSet();
+    Set<String> deletedFiles = ConcurrentHashMap.newKeySet();
     Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
     AtomicInteger deleteThreadsIndex = new AtomicInteger(0);
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -270,7 +270,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     waitUntilAfter(System.currentTimeMillis());
 
-    Set<String> deletedFiles = Sets.newHashSet();
+    Set<String> deletedFiles = ConcurrentHashMap.newKeySet();
     Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
     AtomicInteger deleteThreadsIndex = new AtomicInteger(0);
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -207,7 +207,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     long t4 = rightAfterSnapshot();
 
-    Set<String> deletedFiles = Sets.newHashSet();
+    Set<String> deletedFiles = ConcurrentHashMap.newKeySet();
     Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
     AtomicInteger deleteThreadsIndex = new AtomicInteger(0);
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -270,7 +270,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     waitUntilAfter(System.currentTimeMillis());
 
-    Set<String> deletedFiles = Sets.newHashSet();
+    Set<String> deletedFiles = ConcurrentHashMap.newKeySet();
     Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
     AtomicInteger deleteThreadsIndex = new AtomicInteger(0);
 


### PR DESCRIPTION
This fixes #8824 and other places where `HashSet` can be modified concurrently.

As found in https://github.com/apache/iceberg/actions/runs/7191749083/job/19586958583?pr=9273

```
TestRemoveOrphanFilesAction3 > orphanedFileRemovedWithParallelTasks FAILED
    java.lang.AssertionError: Should delete 4 files expected:<4> but was:<3>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:647)
        at org.apache.iceberg.spark.actions.TestRemoveOrphanFilesAction.orphanedFileRemovedWithParallelTasks(TestRemoveOrphanFilesAction.java:306)
```

The check of `deleteThreads` has passed. That means delete function is working but `deleteFiles` is not correctly modified since `HashSet` is not thread-safe.

```
    Assert.assertEquals(
        deleteThreads,
        Sets.newHashSet(
            "remove-orphan-0", "remove-orphan-1", "remove-orphan-2", "remove-orphan-3"));

    Assert.assertEquals("Should delete 4 files", 4, deletedFiles.size());
```