### PR TITLE
API, Core: Move SQLViewRepresentation to API

### DIFF
--- a/api/src/main/java/org/apache/iceberg/view/SQLViewRepresentation.java
+++ b/api/src/main/java/org/apache/iceberg/view/SQLViewRepresentation.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.view;
+
+/** SQLViewRepresentation represents views in SQL with a given dialect */
+public interface SQLViewRepresentation extends ViewRepresentation {
+
+  @Override
+  default String type() {
+    return Type.SQL;
+  }
+
+  /** The view query SQL text. */
+  String sql();
+
+  /** The view query SQL dialect. */
+  String dialect();
+}

--- a/core/src/main/java/org/apache/iceberg/view/BaseSQLViewRepresentation.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseSQLViewRepresentation.java
@@ -21,16 +21,10 @@ package org.apache.iceberg.view;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface SQLViewRepresentation extends ViewRepresentation {
-
-  @Override
-  default String type() {
-    return Type.SQL;
-  }
-
-  /** The view query SQL text. */
-  String sql();
-
-  /** The view query SQL dialect. */
-  String dialect();
-}
+@Value.Include(value = SQLViewRepresentation.class)
+@SuppressWarnings("ImmutablesStyle")
+@Value.Style(
+    typeImmutable = "ImmutableSQLViewRepresentation",
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
+interface BaseSQLViewRepresentation extends SQLViewRepresentation {}


### PR DESCRIPTION
This moves `SQLViewRepresentation` from `core` to the `api` module mainly so that it's easier usable in the context of https://github.com/apache/iceberg/pull/9247/files#r1419759456