### PR TITLE
Spark 3:5 Migrate tests to JUnit5 in source directory

### DIFF
--- a/data/src/test/java/org/apache/iceberg/RecordWrapperTest.java
+++ b/data/src/test/java/org/apache/iceberg/RecordWrapperTest.java
@@ -24,7 +24,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeWrapper;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class RecordWrapperTest {
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/CatalogTestBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/CatalogTestBase.java
@@ -18,28 +18,39 @@
  */
 package org.apache.iceberg.spark;
 
+import java.nio.file.Path;
 import java.util.Map;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.provider.Arguments;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public abstract class CatalogTestBase extends TestBaseWithCatalog {
 
   // these parameters are broken out to avoid changes that need to modify lots of test suites
-  public static Stream<Arguments> parameters() {
-    return Stream.of(
-        Arguments.of(
-            SparkCatalogConfig.HIVE.catalogName(),
-            SparkCatalogConfig.HIVE.implementation(),
-            SparkCatalogConfig.HIVE.properties()),
-        Arguments.of(
-            SparkCatalogConfig.HADOOP.catalogName(),
-            SparkCatalogConfig.HADOOP.implementation(),
-            SparkCatalogConfig.HADOOP.properties()),
-        Arguments.of(
-            SparkCatalogConfig.SPARK.catalogName(),
-            SparkCatalogConfig.SPARK.implementation(),
-            SparkCatalogConfig.SPARK.properties()));
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        SparkCatalogConfig.HIVE.properties()
+      },
+      {
+        SparkCatalogConfig.HADOOP.catalogName(),
+        SparkCatalogConfig.HADOOP.implementation(),
+        SparkCatalogConfig.HADOOP.properties()
+      },
+      {
+        SparkCatalogConfig.SPARK.catalogName(),
+        SparkCatalogConfig.SPARK.implementation(),
+        SparkCatalogConfig.SPARK.properties()
+      }
+    };
   }
