### PR TITLE
Docs: Nit-fix the parameter of set_current_snapshot procedure in the example

### DIFF
--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -151,7 +151,7 @@ CALL catalog_name.system.set_current_snapshot('db.sample', 1);
 
 Set the current snapshot for `db.sample` to tag `s1`:
 ```sql
-CALL catalog_name.system.set_current_snapshot(table => 'db.sample', tag => 's1');
+CALL catalog_name.system.set_current_snapshot(table => 'db.sample', ref => 's1');
 ```
 
 ### `cherrypick_snapshot`


### PR DESCRIPTION
The document example says the parameter of `set_current_snapshot` like `tag`. But the correct parameter is `ref`.

From the source, the parameter shows `ref`.

https://github.com/apache/iceberg/blob/2eea697297a4c724a950a4bdc9dd29822ea90d8c/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SetCurrentSnapshotProcedure.java#L50
