### PR TITLE
Parquet: Deprecate readSupport and callInit in the read builder

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -1020,6 +1020,8 @@ public class Parquet {
       return this;
     }
 
+    /** @deprecated will be removed in 2.0.0; use {@link #createReaderFunc(Function)} instead */
+    @Deprecated
     public ReadBuilder readSupport(ReadSupport<?> newFilterSupport) {
       this.readSupport = newFilterSupport;
       return this;
@@ -1047,6 +1049,8 @@ public class Parquet {
       return this;
     }
 
+    /** @deprecated will be removed in 2.0.0; use {@link #createReaderFunc(Function)} instead */
+    @Deprecated
     public ReadBuilder callInit() {
       this.callInit = true;
       return this;


### PR DESCRIPTION
Iceberg originally plugged in custom object models using Parquet's `ReadSupport` API, but that API wasn't able to handle filtering without reading the Parquet footer multiple times. Support has been carried forward, but there should be no need for it in 2.0.