+
+  @TempDir protected Path temp;
 
   public CatalogTestBase(SparkCatalogConfig config) {
     super(config);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class TestBaseReader {
 
   @TempDir
-  public Path temp;
+  private Path temp;
 
   private Table table;
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -54,8 +54,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 public class TestBaseReader {
 
-  @TempDir
-  private Path temp;
+  @TempDir private Path temp;
 
   private Table table;
 
@@ -133,10 +132,14 @@ public class TestBaseReader {
       assertThat(reader.get()).as("Reader should return non-null value").isNotNull();
     }
 
-    assertThat(totalTasks * recordPerTask).as("Reader returned incorrect number of records").isEqualTo(countRecords);
+    assertThat(totalTasks * recordPerTask)
+        .as("Reader returned incorrect number of records")
+        .isEqualTo(countRecords);
     tasks.forEach(
         t ->
-            assertThat(reader.isIteratorClosed(t)).as("All iterators should be closed after read exhausion").isTrue());
+            assertThat(reader.isIteratorClosed(t))
+                .as("All iterators should be closed after read exhausion")
+                .isTrue());
   }
 
   @Test
@@ -152,11 +155,17 @@ public class TestBaseReader {
 
     // Total of 2 elements
     assertThat(reader.next()).isTrue();
-    assertThat(reader.isIteratorClosed(firstTask)).as("First iter should not be closed on its last element").isFalse();
+    assertThat(reader.isIteratorClosed(firstTask))
+        .as("First iter should not be closed on its last element")
+        .isFalse();
 
     assertThat(reader.next()).isTrue();
-    assertThat(reader.isIteratorClosed(firstTask)).as("First iter should be closed after moving to second iter").isTrue();
-    assertThat(reader.isIteratorClosed(secondTask)).as("Second iter should not be closed on its last element").isFalse();
+    assertThat(reader.isIteratorClosed(firstTask))
+        .as("First iter should be closed after moving to second iter")
+        .isTrue();
+    assertThat(reader.isIteratorClosed(secondTask))
+        .as("Second iter should not be closed on its last element")
+        .isFalse();
 
     assertThat(reader.next()).isFalse();
     assertThat(reader.isIteratorClosed(firstTask)).isTrue();
@@ -175,7 +184,9 @@ public class TestBaseReader {
 
     tasks.forEach(
         t ->
-            assertThat(reader.hasIterator(t)).as("Iterator should not be created eagerly for tasks").isFalse());
+            assertThat(reader.hasIterator(t))
+                .as("Iterator should not be created eagerly for tasks")
+                .isFalse());
   }
 
   @Test
@@ -199,7 +210,9 @@ public class TestBaseReader {
     tasks.forEach(
         t -> {
           if (reader.hasIterator(t)) {
-            assertThat(reader.isIteratorClosed(t)).as("Iterator should be closed after read exhausion").isTrue();
+            assertThat(reader.isIteratorClosed(t))
+                .as("Iterator should be closed after read exhausion")
+                .isTrue();
           }
         });
   }
@@ -221,10 +234,14 @@ public class TestBaseReader {
     for (int closeAttempt = 0; closeAttempt < 5; closeAttempt++) {
       reader.close();
       for (int i = 0; i < 5; i++) {
-        assertThat(reader.isIteratorClosed(tasks.get(i))).as("Iterator should be closed after read exhausion").isTrue();
+        assertThat(reader.isIteratorClosed(tasks.get(i)))
+            .as("Iterator should be closed after read exhausion")
+            .isTrue();
       }
       for (int i = 5; i < 10; i++) {
-        assertThat(reader.hasIterator(tasks.get(i))).as("Iterator should not be created eagerly for tasks").isFalse();
+        assertThat(reader.hasIterator(tasks.get(i)))
+            .as("Iterator should not be created eagerly for tasks")
+            .isFalse();
       }
     }
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
@@ -254,6 +255,9 @@ public class TestChangelogReader extends TestBase {
   private DataFile writeDataFile(List<Record> records) throws IOException {
     // records all use IDs that are in bucket id_bucket=0
     return FileHelpers.writeDataFile(
-        table, Files.localOutput(temp.resolve("junit").toFile()), TestHelpers.Row.of(0), records);
+        table,
+        Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
+        TestHelpers.Row.of(0),
+        records);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
@@ -64,8 +64,7 @@ public class TestChangelogReader extends TestBase {
   private DataFile dataFile1;
   private DataFile dataFile2;
 
-  @TempDir
-  private Path temp;
+  @TempDir private Path temp;
 
   @BeforeEach
   public void before() throws IOException {
@@ -255,8 +254,6 @@ public class TestChangelogReader extends TestBase {
   private DataFile writeDataFile(List<Record> records) throws IOException {
     // records all use IDs that are in bucket id_bucket=0
     return FileHelpers.writeDataFile(
-        table,
-        Files.localOutput(temp.toFile()),
-        TestHelpers.Row.of(0), records);
+        table, Files.localOutput(temp.toFile()), TestHelpers.Row.of(0), records);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
@@ -65,7 +65,7 @@ public class TestChangelogReader extends TestBase {
   private DataFile dataFile2;
 
   @TempDir
-  public Path temp;
+  private Path temp;
 
   @BeforeEach
   public void before() throws IOException {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
@@ -20,8 +20,10 @@ package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iceberg.ChangelogOperation;
@@ -41,17 +43,15 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TestChangelogReader extends SparkTestBase {
+public class TestChangelogReader extends TestBase {
   private static final Schema SCHEMA =
       new Schema(
           required(1, "id", Types.IntegerType.get()), optional(2, "data", Types.StringType.get()));
@@ -64,9 +64,10 @@ public class TestChangelogReader extends SparkTestBase {
   private DataFile dataFile1;
   private DataFile dataFile2;
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  public Path temp;
 
-  @Before
+  @BeforeEach
   public void before() throws IOException {
     table = catalog.createTable(TableIdentifier.of("default", "test"), SCHEMA, SPEC);
     // create some data
@@ -85,7 +86,7 @@ public class TestChangelogReader extends SparkTestBase {
     dataFile2 = writeDataFile(records2);
   }
 
-  @After
+  @AfterEach
   public void after() {
     catalog.dropTable(TableIdentifier.of("default", "test"));
   }
@@ -176,7 +177,7 @@ public class TestChangelogReader extends SparkTestBase {
       reader.close();
     }
 
-    Assert.assertEquals("Should have no rows", 0, rows.size());
+    assertThat(rows).as("Should have no rows").hasSize(0);
   }
 
   @Test
@@ -254,6 +255,8 @@ public class TestChangelogReader extends SparkTestBase {
   private DataFile writeDataFile(List<Record> records) throws IOException {
     // records all use IDs that are in bucket id_bucket=0
     return FileHelpers.writeDataFile(
-        table, Files.localOutput(temp.newFile()), TestHelpers.Row.of(0), records);
+        table,
+        Files.localOutput(temp.toFile()),
+        TestHelpers.Row.of(0), records);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
@@ -254,6 +254,6 @@ public class TestChangelogReader extends TestBase {
   private DataFile writeDataFile(List<Record> records) throws IOException {
     // records all use IDs that are in bucket id_bucket=0
     return FileHelpers.writeDataFile(
-        table, Files.localOutput(temp.toFile()), TestHelpers.Row.of(0), records);
+        table, Files.localOutput(temp.resolve("junit").toFile()), TestHelpers.Row.of(0), records);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -102,8 +103,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
             "{ \"id\": 3, \"data\": \"c\", \"new_col\": 12.06 }",
             "{ \"id\": 4, \"data\": \"d\", \"new_col\": 14.41 }");
 
-    assertThatThrownBy(
-            () -> threeColDF.writeTo(tableName).option("merge-schema", "true").append())
+    assertThatThrownBy(() -> threeColDF.writeTo(tableName).option("merge-schema", "true").append())
         .isInstanceOf(AnalysisException.class)
         .hasMessageContaining(
             "Cannot write to `testhadoop`.`default`.`table`, the reason is too many data columns");

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -70,8 +70,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
           optional(1, "id", Types.IntegerType.get()), optional(2, "data", Types.StringType.get()));
   private static SparkSession spark = null;
 
-  @TempDir
-  private Path temp;
+  @TempDir private Path temp;
 
   @BeforeAll
   public static void startSpark() {
@@ -220,7 +219,9 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
             .option(SparkReadOptions.SPLIT_SIZE, String.valueOf(splitSize))
             .load(tableLocation);
 
-    assertThat(2).as("Spark partitions should match").isEqualTo(resultDf.javaRDD().getNumPartitions());
+    assertThat(2)
+        .as("Spark partitions should match")
+        .isEqualTo(resultDf.javaRDD().getNumPartitions());
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -71,7 +71,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
   private static SparkSession spark = null;
 
   @TempDir
-  public Path temp;
+  private Path temp;
 
   @BeforeAll
   public static void startSpark() {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -219,9 +219,9 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
             .option(SparkReadOptions.SPLIT_SIZE, String.valueOf(splitSize))
             .load(tableLocation);
 
-    assertThat(2)
+    assertThat(resultDf.javaRDD().getNumPartitions())
         .as("Spark partitions should match")
-        .isEqualTo(resultDf.javaRDD().getNumPartitions());
+        .isEqualTo(2);
   }
 
   @Test
@@ -299,7 +299,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
             .orderBy("id")
             .as(Encoders.bean(SimpleRecord.class))
             .collectAsList();
-    assertThat(expectedRecords.subList(1, 4)).as("Records should match").isEqualTo(result);
+    assertThat(result).as("Records should match").isEqualTo(expectedRecords.subList(1, 4));
 
     // test (2nd snapshot, 3rd snapshot] incremental scan.
     Dataset<Row> resultDf =
@@ -311,8 +311,8 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
             .load(tableLocation);
     List<SimpleRecord> result1 =
         resultDf.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    assertThat(expectedRecords.subList(2, 3)).as("Records should match").isEqualTo(result1);
-    assertThat(1).as("Unprocessed count should match record count").isEqualTo(resultDf.count());
+    assertThat(result1).as("Records should match").isEqualTo(expectedRecords.subList(2, 3));
+    assertThat(resultDf.count()).as("Unprocessed count should match record count").isEqualTo(1);
   }
 
   @Test
@@ -343,7 +343,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
         .commit();
 
     Dataset<Row> entriesDf = spark.read().format("iceberg").load(tableLocation + "#entries");
-    assertThat(2).as("Num partitions must match").isEqualTo(entriesDf.javaRDD().getNumPartitions());
+    assertThat(entriesDf.javaRDD().getNumPartitions()).as("Num partitions must match").isEqualTo(2);
 
     // override the table property using options
     entriesDf =
@@ -352,7 +352,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
             .format("iceberg")
             .option(SparkReadOptions.SPLIT_SIZE, String.valueOf(128 * 1024 * 1024))
             .load(tableLocation + "#entries");
-    assertThat(1).as("Num partitions must match").isEqualTo(entriesDf.javaRDD().getNumPartitions());
+    assertThat(entriesDf.javaRDD().getNumPartitions()).as("Num partitions must match").isEqualTo(1);
   }
 
   @Test
@@ -386,7 +386,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
     Dataset<Row> metadataDf = spark.read().format("iceberg").load(tableLocation + "#entries");
 
     int partitionNum = metadataDf.javaRDD().getNumPartitions();
-    assertThat(expectedSplits).as("Spark partitions should match").isEqualTo(partitionNum);
+    assertThat(partitionNum).as("Spark partitions should match").isEqualTo(expectedSplits);
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -409,8 +409,9 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
 
     Table table = tables.load(tableLocation);
 
-    assertThat(table.currentSnapshot().summary().get("extra-key")).isEqualTo("someValue");
-    assertThat(table.currentSnapshot().summary().get("another-key")).isEqualTo("anotherValue");
+    assertThat(table.currentSnapshot().summary())
+        .containsEntry("extra-key", "someValue")
+        .containsEntry("another-key", "anotherValue");
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
@@ -87,8 +87,7 @@ public class TestForwardCompatibility {
           .addField("identity", 1, "id_zero")
           .build();
 
-  @TempDir
-  private Path temp;
+  @TempDir private Path temp;
 
   private static SparkSession spark = null;
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
@@ -88,7 +88,7 @@ public class TestForwardCompatibility {
           .build();
 
   @TempDir
-  public Path temp;
+  private Path temp;
 
   private static SparkSession spark = null;
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables.java
@@ -26,7 +26,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopTables;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class TestIcebergSourceHadoopTables extends TestIcebergSourceTablesBase {
 
@@ -35,9 +35,9 @@ public class TestIcebergSourceHadoopTables extends TestIcebergSourceTablesBase {
   File tableDir = null;
   String tableLocation = null;
 
-  @Before
+  @BeforeEach
   public void setupTable() throws Exception {
-    this.tableDir = temp.newFolder();
+    this.tableDir = temp.toFile();
     tableDir.delete(); // created by table create
 
     this.tableLocation = tableDir.toURI().toString();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
@@ -27,14 +27,14 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.junit.After;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 
 public class TestIcebergSourceHiveTables extends TestIcebergSourceTablesBase {
 
   private static TableIdentifier currentIdentifier;
 
-  @BeforeClass
+  @BeforeAll
   public static void start() {
     Namespace db = Namespace.of("db");
     if (!catalog.namespaceExists(db)) {
@@ -42,7 +42,7 @@ public class TestIcebergSourceHiveTables extends TestIcebergSourceTablesBase {
     }
   }
 
-  @After
+  @AfterEach
   public void dropTable() throws IOException {
     if (!catalog.tableExists(currentIdentifier)) {
       return;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1556,7 +1556,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .load(loadLocation(tableIdentifier, "partitions"))
             .filter("partition.id < 2")
             .collectAsList();
-    assertThat(filtered).as("Actual results should have one row").hasSize(2);
+    assertThat(filtered).as("Actual results should have one row").hasSize(1);
     TestHelpers.assertEqualsSafe(
         partitionsTable.schema().asStruct(), expected.get(0), filtered.get(0));
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -117,7 +117,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
   private static final PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA).identity("id").build();
 
-  @TempDir private Path temp;
+  @TempDir protected Path temp;
 
   public abstract Table createTable(
       TableIdentifier ident, Schema schema, PartitionSpec spec, Map<String, String> properties);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1990,9 +1990,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .olderThan(System.currentTimeMillis())
             .execute();
 
-    assertThat(Iterables.isEmpty(result1.orphanFileLocations()))
-        .as("Should not delete any metadata files")
-        .isTrue();
+    assertThat(result1.orphanFileLocations()).as("Should not delete any metadata files").isEmpty();
 
     DeleteOrphanFiles.Result result2 =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -2281,7 +2281,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     try {
       return FileHelpers.writeDeleteFile(
           table,
-          Files.localOutput(temp.toFile()),
+          Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
           org.apache.iceberg.TestHelpers.Row.of(1),
           deletes,
           deleteRowSchema);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -702,7 +702,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .load(loadLocation(tableIdentifier, "all_entries"))
             .collectAsList();
 
-    assertThat(table.snapshots().iterator().hasNext()).as("Stage table should have some snapshots").isTrue();
+    assertThat(table.snapshots().iterator()).as("Stage table should have some snapshots").hasNext();
     assertThat(table.currentSnapshot()).as("Stage table should have null currentSnapshot").isNull();
     assertThat(actualAllData).as("Actual results should have two rows").hasSize(2);
     assertThat(actualAllManifests).as("Actual results should have two rows").hasSize(2);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -118,7 +118,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
   private static final PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA).identity("id").build();
 
   @TempDir
-  public Path temp;
+  private Path temp;
 
   public abstract Table createTable(
       TableIdentifier ident, Schema schema, PartitionSpec spec, Map<String, String> properties);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -117,8 +117,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
   private static final PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA).identity("id").build();
 
-  @TempDir
-  private Path temp;
+  @TempDir private Path temp;
 
   public abstract Table createTable(
       TableIdentifier ident, Schema schema, PartitionSpec spec, Map<String, String> properties);
@@ -436,13 +435,19 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
     // count entries
     assertThat(expectedEntryCount)
-            .as("Count should return " + expectedEntryCount)
-            .isEqualTo(spark.read().format("iceberg").load(loadLocation(tableIdentifier, "entries")).count());
+        .as("Count should return " + expectedEntryCount)
+        .isEqualTo(
+            spark.read().format("iceberg").load(loadLocation(tableIdentifier, "entries")).count());
 
     // count all_entries
     assertThat(expectedEntryCount)
-            .as("Count should return " + expectedEntryCount)
-            .isEqualTo(spark.read().format("iceberg").load(loadLocation(tableIdentifier, "all_entries")).count());
+        .as("Count should return " + expectedEntryCount)
+        .isEqualTo(
+            spark
+                .read()
+                .format("iceberg")
+                .load(loadLocation(tableIdentifier, "all_entries"))
+                .count());
   }
 
   @Test
@@ -565,7 +570,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
         String.format(
             "CREATE TABLE parquet_table (data string, id int) "
                 + "USING parquet PARTITIONED BY (id) LOCATION '%s'",
-                temp.toFile()));
+            temp.toFile()));
 
     List<SimpleRecord> records =
         Lists.newArrayList(new SimpleRecord(1, "a"), new SimpleRecord(2, "b"));
@@ -591,7 +596,6 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     table.refresh();
 
     long snapshotId = table.currentSnapshot().snapshotId();
-
 
     assertThat(actual).as("Entries table should have 2 rows").hasSize(2);
     assertThat(0).as("Sequence number must match").isEqualTo(actual.get(0).getLong(0));
@@ -1290,8 +1294,8 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
     assertThat(expectedSchema)
-            .as("Schema should not have partition field")
-            .isEqualTo(partitionsTable.schema().asStruct());
+        .as("Schema should not have partition field")
+        .isEqualTo(partitionsTable.schema().asStruct());
 
     GenericRecordBuilder builder =
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
@@ -1482,10 +1486,10 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     RewriteManifests.Result rewriteManifestResult =
         SparkActions.get().rewriteManifests(table).execute();
     assertThat(rewriteManifestResult.rewrittenManifests())
-            .as("rewrite replaced 2 manifests").hasSize(2);
+        .as("rewrite replaced 2 manifests")
+        .hasSize(2);
 
-    assertThat(rewriteManifestResult.addedManifests())
-            .as("rewrite added 1 manifests").hasSize(1);
+    assertThat(rewriteManifestResult.addedManifests()).as("rewrite added 1 manifests").hasSize(1);
 
     List<Row> actual =
         spark
@@ -1734,8 +1738,8 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
     Dataset<Row> resultDf = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
     assertThat(originalRecords)
-            .as("Records should match")
-            .isEqualTo(resultDf.orderBy("id").collectAsList());
+        .as("Records should match")
+        .isEqualTo(resultDf.orderBy("id").collectAsList());
 
     Snapshot snapshotBeforeAddColumn = table.currentSnapshot();
 
@@ -1765,8 +1769,8 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
     Dataset<Row> resultDf2 = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
     assertThat(updatedRecords)
-            .as("Records should match")
-            .isEqualTo(resultDf2.orderBy("id").collectAsList());
+        .as("Records should match")
+        .isEqualTo(resultDf2.orderBy("id").collectAsList());
 
     Dataset<Row> resultDf3 =
         spark
@@ -1776,12 +1780,10 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .load(loadLocation(tableIdentifier));
 
     assertThat(originalRecords)
-            .as("Records should match")
-            .isEqualTo(resultDf3.orderBy("id").collectAsList());
+        .as("Records should match")
+        .isEqualTo(resultDf3.orderBy("id").collectAsList());
 
-    assertThat(originalSparkSchema)
-            .as("Schemas should match")
-            .isEqualTo(resultDf3.schema());
+    assertThat(originalSparkSchema).as("Schemas should match").isEqualTo(resultDf3.schema());
   }
 
   @Test
@@ -1809,8 +1811,8 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     Dataset<Row> resultDf = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
 
     assertThat(originalRecords)
-            .as("Records should match")
-            .isEqualTo(resultDf.orderBy("id").collectAsList());
+        .as("Records should match")
+        .isEqualTo(resultDf.orderBy("id").collectAsList());
 
     long tsBeforeDropColumn = waitUntilAfter(System.currentTimeMillis());
     table.updateSchema().deleteColumn("data").commit();
@@ -1839,8 +1841,8 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
     Dataset<Row> resultDf2 = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
     assertThat(updatedRecords)
-            .as("Records should match")
-            .isEqualTo(resultDf2.orderBy("id").collectAsList());
+        .as("Records should match")
+        .isEqualTo(resultDf2.orderBy("id").collectAsList());
 
     Dataset<Row> resultDf3 =
         spark
@@ -1850,12 +1852,10 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .load(loadLocation(tableIdentifier));
 
     assertThat(originalRecords)
-            .as("Records should match")
-            .isEqualTo(resultDf3.orderBy("id").collectAsList());
+        .as("Records should match")
+        .isEqualTo(resultDf3.orderBy("id").collectAsList());
 
-    assertThat(originalSparkSchema)
-            .as("Schemas should match")
-            .isEqualTo(resultDf3.schema());
+    assertThat(originalSparkSchema).as("Schemas should match").isEqualTo(resultDf3.schema());
 
     // At tsAfterDropColumn, there has been a schema change, but no new snapshot,
     // so the snapshot as of tsAfterDropColumn is the same as that as of tsBeforeDropColumn.
@@ -1867,12 +1867,10 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .load(loadLocation(tableIdentifier));
 
     assertThat(originalRecords)
-            .as("Records should match")
-            .isEqualTo(resultDf4.orderBy("id").collectAsList());
+        .as("Records should match")
+        .isEqualTo(resultDf4.orderBy("id").collectAsList());
 
-    assertThat(originalSparkSchema)
-            .as("Schemas should match")
-            .isEqualTo(resultDf4.schema());
+    assertThat(originalSparkSchema).as("Schemas should match").isEqualTo(resultDf4.schema());
   }
 
   @Test
@@ -1898,8 +1896,8 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     Dataset<Row> resultDf = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
 
     assertThat(originalRecords)
-            .as("Records should match")
-            .isEqualTo(resultDf.orderBy("id").collectAsList());
+        .as("Records should match")
+        .isEqualTo(resultDf.orderBy("id").collectAsList());
 
     Snapshot snapshotBeforeAddColumn = table.currentSnapshot();
 
@@ -1930,8 +1928,8 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     Dataset<Row> resultDf2 = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
 
     assertThat(updatedRecords)
-            .as("Records should match")
-            .isEqualTo(resultDf2.orderBy("id").collectAsList());
+        .as("Records should match")
+        .isEqualTo(resultDf2.orderBy("id").collectAsList());
 
     table.updateSchema().deleteColumn("data").commit();
 
@@ -1946,8 +1944,8 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     Dataset<Row> resultDf3 = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
 
     assertThat(recordsAfterDropColumn)
-            .as("Records should match")
-            .isEqualTo(resultDf3.orderBy("id").collectAsList());
+        .as("Records should match")
+        .isEqualTo(resultDf3.orderBy("id").collectAsList());
 
     Dataset<Row> resultDf4 =
         spark
@@ -1957,12 +1955,10 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .load(loadLocation(tableIdentifier));
 
     assertThat(originalRecords)
-            .as("Records should match")
-            .isEqualTo(resultDf4.orderBy("id").collectAsList());
+        .as("Records should match")
+        .isEqualTo(resultDf4.orderBy("id").collectAsList());
 
-    assertThat(originalSparkSchema)
-            .as("Schemas should match")
-            .isEqualTo(resultDf4.schema());
+    assertThat(originalSparkSchema).as("Schemas should match").isEqualTo(resultDf4.schema());
   }
 
   @Test
@@ -1995,14 +1991,13 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .execute();
 
     assertThat(Iterables.isEmpty(result1.orphanFileLocations()))
-            .as("Should not delete any metadata files")
-            .isTrue();
+        .as("Should not delete any metadata files")
+        .isTrue();
 
     DeleteOrphanFiles.Result result2 =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    assertThat(result2.orphanFileLocations())
-            .as("Should delete 1 data file").hasSize(1);
+    assertThat(result2.orphanFileLocations()).as("Should delete 1 data file").hasSize(1);
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
     List<SimpleRecord> actualRecords =
@@ -2048,7 +2043,9 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .map(r -> (Integer) r.getAs(DataFile.SPEC_ID.name()))
             .collect(Collectors.toList());
 
-    assertThat(ImmutableList.of(spec0, spec1)).as("Should have two partition specs").isEqualTo(actual);
+    assertThat(ImmutableList.of(spec0, spec1))
+        .as("Should have two partition specs")
+        .isEqualTo(actual);
   }
 
   @Test
@@ -2186,9 +2183,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                 .load(loadLocation(tableIdentifier))
                 .select("tmp_col")
                 .collectAsList();
-        assertThat(actual)
-            .as("Rows must match")
-            .containsExactlyInAnyOrderElementsOf(expected);
+        assertThat(actual).as("Rows must match").containsExactlyInAnyOrderElementsOf(expected);
         dropTable(tableIdentifier);
       }
     }
@@ -2309,8 +2304,8 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
     for (int i = 0; i < dataFiles.size(); ++i) {
       assertThat(expectedPartitionIds.get(i).intValue())
-              .as("Data file should have partition of id " + expectedPartitionIds.get(i))
-              .isEqualTo(dataFiles.get(i).partition().get(0, Integer.class).intValue());
+          .as("Data file should have partition of id " + expectedPartitionIds.get(i))
+          .isEqualTo(dataFiles.get(i).partition().get(0, Integer.class).intValue());
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -236,7 +236,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .collectAsList();
 
     assertThat(actual).as("Results should contain only one status").hasSize(1);
-    assertThat(1).as("That status should be Added (1)").isEqualTo(actual.get(0).getInt(0));
+    assertThat(actual.get(0).getInt(0)).as("That status should be Added (1)").isEqualTo(1);
   }
 
   @Test
@@ -434,20 +434,20 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     final int expectedEntryCount = 1;
 
     // count entries
-    assertThat(expectedEntryCount)
+    assertThat(
+            spark.read().format("iceberg").load(loadLocation(tableIdentifier, "entries")).count())
         .as("Count should return " + expectedEntryCount)
-        .isEqualTo(
-            spark.read().format("iceberg").load(loadLocation(tableIdentifier, "entries")).count());
+        .isEqualTo(expectedEntryCount);
 
     // count all_entries
-    assertThat(expectedEntryCount)
-        .as("Count should return " + expectedEntryCount)
-        .isEqualTo(
+    assertThat(
             spark
                 .read()
                 .format("iceberg")
                 .load(loadLocation(tableIdentifier, "all_entries"))
-                .count());
+                .count())
+        .as("Count should return " + expectedEntryCount)
+        .isEqualTo(expectedEntryCount);
   }
 
   @Test
@@ -598,10 +598,10 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     long snapshotId = table.currentSnapshot().snapshotId();
 
     assertThat(actual).as("Entries table should have 2 rows").hasSize(2);
-    assertThat(0).as("Sequence number must match").isEqualTo(actual.get(0).getLong(0));
-    assertThat(snapshotId).as("Snapshot id must match").isEqualTo(actual.get(0).getLong(1));
-    assertThat(0).as("Sequence number must match").isEqualTo(actual.get(1).getLong(0));
-    assertThat(snapshotId).as("Snapshot id must match").isEqualTo(actual.get(1).getLong(1));
+    assertThat(actual.get(0).getLong(0)).as("Sequence number must match").isEqualTo(0);
+    assertThat(actual.get(0).getLong(1)).as("Snapshot id must match").isEqualTo(snapshotId);
+    assertThat(actual.get(1).getLong(0)).as("Sequence number must match").isEqualTo(0);
+    assertThat(actual.get(1).getLong(1)).as("Snapshot id must match").isEqualTo(snapshotId);
   }
 
   @Test
@@ -1783,7 +1783,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
         .as("Records should match")
         .isEqualTo(resultDf3.orderBy("id").collectAsList());
 
-    assertThat(originalSparkSchema).as("Schemas should match").isEqualTo(resultDf3.schema());
+    assertThat(resultDf3.schema()).as("Schemas should match").isEqualTo(originalSparkSchema);
   }
 
   @Test
@@ -1810,9 +1810,9 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
     Dataset<Row> resultDf = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
 
-    assertThat(originalRecords)
+    assertThat(resultDf.orderBy("id").collectAsList())
         .as("Records should match")
-        .isEqualTo(resultDf.orderBy("id").collectAsList());
+        .isEqualTo(originalRecords);
 
     long tsBeforeDropColumn = waitUntilAfter(System.currentTimeMillis());
     table.updateSchema().deleteColumn("data").commit();
@@ -1840,9 +1840,9 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             RowFactory.create(5, "C"));
 
     Dataset<Row> resultDf2 = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
-    assertThat(updatedRecords)
+    assertThat(resultDf2.orderBy("id").collectAsList())
         .as("Records should match")
-        .isEqualTo(resultDf2.orderBy("id").collectAsList());
+        .isEqualTo(updatedRecords);
 
     Dataset<Row> resultDf3 =
         spark
@@ -1851,11 +1851,11 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .option(SparkReadOptions.AS_OF_TIMESTAMP, tsBeforeDropColumn)
             .load(loadLocation(tableIdentifier));
 
-    assertThat(originalRecords)
+    assertThat(resultDf3.orderBy("id").collectAsList())
         .as("Records should match")
-        .isEqualTo(resultDf3.orderBy("id").collectAsList());
+        .isEqualTo(originalRecords);
 
-    assertThat(originalSparkSchema).as("Schemas should match").isEqualTo(resultDf3.schema());
+    assertThat(resultDf3.schema()).as("Schemas should match").isEqualTo(originalSparkSchema);
 
     // At tsAfterDropColumn, there has been a schema change, but no new snapshot,
     // so the snapshot as of tsAfterDropColumn is the same as that as of tsBeforeDropColumn.
@@ -1866,11 +1866,11 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .option(SparkReadOptions.AS_OF_TIMESTAMP, tsAfterDropColumn)
             .load(loadLocation(tableIdentifier));
 
-    assertThat(originalRecords)
+    assertThat(resultDf4.orderBy("id").collectAsList())
         .as("Records should match")
-        .isEqualTo(resultDf4.orderBy("id").collectAsList());
+        .isEqualTo(originalRecords);
 
-    assertThat(originalSparkSchema).as("Schemas should match").isEqualTo(resultDf4.schema());
+    assertThat(resultDf4.schema()).as("Schemas should match").isEqualTo(originalSparkSchema);
   }
 
   @Test
@@ -1895,9 +1895,9 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
     Dataset<Row> resultDf = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
 
-    assertThat(originalRecords)
+    assertThat(resultDf.orderBy("id").collectAsList())
         .as("Records should match")
-        .isEqualTo(resultDf.orderBy("id").collectAsList());
+        .isEqualTo(originalRecords);
 
     Snapshot snapshotBeforeAddColumn = table.currentSnapshot();
 
@@ -1927,9 +1927,9 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
     Dataset<Row> resultDf2 = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
 
-    assertThat(updatedRecords)
+    assertThat(resultDf2.orderBy("id").collectAsList())
         .as("Records should match")
-        .isEqualTo(resultDf2.orderBy("id").collectAsList());
+        .isEqualTo(updatedRecords);
 
     table.updateSchema().deleteColumn("data").commit();
 
@@ -1943,9 +1943,9 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
     Dataset<Row> resultDf3 = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
 
-    assertThat(recordsAfterDropColumn)
+    assertThat(resultDf3.orderBy("id").collectAsList())
         .as("Records should match")
-        .isEqualTo(resultDf3.orderBy("id").collectAsList());
+        .isEqualTo(recordsAfterDropColumn);
 
     Dataset<Row> resultDf4 =
         spark
@@ -1954,11 +1954,11 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .option(SparkReadOptions.SNAPSHOT_ID, snapshotBeforeAddColumn.snapshotId())
             .load(loadLocation(tableIdentifier));
 
-    assertThat(originalRecords)
+    assertThat(resultDf4.orderBy("id").collectAsList())
         .as("Records should match")
-        .isEqualTo(resultDf4.orderBy("id").collectAsList());
+        .isEqualTo(originalRecords);
 
-    assertThat(originalSparkSchema).as("Schemas should match").isEqualTo(resultDf4.schema());
+    assertThat(resultDf4.schema()).as("Schemas should match").isEqualTo(originalSparkSchema);
   }
 
   @Test
@@ -2003,7 +2003,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     List<SimpleRecord> actualRecords =
         resultDF.as(Encoders.bean(SimpleRecord.class)).collectAsList();
 
-    assertThat(records).as("Rows must match").isEqualTo(actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(records);
   }
 
   @Test
@@ -2298,14 +2298,14 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
   private void assertDataFilePartitions(
       List<DataFile> dataFiles, List<Integer> expectedPartitionIds) {
-    assertThat(expectedPartitionIds)
+    assertThat(dataFiles)
         .as("Table should have " + expectedPartitionIds.size() + " data files")
-        .hasSameSizeAs(dataFiles);
+        .hasSameSizeAs(expectedPartitionIds);
 
     for (int i = 0; i < dataFiles.size(); ++i) {
-      assertThat(expectedPartitionIds.get(i).intValue())
+      assertThat(dataFiles.get(i).partition().get(0, Integer.class).intValue())
           .as("Data file should have partition of id " + expectedPartitionIds.get(i))
-          .isEqualTo(dataFiles.get(i).partition().get(0, Integer.class).intValue());
+          .isEqualTo(expectedPartitionIds.get(i).intValue());
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
@@ -17,6 +17,8 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -33,22 +35,20 @@ import org.apache.spark.sql.types.CharType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.VarcharType;
-import org.assertj.core.api.Assertions;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestIcebergSpark {
 
   private static SparkSession spark = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void startSpark() {
     TestIcebergSpark.spark = SparkSession.builder().master("local[2]").getOrCreate();
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopSpark() {
     SparkSession currentSpark = TestIcebergSpark.spark;
     TestIcebergSpark.spark = null;
@@ -59,69 +59,64 @@ public class TestIcebergSpark {
   public void testRegisterIntegerBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_int_16", DataTypes.IntegerType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_int_16(1)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1),
-        results.get(0).getInt(0));
+
+    assertThat(results).hasSize(1);
+    assertThat((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1))
+            .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
   public void testRegisterShortBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_short_16", DataTypes.ShortType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_short_16(1S)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1),
-        results.get(0).getInt(0));
+    assertThat(results).hasSize(1);
+    assertThat((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1))
+            .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
   public void testRegisterByteBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_byte_16", DataTypes.ByteType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_byte_16(1Y)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1),
-        results.get(0).getInt(0));
+    assertThat(results).hasSize(1);
+    assertThat((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1))
+            .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
   public void testRegisterLongBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_long_16", DataTypes.LongType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_long_16(1L)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.LongType.get()).apply(1L), results.get(0).getInt(0));
+    assertThat(results).hasSize(1);
+    assertThat((int) Transforms.bucket(16).bind(Types.LongType.get()).apply(1L))
+            .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
   public void testRegisterStringBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_string_16", DataTypes.StringType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_string_16('hello')").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"),
-        results.get(0).getInt(0));
+    assertThat(results).hasSize(1);
+    assertThat((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"))
+            .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
   public void testRegisterCharBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_char_16", new CharType(5), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_char_16('hello')").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"),
-        results.get(0).getInt(0));
+    assertThat(results).hasSize(1);
+    assertThat((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"))
+            .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
   public void testRegisterVarCharBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_varchar_16", new VarcharType(5), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_varchar_16('hello')").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"),
-        results.get(0).getInt(0));
+    assertThat(results).hasSize(1);
+    assertThat((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"))
+            .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -129,13 +124,12 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_date_16", DataTypes.DateType, 16);
     List<Row> results =
         spark.sql("SELECT iceberg_bucket_date_16(DATE '2021-06-30')").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int)
+    assertThat(results).hasSize(1);
+    assertThat((int)
             Transforms.bucket(16)
-                .bind(Types.DateType.get())
-                .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30"))),
-        results.get(0).getInt(0));
+                    .bind(Types.DateType.get())
+                    .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30"))))
+            .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -146,42 +140,39 @@ public class TestIcebergSpark {
         spark
             .sql("SELECT iceberg_bucket_timestamp_16(TIMESTAMP '2021-06-30 00:00:00.000')")
             .collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int)
+    assertThat(results).hasSize(1);
+    assertThat((int)
             Transforms.bucket(16)
-                .bind(Types.TimestampType.withZone())
-                .apply(
-                    DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf("2021-06-30 00:00:00.000"))),
-        results.get(0).getInt(0));
+                    .bind(Types.TimestampType.withZone())
+                    .apply(
+                            DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf("2021-06-30 00:00:00.000"))))
+            .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
   public void testRegisterBinaryBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_binary_16", DataTypes.BinaryType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_binary_16(X'0020001F')").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int)
