### PR TITLE
Flink: Support filtering data by matching database

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/SupportsNamespaces.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/SupportsNamespaces.java
@@ -105,6 +105,39 @@ public interface SupportsNamespaces {
   List<Namespace> listNamespaces(Namespace namespace) throws NoSuchNamespaceException;
 
   /**
+   * List child namespaces from the namespace.
+   *
+   * <p>For two existing tables named 'a.b.c.table' and 'a.b.d.table', this method returns:
+   *
+   * <ul>
+   *   <li>Given: {@code Namespace.empty()}
+   *   <li>Returns: {@code Namespace.of("a")}
+   * </ul>
+   *
+   * <ul>
+   *   <li>Given: {@code Namespace.of("a")}
+   *   <li>Returns: {@code Namespace.of("a", "b")}
+   * </ul>
+   *
+   * <ul>
+   *   <li>Given: {@code Namespace.of("a", "b")}
+   *   <li>Returns: {@code Namespace.of("a", "b", "c")} and {@code Namespace.of("a", "b", "d")}
+   * </ul>
+   *
+   * <ul>
+   *   <li>Given: {@code Namespace.of("a", "b", "c")}
+   *   <li>Returns: empty list, because there are no child namespaces
+   * </ul>
+   *
+   * @return a List of child {@link Namespace} names from the given namespace
+   * @throws NoSuchNamespaceException If the namespace does not exist (optional)
+   */
+  default List<Namespace> listNamespaces(Namespace namespace, String databasePattern)
+      throws NoSuchNamespaceException {
+    throw new UnsupportedOperationException("List child namespaces filter by databasePattern");
+  }
+
+  /**
    * Load metadata properties for a namespace.
    *
    * @param namespace a namespace. {@link Namespace}


### PR DESCRIPTION
Overloaded the listNamespaces method to support database filtering; enables more use-case scenarios, as required by my StarRocks.