### PR TITLE
Flink: Create CatalogTestBase for migration to JUnit5

### DIFF
--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.flink;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.util.ArrayUtils;
@@ -27,7 +26,6 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
-import org.apache.iceberg.Parameters;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -60,14 +58,6 @@ public abstract class CatalogTestBase extends TestBase {
   protected String flinkDatabase;
   protected Namespace icebergNamespace;
   protected boolean isHadoopCatalog;
-
-  @Parameters(name = "catalogName={0} baseNamespace={1}")
-  static List<Object[]> parametrs() {
-    return Arrays.asList(
-        new Object[] {"testhive", Namespace.empty()},
-        new Object[] {"testhadoop", Namespace.empty()},
-        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1")});
-  }
 
   @BeforeEach
   public void before() {

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.util.ArrayUtils;
@@ -26,6 +27,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -58,6 +60,14 @@ public abstract class CatalogTestBase extends TestBase {
   protected String flinkDatabase;
   protected Namespace icebergNamespace;
   protected boolean isHadoopCatalog;
+
+  @Parameters(name = "catalogName={0}, baseNamespace={1}")
+  protected static List<Object[]> parameters() {
+    return Arrays.asList(
+        new Object[] {"testhive", Namespace.empty()},
+        new Object[] {"testhadoop", Namespace.empty()},
+        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1")});
+  }
 
   @BeforeEach
   public void before() {

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 @ExtendWith(ParameterizedTestExtension.class)
-public abstract class FlinkCatalogTestBaseJU5 extends TestBase {
+public abstract class CatalogTestBase extends TestBase {
 
   protected static final String DATABASE = "db";
   @TempDir protected File hiveWarehouse;

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBaseJU5.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBaseJU5.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.util.ArrayUtils;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public abstract class FlinkCatalogTestBaseJU5 extends TestBase {
+
+  protected static final String DATABASE = "db";
+  @TempDir protected File hiveWarehouse;
+  @TempDir protected File hadoopWarehouse;
+
+  @Parameter(index = 0)
+  protected String catalogName;
+
+  @Parameter(index = 1)
+  protected Namespace baseNamespace;
+
+  protected Catalog validationCatalog;
+  protected SupportsNamespaces validationNamespaceCatalog;
+  protected Map<String, String> config = Maps.newHashMap();
+
+  protected String flinkDatabase;
+  protected Namespace icebergNamespace;
+  protected boolean isHadoopCatalog;
+
+  @Parameters(name = "catalogName={0} baseNamespace={1}")
+  static List<Object[]> parametrs() {
+    return Arrays.asList(
+        new Object[] {"testhive", Namespace.empty()},
+        new Object[] {"testhadoop", Namespace.empty()},
+        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1")});
+  }
+
+  @BeforeEach
+  public void before() {
+    this.isHadoopCatalog = catalogName.startsWith("testhadoop");
+    this.validationCatalog =
+        isHadoopCatalog
+            ? new HadoopCatalog(hiveConf, "file:" + hadoopWarehouse.getPath())
+            : catalog;
+    this.validationNamespaceCatalog = (SupportsNamespaces) validationCatalog;
+
+    config.put("type", "iceberg");
+    if (!baseNamespace.isEmpty()) {
+      config.put(FlinkCatalogFactory.BASE_NAMESPACE, baseNamespace.toString());
+    }
+    if (isHadoopCatalog) {
+      config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hadoop");
+    } else {
+      config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hive");
+      config.put(CatalogProperties.URI, getURI(hiveConf));
+    }
+    config.put(CatalogProperties.WAREHOUSE_LOCATION, String.format("file://%s", warehouseRoot()));
+
+    this.flinkDatabase = catalogName + "." + DATABASE;
+    this.icebergNamespace =
+        Namespace.of(ArrayUtils.concat(baseNamespace.levels(), new String[] {DATABASE}));
+    sql("CREATE CATALOG %s WITH %s", catalogName, toWithClause(config));
+  }
+
+  @AfterEach
+  public void clean() {
+    dropCatalog(catalogName, true);
+  }
+
+  protected String warehouseRoot() {
+    if (isHadoopCatalog) {
+      return hadoopWarehouse.getAbsolutePath();
+    } else {
+      return hiveWarehouse.getAbsolutePath();
+    }
+  }
+
+  protected String getFullQualifiedTableName(String tableName) {
+    final List<String> levels = Lists.newArrayList(icebergNamespace.levels());
+    levels.add(tableName);
+    return Joiner.on('.').join(levels);
+  }
+
+  static String getURI(HiveConf conf) {
+    return conf.get(HiveConf.ConfVars.METASTOREURIS.varname);
+  }
+
+  static String toWithClause(Map<String, String> props) {
+    StringBuilder builder = new StringBuilder();
+    builder.append("(");
+    int propCount = 0;
+    for (Map.Entry<String, String> entry : props.entrySet()) {
+      if (propCount > 0) {
+        builder.append(",");
+      }
+      builder
+          .append("'")
+          .append(entry.getKey())
+          .append("'")
+          .append("=")
+          .append("'")
+          .append(entry.getValue())
+          .append("'");
+      propCount++;
+    }
+    builder.append(")");
+    return builder.toString();
+  }
+}

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.flink;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +33,6 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.TestTemplate;
 
 public class TestFlinkCatalogDatabase extends CatalogTestBase {
@@ -45,276 +47,212 @@ public class TestFlinkCatalogDatabase extends CatalogTestBase {
 
   @TestTemplate
   public void testCreateNamespace() {
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Database should not already exist")
         .isFalse();
-    sql("CREATE DATABASE %s", flinkDatabase);
 
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    sql("CREATE DATABASE %s", flinkDatabase);
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Database should exist")
         .isTrue();
 
     sql("CREATE DATABASE IF NOT EXISTS %s", flinkDatabase);
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Database should still exist")
         .isTrue();
 
     sql("DROP DATABASE IF EXISTS %s", flinkDatabase);
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Database should be dropped")
         .isFalse();
 
     sql("CREATE DATABASE IF NOT EXISTS %s", flinkDatabase);
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Database should be created")
         .isTrue();
   }
 
   @TestTemplate
   public void testDropEmptyDatabase() {
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should not already exist")
         .isFalse();
-
     sql("CREATE DATABASE %s", flinkDatabase);
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should exist")
         .isTrue();
-
     sql("DROP DATABASE %s", flinkDatabase);
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should have been dropped")
         .isFalse();
   }
 
   @TestTemplate
   public void testDropNonEmptyNamespace() {
-
-    Assumptions.assumeFalse(
-        isHadoopCatalog, "Hadoop catalog throws IOException: Directory is not empty.");
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assumeThat(isHadoopCatalog)
+        .as("Hadoop catalog throws IOException: Directory is not empty.")
+        .isFalse();
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should not already exist")
         .isFalse();
-
     sql("CREATE DATABASE %s", flinkDatabase);
-
     validationCatalog.createTable(
         TableIdentifier.of(icebergNamespace, "tl"),
         new Schema(Types.NestedField.optional(0, "id", Types.LongType.get())));
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should exist")
         .isTrue();
-
-    Assertions.assertThat(validationCatalog.tableExists(TableIdentifier.of(icebergNamespace, "tl")))
+    assertThat(validationCatalog.tableExists(TableIdentifier.of(icebergNamespace, "tl")))
         .as("Table should exist")
         .isTrue();
-
     Assertions.assertThatThrownBy(() -> sql("DROP DATABASE %s", flinkDatabase))
         .cause()
         .isInstanceOf(DatabaseNotEmptyException.class)
         .hasMessage(
             String.format("Database %s in catalog %s is not empty.", DATABASE, catalogName));
-
     sql("DROP TABLE %s.tl", flinkDatabase);
   }
 
   @TestTemplate
   public void testListTables() {
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should not already exist")
         .isFalse();
-
     sql("CREATE DATABASE %s", flinkDatabase);
     sql("USE CATALOG %s", catalogName);
     sql("USE %s", DATABASE);
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should exist")
         .isTrue();
-
-    Assertions.assertThat(sql("SHOW TABLES").size()).as("Should not list any tables").isEqualTo(0);
-
+    assertThat(sql("SHOW TABLES").size()).as("Should not list any tables").isEqualTo(0);
     validationCatalog.createTable(
         TableIdentifier.of(icebergNamespace, "tl"),
         new Schema(Types.NestedField.optional(0, "id", Types.LongType.get())));
 
     List<Row> tables = sql("SHOW TABLES");
-    Assertions.assertThat(tables.size()).as("Only 1 table").isEqualTo(1);
-    Assertions.assertThat("tl").as("Table name should match").isEqualTo(tables.get(0).getField(0));
+    assertThat(tables).hasSize(1);
+    assertThat("tl").as("Table name should match").isEqualTo(tables.get(0).getField(0));
   }
 
   @TestTemplate
   public void testListNamespace() {
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should not already exist")
         .isFalse();
-
     sql("CREATE DATABASE %s", flinkDatabase);
     sql("USE CATALOG %s", catalogName);
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should exist")
         .isTrue();
 
     List<Row> databases = sql("SHOW DATABASES");
 
     if (isHadoopCatalog) {
-      Assertions.assertThat(databases.size()).as("Should have 1 database").isEqualTo(1);
-      Assertions.assertThat(databases.get(0).getField(0))
-          .as("Should have db database")
-          .isEqualTo("db");
+      assertThat(databases).hasSize(1);
+      assertThat(databases.get(0).getField(0)).as("Should have db database").isEqualTo("db");
       if (!baseNamespace.isEmpty()) {
         // test namespace not belongs to this catalog
         validationNamespaceCatalog.createNamespace(
             Namespace.of(baseNamespace.level(0), "UNKNOWN_NAMESPACE"));
         databases = sql("SHOW DATABASES");
-        Assertions.assertThat(databases.size()).as("Should have 1 database").isEqualTo(1);
-        Assertions.assertThat(databases.get(0).getField(0))
-            .as("Should have db database")
-            .isEqualTo("db");
+        assertThat(databases).hasSize(1);
+        assertThat(databases.get(0).getField(0)).as("Should have db database").isEqualTo("db");
       }
     } else {
       // If there are multiple classes extends FlinkTestBase, TestHiveMetastore may loose the
       // creation for default
       // database. See HiveMetaStore.HMSHandler.init.
-      Assertions.assertThat(databases.stream().anyMatch(d -> Objects.equals(d.getField(0), "db")))
-          .as("Should have db database")
-          .isTrue();
+      assertThat(databases)
+          .anyMatch(d -> Objects.equals(d.getField(0), "db"))
+          .as("Should have db database");
     }
   }
 
   @TestTemplate
   public void testCreateNamespaceWithMetadata() {
-    Assumptions.assumeFalse(isHadoopCatalog, "HadoopCatalog does not support namespace metadata");
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assumeThat(isHadoopCatalog).as("HadoopCatalog does not support namespace metadata").isFalse();
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should not already exist")
         .isFalse();
-
     sql("CREATE DATABASE %s WITH ('prop'='value')", flinkDatabase);
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should exist")
         .isTrue();
-
     Map<String, String> nsMetadata =
         validationNamespaceCatalog.loadNamespaceMetadata(icebergNamespace);
-    Assertions.assertThat(nsMetadata.get("prop"))
+    assertThat(nsMetadata.get("prop"))
         .as("Namespace should have expected prop value")
         .isEqualTo("value");
   }
 
   @TestTemplate
   public void testCreateNamespaceWithComment() {
-    Assumptions.assumeFalse(isHadoopCatalog, "HadoopCatalog does not support namespace metadata");
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assumeThat(isHadoopCatalog).as("HadoopCatalog does not support namespace metadata").isFalse();
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should not already exist")
         .isFalse();
 
     sql("CREATE DATABASE %s COMMENT 'namespace doc'", flinkDatabase);
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should exist")
         .isTrue();
-
     Map<String, String> nsMetadata =
         validationNamespaceCatalog.loadNamespaceMetadata(icebergNamespace);
-
-    Assertions.assertThat(nsMetadata.get("comment"))
+    assertThat(nsMetadata.get("comment"))
         .as("Namespace should have expected comment")
         .isEqualTo("namespace doc");
   }
 
   @TestTemplate
   public void testCreateNamespaceWithLocation() throws Exception {
-    Assumptions.assumeFalse(isHadoopCatalog, "HadoopCatalog does not support namespace metadata");
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assumeThat(isHadoopCatalog).as("HadoopCatalog does not support namespace metadata").isFalse();
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should not already exist")
         .isFalse();
 
     Path location = temporaryDirectory.getRoot();
-
     sql("CREATE DATABASE %s WITH ('location'='%s')", flinkDatabase, location);
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should exist")
         .isTrue();
-
     Map<String, String> nsMetadata =
         validationNamespaceCatalog.loadNamespaceMetadata(icebergNamespace);
-
-    Assertions.assertThat(nsMetadata.get("location"))
+    assertThat(nsMetadata.get("location"))
         .as("Namespace should have expected location")
         .isEqualTo("file:" + location.getRoot());
   }
 
   @TestTemplate
   public void testSetProperties() {
-    // Assume.assumeFalse("HadoopCatalog does not support namespace metadata", isHadoopCatalog);
-    Assumptions.assumeFalse(isHadoopCatalog, "HadoopCatalog does not support namespace metadata");
-
-    //      Assert.assertFalse(
-    //          "Namespace should not already exist",
-    //          validationNamespaceCatalog.namespaceExists(icebergNamespace));
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assumeThat(isHadoopCatalog).as("HadoopCatalog does not support namespace metadata").isFalse();
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should not already exist")
         .isFalse();
 
     sql("CREATE DATABASE %s", flinkDatabase);
-
-    //      Assert.assertTrue(
-    //          "Namespace should exist",
-    // validationNamespaceCatalog.namespaceExists(icebergNamespace));
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should exist")
         .isTrue();
 
     Map<String, String> defaultMetadata =
         validationNamespaceCatalog.loadNamespaceMetadata(icebergNamespace);
-
-    //      Assert.assertFalse(
-    //          "Default metadata should not have custom property",
-    //   defaultMetadata.containsKey("prop"));
-
-    Assertions.assertThat(defaultMetadata.containsKey("prop"))
+    assertThat(defaultMetadata.containsKey("prop"))
         .as("Default metadata should not have custom property")
         .isFalse();
-
     sql("ALTER DATABASE %s SET ('prop'='value')", flinkDatabase);
-
     Map<String, String> nsMetadata =
         validationNamespaceCatalog.loadNamespaceMetadata(icebergNamespace);
-
-    //      Assert.assertEquals(
-    //          "Namespace should have expected prop value", "value", nsMetadata.get("prop"));
-
-    Assertions.assertThat(nsMetadata.get("prop"))
+    assertThat(nsMetadata.get("prop"))
         .as("Namespace should have expected prop value")
         .isEqualTo("value");
   }
 
   @TestTemplate
   public void testHadoopNotSupportMeta() {
-
-    Assumptions.assumeTrue(isHadoopCatalog, "HadoopCatalog does not support namespace metadata");
-    Assertions.assertThat(isHadoopCatalog)
-        .as("HadoopCatalog does not support namespace metadata")
-        .isTrue();
-
-    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
+    assumeThat(isHadoopCatalog).as("HadoopCatalog does not support namespace metadata").isTrue();
+    assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should not already exist")
         .isFalse();
-
     Assertions.assertThatThrownBy(
             () -> sql("CREATE DATABASE %s WITH ('prop'='value')", flinkDatabase))
         .cause()

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -22,11 +22,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.types.Row;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -36,6 +38,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
 
 public class TestFlinkCatalogDatabase extends CatalogTestBase {
+
+  @Parameters(name = "catalogName={0}, baseNamespace={1}")
+  static List<Object[]> parameters() {
+    return Arrays.asList(
+        new Object[] {"testhive", Namespace.empty()},
+        new Object[] {"testhadoop", Namespace.empty()},
+        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1")});
+  }
 
   @AfterEach
   @Override
@@ -180,9 +190,7 @@ public class TestFlinkCatalogDatabase extends CatalogTestBase {
         .isTrue();
     Map<String, String> nsMetadata =
         validationNamespaceCatalog.loadNamespaceMetadata(icebergNamespace);
-    assertThat(nsMetadata.get("prop"))
-        .as("Namespace should have expected prop value")
-        .isEqualTo("value");
+    assertThat(nsMetadata).containsEntry("prop", "value");
   }
 
   @TestTemplate
@@ -198,9 +206,7 @@ public class TestFlinkCatalogDatabase extends CatalogTestBase {
         .isTrue();
     Map<String, String> nsMetadata =
         validationNamespaceCatalog.loadNamespaceMetadata(icebergNamespace);
-    assertThat(nsMetadata.get("comment"))
-        .as("Namespace should have expected comment")
-        .isEqualTo("namespace doc");
+    assertThat(nsMetadata).containsEntry("comment", "namespace doc");
   }
 
   @TestTemplate
@@ -217,9 +223,7 @@ public class TestFlinkCatalogDatabase extends CatalogTestBase {
         .isTrue();
     Map<String, String> nsMetadata =
         validationNamespaceCatalog.loadNamespaceMetadata(icebergNamespace);
-    assertThat(nsMetadata.get("location"))
-        .as("Namespace should have expected location")
-        .isEqualTo("file:" + location.getRoot());
+    assertThat(nsMetadata).containsEntry("location", "file:" + location.getRoot());
   }
 
   @TestTemplate
@@ -236,15 +240,11 @@ public class TestFlinkCatalogDatabase extends CatalogTestBase {
 
     Map<String, String> defaultMetadata =
         validationNamespaceCatalog.loadNamespaceMetadata(icebergNamespace);
-    assertThat(defaultMetadata.containsKey("prop"))
-        .as("Default metadata should not have custom property")
-        .isFalse();
+    assertThat(defaultMetadata).doesNotContainKey("prop");
     sql("ALTER DATABASE %s SET ('prop'='value')", flinkDatabase);
     Map<String, String> nsMetadata =
         validationNamespaceCatalog.loadNamespaceMetadata(icebergNamespace);
-    assertThat(nsMetadata.get("prop"))
-        .as("Namespace should have expected prop value")
-        .isEqualTo("value");
+    assertThat(nsMetadata).containsEntry("prop", "value");
   }
 
   @TestTemplate

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -22,13 +22,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.types.Row;
-import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -38,14 +36,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
 
 public class TestFlinkCatalogDatabase extends CatalogTestBase {
-
-  @Parameters(name = "catalogName={0}, baseNamespace={1}")
-  static List<Object[]> parameters() {
-    return Arrays.asList(
-        new Object[] {"testhive", Namespace.empty()},
-        new Object[] {"testhadoop", Namespace.empty()},
-        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1")});
-  }
 
   @AfterEach
   @Override

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -124,7 +124,7 @@ public class TestFlinkCatalogDatabase extends CatalogTestBase {
     assertThat(validationNamespaceCatalog.namespaceExists(icebergNamespace))
         .as("Namespace should exist")
         .isTrue();
-    assertThat(sql("SHOW TABLES").size()).as("Should not list any tables").isEqualTo(0);
+    assertThat(sql("SHOW TABLES")).isEmpty();
     validationCatalog.createTable(
         TableIdentifier.of(icebergNamespace, "tl"),
         new Schema(Types.NestedField.optional(0, "id", Types.LongType.get())));
@@ -163,8 +163,8 @@ public class TestFlinkCatalogDatabase extends CatalogTestBase {
       // creation for default
       // database. See HiveMetaStore.HMSHandler.init.
       assertThat(databases)
-          .anyMatch(d -> Objects.equals(d.getField(0), "db"))
-          .as("Should have db database");
+          .as("Should have db database")
+          .anyMatch(d -> Objects.equals(d.getField(0), "db"));
     }
   }
 

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
@@ -48,7 +48,7 @@ public class TestFlinkCatalogTablePartitions extends CatalogTestBase {
   private Boolean cacheEnabled;
 
   @Parameters(name = "catalogName={0}, baseNamespace={1}, format={2}, cacheEnabled={3}")
-  static Iterable<Object[]> parameters() {
+  protected static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
     for (FileFormat format :
         new FileFormat[] {FileFormat.ORC, FileFormat.AVRO, FileFormat.PARQUET}) {

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestMetadataTableReadableMetrics.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestMetadataTableReadableMetrics.java
@@ -57,7 +57,7 @@ public class TestMetadataTableReadableMetrics extends CatalogTestBase {
   private static final String TABLE_NAME = "test_table";
 
   @Parameters(name = "catalogName={0}, baseNamespace={1}")
-  static List<Object[]> parameters() {
+  protected static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
     String catalogName = "testhive";
     Namespace baseNamespace = Namespace.empty();

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestMetadataTableReadableMetrics.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestMetadataTableReadableMetrics.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.source;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
+import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -72,7 +73,7 @@ public class TestMetadataTableReadableMetrics extends CatalogTestBase {
     return super.getTableEnv();
   }
 
-  @TempDir Path temp;
+  private @TempDir Path temp;
 
   private static final Types.StructType LEAF_STRUCT_TYPE =
       Types.StructType.of(
@@ -130,7 +131,8 @@ public class TestMetadataTableReadableMetrics extends CatalogTestBase {
             createPrimitiveRecord(
                 false, 2, 2L, Float.NaN, 2.0D, new BigDecimal("2.00"), "2", null, null));
 
-    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(temp.toFile()), records);
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(testFile), records);
     table.newAppend().appendFile(dataFile).commit();
     return table;
   }
@@ -148,7 +150,9 @@ public class TestMetadataTableReadableMetrics extends CatalogTestBase {
             createNestedRecord(0L, 0.0),
             createNestedRecord(1L, Double.NaN),
             createNestedRecord(null, null));
-    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(temp.toFile()), records);
+
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(testFile), records);
     table.newAppend().appendFile(dataFile).commit();
   }
 


### PR DESCRIPTION
Base class creation of FlinkCatalogTestBase for the migration to JUnit5 in regards to https://github.com/apache/iceberg/issues/9079