+    assertThat(results).hasSize(1);
+    assertThat((int)
             Transforms.bucket(16)
-                .bind(Types.BinaryType.get())
-                .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F})),
-        results.get(0).getInt(0));
+                    .bind(Types.BinaryType.get())
+                    .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F})))
+            .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
   public void testRegisterDecimalBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_decimal_16", new DecimalType(4, 2), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_decimal_16(11.11)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")),
-        results.get(0).getInt(0));
+    assertThat(results).hasSize(1);
+    assertThat((int) Transforms.bucket(16).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")))
+            .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
   public void testRegisterBooleanBucketUDF() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 IcebergSpark.registerBucketUDF(
                     spark, "iceberg_bucket_boolean_16", DataTypes.BooleanType, 16))
@@ -191,7 +182,7 @@ public class TestIcebergSpark {
 
   @Test
   public void testRegisterDoubleBucketUDF() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 IcebergSpark.registerBucketUDF(
                     spark, "iceberg_bucket_double_16", DataTypes.DoubleType, 16))
@@ -201,7 +192,7 @@ public class TestIcebergSpark {
 
   @Test
   public void testRegisterFloatBucketUDF() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 IcebergSpark.registerBucketUDF(
                     spark, "iceberg_bucket_float_16", DataTypes.FloatType, 16))
@@ -213,37 +204,34 @@ public class TestIcebergSpark {
   public void testRegisterIntegerTruncateUDF() {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_int_4", DataTypes.IntegerType, 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_int_4(1)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        Transforms.truncate(4).bind(Types.IntegerType.get()).apply(1), results.get(0).getInt(0));
+    assertThat(results).hasSize(1);
+    assertThat(Transforms.truncate(4).bind(Types.IntegerType.get()).apply(1))
+            .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
   public void testRegisterLongTruncateUDF() {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_long_4", DataTypes.LongType, 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_long_4(1L)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        Transforms.truncate(4).bind(Types.LongType.get()).apply(1L), results.get(0).getLong(0));
+    assertThat(results).hasSize(1);
+    assertThat(Transforms.truncate(4).bind(Types.LongType.get()).apply(1L))
+            .isEqualTo(results.get(0).getLong(0));
   }
 
   @Test
   public void testRegisterDecimalTruncateUDF() {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_decimal_4", new DecimalType(4, 2), 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_decimal_4(11.11)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        Transforms.truncate(4).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")),
-        results.get(0).getDecimal(0));
+    assertThat(results).hasSize(1);
+    assertThat(Transforms.truncate(4).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11"))).isEqualTo(results.get(0).getDecimal(0));
   }
 
   @Test
   public void testRegisterStringTruncateUDF() {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_string_4", DataTypes.StringType, 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_string_4('hello')").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        Transforms.truncate(4).bind(Types.StringType.get()).apply("hello"),
-        results.get(0).getString(0));
+    assertThat(results).hasSize(1);
+    assertThat(Transforms.truncate(4).bind(Types.StringType.get()).apply("hello"))
+            .isEqualTo(results.get(0).getString(0));
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -62,7 +63,7 @@ public class TestIcebergSpark {
 
     assertThat(results).hasSize(1);
     assertThat((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1))
-            .isEqualTo(results.get(0).getInt(0));
+        .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -71,7 +72,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_short_16(1S)").collectAsList();
     assertThat(results).hasSize(1);
     assertThat((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1))
-            .isEqualTo(results.get(0).getInt(0));
+        .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -80,7 +81,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_byte_16(1Y)").collectAsList();
     assertThat(results).hasSize(1);
     assertThat((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1))
-            .isEqualTo(results.get(0).getInt(0));
+        .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -89,7 +90,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_long_16(1L)").collectAsList();
     assertThat(results).hasSize(1);
     assertThat((int) Transforms.bucket(16).bind(Types.LongType.get()).apply(1L))
-            .isEqualTo(results.get(0).getInt(0));
+        .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -98,7 +99,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_string_16('hello')").collectAsList();
     assertThat(results).hasSize(1);
     assertThat((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"))
-            .isEqualTo(results.get(0).getInt(0));
+        .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -107,7 +108,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_char_16('hello')").collectAsList();
     assertThat(results).hasSize(1);
     assertThat((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"))
-            .isEqualTo(results.get(0).getInt(0));
+        .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -116,7 +117,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_varchar_16('hello')").collectAsList();
     assertThat(results).hasSize(1);
     assertThat((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"))
-            .isEqualTo(results.get(0).getInt(0));
+        .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -125,11 +126,12 @@ public class TestIcebergSpark {
     List<Row> results =
         spark.sql("SELECT iceberg_bucket_date_16(DATE '2021-06-30')").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat((int)
-            Transforms.bucket(16)
+    assertThat(
+            (int)
+                Transforms.bucket(16)
                     .bind(Types.DateType.get())
                     .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30"))))
-            .isEqualTo(results.get(0).getInt(0));
+        .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -141,12 +143,14 @@ public class TestIcebergSpark {
             .sql("SELECT iceberg_bucket_timestamp_16(TIMESTAMP '2021-06-30 00:00:00.000')")
             .collectAsList();
     assertThat(results).hasSize(1);
-    assertThat((int)
-            Transforms.bucket(16)
+    assertThat(
+            (int)
+                Transforms.bucket(16)
                     .bind(Types.TimestampType.withZone())
                     .apply(
-                            DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf("2021-06-30 00:00:00.000"))))
-            .isEqualTo(results.get(0).getInt(0));
+                        DateTimeUtils.fromJavaTimestamp(
+                            Timestamp.valueOf("2021-06-30 00:00:00.000"))))
+        .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -154,11 +158,12 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_binary_16", DataTypes.BinaryType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_binary_16(X'0020001F')").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat((int)
-            Transforms.bucket(16)
+    assertThat(
+            (int)
+                Transforms.bucket(16)
                     .bind(Types.BinaryType.get())
                     .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F})))
-            .isEqualTo(results.get(0).getInt(0));
+        .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -166,8 +171,12 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_decimal_16", new DecimalType(4, 2), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_decimal_16(11.11)").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat((int) Transforms.bucket(16).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")))
-            .isEqualTo(results.get(0).getInt(0));
+    assertThat(
+            (int)
+                Transforms.bucket(16)
+                    .bind(Types.DecimalType.of(4, 2))
+                    .apply(new BigDecimal("11.11")))
+        .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -206,7 +215,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_truncate_int_4(1)").collectAsList();
     assertThat(results).hasSize(1);
     assertThat(Transforms.truncate(4).bind(Types.IntegerType.get()).apply(1))
-            .isEqualTo(results.get(0).getInt(0));
+        .isEqualTo(results.get(0).getInt(0));
   }
 
   @Test
@@ -215,7 +224,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_truncate_long_4(1L)").collectAsList();
     assertThat(results).hasSize(1);
     assertThat(Transforms.truncate(4).bind(Types.LongType.get()).apply(1L))
-            .isEqualTo(results.get(0).getLong(0));
+        .isEqualTo(results.get(0).getLong(0));
   }
 
   @Test
@@ -223,7 +232,9 @@ public class TestIcebergSpark {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_decimal_4", new DecimalType(4, 2), 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_decimal_4(11.11)").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat(Transforms.truncate(4).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11"))).isEqualTo(results.get(0).getDecimal(0));
+    assertThat(
+            Transforms.truncate(4).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")))
+        .isEqualTo(results.get(0).getDecimal(0));
   }
 
   @Test
@@ -232,6 +243,6 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_truncate_string_4('hello')").collectAsList();
     assertThat(results).hasSize(1);
     assertThat(Transforms.truncate(4).bind(Types.StringType.get()).apply("hello"))
-            .isEqualTo(results.get(0).getString(0));
+        .isEqualTo(results.get(0).getString(0));
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
@@ -63,7 +63,7 @@ public class TestIcebergSpark {
 
     assertThat(results).hasSize(1);
     assertThat(results.get(0).getInt(0))
-        .isEqualTo((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1));
+        .isEqualTo(Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1));
   }
 
   @Test
@@ -72,7 +72,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_short_16(1S)").collectAsList();
     assertThat(results).hasSize(1);
     assertThat(results.get(0).getInt(0))
-        .isEqualTo((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1));
+        .isEqualTo(Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1));
   }
 
   @Test
@@ -81,7 +81,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_byte_16(1Y)").collectAsList();
     assertThat(results).hasSize(1);
     assertThat(results.get(0).getInt(0))
-        .isEqualTo((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1));
+        .isEqualTo(Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1));
   }
 
   @Test
@@ -90,7 +90,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_long_16(1L)").collectAsList();
     assertThat(results).hasSize(1);
     assertThat(results.get(0).getInt(0))
-        .isEqualTo((int) Transforms.bucket(16).bind(Types.LongType.get()).apply(1L));
+        .isEqualTo(Transforms.bucket(16).bind(Types.LongType.get()).apply(1L));
   }
 
   @Test
@@ -99,7 +99,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_string_16('hello')").collectAsList();
     assertThat(results).hasSize(1);
     assertThat(results.get(0).getInt(0))
-        .isEqualTo((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"));
+        .isEqualTo(Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"));
   }
 
   @Test
@@ -108,7 +108,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_char_16('hello')").collectAsList();
     assertThat(results).hasSize(1);
     assertThat(results.get(0).getInt(0))
-        .isEqualTo((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"));
+        .isEqualTo(Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"));
   }
 
   @Test
@@ -117,7 +117,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_varchar_16('hello')").collectAsList();
     assertThat(results).hasSize(1);
     assertThat(results.get(0).getInt(0))
-        .isEqualTo((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"));
+        .isEqualTo(Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"));
   }
 
   @Test
@@ -128,10 +128,9 @@ public class TestIcebergSpark {
     assertThat(results).hasSize(1);
     assertThat(results.get(0).getInt(0))
         .isEqualTo(
-            (int)
-                Transforms.bucket(16)
-                    .bind(Types.DateType.get())
-                    .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30"))));
+            Transforms.bucket(16)
+                .bind(Types.DateType.get())
+                .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30"))));
   }
 
   @Test
@@ -145,12 +144,10 @@ public class TestIcebergSpark {
     assertThat(results).hasSize(1);
     assertThat(results.get(0).getInt(0))
         .isEqualTo(
-            (int)
-                Transforms.bucket(16)
-                    .bind(Types.TimestampType.withZone())
-                    .apply(
-                        DateTimeUtils.fromJavaTimestamp(
-                            Timestamp.valueOf("2021-06-30 00:00:00.000"))));
+            Transforms.bucket(16)
+                .bind(Types.TimestampType.withZone())
+                .apply(
+                    DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf("2021-06-30 00:00:00.000"))));
   }
 
   @Test
@@ -160,10 +157,9 @@ public class TestIcebergSpark {
     assertThat(results).hasSize(1);
     assertThat(results.get(0).getInt(0))
         .isEqualTo(
-            (int)
-                Transforms.bucket(16)
-                    .bind(Types.BinaryType.get())
-                    .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F})));
+            Transforms.bucket(16)
+                .bind(Types.BinaryType.get())
+                .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F})));
   }
 
   @Test
