### PR TITLE
Core: Fix Metadata table's UUID

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -44,6 +44,7 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable
   private final SortOrder sortOrder = SortOrder.unsorted();
   private final BaseTable table;
   private final String name;
+  private final UUID uuid;
 
   protected BaseMetadataTable(Table table, String name) {
     super("metadata");
@@ -51,6 +52,7 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable
         table instanceof BaseTable, "Cannot create metadata table for non-data table: %s", table);
     this.table = (BaseTable) table;
     this.name = name;
+    this.uuid = UUID.randomUUID();
   }
 
   /**
@@ -202,7 +204,7 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable
 
   @Override
   public UUID uuid() {
-    return UUID.randomUUID();
+    return uuid;
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeWrapper;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -136,6 +137,18 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         Assert.assertEquals("Residuals must be ignored", Expressions.alwaysTrue(), task.residual());
       }
     }
+  }
+
+  @Test
+  public void testManifestsTableUUID() {
+    Table manifestsTable = new ManifestsTable(table);
+
+    Assertions.assertThat(manifestsTable.uuid())
+        .as("UUID should be consistent on multiple calls")
+        .isEqualTo(manifestsTable.uuid());
+    Assertions.assertThat(manifestsTable.uuid())
+        .as("Metadata table UUID should be different from main table UUID")
+        .isNotEqualTo(table.uuid());
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -140,14 +140,14 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @Test
-  public void testManifestsTableUUID() {
+  public void testMetadataTableUUID() {
     Table manifestsTable = new ManifestsTable(table);
 
     Assertions.assertThat(manifestsTable.uuid())
         .as("UUID should be consistent on multiple calls")
         .isEqualTo(manifestsTable.uuid());
     Assertions.assertThat(manifestsTable.uuid())
-        .as("Metadata table UUID should be different from main table UUID")
+        .as("Metadata table UUID should be different from the base table UUID")
         .isNotEqualTo(table.uuid());
   }
 


### PR DESCRIPTION
`BaseFileRewriteCoordinator`, `ScanTaskSetManager` calls `table.uuid()` of metadata table multiple times for setting and reading from cache. So, uuid has to be consistent on each call for a given table. 

This issue was discovered during https://github.com/apache/iceberg/pull/9298 