### PR TITLE
Core: remove statistic files in CatalogUtil:dropTableData

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -100,7 +100,7 @@ public class CatalogUtil {
 
     LOG.info("Manifests to delete: {}", Joiner.on(", ").join(manifestsToDelete));
 
-    // run all of the deletes
+    // run all the deletes
 
     boolean gcEnabled =
         PropertyUtil.propertyAsBoolean(metadata.properties(), GC_ENABLED, GC_ENABLED_DEFAULT);
@@ -116,6 +116,11 @@ public class CatalogUtil {
         io,
         Iterables.transform(metadata.previousFiles(), TableMetadata.MetadataLogEntry::file),
         "previous metadata",
+        true);
+    deleteFiles(
+        io,
+        Iterables.transform(metadata.statisticsFiles(), StatisticsFile::path),
+        "statistic",
         true);
     deleteFile(io, metadata.metadataFileLocation(), "metadata");
   }

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -100,7 +100,7 @@ public class CatalogUtil {
 
     LOG.info("Manifests to delete: {}", Joiner.on(", ").join(manifestsToDelete));
 
-    // run all the deletes
+    // run all of the deletes
 
     boolean gcEnabled =
         PropertyUtil.propertyAsBoolean(metadata.properties(), GC_ENABLED, GC_ENABLED_DEFAULT);

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -120,7 +120,7 @@ public class CatalogUtil {
     deleteFiles(
         io,
         Iterables.transform(metadata.statisticsFiles(), StatisticsFile::path),
-        "statistic",
+        "statistics",
         true);
     deleteFile(io, metadata.metadataFileLocation(), "metadata");
   }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCatalogUtilDropTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCatalogUtilDropTable.java
@@ -67,10 +67,10 @@ public class TestCatalogUtilDropTable extends HadoopTableTestBase {
     Set<String> manifestLocations = manifestLocations(snapshotSet, table.io());
     Set<String> dataLocations = dataLocations(snapshotSet, table.io());
     Set<String> metadataLocations = metadataLocations(tableMetadata);
-    Set<String> statisticLocations = statisticLocations(tableMetadata);
+    Set<String> statsLocations = statsLocations(tableMetadata);
     Assertions.assertThat(manifestListLocations).as("should have 2 manifest lists").hasSize(2);
     Assertions.assertThat(metadataLocations).as("should have 4 metadata locations").hasSize(4);
-    Assertions.assertThat(statisticLocations).as("should have 1 statistic file").hasSize(1);
+    Assertions.assertThat(statsLocations).as("should have 1 stats file").hasSize(1);
 
     FileIO fileIO = Mockito.mock(FileIO.class);
     Mockito.when(fileIO.newInputFile(Mockito.anyString()))
@@ -90,7 +90,7 @@ public class TestCatalogUtilDropTable extends HadoopTableTestBase {
                     + manifestLocations.size()
                     + dataLocations.size()
                     + metadataLocations.size()
-                    + statisticLocations.size()))
+                    + statsLocations.size()))
         .deleteFile(argumentCaptor.capture());
 
     List<String> deletedPaths = argumentCaptor.getAllValues();
@@ -108,7 +108,7 @@ public class TestCatalogUtilDropTable extends HadoopTableTestBase {
         .containsAll(metadataLocations);
     Assertions.assertThat(deletedPaths)
         .as("should contain all created statistic")
-        .containsAll(statisticLocations);
+        .containsAll(statsLocations);
   }
 
   @Test
@@ -206,7 +206,7 @@ public class TestCatalogUtilDropTable extends HadoopTableTestBase {
     return metadataLocations;
   }
 
-  private Set<String> statisticLocations(TableMetadata tableMetadata) {
+  private Set<String> statsLocations(TableMetadata tableMetadata) {
     return tableMetadata.statisticsFiles().stream()
         .map(StatisticsFile::path)
         .collect(Collectors.toSet());

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCatalogUtilDropTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCatalogUtilDropTable.java
@@ -69,7 +69,7 @@ public class TestCatalogUtilDropTable extends HadoopTableTestBase {
     Set<String> metadataLocations = metadataLocations(tableMetadata);
     Set<String> statisticLocations = statisticLocations(tableMetadata);
     Assertions.assertThat(manifestListLocations).as("should have 2 manifest lists").hasSize(2);
-    Assertions.assertThat(metadataLocations).as("should have 3 metadata locations").hasSize(4);
+    Assertions.assertThat(metadataLocations).as("should have 4 metadata locations").hasSize(4);
     Assertions.assertThat(statisticLocations).as("should have 1 statistic file").hasSize(1);
 
     FileIO fileIO = Mockito.mock(FileIO.class);


### PR DESCRIPTION
This PR attempt to include puffin stats files as part of CatalogUtil table cleanup

CC @RussellSpitzer @findepi 