@@ -173,10 +169,7 @@ public class TestIcebergSpark {
     assertThat(results).hasSize(1);
     assertThat(results.get(0).getInt(0))
         .isEqualTo(
-            (int)
-                Transforms.bucket(16)
-                    .bind(Types.DecimalType.of(4, 2))
-                    .apply(new BigDecimal("11.11")));
+            Transforms.bucket(16).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")));
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
@@ -62,8 +62,8 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_int_16(1)").collectAsList();
 
     assertThat(results).hasSize(1);
-    assertThat((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1))
-        .isEqualTo(results.get(0).getInt(0));
+    assertThat(results.get(0).getInt(0))
+        .isEqualTo((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1));
   }
 
   @Test
@@ -71,8 +71,8 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_short_16", DataTypes.ShortType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_short_16(1S)").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1))
-        .isEqualTo(results.get(0).getInt(0));
+    assertThat(results.get(0).getInt(0))
+        .isEqualTo((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1));
   }
 
   @Test
@@ -80,8 +80,8 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_byte_16", DataTypes.ByteType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_byte_16(1Y)").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1))
-        .isEqualTo(results.get(0).getInt(0));
+    assertThat(results.get(0).getInt(0))
+        .isEqualTo((int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1));
   }
 
   @Test
@@ -89,8 +89,8 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_long_16", DataTypes.LongType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_long_16(1L)").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat((int) Transforms.bucket(16).bind(Types.LongType.get()).apply(1L))
-        .isEqualTo(results.get(0).getInt(0));
+    assertThat(results.get(0).getInt(0))
+        .isEqualTo((int) Transforms.bucket(16).bind(Types.LongType.get()).apply(1L));
   }
 
   @Test
@@ -98,8 +98,8 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_string_16", DataTypes.StringType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_string_16('hello')").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"))
-        .isEqualTo(results.get(0).getInt(0));
+    assertThat(results.get(0).getInt(0))
+        .isEqualTo((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"));
   }
 
   @Test
@@ -107,8 +107,8 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_char_16", new CharType(5), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_char_16('hello')").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"))
-        .isEqualTo(results.get(0).getInt(0));
+    assertThat(results.get(0).getInt(0))
+        .isEqualTo((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"));
   }
 
   @Test
@@ -116,8 +116,8 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_varchar_16", new VarcharType(5), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_varchar_16('hello')").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"))
-        .isEqualTo(results.get(0).getInt(0));
+    assertThat(results.get(0).getInt(0))
+        .isEqualTo((int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"));
   }
 
   @Test
@@ -126,12 +126,12 @@ public class TestIcebergSpark {
     List<Row> results =
         spark.sql("SELECT iceberg_bucket_date_16(DATE '2021-06-30')").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat(
+    assertThat(results.get(0).getInt(0))
+        .isEqualTo(
             (int)
                 Transforms.bucket(16)
                     .bind(Types.DateType.get())
-                    .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30"))))
-        .isEqualTo(results.get(0).getInt(0));
+                    .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30"))));
   }
 
   @Test
@@ -143,14 +143,14 @@ public class TestIcebergSpark {
             .sql("SELECT iceberg_bucket_timestamp_16(TIMESTAMP '2021-06-30 00:00:00.000')")
             .collectAsList();
     assertThat(results).hasSize(1);
-    assertThat(
+    assertThat(results.get(0).getInt(0))
+        .isEqualTo(
             (int)
                 Transforms.bucket(16)
                     .bind(Types.TimestampType.withZone())
                     .apply(
                         DateTimeUtils.fromJavaTimestamp(
-                            Timestamp.valueOf("2021-06-30 00:00:00.000"))))
-        .isEqualTo(results.get(0).getInt(0));
+                            Timestamp.valueOf("2021-06-30 00:00:00.000"))));
   }
 
   @Test
@@ -158,12 +158,12 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_binary_16", DataTypes.BinaryType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_binary_16(X'0020001F')").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat(
+    assertThat(results.get(0).getInt(0))
+        .isEqualTo(
             (int)
                 Transforms.bucket(16)
                     .bind(Types.BinaryType.get())
-                    .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F})))
-        .isEqualTo(results.get(0).getInt(0));
+                    .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F})));
   }
 
   @Test
@@ -171,12 +171,12 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_decimal_16", new DecimalType(4, 2), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_decimal_16(11.11)").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat(
+    assertThat(results.get(0).getInt(0))
+        .isEqualTo(
             (int)
                 Transforms.bucket(16)
                     .bind(Types.DecimalType.of(4, 2))
-                    .apply(new BigDecimal("11.11")))
-        .isEqualTo(results.get(0).getInt(0));
+                    .apply(new BigDecimal("11.11")));
   }
 
   @Test
@@ -214,8 +214,8 @@ public class TestIcebergSpark {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_int_4", DataTypes.IntegerType, 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_int_4(1)").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat(Transforms.truncate(4).bind(Types.IntegerType.get()).apply(1))
-        .isEqualTo(results.get(0).getInt(0));
+    assertThat(results.get(0).getInt(0))
+        .isEqualTo(Transforms.truncate(4).bind(Types.IntegerType.get()).apply(1));
   }
 
   @Test
@@ -223,8 +223,8 @@ public class TestIcebergSpark {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_long_4", DataTypes.LongType, 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_long_4(1L)").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat(Transforms.truncate(4).bind(Types.LongType.get()).apply(1L))
-        .isEqualTo(results.get(0).getLong(0));
+    assertThat(results.get(0).getLong(0))
+        .isEqualTo(Transforms.truncate(4).bind(Types.LongType.get()).apply(1L));
   }
 
   @Test
