### PR TITLE
Core: Make sqlFor case insensitive for dialect check

### DIFF
--- a/core/src/main/java/org/apache/iceberg/view/BaseView.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseView.java
@@ -118,7 +118,7 @@ public class BaseView implements View, Serializable {
     for (ViewRepresentation representation : currentVersion().representations()) {
       if (representation instanceof SQLViewRepresentation) {
         SQLViewRepresentation sqlViewRepresentation = (SQLViewRepresentation) representation;
-        if (sqlViewRepresentation.dialect().equals(dialect)) {
+        if (sqlViewRepresentation.dialect().equalsIgnoreCase(dialect)) {
           return sqlViewRepresentation;
         } else if (closest == null) {
           closest = sqlViewRepresentation;

--- a/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
@@ -1694,6 +1694,28 @@ public abstract class ViewCatalogTests<C extends ViewCatalog & SupportsNamespace
   }
 
   @Test
+  public void testSqlForCaseInsensitive() {
+    TableIdentifier identifier = TableIdentifier.of("ns", "view");
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(identifier.namespace());
+    }
+
+    View view =
+        catalog()
+            .buildView(identifier)
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(identifier.namespace())
+            .withDefaultCatalog(catalog().name())
+            .withQuery("spark", "select * from ns.tbl")
+            .withQuery("trino", "select * from ns.tbl using X")
+            .create();
+
+    assertThat(view.sqlFor("SPARK").sql()).isEqualTo("select * from ns.tbl");
+    assertThat(view.sqlFor("TRINO").sql()).isEqualTo("select * from ns.tbl using X");
+  }
+
+  @Test
   public void testSqlForInvalidArguments() {
     TableIdentifier identifier = TableIdentifier.of("ns", "view");
 


### PR DESCRIPTION
This makes the dialect check case insensitive https://github.com/apache/iceberg/pull/9247/files . Was an oversight, after I refactored the code, the case insensitive change mistakenly became case sensitive. This change also adds a test to catch this case.