### PR TITLE
BugFix: ORC reader is not closed when SortedMerge iterator is used for positional deletes

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -134,7 +134,13 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
 
     try {
       return new VectorizedRowBatchIterator(
-          file.location(), readerSchema, orcFileReader.rows(options), recordsPerBatch);
+          file.location(), readerSchema, orcFileReader.rows(options), recordsPerBatch) {
+        @Override
+        public void close() throws IOException {
+          super.close();
+          orcFileReader.close();
+        }
+      };
     } catch (IOException ioe) {
       throw new RuntimeIOException(ioe, "Failed to get ORC rows for file: %s", file);
     }


### PR DESCRIPTION
````
Caused by: com.amazonaws.thirdparty.apache.http.conn.ConnectionPoolTimeoutException: Timeout waiting for connection from pool
	at com.amazonaws.thirdparty.apache.http.impl.conn.PoolingHttpClientConnectionManager.leaseConnection(PoolingHttpClientConnectionManager.java:316)
	at com.amazonaws.thirdparty.apache.http.impl.conn.PoolingHttpClientConnectionManager$1.get(PoolingHttpClientConnectionManager.java:282)
	at jdk.internal.reflect.GeneratedMethodAccessor37.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.amazonaws.http.conn.ClientConnectionRequestFactory$Handler.invoke(ClientConnectionRequestFactory.java:70)
	at com.amazonaws.http.conn.$Proxy59.get(Unknown Source)
	at com.amazonaws.thirdparty.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:190)
	at com.amazonaws.thirdparty.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
	at com.amazonaws.thirdparty.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
	at com.amazonaws.thirdparty.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
	at com.amazonaws.thirdparty.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56)
	at com.amazonaws.http.apache.client.impl.SdkHttpClient.execute(SdkHttpClient.java:72)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1343)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1154)
	... 92 more
Caused by: org.apache.iceberg.exceptions.RuntimeIOException: Failed to open file: s3a://csl-nfqe-base/cc-cdw-nfqe-wf0jz6/warehouse/tablespace/external/hive/mcd_csi.db/calls/data/year_partition=2016/month=4/00161-8-delete-hive_20231208222325_e6395418-5d4f-4d01-ac77-8440d95efca6-job_17020134738721_0001-2088-00004.orc
	at org.apache.iceberg.orc.ORC.newFileReader(ORC.java:782)
	at org.apache.iceberg.orc.OrcIterable.iterator(OrcIterable.java:83)
	at org.apache.iceberg.orc.OrcIterable.iterator(OrcIterable.java:42)
	at org.apache.iceberg.util.Filter.lambda$filter$0(Filter.java:34)
	at org.apache.iceberg.io.CloseableIterable$2.iterator(CloseableIterable.java:72)
	at org.apache.iceberg.io.CloseableIterable$7$1.<init>(CloseableIterable.java:188)
	at org.apache.iceberg.io.CloseableIterable$7.iterator(CloseableIterable.java:187)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:720)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at org.apache.iceberg.util.SortedMerge.iterator(SortedMerge.java:56)
	at org.apache.iceberg.deletes.Deletes$PositionStreamDeleteIterable.<init>(Deletes.java:278)
	at org.apache.iceberg.deletes.Deletes$PositionStreamDeleteMarker.<init>(Deletes.java:355)
	at org.apache.iceberg.deletes.Deletes.streamingMarker(Deletes.java:229)
	at org.apache.iceberg.data.DeleteFilter.applyPosDeletes(DeleteFilter.java:281)
````