### PR TITLE
Spark 3.5: Migrate tests to JUnit5 in data directory

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.Schema;
@@ -34,9 +35,8 @@ import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.spark.sql.internal.SQLConf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public abstract class AvroDataTest {
 
@@ -63,7 +63,7 @@ public abstract class AvroDataTest {
           required(117, "dec_38_10", Types.DecimalType.of(38, 10)) // Spark's maximum precision
           );
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir public Path temp;
 
   @Test
   public void testSimpleStruct() throws IOException {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -63,7 +63,7 @@ public abstract class AvroDataTest {
           required(117, "dec_38_10", Types.DecimalType.of(38, 10)) // Spark's maximum precision
           );
 
-  @TempDir private Path temp;
+  @TempDir protected Path temp;
 
   @Test
   public void testSimpleStruct() throws IOException {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -63,7 +63,7 @@ public abstract class AvroDataTest {
           required(117, "dec_38_10", Types.DecimalType.of(38, 10)) // Spark's maximum precision
           );
 
-  @TempDir public Path temp;
+  @TempDir private Path temp;
 
   @Test
   public void testSimpleStruct() throws IOException {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -172,9 +172,7 @@ public class GenericsHelpers {
       case BINARY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
         assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat((byte[]) actual)
-            .as("Bytes should match")
-            .isEqualTo(((ByteBuffer) expected).array());
+        assertThat(actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
         assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
@@ -310,9 +308,7 @@ public class GenericsHelpers {
       case BINARY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
         assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat((byte[]) actual)
-            .as("Bytes should match")
-            .isEqualTo(((ByteBuffer) expected).array());
+        assertThat(actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
         assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -84,8 +84,8 @@ public class GenericsHelpers {
     Type keyType = map.keyType();
     Type valueType = map.valueType();
     assertThat(actual.keySet())
-            .as("Should have the same number of keys")
-            .hasSameSizeAs(expected.keySet());
+        .as("Should have the same number of keys")
+        .hasSameSizeAs(expected.keySet());
 
     for (Object expectedKey : expected.keySet()) {
       Object matchingKey = null;
@@ -119,13 +119,11 @@ public class GenericsHelpers {
         assertThat(expected).as("Primitive value should be equal to expected").isEqualTo(actual);
         break;
       case DATE:
-        assertThat(expected)
-            .as("Should expect a LocalDate")
-            .isInstanceOf(LocalDate.class);
+        assertThat(expected).as("Should expect a LocalDate").isInstanceOf(LocalDate.class);
         assertThat(actual).as("Should be a Date").isInstanceOf(Date.class);
         assertThat(actual.toString())
-                .as("ISO-8601 date should be equal")
-                .isEqualTo(String.valueOf(expected));
+            .as("ISO-8601 date should be equal")
+            .isEqualTo(String.valueOf(expected));
         break;
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;
@@ -144,9 +142,7 @@ public class GenericsHelpers {
           assertThat(actualTs).as("Timestamp should be equal").isEqualTo(expected);
         } else {
           // Timestamp
-          assertThat(actual)
-              .as("Should be a LocalDateTime")
-              .isInstanceOf(LocalDateTime.class);
+          assertThat(actual).as("Should be a LocalDateTime").isInstanceOf(LocalDateTime.class);
 
           assertThat(expected)
               .as("Should expect an LocalDateTime")
@@ -157,14 +153,16 @@ public class GenericsHelpers {
         break;
       case STRING:
         assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        assertThat(actual.toString()).as("Strings should be equal").isEqualTo(String.valueOf(expected));
+        assertThat(actual.toString())
+            .as("Strings should be equal")
+            .isEqualTo(String.valueOf(expected));
         break;
       case UUID:
         assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
         assertThat(actual).as("Should be a String").isInstanceOf(String.class);
         assertThat(actual.toString())
-                .as("UUID string representation should match")
-                .isEqualTo(String.valueOf(expected));
+            .as("UUID string representation should match")
+            .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
         assertThat(expected).as("Should expect a byte[]").isInstanceOf(byte[].class);
@@ -172,16 +170,14 @@ public class GenericsHelpers {
         assertThat(actual).as("Bytes should match").isEqualTo(expected);
         break;
       case BINARY:
-        assertThat(expected)
-            .as("Should expect a ByteBuffer")
-            .isInstanceOf(ByteBuffer.class);
+        assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
         assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat((byte[]) actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
+        assertThat((byte[]) actual)
+            .as("Bytes should match")
+            .isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
-        assertThat(expected)
-            .as("Should expect a BigDecimal")
-            .isInstanceOf(BigDecimal.class);
+        assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
         assertThat(actual).as("Should be a BigDecimal").isInstanceOf(BigDecimal.class);
         assertThat(actual).as("BigDecimals should be equal").isEqualTo(expected);
         break;
@@ -191,18 +187,14 @@ public class GenericsHelpers {
         assertEqualsSafe(type.asNestedType().asStructType(), (Record) expected, (Row) actual);
         break;
       case LIST:
-        assertThat(expected)
-            .as("Should expect a Collection")
-            .isInstanceOf(Collection.class);
+        assertThat(expected).as("Should expect a Collection").isInstanceOf(Collection.class);
         assertThat(actual).as("Should be a Seq").isInstanceOf(Seq.class);
         List<?> asList = seqAsJavaListConverter((Seq<?>) actual).asJava();
         assertEqualsSafe(type.asNestedType().asListType(), (Collection<?>) expected, asList);
         break;
       case MAP:
         assertThat(expected).as("Should expect a Collection").isInstanceOf(Map.class);
-        assertThat(actual)
-            .as("Should be a Map")
-            .isInstanceOf(scala.collection.Map.class);
+        assertThat(actual).as("Should be a Map").isInstanceOf(scala.collection.Map.class);
         Map<String, ?> asMap =
             mapAsJavaMapConverter((scala.collection.Map<String, ?>) actual).asJava();
         assertEqualsSafe(type.asNestedType().asMapType(), (Map<?, ?>) expected, asMap);
@@ -270,11 +262,11 @@ public class GenericsHelpers {
         assertThat(expected).as("Primitive value should be equal to expected").isEqualTo(actual);
         break;
       case DATE:
-        assertThat(expected)
-            .as("Should expect a LocalDate")
-            .isInstanceOf(LocalDate.class);
+        assertThat(expected).as("Should expect a LocalDate").isInstanceOf(LocalDate.class);
         int expectedDays = (int) ChronoUnit.DAYS.between(EPOCH_DAY, (LocalDate) expected);
-        assertThat(expectedDays).as("Primitive value should be equal to expected").isEqualTo(actual);
+        assertThat(expectedDays)
+            .as("Primitive value should be equal to expected")
+            .isEqualTo(actual);
         break;
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;
@@ -283,24 +275,32 @@ public class GenericsHelpers {
               .as("Should expect an OffsetDateTime")
               .isInstanceOf(OffsetDateTime.class);
           long expectedMicros = ChronoUnit.MICROS.between(EPOCH, (OffsetDateTime) expected);
-          assertThat(expectedMicros).as("Primitive value should be equal to expected").isEqualTo(actual);
+          assertThat(expectedMicros)
+              .as("Primitive value should be equal to expected")
+              .isEqualTo(actual);
         } else {
           assertThat(expected)
               .as("Should expect an LocalDateTime")
               .isInstanceOf(LocalDateTime.class);
           long expectedMicros =
               ChronoUnit.MICROS.between(EPOCH, ((LocalDateTime) expected).atZone(ZoneId.of("UTC")));
-          assertThat(expectedMicros).as("Primitive value should be equal to expected").isEqualTo(actual);
+          assertThat(expectedMicros)
+              .as("Primitive value should be equal to expected")
+              .isEqualTo(actual);
         }
         break;
       case STRING:
         assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        assertThat(actual.toString()).as("Strings should be equal").isEqualTo(String.valueOf(expected));
+        assertThat(actual.toString())
+            .as("Strings should be equal")
+            .isEqualTo(String.valueOf(expected));
         break;
       case UUID:
         assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
         assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        assertThat(actual.toString()).as("UUID string representation should match").isEqualTo(String.valueOf(expected));
+        assertThat(actual.toString())
+            .as("UUID string representation should match")
+            .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
         assertThat(expected).as("Should expect a byte[]").isInstanceOf(byte[].class);
@@ -308,42 +308,34 @@ public class GenericsHelpers {
         assertThat(actual).as("Bytes should match").isEqualTo(expected);
         break;
       case BINARY:
-        assertThat(expected)
-            .as("Should expect a ByteBuffer")
-            .isInstanceOf(ByteBuffer.class);
+        assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
         assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat((byte[]) actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
+        assertThat((byte[]) actual)
+            .as("Bytes should match")
+            .isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
-        assertThat(expected)
-            .as("Should expect a BigDecimal")
-            .isInstanceOf(BigDecimal.class);
+        assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
         assertThat(actual).as("Should be a Decimal").isInstanceOf(Decimal.class);
         assertThat(((Decimal) actual).toJavaBigDecimal())
-                .as("BigDecimals should be equal")
-                .isEqualTo(expected);
+            .as("BigDecimals should be equal")
+            .isEqualTo(expected);
         break;
       case STRUCT:
         assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
-        assertThat(actual)
-            .as("Should be an InternalRow")
-            .isInstanceOf(InternalRow.class);
+        assertThat(actual).as("Should be an InternalRow").isInstanceOf(InternalRow.class);
         assertEqualsUnsafe(
             type.asNestedType().asStructType(), (Record) expected, (InternalRow) actual);
         break;
       case LIST:
-        assertThat(expected)
-            .as("Should expect a Collection")
-            .isInstanceOf(Collection.class);
+        assertThat(expected).as("Should expect a Collection").isInstanceOf(Collection.class);
         assertThat(actual).as("Should be an ArrayData").isInstanceOf(ArrayData.class);
         assertEqualsUnsafe(
             type.asNestedType().asListType(), (Collection<?>) expected, (ArrayData) actual);
         break;
       case MAP:
         assertThat(expected).as("Should expect a Map").isInstanceOf(Map.class);
-        assertThat(actual)
-            .as("Should be an ArrayBasedMapData")
-            .isInstanceOf(MapData.class);
+        assertThat(actual).as("Should be an ArrayBasedMapData").isInstanceOf(MapData.class);
         assertEqualsUnsafe(type.asNestedType().asMapType(), (Map<?, ?>) expected, (MapData) actual);
         break;
       case TIME:

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.spark.SparkSchemaUtil.convert;
+import static org.assertj.core.api.Assertions.assertThat;
 import static scala.collection.JavaConverters.mapAsJavaMapConverter;
 import static scala.collection.JavaConverters.seqAsJavaListConverter;
 
@@ -47,8 +48,6 @@ import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import scala.collection.Seq;
 
 public class GenericsHelpers {
@@ -84,8 +83,9 @@ public class GenericsHelpers {
   private static void assertEqualsSafe(Types.MapType map, Map<?, ?> expected, Map<?, ?> actual) {
     Type keyType = map.keyType();
     Type valueType = map.valueType();
-    Assert.assertEquals(
-        "Should have the same number of keys", expected.keySet().size(), actual.keySet().size());
+    assertThat(actual.keySet())
+            .as("Should have the same number of keys")
+            .hasSameSizeAs(expected.keySet());
 
     for (Object expectedKey : expected.keySet()) {
       Object matchingKey = null;
@@ -99,7 +99,7 @@ public class GenericsHelpers {
         }
       }
 
-      Assert.assertNotNull("Should have a matching key", matchingKey);
+      assertThat(matchingKey).as("Should have a matching key").isNotNull();
       assertEqualsSafe(valueType, expected.get(expectedKey), actual.get(matchingKey));
     }
   }
@@ -116,88 +116,91 @@ public class GenericsHelpers {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+        assertThat(expected).as("Primitive value should be equal to expected").isEqualTo(actual);
         break;
       case DATE:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a LocalDate")
             .isInstanceOf(LocalDate.class);
-        Assertions.assertThat(actual).as("Should be a Date").isInstanceOf(Date.class);
-        Assert.assertEquals(
-            "ISO-8601 date should be equal", expected.toString(), actual.toString());
+        assertThat(actual).as("Should be a Date").isInstanceOf(Date.class);
+        assertThat(actual.toString())
+                .as("ISO-8601 date should be equal")
+                .isEqualTo(String.valueOf(expected));
         break;
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;
         if (timestampType.shouldAdjustToUTC()) {
           // Timestamptz
-          Assertions.assertThat(actual).as("Should be a Timestamp").isInstanceOf(Timestamp.class);
+          assertThat(actual).as("Should be a Timestamp").isInstanceOf(Timestamp.class);
           Timestamp ts = (Timestamp) actual;
           // milliseconds from nanos has already been added by getTime
           OffsetDateTime actualTs =
               EPOCH.plusNanos((ts.getTime() * 1_000_000) + (ts.getNanos() % 1_000_000));
 
-          Assertions.assertThat(expected)
+          assertThat(expected)
               .as("Should expect an OffsetDateTime")
               .isInstanceOf(OffsetDateTime.class);
-          Assert.assertEquals("Timestamp should be equal", expected, actualTs);
+
+          assertThat(actualTs).as("Timestamp should be equal").isEqualTo(expected);
         } else {
           // Timestamp
-          Assertions.assertThat(actual)
+          assertThat(actual)
               .as("Should be a LocalDateTime")
               .isInstanceOf(LocalDateTime.class);
-          LocalDateTime ts = (LocalDateTime) actual;
 
-          Assertions.assertThat(expected)
+          assertThat(expected)
               .as("Should expect an LocalDateTime")
               .isInstanceOf(LocalDateTime.class);
-          Assert.assertEquals("Timestamp should be equal", expected, ts);
+
+          assertThat(actual).as("Timestamp should be equal").isEqualTo(expected);
         }
         break;
       case STRING:
-        Assertions.assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        Assert.assertEquals("Strings should be equal", String.valueOf(expected), actual);
+        assertThat(actual).as("Should be a String").isInstanceOf(String.class);
+        assertThat(actual.toString()).as("Strings should be equal").isEqualTo(String.valueOf(expected));
         break;
       case UUID:
-        Assertions.assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
-        Assertions.assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        Assert.assertEquals("UUID string representation should match", expected.toString(), actual);
+        assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
+        assertThat(actual).as("Should be a String").isInstanceOf(String.class);
+        assertThat(actual.toString())
+                .as("UUID string representation should match")
+                .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
-        Assertions.assertThat(expected).as("Should expect a byte[]").isInstanceOf(byte[].class);
-        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals("Bytes should match", (byte[]) expected, (byte[]) actual);
+        assertThat(expected).as("Should expect a byte[]").isInstanceOf(byte[].class);
+        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
+        assertThat(actual).as("Bytes should match").isEqualTo(expected);
         break;
       case BINARY:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a ByteBuffer")
             .isInstanceOf(ByteBuffer.class);
-        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals(
-            "Bytes should match", ((ByteBuffer) expected).array(), (byte[]) actual);
+        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
+        assertThat((byte[]) actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a BigDecimal")
             .isInstanceOf(BigDecimal.class);
-        Assertions.assertThat(actual).as("Should be a BigDecimal").isInstanceOf(BigDecimal.class);
-        Assert.assertEquals("BigDecimals should be equal", expected, actual);
+        assertThat(actual).as("Should be a BigDecimal").isInstanceOf(BigDecimal.class);
+        assertThat(actual).as("BigDecimals should be equal").isEqualTo(expected);
         break;
       case STRUCT:
-        Assertions.assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
-        Assertions.assertThat(actual).as("Should be a Row").isInstanceOf(Row.class);
+        assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
+        assertThat(actual).as("Should be a Row").isInstanceOf(Row.class);
         assertEqualsSafe(type.asNestedType().asStructType(), (Record) expected, (Row) actual);
         break;
       case LIST:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a Collection")
             .isInstanceOf(Collection.class);
-        Assertions.assertThat(actual).as("Should be a Seq").isInstanceOf(Seq.class);
+        assertThat(actual).as("Should be a Seq").isInstanceOf(Seq.class);
         List<?> asList = seqAsJavaListConverter((Seq<?>) actual).asJava();
         assertEqualsSafe(type.asNestedType().asListType(), (Collection<?>) expected, asList);
         break;
       case MAP:
-        Assertions.assertThat(expected).as("Should expect a Collection").isInstanceOf(Map.class);
-        Assertions.assertThat(actual)
+        assertThat(expected).as("Should expect a Collection").isInstanceOf(Map.class);
+        assertThat(actual)
             .as("Should be a Map")
             .isInstanceOf(scala.collection.Map.class);
         Map<String, ?> asMap =
@@ -264,84 +267,81 @@ public class GenericsHelpers {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+        assertThat(expected).as("Primitive value should be equal to expected").isEqualTo(actual);
         break;
       case DATE:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a LocalDate")
             .isInstanceOf(LocalDate.class);
         int expectedDays = (int) ChronoUnit.DAYS.between(EPOCH_DAY, (LocalDate) expected);
-        Assert.assertEquals("Primitive value should be equal to expected", expectedDays, actual);
+        assertThat(expectedDays).as("Primitive value should be equal to expected").isEqualTo(actual);
         break;
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;
         if (timestampType.shouldAdjustToUTC()) {
-          Assertions.assertThat(expected)
+          assertThat(expected)
               .as("Should expect an OffsetDateTime")
               .isInstanceOf(OffsetDateTime.class);
           long expectedMicros = ChronoUnit.MICROS.between(EPOCH, (OffsetDateTime) expected);
-          Assert.assertEquals(
-              "Primitive value should be equal to expected", expectedMicros, actual);
+          assertThat(expectedMicros).as("Primitive value should be equal to expected").isEqualTo(actual);
         } else {
-          Assertions.assertThat(expected)
+          assertThat(expected)
               .as("Should expect an LocalDateTime")
               .isInstanceOf(LocalDateTime.class);
           long expectedMicros =
               ChronoUnit.MICROS.between(EPOCH, ((LocalDateTime) expected).atZone(ZoneId.of("UTC")));
-          Assert.assertEquals(
-              "Primitive value should be equal to expected", expectedMicros, actual);
+          assertThat(expectedMicros).as("Primitive value should be equal to expected").isEqualTo(actual);
         }
         break;
       case STRING:
-        Assertions.assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        Assert.assertEquals("Strings should be equal", expected, actual.toString());
+        assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
+        assertThat(actual.toString()).as("Strings should be equal").isEqualTo(String.valueOf(expected));
         break;
       case UUID:
-        Assertions.assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
-        Assertions.assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        Assert.assertEquals(
-            "UUID string representation should match", expected.toString(), actual.toString());
+        assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
+        assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
+        assertThat(actual.toString()).as("UUID string representation should match").isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
-        Assertions.assertThat(expected).as("Should expect a byte[]").isInstanceOf(byte[].class);
-        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals("Bytes should match", (byte[]) expected, (byte[]) actual);
+        assertThat(expected).as("Should expect a byte[]").isInstanceOf(byte[].class);
+        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
+        assertThat(actual).as("Bytes should match").isEqualTo(expected);
         break;
       case BINARY:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a ByteBuffer")
             .isInstanceOf(ByteBuffer.class);
-        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals(
-            "Bytes should match", ((ByteBuffer) expected).array(), (byte[]) actual);
+        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
+        assertThat((byte[]) actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a BigDecimal")
             .isInstanceOf(BigDecimal.class);
-        Assertions.assertThat(actual).as("Should be a Decimal").isInstanceOf(Decimal.class);
-        Assert.assertEquals(
-            "BigDecimals should be equal", expected, ((Decimal) actual).toJavaBigDecimal());
+        assertThat(actual).as("Should be a Decimal").isInstanceOf(Decimal.class);
+        assertThat(((Decimal) actual).toJavaBigDecimal())
+                .as("BigDecimals should be equal")
+                .isEqualTo(expected);
         break;
       case STRUCT:
-        Assertions.assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
-        Assertions.assertThat(actual)
+        assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
+        assertThat(actual)
             .as("Should be an InternalRow")
             .isInstanceOf(InternalRow.class);
         assertEqualsUnsafe(
             type.asNestedType().asStructType(), (Record) expected, (InternalRow) actual);
         break;
       case LIST:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a Collection")
             .isInstanceOf(Collection.class);
-        Assertions.assertThat(actual).as("Should be an ArrayData").isInstanceOf(ArrayData.class);
+        assertThat(actual).as("Should be an ArrayData").isInstanceOf(ArrayData.class);
         assertEqualsUnsafe(
             type.asNestedType().asListType(), (Collection<?>) expected, (ArrayData) actual);
         break;
       case MAP:
-        Assertions.assertThat(expected).as("Should expect a Map").isInstanceOf(Map.class);
-        Assertions.assertThat(actual)
+        assertThat(expected).as("Should expect a Map").isInstanceOf(Map.class);
+        assertThat(actual)
             .as("Should be an ArrayBasedMapData")
             .isInstanceOf(MapData.class);
         assertEqualsUnsafe(type.asNestedType().asMapType(), (Map<?, ?>) expected, (MapData) actual);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -116,7 +116,7 @@ public class GenericsHelpers {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        assertThat(expected).as("Primitive value should be equal to expected").isEqualTo(actual);
+        assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case DATE:
         assertThat(expected).as("Should expect a LocalDate").isInstanceOf(LocalDate.class);
@@ -259,14 +259,14 @@ public class GenericsHelpers {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        assertThat(expected).as("Primitive value should be equal to expected").isEqualTo(actual);
+        assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case DATE:
         assertThat(expected).as("Should expect a LocalDate").isInstanceOf(LocalDate.class);
         int expectedDays = (int) ChronoUnit.DAYS.between(EPOCH_DAY, (LocalDate) expected);
-        assertThat(expectedDays)
+        assertThat(actual)
             .as("Primitive value should be equal to expected")
-            .isEqualTo(actual);
+            .isEqualTo(expectedDays);
         break;
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;
@@ -275,18 +275,18 @@ public class GenericsHelpers {
               .as("Should expect an OffsetDateTime")
               .isInstanceOf(OffsetDateTime.class);
           long expectedMicros = ChronoUnit.MICROS.between(EPOCH, (OffsetDateTime) expected);
-          assertThat(expectedMicros)
+          assertThat(actual)
               .as("Primitive value should be equal to expected")
-              .isEqualTo(actual);
+              .isEqualTo(expectedMicros);
         } else {
           assertThat(expected)
               .as("Should expect an LocalDateTime")
               .isInstanceOf(LocalDateTime.class);
           long expectedMicros =
               ChronoUnit.MICROS.between(EPOCH, ((LocalDateTime) expected).atZone(ZoneId.of("UTC")));
-          assertThat(expectedMicros)
+          assertThat(actual)
               .as("Primitive value should be equal to expected")
-              .isEqualTo(actual);
+              .isEqualTo(expectedMicros);
         }
         break;
       case STRING:

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/ParameterizedAvroDataTest.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/ParameterizedAvroDataTest.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.ListType;
+import org.apache.iceberg.types.Types.LongType;
+import org.apache.iceberg.types.Types.MapType;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.spark.sql.internal.SQLConf;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Copy of {@link AvroDataTest} that marks tests with @{@link org.junit.jupiter.api.TestTemplate}
+ * instead of @{@link Test} to make the tests work in a parameterized environment.
+ */
+public abstract class ParameterizedAvroDataTest {
+
+  protected abstract void writeAndValidate(Schema schema) throws IOException;
+
+  protected static final StructType SUPPORTED_PRIMITIVES =
+      StructType.of(
+          required(100, "id", LongType.get()),
+          optional(101, "data", Types.StringType.get()),
+          required(102, "b", Types.BooleanType.get()),
+          optional(103, "i", Types.IntegerType.get()),
+          required(104, "l", LongType.get()),
+          optional(105, "f", Types.FloatType.get()),
+          required(106, "d", Types.DoubleType.get()),
+          optional(107, "date", Types.DateType.get()),
+          required(108, "ts", Types.TimestampType.withZone()),
+          required(110, "s", Types.StringType.get()),
+          required(111, "uuid", Types.UUIDType.get()),
+          required(112, "fixed", Types.FixedType.ofLength(7)),
+          optional(113, "bytes", Types.BinaryType.get()),
+          required(114, "dec_9_0", Types.DecimalType.of(9, 0)), // int encoded
+          required(115, "dec_11_2", Types.DecimalType.of(11, 2)), // long encoded
+          required(116, "dec_20_5", Types.DecimalType.of(20, 5)), // requires padding
+          required(117, "dec_38_10", Types.DecimalType.of(38, 10)) // Spark's maximum precision
+          );
+
+  @TempDir protected Path temp;
+
+  @TestTemplate
+  public void testSimpleStruct() throws IOException {
+    writeAndValidate(TypeUtil.assignIncreasingFreshIds(new Schema(SUPPORTED_PRIMITIVES.fields())));
+  }
+
+  @TestTemplate
+  public void testStructWithRequiredFields() throws IOException {
+    writeAndValidate(
+        TypeUtil.assignIncreasingFreshIds(
+            new Schema(
+                Lists.transform(SUPPORTED_PRIMITIVES.fields(), Types.NestedField::asRequired))));
+  }
+
+  @TestTemplate
+  public void testStructWithOptionalFields() throws IOException {
+    writeAndValidate(
+        TypeUtil.assignIncreasingFreshIds(
+            new Schema(
+                Lists.transform(SUPPORTED_PRIMITIVES.fields(), Types.NestedField::asOptional))));
+  }
+
+  @TestTemplate
+  public void testNestedStruct() throws IOException {
+    writeAndValidate(
+        TypeUtil.assignIncreasingFreshIds(new Schema(required(1, "struct", SUPPORTED_PRIMITIVES))));
+  }
+
+  @TestTemplate
+  public void testArray() throws IOException {
+    Schema schema =
+        new Schema(
+            required(0, "id", LongType.get()),
+            optional(1, "data", ListType.ofOptional(2, Types.StringType.get())));
+
+    writeAndValidate(schema);
+  }
+
+  @TestTemplate
+  public void testArrayOfStructs() throws IOException {
+    Schema schema =
+        TypeUtil.assignIncreasingFreshIds(
+            new Schema(
+                required(0, "id", LongType.get()),
+                optional(1, "data", ListType.ofOptional(2, SUPPORTED_PRIMITIVES))));
+
+    writeAndValidate(schema);
+  }
+
+  @TestTemplate
+  public void testMap() throws IOException {
+    Schema schema =
+        new Schema(
+            required(0, "id", LongType.get()),
+            optional(
+                1,
+                "data",
+                MapType.ofOptional(2, 3, Types.StringType.get(), Types.StringType.get())));
+
+    writeAndValidate(schema);
+  }
+
+  @TestTemplate
+  public void testNumericMapKey() throws IOException {
+    Schema schema =
+        new Schema(
+            required(0, "id", LongType.get()),
+            optional(1, "data", MapType.ofOptional(2, 3, LongType.get(), Types.StringType.get())));
+
+    writeAndValidate(schema);
+  }
+
+  @TestTemplate
+  public void testComplexMapKey() throws IOException {
+    Schema schema =
+        new Schema(
+            required(0, "id", LongType.get()),
+            optional(
+                1,
+                "data",
+                MapType.ofOptional(
+                    2,
+                    3,
+                    StructType.of(
+                        required(4, "i", Types.IntegerType.get()),
+                        optional(5, "s", Types.StringType.get())),
+                    Types.StringType.get())));
+
+    writeAndValidate(schema);
+  }
+
+  @TestTemplate
+  public void testMapOfStructs() throws IOException {
+    Schema schema =
+        TypeUtil.assignIncreasingFreshIds(
+            new Schema(
+                required(0, "id", LongType.get()),
+                optional(
+                    1,
+                    "data",
+                    MapType.ofOptional(2, 3, Types.StringType.get(), SUPPORTED_PRIMITIVES))));
+
+    writeAndValidate(schema);
+  }
+
+  @TestTemplate
+  public void testMixedTypes() throws IOException {
+    StructType structType =
+        StructType.of(
+            required(0, "id", LongType.get()),
+            optional(
+                1,
+                "list_of_maps",
+                ListType.ofOptional(
+                    2, MapType.ofOptional(3, 4, Types.StringType.get(), SUPPORTED_PRIMITIVES))),
+            optional(
+                5,
+                "map_of_lists",
+                MapType.ofOptional(
+                    6, 7, Types.StringType.get(), ListType.ofOptional(8, SUPPORTED_PRIMITIVES))),
+            required(
+                9,
+                "list_of_lists",
+                ListType.ofOptional(10, ListType.ofOptional(11, SUPPORTED_PRIMITIVES))),
+            required(
+                12,
+                "map_of_maps",
+                MapType.ofOptional(
+                    13,
+                    14,
+                    Types.StringType.get(),
+                    MapType.ofOptional(15, 16, Types.StringType.get(), SUPPORTED_PRIMITIVES))),
+            required(
+                17,
+                "list_of_struct_of_nested_types",
+                ListType.ofOptional(
+                    19,
+                    StructType.of(
+                        Types.NestedField.required(
+                            20,
+                            "m1",
+                            MapType.ofOptional(
+                                21, 22, Types.StringType.get(), SUPPORTED_PRIMITIVES)),
+                        Types.NestedField.optional(
+                            23, "l1", ListType.ofRequired(24, SUPPORTED_PRIMITIVES)),
+                        Types.NestedField.required(
+                            25, "l2", ListType.ofRequired(26, SUPPORTED_PRIMITIVES)),
+                        Types.NestedField.optional(
+                            27,
+                            "m2",
+                            MapType.ofOptional(
+                                28, 29, Types.StringType.get(), SUPPORTED_PRIMITIVES))))));
+
+    Schema schema =
+        new Schema(
+            TypeUtil.assignFreshIds(structType, new AtomicInteger(0)::incrementAndGet)
+                .asStructType()
+                .fields());
+
+    writeAndValidate(schema);
+  }
+
+  @TestTemplate
+  public void testTimestampWithoutZone() throws IOException {
+    Schema schema =
+        TypeUtil.assignIncreasingFreshIds(
+            new Schema(
+                required(0, "id", LongType.get()),
+                optional(1, "ts_without_zone", Types.TimestampType.withoutZone())));
+
+    writeAndValidate(schema);
+  }
+
+  protected void withSQLConf(Map<String, String> conf, Action action) throws IOException {
+    SQLConf sqlConf = SQLConf.get();
+
+    Map<String, String> currentConfValues = Maps.newHashMap();
+    conf.keySet()
+        .forEach(
+            confKey -> {
+              if (sqlConf.contains(confKey)) {
+                String currentConfValue = sqlConf.getConfString(confKey);
+                currentConfValues.put(confKey, currentConfValue);
+              }
+            });
+
+    conf.forEach(
+        (confKey, confValue) -> {
+          if (SQLConf.isStaticConfigKey(confKey)) {
+            throw new RuntimeException("Cannot modify the value of a static config: " + confKey);
+          }
+          sqlConf.setConfString(confKey, confValue);
+        });
+
+    try {
+      action.invoke();
+    } finally {
+      conf.forEach(
+          (confKey, confValue) -> {
+            if (currentConfValues.containsKey(confKey)) {
+              sqlConf.setConfString(confKey, currentConfValues.get(confKey));
+            } else {
+              sqlConf.unsetConf(confKey);
+            }
+          });
+    }
+  }
+
+  @FunctionalInterface
+  protected interface Action {
+    void invoke() throws IOException;
+  }
+}

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.spark.SparkSchemaUtil.convert;
+import static org.assertj.core.api.Assertions.assertThat;
 import static scala.collection.JavaConverters.mapAsJavaMapConverter;
 import static scala.collection.JavaConverters.seqAsJavaListConverter;
 
@@ -77,8 +78,6 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import scala.collection.Seq;
 
 public class TestHelpers {
@@ -143,7 +142,7 @@ public class TestHelpers {
         }
       }
 
-      Assert.assertNotNull("Should have a matching key", matchingKey);
+      assertThat(matchingKey).as("Should have a matching key").isNotNull();
       assertEqualsSafe(valueType, expected.get(expectedKey), actual.get(matchingKey));
     }
   }
@@ -163,28 +162,27 @@ public class TestHelpers {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+        assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case DATE:
-        Assertions.assertThat(expected).as("Should be an int").isInstanceOf(Integer.class);
-        Assertions.assertThat(actual).as("Should be a Date").isInstanceOf(Date.class);
-        int daysFromEpoch = (Integer) expected;
-        LocalDate date = ChronoUnit.DAYS.addTo(EPOCH_DAY, daysFromEpoch);
-        Assert.assertEquals("ISO-8601 date should be equal", date.toString(), actual.toString());
+        assertThat(expected).as("Should be an int").isInstanceOf(Integer.class);
+        assertThat(actual).as("Should be a Date").isInstanceOf(Date.class);
+        LocalDate date = ChronoUnit.DAYS.addTo(EPOCH_DAY, (Integer) expected);
+        assertThat(actual.toString()).as("ISO-8601 date should be equal").isEqualTo(String.valueOf(date));
         break;
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;
 
-        Assertions.assertThat(expected).as("Should be a long").isInstanceOf(Long.class);
+        assertThat(expected).as("Should be a long").isInstanceOf(Long.class);
         if (timestampType.shouldAdjustToUTC()) {
-          Assertions.assertThat(actual).as("Should be a Timestamp").isInstanceOf(Timestamp.class);
+          assertThat(actual).as("Should be a Timestamp").isInstanceOf(Timestamp.class);
 
           Timestamp ts = (Timestamp) actual;
           // milliseconds from nanos has already been added by getTime
           long tsMicros = (ts.getTime() * 1000) + ((ts.getNanos() / 1000) % 1000);
-          Assert.assertEquals("Timestamp micros should be equal", expected, tsMicros);
+          assertThat(tsMicros).as("Timestamp micros should be equal").isEqualTo(expected);
         } else {
-          Assertions.assertThat(actual)
+          assertThat(actual)
               .as("Should be a LocalDateTime")
               .isInstanceOf(LocalDateTime.class);
 
@@ -192,57 +190,55 @@ public class TestHelpers {
           Instant instant = ts.toInstant(ZoneOffset.UTC);
           // milliseconds from nanos has already been added by getTime
           long tsMicros = (instant.toEpochMilli() * 1000) + ((ts.getNano() / 1000) % 1000);
-          Assert.assertEquals("Timestamp micros should be equal", expected, tsMicros);
+          assertThat(tsMicros).as("Timestamp micros should be equal").isEqualTo(expected);
         }
         break;
       case STRING:
-        Assertions.assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        Assert.assertEquals("Strings should be equal", String.valueOf(expected), actual);
+        assertThat(actual).as("Should be a String").isInstanceOf(String.class);
+        assertThat(actual).as("Strings should be equal").isEqualTo(String.valueOf(expected));
         break;
       case UUID:
-        Assertions.assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
-        Assertions.assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        Assert.assertEquals("UUID string representation should match", expected.toString(), actual);
+        assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
+        assertThat(actual).as("Should be a String").isInstanceOf(String.class);
+        assertThat(actual.toString()).as("UUID string representation should match").isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a Fixed")
             .isInstanceOf(GenericData.Fixed.class);
-        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals(
-            "Bytes should match", ((GenericData.Fixed) expected).bytes(), (byte[]) actual);
+        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
+        assertThat(actual).as("Bytes should match").isEqualTo(((GenericData.Fixed) expected).bytes());
         break;
       case BINARY:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a ByteBuffer")
             .isInstanceOf(ByteBuffer.class);
-        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals(
-            "Bytes should match", ((ByteBuffer) expected).array(), (byte[]) actual);
+        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
+        assertThat(actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a BigDecimal")
             .isInstanceOf(BigDecimal.class);
-        Assertions.assertThat(actual).as("Should be a BigDecimal").isInstanceOf(BigDecimal.class);
-        Assert.assertEquals("BigDecimals should be equal", expected, actual);
+        assertThat(actual).as("Should be a BigDecimal").isInstanceOf(BigDecimal.class);
+        assertThat(actual).as("BigDecimals should be equal").isEqualTo(expected);
         break;
       case STRUCT:
-        Assertions.assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
-        Assertions.assertThat(actual).as("Should be a Row").isInstanceOf(Row.class);
+        assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
+        assertThat(actual).as("Should be a Row").isInstanceOf(Row.class);
         assertEqualsSafe(type.asNestedType().asStructType(), (Record) expected, (Row) actual);
         break;
       case LIST:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a Collection")
             .isInstanceOf(Collection.class);
-        Assertions.assertThat(actual).as("Should be a Seq").isInstanceOf(Seq.class);
+        assertThat(actual).as("Should be a Seq").isInstanceOf(Seq.class);
         List<?> asList = seqAsJavaListConverter((Seq<?>) actual).asJava();
         assertEqualsSafe(type.asNestedType().asListType(), (Collection) expected, asList);
         break;
       case MAP:
-        Assertions.assertThat(expected).as("Should expect a Collection").isInstanceOf(Map.class);
-        Assertions.assertThat(actual)
+        assertThat(expected).as("Should expect a Collection").isInstanceOf(Map.class);
+        assertThat(actual)
             .as("Should be a Map")
             .isInstanceOf(scala.collection.Map.class);
         Map<String, ?> asMap =
@@ -304,22 +300,21 @@ public class TestHelpers {
 
     switch (type.typeId()) {
       case LONG:
-        Assertions.assertThat(actual).as("Should be a long").isInstanceOf(Long.class);
+        assertThat(actual).as("Should be a long").isInstanceOf(Long.class);
         if (expected instanceof Integer) {
-          Assert.assertEquals("Values didn't match", ((Number) expected).longValue(), actual);
+          assertThat(actual).as("Values didn't match").isEqualTo(((Number) expected).longValue());
         } else {
-          Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+          assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         }
         break;
       case DOUBLE:
-        Assertions.assertThat(actual).as("Should be a double").isInstanceOf(Double.class);
+        assertThat(actual).as("Should be a double").isInstanceOf(Double.class);
         if (expected instanceof Float) {
-          Assert.assertEquals(
-              "Values didn't match",
-              Double.doubleToLongBits(((Number) expected).doubleValue()),
-              Double.doubleToLongBits((double) actual));
+          assertThat(Double.doubleToLongBits((double) actual))
+                  .as("Values didn't match")
+                  .isEqualTo(Double.doubleToLongBits(((Number) expected).doubleValue()));
         } else {
-          Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+          assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         }
         break;
       case INTEGER:
@@ -327,61 +322,57 @@ public class TestHelpers {
       case BOOLEAN:
       case DATE:
       case TIMESTAMP:
-        Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+        assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case STRING:
-        Assertions.assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        Assert.assertEquals("Strings should be equal", expected, actual.toString());
+        assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
+        assertThat(actual.toString()).as("Strings should be equal").isEqualTo(expected);
         break;
       case UUID:
-        Assertions.assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
-        Assertions.assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        Assert.assertEquals(
-            "UUID string representation should match", expected.toString(), actual.toString());
+        assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
+        assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
+        assertThat(actual.toString()).as("UUID string representation should match").isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a Fixed")
             .isInstanceOf(GenericData.Fixed.class);
-        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals(
-            "Bytes should match", ((GenericData.Fixed) expected).bytes(), (byte[]) actual);
+        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
+        assertThat((byte[]) actual).as("Bytes should match").isEqualTo(((GenericData.Fixed) expected).bytes());
         break;
       case BINARY:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a ByteBuffer")
             .isInstanceOf(ByteBuffer.class);
-        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals(
-            "Bytes should match", ((ByteBuffer) expected).array(), (byte[]) actual);
+        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
+        assertThat((byte[]) actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a BigDecimal")
             .isInstanceOf(BigDecimal.class);
-        Assertions.assertThat(actual).as("Should be a Decimal").isInstanceOf(Decimal.class);
-        Assert.assertEquals(
-            "BigDecimals should be equal", expected, ((Decimal) actual).toJavaBigDecimal());
+        assertThat(actual).as("Should be a Decimal").isInstanceOf(Decimal.class);
+        assertThat(((Decimal) actual).toJavaBigDecimal()).as("BigDecimals should be equal").isEqualTo(expected);
         break;
       case STRUCT:
-        Assertions.assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
-        Assertions.assertThat(actual)
+        assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
+        assertThat(actual)
             .as("Should be an InternalRow")
             .isInstanceOf(InternalRow.class);
         assertEqualsUnsafe(
             type.asNestedType().asStructType(), (Record) expected, (InternalRow) actual);
         break;
       case LIST:
-        Assertions.assertThat(expected)
+        assertThat(expected)
             .as("Should expect a Collection")
             .isInstanceOf(Collection.class);
-        Assertions.assertThat(actual).as("Should be an ArrayData").isInstanceOf(ArrayData.class);
+        assertThat(actual).as("Should be an ArrayData").isInstanceOf(ArrayData.class);
         assertEqualsUnsafe(
             type.asNestedType().asListType(), (Collection) expected, (ArrayData) actual);
         break;
       case MAP:
-        Assertions.assertThat(expected).as("Should expect a Map").isInstanceOf(Map.class);
-        Assertions.assertThat(actual)
+        assertThat(expected).as("Should expect a Map").isInstanceOf(Map.class);
+        assertThat(actual)
             .as("Should be an ArrayBasedMapData")
             .isInstanceOf(MapData.class);
         assertEqualsUnsafe(type.asNestedType().asMapType(), (Map) expected, (MapData) actual);
@@ -403,7 +394,7 @@ public class TestHelpers {
   public static void assertEquals(
       String prefix, Types.StructType type, InternalRow expected, Row actual) {
     if (expected == null || actual == null) {
-      Assert.assertEquals(prefix, expected, actual);
+      assertThat(actual).as(prefix).isEqualTo(expected);
     } else {
       List<Types.NestedField> fields = type.fields();
       for (int c = 0; c < fields.size(); ++c) {
@@ -419,10 +410,9 @@ public class TestHelpers {
           case DECIMAL:
           case DATE:
           case TIMESTAMP:
-            Assert.assertEquals(
-                prefix + "." + fieldName + " - " + childType,
-                getValue(expected, c, childType),
-                getPrimitiveValue(actual, c, childType));
+            assertThat(getPrimitiveValue(actual, c, childType))
+                    .as(prefix + "." + fieldName + " - " + childType)
+                    .isEqualTo(getValue(expected, c, childType));
             break;
           case UUID:
           case FIXED:
@@ -466,9 +456,9 @@ public class TestHelpers {
   private static void assertEqualsLists(
       String prefix, Types.ListType type, ArrayData expected, List actual) {
     if (expected == null || actual == null) {
-      Assert.assertEquals(prefix, expected, actual);
+      assertThat(actual).as(prefix).isEqualTo(expected);
     } else {
-      Assert.assertEquals(prefix + " length", expected.numElements(), actual.size());
+      assertThat(actual.size()).as(prefix + "length").isEqualTo(expected.numElements());
       Type childType = type.elementType();
       for (int e = 0; e < expected.numElements(); ++e) {
         switch (childType.typeId()) {
@@ -481,10 +471,9 @@ public class TestHelpers {
           case DECIMAL:
           case DATE:
           case TIMESTAMP:
-            Assert.assertEquals(
-                prefix + ".elem " + e + " - " + childType,
-                getValue(expected, e, childType),
-                actual.get(e));
+            assertThat(actual.get(e))
+                    .as(prefix + ".elem " + e + " - " + childType)
+                    .isEqualTo(getValue(expected, e, childType));
             break;
           case UUID:
           case FIXED:
@@ -528,21 +517,20 @@ public class TestHelpers {
   private static void assertEqualsMaps(
       String prefix, Types.MapType type, MapData expected, Map<?, ?> actual) {
     if (expected == null || actual == null) {
-      Assert.assertEquals(prefix, expected, actual);
+      assertThat(actual).as(prefix).isEqualTo(expected);
     } else {
       Type keyType = type.keyType();
       Type valueType = type.valueType();
       ArrayData expectedKeyArray = expected.keyArray();
       ArrayData expectedValueArray = expected.valueArray();
-      Assert.assertEquals(prefix + " length", expected.numElements(), actual.size());
+      assertThat(actual.size()).as(prefix + " length").isEqualTo(expected.numElements());
       for (int e = 0; e < expected.numElements(); ++e) {
         Object expectedKey = getValue(expectedKeyArray, e, keyType);
         Object actualValue = actual.get(expectedKey);
         if (actualValue == null) {
-          Assert.assertEquals(
-              prefix + ".key=" + expectedKey + " has null",
-              true,
-              expected.valueArray().isNullAt(e));
+          assertThat(true)
+                  .as(prefix + ".key=" + expectedKey + " has null")
+                  .isEqualTo(expected.valueArray().isNullAt(e));
         } else {
           switch (valueType.typeId()) {
             case BOOLEAN:
@@ -554,10 +542,9 @@ public class TestHelpers {
             case DECIMAL:
             case DATE:
             case TIMESTAMP:
-              Assert.assertEquals(
-                  prefix + ".key=" + expectedKey + " - " + valueType,
-                  getValue(expectedValueArray, e, valueType),
-                  actual.get(expectedKey));
+              assertThat(actual.get(expectedKey))
+                      .as(prefix + ".key=" + expectedKey + " - " + valueType)
+                      .isEqualTo(getValue(expectedValueArray, e, valueType));
               break;
             case UUID:
             case FIXED:
@@ -687,11 +674,7 @@ public class TestHelpers {
   }
 
   private static void assertEqualBytes(String context, byte[] expected, byte[] actual) {
-    if (expected == null || actual == null) {
-      Assert.assertEquals(context, expected, actual);
-    } else {
-      Assert.assertArrayEquals(context, expected, actual);
-    }
+      assertThat(actual).as(context).isEqualTo(expected);
   }
 
   static void assertEquals(Schema schema, Object expected, Object actual) {
@@ -704,28 +687,28 @@ public class TestHelpers {
     }
 
     if (type instanceof StructType) {
-      Assertions.assertThat(expected)
+      assertThat(expected)
           .as("Expected should be an InternalRow: " + context)
           .isInstanceOf(InternalRow.class);
-      Assertions.assertThat(actual)
+      assertThat(actual)
           .as("Actual should be an InternalRow: " + context)
           .isInstanceOf(InternalRow.class);
       assertEquals(context, (StructType) type, (InternalRow) expected, (InternalRow) actual);
 
     } else if (type instanceof ArrayType) {
-      Assertions.assertThat(expected)
+      assertThat(expected)
           .as("Expected should be an ArrayData: " + context)
           .isInstanceOf(ArrayData.class);
-      Assertions.assertThat(actual)
+      assertThat(actual)
           .as("Actual should be an ArrayData: " + context)
           .isInstanceOf(ArrayData.class);
       assertEquals(context, (ArrayType) type, (ArrayData) expected, (ArrayData) actual);
 
     } else if (type instanceof MapType) {
-      Assertions.assertThat(expected)
+      assertThat(expected)
           .as("Expected should be a MapData: " + context)
           .isInstanceOf(MapData.class);
-      Assertions.assertThat(actual)
+      assertThat(actual)
           .as("Actual should be a MapData: " + context)
           .isInstanceOf(MapData.class);
       assertEquals(context, (MapType) type, (MapData) expected, (MapData) actual);
@@ -733,13 +716,13 @@ public class TestHelpers {
     } else if (type instanceof BinaryType) {
       assertEqualBytes(context, (byte[]) expected, (byte[]) actual);
     } else {
-      Assert.assertEquals("Value should match expected: " + context, expected, actual);
+      assertThat(actual).as("Value should match expected: " + context).isEqualTo(expected);
     }
   }
 
   private static void assertEquals(
       String context, StructType struct, InternalRow expected, InternalRow actual) {
-    Assert.assertEquals("Should have correct number of fields", struct.size(), actual.numFields());
+    assertThat(actual.numFields()).as("Should have correct number of fields").isEqualTo(struct.size());
     for (int i = 0; i < actual.numFields(); i += 1) {
       StructField field = struct.fields()[i];
       DataType type = field.dataType();
@@ -753,8 +736,9 @@ public class TestHelpers {
 
   private static void assertEquals(
       String context, ArrayType array, ArrayData expected, ArrayData actual) {
-    Assert.assertEquals(
-        "Should have the same number of elements", expected.numElements(), actual.numElements());
+    assertThat(actual.numElements())
+            .as("Should have the same number of elements")
+            .isEqualTo(expected.numElements());
     DataType type = array.elementType();
     for (int i = 0; i < actual.numElements(); i += 1) {
       assertEquals(
@@ -766,8 +750,9 @@ public class TestHelpers {
   }
 
   private static void assertEquals(String context, MapType map, MapData expected, MapData actual) {
-    Assert.assertEquals(
-        "Should have the same number of elements", expected.numElements(), actual.numElements());
+    assertThat(actual.numElements())
+            .as("Should have the same number of elements")
+            .isEqualTo(expected.numElements());
 
     DataType keyType = map.keyType();
     ArrayData expectedKeys = expected.keyArray();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -168,7 +168,9 @@ public class TestHelpers {
         assertThat(expected).as("Should be an int").isInstanceOf(Integer.class);
         assertThat(actual).as("Should be a Date").isInstanceOf(Date.class);
         LocalDate date = ChronoUnit.DAYS.addTo(EPOCH_DAY, (Integer) expected);
-        assertThat(actual.toString()).as("ISO-8601 date should be equal").isEqualTo(String.valueOf(date));
+        assertThat(actual.toString())
+            .as("ISO-8601 date should be equal")
+            .isEqualTo(String.valueOf(date));
         break;
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;
@@ -182,9 +184,7 @@ public class TestHelpers {
           long tsMicros = (ts.getTime() * 1000) + ((ts.getNanos() / 1000) % 1000);
           assertThat(tsMicros).as("Timestamp micros should be equal").isEqualTo(expected);
         } else {
-          assertThat(actual)
-              .as("Should be a LocalDateTime")
-              .isInstanceOf(LocalDateTime.class);
+          assertThat(actual).as("Should be a LocalDateTime").isInstanceOf(LocalDateTime.class);
 
           LocalDateTime ts = (LocalDateTime) actual;
           Instant instant = ts.toInstant(ZoneOffset.UTC);
@@ -200,26 +200,24 @@ public class TestHelpers {
       case UUID:
         assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
         assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        assertThat(actual.toString()).as("UUID string representation should match").isEqualTo(String.valueOf(expected));
+        assertThat(actual.toString())
+            .as("UUID string representation should match")
+            .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
-        assertThat(expected)
-            .as("Should expect a Fixed")
-            .isInstanceOf(GenericData.Fixed.class);
+        assertThat(expected).as("Should expect a Fixed").isInstanceOf(GenericData.Fixed.class);
         assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Bytes should match").isEqualTo(((GenericData.Fixed) expected).bytes());
+        assertThat(actual)
+            .as("Bytes should match")
+            .isEqualTo(((GenericData.Fixed) expected).bytes());
         break;
       case BINARY:
-        assertThat(expected)
-            .as("Should expect a ByteBuffer")
-            .isInstanceOf(ByteBuffer.class);
+        assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
         assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
         assertThat(actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
-        assertThat(expected)
-            .as("Should expect a BigDecimal")
-            .isInstanceOf(BigDecimal.class);
+        assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
         assertThat(actual).as("Should be a BigDecimal").isInstanceOf(BigDecimal.class);
         assertThat(actual).as("BigDecimals should be equal").isEqualTo(expected);
         break;
@@ -229,18 +227,14 @@ public class TestHelpers {
         assertEqualsSafe(type.asNestedType().asStructType(), (Record) expected, (Row) actual);
         break;
       case LIST:
-        assertThat(expected)
-            .as("Should expect a Collection")
-            .isInstanceOf(Collection.class);
+        assertThat(expected).as("Should expect a Collection").isInstanceOf(Collection.class);
         assertThat(actual).as("Should be a Seq").isInstanceOf(Seq.class);
         List<?> asList = seqAsJavaListConverter((Seq<?>) actual).asJava();
         assertEqualsSafe(type.asNestedType().asListType(), (Collection) expected, asList);
         break;
       case MAP:
         assertThat(expected).as("Should expect a Collection").isInstanceOf(Map.class);
-        assertThat(actual)
-            .as("Should be a Map")
-            .isInstanceOf(scala.collection.Map.class);
+        assertThat(actual).as("Should be a Map").isInstanceOf(scala.collection.Map.class);
         Map<String, ?> asMap =
             mapAsJavaMapConverter((scala.collection.Map<String, ?>) actual).asJava();
         assertEqualsSafe(type.asNestedType().asMapType(), (Map<String, ?>) expected, asMap);
@@ -311,8 +305,8 @@ public class TestHelpers {
         assertThat(actual).as("Should be a double").isInstanceOf(Double.class);
         if (expected instanceof Float) {
           assertThat(Double.doubleToLongBits((double) actual))
-                  .as("Values didn't match")
-                  .isEqualTo(Double.doubleToLongBits(((Number) expected).doubleValue()));
+              .as("Values didn't match")
+              .isEqualTo(Double.doubleToLongBits(((Number) expected).doubleValue()));
         } else {
           assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         }
@@ -331,50 +325,46 @@ public class TestHelpers {
       case UUID:
         assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
         assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        assertThat(actual.toString()).as("UUID string representation should match").isEqualTo(String.valueOf(expected));
+        assertThat(actual.toString())
+            .as("UUID string representation should match")
+            .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
-        assertThat(expected)
-            .as("Should expect a Fixed")
-            .isInstanceOf(GenericData.Fixed.class);
+        assertThat(expected).as("Should expect a Fixed").isInstanceOf(GenericData.Fixed.class);
         assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat((byte[]) actual).as("Bytes should match").isEqualTo(((GenericData.Fixed) expected).bytes());
+        assertThat((byte[]) actual)
+            .as("Bytes should match")
+            .isEqualTo(((GenericData.Fixed) expected).bytes());
         break;
       case BINARY:
-        assertThat(expected)
-            .as("Should expect a ByteBuffer")
-            .isInstanceOf(ByteBuffer.class);
+        assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
         assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat((byte[]) actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
+        assertThat((byte[]) actual)
+            .as("Bytes should match")
+            .isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
-        assertThat(expected)
-            .as("Should expect a BigDecimal")
-            .isInstanceOf(BigDecimal.class);
+        assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
         assertThat(actual).as("Should be a Decimal").isInstanceOf(Decimal.class);
-        assertThat(((Decimal) actual).toJavaBigDecimal()).as("BigDecimals should be equal").isEqualTo(expected);
+        assertThat(((Decimal) actual).toJavaBigDecimal())
+            .as("BigDecimals should be equal")
+            .isEqualTo(expected);
         break;
       case STRUCT:
         assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
-        assertThat(actual)
-            .as("Should be an InternalRow")
-            .isInstanceOf(InternalRow.class);
+        assertThat(actual).as("Should be an InternalRow").isInstanceOf(InternalRow.class);
         assertEqualsUnsafe(
             type.asNestedType().asStructType(), (Record) expected, (InternalRow) actual);
         break;
       case LIST:
-        assertThat(expected)
-            .as("Should expect a Collection")
-            .isInstanceOf(Collection.class);
+        assertThat(expected).as("Should expect a Collection").isInstanceOf(Collection.class);
         assertThat(actual).as("Should be an ArrayData").isInstanceOf(ArrayData.class);
         assertEqualsUnsafe(
             type.asNestedType().asListType(), (Collection) expected, (ArrayData) actual);
         break;
       case MAP:
         assertThat(expected).as("Should expect a Map").isInstanceOf(Map.class);
-        assertThat(actual)
-            .as("Should be an ArrayBasedMapData")
-            .isInstanceOf(MapData.class);
+        assertThat(actual).as("Should be an ArrayBasedMapData").isInstanceOf(MapData.class);
         assertEqualsUnsafe(type.asNestedType().asMapType(), (Map) expected, (MapData) actual);
         break;
       case TIME:
@@ -411,8 +401,8 @@ public class TestHelpers {
           case DATE:
           case TIMESTAMP:
             assertThat(getPrimitiveValue(actual, c, childType))
-                    .as(prefix + "." + fieldName + " - " + childType)
-                    .isEqualTo(getValue(expected, c, childType));
+                .as(prefix + "." + fieldName + " - " + childType)
+                .isEqualTo(getValue(expected, c, childType));
             break;
           case UUID:
           case FIXED:
@@ -472,8 +462,8 @@ public class TestHelpers {
           case DATE:
           case TIMESTAMP:
             assertThat(actual.get(e))
-                    .as(prefix + ".elem " + e + " - " + childType)
-                    .isEqualTo(getValue(expected, e, childType));
+                .as(prefix + ".elem " + e + " - " + childType)
+                .isEqualTo(getValue(expected, e, childType));
             break;
           case UUID:
           case FIXED:
@@ -529,8 +519,8 @@ public class TestHelpers {
         Object actualValue = actual.get(expectedKey);
         if (actualValue == null) {
           assertThat(true)
-                  .as(prefix + ".key=" + expectedKey + " has null")
-                  .isEqualTo(expected.valueArray().isNullAt(e));
+              .as(prefix + ".key=" + expectedKey + " has null")
+              .isEqualTo(expected.valueArray().isNullAt(e));
         } else {
           switch (valueType.typeId()) {
             case BOOLEAN:
@@ -543,8 +533,8 @@ public class TestHelpers {
             case DATE:
             case TIMESTAMP:
               assertThat(actual.get(expectedKey))
-                      .as(prefix + ".key=" + expectedKey + " - " + valueType)
-                      .isEqualTo(getValue(expectedValueArray, e, valueType));
+                  .as(prefix + ".key=" + expectedKey + " - " + valueType)
+                  .isEqualTo(getValue(expectedValueArray, e, valueType));
               break;
             case UUID:
             case FIXED:
@@ -674,7 +664,7 @@ public class TestHelpers {
   }
 
   private static void assertEqualBytes(String context, byte[] expected, byte[] actual) {
-      assertThat(actual).as(context).isEqualTo(expected);
+    assertThat(actual).as(context).isEqualTo(expected);
   }
 
   static void assertEquals(Schema schema, Object expected, Object actual) {
@@ -708,9 +698,7 @@ public class TestHelpers {
       assertThat(expected)
           .as("Expected should be a MapData: " + context)
           .isInstanceOf(MapData.class);
-      assertThat(actual)
-          .as("Actual should be a MapData: " + context)
-          .isInstanceOf(MapData.class);
+      assertThat(actual).as("Actual should be a MapData: " + context).isInstanceOf(MapData.class);
       assertEquals(context, (MapType) type, (MapData) expected, (MapData) actual);
 
     } else if (type instanceof BinaryType) {
@@ -722,7 +710,9 @@ public class TestHelpers {
 
   private static void assertEquals(
       String context, StructType struct, InternalRow expected, InternalRow actual) {
-    assertThat(actual.numFields()).as("Should have correct number of fields").isEqualTo(struct.size());
+    assertThat(actual.numFields())
+        .as("Should have correct number of fields")
+        .isEqualTo(struct.size());
     for (int i = 0; i < actual.numFields(); i += 1) {
       StructField field = struct.fields()[i];
       DataType type = field.dataType();
@@ -737,8 +727,8 @@ public class TestHelpers {
   private static void assertEquals(
       String context, ArrayType array, ArrayData expected, ArrayData actual) {
     assertThat(actual.numElements())
-            .as("Should have the same number of elements")
-            .isEqualTo(expected.numElements());
+        .as("Should have the same number of elements")
+        .isEqualTo(expected.numElements());
     DataType type = array.elementType();
     for (int i = 0; i < actual.numElements(); i += 1) {
       assertEquals(
@@ -751,8 +741,8 @@ public class TestHelpers {
 
   private static void assertEquals(String context, MapType map, MapData expected, MapData actual) {
     assertThat(actual.numElements())
-            .as("Should have the same number of elements")
-            .isEqualTo(expected.numElements());
+        .as("Should have the same number of elements")
+        .isEqualTo(expected.numElements());
 
     DataType keyType = map.keyType();
     ArrayData expectedKeys = expected.keyArray();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -332,16 +332,14 @@ public class TestHelpers {
       case FIXED:
         assertThat(expected).as("Should expect a Fixed").isInstanceOf(GenericData.Fixed.class);
         assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat((byte[]) actual)
+        assertThat(actual)
             .as("Bytes should match")
             .isEqualTo(((GenericData.Fixed) expected).bytes());
         break;
       case BINARY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
         assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat((byte[]) actual)
-            .as("Bytes should match")
-            .isEqualTo(((ByteBuffer) expected).array());
+        assertThat(actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
         assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.UUID;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.FileAppender;
@@ -42,7 +43,7 @@ public class TestOrcWrite {
 
   @Test
   public void splitOffsets() throws IOException {
-    File testFile = temp.toFile();
+    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     Iterable<InternalRow> rows = RandomData.generateSpark(SCHEMA, 1, 0L);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.UUID;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.FileAppender;
@@ -43,7 +42,7 @@ public class TestOrcWrite {
 
   @Test
   public void splitOffsets() throws IOException {
-    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     Iterable<InternalRow> rows = RandomData.generateSpark(SCHEMA, 1, 0L);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
@@ -19,22 +19,23 @@
 package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestOrcWrite {
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private static final Schema SCHEMA =
       new Schema(
@@ -42,8 +43,8 @@ public class TestOrcWrite {
 
   @Test
   public void splitOffsets() throws IOException {
-    File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = temp.toFile();
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     Iterable<InternalRow> rows = RandomData.generateSpark(SCHEMA, 1, 0L);
     FileAppender<InternalRow> writer =
@@ -54,6 +55,6 @@ public class TestOrcWrite {
 
     writer.addAll(rows);
     writer.close();
-    Assert.assertNotNull("Split offsets not present", writer.splitOffsets());
+    assertThat(writer.splitOffsets()).as("Split offsets not present").isNotNull();
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.UUID;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.FileAppender;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.UUID;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
@@ -194,7 +195,7 @@ public class TestParquetAvroReader {
   public void testCorrectness() throws IOException {
     Iterable<Record> records = RandomData.generate(COMPLEX_SCHEMA, 50_000, 34139);
 
-    File testFile = temp.toFile();
+    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =
@@ -224,7 +225,7 @@ public class TestParquetAvroReader {
   }
 
   private File writeTestData(Schema schema, int numRecords, int seed) throws IOException {
-    File testFile = temp.toFile();
+    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
-import java.util.UUID;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
@@ -195,7 +194,7 @@ public class TestParquetAvroReader {
   public void testCorrectness() throws IOException {
     Iterable<Record> records = RandomData.generate(COMPLEX_SCHEMA, 50_000, 34139);
 
-    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =
@@ -225,7 +224,7 @@ public class TestParquetAvroReader {
   }
 
   private File writeTestData(Schema schema, int numRecords, int seed) throws IOException {
-    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroWriter.java
@@ -91,7 +91,7 @@ public class TestParquetAvroWriter {
   public void testCorrectness() throws IOException {
     Iterable<Record> records = RandomData.generate(COMPLEX_SCHEMA, 50_000, 34139);
 
-    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroWriter.java
@@ -20,9 +20,11 @@ package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Files;
@@ -35,13 +37,11 @@ import org.apache.iceberg.parquet.ParquetAvroWriter;
 import org.apache.iceberg.parquet.ParquetSchemaUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.schema.MessageType;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestParquetAvroWriter {
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private static final Schema COMPLEX_SCHEMA =
       new Schema(
@@ -90,8 +90,8 @@ public class TestParquetAvroWriter {
   public void testCorrectness() throws IOException {
     Iterable<Record> records = RandomData.generate(COMPLEX_SCHEMA, 50_000, 34139);
 
-    File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = temp.toFile();
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =
         Parquet.write(Files.localOutput(testFile))
@@ -115,7 +115,7 @@ public class TestParquetAvroWriter {
       Iterator<Record> iter = records.iterator();
       for (Record actual : reader) {
         Record expected = iter.next();
-        Assert.assertEquals("Record " + recordNum + " should match expected", expected, actual);
+        assertThat(actual).as("Record " + recordNum + " should match expected").isEqualTo(expected);
         recordNum += 1;
       }
     }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroWriter.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.UUID;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
@@ -90,7 +91,7 @@ public class TestParquetAvroWriter {
   public void testCorrectness() throws IOException {
     Iterable<Record> records = RandomData.generate(COMPLEX_SCHEMA, 50_000, 34139);
 
-    File testFile = temp.toFile();
+    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroWriter.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
-import java.util.UUID;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroEnums.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroEnums.java
@@ -66,7 +66,7 @@ public class TestSparkAvroEnums {
     Record enumRecord3 = new GenericData.Record(avroSchema); // null enum
     List<Record> expected = ImmutableList.of(enumRecord1, enumRecord2, enumRecord3);
 
-    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (DataFileWriter<Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroEnums.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroEnums.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.UUID;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
@@ -65,7 +66,7 @@ public class TestSparkAvroEnums {
     Record enumRecord3 = new GenericData.Record(avroSchema); // null enum
     List<Record> expected = ImmutableList.of(enumRecord1, enumRecord2, enumRecord3);
 
-    File testFile = temp.toFile();
+    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (DataFileWriter<Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroEnums.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroEnums.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.UUID;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroEnums.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroEnums.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.iceberg.spark.data;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroEnums.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroEnums.java
@@ -17,9 +17,11 @@
  * under the License.
  */
 package org.apache.iceberg.spark.data;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileWriter;
@@ -34,14 +36,12 @@ import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestSparkAvroEnums {
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   @Test
   public void writeAndValidateEnums() throws IOException {
@@ -64,8 +64,8 @@ public class TestSparkAvroEnums {
     Record enumRecord3 = new GenericData.Record(avroSchema); // null enum
     List<Record> expected = ImmutableList.of(enumRecord1, enumRecord2, enumRecord3);
 
-    File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = temp.toFile();
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (DataFileWriter<Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
       writer.create(avroSchema, testFile);
@@ -90,7 +90,7 @@ public class TestSparkAvroEnums {
           expected.get(i).get("enumCol") == null ? null : expected.get(i).get("enumCol").toString();
       String sparkString =
           rows.get(i).getUTF8String(0) == null ? null : rows.get(i).getUTF8String(0).toString();
-      Assert.assertEquals(expectedEnumString, sparkString);
+      assertThat(sparkString).isEqualTo(expectedEnumString);
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
@@ -38,7 +39,7 @@ public class TestSparkAvroReader extends AvroDataTest {
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expected = RandomData.generateList(schema, 100, 0L);
 
-    File testFile = temp.toFile();
+    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.spark.data.TestHelpers.assertEqualsUnsafe;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,15 +32,14 @@ import org.apache.iceberg.avro.AvroIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.junit.Assert;
 
 public class TestSparkAvroReader extends AvroDataTest {
   @Override
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expected = RandomData.generateList(schema, 100, 0L);
 
-    File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = temp.toFile();
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =
         Avro.write(Files.localOutput(testFile)).schema(schema).named("test").build()) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
@@ -39,7 +39,7 @@ public class TestSparkAvroReader extends AvroDataTest {
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expected = RandomData.generateList(schema, 100, 0L);
 
-    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import java.util.UUID;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -48,7 +48,9 @@ public class TestSparkDateTimes {
   public void checkSparkDate(String dateString) {
     Literal<Integer> date = Literal.of(dateString).to(Types.DateType.get());
     String sparkDate = DateTimeUtils.toJavaDate(date.value()).toString();
-    assertThat(sparkDate).as("Should be the same date (" + date.value() + ")").isEqualTo(dateString);
+    assertThat(sparkDate)
+        .as("Should be the same date (" + date.value() + ")")
+        .isEqualTo(dateString);
   }
 
   @Test
@@ -69,6 +71,8 @@ public class TestSparkDateTimes {
     ZoneId zoneId = DateTimeUtils.getZoneId("UTC");
     TimestampFormatter formatter = TimestampFormatter.getFractionFormatter(zoneId);
     String sparkTimestamp = formatter.format(ts.value());
-    assertThat(sparkTimestamp).as("Should be the same timestamp (" + ts.value() + ")").isEqualTo(sparkRepr);
+    assertThat(sparkTimestamp)
+        .as("Should be the same timestamp (" + ts.value() + ")")
+        .isEqualTo(sparkRepr);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -18,14 +18,15 @@
  */
 package org.apache.iceberg.spark.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.ZoneId;
 import java.util.TimeZone;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.catalyst.util.TimestampFormatter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkDateTimes {
   @Test
@@ -47,7 +48,7 @@ public class TestSparkDateTimes {
   public void checkSparkDate(String dateString) {
     Literal<Integer> date = Literal.of(dateString).to(Types.DateType.get());
     String sparkDate = DateTimeUtils.toJavaDate(date.value()).toString();
-    Assert.assertEquals("Should be the same date (" + date.value() + ")", dateString, sparkDate);
+    assertThat(sparkDate).as("Should be the same date (" + date.value() + ")").isEqualTo(dateString);
   }
 
   @Test
@@ -68,7 +69,6 @@ public class TestSparkDateTimes {
     ZoneId zoneId = DateTimeUtils.getZoneId("UTC");
     TimestampFormatter formatter = TimestampFormatter.getFractionFormatter(zoneId);
     String sparkTimestamp = formatter.format(ts.value());
-    Assert.assertEquals(
-        "Should be the same timestamp (" + ts.value() + ")", sparkRepr, sparkTimestamp);
+    assertThat(sparkTimestamp).as("Should be the same timestamp (" + ts.value() + ")").isEqualTo(sparkRepr);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
@@ -200,10 +200,10 @@ public class TestSparkOrcReadMetadataColumns {
       final Iterator<InternalRow> actualRows = reader.iterator();
       final Iterator<InternalRow> expectedRows = expected.iterator();
       while (expectedRows.hasNext()) {
-        assertThat(actualRows.hasNext()).as("Should have expected number of rows").isTrue();
+        assertThat(actualRows).as("Should have expected number of rows").hasNext();
         TestHelpers.assertEquals(PROJECTION_SCHEMA, expectedRows.next(), actualRows.next());
       }
-      assertThat(actualRows.hasNext()).as("Should not have extra rows").isFalse();
+      assertThat(actualRows).as("Should not have extra rows").isExhausted();
     } finally {
       if (reader != null) {
         reader.close();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
@@ -57,7 +57,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -126,18 +126,18 @@ public class TestSparkOrcReadMetadataColumns {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadRowNumbers() throws IOException {
     readAndValidate(null, null, null, EXPECTED_ROWS);
   }
 
-  @Test
+  @TestTemplate
   public void testReadRowNumbersWithFilter() throws IOException {
     readAndValidate(
         Expressions.greaterThanOrEqual("id", 500), null, null, EXPECTED_ROWS.subList(500, 1000));
   }
 
-  @Test
+  @TestTemplate
   public void testReadRowNumbersWithSplits() throws IOException {
     Reader reader;
     try {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
@@ -110,7 +110,7 @@ public class TestSparkOrcReadMetadataColumns {
 
   @BeforeEach
   public void writeFile() throws IOException {
-    File testFile = temp.toFile();
+    testFile = temp.toFile();
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<InternalRow> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -111,7 +110,7 @@ public class TestSparkOrcReadMetadataColumns {
 
   @BeforeEach
   public void writeFile() throws IOException {
-    testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<InternalRow> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.CloseableIterable;
@@ -63,7 +62,7 @@ public class TestSparkOrcReader extends AvroDataTest {
 
   private void writeAndValidateRecords(Schema schema, Iterable<InternalRow> expected)
       throws IOException {
-    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<InternalRow> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
@@ -81,10 +81,10 @@ public class TestSparkOrcReader extends AvroDataTest {
       final Iterator<InternalRow> actualRows = reader.iterator();
       final Iterator<InternalRow> expectedRows = expected.iterator();
       while (expectedRows.hasNext()) {
-        assertThat(actualRows.hasNext()).as("Should have expected number of rows").isTrue();
+        assertThat(actualRows).as("Should have expected number of rows").hasNext();
         assertEquals(schema, expectedRows.next(), actualRows.next());
       }
-      assertThat(actualRows.hasNext()).as("Should not have extra rows").isFalse();
+      assertThat(actualRows).as("Should not have extra rows").isExhausted();
     }
 
     try (CloseableIterable<ColumnarBatch> reader =
@@ -97,10 +97,10 @@ public class TestSparkOrcReader extends AvroDataTest {
       final Iterator<InternalRow> actualRows = batchesToRows(reader.iterator());
       final Iterator<InternalRow> expectedRows = expected.iterator();
       while (expectedRows.hasNext()) {
-        assertThat(actualRows.hasNext()).as("Should have expected number of rows").isTrue();
+        assertThat(actualRows).as("Should have expected number of rows").hasNext();
         assertEquals(schema, expectedRows.next(), actualRows.next());
       }
-      assertThat(actualRows.hasNext()).as("Should not have extra rows").isFalse();
+      assertThat(actualRows).as("Should not have extra rows").isExhausted();
     }
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.spark.data.TestHelpers.assertEquals;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,8 +38,7 @@ import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkOrcReader extends AvroDataTest {
   @Override
@@ -62,8 +62,8 @@ public class TestSparkOrcReader extends AvroDataTest {
 
   private void writeAndValidateRecords(Schema schema, Iterable<InternalRow> expected)
       throws IOException {
-    final File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = temp.toFile();
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<InternalRow> writer =
         ORC.write(Files.localOutput(testFile))
@@ -81,10 +81,10 @@ public class TestSparkOrcReader extends AvroDataTest {
       final Iterator<InternalRow> actualRows = reader.iterator();
       final Iterator<InternalRow> expectedRows = expected.iterator();
       while (expectedRows.hasNext()) {
-        Assert.assertTrue("Should have expected number of rows", actualRows.hasNext());
+        assertThat(actualRows.hasNext()).as("Should have expected number of rows").isTrue();
         assertEquals(schema, expectedRows.next(), actualRows.next());
       }
-      Assert.assertFalse("Should not have extra rows", actualRows.hasNext());
+      assertThat(actualRows.hasNext()).as("Should not have extra rows").isFalse();
     }
 
     try (CloseableIterable<ColumnarBatch> reader =
@@ -97,10 +97,10 @@ public class TestSparkOrcReader extends AvroDataTest {
       final Iterator<InternalRow> actualRows = batchesToRows(reader.iterator());
       final Iterator<InternalRow> expectedRows = expected.iterator();
       while (expectedRows.hasNext()) {
-        Assert.assertTrue("Should have expected number of rows", actualRows.hasNext());
+        assertThat(actualRows.hasNext()).as("Should have expected number of rows").isTrue();
         assertEquals(schema, expectedRows.next(), actualRows.next());
       }
-      Assert.assertFalse("Should not have extra rows", actualRows.hasNext());
+      assertThat(actualRows.hasNext()).as("Should not have extra rows").isFalse();
     }
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.CloseableIterable;
@@ -62,7 +63,7 @@ public class TestSparkOrcReader extends AvroDataTest {
 
   private void writeAndValidateRecords(Schema schema, Iterable<InternalRow> expected)
       throws IOException {
-    File testFile = temp.toFile();
+    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<InternalRow> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -295,11 +295,11 @@ public class TestSparkParquetReadMetadataColumns {
       final Iterator<InternalRow> actualRows = reader.iterator();
 
       for (InternalRow internalRow : expected) {
-        assertThat(actualRows.hasNext()).as("Should have expected number of rows").isTrue();
+        assertThat(actualRows).as("Should have expected number of rows").hasNext();
         TestHelpers.assertEquals(PROJECTION_SCHEMA, internalRow, actualRows.next());
       }
 
-      assertThat(actualRows.hasNext()).as("Should not have extra rows").isFalse();
+      assertThat(actualRows).as("Should not have extra rows").isExhausted();
     }
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -118,8 +118,7 @@ public class TestSparkParquetReadMetadataColumns {
     return new Object[][] {new Object[] {false}, new Object[] {true}};
   }
 
-  @TempDir
-  public java.nio.file.Path temp;
+  @TempDir public java.nio.file.Path temp;
 
   private final boolean vectorized;
   private File testFile;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,12 +59,9 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -119,7 +118,8 @@ public class TestSparkParquetReadMetadataColumns {
     return new Object[][] {new Object[] {false}, new Object[] {true}};
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  public java.nio.file.Path temp;
 
   private final boolean vectorized;
   private File testFile;
@@ -128,14 +128,14 @@ public class TestSparkParquetReadMetadataColumns {
     this.vectorized = vectorized;
   }
 
-  @Before
+  @BeforeEach
   public void writeFile() throws IOException {
     List<Path> fileSplits = Lists.newArrayList();
     StructType struct = SparkSchemaUtil.convert(DATA_SCHEMA);
     Configuration conf = new Configuration();
 
-    testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    testFile = temp.toFile();
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
     ParquetFileWriter parquetFileWriter =
         new ParquetFileWriter(
             conf,
@@ -144,8 +144,8 @@ public class TestSparkParquetReadMetadataColumns {
 
     parquetFileWriter.start();
     for (int i = 0; i < NUM_ROW_GROUPS; i += 1) {
-      File split = temp.newFile();
-      Assert.assertTrue("Delete should succeed", split.delete());
+      File split = temp.toFile();
+      assertThat(split.delete()).as("Delete should succeed").isTrue();
       fileSplits.add(new Path(split.getAbsolutePath()));
       try (FileAppender<InternalRow> writer =
           Parquet.write(Files.localOutput(split))
@@ -171,7 +171,7 @@ public class TestSparkParquetReadMetadataColumns {
 
   @Test
   public void testReadRowNumbersWithDelete() throws IOException {
-    Assume.assumeTrue(vectorized);
+    assumeTrue(vectorized);
 
     List<InternalRow> expectedRowsAfterDelete = Lists.newArrayList();
     EXPECTED_ROWS.forEach(row -> expectedRowsAfterDelete.add(row.copy()));
@@ -295,11 +295,11 @@ public class TestSparkParquetReadMetadataColumns {
       final Iterator<InternalRow> actualRows = reader.iterator();
 
       for (InternalRow internalRow : expected) {
-        Assert.assertTrue("Should have expected number of rows", actualRows.hasNext());
+        assertThat(actualRows.hasNext()).as("Should have expected number of rows").isTrue();
         TestHelpers.assertEquals(PROJECTION_SCHEMA, internalRow, actualRows.next());
       }
 
-      Assert.assertFalse("Should not have extra rows", actualRows.hasNext());
+      assertThat(actualRows.hasNext()).as("Should not have extra rows").isFalse();
     }
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Files;
@@ -132,7 +131,7 @@ public class TestSparkParquetReadMetadataColumns {
     StructType struct = SparkSchemaUtil.convert(DATA_SCHEMA);
     Configuration conf = new Configuration();
 
-    testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
     ParquetFileWriter parquetFileWriter =
         new ParquetFileWriter(
@@ -142,7 +141,7 @@ public class TestSparkParquetReadMetadataColumns {
 
     parquetFileWriter.start();
     for (int i = 0; i < NUM_ROW_GROUPS; i += 1) {
-      File split = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+      File split = File.createTempFile("junit", null, temp.toFile());
       assertThat(split.delete()).as("Delete should succeed").isTrue();
       fileSplits.add(new Path(split.getAbsolutePath()));
       try (FileAppender<InternalRow> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,10 +29,14 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
@@ -57,16 +63,12 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestSparkParquetReadMetadataColumns {
   private static final Schema DATA_SCHEMA =
       new Schema(
@@ -114,28 +116,24 @@ public class TestSparkParquetReadMetadataColumns {
     }
   }
 
-  @Parameterized.Parameters(name = "vectorized = {0}")
+  @Parameters(name = "vectorized = {0}")
   public static Object[][] parameters() {
     return new Object[][] {new Object[] {false}, new Object[] {true}};
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir protected java.nio.file.Path temp;
 
-  private final boolean vectorized;
+  @Parameter private boolean vectorized;
   private File testFile;
 
-  public TestSparkParquetReadMetadataColumns(boolean vectorized) {
-    this.vectorized = vectorized;
-  }
-
-  @Before
+  @BeforeEach
   public void writeFile() throws IOException {
     List<Path> fileSplits = Lists.newArrayList();
     StructType struct = SparkSchemaUtil.convert(DATA_SCHEMA);
     Configuration conf = new Configuration();
 
-    testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
     ParquetFileWriter parquetFileWriter =
         new ParquetFileWriter(
             conf,
@@ -144,8 +142,8 @@ public class TestSparkParquetReadMetadataColumns {
 
     parquetFileWriter.start();
     for (int i = 0; i < NUM_ROW_GROUPS; i += 1) {
-      File split = temp.newFile();
-      Assert.assertTrue("Delete should succeed", split.delete());
+      File split = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+      assertThat(split.delete()).as("Delete should succeed").isTrue();
       fileSplits.add(new Path(split.getAbsolutePath()));
       try (FileAppender<InternalRow> writer =
           Parquet.write(Files.localOutput(split))
@@ -164,14 +162,14 @@ public class TestSparkParquetReadMetadataColumns {
             .getKeyValueMetaData());
   }
 
-  @Test
+  @TestTemplate
   public void testReadRowNumbers() throws IOException {
     readAndValidate(null, null, null, EXPECTED_ROWS);
   }
 
-  @Test
+  @TestTemplate
   public void testReadRowNumbersWithDelete() throws IOException {
-    Assume.assumeTrue(vectorized);
+    assumeThat(vectorized).isTrue();
 
     List<InternalRow> expectedRowsAfterDelete = Lists.newArrayList();
     EXPECTED_ROWS.forEach(row -> expectedRowsAfterDelete.add(row.copy()));
@@ -229,7 +227,7 @@ public class TestSparkParquetReadMetadataColumns {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadRowNumbersWithFilter() throws IOException {
     // current iceberg supports row group filter.
     for (int i = 1; i < 5; i += 1) {
@@ -243,7 +241,7 @@ public class TestSparkParquetReadMetadataColumns {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadRowNumbersWithSplits() throws IOException {
     ParquetFileReader fileReader =
         new ParquetFileReader(
@@ -295,11 +293,11 @@ public class TestSparkParquetReadMetadataColumns {
       final Iterator<InternalRow> actualRows = reader.iterator();
 
       for (InternalRow internalRow : expected) {
-        Assert.assertTrue("Should have expected number of rows", actualRows.hasNext());
+        assertThat(actualRows).as("Should have expected number of rows").hasNext();
         TestHelpers.assertEquals(PROJECTION_SCHEMA, internalRow, actualRows.next());
       }
 
-      Assert.assertFalse("Should not have extra rows", actualRows.hasNext());
+      assertThat(actualRows).as("Should not have extra rows").isExhausted();
     }
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFiles;
@@ -73,7 +72,7 @@ public class TestSparkParquetReader extends AvroDataTest {
 
     List<GenericData.Record> expected = RandomData.generateList(schema, 100, 0L);
 
-    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<GenericData.Record> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFiles;
@@ -72,7 +73,7 @@ public class TestSparkParquetReader extends AvroDataTest {
 
     List<GenericData.Record> expected = RandomData.generateList(schema, 100, 0L);
 
-    File testFile = temp.toFile();
+    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<GenericData.Record> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
@@ -63,7 +63,10 @@ import org.junit.jupiter.api.Test;
 public class TestSparkParquetReader extends AvroDataTest {
   @Override
   protected void writeAndValidate(Schema schema) throws IOException {
-    assumeTrue(null == TypeUtil.find(schema,
+    assumeTrue(
+        null
+            == TypeUtil.find(
+                schema,
                 type -> type.isMapType() && type.asMapType().keyType() != Types.StringType.get()),
         "Parquet Avro cannot write non-string map keys");
 
@@ -108,7 +111,7 @@ public class TestSparkParquetReader extends AvroDataTest {
             schema,
             PartitionSpec.unpartitioned(),
             ImmutableMap.of(),
-                java.nio.file.Files.createTempDirectory(temp, null).toFile().getCanonicalPath());
+            java.nio.file.Files.createTempDirectory(temp, null).toFile().getCanonicalPath());
 
     table
         .newAppend()
@@ -126,8 +129,7 @@ public class TestSparkParquetReader extends AvroDataTest {
 
   @Test
   public void testInt96TimestampProducedBySparkIsReadCorrectly() throws IOException {
-    String outputFilePath =
-        String.format("%s/%s", temp.toAbsolutePath(), "parquet_int96.parquet");
+    String outputFilePath = String.format("%s/%s", temp.toAbsolutePath(), "parquet_int96.parquet");
     HadoopOutputFile outputFile =
         HadoopOutputFile.fromPath(
             new org.apache.hadoop.fs.Path(outputFilePath), new Configuration());

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
@@ -84,10 +84,10 @@ public class TestSparkParquetReader extends AvroDataTest {
             .build()) {
       Iterator<InternalRow> rows = reader.iterator();
       for (GenericData.Record record : expected) {
-        assertThat(rows.hasNext()).as("Should have expected number of rows").isTrue();
+        assertThat(rows).as("Should have expected number of rows").hasNext();
         assertEqualsUnsafe(schema.asStruct(), record, rows.next());
       }
-      assertThat(rows.hasNext()).as("Should not have extra rows").isFalse();
+      assertThat(rows).as("Should not have extra rows").isExhausted();
     }
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.spark.data;
 import static org.apache.iceberg.spark.data.TestHelpers.assertEqualsUnsafe;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,12 +63,12 @@ import org.junit.jupiter.api.Test;
 public class TestSparkParquetReader extends AvroDataTest {
   @Override
   protected void writeAndValidate(Schema schema) throws IOException {
-    assumeTrue(
-        null
-            == TypeUtil.find(
+    assumeThat(
+            TypeUtil.find(
                 schema,
-                type -> type.isMapType() && type.asMapType().keyType() != Types.StringType.get()),
-        "Parquet Avro cannot write non-string map keys");
+                type -> type.isMapType() && type.asMapType().keyType() != Types.StringType.get()))
+        .as("Parquet Avro cannot write non-string map keys")
+        .isNull();
 
     List<GenericData.Record> expected = RandomData.generateList(schema, 100, 0L);
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
-import java.util.UUID;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.CloseableIterable;
@@ -89,7 +88,7 @@ public class TestSparkParquetWriter {
     int numRows = 50_000;
     Iterable<InternalRow> records = RandomData.generateSpark(COMPLEX_SCHEMA, numRows, 19981);
 
-    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<InternalRow> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -110,10 +110,10 @@ public class TestSparkParquetWriter {
       Iterator<InternalRow> expected = records.iterator();
       Iterator<InternalRow> rows = reader.iterator();
       for (int i = 0; i < numRows; i += 1) {
-        assertThat(rows.hasNext()).as("Should have expected number of rows").isTrue();
+        assertThat(rows).as("Should have expected number of rows").hasNext();
         TestHelpers.assertEquals(COMPLEX_SCHEMA, expected.next(), rows.next());
       }
-      assertThat(rows.hasNext()).as("Should not have extra rows").isFalse();
+      assertThat(rows).as("Should not have extra rows").isExhausted();
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
-import java.util.UUID;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.CloseableIterable;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class TestSparkParquetWriter {
-  @TempDir public Path temp;
+  @TempDir private Path temp;
 
   private static final Schema COMPLEX_SCHEMA =
       new Schema(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.UUID;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.CloseableIterable;
@@ -88,7 +89,7 @@ public class TestSparkParquetWriter {
     int numRows = 50_000;
     Iterable<InternalRow> records = RandomData.generateSpark(COMPLEX_SCHEMA, numRows, 19981);
 
-    File testFile = temp.toFile();
+    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<InternalRow> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -20,10 +20,13 @@ package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.UUID;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.CloseableIterable;
@@ -32,13 +35,11 @@ import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestSparkParquetWriter {
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir public Path temp;
 
   private static final Schema COMPLEX_SCHEMA =
       new Schema(
@@ -88,8 +89,8 @@ public class TestSparkParquetWriter {
     int numRows = 50_000;
     Iterable<InternalRow> records = RandomData.generateSpark(COMPLEX_SCHEMA, numRows, 19981);
 
-    File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = temp.toFile();
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<InternalRow> writer =
         Parquet.write(Files.localOutput(testFile))
@@ -110,10 +111,10 @@ public class TestSparkParquetWriter {
       Iterator<InternalRow> expected = records.iterator();
       Iterator<InternalRow> rows = reader.iterator();
       for (int i = 0; i < numRows; i += 1) {
-        Assert.assertTrue("Should have expected number of rows", rows.hasNext());
+        assertThat(rows.hasNext()).as("Should have expected number of rows").isTrue();
         TestHelpers.assertEquals(COMPLEX_SCHEMA, expected.next(), rows.next());
       }
-      Assert.assertFalse("Should not have extra rows", rows.hasNext());
+      assertThat(rows.hasNext()).as("Should not have extra rows").isFalse();
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkRecordOrcReaderWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkRecordOrcReaderWriter.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,15 +39,14 @@ import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkRecordOrcReaderWriter extends AvroDataTest {
   private static final int NUM_RECORDS = 200;
 
   private void writeAndValidate(Schema schema, List<Record> expectedRecords) throws IOException {
-    final File originalFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", originalFile.delete());
+    final File originalFile = temp.toFile();
+    assertThat(originalFile.delete()).as("Delete should succeed").isTrue();
 
     // Write few generic records into the original test file.
     try (FileAppender<Record> writer =
@@ -68,8 +68,8 @@ public class TestSparkRecordOrcReaderWriter extends AvroDataTest {
       assertEqualsUnsafe(schema.asStruct(), expectedRecords, reader, expectedRecords.size());
     }
 
-    final File anotherFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", anotherFile.delete());
+    final File anotherFile = temp.toFile();
+    assertThat(anotherFile.delete()).as("Delete should succeed").isTrue();
 
     // Write those spark InternalRows into a new file again.
     try (FileAppender<InternalRow> writer =
@@ -130,12 +130,12 @@ public class TestSparkRecordOrcReaderWriter extends AvroDataTest {
     Iterator<Record> expectedIter = expected.iterator();
     Iterator<Record> actualIter = actual.iterator();
     for (int i = 0; i < size; i += 1) {
-      Assert.assertTrue("Expected iterator should have more rows", expectedIter.hasNext());
-      Assert.assertTrue("Actual iterator should have more rows", actualIter.hasNext());
-      Assert.assertEquals("Should have same rows.", expectedIter.next(), actualIter.next());
+      assertThat(expectedIter.hasNext()).as("Expected iterator should have more rows").isTrue();
+      assertThat(actualIter.hasNext()).as("Actual iterator should have more rows").isTrue();
+      assertThat(actualIter.next()).as("Should have same rows.").isEqualTo(expectedIter.next());
     }
-    Assert.assertFalse("Expected iterator should not have any extra rows.", expectedIter.hasNext());
-    Assert.assertFalse("Actual iterator should not have any extra rows.", actualIter.hasNext());
+    assertThat(expectedIter.hasNext()).as("Expected iterator should not have any extra rows.").isFalse();
+    assertThat(actualIter.hasNext()).as("Actual iterator should not have any extra rows.").isFalse();
   }
 
   private static void assertEqualsUnsafe(
@@ -143,11 +143,11 @@ public class TestSparkRecordOrcReaderWriter extends AvroDataTest {
     Iterator<Record> expectedIter = expected.iterator();
     Iterator<InternalRow> actualIter = actual.iterator();
     for (int i = 0; i < size; i += 1) {
-      Assert.assertTrue("Expected iterator should have more rows", expectedIter.hasNext());
-      Assert.assertTrue("Actual iterator should have more rows", actualIter.hasNext());
+      assertThat(expectedIter.hasNext()).as("Expected iterator should have more rows").isTrue();
+      assertThat(actualIter.hasNext()).as("Actual iterator should have more rows").isTrue();
       GenericsHelpers.assertEqualsUnsafe(struct, expectedIter.next(), actualIter.next());
     }
-    Assert.assertFalse("Expected iterator should not have any extra rows.", expectedIter.hasNext());
-    Assert.assertFalse("Actual iterator should not have any extra rows.", actualIter.hasNext());
+    assertThat(expectedIter.hasNext()).as("Expected iterator should not have any extra rows.").isFalse();
+    assertThat(actualIter.hasNext()).as("Actual iterator should not have any extra rows.").isFalse();
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkRecordOrcReaderWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkRecordOrcReaderWriter.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
@@ -46,8 +45,7 @@ public class TestSparkRecordOrcReaderWriter extends AvroDataTest {
   private static final int NUM_RECORDS = 200;
 
   private void writeAndValidate(Schema schema, List<Record> expectedRecords) throws IOException {
-    final File originalFile =
-        File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    final File originalFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(originalFile.delete()).as("Delete should succeed").isTrue();
 
     // Write few generic records into the original test file.
@@ -70,7 +68,7 @@ public class TestSparkRecordOrcReaderWriter extends AvroDataTest {
       assertEqualsUnsafe(schema.asStruct(), expectedRecords, reader, expectedRecords.size());
     }
 
-    final File anotherFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    final File anotherFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(anotherFile.delete()).as("Delete should succeed").isTrue();
 
     // Write those spark InternalRows into a new file again.

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkRecordOrcReaderWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkRecordOrcReaderWriter.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
@@ -45,7 +46,8 @@ public class TestSparkRecordOrcReaderWriter extends AvroDataTest {
   private static final int NUM_RECORDS = 200;
 
   private void writeAndValidate(Schema schema, List<Record> expectedRecords) throws IOException {
-    final File originalFile = temp.toFile();
+    final File originalFile =
+        File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(originalFile.delete()).as("Delete should succeed").isTrue();
 
     // Write few generic records into the original test file.
@@ -68,7 +70,7 @@ public class TestSparkRecordOrcReaderWriter extends AvroDataTest {
       assertEqualsUnsafe(schema.asStruct(), expectedRecords, reader, expectedRecords.size());
     }
 
-    final File anotherFile = temp.toFile();
+    final File anotherFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(anotherFile.delete()).as("Delete should succeed").isTrue();
 
     // Write those spark InternalRows into a new file again.

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkRecordOrcReaderWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkRecordOrcReaderWriter.java
@@ -130,12 +130,12 @@ public class TestSparkRecordOrcReaderWriter extends AvroDataTest {
     Iterator<Record> expectedIter = expected.iterator();
     Iterator<Record> actualIter = actual.iterator();
     for (int i = 0; i < size; i += 1) {
-      assertThat(expectedIter.hasNext()).as("Expected iterator should have more rows").isTrue();
-      assertThat(actualIter.hasNext()).as("Actual iterator should have more rows").isTrue();
+      assertThat(expectedIter).as("Expected iterator should have more rows").hasNext();
+      assertThat(actualIter).as("Actual iterator should have more rows").hasNext();
       assertThat(actualIter.next()).as("Should have same rows.").isEqualTo(expectedIter.next());
     }
-    assertThat(expectedIter.hasNext()).as("Expected iterator should not have any extra rows.").isFalse();
-    assertThat(actualIter.hasNext()).as("Actual iterator should not have any extra rows.").isFalse();
+    assertThat(expectedIter).as("Expected iterator should not have any extra rows.").isExhausted();
+    assertThat(actualIter).as("Actual iterator should not have any extra rows.").isExhausted();
   }
 
   private static void assertEqualsUnsafe(
@@ -143,11 +143,11 @@ public class TestSparkRecordOrcReaderWriter extends AvroDataTest {
     Iterator<Record> expectedIter = expected.iterator();
     Iterator<InternalRow> actualIter = actual.iterator();
     for (int i = 0; i < size; i += 1) {
-      assertThat(expectedIter.hasNext()).as("Expected iterator should have more rows").isTrue();
-      assertThat(actualIter.hasNext()).as("Actual iterator should have more rows").isTrue();
+      assertThat(expectedIter).as("Expected iterator should have more rows").hasNext();
+      assertThat(actualIter).as("Actual iterator should have more rows").hasNext();
       GenericsHelpers.assertEqualsUnsafe(struct, expectedIter.next(), actualIter.next());
     }
-    assertThat(expectedIter.hasNext()).as("Expected iterator should not have any extra rows.").isFalse();
-    assertThat(actualIter.hasNext()).as("Actual iterator should not have any extra rows.").isFalse();
+    assertThat(expectedIter).as("Expected iterator should not have any extra rows.").isExhausted();
+    assertThat(actualIter).as("Actual iterator should not have any extra rows.").isExhausted();
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.UUID;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.FileAppender;
@@ -59,8 +58,7 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
   @Test
   public void testMixedDictionaryNonDictionaryReads() throws IOException {
     Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
-    File dictionaryEncodedFile =
-        File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File dictionaryEncodedFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(dictionaryEncodedFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> dictionaryEncodableData =
         RandomData.generateDictionaryEncodableData(
@@ -70,7 +68,7 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
       writer.addAll(dictionaryEncodableData);
     }
 
-    File plainEncodingFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File plainEncodingFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(plainEncodingFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> nonDictionaryData =
         RandomData.generate(schema, 10000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE);
@@ -79,7 +77,7 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
     }
 
     int rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
-    File mixedFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File mixedFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(mixedFile.delete()).as("Delete should succeed").isTrue();
     Parquet.concat(
         ImmutableList.of(dictionaryEncodedFile, plainEncodingFile, dictionaryEncodedFile),

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.data.parquet.vectorized;
 
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,9 +33,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.spark.data.RandomData;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVectorizedReads {
 
@@ -52,14 +52,14 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
 
   @Test
   @Override
-  @Ignore // Ignored since this code path is already tested in TestParquetVectorizedReads
+  @Disabled // Ignored since this code path is already tested in TestParquetVectorizedReads
   public void testVectorizedReadsWithNewContainers() throws IOException {}
 
   @Test
   public void testMixedDictionaryNonDictionaryReads() throws IOException {
     Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
-    File dictionaryEncodedFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", dictionaryEncodedFile.delete());
+    File dictionaryEncodedFile = temp.toFile();
+    assertThat(dictionaryEncodedFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> dictionaryEncodableData =
         RandomData.generateDictionaryEncodableData(
             schema, 10000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE);
@@ -68,8 +68,8 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
       writer.addAll(dictionaryEncodableData);
     }
 
-    File plainEncodingFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", plainEncodingFile.delete());
+    File plainEncodingFile = temp.toFile();
+    assertThat(plainEncodingFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> nonDictionaryData =
         RandomData.generate(schema, 10000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE);
     try (FileAppender<GenericData.Record> writer = getParquetWriter(schema, plainEncodingFile)) {
@@ -77,8 +77,8 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
     }
 
     int rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
-    File mixedFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", mixedFile.delete());
+    File mixedFile = temp.toFile();
+    assertThat(mixedFile.delete()).as("Delete should succeed").isTrue();
     Parquet.concat(
         ImmutableList.of(dictionaryEncodedFile, plainEncodingFile, dictionaryEncodedFile),
         mixedFile,

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.UUID;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.FileAppender;
@@ -58,7 +59,8 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
   @Test
   public void testMixedDictionaryNonDictionaryReads() throws IOException {
     Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
-    File dictionaryEncodedFile = temp.toFile();
+    File dictionaryEncodedFile =
+        File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(dictionaryEncodedFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> dictionaryEncodableData =
         RandomData.generateDictionaryEncodableData(
@@ -68,7 +70,7 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
       writer.addAll(dictionaryEncodableData);
     }
 
-    File plainEncodingFile = temp.toFile();
+    File plainEncodingFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(plainEncodingFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> nonDictionaryData =
         RandomData.generate(schema, 10000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE);
@@ -77,7 +79,7 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
     }
 
     int rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
-    File mixedFile = temp.toFile();
+    File mixedFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(mixedFile.delete()).as("Delete should succeed").isTrue();
     Parquet.concat(
         ImmutableList.of(dictionaryEncodedFile, plainEncodingFile, dictionaryEncodedFile),

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryFallbackToPlainEncodingVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryFallbackToPlainEncodingVectorizedReads.java
@@ -29,8 +29,8 @@ import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Function;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.spark.data.RandomData;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TestParquetDictionaryFallbackToPlainEncodingVectorizedReads
     extends TestParquetVectorizedReads {
@@ -65,11 +65,11 @@ public class TestParquetDictionaryFallbackToPlainEncodingVectorizedReads
 
   @Test
   @Override
-  @Ignore // Fallback encoding not triggered when data is mostly null
+  @Disabled // Fallback encoding not triggered when data is mostly null
   public void testMostlyNullsForOptionalFields() {}
 
   @Test
   @Override
-  @Ignore // Ignored since this code path is already tested in TestParquetVectorizedReads
+  @Disabled // Ignored since this code path is already tested in TestParquetVectorizedReads
   public void testVectorizedReadsWithNewContainers() throws IOException {}
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.UUID;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
@@ -92,7 +91,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         generateData(schema, numRecords, seed, nullPercentage, transform);
 
     // write a test parquet file using iceberg writer
-    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<GenericData.Record> writer = getParquetWriter(schema, testFile)) {
@@ -275,7 +274,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
             optional(102, "float_data", Types.FloatType.get()),
             optional(103, "decimal_data", Types.DecimalType.of(10, 5)));
 
-    File dataFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File dataFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(dataFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> data =
         generateData(writeSchema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
@@ -304,7 +303,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
             optional(103, "double_data", Types.DoubleType.get()),
             optional(104, "decimal_data", Types.DecimalType.of(25, 5)));
 
-    File dataFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File dataFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(dataFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
@@ -319,7 +318,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
     // Longs, ints, string types etc use delta encoding and which are not supported for vectorized
     // reads
     Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
-    File dataFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File dataFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(dataFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -80,12 +80,14 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       Function<GenericData.Record, GenericData.Record> transform)
       throws IOException {
     // Write test data
-    assumeThat(null
-            == TypeUtil.find(
-            schema,
-            type -> type.isMapType() && type.asMapType().keyType() != Types.StringType.get()))
-            .as("Parquet Avro cannot write non-string map keys")
-            .isTrue();
+    assumeThat(
+            null
+                == TypeUtil.find(
+                    schema,
+                    type ->
+                        type.isMapType() && type.asMapType().keyType() != Types.StringType.get()))
+        .as("Parquet Avro cannot write non-string map keys")
+        .isTrue();
 
     Iterable<GenericData.Record> expected =
         generateData(schema, numRecords, seed, nullPercentage, transform);
@@ -325,8 +327,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
     try (FileAppender<GenericData.Record> writer = getParquetV2Writer(schema, dataFile)) {
       writer.addAll(data);
     }
-    assertThatThrownBy(
-            () -> assertRecordsMatch(schema, 30000, data, dataFile, false, BATCH_SIZE))
+    assertThatThrownBy(() -> assertRecordsMatch(schema, 30000, data, dataFile, false, BATCH_SIZE))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessageStartingWith("Cannot support vectorized reads for column")
         .hasMessageEndingWith("Disable vectorized reads to read this table/file");

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.UUID;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
@@ -91,7 +92,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         generateData(schema, numRecords, seed, nullPercentage, transform);
 
     // write a test parquet file using iceberg writer
-    File testFile = temp.toFile();
+    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<GenericData.Record> writer = getParquetWriter(schema, testFile)) {
@@ -274,7 +275,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
             optional(102, "float_data", Types.FloatType.get()),
             optional(103, "decimal_data", Types.DecimalType.of(10, 5)));
 
-    File dataFile = temp.toFile();
+    File dataFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(dataFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> data =
         generateData(writeSchema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
@@ -303,7 +304,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
             optional(103, "double_data", Types.DoubleType.get()),
             optional(104, "decimal_data", Types.DecimalType.of(25, 5)));
 
-    File dataFile = temp.toFile();
+    File dataFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(dataFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
@@ -318,7 +319,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
     // Longs, ints, string types etc use delta encoding and which are not supported for vectorized
     // reads
     Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
-    File dataFile = temp.toFile();
+    File dataFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
     assertThat(dataFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -20,6 +20,9 @@ package org.apache.iceberg.spark.data.parquet.vectorized;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,11 +49,8 @@ import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TestParquetVectorizedReads extends AvroDataTest {
   private static final int NUM_ROWS = 200_000;
@@ -80,19 +80,19 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       Function<GenericData.Record, GenericData.Record> transform)
       throws IOException {
     // Write test data
-    Assume.assumeTrue(
-        "Parquet Avro cannot write non-string map keys",
-        null
+    assumeThat(null
             == TypeUtil.find(
-                schema,
-                type -> type.isMapType() && type.asMapType().keyType() != Types.StringType.get()));
+            schema,
+            type -> type.isMapType() && type.asMapType().keyType() != Types.StringType.get()))
+            .as("Parquet Avro cannot write non-string map keys")
+            .isTrue();
 
     Iterable<GenericData.Record> expected =
         generateData(schema, numRecords, seed, nullPercentage, transform);
 
     // write a test parquet file using iceberg writer
-    File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = temp.toFile();
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<GenericData.Record> writer = getParquetWriter(schema, testFile)) {
       writer.addAll(expected);
@@ -157,49 +157,49 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         numRowsRead += batch.numRows();
         TestHelpers.assertEqualsBatch(schema.asStruct(), expectedIter, batch);
       }
-      Assert.assertEquals(expectedSize, numRowsRead);
+      assertThat(numRowsRead).isEqualTo(expectedSize);
     }
   }
 
   @Override
   @Test
-  @Ignore
+  @Disabled
   public void testArray() {}
 
   @Override
   @Test
-  @Ignore
+  @Disabled
   public void testArrayOfStructs() {}
 
   @Override
   @Test
-  @Ignore
+  @Disabled
   public void testMap() {}
 
   @Override
   @Test
-  @Ignore
+  @Disabled
   public void testNumericMapKey() {}
 
   @Override
   @Test
-  @Ignore
+  @Disabled
   public void testComplexMapKey() {}
 
   @Override
   @Test
-  @Ignore
+  @Disabled
   public void testMapOfStructs() {}
 
   @Override
   @Test
-  @Ignore
+  @Disabled
   public void testMixedTypes() {}
 
   @Test
   @Override
   public void testNestedStruct() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 VectorizedSparkParquetReaders.buildReader(
                     TypeUtil.assignIncreasingFreshIds(
@@ -274,8 +274,8 @@ public class TestParquetVectorizedReads extends AvroDataTest {
             optional(102, "float_data", Types.FloatType.get()),
             optional(103, "decimal_data", Types.DecimalType.of(10, 5)));
 
-    File dataFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", dataFile.delete());
+    File dataFile = temp.toFile();
+    assertThat(dataFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> data =
         generateData(writeSchema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<GenericData.Record> writer = getParquetWriter(writeSchema, dataFile)) {
@@ -303,8 +303,8 @@ public class TestParquetVectorizedReads extends AvroDataTest {
             optional(103, "double_data", Types.DoubleType.get()),
             optional(104, "decimal_data", Types.DecimalType.of(25, 5)));
 
-    File dataFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", dataFile.delete());
+    File dataFile = temp.toFile();
+    assertThat(dataFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<GenericData.Record> writer = getParquetV2Writer(schema, dataFile)) {
@@ -318,14 +318,14 @@ public class TestParquetVectorizedReads extends AvroDataTest {
     // Longs, ints, string types etc use delta encoding and which are not supported for vectorized
     // reads
     Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
-    File dataFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", dataFile.delete());
+    File dataFile = temp.toFile();
+    assertThat(dataFile.delete()).as("Delete should succeed").isTrue();
     Iterable<GenericData.Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<GenericData.Record> writer = getParquetV2Writer(schema, dataFile)) {
       writer.addAll(data);
     }
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> assertRecordsMatch(schema, 30000, data, dataFile, false, BATCH_SIZE))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessageStartingWith("Cannot support vectorized reads for column")

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -81,13 +81,11 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       throws IOException {
     // Write test data
     assumeThat(
-            null
-                == TypeUtil.find(
-                    schema,
-                    type ->
-                        type.isMapType() && type.asMapType().keyType() != Types.StringType.get()))
+            TypeUtil.find(
+                schema,
+                type -> type.isMapType() && type.asMapType().keyType() != Types.StringType.get()))
         .as("Parquet Avro cannot write non-string map keys")
-        .isTrue();
+        .isNull();
 
     Iterable<GenericData.Record> expected =
         generateData(schema, numRecords, seed, nullPercentage, transform);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestAvroScan.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestAvroScan.java
@@ -68,7 +68,7 @@ public class TestAvroScan extends AvroDataTest {
 
   @Override
   protected void writeAndValidate(Schema schema) throws IOException {
-    File parent = new File(temp.toFile(), "avro");
+    File parent = temp.resolve("avro").toFile();
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
     dataFolder.mkdirs();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestAvroScan.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestAvroScan.java
@@ -72,7 +72,6 @@ public class TestAvroScan extends AvroDataTest {
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
     dataFolder.mkdirs();
-    //    assertThat(dataFolder.mkdirs()).as("Mkdir should succeed").isTrue();
 
     File avroFile =
         new File(dataFolder, FileFormat.AVRO.addExtension(UUID.randomUUID().toString()));

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -54,7 +54,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkWriteOptions;
-import org.apache.iceberg.spark.data.AvroDataTest;
+import org.apache.iceberg.spark.data.ParameterizedAvroDataTest;
 import org.apache.iceberg.spark.data.RandomData;
 import org.apache.iceberg.spark.data.SparkAvroReader;
 import org.apache.iceberg.types.Types;
@@ -76,7 +76,7 @@ import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ParameterizedTestExtension.class)
-public class TestDataFrameWrites extends AvroDataTest {
+public class TestDataFrameWrites extends ParameterizedAvroDataTest {
   private static final Configuration CONF = new Configuration();
 
   @Parameters(name = "format = {0}")
@@ -84,7 +84,7 @@ public class TestDataFrameWrites extends AvroDataTest {
     return Arrays.asList("parquet", "avro", "orc");
   }
 
-  @Parameter private String format = "parquet";
+  @Parameter private String format;
 
   private static SparkSession spark = null;
   private static JavaSparkContext sc = null;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -289,7 +289,7 @@ public class TestDataFrameWrites extends AvroDataTest {
         .as("Spark 3 rejects writing nulls to a required column")
         .startsWith("2");
 
-    File location = new File(temp.resolve("parquet").toFile(), "test");
+    File location = temp.resolve("parquet").resolve("test").toFile();
     String sourcePath = String.format("%s/nullable_poc/sourceFolder/", location.toString());
     String targetPath = String.format("%s/nullable_poc/targetFolder/", location.toString());
 
@@ -343,7 +343,7 @@ public class TestDataFrameWrites extends AvroDataTest {
         .as("Spark 3 rejects writing nulls to a required column")
         .startsWith("2");
 
-    File location = new File(temp.resolve("parquet").toFile(), "test");
+    File location = temp.resolve("parquet").resolve("test").toFile();
     String sourcePath = String.format("%s/nullable_poc/sourceFolder/", location.toString());
     String targetPath = String.format("%s/nullable_poc/targetFolder/", location.toString());
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -34,7 +34,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.UUID;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Files;
@@ -250,7 +249,7 @@ public class TestDataFrameWrites extends AvroDataTest {
   private Dataset<Row> createDataset(Iterable<Record> records, Schema schema) throws IOException {
     // this uses the SparkAvroReader to create a DataFrame from the list of records
     // it assumes that SparkAvroReader is correct
-    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -146,7 +146,7 @@ public class TestDataFrameWrites extends AvroDataTest {
   @TestTemplate
   public void testWriteWithCustomDataLocation() throws IOException {
     File location = createTableFolder();
-    File tablePropertyDataLocation = new File(temp.toFile(), "test-table-property-data-dir");
+    File tablePropertyDataLocation = temp.resolve("test-table-property-data-dir").toFile();
     Table table = createTable(new Schema(SUPPORTED_PRIMITIVES.fields()), location);
     table
         .updateProperties()
@@ -156,7 +156,7 @@ public class TestDataFrameWrites extends AvroDataTest {
   }
 
   private File createTableFolder() throws IOException {
-    File parent = new File(temp.toFile(), "parquet");
+    File parent = temp.resolve("parquet").toFile();
     File location = new File(parent, "test");
     assertThat(location.mkdirs()).as("Mkdir should succeed").isTrue();
     return location;
@@ -289,7 +289,7 @@ public class TestDataFrameWrites extends AvroDataTest {
         .as("Spark 3 rejects writing nulls to a required column")
         .startsWith("2");
 
-    File location = new File(new File(temp.toFile(), "parquet"), "test");
+    File location = new File(temp.resolve("parquet").toFile(), "test");
     String sourcePath = String.format("%s/nullable_poc/sourceFolder/", location.toString());
     String targetPath = String.format("%s/nullable_poc/targetFolder/", location.toString());
 
@@ -343,7 +343,7 @@ public class TestDataFrameWrites extends AvroDataTest {
         .as("Spark 3 rejects writing nulls to a required column")
         .startsWith("2");
 
-    File location = new File(new File(temp.toFile(), "parquet"), "test");
+    File location = new File(temp.resolve("parquet").toFile(), "test");
     String sourcePath = String.format("%s/nullable_poc/sourceFolder/", location.toString());
     String targetPath = String.format("%s/nullable_poc/targetFolder/", location.toString());
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -147,7 +147,7 @@ public class TestDataFrameWrites extends AvroDataTest {
   @Test
   public void testWriteWithCustomDataLocation() throws IOException {
     File location = createTableFolder();
-    File tablePropertyDataLocation = temp.newFolder("test-table-property-data-dir");
+    File tablePropertyDataLocation = temp.resolve("test-table-property-data-dir").toFile();
     Table table = createTable(new Schema(SUPPORTED_PRIMITIVES.fields()), location);
     table
         .updateProperties()
@@ -157,7 +157,7 @@ public class TestDataFrameWrites extends AvroDataTest {
   }
 
   private File createTableFolder() throws IOException {
-    File parent = temp.newFolder("parquet");
+    File parent = temp.resolve("parquet").toFile();
     File location = new File(parent, "test");
     Assert.assertTrue("Mkdir should succeed", location.mkdirs());
     return location;
@@ -247,7 +247,7 @@ public class TestDataFrameWrites extends AvroDataTest {
   private Dataset<Row> createDataset(Iterable<Record> records, Schema schema) throws IOException {
     // this uses the SparkAvroReader to create a DataFrame from the list of records
     // it assumes that SparkAvroReader is correct
-    File testFile = temp.newFile();
+    File testFile = temp.toFile();
     Assert.assertTrue("Delete should succeed", testFile.delete());
 
     try (FileAppender<Record> writer =
@@ -285,7 +285,7 @@ public class TestDataFrameWrites extends AvroDataTest {
     Assume.assumeTrue(
         "Spark 3 rejects writing nulls to a required column", spark.version().startsWith("2"));
 
-    File location = new File(temp.newFolder("parquet"), "test");
+    File location = new File(temp.resolve("parquet").toFile(), "test");
     String sourcePath = String.format("%s/nullable_poc/sourceFolder/", location.toString());
     String targetPath = String.format("%s/nullable_poc/targetFolder/", location.toString());
 
@@ -338,7 +338,7 @@ public class TestDataFrameWrites extends AvroDataTest {
     Assume.assumeTrue(
         "Spark 3 rejects writing nulls to a required column", spark.version().startsWith("2"));
 
-    File location = new File(temp.newFolder("parquet"), "test");
+    File location = new File(temp.resolve("parquet").toFile(), "test");
     String sourcePath = String.format("%s/nullable_poc/sourceFolder/", location.toString());
     String targetPath = String.format("%s/nullable_poc/targetFolder/", location.toString());
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -194,15 +194,12 @@ public class TestDataFrameWrites extends AvroDataTest {
         .addedDataFiles(table.io())
         .forEach(
             dataFile ->
-                assertThat(
-                        URI.create(dataFile.path().toString())
-                            .getPath()
-                            .startsWith(expectedDataDir.getAbsolutePath()))
+                assertThat(URI.create(dataFile.path().toString()).getPath())
                     .as(
                         String.format(
                             "File should have the parent directory %s, but has: %s.",
                             expectedDataDir.getAbsolutePath(), dataFile.path()))
-                    .isTrue());
+                    .startsWith(expectedDataDir.getAbsolutePath()));
   }
 
   private List<Row> readTable(String location) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -21,18 +21,26 @@ package org.apache.iceberg.spark.source;
 import static org.apache.iceberg.spark.SparkSchemaUtil.convert;
 import static org.apache.iceberg.spark.data.TestHelpers.assertEqualsSafe;
 import static org.apache.iceberg.spark.data.TestHelpers.assertEqualsUnsafe;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
@@ -63,29 +71,21 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.assertj.core.api.Assertions;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestDataFrameWrites extends AvroDataTest {
   private static final Configuration CONF = new Configuration();
 
-  private final String format;
-
-  @Parameterized.Parameters(name = "format = {0}")
-  public static Object[] parameters() {
-    return new Object[] {"parquet", "avro", "orc"};
+  @Parameters(name = "format = {0}")
+  public static Collection<String> parameters() {
+    return Arrays.asList("parquet", "avro", "orc");
   }
 
-  public TestDataFrameWrites(String format) {
-    this.format = format;
-  }
+  @Parameter private String format = "parquet";
 
   private static SparkSession spark = null;
   private static JavaSparkContext sc = null;
@@ -123,13 +123,13 @@ public class TestDataFrameWrites extends AvroDataTest {
           "{\"optionalField\": \"d3\", \"requiredField\": \"bid_103\"}",
           "{\"optionalField\": \"d4\", \"requiredField\": \"bid_104\"}");
 
-  @BeforeClass
+  @BeforeAll
   public static void startSpark() {
     TestDataFrameWrites.spark = SparkSession.builder().master("local[2]").getOrCreate();
     TestDataFrameWrites.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopSpark() {
     SparkSession currentSpark = TestDataFrameWrites.spark;
     TestDataFrameWrites.spark = null;
@@ -144,10 +144,10 @@ public class TestDataFrameWrites extends AvroDataTest {
     writeAndValidateWithLocations(table, location, new File(location, "data"));
   }
 
-  @Test
+  @TestTemplate
   public void testWriteWithCustomDataLocation() throws IOException {
     File location = createTableFolder();
-    File tablePropertyDataLocation = temp.resolve("test-table-property-data-dir").toFile();
+    File tablePropertyDataLocation = new File(temp.toFile(), "test-table-property-data-dir");
     Table table = createTable(new Schema(SUPPORTED_PRIMITIVES.fields()), location);
     table
         .updateProperties()
@@ -157,9 +157,9 @@ public class TestDataFrameWrites extends AvroDataTest {
   }
 
   private File createTableFolder() throws IOException {
-    File parent = temp.resolve("parquet").toFile();
+    File parent = new File(temp.toFile(), "parquet");
     File location = new File(parent, "test");
-    Assert.assertTrue("Mkdir should succeed", location.mkdirs());
+    assertThat(location.mkdirs()).as("Mkdir should succeed").isTrue();
     return location;
   }
 
@@ -186,21 +186,24 @@ public class TestDataFrameWrites extends AvroDataTest {
     while (expectedIter.hasNext() && actualIter.hasNext()) {
       assertEqualsSafe(tableSchema.asStruct(), expectedIter.next(), actualIter.next());
     }
-    Assert.assertEquals(
-        "Both iterators should be exhausted", expectedIter.hasNext(), actualIter.hasNext());
+    assertThat(actualIter.hasNext())
+        .as("Both iterators should be exhausted")
+        .isEqualTo(expectedIter.hasNext());
 
     table
         .currentSnapshot()
         .addedDataFiles(table.io())
         .forEach(
             dataFile ->
-                Assert.assertTrue(
-                    String.format(
-                        "File should have the parent directory %s, but has: %s.",
-                        expectedDataDir.getAbsolutePath(), dataFile.path()),
-                    URI.create(dataFile.path().toString())
-                        .getPath()
-                        .startsWith(expectedDataDir.getAbsolutePath())));
+                assertThat(
+                        URI.create(dataFile.path().toString())
+                            .getPath()
+                            .startsWith(expectedDataDir.getAbsolutePath()))
+                    .as(
+                        String.format(
+                            "File should have the parent directory %s, but has: %s.",
+                            expectedDataDir.getAbsolutePath(), dataFile.path()))
+                    .isTrue());
   }
 
   private List<Row> readTable(String location) {
@@ -247,8 +250,8 @@ public class TestDataFrameWrites extends AvroDataTest {
   private Dataset<Row> createDataset(Iterable<Record> records, Schema schema) throws IOException {
     // this uses the SparkAvroReader to create a DataFrame from the list of records
     // it assumes that SparkAvroReader is correct
-    File testFile = temp.toFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = File.createTempFile(UUID.randomUUID().toString(), null, temp.toFile());
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =
         Avro.write(Files.localOutput(testFile)).schema(schema).named("test").build()) {
@@ -272,20 +275,22 @@ public class TestDataFrameWrites extends AvroDataTest {
         assertEqualsUnsafe(schema.asStruct(), recordIter.next(), row);
         rows.add(row);
       }
-      Assert.assertEquals(
-          "Both iterators should be exhausted", recordIter.hasNext(), readIter.hasNext());
+      assertThat(readIter.hasNext())
+          .as("Both iterators should be exhausted")
+          .isEqualTo(recordIter.hasNext());
     }
 
     JavaRDD<InternalRow> rdd = sc.parallelize(rows);
     return spark.internalCreateDataFrame(JavaRDD.toRDD(rdd), convert(schema), false);
   }
 
-  @Test
+  @TestTemplate
   public void testNullableWithWriteOption() throws IOException {
-    Assume.assumeTrue(
-        "Spark 3 rejects writing nulls to a required column", spark.version().startsWith("2"));
+    assumeThat(spark.version())
+        .as("Spark 3 rejects writing nulls to a required column")
+        .startsWith("2");
 
-    File location = new File(temp.resolve("parquet").toFile(), "test");
+    File location = new File(new File(temp.toFile(), "parquet"), "test");
     String sourcePath = String.format("%s/nullable_poc/sourceFolder/", location.toString());
     String targetPath = String.format("%s/nullable_poc/targetFolder/", location.toString());
 
@@ -330,15 +335,16 @@ public class TestDataFrameWrites extends AvroDataTest {
 
     // read all data
     List<Row> rows = spark.read().format("iceberg").load(targetPath).collectAsList();
-    Assert.assertEquals("Should contain 6 rows", 6, rows.size());
+    assumeThat(rows).as("Should contain 6 rows").hasSize(6);
   }
 
-  @Test
+  @TestTemplate
   public void testNullableWithSparkSqlOption() throws IOException {
-    Assume.assumeTrue(
-        "Spark 3 rejects writing nulls to a required column", spark.version().startsWith("2"));
+    assumeThat(spark.version())
+        .as("Spark 3 rejects writing nulls to a required column")
+        .startsWith("2");
 
-    File location = new File(temp.resolve("parquet").toFile(), "test");
+    File location = new File(new File(temp.toFile(), "parquet"), "test");
     String sourcePath = String.format("%s/nullable_poc/sourceFolder/", location.toString());
     String targetPath = String.format("%s/nullable_poc/targetFolder/", location.toString());
 
@@ -389,10 +395,10 @@ public class TestDataFrameWrites extends AvroDataTest {
 
     // read all data
     List<Row> rows = newSparkSession.read().format("iceberg").load(targetPath).collectAsList();
-    Assert.assertEquals("Should contain 6 rows", 6, rows.size());
+    assumeThat(rows).as("Should contain 6 rows").hasSize(6);
   }
 
-  @Test
+  @TestTemplate
   public void testFaultToleranceOnWrite() throws IOException {
     File location = createTableFolder();
     Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
@@ -408,8 +414,7 @@ public class TestDataFrameWrites extends AvroDataTest {
 
     Iterable<Record> records2 = RandomData.generate(schema, 100, 0L);
 
-    Assertions.assertThatThrownBy(
-            () -> writeDataWithFailOnPartition(records2, schema, location.toString()))
+    assertThatThrownBy(() -> writeDataWithFailOnPartition(records2, schema, location.toString()))
         .isInstanceOf(SparkException.class);
 
     table.refresh();
@@ -417,7 +422,7 @@ public class TestDataFrameWrites extends AvroDataTest {
     Snapshot snapshotAfterFailingWrite = table.currentSnapshot();
     List<Row> resultAfterFailingWrite = readTable(location.toString());
 
-    Assert.assertEquals(snapshotAfterFailingWrite, snapshotBeforeFailingWrite);
-    Assert.assertEquals(resultAfterFailingWrite, resultBeforeFailingWrite);
+    assertThat(snapshotBeforeFailingWrite).isEqualTo(snapshotAfterFailingWrite);
+    assertThat(resultBeforeFailingWrite).isEqualTo(resultAfterFailingWrite);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetScan.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetScan.java
@@ -47,7 +47,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
-import org.apache.iceberg.spark.data.AvroDataTest;
+import org.apache.iceberg.spark.data.ParameterizedAvroDataTest;
 import org.apache.iceberg.spark.data.RandomData;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.types.TypeUtil;
@@ -62,7 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 @ExtendWith(ParameterizedTestExtension.class)
-public class TestParquetScan extends AvroDataTest {
+public class TestParquetScan extends ParameterizedAvroDataTest {
   private static final Configuration CONF = new Configuration();
 
   private static SparkSession spark = null;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetScan.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetScan.java
@@ -96,7 +96,7 @@ public class TestParquetScan extends ParameterizedAvroDataTest {
                 type -> type.isMapType() && type.asMapType().keyType() != Types.StringType.get()))
         .as("Cannot handle non-string map keys in parquet-avro")
         .isNull();
-    ;
+
     assertThat(vectorized).as("should not be null").isNotNull();
     Table table = createTable(schema);
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetScan.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetScan.java
@@ -143,7 +143,7 @@ public class TestParquetScan extends AvroDataTest {
   }
 
   private Table createTable(Schema schema) throws IOException {
-    File parent = new File(temp.toFile(), "parquet");
+    File parent = temp.resolve("parquet").toFile();
     File location = new File(parent, "test");
     HadoopTables tables = new HadoopTables(CONF);
     return tables.create(schema, PartitionSpec.unpartitioned(), location.toString());


### PR DESCRIPTION
Since migrating Spark 3.5v to Junit5 is a large task, I'm splitting my work into multiple easy-to-review PR's, split by directory. 

This PR contains the Junit5 migration for Spark 3.5v for the `spark/data` directory, and any files that inherit from this directory.

Issue: #9086

TODO:
- [x] self-review