### PR TITLE
API: Fix day partition transform result type

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -318,7 +318,7 @@ Partition field IDs must be reused if an existing partition spec contains an equ
 | **`truncate[W]`** | Value truncated to width `W` (see below)                     | `int`, `long`, `decimal`, `string`                                                                        | Source type |
 | **`year`**        | Extract a date or timestamp year, as years from 1970         | `date`, `timestamp`, `timestamptz`, `timestamp_ns`, `timestamptz_ns`                                      | `int`       |
 | **`month`**       | Extract a date or timestamp month, as months from 1970-01-01 | `date`, `timestamp`, `timestamptz`, `timestamp_ns`, `timestamptz_ns`                                      | `int`       |
-| **`day`**         | Extract a date or timestamp day, as days from 1970-01-01     | `date`, `timestamp`, `timestamptz`, `timestamp_ns`, `timestamptz_ns`                                      | `int`       |
+| **`day`**         | Extract a date or timestamp day, as days from 1970-01-01     | `date`, `timestamp`, `timestamptz`, `timestamp_ns`, `timestamptz_ns`                                      | `date`      |
 | **`hour`**        | Extract a timestamp hour, as hours from 1970-01-01 00:00:00  | `timestamp`, `timestamptz`, `timestamp_ns`, `timestamptz_ns`                                              | `int`       |
 | **`void`**        | Always produces `null`                                       | Any                                                                                                       | Source type or `int` |
 


### PR DESCRIPTION
It seems that #5980 erroneously reverted the documentation for the day partition transformation function (originally added by #447).  [We can see from the code that day is special cased to return date.](https://github.com/apache/iceberg/blob/980733c2e1eb10b6e0d2ac6643490a827c806c28/api/src/main/java/org/apache/iceberg/transforms/Dates.java#L93)