@@ -232,9 +232,9 @@ public class TestIcebergSpark {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_decimal_4", new DecimalType(4, 2), 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_decimal_4(11.11)").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat(
-            Transforms.truncate(4).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")))
-        .isEqualTo(results.get(0).getDecimal(0));
+    assertThat(results.get(0).getDecimal(0))
+        .isEqualTo(
+            Transforms.truncate(4).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")));
   }
 
   @Test
@@ -242,7 +242,7 @@ public class TestIcebergSpark {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_string_4", DataTypes.StringType, 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_string_4('hello')").collectAsList();
     assertThat(results).hasSize(1);
-    assertThat(Transforms.truncate(4).bind(Types.StringType.get()).apply("hello"))
-        .isEqualTo(results.get(0).getString(0));
+    assertThat(results.get(0).getString(0))
+        .isEqualTo(Transforms.truncate(4).bind(Types.StringType.get()).apply("hello"));
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestInternalRowWrapper.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestInternalRowWrapper.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark.source;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Iterator;
 import org.apache.iceberg.RecordWrapperTest;
 import org.apache.iceberg.Schema;
@@ -29,18 +31,17 @@ import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.data.RandomData;
 import org.apache.iceberg.util.StructLikeWrapper;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.junit.Assert;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 
 public class TestInternalRowWrapper extends RecordWrapperTest {
 
-  @Ignore
+  @Disabled
   @Override
   public void testTimestampWithoutZone() {
     // Spark does not support timestamp without zone.
   }
 
-  @Ignore
+  @Disabled
   @Override
   public void testTime() {
     // Spark does not support time fields.
@@ -61,8 +62,8 @@ public class TestInternalRowWrapper extends RecordWrapperTest {
     StructLikeWrapper actualWrapper = StructLikeWrapper.forType(schema.asStruct());
     StructLikeWrapper expectedWrapper = StructLikeWrapper.forType(schema.asStruct());
     for (int i = 0; i < numRecords; i++) {
-      Assert.assertTrue("Should have more records", actual.hasNext());
-      Assert.assertTrue("Should have more InternalRow", expected.hasNext());
+      assertThat(actual).as("Should have more records").hasNext();
+      assertThat(expected).as("Should have more InternalRow").hasNext();
 
       StructLike recordStructLike = recordWrapper.wrap(actual.next());
       StructLike rowStructLike = rowWrapper.wrap(expected.next());
@@ -73,7 +74,7 @@ public class TestInternalRowWrapper extends RecordWrapperTest {
           expectedWrapper.set(rowStructLike));
     }
 
-    Assert.assertFalse("Shouldn't have more record", actual.hasNext());
-    Assert.assertFalse("Shouldn't have more InternalRow", expected.hasNext());
+    assertThat(actual).as("Shouldn't have more record").isExhausted();
+    assertThat(expected).as("Shouldn't have more InternalRow").isExhausted();
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
@@ -53,8 +53,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 public class TestMetadataTableReadableMetrics extends TestBaseWithCatalog {
 
-  @TempDir
-  private Path temp;
+  @TempDir private Path temp;
 
   private static final Types.StructType LEAF_STRUCT_TYPE =
       Types.StructType.of(
@@ -125,8 +124,7 @@ public class TestMetadataTableReadableMetrics extends TestBaseWithCatalog {
             createPrimitiveRecord(
                 false, 2, 2L, Float.NaN, 2.0D, new BigDecimal("2.00"), "2", null, null));
 
-    DataFile dataFile =
-        FileHelpers.writeDataFile(table, Files.localOutput(temp.toFile()), records);
+    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(temp.toFile()), records);
     table.newAppend().appendFile(dataFile).commit();
     return table;
   }
@@ -144,8 +142,7 @@ public class TestMetadataTableReadableMetrics extends TestBaseWithCatalog {
             createNestedRecord(0L, 0.0),
             createNestedRecord(1L, Double.NaN),
             createNestedRecord(null, null));
-    DataFile dataFile =
-        FileHelpers.writeDataFile(table, Files.localOutput(temp.toFile()), records);
+    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(temp.toFile()), records);
     table.newAppend().appendFile(dataFile).commit();
     return Pair.of(table, dataFile);
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class TestMetadataTableReadableMetrics extends TestBaseWithCatalog {
 
   @TempDir
-  public Path temp;
+  private Path temp;
 
   private static final Types.StructType LEAF_STRUCT_TYPE =
       Types.StructType.of(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
@@ -24,6 +24,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -41,19 +42,19 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkCatalogConfig;
-import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TestMetadataTableReadableMetrics extends SparkTestBaseWithCatalog {
+public class TestMetadataTableReadableMetrics extends TestBaseWithCatalog {
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  public Path temp;
 
   private static final Types.StructType LEAF_STRUCT_TYPE =
       Types.StructType.of(
@@ -125,7 +126,7 @@ public class TestMetadataTableReadableMetrics extends SparkTestBaseWithCatalog {
                 false, 2, 2L, Float.NaN, 2.0D, new BigDecimal("2.00"), "2", null, null));
 
     DataFile dataFile =
-        FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), records);
+        FileHelpers.writeDataFile(table, Files.localOutput(temp.toFile()), records);
     table.newAppend().appendFile(dataFile).commit();
     return table;
   }
@@ -144,12 +145,12 @@ public class TestMetadataTableReadableMetrics extends SparkTestBaseWithCatalog {
             createNestedRecord(1L, Double.NaN),
             createNestedRecord(null, null));
     DataFile dataFile =
-        FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), records);
+        FileHelpers.writeDataFile(table, Files.localOutput(temp.toFile()), records);
     table.newAppend().appendFile(dataFile).commit();
     return Pair.of(table, dataFile);
   }
 
-  @After
+  @AfterEach
   public void dropTable() {
     sql("DROP TABLE %s", tableName);
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPathIdentifier.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPathIdentifier.java
@@ -48,8 +48,7 @@ public class TestPathIdentifier extends TestBase {
       new Schema(
           required(1, "id", Types.LongType.get()), required(2, "data", Types.StringType.get()));
 
-  @TempDir
-  private Path temp;
+  @TempDir private Path temp;
   private File tableLocation;
   private PathIdentifier identifier;
   private SparkCatalog sparkCatalog;
@@ -77,8 +76,7 @@ public class TestPathIdentifier extends TestBase {
 
     assertThat(table.table().location()).isEqualTo(tableLocation.getAbsolutePath());
     assertThat(table.table()).isInstanceOf(BaseTable.class);
-    assertThat(((BaseTable) table.table()).operations())
-        .isInstanceOf(HadoopTableOperations.class);
+    assertThat(((BaseTable) table.table()).operations()).isInstanceOf(HadoopTableOperations.class);
 
     assertThat(sparkCatalog.loadTable(identifier)).isEqualTo(table);
     assertThat(sparkCatalog.dropTable(identifier)).isTrue();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPathIdentifier.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPathIdentifier.java
@@ -74,11 +74,11 @@ public class TestPathIdentifier extends TestBase {
             sparkCatalog.createTable(
                 identifier, SparkSchemaUtil.convert(SCHEMA), new Transform[0], ImmutableMap.of());
 
-    assertThat(table.table().location()).isEqualTo(tableLocation.getAbsolutePath());
+    assertThat(tableLocation.getAbsolutePath()).isEqualTo(table.table().location());
     assertThat(table.table()).isInstanceOf(BaseTable.class);
     assertThat(((BaseTable) table.table()).operations()).isInstanceOf(HadoopTableOperations.class);
 
-    assertThat(sparkCatalog.loadTable(identifier)).isEqualTo(table);
+    assertThat(table).isEqualTo(sparkCatalog.loadTable(identifier));
     assertThat(sparkCatalog.dropTable(identifier)).isTrue();
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPathIdentifier.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPathIdentifier.java
@@ -49,7 +49,7 @@ public class TestPathIdentifier extends TestBase {
           required(1, "id", Types.LongType.get()), required(2, "data", Types.StringType.get()));
 
   @TempDir
-  public Path temp;
+  private Path temp;
   private File tableLocation;
   private PathIdentifier identifier;
   private SparkCatalog sparkCatalog;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -50,7 +50,7 @@ public abstract class TestReadProjection {
   protected abstract Record writeAndRead(
       String desc, Schema writeSchema, Schema readSchema, Record record) throws IOException;
 
-  @TempDir private Path temp;
+  @TempDir protected Path temp;
 
   @Test
   public void testFullProjection() throws Exception {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -51,7 +51,7 @@ public abstract class TestReadProjection {
       String desc, Schema writeSchema, Schema readSchema, Record record) throws IOException;
 
   @TempDir
-  public Path temp;
+  private Path temp;
 
   @Test
   public void testFullProjection() throws Exception {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -36,7 +36,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -73,8 +72,7 @@ public abstract class TestReadProjection {
     int cmp =
         Comparators.charSequences().compare("test", (CharSequence) projected.getField("data"));
 
-    // TODO: update this Assert with AssertJ
-    Assert.assertEquals("Should contain the correct data value", 0, cmp);
+    assertThat(cmp).as("Should contain the correct data value").isEqualTo(0);
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -50,8 +50,7 @@ public abstract class TestReadProjection {
   protected abstract Record writeAndRead(
       String desc, Schema writeSchema, Schema readSchema, Record record) throws IOException;
 
-  @TempDir
-  private Path temp;
+  @TempDir private Path temp;
 
   @Test
   public void testFullProjection() throws Exception {
@@ -66,13 +65,13 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("full_projection", schema, schema, record);
 
-    assertThat(34L).as("Should contain the correct id value")
-            .isEqualTo((long) projected.getField("id"));
+    assertThat(34L)
+        .as("Should contain the correct id value")
+        .isEqualTo((long) projected.getField("id"));
 
     int cmp =
         Comparators.charSequences().compare("test", (CharSequence) projected.getField("data"));
-    assertThat(0).as("Should contain the correct data value")
-            .isEqualTo(cmp);
+    assertThat(0).as("Should contain the correct data value").isEqualTo(cmp);
   }
 
   @Test
@@ -97,9 +96,10 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("reordered_full_projection", schema, reordered, record);
 
-    assertThat("test").as("Should contain the correct 0 value").isEqualTo(projected.get(0).toString());
+    assertThat("test")
+        .as("Should contain the correct 0 value")
+        .isEqualTo(projected.get(0).toString());
     assertThat(34L).as("Should contain the correct 1 value").isEqualTo(projected.get(1));
-
   }
 
   @Test
@@ -126,7 +126,9 @@ public abstract class TestReadProjection {
     Record projected = writeAndRead("reordered_projection", schema, reordered, record);
 
     assertThat(projected.get(0)).as("Should contain the correct 0 value").isNull();
-    assertThat("test").as("Should contain the correct 1 value").isEqualTo(projected.get(1).toString());
+    assertThat("test")
+        .as("Should contain the correct 1 value")
+        .isEqualTo(projected.get(1).toString());
     assertThat(projected.get(2)).as("Should contain the correct 2 value").isNull();
   }
 
@@ -145,8 +147,7 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @Test
@@ -164,7 +165,9 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("basic_projection_id", writeSchema, idOnly, record);
     assertThat(projected.getField("data")).as("Should not project data").isNull();
-    assertThat(34L).as("Should contain the correct id value").isEqualTo((long) projected.getField("id"));
+    assertThat(34L)
+        .as("Should contain the correct id value")
+        .isEqualTo((long) projected.getField("id"));
 
     Schema dataOnly = new Schema(Types.NestedField.optional(1, "data", Types.StringType.get()));
 
@@ -193,7 +196,9 @@ public abstract class TestReadProjection {
             Types.NestedField.optional(1, "renamed", Types.StringType.get()));
 
     Record projected = writeAndRead("project_and_rename", writeSchema, readSchema, record);
-    assertThat(34L).as("Should contain the correct id value").isEqualTo((long) projected.getField("id"));
+    assertThat(34L)
+        .as("Should contain the correct id value")
+        .isEqualTo((long) projected.getField("id"));
 
     int cmp =
         Comparators.charSequences().compare("test", (CharSequence) projected.getField("renamed"));
@@ -223,7 +228,9 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
     Record projectedLocation = (Record) projected.getField("location");
-    assertThat(34L).as("Should contain the correct id value").isEqualTo((long) projected.getField("id"));
+    assertThat(34L)
+        .as("Should contain the correct id value")
+        .isEqualTo((long) projected.getField("id"));
     assertThat(projectedLocation).as("Should not project location").isNull();
 
     Schema latOnly =
@@ -239,8 +246,8 @@ public abstract class TestReadProjection {
     assertThat(projected.getField("location")).as("Should project location").isNotNull();
     assertThat(projectedLocation.getField("long")).as("Should not project longitude").isNull();
     assertThat(52.995143f)
-            .as("Should project latitude")
-            .isCloseTo((float) projectedLocation.getField("lat"), within(0.000001f));
+        .as("Should project latitude")
+        .isCloseTo((float) projectedLocation.getField("lat"), within(0.000001f));
 
     Schema longOnly =
         new Schema(
@@ -256,8 +263,8 @@ public abstract class TestReadProjection {
     assertThat(projected.getField("location")).as("Should project location").isNotNull();
     assertThat(projectedLocation.getField("lat")).as("Should not project latitude").isNull();
     assertThat(-1.539054f)
-            .as("Should project longitude")
-            .isCloseTo((float) projectedLocation.getField("long"), within(0.000001f));
+        .as("Should project longitude")
+        .isCloseTo((float) projectedLocation.getField("long"), within(0.000001f));
 
     Schema locationOnly = writeSchema.select("location");
     projected = writeAndRead("location_only", writeSchema, locationOnly, record);
@@ -266,11 +273,11 @@ public abstract class TestReadProjection {
     assertThat(projected.getField("id")).as("Should not project id").isNull();
     assertThat(projected.getField("location")).as("Should project location").isNotNull();
     assertThat(52.995143f)
-            .as("Should project latitude")
-            .isCloseTo((float) projectedLocation.getField("lat"), within(0.000001f));
+        .as("Should project latitude")
+        .isCloseTo((float) projectedLocation.getField("lat"), within(0.000001f));
     assertThat(-1.539054f)
-            .as("Should project longitude")
-            .isCloseTo((float) projectedLocation.getField("long"), within(0.000001f));
+        .as("Should project longitude")
+        .isCloseTo((float) projectedLocation.getField("long"), within(0.000001f));
   }
 
   @Test
@@ -292,26 +299,31 @@ public abstract class TestReadProjection {
     Schema idOnly = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    assertThat(34L).as("Should contain the correct id value").isEqualTo((long) projected.getField("id"));
+    assertThat(34L)
+        .as("Should contain the correct id value")
+        .isEqualTo((long) projected.getField("id"));
     assertThat(projected.getField("properties")).as("Should not project properties map").isNull();
 
     Schema keyOnly = writeSchema.select("properties.key");
     projected = writeAndRead("key_only", writeSchema, keyOnly, record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
-    assertThat(properties).as("Should project entire map")
-            .isEqualTo(toStringMap((Map) projected.getField("properties")));
+    assertThat(properties)
+        .as("Should project entire map")
+        .isEqualTo(toStringMap((Map) projected.getField("properties")));
 
     Schema valueOnly = writeSchema.select("properties.value");
     projected = writeAndRead("value_only", writeSchema, valueOnly, record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
-    assertThat(properties).as("Should project entire map")
-            .isEqualTo(toStringMap((Map) projected.getField("properties")));
+    assertThat(properties)
+        .as("Should project entire map")
+        .isEqualTo(toStringMap((Map) projected.getField("properties")));
 
     Schema mapOnly = writeSchema.select("properties");
     projected = writeAndRead("map_only", writeSchema, mapOnly, record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
-    assertThat(properties).as("Should project entire map")
-            .isEqualTo(toStringMap((Map) projected.getField("properties")));
+    assertThat(properties)
+        .as("Should project entire map")
+        .isEqualTo(toStringMap((Map) projected.getField("properties")));
   }
 
   private Map<String, ?> toStringMap(Map<?, ?> map) {
@@ -355,35 +367,38 @@ public abstract class TestReadProjection {
     Schema idOnly = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    assertThat(34L).as("Should contain the correct id value")
-            .isEqualTo((long) projected.getField("id"));
+    assertThat(34L)
+        .as("Should contain the correct id value")
+        .isEqualTo((long) projected.getField("id"));
     assertThat(projected.getField("locations")).as("Should not project locations map").isNull();
 
     projected = writeAndRead("all_locations", writeSchema, writeSchema.select("locations"), record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
-    assertThat(record.getField("locations")).as("Should project locations map")
-            .isEqualTo(toStringMap((Map) projected.getField("locations")));
+    assertThat(record.getField("locations"))
+        .as("Should project locations map")
+        .isEqualTo(toStringMap((Map) projected.getField("locations")));
 
     projected = writeAndRead("lat_only", writeSchema, writeSchema.select("locations.lat"), record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
 
     Map<String, ?> locations = toStringMap((Map) projected.getField("locations"));
     assertThat(locations).as("Should project locations map").isNotNull();
-    assertThat(Sets.newHashSet("L1", "L2")).as("Should contain L1 and L2")
-            .isEqualTo(locations.keySet());
+    assertThat(Sets.newHashSet("L1", "L2"))
+        .as("Should contain L1 and L2")
+        .isEqualTo(locations.keySet());
 
     Record projectedL1 = (Record) locations.get("L1");
     assertThat(projectedL1).as("L1 should not be null").isNotNull();
     assertThat(53.992811f)
-            .as("L1 should contain lat")
-            .isCloseTo((float) projectedL1.getField("lat"), within(0.000001f));
+        .as("L1 should contain lat")
+        .isCloseTo((float) projectedL1.getField("lat"), within(0.000001f));
     assertThat(projectedL1.getField("long")).as("L1 should not contain long").isNull();
 
     Record projectedL2 = (Record) locations.get("L2");
     assertThat(projectedL2).as("L2 should not be null").isNotNull();
     assertThat(52.995143f)
-            .as("L2 should contain lat")
-            .isCloseTo((float) projectedL2.getField("lat"), within(0.000001f));
+        .as("L2 should contain lat")
+        .isCloseTo((float) projectedL2.getField("lat"), within(0.000001f));
     assertThat(projectedL2.getField("long")).as("L2 should not contain long").isNull();
 
     projected =
@@ -392,22 +407,23 @@ public abstract class TestReadProjection {
 
     locations = toStringMap((Map) projected.getField("locations"));
     assertThat(locations).as("Should project locations map").isNotNull();
-    assertThat(Sets.newHashSet("L1", "L2")).as("Should contain L1 and L2")
-                    .isEqualTo(locations.keySet());
+    assertThat(Sets.newHashSet("L1", "L2"))
+        .as("Should contain L1 and L2")
+        .isEqualTo(locations.keySet());
 
     projectedL1 = (Record) locations.get("L1");
     assertThat(projectedL1).as("L1 should not be null").isNotNull();
     assertThat(projectedL1.getField("lat")).as("L1 should not contain lat").isNull();
     assertThat(-1.542616f)
-            .as("L1 should contain long")
-            .isCloseTo((float) projectedL1.getField("long"), within(0.000001f));
+        .as("L1 should contain long")
+        .isCloseTo((float) projectedL1.getField("long"), within(0.000001f));
 
     projectedL2 = (Record) locations.get("L2");
     assertThat(projectedL2).as("L2 should not be null").isNotNull();
     assertThat(projectedL2.getField("lat")).as("L2 should not contain lat").isNull();
     assertThat(-1.539054f)
-            .as("L2 should contain long")
-            .isCloseTo((float) projectedL2.getField("long"), within(0.000001f));
+        .as("L2 should contain long")
+        .isCloseTo((float) projectedL2.getField("long"), within(0.000001f));
 
     Schema latitiudeRenamed =
         new Schema(
@@ -425,22 +441,23 @@ public abstract class TestReadProjection {
     assertThat(projected.getField("id")).as("Should not project id").isNull();
     locations = toStringMap((Map) projected.getField("locations"));
     assertThat(locations).as("Should project locations map").isNotNull();
-    assertThat(Sets.newHashSet("L1", "L2")).as("Should contain L1 and L2")
-            .isEqualTo(locations.keySet());
+    assertThat(Sets.newHashSet("L1", "L2"))
+        .as("Should contain L1 and L2")
+        .isEqualTo(locations.keySet());
 
     projectedL1 = (Record) locations.get("L1");
     assertThat(projectedL1).as("L1 should not be null").isNotNull();
     assertThat(53.992811f)
-            .as("L1 should contain latitude")
-            .isCloseTo((float) projectedL1.getField("latitude"), within(0.000001f));
+        .as("L1 should contain latitude")
+        .isCloseTo((float) projectedL1.getField("latitude"), within(0.000001f));
     assertThat(projectedL1.getField("lat")).as("L1 should not contain lat").isNull();
     assertThat(projectedL1.getField("long")).as("L1 should not contain long").isNull();
 
     projectedL2 = (Record) locations.get("L2");
     assertThat(projectedL2).as("L2 should not be null").isNotNull();
     assertThat(52.995143f)
-            .as("L2 should contain latitude")
-            .isCloseTo((float) projectedL2.getField("latitude"), within(0.000001f));
+        .as("L2 should contain latitude")
+        .isCloseTo((float) projectedL2.getField("latitude"), within(0.000001f));
     assertThat(projectedL2.getField("lat")).as("L2 should not contain lat").isNull();
     assertThat(projectedL2.getField("long")).as("L2 should not contain long").isNull();
   }
@@ -462,8 +479,9 @@ public abstract class TestReadProjection {
     Schema idOnly = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    assertThat(34L).as("Should contain the correct id value")
-            .isEqualTo((long) projected.getField("id"));
+    assertThat(34L)
+        .as("Should contain the correct id value")
+        .isEqualTo((long) projected.getField("id"));
     assertThat(projected.getField("values")).as("Should not project values list").isNull();
 
     Schema elementOnly = writeSchema.select("values.element");
@@ -505,14 +523,16 @@ public abstract class TestReadProjection {
     Schema idOnly = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    assertThat(34L).as("Should contain the correct id value")
-            .isEqualTo((long) projected.getField("id"));
+    assertThat(34L)
+        .as("Should contain the correct id value")
+        .isEqualTo((long) projected.getField("id"));
     assertThat(projected.getField("points")).as("Should not project points list").isNull();
 
     projected = writeAndRead("all_points", writeSchema, writeSchema.select("points"), record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
-    assertThat(record.getField("points")).as("Should project points list")
-            .isEqualTo(projected.getField("points"));
+    assertThat(record.getField("points"))
+        .as("Should project points list")
+        .isEqualTo(projected.getField("points"));
 
     projected = writeAndRead("x_only", writeSchema, writeSchema.select("points.x"), record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.Schema;
@@ -37,8 +36,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public abstract class TestReadProjection {
   final String format;
@@ -50,7 +51,7 @@ public abstract class TestReadProjection {
   protected abstract Record writeAndRead(
       String desc, Schema writeSchema, Schema readSchema, Record record) throws IOException;
 
-  @TempDir protected Path temp;
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
 
   @Test
   public void testFullProjection() throws Exception {
@@ -71,7 +72,9 @@ public abstract class TestReadProjection {
 
     int cmp =
         Comparators.charSequences().compare("test", (CharSequence) projected.getField("data"));
-    assertThat(cmp).as("Should contain the correct data value").isEqualTo(0);
+
+    // TODO: update this Assert with AssertJ
+    Assert.assertEquals("Should contain the correct data value", 0, cmp);
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -65,13 +65,13 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("full_projection", schema, schema, record);
 
-    assertThat(34L)
+    assertThat((long) projected.getField("id"))
         .as("Should contain the correct id value")
-        .isEqualTo((long) projected.getField("id"));
+        .isEqualTo(34L);
 
     int cmp =
         Comparators.charSequences().compare("test", (CharSequence) projected.getField("data"));
-    assertThat(0).as("Should contain the correct data value").isEqualTo(cmp);
+    assertThat(cmp).as("Should contain the correct data value").isEqualTo(0);
   }
 
   @Test
@@ -96,10 +96,10 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("reordered_full_projection", schema, reordered, record);
 
-    assertThat("test")
+    assertThat(projected.get(0).toString())
         .as("Should contain the correct 0 value")
-        .isEqualTo(projected.get(0).toString());
-    assertThat(34L).as("Should contain the correct 1 value").isEqualTo(projected.get(1));
+        .isEqualTo("test");
+    assertThat(projected.get(1)).as("Should contain the correct 1 value").isEqualTo(34L);
   }
 
   @Test
@@ -126,9 +126,9 @@ public abstract class TestReadProjection {
     Record projected = writeAndRead("reordered_projection", schema, reordered, record);
 
     assertThat(projected.get(0)).as("Should contain the correct 0 value").isNull();
-    assertThat("test")
+    assertThat(projected.get(1).toString())
         .as("Should contain the correct 1 value")
-        .isEqualTo(projected.get(1).toString());
+        .isEqualTo("test");
     assertThat(projected.get(2)).as("Should contain the correct 2 value").isNull();
   }
 
@@ -165,9 +165,9 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("basic_projection_id", writeSchema, idOnly, record);
     assertThat(projected.getField("data")).as("Should not project data").isNull();
-    assertThat(34L)
+    assertThat((long) projected.getField("id"))
         .as("Should contain the correct id value")
-        .isEqualTo((long) projected.getField("id"));
+        .isEqualTo(34L);
 
     Schema dataOnly = new Schema(Types.NestedField.optional(1, "data", Types.StringType.get()));
 
@@ -176,7 +176,7 @@ public abstract class TestReadProjection {
 
     int cmp =
         Comparators.charSequences().compare("test", (CharSequence) projected.getField("data"));
-    assertThat(0).as("Should contain the correct data value").isEqualTo(cmp);
+    assertThat(cmp).as("Should contain the correct data value").isEqualTo(0);
   }
 
   @Test
@@ -196,13 +196,13 @@ public abstract class TestReadProjection {
             Types.NestedField.optional(1, "renamed", Types.StringType.get()));
 
     Record projected = writeAndRead("project_and_rename", writeSchema, readSchema, record);
-    assertThat(34L)
+    assertThat((long) projected.getField("id"))
         .as("Should contain the correct id value")
-        .isEqualTo((long) projected.getField("id"));
+        .isEqualTo(34L);
 
     int cmp =
         Comparators.charSequences().compare("test", (CharSequence) projected.getField("renamed"));
-    assertThat(0).as("Should contain the correct data/renamed value").isEqualTo(cmp);
+    assertThat(cmp).as("Should contain the correct data/renamed value").isEqualTo(0);
   }
 
   @Test
@@ -228,9 +228,9 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
     Record projectedLocation = (Record) projected.getField("location");
-    assertThat(34L)
+    assertThat((long) projected.getField("id"))
         .as("Should contain the correct id value")
-        .isEqualTo((long) projected.getField("id"));
+        .isEqualTo(34L);
     assertThat(projectedLocation).as("Should not project location").isNull();
 
     Schema latOnly =
@@ -245,9 +245,9 @@ public abstract class TestReadProjection {
     assertThat(projected.getField("id")).as("Should not project id").isNull();
     assertThat(projected.getField("location")).as("Should project location").isNotNull();
     assertThat(projectedLocation.getField("long")).as("Should not project longitude").isNull();
-    assertThat(52.995143f)
+    assertThat((float) projectedLocation.getField("lat"))
         .as("Should project latitude")
-        .isCloseTo((float) projectedLocation.getField("lat"), within(0.000001f));
+        .isCloseTo(52.995143f, within(0.000001f));
 
     Schema longOnly =
         new Schema(
@@ -262,9 +262,9 @@ public abstract class TestReadProjection {
     assertThat(projected.getField("id")).as("Should not project id").isNull();
     assertThat(projected.getField("location")).as("Should project location").isNotNull();
     assertThat(projectedLocation.getField("lat")).as("Should not project latitude").isNull();
-    assertThat(-1.539054f)
+    assertThat((float) projectedLocation.getField("long"))
         .as("Should project longitude")
-        .isCloseTo((float) projectedLocation.getField("long"), within(0.000001f));
+        .isCloseTo(-1.539054f, within(0.000001f));
 
     Schema locationOnly = writeSchema.select("location");
     projected = writeAndRead("location_only", writeSchema, locationOnly, record);
@@ -272,12 +272,12 @@ public abstract class TestReadProjection {
 
     assertThat(projected.getField("id")).as("Should not project id").isNull();
     assertThat(projected.getField("location")).as("Should project location").isNotNull();
-    assertThat(52.995143f)
+    assertThat((float) projectedLocation.getField("lat"))
         .as("Should project latitude")
-        .isCloseTo((float) projectedLocation.getField("lat"), within(0.000001f));
-    assertThat(-1.539054f)
+        .isCloseTo(52.995143f, within(0.000001f));
+    assertThat((float) projectedLocation.getField("long"))
         .as("Should project longitude")
-        .isCloseTo((float) projectedLocation.getField("long"), within(0.000001f));
+        .isCloseTo(-1.539054f, within(0.000001f));
   }
 
   @Test
@@ -299,31 +299,31 @@ public abstract class TestReadProjection {
     Schema idOnly = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    assertThat(34L)
+    assertThat((long) projected.getField("id"))
         .as("Should contain the correct id value")
-        .isEqualTo((long) projected.getField("id"));
+        .isEqualTo(34L);
     assertThat(projected.getField("properties")).as("Should not project properties map").isNull();
 
     Schema keyOnly = writeSchema.select("properties.key");
     projected = writeAndRead("key_only", writeSchema, keyOnly, record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
-    assertThat(properties)
+    assertThat(toStringMap((Map) projected.getField("properties")))
         .as("Should project entire map")
-        .isEqualTo(toStringMap((Map) projected.getField("properties")));
+        .isEqualTo(properties);
 
     Schema valueOnly = writeSchema.select("properties.value");
     projected = writeAndRead("value_only", writeSchema, valueOnly, record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
-    assertThat(properties)
+    assertThat(toStringMap((Map) projected.getField("properties")))
         .as("Should project entire map")
-        .isEqualTo(toStringMap((Map) projected.getField("properties")));
+        .isEqualTo(properties);
 
     Schema mapOnly = writeSchema.select("properties");
     projected = writeAndRead("map_only", writeSchema, mapOnly, record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
-    assertThat(properties)
+    assertThat(toStringMap((Map) projected.getField("properties")))
         .as("Should project entire map")
-        .isEqualTo(toStringMap((Map) projected.getField("properties")));
+        .isEqualTo(properties);
   }
 
   private Map<String, ?> toStringMap(Map<?, ?> map) {
@@ -374,31 +374,31 @@ public abstract class TestReadProjection {
 
     projected = writeAndRead("all_locations", writeSchema, writeSchema.select("locations"), record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
-    assertThat(record.getField("locations"))
+    assertThat(toStringMap((Map) projected.getField("locations")))
         .as("Should project locations map")
-        .isEqualTo(toStringMap((Map) projected.getField("locations")));
+        .isEqualTo(record.getField("locations"));
 
     projected = writeAndRead("lat_only", writeSchema, writeSchema.select("locations.lat"), record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
 
     Map<String, ?> locations = toStringMap((Map) projected.getField("locations"));
     assertThat(locations).as("Should project locations map").isNotNull();
-    assertThat(Sets.newHashSet("L1", "L2"))
+    assertThat(locations.keySet())
         .as("Should contain L1 and L2")
-        .isEqualTo(locations.keySet());
+        .isEqualTo(Sets.newHashSet("L1", "L2"));
 
     Record projectedL1 = (Record) locations.get("L1");
     assertThat(projectedL1).as("L1 should not be null").isNotNull();
-    assertThat(53.992811f)
+    assertThat((float) projectedL1.getField("lat"))
         .as("L1 should contain lat")
-        .isCloseTo((float) projectedL1.getField("lat"), within(0.000001f));
+        .isCloseTo(53.992811f, within(0.000001f));
     assertThat(projectedL1.getField("long")).as("L1 should not contain long").isNull();
 
     Record projectedL2 = (Record) locations.get("L2");
     assertThat(projectedL2).as("L2 should not be null").isNotNull();
-    assertThat(52.995143f)
+    assertThat((float) projectedL2.getField("lat"))
         .as("L2 should contain lat")
-        .isCloseTo((float) projectedL2.getField("lat"), within(0.000001f));
+        .isCloseTo(52.995143f, within(0.000001f));
     assertThat(projectedL2.getField("long")).as("L2 should not contain long").isNull();
 
     projected =
@@ -407,23 +407,23 @@ public abstract class TestReadProjection {
 
     locations = toStringMap((Map) projected.getField("locations"));
     assertThat(locations).as("Should project locations map").isNotNull();
-    assertThat(Sets.newHashSet("L1", "L2"))
+    assertThat(locations.keySet())
         .as("Should contain L1 and L2")
-        .isEqualTo(locations.keySet());
+        .isEqualTo(Sets.newHashSet("L1", "L2"));
 
     projectedL1 = (Record) locations.get("L1");
     assertThat(projectedL1).as("L1 should not be null").isNotNull();
     assertThat(projectedL1.getField("lat")).as("L1 should not contain lat").isNull();
-    assertThat(-1.542616f)
+    assertThat((float) projectedL1.getField("long"))
         .as("L1 should contain long")
-        .isCloseTo((float) projectedL1.getField("long"), within(0.000001f));
+        .isCloseTo(-1.542616f, within(0.000001f));
 
     projectedL2 = (Record) locations.get("L2");
     assertThat(projectedL2).as("L2 should not be null").isNotNull();
     assertThat(projectedL2.getField("lat")).as("L2 should not contain lat").isNull();
-    assertThat(-1.539054f)
+    assertThat((float) projectedL2.getField("long"))
         .as("L2 should contain long")
-        .isCloseTo((float) projectedL2.getField("long"), within(0.000001f));
+        .isCloseTo(-1.539054f, within(0.000001f));
 
     Schema latitiudeRenamed =
         new Schema(
@@ -441,23 +441,23 @@ public abstract class TestReadProjection {
     assertThat(projected.getField("id")).as("Should not project id").isNull();
     locations = toStringMap((Map) projected.getField("locations"));
     assertThat(locations).as("Should project locations map").isNotNull();
-    assertThat(Sets.newHashSet("L1", "L2"))
+    assertThat(locations.keySet())
         .as("Should contain L1 and L2")
-        .isEqualTo(locations.keySet());
+        .isEqualTo(Sets.newHashSet("L1", "L2"));
 
     projectedL1 = (Record) locations.get("L1");
     assertThat(projectedL1).as("L1 should not be null").isNotNull();
-    assertThat(53.992811f)
+    assertThat((float) projectedL1.getField("latitude"))
         .as("L1 should contain latitude")
-        .isCloseTo((float) projectedL1.getField("latitude"), within(0.000001f));
+        .isCloseTo(53.992811f, within(0.000001f));
     assertThat(projectedL1.getField("lat")).as("L1 should not contain lat").isNull();
     assertThat(projectedL1.getField("long")).as("L1 should not contain long").isNull();
 
     projectedL2 = (Record) locations.get("L2");
     assertThat(projectedL2).as("L2 should not be null").isNotNull();
-    assertThat(52.995143f)
+    assertThat((float) projectedL2.getField("latitude"))
         .as("L2 should contain latitude")
-        .isCloseTo((float) projectedL2.getField("latitude"), within(0.000001f));
+        .isCloseTo(52.995143f, within(0.000001f));
     assertThat(projectedL2.getField("lat")).as("L2 should not contain lat").isNull();
     assertThat(projectedL2.getField("long")).as("L2 should not contain long").isNull();
   }
@@ -479,20 +479,20 @@ public abstract class TestReadProjection {
     Schema idOnly = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    assertThat(34L)
+    assertThat((long) projected.getField("id"))
         .as("Should contain the correct id value")
-        .isEqualTo((long) projected.getField("id"));
+        .isEqualTo(34L);
     assertThat(projected.getField("values")).as("Should not project values list").isNull();
 
     Schema elementOnly = writeSchema.select("values.element");
     projected = writeAndRead("element_only", writeSchema, elementOnly, record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
-    assertThat(values).as("Should project entire list").isEqualTo(projected.getField("values"));
+    assertThat(projected.getField("values")).as("Should project entire list").isEqualTo(values);
 
     Schema listOnly = writeSchema.select("values");
     projected = writeAndRead("list_only", writeSchema, listOnly, record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
-    assertThat(values).as("Should project entire list").isEqualTo(projected.getField("values"));
+    assertThat(projected.getField("values")).as("Should project entire list").isEqualTo(values);
   }
 
   @Test
@@ -523,16 +523,16 @@ public abstract class TestReadProjection {
     Schema idOnly = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    assertThat(34L)
+    assertThat((long) projected.getField("id"))
         .as("Should contain the correct id value")
-        .isEqualTo((long) projected.getField("id"));
+        .isEqualTo(34L);
     assertThat(projected.getField("points")).as("Should not project points list").isNull();
 
     projected = writeAndRead("all_points", writeSchema, writeSchema.select("points"), record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
-    assertThat(record.getField("points"))
+    assertThat(projected.getField("points"))
         .as("Should project points list")
-        .isEqualTo(projected.getField("points"));
+        .isEqualTo(record.getField("points"));
 
     projected = writeAndRead("x_only", writeSchema, writeSchema.select("points.x"), record);
     assertThat(projected.getField("id")).as("Should not project id").isNull();
@@ -542,11 +542,11 @@ public abstract class TestReadProjection {
     assertThat(points).as("Should read 2 points").hasSize(2);
 
     Record projectedP1 = points.get(0);
-    assertThat(1).as("Should project x").isEqualTo((int) projectedP1.getField("x"));
+    assertThat((int) projectedP1.getField("x")).as("Should project x").isEqualTo(1);
     assertThat(projected.getField("y")).as("Should not project y").isNull();
 
     Record projectedP2 = points.get(1);
-    assertThat(3).as("Should project x").isEqualTo((int) projectedP2.getField("x"));
+    assertThat((int) projectedP2.getField("x")).as("Should project x").isEqualTo(3);
     assertThat(projected.getField("y")).as("Should not project y").isNull();
 
     projected = writeAndRead("y_only", writeSchema, writeSchema.select("points.y"), record);
@@ -558,7 +558,7 @@ public abstract class TestReadProjection {
 
     projectedP1 = points.get(0);
     assertThat(projectedP1.getField("x")).as("Should not project x").isNull();
-    assertThat(2).as("Should project y").isEqualTo((int) projectedP1.getField("y"));
+    assertThat((int) projectedP1.getField("y")).as("Should project y").isEqualTo(2);
 
     projectedP2 = points.get(1);
     assertThat(projectedP2.getField("x")).as("Should not project x").isNull();
@@ -584,7 +584,7 @@ public abstract class TestReadProjection {
     projectedP1 = points.get(0);
     assertThat(projectedP1.getField("x")).as("Should not project x").isNull();
     assertThat(projectedP1.getField("y")).as("Should not project y").isNull();
-    assertThat(2).as("Should project z").isEqualTo((int) projectedP1.getField("z"));
+    assertThat((int) projectedP1.getField("z")).as("Should project z").isEqualTo(2);
 
     projectedP2 = points.get(1);
     assertThat(projectedP2.getField("x")).as("Should not project x").isNull();
@@ -611,12 +611,12 @@ public abstract class TestReadProjection {
     assertThat(points).as("Should read 2 points").hasSize(2);
 
     projectedP1 = points.get(0);
-    assertThat(1).as("Should project x").isEqualTo((int) projectedP1.getField("x"));
-    assertThat(2).as("Should project y").isEqualTo((int) projectedP1.getField("y"));
+    assertThat((int) projectedP1.getField("x")).as("Should project x").isEqualTo(1);
+    assertThat((int) projectedP1.getField("y")).as("Should project y").isEqualTo(2);
     assertThat(projectedP1.getField("z")).as("Should contain null z").isNull();
 
     projectedP2 = points.get(1);
-    assertThat(3).as("Should project x").isEqualTo((int) projectedP2.getField("x"));
+    assertThat((int) projectedP2.getField("x")).as("Should project x").isEqualTo(3);
     assertThat(projectedP2.getField("y")).as("Should project null y").isNull();
     assertThat(projectedP2.getField("z")).as("Should contain null z").isNull();
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAggregates.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAggregates.java
@@ -51,23 +51,23 @@ public class TestSparkAggregates {
           Max max = new Max(namedReference);
           Expression expectedMax = Expressions.max(unquoted);
           Expression actualMax = SparkAggregates.convert(max);
-          assertThat(expectedMax.toString())
+          assertThat(String.valueOf(actualMax))
               .as("Max must match")
-              .isEqualTo(String.valueOf(actualMax));
+              .isEqualTo(expectedMax.toString());
 
           Min min = new Min(namedReference);
           Expression expectedMin = Expressions.min(unquoted);
           Expression actualMin = SparkAggregates.convert(min);
-          assertThat(expectedMin.toString())
+          assertThat(String.valueOf(actualMin))
               .as("Min must match")
-              .isEqualTo(String.valueOf(actualMin));
+              .isEqualTo(expectedMin.toString());
 
           Count count = new Count(namedReference, false);
           Expression expectedCount = Expressions.count(unquoted);
           Expression actualCount = SparkAggregates.convert(count);
-          assertThat(expectedCount.toString())
+          assertThat(String.valueOf(actualCount))
               .as("Count must match")
-              .isEqualTo(String.valueOf(actualCount));
+              .isEqualTo(expectedCount.toString());
 
           Count countDistinct = new Count(namedReference, true);
           Expression convertedCountDistinct = SparkAggregates.convert(countDistinct);
@@ -76,9 +76,9 @@ public class TestSparkAggregates {
           CountStar countStar = new CountStar();
           Expression expectedCountStar = Expressions.countStar();
           Expression actualCountStar = SparkAggregates.convert(countStar);
-          assertThat(expectedCountStar.toString())
+          assertThat(String.valueOf(actualCountStar))
               .as("CountStar must match")
-              .isEqualTo(String.valueOf(actualCountStar));
+              .isEqualTo(expectedCountStar.toString());
         });
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAggregates.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAggregates.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
@@ -50,17 +51,23 @@ public class TestSparkAggregates {
           Max max = new Max(namedReference);
           Expression expectedMax = Expressions.max(unquoted);
           Expression actualMax = SparkAggregates.convert(max);
-          assertThat(expectedMax.toString()).as("Max must match").isEqualTo(String.valueOf(actualMax));
+          assertThat(expectedMax.toString())
+              .as("Max must match")
+              .isEqualTo(String.valueOf(actualMax));
 
           Min min = new Min(namedReference);
           Expression expectedMin = Expressions.min(unquoted);
           Expression actualMin = SparkAggregates.convert(min);
-          assertThat(expectedMin.toString()).as("Min must match").isEqualTo(String.valueOf(actualMin));
+          assertThat(expectedMin.toString())
+              .as("Min must match")
+              .isEqualTo(String.valueOf(actualMin));
 
           Count count = new Count(namedReference, false);
           Expression expectedCount = Expressions.count(unquoted);
           Expression actualCount = SparkAggregates.convert(count);
-          assertThat(expectedCount.toString()).as("Count must match").isEqualTo(String.valueOf(actualCount));
+          assertThat(expectedCount.toString())
+              .as("Count must match")
+              .isEqualTo(String.valueOf(actualCount));
 
           Count countDistinct = new Count(namedReference, true);
           Expression convertedCountDistinct = SparkAggregates.convert(countDistinct);
@@ -69,7 +76,9 @@ public class TestSparkAggregates {
           CountStar countStar = new CountStar();
           Expression expectedCountStar = Expressions.countStar();
           Expression actualCountStar = SparkAggregates.convert(countStar);
-          assertThat(expectedCountStar.toString()).as("CountStar must match").isEqualTo(String.valueOf(actualCountStar));
+          assertThat(expectedCountStar.toString())
+              .as("CountStar must match")
+              .isEqualTo(String.valueOf(actualCountStar));
         });
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAggregates.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAggregates.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 import org.apache.iceberg.expressions.Expression;
@@ -29,8 +30,7 @@ import org.apache.spark.sql.connector.expressions.aggregate.Count;
 import org.apache.spark.sql.connector.expressions.aggregate.CountStar;
 import org.apache.spark.sql.connector.expressions.aggregate.Max;
 import org.apache.spark.sql.connector.expressions.aggregate.Min;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkAggregates {
 
@@ -50,27 +50,26 @@ public class TestSparkAggregates {
           Max max = new Max(namedReference);
           Expression expectedMax = Expressions.max(unquoted);
           Expression actualMax = SparkAggregates.convert(max);
-          Assert.assertEquals("Max must match", expectedMax.toString(), actualMax.toString());
+          assertThat(expectedMax.toString()).as("Max must match").isEqualTo(String.valueOf(actualMax));
 
           Min min = new Min(namedReference);
           Expression expectedMin = Expressions.min(unquoted);
           Expression actualMin = SparkAggregates.convert(min);
-          Assert.assertEquals("Min must match", expectedMin.toString(), actualMin.toString());
+          assertThat(expectedMin.toString()).as("Min must match").isEqualTo(String.valueOf(actualMin));
 
           Count count = new Count(namedReference, false);
           Expression expectedCount = Expressions.count(unquoted);
           Expression actualCount = SparkAggregates.convert(count);
-          Assert.assertEquals("Count must match", expectedCount.toString(), actualCount.toString());
+          assertThat(expectedCount.toString()).as("Count must match").isEqualTo(String.valueOf(actualCount));
 
           Count countDistinct = new Count(namedReference, true);
           Expression convertedCountDistinct = SparkAggregates.convert(countDistinct);
-          Assert.assertNull("Count Distinct is converted to null", convertedCountDistinct);
+          assertThat(convertedCountDistinct).as("Count Distinct is converted to null").isNull();
 
           CountStar countStar = new CountStar();
           Expression expectedCountStar = Expressions.countStar();
           Expression actualCountStar = SparkAggregates.convert(countStar);
-          Assert.assertEquals(
-              "CountStar must match", expectedCountStar.toString(), actualCountStar.toString());
+          assertThat(expectedCountStar.toString()).as("CountStar must match").isEqualTo(String.valueOf(actualCountStar));
         });
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogCacheExpiration.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogCacheExpiration.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 import org.apache.iceberg.CachingCatalog;
@@ -25,13 +26,12 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.SparkSessionCatalog;
-import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
-import org.assertj.core.api.Assertions;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-public class TestSparkCatalogCacheExpiration extends SparkTestBaseWithCatalog {
+public class TestSparkCatalogCacheExpiration extends TestBaseWithCatalog {
 
   private static final String sessionCatalogName = "spark_catalog";
   private static final String sessionCatalogImpl = SparkSessionCatalog.class.getName();
@@ -57,7 +57,7 @@ public class TestSparkCatalogCacheExpiration extends SparkTestBaseWithCatalog {
 
   // Add more catalogs to the spark session, so we only need to start spark one time for multiple
   // different catalog configuration tests.
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     // Catalog - expiration_disabled: Catalog with caching on and expiration disabled.
     ImmutableMap.of(
@@ -93,18 +93,18 @@ public class TestSparkCatalogCacheExpiration extends SparkTestBaseWithCatalog {
   @Test
   public void testSparkSessionCatalogWithExpirationEnabled() {
     SparkSessionCatalog<?> sparkCatalog = sparkSessionCatalog();
-    Assertions.assertThat(sparkCatalog)
+    assertThat(sparkCatalog)
         .extracting("icebergCatalog")
         .extracting("cacheEnabled")
         .isEqualTo(true);
 
-    Assertions.assertThat(sparkCatalog)
+    assertThat(sparkCatalog)
         .extracting("icebergCatalog")
         .extracting("icebergCatalog")
         .isInstanceOfSatisfying(
             Catalog.class,
             icebergCatalog -> {
-              Assertions.assertThat(icebergCatalog)
+              assertThat(icebergCatalog)
                   .isExactlyInstanceOf(CachingCatalog.class)
                   .extracting("expirationIntervalMillis")
                   .isEqualTo(3000L);
@@ -114,14 +114,14 @@ public class TestSparkCatalogCacheExpiration extends SparkTestBaseWithCatalog {
   @Test
   public void testCacheEnabledAndExpirationDisabled() {
     SparkCatalog sparkCatalog = getSparkCatalog("expiration_disabled");
-    Assertions.assertThat(sparkCatalog).extracting("cacheEnabled").isEqualTo(true);
+    assertThat(sparkCatalog).extracting("cacheEnabled").isEqualTo(true);
 
-    Assertions.assertThat(sparkCatalog)
+    assertThat(sparkCatalog)
         .extracting("icebergCatalog")
         .isInstanceOfSatisfying(
             CachingCatalog.class,
             icebergCatalog -> {
-              Assertions.assertThat(icebergCatalog)
+              assertThat(icebergCatalog)
                   .extracting("expirationIntervalMillis")
                   .isEqualTo(-1L);
             });
@@ -130,14 +130,14 @@ public class TestSparkCatalogCacheExpiration extends SparkTestBaseWithCatalog {
   @Test
   public void testCacheDisabledImplicitly() {
     SparkCatalog sparkCatalog = getSparkCatalog("cache_disabled_implicitly");
-    Assertions.assertThat(sparkCatalog).extracting("cacheEnabled").isEqualTo(false);
+    assertThat(sparkCatalog).extracting("cacheEnabled").isEqualTo(false);
 
-    Assertions.assertThat(sparkCatalog)
+    assertThat(sparkCatalog)
         .extracting("icebergCatalog")
         .isInstanceOfSatisfying(
             Catalog.class,
             icebergCatalog ->
-                Assertions.assertThat(icebergCatalog).isNotInstanceOf(CachingCatalog.class));
+                assertThat(icebergCatalog).isNotInstanceOf(CachingCatalog.class));
   }
 
   private SparkSessionCatalog<?> sparkSessionCatalog() {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogCacheExpiration.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogCacheExpiration.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
@@ -121,9 +122,7 @@ public class TestSparkCatalogCacheExpiration extends TestBaseWithCatalog {
         .isInstanceOfSatisfying(
             CachingCatalog.class,
             icebergCatalog -> {
-              assertThat(icebergCatalog)
-                  .extracting("expirationIntervalMillis")
-                  .isEqualTo(-1L);
+              assertThat(icebergCatalog).extracting("expirationIntervalMillis").isEqualTo(-1L);
             });
   }
 
@@ -136,8 +135,7 @@ public class TestSparkCatalogCacheExpiration extends TestBaseWithCatalog {
         .extracting("icebergCatalog")
         .isInstanceOfSatisfying(
             Catalog.class,
-            icebergCatalog ->
-                assertThat(icebergCatalog).isNotInstanceOf(CachingCatalog.class));
+            icebergCatalog -> assertThat(icebergCatalog).isNotInstanceOf(CachingCatalog.class));
   }
 
   private SparkSessionCatalog<?> sparkSessionCatalog() {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
@@ -133,8 +133,7 @@ public class TestSparkDataFile {
     currentSpark.stop();
   }
 
-  @TempDir
-  private Path temp;
+  @TempDir private Path temp;
   private String tableLocation = null;
 
   @BeforeEach

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -70,12 +71,11 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.StructType;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestSparkDataFile {
 
@@ -119,13 +119,13 @@ public class TestSparkDataFile {
   private static SparkSession spark;
   private static JavaSparkContext sparkContext = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void startSpark() {
     TestSparkDataFile.spark = SparkSession.builder().master("local[2]").getOrCreate();
     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopSpark() {
     SparkSession currentSpark = TestSparkDataFile.spark;
     TestSparkDataFile.spark = null;
@@ -133,12 +133,13 @@ public class TestSparkDataFile {
     currentSpark.stop();
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  private Path temp;
   private String tableLocation = null;
 
-  @Before
+  @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.newFolder();
+    File tableDir = temp.toFile();
     this.tableLocation = tableDir.toURI().toString();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadMetrics.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadMetrics.java
@@ -18,24 +18,24 @@
  */
 package org.apache.iceberg.spark.source;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static scala.collection.JavaConverters.seqAsJavaListConverter;
 
 import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.execution.metric.SQLMetric;
-import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import scala.collection.JavaConverters;
 
-public class TestSparkReadMetrics extends SparkTestBaseWithCatalog {
+public class TestSparkReadMetrics extends TestBaseWithCatalog {
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
@@ -57,30 +57,30 @@ public class TestSparkReadMetrics extends SparkTestBaseWithCatalog {
     Map<String, SQLMetric> metricsMap =
         JavaConverters.mapAsJavaMapConverter(sparkPlans.get(0).metrics()).asJava();
     // Common
-    Assertions.assertThat(metricsMap.get("totalPlanningDuration").value()).isNotEqualTo(0);
+    assertThat(metricsMap.get("totalPlanningDuration").value()).isNotEqualTo(0);
 
     // data manifests
-    Assertions.assertThat(metricsMap.get("totalDataManifest").value()).isEqualTo(2);
-    Assertions.assertThat(metricsMap.get("scannedDataManifests").value()).isEqualTo(2);
-    Assertions.assertThat(metricsMap.get("skippedDataManifests").value()).isEqualTo(0);
+    assertThat(metricsMap.get("totalDataManifest").value()).isEqualTo(2);
+    assertThat(metricsMap.get("scannedDataManifests").value()).isEqualTo(2);
+    assertThat(metricsMap.get("skippedDataManifests").value()).isEqualTo(0);
 
     // data files
-    Assertions.assertThat(metricsMap.get("resultDataFiles").value()).isEqualTo(1);
-    Assertions.assertThat(metricsMap.get("skippedDataFiles").value()).isEqualTo(1);
-    Assertions.assertThat(metricsMap.get("totalDataFileSize").value()).isNotEqualTo(0);
+    assertThat(metricsMap.get("resultDataFiles").value()).isEqualTo(1);
+    assertThat(metricsMap.get("skippedDataFiles").value()).isEqualTo(1);
+    assertThat(metricsMap.get("totalDataFileSize").value()).isNotEqualTo(0);
 
     // delete manifests
-    Assertions.assertThat(metricsMap.get("totalDeleteManifests").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("scannedDeleteManifests").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("skippedDeleteManifests").value()).isEqualTo(0);
+    assertThat(metricsMap.get("totalDeleteManifests").value()).isEqualTo(0);
+    assertThat(metricsMap.get("scannedDeleteManifests").value()).isEqualTo(0);
+    assertThat(metricsMap.get("skippedDeleteManifests").value()).isEqualTo(0);
 
     // delete files
-    Assertions.assertThat(metricsMap.get("totalDeleteFileSize").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("resultDeleteFiles").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("equalityDeleteFiles").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("indexedDeleteFiles").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("positionalDeleteFiles").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("skippedDeleteFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("totalDeleteFileSize").value()).isEqualTo(0);
+    assertThat(metricsMap.get("resultDeleteFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("equalityDeleteFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("indexedDeleteFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("positionalDeleteFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("skippedDeleteFiles").value()).isEqualTo(0);
   }
 
   @Test
@@ -101,30 +101,30 @@ public class TestSparkReadMetrics extends SparkTestBaseWithCatalog {
         JavaConverters.mapAsJavaMapConverter(sparkPlans.get(0).metrics()).asJava();
 
     // Common
-    Assertions.assertThat(metricsMap.get("totalPlanningDuration").value()).isNotEqualTo(0);
+    assertThat(metricsMap.get("totalPlanningDuration").value()).isNotEqualTo(0);
 
     // data manifests
-    Assertions.assertThat(metricsMap.get("totalDataManifest").value()).isEqualTo(2);
-    Assertions.assertThat(metricsMap.get("scannedDataManifests").value()).isEqualTo(2);
-    Assertions.assertThat(metricsMap.get("skippedDataManifests").value()).isEqualTo(0);
+    assertThat(metricsMap.get("totalDataManifest").value()).isEqualTo(2);
+    assertThat(metricsMap.get("scannedDataManifests").value()).isEqualTo(2);
+    assertThat(metricsMap.get("skippedDataManifests").value()).isEqualTo(0);
 
     // data files
-    Assertions.assertThat(metricsMap.get("resultDataFiles").value()).isEqualTo(1);
-    Assertions.assertThat(metricsMap.get("skippedDataFiles").value()).isEqualTo(1);
-    Assertions.assertThat(metricsMap.get("totalDataFileSize").value()).isNotEqualTo(0);
+    assertThat(metricsMap.get("resultDataFiles").value()).isEqualTo(1);
+    assertThat(metricsMap.get("skippedDataFiles").value()).isEqualTo(1);
+    assertThat(metricsMap.get("totalDataFileSize").value()).isNotEqualTo(0);
 
     // delete manifests
-    Assertions.assertThat(metricsMap.get("totalDeleteManifests").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("scannedDeleteManifests").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("skippedDeleteManifests").value()).isEqualTo(0);
+    assertThat(metricsMap.get("totalDeleteManifests").value()).isEqualTo(0);
+    assertThat(metricsMap.get("scannedDeleteManifests").value()).isEqualTo(0);
+    assertThat(metricsMap.get("skippedDeleteManifests").value()).isEqualTo(0);
 
     // delete files
-    Assertions.assertThat(metricsMap.get("totalDeleteFileSize").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("resultDeleteFiles").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("equalityDeleteFiles").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("indexedDeleteFiles").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("positionalDeleteFiles").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("skippedDeleteFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("totalDeleteFileSize").value()).isEqualTo(0);
+    assertThat(metricsMap.get("resultDeleteFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("equalityDeleteFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("indexedDeleteFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("positionalDeleteFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("skippedDeleteFiles").value()).isEqualTo(0);
   }
 
   @Test
@@ -152,29 +152,29 @@ public class TestSparkReadMetrics extends SparkTestBaseWithCatalog {
         JavaConverters.mapAsJavaMapConverter(sparkPlans.get(0).metrics()).asJava();
 
     // Common
-    Assertions.assertThat(metricsMap.get("totalPlanningDuration").value()).isNotEqualTo(0);
+    assertThat(metricsMap.get("totalPlanningDuration").value()).isNotEqualTo(0);
 
     // data manifests
-    Assertions.assertThat(metricsMap.get("totalDataManifest").value()).isEqualTo(1);
-    Assertions.assertThat(metricsMap.get("scannedDataManifests").value()).isEqualTo(1);
-    Assertions.assertThat(metricsMap.get("skippedDataManifests").value()).isEqualTo(0);
+    assertThat(metricsMap.get("totalDataManifest").value()).isEqualTo(1);
+    assertThat(metricsMap.get("scannedDataManifests").value()).isEqualTo(1);
+    assertThat(metricsMap.get("skippedDataManifests").value()).isEqualTo(0);
 
     // data files
-    Assertions.assertThat(metricsMap.get("resultDataFiles").value()).isEqualTo(1);
-    Assertions.assertThat(metricsMap.get("skippedDataFiles").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("totalDataFileSize").value()).isNotEqualTo(0);
+    assertThat(metricsMap.get("resultDataFiles").value()).isEqualTo(1);
+    assertThat(metricsMap.get("skippedDataFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("totalDataFileSize").value()).isNotEqualTo(0);
 
     // delete manifests
-    Assertions.assertThat(metricsMap.get("totalDeleteManifests").value()).isEqualTo(1);
-    Assertions.assertThat(metricsMap.get("scannedDeleteManifests").value()).isEqualTo(1);
-    Assertions.assertThat(metricsMap.get("skippedDeleteManifests").value()).isEqualTo(0);
+    assertThat(metricsMap.get("totalDeleteManifests").value()).isEqualTo(1);
+    assertThat(metricsMap.get("scannedDeleteManifests").value()).isEqualTo(1);
+    assertThat(metricsMap.get("skippedDeleteManifests").value()).isEqualTo(0);
 
     // delete files
-    Assertions.assertThat(metricsMap.get("totalDeleteFileSize").value()).isNotEqualTo(0);
-    Assertions.assertThat(metricsMap.get("resultDeleteFiles").value()).isEqualTo(1);
-    Assertions.assertThat(metricsMap.get("equalityDeleteFiles").value()).isEqualTo(0);
-    Assertions.assertThat(metricsMap.get("indexedDeleteFiles").value()).isEqualTo(1);
-    Assertions.assertThat(metricsMap.get("positionalDeleteFiles").value()).isEqualTo(1);
-    Assertions.assertThat(metricsMap.get("skippedDeleteFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("totalDeleteFileSize").value()).isNotEqualTo(0);
+    assertThat(metricsMap.get("resultDeleteFiles").value()).isEqualTo(1);
+    assertThat(metricsMap.get("equalityDeleteFiles").value()).isEqualTo(0);
+    assertThat(metricsMap.get("indexedDeleteFiles").value()).isEqualTo(1);
+    assertThat(metricsMap.get("positionalDeleteFiles").value()).isEqualTo(1);
+    assertThat(metricsMap.get("skippedDeleteFiles").value()).isEqualTo(0);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
@@ -110,7 +110,7 @@ public class TestSparkReadProjection extends TestReadProjection {
   @Override
   protected Record writeAndRead(String desc, Schema writeSchema, Schema readSchema, Record record)
       throws IOException {
-    File parent = temp.newFolder(desc);
+    File parent = temp.resolve(desc).toFile();
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
     Assert.assertTrue("mkdirs should succeed", dataFolder.mkdirs());

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
@@ -110,7 +110,7 @@ public class TestSparkReadProjection extends TestReadProjection {
   @Override
   protected Record writeAndRead(String desc, Schema writeSchema, Schema readSchema, Record record)
       throws IOException {
-    File parent = temp.resolve(desc).toFile();
+    File parent = temp.newFolder(desc);
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
     Assert.assertTrue("mkdirs should succeed", dataFolder.mkdirs());

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkStagedScan.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkStagedScan.java
@@ -35,7 +35,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 
 public class TestSparkStagedScan extends CatalogTestBase {
 
@@ -49,7 +49,7 @@ public class TestSparkStagedScan extends CatalogTestBase {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testTaskSetLoading() throws NoSuchTableException, IOException {
     sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
 
@@ -84,7 +84,7 @@ public class TestSparkStagedScan extends CatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testTaskSetPlanning() throws NoSuchTableException, IOException {
     sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkStagedScan.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkStagedScan.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -110,7 +111,9 @@ public class TestSparkStagedScan extends CatalogTestBase {
               .option(SparkReadOptions.SCAN_TASK_SET_ID, setID)
               .option(SparkReadOptions.SPLIT_SIZE, tasks.get(0).file().fileSizeInBytes())
               .load(tableName);
-      assertThat(2).as("Num partitions should match").isEqualTo(scanDF.javaRDD().getNumPartitions());
+      assertThat(2)
+          .as("Num partitions should match")
+          .isEqualTo(scanDF.javaRDD().getNumPartitions());
 
       // load the staged file set and make sure we combine both files into a single split
       scanDF =
@@ -120,7 +123,9 @@ public class TestSparkStagedScan extends CatalogTestBase {
               .option(SparkReadOptions.SCAN_TASK_SET_ID, setID)
               .option(SparkReadOptions.SPLIT_SIZE, Long.MAX_VALUE)
               .load(tableName);
-      assertThat(1).as("Num partitions should match").isEqualTo(scanDF.javaRDD().getNumPartitions());
+      assertThat(1)
+          .as("Num partitions should match")
+          .isEqualTo(scanDF.javaRDD().getNumPartitions());
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkStagedScan.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkStagedScan.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -26,25 +27,23 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.ScanTaskSetManager;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-public class TestSparkStagedScan extends SparkCatalogTestBase {
+public class TestSparkStagedScan extends CatalogTestBase {
 
   public TestSparkStagedScan(
       String catalogName, String implementation, Map<String, String> config) {
     super(catalogName, implementation, config);
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
@@ -59,7 +58,7 @@ public class TestSparkStagedScan extends SparkCatalogTestBase {
     df.writeTo(tableName).append();
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should produce 1 snapshot", 1, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should produce 1 snapshot").hasSize(1);
 
     try (CloseableIterable<FileScanTask> fileScanTasks = table.newScan().planFiles()) {
       ScanTaskSetManager taskSetManager = ScanTaskSetManager.get();
@@ -95,7 +94,7 @@ public class TestSparkStagedScan extends SparkCatalogTestBase {
     df.coalesce(1).writeTo(tableName).append();
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should produce 2 snapshots", 2, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should produce 2 snapshot").hasSize(2);
 
     try (CloseableIterable<FileScanTask> fileScanTasks = table.newScan().planFiles()) {
       ScanTaskSetManager taskSetManager = ScanTaskSetManager.get();
@@ -111,7 +110,7 @@ public class TestSparkStagedScan extends SparkCatalogTestBase {
               .option(SparkReadOptions.SCAN_TASK_SET_ID, setID)
               .option(SparkReadOptions.SPLIT_SIZE, tasks.get(0).file().fileSizeInBytes())
               .load(tableName);
-      Assert.assertEquals("Num partitions should match", 2, scanDF.javaRDD().getNumPartitions());
+      assertThat(2).as("Num partitions should match").isEqualTo(scanDF.javaRDD().getNumPartitions());
 
       // load the staged file set and make sure we combine both files into a single split
       scanDF =
@@ -121,7 +120,7 @@ public class TestSparkStagedScan extends SparkCatalogTestBase {
               .option(SparkReadOptions.SCAN_TASK_SET_ID, setID)
               .option(SparkReadOptions.SPLIT_SIZE, Long.MAX_VALUE)
               .load(tableName);
-      Assert.assertEquals("Num partitions should match", 1, scanDF.javaRDD().getNumPartitions());
+      assertThat(1).as("Num partitions should match").isEqualTo(scanDF.javaRDD().getNumPartitions());
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkStagedScan.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkStagedScan.java
@@ -111,9 +111,9 @@ public class TestSparkStagedScan extends CatalogTestBase {
               .option(SparkReadOptions.SCAN_TASK_SET_ID, setID)
               .option(SparkReadOptions.SPLIT_SIZE, tasks.get(0).file().fileSizeInBytes())
               .load(tableName);
-      assertThat(2)
+      assertThat(scanDF.javaRDD().getNumPartitions())
           .as("Num partitions should match")
-          .isEqualTo(scanDF.javaRDD().getNumPartitions());
+          .isEqualTo(2);
 
       // load the staged file set and make sure we combine both files into a single split
       scanDF =
@@ -123,9 +123,9 @@ public class TestSparkStagedScan extends CatalogTestBase {
               .option(SparkReadOptions.SCAN_TASK_SET_ID, setID)
               .option(SparkReadOptions.SPLIT_SIZE, Long.MAX_VALUE)
               .load(tableName);
-      assertThat(1)
+      assertThat(scanDF.javaRDD().getNumPartitions())
           .as("Num partitions should match")
-          .isEqualTo(scanDF.javaRDD().getNumPartitions());
+          .isEqualTo(1);
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -28,7 +28,7 @@ import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 
 public class TestSparkTable extends CatalogTestBase {
 
@@ -46,7 +46,7 @@ public class TestSparkTable extends CatalogTestBase {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testTableEquality() throws NoSuchTableException {
     CatalogManager catalogManager = spark.sessionState().catalogManager();
     TableCatalog catalog = (TableCatalog) catalogManager.catalog(catalogName);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -17,30 +17,30 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
+import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class TestSparkTable extends SparkCatalogTestBase {
+public class TestSparkTable extends CatalogTestBase {
 
   public TestSparkTable(String catalogName, String implementation, Map<String, String> config) {
     super(catalogName, implementation, config);
   }
 
-  @Before
+  @BeforeEach
   public void createTable() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
   }
 
-  @After
+  @AfterEach
   public void removeTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
@@ -54,7 +54,7 @@ public class TestSparkTable extends SparkCatalogTestBase {
     SparkTable table2 = (SparkTable) catalog.loadTable(identifier);
 
     // different instances pointing to the same table must be equivalent
-    Assert.assertNotSame("References must be different", table1, table2);
-    Assert.assertEquals("Tables must be equivalent", table1, table2);
+    assertThat(table1).as("References must be different").isNotSameAs(table2);
+    assertThat(table1).as("Tables must be equivalent").isEqualTo(table2);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStreamingOffset.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStreamingOffset.java
@@ -17,12 +17,12 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Arrays;
 import org.apache.iceberg.util.JsonUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestStreamingOffset {
 
@@ -35,10 +35,8 @@ public class TestStreamingOffset {
           new StreamingOffset(System.currentTimeMillis(), 3L, false),
           new StreamingOffset(System.currentTimeMillis(), 4L, true)
         };
-    Assert.assertArrayEquals(
-        "StreamingOffsets should match",
-        expected,
-        Arrays.stream(expected).map(elem -> StreamingOffset.fromJson(elem.json())).toArray());
+    assertThat(expected).as("StreamingOffsets should match")
+                    .isEqualTo(Arrays.stream(expected).map(elem -> StreamingOffset.fromJson(elem.json())).toArray());
   }
 
   @Test
@@ -51,6 +49,6 @@ public class TestStreamingOffset {
     actual.put("scan_all_files", false);
     String expectedJson = expected.json();
     String actualJson = JsonUtil.mapper().writeValueAsString(actual);
-    Assert.assertEquals("Json should match", expectedJson, actualJson);
+    assertThat(expectedJson).isEqualTo(actualJson);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStreamingOffset.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStreamingOffset.java
@@ -36,10 +36,9 @@ public class TestStreamingOffset {
           new StreamingOffset(System.currentTimeMillis(), 3L, false),
           new StreamingOffset(System.currentTimeMillis(), 4L, true)
         };
-    assertThat(expected)
+    assertThat(Arrays.stream(expected).map(elem -> StreamingOffset.fromJson(elem.json())).toArray())
         .as("StreamingOffsets should match")
-        .isEqualTo(
-            Arrays.stream(expected).map(elem -> StreamingOffset.fromJson(elem.json())).toArray());
+        .isEqualTo(expected);
   }
 
   @Test
@@ -52,6 +51,6 @@ public class TestStreamingOffset {
     actual.put("scan_all_files", false);
     String expectedJson = expected.json();
     String actualJson = JsonUtil.mapper().writeValueAsString(actual);
-    assertThat(expectedJson).isEqualTo(actualJson);
+    assertThat(actualJson).isEqualTo(expectedJson);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStreamingOffset.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStreamingOffset.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.iceberg.spark.source;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -35,8 +36,10 @@ public class TestStreamingOffset {
           new StreamingOffset(System.currentTimeMillis(), 3L, false),
           new StreamingOffset(System.currentTimeMillis(), 4L, true)
         };
-    assertThat(expected).as("StreamingOffsets should match")
-                    .isEqualTo(Arrays.stream(expected).map(elem -> StreamingOffset.fromJson(elem.json())).toArray());
+    assertThat(expected)
+        .as("StreamingOffsets should match")
+        .isEqualTo(
+            Arrays.stream(expected).map(elem -> StreamingOffset.fromJson(elem.json())).toArray());
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
@@ -58,7 +58,7 @@ public class TestStructuredStreaming {
   private static SparkSession spark = null;
 
   @TempDir
-  public Path temp;
+  private Path temp;
 
   @BeforeAll
   public static void startSpark() {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
@@ -127,8 +127,8 @@ public class TestStructuredStreaming {
       List<SimpleRecord> actual =
           result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
 
-      assertThat(expected).as("Number of rows should match").hasSameSizeAs(actual);
-      assertThat(expected).as("Result rows should match").isEqualTo(actual);
+      assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+      assertThat(actual).as("Result rows should match").isEqualTo(expected);
       assertThat(table.snapshots()).as("Number of snapshots should match").hasSize(2);
     } finally {
       for (StreamingQuery query : spark.streams().active()) {
@@ -188,8 +188,8 @@ public class TestStructuredStreaming {
       List<SimpleRecord> actual =
           result.orderBy("data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
 
-      assertThat(expected).as("Number of rows should match").hasSameSizeAs(actual);
-      assertThat(expected).as("Result rows should match").isEqualTo(actual);
+      assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+      assertThat(actual).as("Result rows should match").isEqualTo(expected);
       assertThat(table.snapshots()).as("Number of snapshots should match").hasSize(2);
     } finally {
       for (StreamingQuery query : spark.streams().active()) {
@@ -249,8 +249,8 @@ public class TestStructuredStreaming {
       List<SimpleRecord> actual =
           result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
 
-      assertThat(expected).as("Number of rows should match").hasSameSizeAs(actual);
-      assertThat(expected).as("Result rows should match").isEqualTo(actual);
+      assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
+      assertThat(actual).as("Result rows should match").isEqualTo(expected);
       assertThat(table.snapshots()).as("Number of snapshots should match").hasSize(2);
     } finally {
       for (StreamingQuery query : spark.streams().active()) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
@@ -57,8 +57,7 @@ public class TestStructuredStreaming {
           optional(1, "id", Types.IntegerType.get()), optional(2, "data", Types.StringType.get()));
   private static SparkSession spark = null;
 
-  @TempDir
-  private Path temp;
+  @TempDir private Path temp;
 
   @BeforeAll
   public static void startSpark() {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
@@ -74,7 +74,7 @@ public class TestWriteMetricsConfig {
                   required(5, "data", Types.StringType.get()))));
 
   @TempDir
-  public Path temp;
+  private Path temp;
 
   private static SparkSession spark = null;
   private static JavaSparkContext sc = null;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
@@ -215,10 +215,8 @@ public class TestWriteMetricsConfig {
       DataFile file = task.file();
       assertThat(file.nullValueCounts()).hasSize(2);
       assertThat(file.valueCounts()).hasSize(2);
-      assertThat(file.lowerBounds()).hasSize(1);
-      assertThat(file.lowerBounds()).containsKey(id.fieldId());
-      assertThat(file.upperBounds()).hasSize(1);
-      assertThat(file.upperBounds()).containsKey(id.fieldId());
+      assertThat(file.lowerBounds()).hasSize(1).containsKey(id.fieldId());
+      assertThat(file.upperBounds()).hasSize(1).containsKey(id.fieldId());
     }
   }
 
@@ -271,27 +269,27 @@ public class TestWriteMetricsConfig {
       DataFile file = task.file();
 
       Map<Integer, Long> nullValueCounts = file.nullValueCounts();
-      assertThat(nullValueCounts).hasSize(3);
-      assertThat(nullValueCounts).containsKey(longCol.fieldId());
-      assertThat(nullValueCounts).containsKey(recordId.fieldId());
-      assertThat(nullValueCounts).containsKey(recordData.fieldId());
+      assertThat(nullValueCounts)
+          .hasSize(3)
+          .containsKey(longCol.fieldId())
+          .containsKey(recordId.fieldId())
+          .containsKey(recordData.fieldId());
 
       Map<Integer, Long> valueCounts = file.valueCounts();
-      assertThat(valueCounts).hasSize(3);
-      assertThat(valueCounts).containsKey(longCol.fieldId());
-      assertThat(valueCounts).containsKey(recordId.fieldId());
-      assertThat(valueCounts).containsKey(recordData.fieldId());
+      assertThat(valueCounts)
+          .hasSize(3)
+          .containsKey(longCol.fieldId())
+          .containsKey(recordId.fieldId())
+          .containsKey(recordData.fieldId());
 
       Map<Integer, ByteBuffer> lowerBounds = file.lowerBounds();
-      assertThat(lowerBounds).hasSize(2);
-      assertThat(lowerBounds).containsKey(recordId.fieldId());
+      assertThat(lowerBounds).hasSize(2).containsKey(recordId.fieldId());
 
       ByteBuffer recordDataLowerBound = lowerBounds.get(recordData.fieldId());
       assertThat(ByteBuffers.toByteArray(recordDataLowerBound)).hasSize(2);
 
       Map<Integer, ByteBuffer> upperBounds = file.upperBounds();
-      assertThat(upperBounds).hasSize(2);
-      assertThat(upperBounds).containsKey(recordId.fieldId());
+      assertThat(upperBounds).hasSize(2).containsKey(recordId.fieldId());
 
       ByteBuffer recordDataUpperBound = upperBounds.get(recordData.fieldId());
       assertThat(ByteBuffers.toByteArray(recordDataUpperBound)).hasSize(2);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
@@ -73,8 +73,7 @@ public class TestWriteMetricsConfig {
                   required(4, "id", Types.IntegerType.get()),
                   required(5, "data", Types.StringType.get()))));
 
-  @TempDir
-  private Path temp;
+  @TempDir private Path temp;
 
   private static SparkSession spark = null;
   private static JavaSparkContext sc = null;
@@ -233,8 +232,7 @@ public class TestWriteMetricsConfig {
     properties.put(TableProperties.DEFAULT_WRITE_METRICS_MODE, "counts");
     properties.put("write.metadata.metrics.column.ids", "full");
 
-    assertThatThrownBy(
-            () -> tables.create(SIMPLE_SCHEMA, spec, properties, tableLocation))
+    assertThatThrownBy(() -> tables.create(SIMPLE_SCHEMA, spec, properties, tableLocation))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith(
             "Invalid metrics config, could not find column ids from table prop write.metadata.metrics.column.ids in schema table");
@@ -294,7 +292,7 @@ public class TestWriteMetricsConfig {
       Map<Integer, ByteBuffer> upperBounds = file.upperBounds();
       assertThat(upperBounds).hasSize(2);
       assertThat(upperBounds).containsKey(recordId.fieldId());
-      
+
       ByteBuffer recordDataUpperBound = upperBounds.get(recordData.fieldId());
       assertThat(ByteBuffers.toByteArray(recordDataUpperBound)).hasSize(2);
     }


### PR DESCRIPTION
This PR contains the part of the files to migrate for Spark 3.5v in the source directory. The remaining files will be migrated in a seperate PR.

Related to PR : #9341 

Issue: #9086 

TODO:

- [x] self-review