### PR TITLE
Spark 3.5: Migrate tests to JUnit5 in actions directory

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -151,7 +151,7 @@ public class TestCreateActions extends CatalogTestBase {
   private TableCatalog catalog;
 
   @BeforeEach
-  public void before() {
+  public void beforeEach() {
     try {
       this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     } catch (IOException e) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -528,11 +528,8 @@ public class TestCreateActions extends CatalogTestBase {
 
     for (Map.Entry<String, String> entry : expectedProps.entrySet()) {
       assertThat(table.properties())
-          .as("Created table missing property " + entry.getKey())
-          .containsKey(entry.getKey());
-      assertThat(table.properties().get(entry.getKey()))
           .as("Property value is not the expected value")
-          .isEqualTo(entry.getValue());
+          .containsEntry(entry.getKey(), entry.getValue());
     }
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -151,7 +151,9 @@ public class TestCreateActions extends CatalogTestBase {
   private TableCatalog catalog;
 
   @BeforeEach
-  public void beforeEach() {
+  @Override
+  public void before() {
+    super.before();
     try {
       this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     } catch (IOException e) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -95,7 +95,7 @@ public class TestCreateActions extends CatalogTestBase {
 
   private static final String NAMESPACE = "default";
 
-  @Parameters(name = "Catalog Name {0} - Options {2}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, type = {3}")
   public static Object[][] parameters() {
     return new Object[][] {
       new Object[] {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -18,10 +18,14 @@
  */
 package org.apache.iceberg.spark.actions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,6 +35,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -40,9 +45,9 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkCatalog;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.iceberg.spark.source.SparkTable;
@@ -68,20 +73,15 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
 import scala.Option;
 import scala.Some;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
-public class TestCreateActions extends SparkCatalogTestBase {
+public class TestCreateActions extends CatalogTestBase {
   private static final String CREATE_PARTITIONED_PARQUET =
       "CREATE TABLE %s (id INT, data STRING) " + "using parquet PARTITIONED BY (id) LOCATION '%s'";
   private static final String CREATE_PARQUET =
@@ -94,7 +94,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
   private static final String NAMESPACE = "default";
 
-  @Parameterized.Parameters(name = "Catalog Name {0} - Options {2}")
+  @Parameters(name = "Catalog Name {0} - Options {2}")
   public static Object[][] parameters() {
     return new Object[][] {
       new Object[] {
@@ -136,8 +136,6 @@ public class TestCreateActions extends SparkCatalogTestBase {
     };
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
-
   private String baseTableName = "baseTable";
   private File tableDir;
   private String tableLocation;
@@ -150,10 +148,10 @@ public class TestCreateActions extends SparkCatalogTestBase {
     this.type = config.get("type");
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     try {
-      this.tableDir = temp.newFolder();
+      this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -179,31 +177,33 @@ public class TestCreateActions extends SparkCatalogTestBase {
         .saveAsTable(baseTableName);
   }
 
-  @After
+  @AfterEach
   public void after() throws IOException {
     // Drop the hive table.
     spark.sql(String.format("DROP TABLE IF EXISTS %s", baseTableName));
   }
 
-  @Test
+  @TestTemplate
   public void testMigratePartitioned() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_migrate_partitioned_table");
     String dest = source;
     createSourceTable(CREATE_PARTITIONED_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedTableWithUnRecoveredPartitions() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_unrecovered_partitions");
     String dest = source;
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     sql(CREATE_PARTITIONED_PARQUET, source, location);
 
     // Data generation and partition addition
@@ -219,15 +219,16 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedTableWithCustomPartitions() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_custom_parts");
     String dest = source;
-    File tblLocation = temp.newFolder();
-    File partitionDataLoc = temp.newFolder();
+    File tblLocation = Files.createTempDirectory(temp, "junit").toFile();
+    File partitionDataLoc = Files.createTempDirectory(temp, "junit").toFile();
 
     // Data generation and partition addition
     spark.sql(String.format(CREATE_PARTITIONED_PARQUET, source, tblLocation));
@@ -243,11 +244,12 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testAddColumnOnMigratedTableAtEnd() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_add_column_migrated_table");
     String dest = source;
     createSourceTable(CREATE_PARQUET, source);
@@ -264,30 +266,31 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String newCol1 = "newCol1";
     sparkTable.table().updateSchema().addColumn(newCol1, Types.IntegerType.get()).commit();
     Schema afterSchema = table.schema();
-    Assert.assertNull(beforeSchema.findField(newCol1));
-    Assert.assertNotNull(afterSchema.findField(newCol1));
+    assertThat(beforeSchema.findField(newCol1)).isNull();
+    assertThat(afterSchema.findField(newCol1)).isNotNull();
 
     // reads should succeed without any exceptions
     List<Object[]> results1 = sql("select * from %s order by id", dest);
-    Assert.assertFalse(results1.isEmpty());
+    assertThat(results1).isNotEmpty();
     assertEquals("Output must match", results1, expected1);
 
     String newCol2 = "newCol2";
     sql("ALTER TABLE %s ADD COLUMN %s INT", dest, newCol2);
     StructType schema = spark.table(dest).schema();
-    Assert.assertTrue(Arrays.asList(schema.fieldNames()).contains(newCol2));
+    assertThat(schema.fieldNames()).contains(newCol2);
 
     // reads should succeed without any exceptions
     List<Object[]> results2 = sql("select * from %s order by id", dest);
-    Assert.assertFalse(results2.isEmpty());
+    assertThat(results2).isNotEmpty();
     assertEquals("Output must match", results2, expected2);
   }
 
-  @Test
+  @TestTemplate
   public void testAddColumnOnMigratedTableAtMiddle() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_add_column_migrated_table_middle");
     String dest = source;
     createSourceTable(CREATE_PARQUET, source);
@@ -308,26 +311,27 @@ public class TestCreateActions extends SparkCatalogTestBase {
         .moveAfter(newCol1, "id")
         .commit();
     Schema afterSchema = table.schema();
-    Assert.assertNull(beforeSchema.findField(newCol1));
-    Assert.assertNotNull(afterSchema.findField(newCol1));
+    assertThat(beforeSchema.findField(newCol1)).isNull();
+    assertThat(afterSchema.findField(newCol1)).isNotNull();
 
     // reads should succeed
     List<Object[]> results = sql("select * from %s order by id", dest);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", results, expected);
   }
 
-  @Test
+  @TestTemplate
   public void removeColumnsAtEnd() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_remove_column_migrated_table");
     String dest = source;
 
     String colName1 = "newCol1";
     String colName2 = "newCol2";
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     spark
         .range(10)
         .selectExpr("cast(id as INT)", "CAST(id as INT) " + colName1, "CAST(id as INT) " + colName2)
@@ -346,29 +350,30 @@ public class TestCreateActions extends SparkCatalogTestBase {
     Schema beforeSchema = table.schema();
     sparkTable.table().updateSchema().deleteColumn(colName1).commit();
     Schema afterSchema = table.schema();
-    Assert.assertNotNull(beforeSchema.findField(colName1));
-    Assert.assertNull(afterSchema.findField(colName1));
+    assertThat(beforeSchema.findField(colName1)).isNotNull();
+    assertThat(afterSchema.findField(colName1)).isNull();
 
     // reads should succeed without any exceptions
     List<Object[]> results1 = sql("select * from %s order by id", dest);
-    Assert.assertFalse(results1.isEmpty());
+    assertThat(results1).isNotEmpty();
     assertEquals("Output must match", expected1, results1);
 
     sql("ALTER TABLE %s DROP COLUMN %s", dest, colName2);
     StructType schema = spark.table(dest).schema();
-    Assert.assertFalse(Arrays.asList(schema.fieldNames()).contains(colName2));
+    assertThat(schema.fieldNames()).doesNotContain(colName2);
 
     // reads should succeed without any exceptions
     List<Object[]> results2 = sql("select * from %s order by id", dest);
-    Assert.assertFalse(results2.isEmpty());
+    assertThat(results2).isNotEmpty();
     assertEquals("Output must match", expected2, results2);
   }
 
-  @Test
+  @TestTemplate
   public void removeColumnFromMiddle() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_remove_column_migrated_table_from_middle");
     String dest = source;
     String dropColumnName = "col1";
@@ -388,31 +393,32 @@ public class TestCreateActions extends SparkCatalogTestBase {
     // drop column
     sql("ALTER TABLE %s DROP COLUMN %s", dest, "col1");
     StructType schema = spark.table(dest).schema();
-    Assert.assertFalse(Arrays.asList(schema.fieldNames()).contains(dropColumnName));
+    assertThat(schema.fieldNames()).doesNotContain(dropColumnName);
 
     // reads should return same output as that of non-iceberg table
     List<Object[]> results = sql("select * from %s order by id", dest);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", expected, results);
   }
 
-  @Test
+  @TestTemplate
   public void testMigrateUnpartitioned() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_migrate_unpartitioned_table");
     String dest = source;
     createSourceTable(CREATE_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotPartitioned() throws Exception {
-    Assume.assumeTrue(
-        "Cannot snapshot with arbitrary location in a hadoop based catalog",
-        !type.equals("hadoop"));
-    File location = temp.newFolder();
+    assumeThat(type)
+        .as("Cannot snapshot with arbitrary location in a hadoop based catalog")
+        .isNotEqualTo("hadoop");
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     String source = sourceName("test_snapshot_partitioned_table");
     String dest = destName("iceberg_snapshot_partitioned");
     createSourceTable(CREATE_PARTITIONED_PARQUET, source);
@@ -423,12 +429,12 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertIsolatedSnapshot(source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotUnpartitioned() throws Exception {
-    Assume.assumeTrue(
-        "Cannot snapshot with arbitrary location in a hadoop based catalog",
-        !type.equals("hadoop"));
-    File location = temp.newFolder();
+    assumeThat(type)
+        .as("Cannot snapshot with arbitrary location in a hadoop based catalog")
+        .isNotEqualTo("hadoop");
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     String source = sourceName("test_snapshot_unpartitioned_table");
     String dest = destName("iceberg_snapshot_unpartitioned");
     createSourceTable(CREATE_PARQUET, source);
@@ -439,12 +445,12 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertIsolatedSnapshot(source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotHiveTable() throws Exception {
-    Assume.assumeTrue(
-        "Cannot snapshot with arbitrary location in a hadoop based catalog",
-        !type.equals("hadoop"));
-    File location = temp.newFolder();
+    assumeThat(type)
+        .as("Cannot snapshot with arbitrary location in a hadoop based catalog")
+        .isNotEqualTo("hadoop");
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     String source = sourceName("snapshot_hive_table");
     String dest = destName("iceberg_snapshot_hive_table");
     createSourceTable(CREATE_HIVE_EXTERNAL_PARQUET, source);
@@ -455,19 +461,19 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertIsolatedSnapshot(source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testMigrateHiveTable() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
     String source = sourceName("migrate_hive_table");
     String dest = source;
     createSourceTable(CREATE_HIVE_EXTERNAL_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotManagedHiveTable() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    File location = temp.newFolder();
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     String source = sourceName("snapshot_managed_hive_table");
     String dest = destName("iceberg_snapshot_managed_hive_table");
     createSourceTable(CREATE_HIVE_PARQUET, source);
@@ -478,10 +484,10 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertIsolatedSnapshot(source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testMigrateManagedHiveTable() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    File location = temp.newFolder();
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     String source = sourceName("migrate_managed_hive_table");
     String dest = destName("iceberg_migrate_managed_hive_table");
     createSourceTable(CREATE_HIVE_PARQUET, source);
@@ -491,7 +497,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
         dest);
   }
 
-  @Test
+  @TestTemplate
   public void testProperties() throws Exception {
     String source = sourceName("test_properties_table");
     String dest = destName("iceberg_properties");
@@ -516,17 +522,16 @@ public class TestCreateActions extends SparkCatalogTestBase {
     expectedProps.put("dogs", "sundance");
 
     for (Map.Entry<String, String> entry : expectedProps.entrySet()) {
-      Assert.assertTrue(
-          "Created table missing property " + entry.getKey(),
-          table.properties().containsKey(entry.getKey()));
-      Assert.assertEquals(
-          "Property value is not the expected value",
-          entry.getValue(),
-          table.properties().get(entry.getKey()));
+      assertThat(table.properties())
+          .as("Created table missing property " + entry.getKey())
+          .containsKey(entry.getKey());
+      assertThat(table.properties().get(entry.getKey()))
+          .as("Property value is not the expected value")
+          .isEqualTo(entry.getValue());
     }
   }
 
-  @Test
+  @TestTemplate
   public void testSparkTableReservedProperties() throws Exception {
     String destTableName = "iceberg_reserved_properties";
     String source = sourceName("test_reserved_properties_table");
@@ -542,28 +547,36 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String[] keys = {"provider", "format", "current-snapshot-id", "location", "sort-order"};
 
     for (String entry : keys) {
-      Assert.assertTrue(
-          "Created table missing reserved property " + entry,
-          table.properties().containsKey(entry));
+      assertThat(table.properties())
+          .as("Created table missing reserved property " + entry)
+          .containsKey(entry);
     }
 
-    Assert.assertEquals("Unexpected provider", "iceberg", table.properties().get("provider"));
-    Assert.assertEquals("Unexpected format", "iceberg/parquet", table.properties().get("format"));
-    Assert.assertNotEquals(
-        "No current-snapshot-id found", "none", table.properties().get("current-snapshot-id"));
-    Assert.assertTrue(
-        "Location isn't correct", table.properties().get("location").endsWith(destTableName));
+    assertThat(table.properties().get("provider")).as("Unexpected provider").isEqualTo("iceberg");
+    assertThat(table.properties().get("format"))
+        .as("Unexpected provider")
+        .isEqualTo("iceberg/parquet");
+    assertThat(table.properties().get("current-snapshot-id"))
+        .as("No current-snapshot-id found")
+        .isNotEqualTo("none");
+    assertThat(table.properties().get("location"))
+        .as("Location isn't correct")
+        .endsWith(destTableName);
 
-    Assert.assertEquals("Unexpected format-version", "1", table.properties().get("format-version"));
+    assertThat(table.properties().get("format-version"))
+        .as("Unexpected format-version")
+        .isEqualTo("1");
     table.table().updateProperties().set("format-version", "2").commit();
-    Assert.assertEquals("Unexpected format-version", "2", table.properties().get("format-version"));
+    assertThat(table.properties().get("format-version"))
+        .as("Unexpected format-version")
+        .isEqualTo("2");
 
-    Assert.assertEquals(
-        "Sort-order isn't correct",
-        "id ASC NULLS FIRST, data DESC NULLS LAST",
-        table.properties().get("sort-order"));
-    Assert.assertNull(
-        "Identifier fields should be null", table.properties().get("identifier-fields"));
+    assertThat(table.properties().get("sort-order"))
+        .as("Sort-order isn't correct")
+        .isEqualTo("id ASC NULLS FIRST, data DESC NULLS LAST");
+    assertThat(table.properties().get("identifier-fields"))
+        .as("Identifier fields should be null")
+        .isNull();
 
     table
         .table()
@@ -572,11 +585,12 @@ public class TestCreateActions extends SparkCatalogTestBase {
         .requireColumn("id")
         .setIdentifierFields("id")
         .commit();
-    Assert.assertEquals(
-        "Identifier fields aren't correct", "[id]", table.properties().get("identifier-fields"));
+    assertThat(table.properties().get("identifier-fields"))
+        .as("Identifier fields aren't correct")
+        .isEqualTo("[id]");
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotDefaultLocation() throws Exception {
     String source = sourceName("test_snapshot_default");
     String dest = destName("iceberg_snapshot_default");
@@ -585,13 +599,14 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertIsolatedSnapshot(source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void schemaEvolutionTestWithSparkAPI() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
 
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     String tblName = sourceName("schema_evolution_test");
 
     // Data generation and partition addition
@@ -639,11 +654,12 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertEquals("Output must match", expectedAfterAddColumn, afterMigarteAfterAddResults);
   }
 
-  @Test
+  @TestTemplate
   public void schemaEvolutionTestWithSparkSQL() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String tblName = sourceName("schema_evolution_test_sql");
 
     // Data generation and partition addition
@@ -686,52 +702,52 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertEquals("Output must match", expectedAfterAddColumn, afterMigarteAfterAddResults);
   }
 
-  @Test
+  @TestTemplate
   public void testHiveStyleThreeLevelList() throws Exception {
     threeLevelList(true);
   }
 
-  @Test
+  @TestTemplate
   public void testThreeLevelList() throws Exception {
     threeLevelList(false);
   }
 
-  @Test
+  @TestTemplate
   public void testHiveStyleThreeLevelListWithNestedStruct() throws Exception {
     threeLevelListWithNestedStruct(true);
   }
 
-  @Test
+  @TestTemplate
   public void testThreeLevelListWithNestedStruct() throws Exception {
     threeLevelListWithNestedStruct(false);
   }
 
-  @Test
+  @TestTemplate
   public void testHiveStyleThreeLevelLists() throws Exception {
     threeLevelLists(true);
   }
 
-  @Test
+  @TestTemplate
   public void testThreeLevelLists() throws Exception {
     threeLevelLists(false);
   }
 
-  @Test
+  @TestTemplate
   public void testHiveStyleStructOfThreeLevelLists() throws Exception {
     structOfThreeLevelLists(true);
   }
 
-  @Test
+  @TestTemplate
   public void testStructOfThreeLevelLists() throws Exception {
     structOfThreeLevelLists(false);
   }
 
-  @Test
+  @TestTemplate
   public void testTwoLevelList() throws IOException {
     spark.conf().set("spark.sql.parquet.writeLegacyFormat", true);
 
     String tableName = sourceName("testTwoLevelList");
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
 
     StructType sparkSchema =
         new StructType(
@@ -791,7 +807,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
             HadoopInputFile.fromPath(
                 new Path(parquetFile.getPath()), spark.sessionState().newHadoopConf()));
     MessageType schema = pqReader.getFooter().getFileMetaData().getSchema();
-    Assert.assertEquals(MessageTypeParser.parseMessageType(expectedParquetSchema), schema);
+    assertThat(schema).isEqualTo(MessageTypeParser.parseMessageType(expectedParquetSchema));
 
     // create sql table on top of it
     sql(
@@ -806,7 +822,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", expected, results);
   }
 
@@ -814,7 +830,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     spark.conf().set("spark.sql.parquet.writeLegacyFormat", useLegacyMode);
 
     String tableName = sourceName(String.format("threeLevelList_%s", useLegacyMode));
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     sql(
         "CREATE TABLE %s (col1 ARRAY<STRUCT<col2 INT>>)" + " STORED AS parquet" + " LOCATION '%s'",
         tableName, location);
@@ -828,7 +844,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", expected, results);
   }
 
@@ -837,7 +853,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     String tableName =
         sourceName(String.format("threeLevelListWithNestedStruct_%s", useLegacyMode));
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     sql(
         "CREATE TABLE %s (col1 ARRAY<STRUCT<col2 STRUCT<col3 INT>>>)"
             + " STORED AS parquet"
@@ -853,7 +869,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", expected, results);
   }
 
@@ -861,7 +877,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     spark.conf().set("spark.sql.parquet.writeLegacyFormat", useLegacyMode);
 
     String tableName = sourceName(String.format("threeLevelLists_%s", useLegacyMode));
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     sql(
         "CREATE TABLE %s (col1 ARRAY<STRUCT<col2 INT>>, col3 ARRAY<STRUCT<col4 INT>>)"
             + " STORED AS parquet"
@@ -880,7 +896,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", expected, results);
   }
 
@@ -888,7 +904,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     spark.conf().set("spark.sql.parquet.writeLegacyFormat", useLegacyMode);
 
     String tableName = sourceName(String.format("structOfThreeLevelLists_%s", useLegacyMode));
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     sql(
         "CREATE TABLE %s (col1 STRUCT<col2 ARRAY<STRUCT<col3 INT>>>)"
             + " STORED AS parquet"
@@ -904,7 +920,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", expected, results);
   }
 
@@ -925,7 +941,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
   private void createSourceTable(String createStatement, String tableName)
       throws IOException, NoSuchTableException, NoSuchDatabaseException, ParseException {
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     spark.sql(String.format(createStatement, tableName, location));
     CatalogTable table = loadSessionTable(tableName);
     String format = table.provider().get();
@@ -945,8 +961,9 @@ public class TestCreateActions extends SparkCatalogTestBase {
     long expectedFiles = expectedFilesCount(source);
     MigrateTable.Result migratedFiles = migrateAction.execute();
     validateTables(source, dest);
-    Assert.assertEquals(
-        "Expected number of migrated files", expectedFiles, migratedFiles.migratedDataFilesCount());
+    assertThat(migratedFiles.migratedDataFilesCount())
+        .as("Expected number of migrated files")
+        .isEqualTo(expectedFiles);
   }
 
   // Counts the number of files in the source table, makes sure the same files exist in the
@@ -956,26 +973,31 @@ public class TestCreateActions extends SparkCatalogTestBase {
     long expectedFiles = expectedFilesCount(source);
     SnapshotTable.Result snapshotTableResult = snapshotTable.execute();
     validateTables(source, dest);
-    Assert.assertEquals(
-        "Expected number of imported snapshot files",
-        expectedFiles,
-        snapshotTableResult.importedDataFilesCount());
+    assertThat(snapshotTableResult.importedDataFilesCount())
+        .as("Expected number of imported snapshot files")
+        .isEqualTo(expectedFiles);
   }
 
   private void validateTables(String source, String dest)
       throws NoSuchTableException, ParseException {
     List<Row> expected = spark.table(source).collectAsList();
     SparkTable destTable = loadTable(dest);
-    Assert.assertEquals(
-        "Provider should be iceberg",
-        "iceberg",
-        destTable.properties().get(TableCatalog.PROP_PROVIDER));
+    assertThat(destTable.properties().get(TableCatalog.PROP_PROVIDER))
+        .as("Provider should be iceberg")
+        .isEqualTo("iceberg");
     List<Row> actual = spark.table(dest).collectAsList();
-    Assert.assertTrue(
-        String.format(
-            "Rows in migrated table did not match\nExpected :%s rows \nFound    :%s",
-            expected, actual),
-        expected.containsAll(actual) && actual.containsAll(expected));
+    assertThat(actual)
+        .as(
+            String.format(
+                "Rows in migrated table did not match\nExpected :%s rows \nFound    :%s",
+                expected, actual))
+        .containsAll(expected);
+    assertThat(expected)
+        .as(
+            String.format(
+                "Rows in migrated table did not match\nExpected :%s rows \nFound    :%s",
+                expected, actual))
+        .containsAll(actual);
   }
 
   private long expectedFilesCount(String source)
@@ -1016,14 +1038,15 @@ public class TestCreateActions extends SparkCatalogTestBase {
     df.write().format("iceberg").mode("append").saveAsTable(dest);
 
     List<Row> result = spark.sql(String.format("SELECT * FROM %s", source)).collectAsList();
-    Assert.assertEquals(
-        "No additional rows should be added to the original table", expected.size(), result.size());
+    assertThat(result)
+        .as("No additional rows should be added to the original table")
+        .hasSameSizeAs(expected);
 
     List<Row> snapshot =
         spark
             .sql(String.format("SELECT * FROM %s WHERE id = 4 AND data = 'd'", dest))
             .collectAsList();
-    Assert.assertEquals("Added row not found in snapshot", 1, snapshot.size());
+    assertThat(snapshot).as("Added row not found in snapshot").hasSize(1);
   }
 
   private String sourceName(String source) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -19,8 +19,11 @@
 package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -44,20 +47,16 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TestDeleteReachableFilesAction extends SparkTestBase {
+public class TestDeleteReachableFilesAction extends TestBase {
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
       new Schema(
@@ -113,13 +112,13 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
           .withRecordCount(1)
           .build();
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private Table table;
 
-  @Before
+  @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.newFolder();
+    File tableDir = temp.resolve("junit").toFile();
     String tableLocation = tableDir.toURI().toString();
     this.table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
     spark.conf().set("spark.sql.shuffle.partitions", SHUFFLE_PARTITIONS);
@@ -133,30 +132,30 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
       long expectedManifestListsDeleted,
       long expectedOtherFilesDeleted,
       DeleteReachableFiles.Result results) {
-    Assert.assertEquals(
-        "Incorrect number of manifest files deleted",
-        expectedManifestsDeleted,
-        results.deletedManifestsCount());
-    Assert.assertEquals(
-        "Incorrect number of datafiles deleted",
-        expectedDatafiles,
-        results.deletedDataFilesCount());
-    Assert.assertEquals(
-        "Incorrect number of position delete files deleted",
-        expectedPosDeleteFiles,
-        results.deletedPositionDeleteFilesCount());
-    Assert.assertEquals(
-        "Incorrect number of equality delete files deleted",
-        expectedEqDeleteFiles,
-        results.deletedEqualityDeleteFilesCount());
-    Assert.assertEquals(
-        "Incorrect number of manifest lists deleted",
-        expectedManifestListsDeleted,
-        results.deletedManifestListsCount());
-    Assert.assertEquals(
-        "Incorrect number of other lists deleted",
-        expectedOtherFilesDeleted,
-        results.deletedOtherFilesCount());
+
+    assertThat(results.deletedManifestsCount())
+        .as("Incorrect number of manifest files deleted")
+        .isEqualTo(expectedManifestsDeleted);
+
+    assertThat(results.deletedDataFilesCount())
+        .as("Incorrect number of datafiles deleted")
+        .isEqualTo(expectedDatafiles);
+
+    assertThat(results.deletedPositionDeleteFilesCount())
+        .as("Incorrect number of position delete files deleted")
+        .isEqualTo(expectedPosDeleteFiles);
+
+    assertThat(results.deletedEqualityDeleteFilesCount())
+        .as("Incorrect number of equality delete files deleted")
+        .isEqualTo(expectedEqDeleteFiles);
+
+    assertThat(results.deletedManifestListsCount())
+        .as("Incorrect number of manifest lists deleted")
+        .isEqualTo(expectedManifestListsDeleted);
+
+    assertThat(results.deletedOtherFilesCount())
+        .as("Incorrect number of other lists deleted")
+        .isEqualTo(expectedOtherFilesDeleted);
   }
 
   @Test
@@ -196,15 +195,17 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
 
     // Verifies that the delete methods ran in the threads created by the provided ExecutorService
     // ThreadFactory
-    Assert.assertEquals(
-        deleteThreads,
-        Sets.newHashSet("remove-files-0", "remove-files-1", "remove-files-2", "remove-files-3"));
+    assertThat(deleteThreads)
+        .isEqualTo(
+            Sets.newHashSet(
+                "remove-files-0", "remove-files-1", "remove-files-2", "remove-files-3"));
 
     Lists.newArrayList(FILE_A, FILE_B, FILE_C, FILE_D)
         .forEach(
             file ->
-                Assert.assertTrue(
-                    "FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString())));
+                assertThat(deletedFiles)
+                    .as("FILE_A should be deleted")
+                    .contains(FILE_A.path().toString()));
     checkRemoveFilesResults(4L, 0, 0, 6L, 4L, 6, result);
   }
 
@@ -329,10 +330,9 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
 
           checkRemoveFilesResults(3L, 0, 0, 4L, 3L, 5, results);
 
-          Assert.assertEquals(
-              "Expected total jobs to be equal to total number of shuffle partitions",
-              totalJobsRun,
-              SHUFFLE_PARTITIONS);
+          assertThat(totalJobsRun)
+              .as("Expected total jobs to be equal to total number of shuffle partitions")
+              .isEqualTo(SHUFFLE_PARTITIONS);
         });
   }
 
@@ -345,11 +345,10 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         sparkActions().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
-    Assert.assertTrue(
-        "Should remove v1 file",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("v1.metadata.json")));
+    assertThat(result.orphanFileLocations()).as("Should delete 1 file").size().isOne();
+    assertThat(StreamSupport.stream(result.orphanFileLocations().spliterator(), false))
+        .as("Should remove v1 file")
+        .anyMatch(file -> file.contains("v1.metadata.json"));
 
     DeleteReachableFiles baseRemoveFilesSparkAction =
         sparkActions().deleteReachableFiles(metadataLocation(table)).io(table.io());
@@ -363,7 +362,7 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     DeleteReachableFiles baseRemoveFilesSparkAction =
         sparkActions().deleteReachableFiles(metadataLocation(table)).io(null);
 
-    Assertions.assertThatThrownBy(baseRemoveFilesSparkAction::execute)
+    assertThatThrownBy(baseRemoveFilesSparkAction::execute)
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("File IO cannot be null");
   }
@@ -372,8 +371,7 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
   public void testRemoveFilesActionWhenGarbageCollectionDisabled() {
     table.updateProperties().set(TableProperties.GC_ENABLED, "false").commit();
 
-    Assertions.assertThatThrownBy(
-            () -> sparkActions().deleteReachableFiles(metadataLocation(table)).execute())
+    assertThatThrownBy(() -> sparkActions().deleteReachableFiles(metadataLocation(table)).execute())
         .isInstanceOf(ValidationException.class)
         .hasMessage(
             "Cannot delete files: GC is disabled (deleting files may corrupt other tables)");

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -132,7 +132,6 @@ public class TestDeleteReachableFilesAction extends TestBase {
       long expectedManifestListsDeleted,
       long expectedOtherFilesDeleted,
       DeleteReachableFiles.Result results) {
-
     assertThat(results.deletedManifestsCount())
         .as("Incorrect number of manifest files deleted")
         .isEqualTo(expectedManifestsDeleted);
@@ -345,7 +344,7 @@ public class TestDeleteReachableFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         sparkActions().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    assertThat(result.orphanFileLocations()).as("Should delete 1 file").size().isOne();
+    assertThat(result.orphanFileLocations()).as("Should delete 1 file").hasSize(1);
     assertThat(StreamSupport.stream(result.orphanFileLocations().spliterator(), false))
         .as("Should remove v1 file")
         .anyMatch(file -> file.contains("v1.metadata.json"));

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -187,10 +187,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     ExpireSnapshots.Result results =
         SparkActions.get().expireSnapshots(table).expireOlderThan(end).execute();
 
-    assertThat(table.snapshots())
-        .as("Table does not have 1 snapshot after expiration")
-        .size()
-        .isOne();
+    assertThat(table.snapshots()).as("Table does not have 1 snapshot after expiration").hasSize(1);
 
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, results);
   }
@@ -332,7 +329,7 @@ public class TestExpireSnapshotsAction extends TestBase {
             .expireSnapshotId(secondSnapshotID)
             .execute();
 
-    assertThat(table.snapshots()).as("Should have one snapshots.").size().isOne();
+    assertThat(table.snapshots()).as("Should have one snapshots.").hasSize(1);
     assertThat(table.snapshot(firstSnapshotId)).as("First snapshot should not present.").isNull();
     assertThat(table.snapshot(secondSnapshotID)).as("Second snapshot should not present.").isNull();
 
@@ -477,7 +474,7 @@ public class TestExpireSnapshotsAction extends TestBase {
             .expireOlderThan(thirdSnapshot.timestampMillis())
             .execute();
 
-    assertThat(table.snapshots()).as("Should have one snapshots.").size().isOne();
+    assertThat(table.snapshots()).as("Should have one snapshots.").hasSize(1);
     assertThat(table.snapshot(secondSnapshot.snapshotId()))
         .as("Second snapshot should not present.")
         .isNull();
@@ -514,7 +511,7 @@ public class TestExpireSnapshotsAction extends TestBase {
             .retainLast(1)
             .execute();
 
-    assertThat(table.snapshots()).as("Should have one snapshots.").size().isOne();
+    assertThat(table.snapshots()).as("Should have one snapshots.").hasSize(1);
     assertThat(table.snapshot(secondSnapshot.snapshotId()))
         .as("Second snapshot should not present.")
         .isNull();
@@ -805,10 +802,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     table.newAppend().appendFile(FILE_A).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
-    assertThat(firstSnapshot.allManifests(table.io()))
-        .as("Should create one manifest")
-        .size()
-        .isOne();
+    assertThat(firstSnapshot.allManifests(table.io())).as("Should create one manifest").hasSize(1);
 
     rightAfterSnapshot();
 
@@ -817,8 +811,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     Snapshot secondSnapshot = table.currentSnapshot();
     assertThat(secondSnapshot.allManifests(table.io()))
         .as("Should create replace manifest with a rewritten manifest")
-        .size()
-        .isOne();
+        .hasSize(1);
 
     table.newAppend().appendFile(FILE_B).commit();
 
@@ -874,10 +867,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
-    assertThat(firstSnapshot.allManifests(table.io()))
-        .as("Should create one manifest")
-        .size()
-        .isOne();
+    assertThat(firstSnapshot.allManifests(table.io())).as("Should create one manifest").hasSize(1);
 
     rightAfterSnapshot();
 
@@ -889,8 +879,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     Snapshot secondSnapshot = table.currentSnapshot();
     assertThat(secondSnapshot.allManifests(table.io()))
         .as("Should replace manifest with a rewritten manifest")
-        .size()
-        .isOne();
+        .hasSize(1);
     table
         .newFastAppend() // do not merge to keep the last snapshot's manifest valid
         .appendFile(FILE_C)
@@ -944,10 +933,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
-    assertThat(firstSnapshot.allManifests(table.io()))
-        .as("Should create one manifest")
-        .size()
-        .isOne();
+    assertThat(firstSnapshot.allManifests(table.io())).as("Should create one manifest").hasSize(1);
 
     rightAfterSnapshot();
 
@@ -957,7 +943,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     Set<ManifestFile> secondSnapshotManifests =
         Sets.newHashSet(secondSnapshot.allManifests(table.io()));
     secondSnapshotManifests.removeAll(firstSnapshot.allManifests(table.io()));
-    assertThat(secondSnapshotManifests).as("Should add one new manifest for append").size().isOne();
+    assertThat(secondSnapshotManifests).as("Should add one new manifest for append").hasSize(1);
 
     table.manageSnapshots().rollbackTo(firstSnapshot.snapshotId()).commit();
 
@@ -1002,10 +988,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     table.newAppend().appendFile(FILE_A).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
-    assertThat(firstSnapshot.allManifests(table.io()))
-        .as("Should create one manifest")
-        .size()
-        .isOne();
+    assertThat(firstSnapshot.allManifests(table.io())).as("Should create one manifest").hasSize(1);
     rightAfterSnapshot();
 
     table.newAppend().appendFile(FILE_B).commit();
@@ -1014,7 +997,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     Set<ManifestFile> secondSnapshotManifests =
         Sets.newHashSet(secondSnapshot.allManifests(table.io()));
     secondSnapshotManifests.removeAll(firstSnapshot.allManifests(table.io()));
-    assertThat(secondSnapshotManifests).as("Should add one new manifest for append").size().isOne();
+    assertThat(secondSnapshotManifests).as("Should add one new manifest for append").hasSize(1);
 
     table.manageSnapshots().rollbackTo(firstSnapshot.snapshotId()).commit();
 
@@ -1168,7 +1151,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     assertThat(table.snapshot(firstSnapshot.snapshotId()))
         .as("Should remove the oldest snapshot")
         .isNull();
-    assertThat(pending).as("Pending deletes should contain one row").size().isOne();
+    assertThat(pending).as("Pending deletes should contain one row").hasSize(1);
 
     assertThat(pending.get(0).getPath())
         .as("Pending delete should be the expired manifest list location")
@@ -1248,10 +1231,10 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 1L, result);
 
     List<FileInfo> typedExpiredFiles = action.expireFiles().collectAsList();
-    assertThat(typedExpiredFiles).as("Expired results must match").size().isOne();
+    assertThat(typedExpiredFiles).as("Expired results must match").hasSize(1);
 
     List<FileInfo> untypedExpiredFiles = action.expireFiles().collectAsList();
-    assertThat(untypedExpiredFiles).as("Expired results must match").size().isOne();
+    assertThat(untypedExpiredFiles).as("Expired results must match").hasSize(1);
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -19,9 +19,12 @@
 package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,18 +55,15 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TestExpireSnapshotsAction extends SparkTestBase {
+public class TestExpireSnapshotsAction extends TestBase {
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
       new Schema(
@@ -119,15 +119,15 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
           .withRecordCount(1)
           .build();
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private File tableDir;
   private String tableLocation;
   private Table table;
 
-  @Before
+  @BeforeEach
   public void setupTableLocation() throws Exception {
-    this.tableDir = temp.newFolder();
+    this.tableDir = temp.resolve("junit").toFile();
     this.tableLocation = tableDir.toURI().toString();
     this.table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
     spark.conf().set("spark.sql.shuffle.partitions", SHUFFLE_PARTITIONS);
@@ -153,26 +153,25 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
       long expectedManifestListsDeleted,
       ExpireSnapshots.Result results) {
 
-    Assert.assertEquals(
-        "Incorrect number of manifest files deleted",
-        expectedManifestsDeleted,
-        results.deletedManifestsCount());
-    Assert.assertEquals(
-        "Incorrect number of datafiles deleted",
-        expectedDatafiles,
-        results.deletedDataFilesCount());
-    Assert.assertEquals(
-        "Incorrect number of pos deletefiles deleted",
-        expectedPosDeleteFiles,
-        results.deletedPositionDeleteFilesCount());
-    Assert.assertEquals(
-        "Incorrect number of eq deletefiles deleted",
-        expectedEqDeleteFiles,
-        results.deletedEqualityDeleteFilesCount());
-    Assert.assertEquals(
-        "Incorrect number of manifest lists deleted",
-        expectedManifestListsDeleted,
-        results.deletedManifestListsCount());
+    assertThat(results.deletedManifestsCount())
+        .as("Incorrect number of manifest files deleted")
+        .isEqualTo(expectedManifestsDeleted);
+
+    assertThat(results.deletedDataFilesCount())
+        .as("Incorrect number of datafiles deleted")
+        .isEqualTo(expectedDatafiles);
+
+    assertThat(results.deletedPositionDeleteFilesCount())
+        .as("Incorrect number of pos deletefiles deleted")
+        .isEqualTo(expectedPosDeleteFiles);
+
+    assertThat(results.deletedEqualityDeleteFilesCount())
+        .as("Incorrect number of eq deletefiles deleted")
+        .isEqualTo(expectedEqDeleteFiles);
+
+    assertThat(results.deletedManifestListsCount())
+        .as("Incorrect number of manifest lists deleted")
+        .isEqualTo(expectedManifestListsDeleted);
   }
 
   @Test
@@ -188,8 +187,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     ExpireSnapshots.Result results =
         SparkActions.get().expireSnapshots(table).expireOlderThan(end).execute();
 
-    Assert.assertEquals(
-        "Table does not have 1 snapshot after expiration", 1, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots())
+        .as("Table does not have 1 snapshot after expiration")
+        .size()
+        .isOne();
 
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, results);
   }
@@ -234,13 +235,16 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     // Verifies that the delete methods ran in the threads created by the provided ExecutorService
     // ThreadFactory
-    Assert.assertEquals(
-        deleteThreads,
-        Sets.newHashSet(
-            "remove-snapshot-0", "remove-snapshot-1", "remove-snapshot-2", "remove-snapshot-3"));
+    assertThat(deleteThreads)
+        .isEqualTo(
+            Sets.newHashSet(
+                "remove-snapshot-0",
+                "remove-snapshot-1",
+                "remove-snapshot-2",
+                "remove-snapshot-3"));
 
-    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
-    Assert.assertTrue("FILE_B should be deleted", deletedFiles.contains(FILE_B.path().toString()));
+    assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.path().toString());
+    assertThat(deletedFiles).as("FILE_B should be deleted").contains(FILE_B.path().toString());
 
     checkExpirationResults(2L, 0L, 0L, 3L, 3L, result);
   }
@@ -296,10 +300,8 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     // Retain last 2 snapshots
     SparkActions.get().expireSnapshots(table).expireOlderThan(t3).retainLast(2).execute();
 
-    Assert.assertEquals(
-        "Should have two snapshots.", 2, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertEquals(
-        "First snapshot should not present.", null, table.snapshot(firstSnapshotId));
+    assertThat(table.snapshots()).as("Should have two snapshots.").hasSize(2);
+    assertThat(table.snapshot(firstSnapshotId)).as("First snapshot should not present.").isNull();
   }
 
   @Test
@@ -330,12 +332,9 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .expireSnapshotId(secondSnapshotID)
             .execute();
 
-    Assert.assertEquals(
-        "Should have one snapshots.", 1, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertEquals(
-        "First snapshot should not present.", null, table.snapshot(firstSnapshotId));
-    Assert.assertEquals(
-        "Second snapshot should not be present.", null, table.snapshot(secondSnapshotID));
+    assertThat(table.snapshots()).as("Should have one snapshots.").size().isOne();
+    assertThat(table.snapshot(firstSnapshotId)).as("First snapshot should not present.").isNull();
+    assertThat(table.snapshot(secondSnapshotID)).as("Second snapshot should not present.").isNull();
 
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, result);
   }
@@ -366,10 +365,8 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .retainLast(3)
             .execute();
 
-    Assert.assertEquals(
-        "Should have two snapshots.", 2, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertEquals(
-        "First snapshot should not present.", null, table.snapshot(firstSnapshotId));
+    assertThat(table.snapshots()).as("Should have 2 snapshots.").hasSize(2);
+    assertThat(table.snapshot(firstSnapshotId)).as("First snapshot should not present.").isNull();
     checkExpirationResults(0L, 0L, 0L, 0L, 1L, result);
   }
 
@@ -393,12 +390,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     ExpireSnapshots.Result result =
         SparkActions.get().expireSnapshots(table).expireOlderThan(t2).retainLast(3).execute();
 
-    Assert.assertEquals(
-        "Should have two snapshots", 2, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertEquals(
-        "First snapshot should still present",
-        firstSnapshotId,
-        table.snapshot(firstSnapshotId).snapshotId());
+    assertThat(table.snapshots()).as("Should have two snapshots.").hasSize(2);
+    assertThat(table.snapshot(firstSnapshotId))
+        .as("First snapshot should still be present.")
+        .isNotNull();
     checkExpirationResults(0L, 0L, 0L, 0L, 0L, result);
   }
 
@@ -434,10 +429,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .retainLast(2)
             .execute();
 
-    Assert.assertEquals(
-        "Should have three snapshots.", 3, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertNotNull(
-        "Second snapshot should present.", table.snapshot(secondSnapshot.snapshotId()));
+    assertThat(table.snapshots()).as("Should have three snapshots.").hasSize(3);
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("First snapshot should be present.")
+        .isNotNull();
     checkExpirationResults(0L, 0L, 0L, 0L, 1L, result);
   }
 
@@ -447,7 +442,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     table.newAppend().appendFile(FILE_A).commit();
 
-    Assertions.assertThatThrownBy(() -> SparkActions.get().expireSnapshots(table))
+    assertThatThrownBy(() -> SparkActions.get().expireSnapshots(table))
         .isInstanceOf(ValidationException.class)
         .hasMessage(
             "Cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)");
@@ -482,10 +477,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .expireOlderThan(thirdSnapshot.timestampMillis())
             .execute();
 
-    Assert.assertEquals(
-        "Should have one snapshots.", 1, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertNull(
-        "Second snapshot should not present.", table.snapshot(secondSnapshot.snapshotId()));
+    assertThat(table.snapshots()).as("Should have one snapshots.").size().isOne();
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("Second snapshot should not present.")
+        .isNull();
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, result);
   }
 
@@ -519,17 +514,16 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .retainLast(1)
             .execute();
 
-    Assert.assertEquals(
-        "Should have one snapshots.", 1, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertNull(
-        "Second snapshot should not present.", table.snapshot(secondSnapshot.snapshotId()));
+    assertThat(table.snapshots()).as("Should have one snapshots.").size().isOne();
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("Second snapshot should not present.")
+        .isNull();
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, result);
   }
 
   @Test
   public void testRetainZeroSnapshots() {
-    Assertions.assertThatThrownBy(
-            () -> SparkActions.get().expireSnapshots(table).retainLast(0).execute())
+    assertThatThrownBy(() -> SparkActions.get().expireSnapshots(table).retainLast(0).execute())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Number of snapshots to retain must be at least 1, cannot be: 0");
   }
@@ -553,7 +547,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
+    assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.path().toString());
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, result);
   }
 
@@ -582,7 +576,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
+    assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.path().toString());
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, result);
   }
 
@@ -639,11 +633,12 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
                 expectedDeletes.add(file.path());
               }
             });
-    Assert.assertSame(
-        "Files deleted count should be expected", expectedDeletes.size(), deletedFiles.size());
+    assertThat(expectedDeletes)
+        .as("Files deleted count should be expected")
+        .hasSameSizeAs(deletedFiles);
     // Take the diff
     expectedDeletes.removeAll(deletedFiles);
-    Assert.assertTrue("Exactly same files should be deleted", expectedDeletes.isEmpty());
+    assertThat(expectedDeletes).as("Exactly same files should be deleted").isEmpty();
   }
 
   /**
@@ -659,7 +654,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     // `B` commit
     Set<String> deletedAFiles = Sets.newHashSet();
     table.newOverwrite().addFile(FILE_B).deleteFile(FILE_A).deleteWith(deletedAFiles::add).commit();
-    Assert.assertTrue("No files should be physically deleted", deletedAFiles.isEmpty());
+    assertThat(deletedAFiles).as("No files should be physically deleted").isEmpty();
 
     // pick the snapshot 'B`
     Snapshot snapshotB = table.currentSnapshot();
@@ -694,7 +689,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        Assert.assertFalse(deletedFiles.contains(item.path().toString()));
+                        assertThat(deletedFiles).doesNotContain(item.path().toString());
                       });
             });
 
@@ -743,7 +738,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        Assert.assertFalse(deletedFiles.contains(item.path().toString()));
+                        assertThat(deletedFiles).doesNotContain(item.path().toString());
                       });
             });
     checkExpirationResults(0L, 0L, 0L, 1L, 1L, firstResult);
@@ -763,7 +758,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        Assert.assertFalse(deletedFiles.contains(item.path().toString()));
+                        assertThat(deletedFiles).doesNotContain(item.path().toString());
                       });
             });
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, secondResult);
@@ -792,16 +787,15 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertEquals(
-        "Expire should not change current snapshot",
-        snapshotId,
-        table.currentSnapshot().snapshotId());
-    Assert.assertNull(
-        "Expire should remove the oldest snapshot", table.snapshot(firstSnapshot.snapshotId()));
-    Assert.assertEquals(
-        "Should remove only the expired manifest list location",
-        Sets.newHashSet(firstSnapshot.manifestListLocation()),
-        deletedFiles);
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Expire should not change current snapshot.")
+        .isEqualTo(snapshotId);
+    assertThat(table.snapshot(firstSnapshot.snapshotId()))
+        .as("Expire should remove the oldest snapshot.")
+        .isNull();
+    assertThat(deletedFiles)
+        .as("Should remove only the expired manifest list location.")
+        .isEqualTo(Sets.newHashSet(firstSnapshot.manifestListLocation()));
 
     checkExpirationResults(0, 0, 0, 0, 1, result);
   }
@@ -811,18 +805,20 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.newAppend().appendFile(FILE_A).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
-    Assert.assertEquals(
-        "Should create one manifest", 1, firstSnapshot.allManifests(table.io()).size());
+    assertThat(firstSnapshot.allManifests(table.io()))
+        .as("Should create one manifest")
+        .size()
+        .isOne();
 
     rightAfterSnapshot();
 
     table.newDelete().deleteFile(FILE_A).commit();
 
     Snapshot secondSnapshot = table.currentSnapshot();
-    Assert.assertEquals(
-        "Should create replace manifest with a rewritten manifest",
-        1,
-        secondSnapshot.allManifests(table.io()).size());
+    assertThat(secondSnapshot.allManifests(table.io()))
+        .as("Should create replace manifest with a rewritten manifest")
+        .size()
+        .isOne();
 
     table.newAppend().appendFile(FILE_B).commit();
 
@@ -841,31 +837,31 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertEquals(
-        "Expire should not change current snapshot",
-        snapshotId,
-        table.currentSnapshot().snapshotId());
-    Assert.assertNull(
-        "Expire should remove the oldest snapshot", table.snapshot(firstSnapshot.snapshotId()));
-    Assert.assertNull(
-        "Expire should remove the second oldest snapshot",
-        table.snapshot(secondSnapshot.snapshotId()));
-
-    Assert.assertEquals(
-        "Should remove expired manifest lists and deleted data file",
-        Sets.newHashSet(
-            firstSnapshot.manifestListLocation(), // snapshot expired
-            firstSnapshot
-                .allManifests(table.io())
-                .get(0)
-                .path(), // manifest was rewritten for delete
-            secondSnapshot.manifestListLocation(), // snapshot expired
-            secondSnapshot
-                .allManifests(table.io())
-                .get(0)
-                .path(), // manifest contained only deletes, was dropped
-            FILE_A.path()), // deleted
-        deletedFiles);
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Expire should not change current snapshot.")
+        .isEqualTo(snapshotId);
+    assertThat(table.snapshot(firstSnapshot.snapshotId()))
+        .as("Expire should remove the oldest snapshot.")
+        .isNull();
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("Expire should remove the second oldest snapshot.")
+        .isNull();
+    assertThat(deletedFiles)
+        .as("Should remove expired manifest lists and deleted data file.")
+        .isEqualTo(
+            Sets.newHashSet(
+                firstSnapshot.manifestListLocation(), // snapshot expired
+                firstSnapshot
+                    .allManifests(table.io())
+                    .get(0)
+                    .path(), // manifest was rewritten for delete
+                secondSnapshot.manifestListLocation(), // snapshot expired
+                secondSnapshot
+                    .allManifests(table.io())
+                    .get(0)
+                    .path(), // manifest contained only deletes, was dropped
+                FILE_A.path()) // deleted
+            );
 
     checkExpirationResults(1, 0, 0, 2, 2, result);
   }
@@ -878,8 +874,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
-    Assert.assertEquals(
-        "Should create one manifest", 1, firstSnapshot.allManifests(table.io()).size());
+    assertThat(firstSnapshot.allManifests(table.io()))
+        .as("Should create one manifest")
+        .size()
+        .isOne();
 
     rightAfterSnapshot();
 
@@ -889,11 +887,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
         .commit();
 
     Snapshot secondSnapshot = table.currentSnapshot();
-    Assert.assertEquals(
-        "Should replace manifest with a rewritten manifest",
-        1,
-        secondSnapshot.allManifests(table.io()).size());
-
+    assertThat(secondSnapshot.allManifests(table.io()))
+        .as("Should replace manifest with a rewritten manifest")
+        .size()
+        .isOne();
     table
         .newFastAppend() // do not merge to keep the last snapshot's manifest valid
         .appendFile(FILE_C)
@@ -914,28 +911,28 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertEquals(
-        "Expire should not change current snapshot",
-        snapshotId,
-        table.currentSnapshot().snapshotId());
-    Assert.assertNull(
-        "Expire should remove the oldest snapshot", table.snapshot(firstSnapshot.snapshotId()));
-    Assert.assertNull(
-        "Expire should remove the second oldest snapshot",
-        table.snapshot(secondSnapshot.snapshotId()));
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Expire should not change current snapshot.")
+        .isEqualTo(snapshotId);
+    assertThat(table.snapshot(firstSnapshot.snapshotId()))
+        .as("Expire should remove the oldest snapshot.")
+        .isNull();
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("Expire should remove the second oldest snapshot.")
+        .isNull();
 
-    Assert.assertEquals(
-        "Should remove expired manifest lists and deleted data file",
-        Sets.newHashSet(
-            firstSnapshot.manifestListLocation(), // snapshot expired
-            firstSnapshot
-                .allManifests(table.io())
-                .get(0)
-                .path(), // manifest was rewritten for delete
-            secondSnapshot.manifestListLocation(), // snapshot expired
-            FILE_A.path()), // deleted
-        deletedFiles);
-
+    assertThat(deletedFiles)
+        .as("Should remove expired manifest lists and deleted data file.")
+        .isEqualTo(
+            Sets.newHashSet(
+                firstSnapshot.manifestListLocation(), // snapshot expired
+                firstSnapshot
+                    .allManifests(table.io())
+                    .get(0)
+                    .path(), // manifest was rewritten for delete
+                secondSnapshot.manifestListLocation(), // snapshot expired
+                FILE_A.path()) // deleted
+            );
     checkExpirationResults(1, 0, 0, 1, 2, result);
   }
 
@@ -947,8 +944,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
-    Assert.assertEquals(
-        "Should create one manifest", 1, firstSnapshot.allManifests(table.io()).size());
+    assertThat(firstSnapshot.allManifests(table.io()))
+        .as("Should create one manifest")
+        .size()
+        .isOne();
 
     rightAfterSnapshot();
 
@@ -958,8 +957,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     Set<ManifestFile> secondSnapshotManifests =
         Sets.newHashSet(secondSnapshot.allManifests(table.io()));
     secondSnapshotManifests.removeAll(firstSnapshot.allManifests(table.io()));
-    Assert.assertEquals(
-        "Should add one new manifest for append", 1, secondSnapshotManifests.size());
+    assertThat(secondSnapshotManifests).as("Should add one new manifest for append").size().isOne();
 
     table.manageSnapshots().rollbackTo(firstSnapshot.snapshotId()).commit();
 
@@ -976,23 +974,25 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertEquals(
-        "Expire should not change current snapshot",
-        snapshotId,
-        table.currentSnapshot().snapshotId());
-    Assert.assertNotNull(
-        "Expire should keep the oldest snapshot, current",
-        table.snapshot(firstSnapshot.snapshotId()));
-    Assert.assertNull(
-        "Expire should remove the orphaned snapshot", table.snapshot(secondSnapshot.snapshotId()));
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Expire should not change current snapshot.")
+        .isEqualTo(snapshotId);
 
-    Assert.assertEquals(
-        "Should remove expired manifest lists and reverted appended data file",
-        Sets.newHashSet(
-            secondSnapshot.manifestListLocation(), // snapshot expired
-            Iterables.getOnlyElement(secondSnapshotManifests)
-                .path()), // manifest is no longer referenced
-        deletedFiles);
+    assertThat(table.snapshot(firstSnapshot.snapshotId()))
+        .as("Expire should keep the oldest snapshot, current.")
+        .isNotNull();
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("Expire should remove the orphaned snapshot.")
+        .isNull();
+
+    assertThat(deletedFiles)
+        .as("Should remove expired manifest lists and reverted appended data file")
+        .isEqualTo(
+            Sets.newHashSet(
+                secondSnapshot.manifestListLocation(), // snapshot expired
+                Iterables.getOnlyElement(secondSnapshotManifests)
+                    .path()) // manifest is no longer referenced
+            );
 
     checkExpirationResults(0, 0, 0, 1, 1, result);
   }
@@ -1002,9 +1002,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.newAppend().appendFile(FILE_A).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
-    Assert.assertEquals(
-        "Should create one manifest", 1, firstSnapshot.allManifests(table.io()).size());
-
+    assertThat(firstSnapshot.allManifests(table.io()))
+        .as("Should create one manifest")
+        .size()
+        .isOne();
     rightAfterSnapshot();
 
     table.newAppend().appendFile(FILE_B).commit();
@@ -1013,8 +1014,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     Set<ManifestFile> secondSnapshotManifests =
         Sets.newHashSet(secondSnapshot.allManifests(table.io()));
     secondSnapshotManifests.removeAll(firstSnapshot.allManifests(table.io()));
-    Assert.assertEquals(
-        "Should add one new manifest for append", 1, secondSnapshotManifests.size());
+    assertThat(secondSnapshotManifests).as("Should add one new manifest for append").size().isOne();
 
     table.manageSnapshots().rollbackTo(firstSnapshot.snapshotId()).commit();
 
@@ -1031,24 +1031,26 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertEquals(
-        "Expire should not change current snapshot",
-        snapshotId,
-        table.currentSnapshot().snapshotId());
-    Assert.assertNotNull(
-        "Expire should keep the oldest snapshot, current",
-        table.snapshot(firstSnapshot.snapshotId()));
-    Assert.assertNull(
-        "Expire should remove the orphaned snapshot", table.snapshot(secondSnapshot.snapshotId()));
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Expire should not change current snapshot.")
+        .isEqualTo(snapshotId);
 
-    Assert.assertEquals(
-        "Should remove expired manifest lists and reverted appended data file",
-        Sets.newHashSet(
-            secondSnapshot.manifestListLocation(), // snapshot expired
-            Iterables.getOnlyElement(secondSnapshotManifests)
-                .path(), // manifest is no longer referenced
-            FILE_B.path()), // added, but rolled back
-        deletedFiles);
+    assertThat(table.snapshot(firstSnapshot.snapshotId()))
+        .as("Expire should keep the oldest snapshot, current.")
+        .isNotNull();
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("Expire should remove the orphaned snapshot.")
+        .isNull();
+
+    assertThat(deletedFiles)
+        .as("Should remove expired manifest lists and reverted appended data file")
+        .isEqualTo(
+            Sets.newHashSet(
+                secondSnapshot.manifestListLocation(), // snapshot expired
+                Iterables.getOnlyElement(secondSnapshotManifests)
+                    .path(), // manifest is no longer referenced
+                FILE_B.path()) // added, but rolled back
+            );
 
     checkExpirationResults(1, 0, 0, 1, 1, result);
   }
@@ -1112,10 +1114,9 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .map(CharSequence::toString)
             .collect(Collectors.toSet()));
 
-    Assert.assertEquals(
-        "Should remove expired manifest lists and deleted data file",
-        expectedDeletes,
-        deletedFiles);
+    assertThat(deletedFiles)
+        .as("Should remove expired manifest lists and deleted data file")
+        .isEqualTo(expectedDeletes);
 
     checkExpirationResults(1, 1, 1, 6, 4, result);
   }
@@ -1160,25 +1161,28 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     List<FileInfo> pending = pendingDeletes.collectAsList();
 
-    Assert.assertEquals(
-        "Should not change current snapshot", snapshotId, table.currentSnapshot().snapshotId());
-    Assert.assertNull(
-        "Should remove the oldest snapshot", table.snapshot(firstSnapshot.snapshotId()));
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Should not change current snapshot.")
+        .isEqualTo(snapshotId);
 
-    Assert.assertEquals("Pending deletes should contain one row", 1, pending.size());
-    Assert.assertEquals(
-        "Pending delete should be the expired manifest list location",
-        firstSnapshot.manifestListLocation(),
-        pending.get(0).getPath());
-    Assert.assertEquals(
-        "Pending delete should be a manifest list", "Manifest List", pending.get(0).getType());
+    assertThat(table.snapshot(firstSnapshot.snapshotId()))
+        .as("Should remove the oldest snapshot")
+        .isNull();
+    assertThat(pending).as("Pending deletes should contain one row").size().isOne();
 
-    Assert.assertEquals("Should not delete any files", 0, deletedFiles.size());
+    assertThat(pending.get(0).getPath())
+        .as("Pending delete should be the expired manifest list location")
+        .isEqualTo(firstSnapshot.manifestListLocation());
 
-    Assert.assertEquals(
-        "Multiple calls to expire should return the same count of deleted files",
-        pendingDeletes.count(),
-        action.expireFiles().count());
+    assertThat(pending.get(0).getType())
+        .as("Pending delete should be a manifest list")
+        .isEqualTo("Manifest List");
+
+    assertThat(deletedFiles).as("Should not delete any files").hasSize(0);
+
+    assertThat(action.expireFiles().count())
+        .as("Multiple calls to expire should return the same count of deleted files")
+        .isEqualTo(pendingDeletes.count());
   }
 
   @Test
@@ -1208,10 +1212,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
           checkExpirationResults(1L, 0L, 0L, 1L, 2L, results);
 
-          Assert.assertEquals(
-              "Expected total number of jobs with stream-results should match the expected number",
-              4L,
-              jobsRunDuringStreamResults);
+          assertThat(jobsRunDuringStreamResults)
+              .as(
+                  "Expected total number of jobs with stream-results should match the expected number")
+              .isEqualTo(4L);
         });
   }
 
@@ -1244,10 +1248,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 1L, result);
 
     List<FileInfo> typedExpiredFiles = action.expireFiles().collectAsList();
-    Assert.assertEquals("Expired results must match", 1, typedExpiredFiles.size());
+    assertThat(typedExpiredFiles).as("Expired results must match").size().isOne();
 
     List<FileInfo> untypedExpiredFiles = action.expireFiles().collectAsList();
-    Assert.assertEquals("Expired results must match", 1, untypedExpiredFiles.size());
+    assertThat(untypedExpiredFiles).as("Expired results must match").size().isOne();
   }
 
   @Test
@@ -1312,8 +1316,9 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
         .deleteWith(deletedFiles::add)
         .execute();
 
-    Assert.assertEquals(
-        "All reachable files before expiration should be deleted", expectedDeletes, deletedFiles);
+    assertThat(deletedFiles)
+        .as("All reachable files before expiration should be deleted")
+        .isEqualTo(expectedDeletes);
   }
 
   @Test
@@ -1344,9 +1349,9 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     // C, D should be retained (live)
     // B should be retained (previous snapshot points to it)
     // A should be deleted
-    Assert.assertTrue(deletedFiles.contains(FILE_A.path().toString()));
-    Assert.assertFalse(deletedFiles.contains(FILE_B.path().toString()));
-    Assert.assertFalse(deletedFiles.contains(FILE_C.path().toString()));
-    Assert.assertFalse(deletedFiles.contains(FILE_D.path().toString()));
+    assertThat(deletedFiles).contains(FILE_A.path().toString());
+    assertThat(deletedFiles).doesNotContain(FILE_B.path().toString());
+    assertThat(deletedFiles).doesNotContain(FILE_C.path().toString());
+    assertThat(deletedFiles).doesNotContain(FILE_D.path().toString());
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -329,7 +329,7 @@ public class TestExpireSnapshotsAction extends TestBase {
             .expireSnapshotId(secondSnapshotID)
             .execute();
 
-    assertThat(table.snapshots()).as("Should have one snapshots.").hasSize(1);
+    assertThat(table.snapshots()).as("Should have one snapshot.").hasSize(1);
     assertThat(table.snapshot(firstSnapshotId)).as("First snapshot should not present.").isNull();
     assertThat(table.snapshot(secondSnapshotID)).as("Second snapshot should not present.").isNull();
 
@@ -474,7 +474,7 @@ public class TestExpireSnapshotsAction extends TestBase {
             .expireOlderThan(thirdSnapshot.timestampMillis())
             .execute();
 
-    assertThat(table.snapshots()).as("Should have one snapshots.").hasSize(1);
+    assertThat(table.snapshots()).as("Should have one snapshot.").hasSize(1);
     assertThat(table.snapshot(secondSnapshot.snapshotId()))
         .as("Second snapshot should not present.")
         .isNull();
@@ -511,7 +511,7 @@ public class TestExpireSnapshotsAction extends TestBase {
             .retainLast(1)
             .execute();
 
-    assertThat(table.snapshots()).as("Should have one snapshots.").hasSize(1);
+    assertThat(table.snapshots()).as("Should have one snapshot.").hasSize(1);
     assertThat(table.snapshot(secondSnapshot.snapshotId()))
         .as("Second snapshot should not present.")
         .isNull();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -142,7 +142,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
     List<String> invalidFiles = Lists.newArrayList(allFiles);
     invalidFiles.removeAll(validFiles);
-    assertThat(invalidFiles).as("Should be 1 invalid files").size().isOne();
+    assertThat(invalidFiles).as("Should be 1 invalid files").hasSize(1);
 
     waitUntilAfter(System.currentTimeMillis());
 
@@ -210,10 +210,10 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     List<Snapshot> snapshots = Lists.newArrayList(table.snapshots());
 
     List<String> snapshotFiles1 = snapshotFiles(snapshots.get(0).snapshotId());
-    assertThat(snapshotFiles1).size().isOne();
+    assertThat(snapshotFiles1).hasSize(1);
 
     List<String> snapshotFiles2 = snapshotFiles(snapshots.get(1).snapshotId());
-    assertThat(snapshotFiles2).size().isOne();
+    assertThat(snapshotFiles2).hasSize(1);
 
     List<String> snapshotFiles3 = snapshotFiles(snapshots.get(2).snapshotId());
     assertThat(snapshotFiles3).hasSize(2);
@@ -369,7 +369,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    assertThat(result.orphanFileLocations()).as("Should delete 1 file").size().isOne();
+    assertThat(result.orphanFileLocations()).as("Should delete 1 file").hasSize(1);
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
@@ -428,7 +428,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    assertThat(result.orphanFileLocations()).as("Should delete 1 file").size().isOne();
+    assertThat(result.orphanFileLocations()).as("Should delete 1 file").hasSize(1);
     assertThat(StreamSupport.stream(result.orphanFileLocations().spliterator(), false))
         .as("Should remove v1 file")
         .anyMatch(file -> file.contains("v1.metadata.json"));
@@ -637,7 +637,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
             .select("file_path")
             .as(Encoders.STRING())
             .collectAsList();
-    assertThat(validFiles).as("Should be 1 valid files").size().isOne();
+    assertThat(validFiles).as("Should be 1 valid files").hasSize(1);
     String validFile = validFiles.get(0);
 
     df.write().mode("append").parquet(tableLocation + "/data");
@@ -653,7 +653,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
     List<String> invalidFiles = Lists.newArrayList(allFiles);
     invalidFiles.removeIf(file -> file.contains(validFile));
-    assertThat(invalidFiles).as("Should be 1 invalid file").size().isOne();
+    assertThat(invalidFiles).as("Should be 1 invalid file").hasSize(1);
 
     waitUntilAfter(System.currentTimeMillis());
 
@@ -699,7 +699,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         SparkActions.get().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    assertThat(result.orphanFileLocations()).as("Should delete only 1 files").size().isOne();
+    assertThat(result.orphanFileLocations()).as("Should delete only 1 files").hasSize(1);
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(table.location());
     List<ThreeColumnRecord> actualRecords =
@@ -807,7 +807,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
         invalidFiles.stream()
             .map(FilePathLastModifiedRecord::getFilePath)
             .collect(Collectors.toList());
-    assertThat(invalidFiles).as("Should be 1 invalid file").size().isOne();
+    assertThat(invalidFiles).as("Should be 1 invalid file").hasSize(1);
 
     // sleep for 1 second to ensure files will be old enough
     waitUntilAfter(System.currentTimeMillis());
@@ -961,7 +961,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
     Iterable<String> orphanFileLocations = result.orphanFileLocations();
-    assertThat(orphanFileLocations).as("Should be orphan files").size().isOne();
+    assertThat(orphanFileLocations).as("Should be orphan files").hasSize(1);
     assertThat(Iterables.getOnlyElement(orphanFileLocations))
         .as("Deleted file")
         .isEqualTo(statsLocation.toURI().toString());

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -142,7 +142,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
     List<String> invalidFiles = Lists.newArrayList(allFiles);
     invalidFiles.removeAll(validFiles);
-    assertThat(invalidFiles).as("Should be 1 invalid files").hasSize(1);
+    assertThat(invalidFiles).as("Should be 1 invalid file").hasSize(1);
 
     waitUntilAfter(System.currentTimeMillis());
 
@@ -637,7 +637,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
             .select("file_path")
             .as(Encoders.STRING())
             .collectAsList();
-    assertThat(validFiles).as("Should be 1 valid files").hasSize(1);
+    assertThat(validFiles).as("Should be 1 valid file").hasSize(1);
     String validFile = validFiles.get(0);
 
     df.write().mode("append").parquet(tableLocation + "/data");
@@ -699,7 +699,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         SparkActions.get().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    assertThat(result.orphanFileLocations()).as("Should delete only 1 files").hasSize(1);
+    assertThat(result.orphanFileLocations()).as("Should delete only 1 file").hasSize(1);
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(table.location());
     List<ThreeColumnRecord> actualRecords =
@@ -946,7 +946,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
         .olderThan(System.currentTimeMillis() + 1000)
         .execute();
 
-    assertThat(statsLocation.exists()).as("stats file should exist").isTrue();
+    assertThat(statsLocation).as("stats file should exist").exists();
     assertThat(statsLocation.length())
         .as("stats file length")
         .isEqualTo(statisticsFile.fileSizeInBytes());
@@ -961,7 +961,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
     Iterable<String> orphanFileLocations = result.orphanFileLocations();
-    assertThat(orphanFileLocations).as("Should be orphan files").hasSize(1);
+    assertThat(orphanFileLocations).as("Should be orphan file").hasSize(1);
     assertThat(Iterables.getOnlyElement(orphanFileLocations))
         .as("Deleted file")
         .isEqualTo(statsLocation.toURI().toString());

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark.actions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.util.Map;
 import java.util.stream.StreamSupport;
@@ -29,9 +31,8 @@ import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.expressions.Transform;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
   @Test
@@ -58,10 +59,9 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    Assert.assertTrue(
-        "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+    assertThat(StreamSupport.stream(results.orphanFileLocations().spliterator(), false))
+        .as("trash file should be removed")
+        .anyMatch(file -> file.contains("file:" + location + "/data/trashfile"));
   }
 
   @Test
@@ -88,10 +88,9 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    Assert.assertTrue(
-        "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+    assertThat(StreamSupport.stream(results.orphanFileLocations().spliterator(), false))
+        .as("trash file should be removed")
+        .anyMatch(file -> file.contains("file:" + location + "/data/trashfile"));
   }
 
   @Test
@@ -118,10 +117,10 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    Assert.assertTrue(
-        "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+
+    assertThat(StreamSupport.stream(results.orphanFileLocations().spliterator(), false))
+        .as("trash file should be removed")
+        .anyMatch(file -> file.contains("file:" + location + "/data/trashfile"));
   }
 
   @Test
@@ -151,10 +150,9 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    Assert.assertTrue(
-        "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+    assertThat(StreamSupport.stream(results.orphanFileLocations().spliterator(), false))
+        .as("trash file should be removed")
+        .anyMatch(file -> file.contains("file:" + location + "/data/trashfile"));
   }
 
   @Test
@@ -184,13 +182,12 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    Assert.assertTrue(
-        "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+    assertThat(StreamSupport.stream(results.orphanFileLocations().spliterator(), false))
+        .as("trash file should be removed")
+        .anyMatch(file -> file.contains("file:" + location + "/data/trashfile"));
   }
 
-  @After
+  @AfterEach
   public void resetSparkSessionCatalog() throws Exception {
     spark.conf().unset("spark.sql.catalog.spark_catalog");
     spark.conf().unset("spark.sql.catalog.spark_catalog.type");

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -277,8 +277,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults())
         .as("Should have 1 fileGroup because all files were not correctly partitioned")
-        .size()
-        .isOne();
+        .hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     List<Object[]> postRewriteData = currentData();
@@ -1002,7 +1001,7 @@ public class TestRewriteDataFilesAction extends TestBase {
                 RewriteDataFiles.TARGET_FILE_SIZE_BYTES, Integer.toString(averageFileSize(table)))
             .execute();
 
-    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     table.refresh();
@@ -1038,8 +1037,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults())
         .as("Should have 1 fileGroups because all files were not correctly partitioned")
-        .size()
-        .isOne();
+        .hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     table.refresh();
@@ -1070,7 +1068,7 @@ public class TestRewriteDataFilesAction extends TestBase {
                 RewriteDataFiles.TARGET_FILE_SIZE_BYTES, Integer.toString(averageFileSize(table)))
             .execute();
 
-    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     table.refresh();
@@ -1109,7 +1107,7 @@ public class TestRewriteDataFilesAction extends TestBase {
                 Integer.toString(averageFileSize(table) / partitions))
             .execute();
 
-    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     table.refresh();
@@ -1146,9 +1144,9 @@ public class TestRewriteDataFilesAction extends TestBase {
             .option(SizeBasedFileRewriter.MIN_INPUT_FILES, "1")
             .execute();
 
-    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(table.currentSnapshot().addedDataFiles(table.io()))
         .as("Should have written 40+ files")
         .hasSizeGreaterThanOrEqualTo(40);
@@ -1226,12 +1224,11 @@ public class TestRewriteDataFilesAction extends TestBase {
             .option(SizeBasedFileRewriter.MIN_INPUT_FILES, "1")
             .execute();
 
-    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
     assertThat(table.currentSnapshot().addedDataFiles(table.io()))
         .as("Should have written 40+ files")
-        .size()
-        .isGreaterThanOrEqualTo(40);
+        .hasSizeGreaterThanOrEqualTo(40);
 
     table.refresh();
 
@@ -1284,12 +1281,11 @@ public class TestRewriteDataFilesAction extends TestBase {
             .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
             .execute();
 
-    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
     assertThat(table.currentSnapshot().addedDataFiles(table.io()))
         .as("Should have written 1 file")
-        .size()
-        .isOne();
+        .hasSize(1);
 
     table.refresh();
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -25,6 +25,7 @@ import static org.apache.spark.sql.functions.current_date;
 import static org.apache.spark.sql.functions.date_add;
 import static org.apache.spark.sql.functions.expr;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.spy;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -82,7 +84,6 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -92,8 +93,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.ScanTaskSetManager;
 import org.apache.iceberg.spark.SparkTableUtil;
-import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.SparkWriteOptions;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.spark.actions.RewriteDataFilesSparkAction.RewriteExecutionContext;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
@@ -106,17 +107,14 @@ import org.apache.iceberg.util.StructLikeMap;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.internal.SQLConf;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
-public class TestRewriteDataFilesAction extends SparkTestBase {
+public class TestRewriteDataFilesAction extends TestBase {
 
   private static final int SCALE = 400000;
 
@@ -127,21 +125,21 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
           optional(2, "c2", Types.StringType.get()),
           optional(3, "c3", Types.StringType.get()));
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private final FileRewriteCoordinator coordinator = FileRewriteCoordinator.get();
   private final ScanTaskSetManager manager = ScanTaskSetManager.get();
   private String tableLocation = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupSpark() {
     // disable AQE as tests assume that writes generate a particular number of files
     spark.conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), "false");
   }
 
-  @Before
+  @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.newFolder();
+    File tableDir = temp.resolve("junit").toFile();
     this.tableLocation = tableDir.toURI().toString();
   }
 
@@ -157,11 +155,11 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     Map<String, String> options = Maps.newHashMap();
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
 
-    Assert.assertNull("Table must be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
 
     basicRewrite(table).execute();
 
-    Assert.assertNull("Table must stay empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).as("Table must stay empty").isNull();
   }
 
   @Test
@@ -172,8 +170,10 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     long dataSizeBefore = testDataSize(table);
 
     Result result = basicRewrite(table).execute();
-    Assert.assertEquals("Action should rewrite 4 data files", 4, result.rewrittenDataFilesCount());
-    Assert.assertEquals("Action should add 1 data file", 1, result.addedDataFilesCount());
+    assertThat(result.rewrittenDataFilesCount())
+        .as("Action should rewrite 4 data files")
+        .isEqualTo(4);
+    assertThat(result.addedDataFilesCount()).as("Action should add 1 data file").isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     shouldHaveFiles(table, 1);
@@ -190,8 +190,10 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     long dataSizeBefore = testDataSize(table);
 
     Result result = basicRewrite(table).execute();
-    Assert.assertEquals("Action should rewrite 8 data files", 8, result.rewrittenDataFilesCount());
-    Assert.assertEquals("Action should add 4 data file", 4, result.addedDataFilesCount());
+    assertThat(result.rewrittenDataFilesCount())
+        .as("Action should rewrite 8 data files")
+        .isEqualTo(8);
+    assertThat(result.addedDataFilesCount()).as("Action should add 4 data file").isEqualTo(4);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     shouldHaveFiles(table, 4);
@@ -213,8 +215,10 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .filter(Expressions.startsWith("c2", "foo"))
             .execute();
 
-    Assert.assertEquals("Action should rewrite 2 data files", 2, result.rewrittenDataFilesCount());
-    Assert.assertEquals("Action should add 1 data file", 1, result.addedDataFilesCount());
+    assertThat(result.rewrittenDataFilesCount())
+        .as("Action should rewrite 2 data files")
+        .isEqualTo(2);
+    assertThat(result.addedDataFilesCount()).as("Action should add 1 data file").isOne();
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
 
     shouldHaveFiles(table, 7);
@@ -271,10 +275,10 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
                 Integer.toString(averageFileSize(table) + 1001))
             .execute();
 
-    Assert.assertEquals(
-        "Should have 1 fileGroup because all files were not correctly partitioned",
-        1,
-        result.rewriteResults().size());
+    assertThat(result.rewriteResults())
+        .as("Should have 1 fileGroup because all files were not correctly partitioned")
+        .size()
+        .isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     List<Object[]> postRewriteData = currentData();
@@ -320,12 +324,14 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .option(SizeBasedFileRewriter.MAX_FILE_SIZE_BYTES, Long.toString(Long.MAX_VALUE))
             .option(SizeBasedDataRewriter.DELETE_FILE_THRESHOLD, "2")
             .execute();
-    Assert.assertEquals("Action should rewrite 2 data files", 2, result.rewrittenDataFilesCount());
+    assertThat(result.rewrittenDataFilesCount())
+        .as("Action should rewrite 2 data files")
+        .isEqualTo(2);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
 
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
-    Assert.assertEquals("7 rows are removed", total - 7, actualRecords.size());
+    assertThat(actualRecords).as("7 rows are removed").hasSize(total - 7);
   }
 
   @Test
@@ -353,23 +359,22 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .rewriteDataFiles(table)
             .option(SizeBasedDataRewriter.DELETE_FILE_THRESHOLD, "1")
             .execute();
-    Assert.assertEquals("Action should rewrite 1 data files", 1, result.rewrittenDataFilesCount());
+    assertThat(result.rewrittenDataFilesCount()).as("Action should rewrite 1 data files").isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
-    Assert.assertEquals(
-        "Data manifest should not have existing data file",
-        0,
-        (long) table.currentSnapshot().dataManifests(table.io()).get(0).existingFilesCount());
-    Assert.assertEquals(
-        "Data manifest should have 1 delete data file",
-        1L,
-        (long) table.currentSnapshot().dataManifests(table.io()).get(0).deletedFilesCount());
-    Assert.assertEquals(
-        "Delete manifest added row count should equal total count",
-        total,
-        (long) table.currentSnapshot().deleteManifests(table.io()).get(0).addedRowsCount());
+    assertThat(table.currentSnapshot().dataManifests(table.io()).get(0).existingFilesCount())
+        .as("Data manifest should not have existing data file")
+        .isZero();
+
+    assertThat((long) table.currentSnapshot().dataManifests(table.io()).get(0).deletedFilesCount())
+        .as("Data manifest should have 1 delete data file")
+        .isEqualTo(1L);
+
+    assertThat(table.currentSnapshot().deleteManifests(table.io()).get(0).addedRowsCount())
+        .as("Delete manifest added row count should equal total count")
+        .isEqualTo(total);
   }
 
   @Test
@@ -384,8 +389,10 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
 
     Result result =
         basicRewrite(table).option(RewriteDataFiles.USE_STARTING_SEQUENCE_NUMBER, "true").execute();
-    Assert.assertEquals("Action should rewrite 8 data files", 8, result.rewrittenDataFilesCount());
-    Assert.assertEquals("Action should add 4 data file", 4, result.addedDataFilesCount());
+    assertThat(result.rewrittenDataFilesCount())
+        .as("Action should rewrite 8 data files")
+        .isEqualTo(8);
+    assertThat(result.addedDataFilesCount()).as("Action should add 4 data files").isEqualTo(4);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     shouldHaveFiles(table, 4);
@@ -393,15 +400,16 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     assertEquals("Rows must match", expectedRecords, actualRecords);
 
     table.refresh();
-    Assert.assertTrue(
-        "Table sequence number should be incremented",
-        oldSequenceNumber < table.currentSnapshot().sequenceNumber());
+    assertThat(table.currentSnapshot().sequenceNumber())
+        .as("Table sequence number should be incremented")
+        .isGreaterThan(oldSequenceNumber);
 
     Dataset<Row> rows = SparkTableUtil.loadMetadataTable(spark, table, MetadataTableType.ENTRIES);
     for (Row row : rows.collectAsList()) {
       if (row.getInt(0) == 1) {
-        Assert.assertEquals(
-            "Expect old sequence number for added entries", oldSequenceNumber, row.getLong(2));
+        assertThat(row.getLong(2))
+            .as("Expect old sequence number for added entries")
+            .isEqualTo(oldSequenceNumber);
       }
     }
   }
@@ -414,13 +422,15 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     List<Object[]> expectedRecords = currentData();
     table.refresh();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
-    Assert.assertEquals("Table sequence number should be 0", 0, oldSequenceNumber);
+    assertThat(oldSequenceNumber).as("Table sequence number should be 0").isZero();
     long dataSizeBefore = testDataSize(table);
 
     Result result =
         basicRewrite(table).option(RewriteDataFiles.USE_STARTING_SEQUENCE_NUMBER, "true").execute();
-    Assert.assertEquals("Action should rewrite 8 data files", 8, result.rewrittenDataFilesCount());
-    Assert.assertEquals("Action should add 4 data file", 4, result.addedDataFilesCount());
+    assertThat(result.rewrittenDataFilesCount())
+        .as("Action should rewrite 8 data files")
+        .isEqualTo(8);
+    assertThat(result.addedDataFilesCount()).as("Action should add 4 data files").isEqualTo(4);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     shouldHaveFiles(table, 4);
@@ -428,15 +438,15 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     assertEquals("Rows must match", expectedRecords, actualRecords);
 
     table.refresh();
-    Assert.assertEquals(
-        "Table sequence number should still be 0",
-        oldSequenceNumber,
-        table.currentSnapshot().sequenceNumber());
+    assertThat(table.currentSnapshot().sequenceNumber())
+        .as("Table sequence number should still be 0")
+        .isEqualTo(oldSequenceNumber);
 
     Dataset<Row> rows = SparkTableUtil.loadMetadataTable(spark, table, MetadataTableType.ENTRIES);
     for (Row row : rows.collectAsList()) {
-      Assert.assertEquals(
-          "Expect sequence number 0 for all entries", oldSequenceNumber, row.getLong(2));
+      assertThat(row.getLong(2))
+          .as("Expect sequence number 0 for all entries")
+          .isEqualTo(oldSequenceNumber);
     }
   }
 
@@ -462,15 +472,19 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     CloseableIterable<FileScanTask> tasks =
         table.newScan().ignoreResiduals().filter(Expressions.equal("c3", "0")).planFiles();
     for (FileScanTask task : tasks) {
-      Assert.assertEquals("Residuals must be ignored", Expressions.alwaysTrue(), task.residual());
+      assertThat(task.residual())
+          .as("Residuals must be ignored")
+          .isEqualTo(Expressions.alwaysTrue());
     }
 
     shouldHaveFiles(table, 2);
 
     long dataSizeBefore = testDataSize(table);
     Result result = basicRewrite(table).filter(Expressions.equal("c3", "0")).execute();
-    Assert.assertEquals("Action should rewrite 2 data files", 2, result.rewrittenDataFilesCount());
-    Assert.assertEquals("Action should add 1 data file", 1, result.addedDataFilesCount());
+    assertThat(result.rewrittenDataFilesCount())
+        .as("Action should rewrite 2 data files")
+        .isEqualTo(2);
+    assertThat(result.addedDataFilesCount()).as("Action should add 1 data file").isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     List<Object[]> actualRecords = currentData();
@@ -493,8 +507,8 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .option(SizeBasedFileRewriter.MAX_FILE_SIZE_BYTES, Long.toString(targetSize * 2 - 2000))
             .execute();
 
-    Assert.assertEquals("Action should delete 1 data files", 1, result.rewrittenDataFilesCount());
-    Assert.assertEquals("Action should add 2 data files", 2, result.addedDataFilesCount());
+    assertThat(result.rewrittenDataFilesCount()).as("Action should delete 1 data files").isOne();
+    assertThat(result.addedDataFilesCount()).as("Action should add 2 data files").isEqualTo(2);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     shouldHaveFiles(table, 2);
@@ -525,10 +539,12 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .option(SizeBasedFileRewriter.MIN_FILE_SIZE_BYTES, Integer.toString(targetSize - 1000))
             .execute();
 
-    Assert.assertEquals("Action should delete 3 data files", 3, result.rewrittenDataFilesCount());
+    assertThat(result.rewrittenDataFilesCount())
+        .as("Action should delete 3 data files")
+        .isEqualTo(3);
     // Should Split the big files into 3 pieces, one of which should be combined with the two
     // smaller files
-    Assert.assertEquals("Action should add 3 data files", 3, result.addedDataFilesCount());
+    assertThat(result.addedDataFilesCount()).as("Action should add 3 data files").isEqualTo(3);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     shouldHaveFiles(table, 3);
@@ -558,8 +574,10 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
                 Integer.toString(targetSize - 100)) // All files too small
             .execute();
 
-    Assert.assertEquals("Action should delete 4 data files", 4, result.rewrittenDataFilesCount());
-    Assert.assertEquals("Action should add 3 data files", 3, result.addedDataFilesCount());
+    assertThat(result.rewrittenDataFilesCount())
+        .as("Action should delete 4 data files")
+        .isEqualTo(4);
+    assertThat(result.addedDataFilesCount()).as("Action should add 3 data files").isEqualTo(3);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     shouldHaveFiles(table, 3);
@@ -587,7 +605,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "10")
             .execute();
 
-    Assert.assertEquals("Should have 10 fileGroups", result.rewriteResults().size(), 10);
+    assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     table.refresh();
@@ -615,7 +633,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .option(SizeBasedFileRewriter.MIN_INPUT_FILES, "1")
             .execute();
 
-    Assert.assertEquals("Should have 10 fileGroups", result.rewriteResults().size(), 10);
+    assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     table.refresh();
@@ -644,7 +662,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3")
             .execute();
 
-    Assert.assertEquals("Should have 10 fileGroups", result.rewriteResults().size(), 10);
+    assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     table.refresh();
@@ -676,7 +694,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
         .when(spyRewrite)
         .rewriteFiles(any(), argThat(failGroup));
 
-    Assertions.assertThatThrownBy(spyRewrite::execute)
+    assertThatThrownBy(spyRewrite::execute)
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Rewrite Failed");
 
@@ -710,7 +728,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
 
     doReturn(util).when(spyRewrite).commitManager(table.currentSnapshot().snapshotId());
 
-    Assertions.assertThatThrownBy(spyRewrite::execute)
+    assertThatThrownBy(spyRewrite::execute)
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Commit Failure");
 
@@ -745,7 +763,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
         .when(spyRewrite)
         .rewriteFiles(any(), argThat(failGroup));
 
-    Assertions.assertThatThrownBy(spyRewrite::execute)
+    assertThatThrownBy(spyRewrite::execute)
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Rewrite Failed");
 
@@ -875,7 +893,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     RewriteDataFiles.Result result = spyRewrite.execute();
 
     // Commit 1: 4/4 + Commit 2 failed 0/4 + Commit 3: 2/2 == 6 out of 10 total groups comitted
-    Assert.assertEquals("Should have 6 fileGroups", 6, result.rewriteResults().size());
+    assertThat(result.rewriteResults()).as("Should have 6 fileGroups").hasSize(6);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
 
     table.refresh();
@@ -893,7 +911,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
   public void testInvalidOptions() {
     Table table = createTable(20);
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 basicRewrite(table)
                     .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
@@ -904,7 +922,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             "Cannot set partial-progress.max-commits to -5, "
                 + "the value must be positive when partial-progress.enabled is true");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 basicRewrite(table)
                     .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "-5")
@@ -913,17 +931,17 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
         .hasMessage(
             "Cannot set max-concurrent-file-group-rewrites to -5, the value must be positive.");
 
-    Assertions.assertThatThrownBy(() -> basicRewrite(table).option("foobarity", "-5").execute())
+    assertThatThrownBy(() -> basicRewrite(table).option("foobarity", "-5").execute())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Cannot use options [foobarity], they are not supported by the action or the rewriter BIN-PACK");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> basicRewrite(table).option(RewriteDataFiles.REWRITE_JOB_ORDER, "foo").execute())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid rewrite job order name: foo");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 basicRewrite(table)
                     .sort(SortOrder.builderFor(table.schema()).asc("c2").build())
@@ -953,7 +971,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
                 RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
             .execute();
 
-    Assert.assertEquals("Should have 10 fileGroups", result.rewriteResults().size(), 10);
+    assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     table.refresh();
@@ -984,7 +1002,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
                 RewriteDataFiles.TARGET_FILE_SIZE_BYTES, Integer.toString(averageFileSize(table)))
             .execute();
 
-    Assert.assertEquals("Should have 1 fileGroups", result.rewriteResults().size(), 1);
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     table.refresh();
@@ -1018,10 +1036,10 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
                 RewriteDataFiles.TARGET_FILE_SIZE_BYTES, Integer.toString(averageFileSize(table)))
             .execute();
 
-    Assert.assertEquals(
-        "Should have 1 fileGroup because all files were not correctly partitioned",
-        result.rewriteResults().size(),
-        1);
+    assertThat(result.rewriteResults())
+        .as("Should have 1 fileGroups because all files were not correctly partitioned")
+        .size()
+        .isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     table.refresh();
@@ -1052,7 +1070,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
                 RewriteDataFiles.TARGET_FILE_SIZE_BYTES, Integer.toString(averageFileSize(table)))
             .execute();
 
-    Assert.assertEquals("Should have 1 fileGroups", result.rewriteResults().size(), 1);
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     table.refresh();
@@ -1091,7 +1109,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
                 Integer.toString(averageFileSize(table) / partitions))
             .execute();
 
-    Assert.assertEquals("Should have 1 fileGroups", result.rewriteResults().size(), 1);
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
     table.refresh();
@@ -1128,11 +1146,12 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .option(SizeBasedFileRewriter.MIN_INPUT_FILES, "1")
             .execute();
 
-    Assert.assertEquals("Should have 1 fileGroups", result.rewriteResults().size(), 1);
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-    Assert.assertTrue(
-        "Should have written 40+ files",
-        Iterables.size(table.currentSnapshot().addedDataFiles(table.io())) >= 40);
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
+    assertThat(table.currentSnapshot().addedDataFiles(table.io()))
+        .as("Should have written 40+ files")
+        .hasSizeGreaterThanOrEqualTo(40);
 
     table.refresh();
 
@@ -1166,7 +1185,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
 
     doReturn(util).when(spyAction).commitManager(table.currentSnapshot().snapshotId());
 
-    Assertions.assertThatThrownBy(spyAction::execute)
+    assertThatThrownBy(spyAction::execute)
         .isInstanceOf(CommitStateUnknownException.class)
         .hasMessageStartingWith(
             "Unknown State\n" + "Cannot determine whether the commit was successful or not");
@@ -1190,8 +1209,8 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     double originalFilesC2C3 =
         percentFilesRequired(table, new String[] {"c2", "c3"}, new String[] {"foo23", "bar23"});
 
-    Assert.assertTrue("Should require all files to scan c2", originalFilesC2 > 0.99);
-    Assert.assertTrue("Should require all files to scan c3", originalFilesC3 > 0.99);
+    assertThat(originalFilesC2).as("Should require all files to scan c2").isGreaterThan(0.99);
+    assertThat(originalFilesC3).as("Should require all files to scan c3").isGreaterThan(0.99);
 
     long dataSizeBefore = testDataSize(table);
     RewriteDataFiles.Result result =
@@ -1207,10 +1226,12 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .option(SizeBasedFileRewriter.MIN_INPUT_FILES, "1")
             .execute();
 
-    Assert.assertEquals("Should have 1 fileGroups", 1, result.rewriteResults().size());
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-    int zOrderedFilesTotal = Iterables.size(table.currentSnapshot().addedDataFiles(table.io()));
-    Assert.assertTrue("Should have written 40+ files", zOrderedFilesTotal >= 40);
+    assertThat(table.currentSnapshot().addedDataFiles(table.io()))
+        .as("Should have written 40+ files")
+        .size()
+        .isGreaterThanOrEqualTo(40);
 
     table.refresh();
 
@@ -1225,15 +1246,15 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     double filesScannedC2C3 =
         percentFilesRequired(table, new String[] {"c2", "c3"}, new String[] {"foo23", "bar23"});
 
-    Assert.assertTrue(
-        "Should have reduced the number of files required for c2",
-        filesScannedC2 < originalFilesC2);
-    Assert.assertTrue(
-        "Should have reduced the number of files required for c3",
-        filesScannedC3 < originalFilesC3);
-    Assert.assertTrue(
-        "Should have reduced the number of files required for a c2,c3 predicate",
-        filesScannedC2C3 < originalFilesC2C3);
+    assertThat(originalFilesC2)
+        .as("Should have reduced the number of files required for c2")
+        .isGreaterThan(filesScannedC2);
+    assertThat(originalFilesC3)
+        .as("Should have reduced the number of files required for c3")
+        .isGreaterThan(filesScannedC3);
+    assertThat(originalFilesC2C3)
+        .as("Should have reduced the number of files required for c2,c3 predicate")
+        .isGreaterThan(filesScannedC2C3);
   }
 
   @Test
@@ -1263,10 +1284,12 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
             .execute();
 
-    Assert.assertEquals("Should have 1 fileGroups", 1, result.rewriteResults().size());
+    assertThat(result.rewriteResults()).as("Should have 1 fileGroups").size().isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-    int zOrderedFilesTotal = Iterables.size(table.currentSnapshot().addedDataFiles(table.io()));
-    Assert.assertEquals("Should have written 1 file", 1, zOrderedFilesTotal);
+    assertThat(table.currentSnapshot().addedDataFiles(table.io()))
+        .as("Should have written 1 file")
+        .size()
+        .isOne();
 
     table.refresh();
 
@@ -1285,15 +1308,15 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
 
     SortOrder sortOrder = SortOrder.builderFor(table.schema()).asc("c2").build();
 
-    Assertions.assertThatThrownBy(() -> actions().rewriteDataFiles(table).binPack().sort())
+    assertThatThrownBy(() -> actions().rewriteDataFiles(table).binPack().sort())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Must use only one rewriter type (bin-pack, sort, zorder)");
 
-    Assertions.assertThatThrownBy(() -> actions().rewriteDataFiles(table).sort(sortOrder).binPack())
+    assertThatThrownBy(() -> actions().rewriteDataFiles(table).sort(sortOrder).binPack())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Must use only one rewriter type (bin-pack, sort, zorder)");
 
-    Assertions.assertThatThrownBy(() -> actions().rewriteDataFiles(table).sort(sortOrder).binPack())
+    assertThatThrownBy(() -> actions().rewriteDataFiles(table).sort(sortOrder).binPack())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Must use only one rewriter type (bin-pack, sort, zorder)");
   }
@@ -1325,9 +1348,9 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .collect(Collectors.toList());
 
     expected.sort(Comparator.naturalOrder());
-    Assert.assertEquals("Size in bytes order should be ascending", actual, expected);
+    assertThat(actual).as("Size in bytes order should be ascending").isEqualTo(expected);
     Collections.reverse(expected);
-    Assert.assertNotEquals("Size in bytes order should not be descending", actual, expected);
+    assertThat(actual).as("Size in bytes order should not be descending").isNotEqualTo(expected);
   }
 
   @Test
@@ -1357,9 +1380,9 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .collect(Collectors.toList());
 
     expected.sort(Comparator.reverseOrder());
-    Assert.assertEquals("Size in bytes order should be descending", actual, expected);
+    assertThat(actual).as("Size in bytes order should be descending").isEqualTo(expected);
     Collections.reverse(expected);
-    Assert.assertNotEquals("Size in bytes order should not be ascending", actual, expected);
+    assertThat(actual).as("Size in bytes order should not be ascending").isNotEqualTo(expected);
   }
 
   @Test
@@ -1389,9 +1412,9 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .collect(Collectors.toList());
 
     expected.sort(Comparator.naturalOrder());
-    Assert.assertEquals("Number of files order should be ascending", actual, expected);
+    assertThat(actual).as("Number of files order should be ascending").isEqualTo(expected);
     Collections.reverse(expected);
-    Assert.assertNotEquals("Number of files order should not be descending", actual, expected);
+    assertThat(actual).as("Number of files order should not be descending").isNotEqualTo(expected);
   }
 
   @Test
@@ -1421,9 +1444,9 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .collect(Collectors.toList());
 
     expected.sort(Comparator.reverseOrder());
-    Assert.assertEquals("Number of files order should be descending", actual, expected);
+    assertThat(actual).as("Number of files order should be descending").isEqualTo(expected);
     Collections.reverse(expected);
-    Assert.assertNotEquals("Number of files order should not be ascending", actual, expected);
+    assertThat(actual).as("Number of files order should not be ascending").isNotEqualTo(expected);
   }
 
   private Stream<RewriteFileGroup> toGroupStream(Table table, RewriteDataFilesSparkAction rewrite) {
@@ -1447,48 +1470,50 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
   protected void shouldHaveMultipleFiles(Table table) {
     table.refresh();
     int numFiles = Iterables.size(table.newScan().planFiles());
-    Assert.assertTrue(String.format("Should have multiple files, had %d", numFiles), numFiles > 1);
+    assertThat(numFiles)
+        .as(String.format("Should have multiple files, had %d", numFiles))
+        .isGreaterThan(1);
   }
 
   protected void shouldHaveFiles(Table table, int numExpected) {
     table.refresh();
     int numFiles = Iterables.size(table.newScan().planFiles());
-    Assert.assertEquals("Did not have the expected number of files", numExpected, numFiles);
+    assertThat(numFiles).as("Did not have the expected number of files").isEqualTo(numExpected);
   }
 
   protected void shouldHaveSnapshots(Table table, int expectedSnapshots) {
     table.refresh();
     int actualSnapshots = Iterables.size(table.snapshots());
-    Assert.assertEquals(
-        "Table did not have the expected number of snapshots", expectedSnapshots, actualSnapshots);
+    assertThat(actualSnapshots)
+        .as("Table did not have the expected number of snapshots")
+        .isEqualTo(expectedSnapshots);
   }
 
   protected void shouldHaveNoOrphans(Table table) {
-    Assert.assertEquals(
-        "Should not have found any orphan files",
-        ImmutableList.of(),
-        actions()
-            .deleteOrphanFiles(table)
-            .olderThan(System.currentTimeMillis())
-            .execute()
-            .orphanFileLocations());
+    assertThat(
+            actions()
+                .deleteOrphanFiles(table)
+                .olderThan(System.currentTimeMillis())
+                .execute()
+                .orphanFileLocations())
+        .as("Should not have found any orphan files")
+        .isEmpty();
   }
 
   protected void shouldHaveACleanCache(Table table) {
-    Assert.assertEquals(
-        "Should not have any entries in cache", ImmutableSet.of(), cacheContents(table));
+    assertThat(cacheContents(table)).as("Should not have any entries in cache").isEmpty();
   }
 
   protected <T> void shouldHaveLastCommitSorted(Table table, String column) {
     List<Pair<Pair<T, T>, Pair<T, T>>> overlappingFiles = checkForOverlappingFiles(table, column);
 
-    Assert.assertEquals("Found overlapping files", Collections.emptyList(), overlappingFiles);
+    assertThat(overlappingFiles).as("Found overlapping files").isEmpty();
   }
 
   protected <T> void shouldHaveLastCommitUnsorted(Table table, String column) {
     List<Pair<Pair<T, T>, Pair<T, T>>> overlappingFiles = checkForOverlappingFiles(table, column);
 
-    Assert.assertNotEquals("Found no overlapping files", Collections.emptyList(), overlappingFiles);
+    assertThat(overlappingFiles).as("Found no overlapping files").isNotEmpty();
   }
 
   private <T> Pair<T, T> boundsOf(DataFile file, NestedField field, Class<T> javaClass) {
@@ -1567,7 +1592,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
         .updateProperties()
         .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(20 * 1024))
         .commit();
-    Assert.assertNull("Table must be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
     return table;
   }
 
@@ -1587,7 +1612,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
       int partitions, int files, int numRecords, Map<String, String> options) {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
-    Assert.assertNull("Table must be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
 
     writeRecords(files, numRecords, partitions);
     return table;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -184,13 +184,13 @@ public class TestRewriteManifestsAction extends TestBase {
             .execute();
 
     assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifests").hasSize(2);
-    assertThat(result.addedManifests()).as("Action should add 1 manifests").size().isOne();
+    assertThat(result.addedManifests()).as("Action should add 1 manifests").hasSize(1);
     assertManifestsLocation(result.addedManifests());
 
     table.refresh();
 
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    assertThat(newManifests).as("Should have 1 manifests after rewrite").size().isOne();
+    assertThat(newManifests).as("Should have 1 manifests after rewrite").hasSize(1);
 
     assertThat(newManifests.get(0).existingFilesCount()).isEqualTo(4);
     assertThat(newManifests.get(0).hasAddedFiles()).isFalse();
@@ -257,7 +257,7 @@ public class TestRewriteManifestsAction extends TestBase {
 
     // table should reflect the changes, since the commit was successful
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    assertThat(newManifests).as("Should have 1 manifests after rewrite").size().isOne();
+    assertThat(newManifests).as("Should have 1 manifests after rewrite").hasSize(1);
 
     assertThat(newManifests.get(0).existingFilesCount()).isEqualTo(4);
     assertThat(newManifests.get(0).hasAddedFiles()).isFalse();
@@ -410,7 +410,7 @@ public class TestRewriteManifestsAction extends TestBase {
       assertThat(result.rewrittenManifests())
           .as("Action should rewrite all manifests")
           .isEqualTo(snapshot.allManifests(table.io()));
-      assertThat(result.addedManifests()).as("Action should add 1 manifest").size().isOne();
+      assertThat(result.addedManifests()).as("Action should add 1 manifest").hasSize(1);
       assertManifestsLocation(result.addedManifests(), rewriteStagingLocation);
 
     } finally {
@@ -434,7 +434,7 @@ public class TestRewriteManifestsAction extends TestBase {
     table.newFastAppend().appendManifest(appendManifest).commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    assertThat(manifests).as("Should have 1 manifests before rewrite").size().isOne();
+    assertThat(manifests).as("Should have 1 manifests before rewrite").hasSize(1);
 
     // set the target manifest size to a small value to force splitting records into multiple files
     table
@@ -456,7 +456,7 @@ public class TestRewriteManifestsAction extends TestBase {
             .stagingLocation(stagingLocation)
             .execute();
 
-    assertThat(result.rewrittenManifests()).size().isOne();
+    assertThat(result.rewrittenManifests()).hasSize(1);
     assertThat(result.addedManifests()).hasSizeGreaterThanOrEqualTo(2);
     assertManifestsLocation(result.addedManifests(), stagingLocation);
 
@@ -509,7 +509,7 @@ public class TestRewriteManifestsAction extends TestBase {
             .execute();
 
     assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifest").hasSize(2);
-    assertThat(result.addedManifests()).as("Action should add 1 manifests").size().isOne();
+    assertThat(result.addedManifests()).as("Action should add 1 manifests").hasSize(1);
     assertManifestsLocation(result.addedManifests(), stagingLocation);
 
     table.refresh();
@@ -573,13 +573,13 @@ public class TestRewriteManifestsAction extends TestBase {
             .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
             .execute();
     assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifests").hasSize(2);
-    assertThat(result.addedManifests()).as("Action should add 1 manifests").size().isOne();
+    assertThat(result.addedManifests()).as("Action should add 1 manifests").hasSize(1);
     assertManifestsLocation(result.addedManifests());
 
     table.refresh();
 
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    assertThat(newManifests).as("Should have 1 manifests after rewrite").size().isOne();
+    assertThat(newManifests).as("Should have 1 manifests after rewrite").hasSize(1);
 
     ManifestFile newManifest = Iterables.getOnlyElement(newManifests);
     assertThat(newManifest.existingFilesCount()).isEqualTo(2);
@@ -646,7 +646,7 @@ public class TestRewriteManifestsAction extends TestBase {
             .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
             .execute();
 
-    assertThat(result.rewrittenManifests()).size().isOne();
+    assertThat(result.rewrittenManifests()).hasSize(1);
     assertThat(result.addedManifests()).hasSizeGreaterThanOrEqualTo(2);
     assertManifestsLocation(result.addedManifests());
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -25,6 +25,7 @@ import static org.apache.iceberg.ValidationHelpers.snapshotIds;
 import static org.apache.iceberg.ValidationHelpers.validateDataManifest;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
@@ -32,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -45,6 +47,9 @@ import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.Schema;
@@ -65,8 +70,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkTableUtil;
-import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.SparkWriteOptions;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
@@ -75,18 +80,13 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.TableIdentifier;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(Parameterized.class)
-public class TestRewriteManifestsAction extends SparkTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRewriteManifestsAction extends TestBase {
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
@@ -95,39 +95,40 @@ public class TestRewriteManifestsAction extends SparkTestBase {
           optional(2, "c2", Types.StringType.get()),
           optional(3, "c3", Types.StringType.get()));
 
-  @Parameters(name = "snapshotIdInheritanceEnabled = {0}, useCaching = {1}, formatVersion = {2}")
+  @Parameters(
+      name =
+          "snapshotIdInheritanceEnabled = {0}, useCaching = {1}, shouldStageManifests = {2}, formatVersion = {3}")
   public static Object[] parameters() {
     return new Object[][] {
-      new Object[] {"true", "true", 1},
-      new Object[] {"false", "true", 1},
-      new Object[] {"true", "false", 2},
-      new Object[] {"false", "false", 2}
+      new Object[] {"true", "true", false, 1},
+      new Object[] {"false", "true", true, 1},
+      new Object[] {"true", "false", false, 2},
+      new Object[] {"false", "false", false, 2}
     };
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @Parameter private String snapshotIdInheritanceEnabled;
 
-  private final String snapshotIdInheritanceEnabled;
-  private final String useCaching;
-  private final int formatVersion;
-  private final boolean shouldStageManifests;
+  @Parameter(index = 1)
+  private String useCaching;
+
+  @Parameter(index = 2)
+  private boolean shouldStageManifests;
+
+  @Parameter(index = 3)
+  private int formatVersion;
+
   private String tableLocation = null;
 
-  public TestRewriteManifestsAction(
-      String snapshotIdInheritanceEnabled, String useCaching, int formatVersion) {
-    this.snapshotIdInheritanceEnabled = snapshotIdInheritanceEnabled;
-    this.useCaching = useCaching;
-    this.formatVersion = formatVersion;
-    this.shouldStageManifests = formatVersion == 1 && snapshotIdInheritanceEnabled.equals("false");
-  }
+  @TempDir private Path temp;
 
-  @Before
+  @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.newFolder();
+    File tableDir = temp.resolve("junit").toFile();
     this.tableLocation = tableDir.toURI().toString();
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteManifestsEmptyTable() throws IOException {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
@@ -135,7 +136,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
 
-    Assert.assertNull("Table must be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
 
     SparkActions actions = SparkActions.get();
 
@@ -143,13 +144,13 @@ public class TestRewriteManifestsAction extends SparkTestBase {
         .rewriteManifests(table)
         .rewriteIf(manifest -> true)
         .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
-        .stagingLocation(temp.newFolder().toString())
+        .stagingLocation(java.nio.file.Files.createTempDirectory(temp, "junit").toString())
         .execute();
 
-    Assert.assertNull("Table must stay empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).as("Table must stay empty").isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteSmallManifestsNonPartitionedTable() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
@@ -171,7 +172,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     table.refresh();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 2 manifests before rewrite", 2, manifests.size());
+    assertThat(manifests).as("Should have 2 manifests before rewrite").hasSize(2);
 
     SparkActions actions = SparkActions.get();
 
@@ -182,20 +183,18 @@ public class TestRewriteManifestsAction extends SparkTestBase {
             .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
             .execute();
 
-    Assert.assertEquals(
-        "Action should rewrite 2 manifests", 2, Iterables.size(result.rewrittenManifests()));
-    Assert.assertEquals(
-        "Action should add 1 manifests", 1, Iterables.size(result.addedManifests()));
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifests").hasSize(2);
+    assertThat(result.addedManifests()).as("Action should add 1 manifests").size().isOne();
     assertManifestsLocation(result.addedManifests());
 
     table.refresh();
 
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 1 manifests after rewrite", 1, newManifests.size());
+    assertThat(newManifests).as("Should have 1 manifests after rewrite").size().isOne();
 
-    Assert.assertEquals(4, (long) newManifests.get(0).existingFilesCount());
-    Assert.assertFalse(newManifests.get(0).hasAddedFiles());
-    Assert.assertFalse(newManifests.get(0).hasDeletedFiles());
+    assertThat(newManifests.get(0).existingFilesCount()).isEqualTo(4);
+    assertThat(newManifests.get(0).hasAddedFiles()).isFalse();
+    assertThat(newManifests.get(0).hasDeletedFiles()).isFalse();
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records1);
@@ -205,10 +204,10 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     List<ThreeColumnRecord> actualRecords =
         resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
 
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteManifestsWithCommitStateUnknownException() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
@@ -230,7 +229,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     table.refresh();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 2 manifests before rewrite", 2, manifests.size());
+    assertThat(manifests).as("Should have 2 manifests before rewrite").hasSize(2);
 
     SparkActions actions = SparkActions.get();
 
@@ -248,7 +247,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     Table spyTable = spy(table);
     when(spyTable.rewriteManifests()).thenReturn(spyNewRewriteManifests);
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> actions.rewriteManifests(spyTable).rewriteIf(manifest -> true).execute())
         .cause()
         .isInstanceOf(RuntimeException.class)
@@ -258,11 +257,11 @@ public class TestRewriteManifestsAction extends SparkTestBase {
 
     // table should reflect the changes, since the commit was successful
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 1 manifests after rewrite", 1, newManifests.size());
+    assertThat(newManifests).as("Should have 1 manifests after rewrite").size().isOne();
 
-    Assert.assertEquals(4, (long) newManifests.get(0).existingFilesCount());
-    Assert.assertFalse(newManifests.get(0).hasAddedFiles());
-    Assert.assertFalse(newManifests.get(0).hasDeletedFiles());
+    assertThat(newManifests.get(0).existingFilesCount()).isEqualTo(4);
+    assertThat(newManifests.get(0).hasAddedFiles()).isFalse();
+    assertThat(newManifests.get(0).hasDeletedFiles()).isFalse();
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records1);
@@ -272,10 +271,10 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     List<ThreeColumnRecord> actualRecords =
         resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
 
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteSmallManifestsPartitionedTable() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
     Map<String, String> options = Maps.newHashMap();
@@ -309,7 +308,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     table.refresh();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 4 manifests before rewrite", 4, manifests.size());
+    assertThat(manifests).as("Should have 4 manifests before rewrite").hasSize(4);
 
     SparkActions actions = SparkActions.get();
 
@@ -329,24 +328,23 @@ public class TestRewriteManifestsAction extends SparkTestBase {
             .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
             .execute();
 
-    Assert.assertEquals(
-        "Action should rewrite 4 manifests", 4, Iterables.size(result.rewrittenManifests()));
-    Assert.assertEquals(
-        "Action should add 2 manifests", 2, Iterables.size(result.addedManifests()));
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 4 manifests").hasSize(4);
+    assertThat(result.addedManifests()).as("Action should add 2 manifests").hasSize(2);
     assertManifestsLocation(result.addedManifests());
 
     table.refresh();
 
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 2 manifests after rewrite", 2, newManifests.size());
 
-    Assert.assertEquals(4, (long) newManifests.get(0).existingFilesCount());
-    Assert.assertFalse(newManifests.get(0).hasAddedFiles());
-    Assert.assertFalse(newManifests.get(0).hasDeletedFiles());
+    assertThat(newManifests).as("Should have 2 manifests after rewrite").hasSize(2);
 
-    Assert.assertEquals(4, (long) newManifests.get(1).existingFilesCount());
-    Assert.assertFalse(newManifests.get(1).hasAddedFiles());
-    Assert.assertFalse(newManifests.get(1).hasDeletedFiles());
+    assertThat(newManifests.get(0).existingFilesCount()).isEqualTo(4);
+    assertThat(newManifests.get(0).hasAddedFiles()).isFalse();
+    assertThat(newManifests.get(0).hasDeletedFiles()).isFalse();
+
+    assertThat(newManifests.get(1).existingFilesCount()).isEqualTo(4);
+    assertThat(newManifests.get(1).hasAddedFiles()).isFalse();
+    assertThat(newManifests.get(1).hasDeletedFiles()).isFalse();
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records1);
@@ -358,10 +356,10 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     List<ThreeColumnRecord> actualRecords =
         resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
 
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteImportedManifests() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c3").build();
     Map<String, String> options = Maps.newHashMap();
@@ -372,7 +370,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     List<ThreeColumnRecord> records =
         Lists.newArrayList(
             new ThreeColumnRecord(1, null, "AAAA"), new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB"));
-    File parquetTableDir = temp.newFolder("parquet_table");
+    File parquetTableDir = temp.resolve("parquet_table").toFile();
     String parquetTableLocation = parquetTableDir.toURI().toString();
 
     try {
@@ -386,7 +384,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
           .partitionBy("c3")
           .saveAsTable("parquet_table");
 
-      File stagingDir = temp.newFolder("staging-dir");
+      File stagingDir = temp.resolve("staging-dir").toFile();
       SparkTableUtil.importSparkTable(
           spark, new TableIdentifier("parquet_table"), table, stagingDir.toString());
 
@@ -398,7 +396,8 @@ public class TestRewriteManifestsAction extends SparkTestBase {
 
       SparkActions actions = SparkActions.get();
 
-      String rewriteStagingLocation = temp.newFolder().toString();
+      String rewriteStagingLocation =
+          java.nio.file.Files.createTempDirectory(temp, "junit").toString();
 
       RewriteManifests.Result result =
           actions
@@ -408,12 +407,10 @@ public class TestRewriteManifestsAction extends SparkTestBase {
               .stagingLocation(rewriteStagingLocation)
               .execute();
 
-      Assert.assertEquals(
-          "Action should rewrite all manifests",
-          snapshot.allManifests(table.io()),
-          result.rewrittenManifests());
-      Assert.assertEquals(
-          "Action should add 1 manifest", 1, Iterables.size(result.addedManifests()));
+      assertThat(result.rewrittenManifests())
+          .as("Action should rewrite all manifests")
+          .isEqualTo(snapshot.allManifests(table.io()));
+      assertThat(result.addedManifests()).as("Action should add 1 manifest").size().isOne();
       assertManifestsLocation(result.addedManifests(), rewriteStagingLocation);
 
     } finally {
@@ -421,7 +418,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteLargeManifestsPartitionedTable() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c3").build();
     Map<String, String> options = Maps.newHashMap();
@@ -437,7 +434,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     table.newFastAppend().appendManifest(appendManifest).commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 1 manifests before rewrite", 1, manifests.size());
+    assertThat(manifests).as("Should have 1 manifests before rewrite").size().isOne();
 
     // set the target manifest size to a small value to force splitting records into multiple files
     table
@@ -449,7 +446,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
 
     SparkActions actions = SparkActions.get();
 
-    String stagingLocation = temp.newFolder().toString();
+    String stagingLocation = java.nio.file.Files.createTempDirectory(temp, "junit").toString();
 
     RewriteManifests.Result result =
         actions
@@ -459,17 +456,17 @@ public class TestRewriteManifestsAction extends SparkTestBase {
             .stagingLocation(stagingLocation)
             .execute();
 
-    Assertions.assertThat(result.rewrittenManifests()).hasSize(1);
-    Assertions.assertThat(result.addedManifests()).hasSizeGreaterThanOrEqualTo(2);
+    assertThat(result.rewrittenManifests()).size().isOne();
+    assertThat(result.addedManifests()).hasSizeGreaterThanOrEqualTo(2);
     assertManifestsLocation(result.addedManifests(), stagingLocation);
 
     table.refresh();
 
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    Assertions.assertThat(newManifests).hasSizeGreaterThanOrEqualTo(2);
+    assertThat(newManifests).hasSizeGreaterThanOrEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteManifestsWithPredicate() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
     Map<String, String> options = Maps.newHashMap();
@@ -493,11 +490,11 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     table.refresh();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 3 manifests before rewrite", 3, manifests.size());
+    assertThat(manifests).as("Should have 3 manifests before rewrite").hasSize(3);
 
     SparkActions actions = SparkActions.get();
 
-    String stagingLocation = temp.newFolder().toString();
+    String stagingLocation = java.nio.file.Files.createTempDirectory(temp, "junit").toString();
 
     // rewrite only the first manifest
     RewriteManifests.Result result =
@@ -511,22 +508,22 @@ public class TestRewriteManifestsAction extends SparkTestBase {
             .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
             .execute();
 
-    Assert.assertEquals(
-        "Action should rewrite 2 manifest", 2, Iterables.size(result.rewrittenManifests()));
-    Assert.assertEquals(
-        "Action should add 1 manifests", 1, Iterables.size(result.addedManifests()));
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifest").hasSize(2);
+    assertThat(result.addedManifests()).as("Action should add 1 manifests").size().isOne();
     assertManifestsLocation(result.addedManifests(), stagingLocation);
 
     table.refresh();
 
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 2 manifests after rewrite", 2, newManifests.size());
-
-    Assert.assertFalse("First manifest must be rewritten", newManifests.contains(manifests.get(0)));
-    Assert.assertFalse(
-        "Second manifest must be rewritten", newManifests.contains(manifests.get(1)));
-    Assert.assertTrue(
-        "Third manifest must not be rewritten", newManifests.contains(manifests.get(2)));
+    assertThat(newManifests)
+        .as("Should have 2 manifests after rewrite")
+        .hasSize(2)
+        .as("First manifest must be rewritten")
+        .doesNotContain(manifests.get(0))
+        .as("Second manifest must be rewritten")
+        .doesNotContain(manifests.get(1))
+        .as("Third manifest must not be rewritten")
+        .contains(manifests.get(2));
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.add(records1.get(0));
@@ -539,10 +536,10 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     List<ThreeColumnRecord> actualRecords =
         resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
 
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteSmallManifestsNonPartitionedV2Table() {
     assumeThat(formatVersion).isGreaterThan(1);
 
@@ -567,7 +564,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     DataFile file2 = Iterables.getOnlyElement(snapshot2.addedDataFiles(table.io()));
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 2 manifests before rewrite", 2, manifests.size());
+    assertThat(manifests).as("Should have 2 manifests before rewrite").hasSize(2);
 
     SparkActions actions = SparkActions.get();
     RewriteManifests.Result result =
@@ -575,21 +572,19 @@ public class TestRewriteManifestsAction extends SparkTestBase {
             .rewriteManifests(table)
             .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
             .execute();
-    Assert.assertEquals(
-        "Action should rewrite 2 manifests", 2, Iterables.size(result.rewrittenManifests()));
-    Assert.assertEquals(
-        "Action should add 1 manifests", 1, Iterables.size(result.addedManifests()));
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifests").hasSize(2);
+    assertThat(result.addedManifests()).as("Action should add 1 manifests").size().isOne();
     assertManifestsLocation(result.addedManifests());
 
     table.refresh();
 
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 1 manifests after rewrite", 1, newManifests.size());
+    assertThat(newManifests).as("Should have 1 manifests after rewrite").size().isOne();
 
     ManifestFile newManifest = Iterables.getOnlyElement(newManifests);
-    Assert.assertEquals(2, (long) newManifest.existingFilesCount());
-    Assert.assertFalse(newManifest.hasAddedFiles());
-    Assert.assertFalse(newManifest.hasDeletedFiles());
+    assertThat(newManifest.existingFilesCount()).isEqualTo(2);
+    assertThat(newManifest.hasAddedFiles()).isFalse();
+    assertThat(newManifest.hasDeletedFiles()).isFalse();
 
     validateDataManifest(
         table,
@@ -607,10 +602,10 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     List<ThreeColumnRecord> actualRecords =
         resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
 
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteLargeManifestsEvolvedUnpartitionedV1Table() throws IOException {
     assumeThat(formatVersion).isEqualTo(1);
 
@@ -651,7 +646,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
             .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
             .execute();
 
-    assertThat(result.rewrittenManifests()).hasSize(1);
+    assertThat(result.rewrittenManifests()).size().isOne();
     assertThat(result.addedManifests()).hasSizeGreaterThanOrEqualTo(2);
     assertManifestsLocation(result.addedManifests());
 
@@ -659,7 +654,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     assertThat(manifests).hasSizeGreaterThanOrEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteSmallDeleteManifestsNonPartitionedTable() throws IOException {
     assumeThat(formatVersion).isGreaterThan(1);
 
@@ -732,7 +727,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     assertThat(actualRecords()).isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteSmallDeleteManifestsPartitionedTable() throws IOException {
     assumeThat(formatVersion).isGreaterThan(1);
 
@@ -835,7 +830,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     assertThat(actualRecords()).isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteLargeDeleteManifestsPartitionedTable() throws IOException {
     assumeThat(formatVersion).isGreaterThan(1);
 
@@ -874,7 +869,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
 
     SparkActions actions = SparkActions.get();
 
-    String stagingLocation = temp.newFolder().toString();
+    String stagingLocation = java.nio.file.Files.createTempDirectory(temp, "junit").toString();
 
     RewriteManifests.Result result =
         actions
@@ -948,8 +943,8 @@ public class TestRewriteManifestsAction extends SparkTestBase {
   }
 
   private ManifestFile writeManifest(Table table, List<DataFile> files) throws IOException {
-    File manifestFile = temp.newFile("generated-manifest.avro");
-    Assert.assertTrue(manifestFile.delete());
+    File manifestFile = File.createTempFile("generated-manifest", ".avro", temp.toFile());
+    assertThat(manifestFile.delete()).isTrue();
     OutputFile outputFile = table.io().newOutputFile(manifestFile.getCanonicalPath());
 
     ManifestWriter<DataFile> writer =
@@ -1018,7 +1013,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
   private Pair<DeleteFile, CharSequenceSet> writePosDeletes(
       Table table, StructLike partition, List<Pair<CharSequence, Long>> deletes)
       throws IOException {
-    OutputFile outputFile = Files.localOutput(temp.newFile());
+    OutputFile outputFile = Files.localOutput(File.createTempFile("junit", null, temp.toFile()));
     return FileHelpers.writeDeleteFile(table, outputFile, partition, deletes);
   }
 
@@ -1036,7 +1031,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
       deletes.add(delete.copy(key, value));
     }
 
-    OutputFile outputFile = Files.localOutput(temp.newFile());
+    OutputFile outputFile = Files.localOutput(File.createTempFile("junit", null, temp.toFile()));
     return FileHelpers.writeDeleteFile(table, outputFile, partition, deletes, deleteSchema);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.Parameter;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionSpec;
@@ -109,13 +110,9 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
   }
 
   @TempDir private Path temp;
-  private final FileFormat format;
 
-  public TestRewritePositionDeleteFilesAction(
-      String catalogName, String implementation, Map<String, String> config, FileFormat format) {
-    super(catalogName, implementation, config);
-    this.format = format;
-  }
+  @Parameter(index = 3)
+  private FileFormat format;
 
   @AfterEach
   public void cleanup() {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -19,8 +19,12 @@
 package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +40,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Partitioning;
@@ -59,8 +64,8 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.spark.source.FourColumnRecord;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
@@ -69,14 +74,11 @@ import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.StructLikeMap;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
+public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
 
   private static final String TABLE_NAME = "test_table";
   private static final Schema SCHEMA =
@@ -94,9 +96,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   private static final int SCALE = 4000;
   private static final int DELETES_SCALE = 1000;
 
-  @Parameterized.Parameters(
-      name =
-          "formatVersion = {0}, catalogName = {1}, implementation = {2}, config = {3}, fileFormat = {4}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, fileFormat = {3}")
   public static Object[][] parameters() {
     return new Object[][] {
       {
@@ -108,8 +108,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     };
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
-
+  @TempDir private Path temp;
   private final FileFormat format;
 
   public TestRewritePositionDeleteFilesAction(
@@ -118,12 +117,12 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     this.format = format;
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     validationCatalog.dropTable(TableIdentifier.of("default", TABLE_NAME));
   }
 
-  @Test
+  @TestTemplate
   public void testEmptyTable() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
     Table table =
@@ -131,24 +130,24 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
             TableIdentifier.of("default", TABLE_NAME), SCHEMA, spec, tableProperties());
 
     Result result = SparkActions.get(spark).rewritePositionDeletes(table).execute();
-    Assert.assertEquals("No rewritten delete files", 0, result.rewrittenDeleteFilesCount());
-    Assert.assertEquals("No added delete files", 0, result.addedDeleteFilesCount());
+    assertThat(result.rewrittenDeleteFilesCount()).as("No rewritten delete files").isZero();
+    assertThat(result.addedDeleteFilesCount()).as("No added delete files").isZero();
   }
 
-  @Test
+  @TestTemplate
   public void testUnpartitioned() throws Exception {
     Table table = createTableUnpartitioned(2, SCALE);
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
-    Assert.assertEquals(2, dataFiles.size());
+    assertThat(dataFiles).hasSize(2);
 
     List<DeleteFile> deleteFiles = deleteFiles(table);
-    Assert.assertEquals(2, deleteFiles.size());
+    assertThat(deleteFiles).hasSize(2);
 
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
-    Assert.assertEquals(2000, expectedRecords.size());
-    Assert.assertEquals(2000, expectedDeletes.size());
+    assertThat(expectedRecords).hasSize(2000);
+    assertThat(expectedDeletes).hasSize(2000);
 
     Result result =
         SparkActions.get(spark)
@@ -156,7 +155,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
             .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
             .execute();
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    Assert.assertEquals("Expected 1 new delete file", 1, newDeleteFiles.size());
+    assertThat(newDeleteFiles).as("Expected 1 new delete file").size().isOne();
     assertLocallySorted(newDeleteFiles);
     assertNotContains(deleteFiles, newDeleteFiles);
     checkResult(result, deleteFiles, newDeleteFiles, 1);
@@ -168,21 +167,21 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertEquals("Position deletes must match", expectedDeletes, actualDeletes);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteAll() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
-    Assert.assertEquals(4, dataFiles.size());
+    assertThat(dataFiles).hasSize(4);
 
     List<DeleteFile> deleteFiles = deleteFiles(table);
-    Assert.assertEquals(8, deleteFiles.size());
+    assertThat(deleteFiles).hasSize(8);
 
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
-    Assert.assertEquals(12000, expectedRecords.size());
-    Assert.assertEquals(4000, expectedDeletes.size());
+    assertThat(expectedRecords).hasSize(12000);
+    assertThat(expectedDeletes).hasSize(4000);
 
     Result result =
         SparkActions.get(spark)
@@ -192,7 +191,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
             .execute();
 
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    Assert.assertEquals("Should have 4 delete files", 4, newDeleteFiles.size());
+    assertThat(newDeleteFiles).hasSize(4);
     assertNotContains(deleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, deleteFiles, newDeleteFiles, 4);
@@ -204,23 +203,23 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertEquals("Position deletes must match", expectedDeletes, actualDeletes);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteFilter() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
     table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
-    Assert.assertEquals(4, dataFiles.size());
+    assertThat(dataFiles).hasSize(4);
 
     List<DeleteFile> deleteFiles = deleteFiles(table);
-    Assert.assertEquals(8, deleteFiles.size());
+    assertThat(deleteFiles).hasSize(8);
 
     table.refresh();
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
-    Assert.assertEquals(12000, expectedRecords.size()); // 16000 data - 4000 delete rows
-    Assert.assertEquals(4000, expectedDeletes.size());
+    assertThat(expectedRecords).hasSize(12000);
+    assertThat(expectedDeletes).hasSize(4000);
 
     Expression filter =
         Expressions.and(
@@ -236,7 +235,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
             .execute();
 
     List<DeleteFile> newDeleteFiles = except(deleteFiles(table), deleteFiles);
-    Assert.assertEquals("Should have 4 delete files", 2, newDeleteFiles.size());
+    assertThat(newDeleteFiles).as("Should have 4 delete files").hasSize(2);
 
     List<DeleteFile> expectedRewrittenFiles =
         filterFiles(table, deleteFiles, ImmutableList.of(1), ImmutableList.of(2));
@@ -249,21 +248,21 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertEquals("Position deletes must match", expectedDeletes, actualDeletes);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteToSmallerTarget() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
-    Assert.assertEquals(4, dataFiles.size());
+    assertThat(dataFiles).hasSize(4);
 
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
-    Assert.assertEquals(12000, expectedRecords.size());
-    Assert.assertEquals(4000, expectedDeletes.size());
+    assertThat(expectedRecords).hasSize(12000);
+    assertThat(expectedDeletes).hasSize(4000);
 
     List<DeleteFile> deleteFiles = deleteFiles(table);
-    Assert.assertEquals(8, deleteFiles.size());
+    assertThat(deleteFiles).hasSize(8);
 
     long avgSize = size(deleteFiles) / deleteFiles.size();
 
@@ -274,7 +273,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
             .option(SizeBasedFileRewriter.TARGET_FILE_SIZE_BYTES, String.valueOf(avgSize / 2))
             .execute();
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    Assert.assertEquals("Should have 8 new delete files", 8, newDeleteFiles.size());
+    assertThat(newDeleteFiles).as("Should have 8 new delete files").hasSize(8);
     assertNotContains(deleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, deleteFiles, newDeleteFiles, 4);
@@ -286,7 +285,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertEquals("Position deletes must match", expectedDeletes, actualDeletes);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveDanglingDeletes() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
@@ -298,15 +297,15 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
         dataFiles,
         true /* Disable commit-time ManifestFilterManager removal of dangling deletes */);
 
-    Assert.assertEquals(4, dataFiles.size());
+    assertThat(dataFiles).hasSize(4);
 
     List<DeleteFile> deleteFiles = deleteFiles(table);
-    Assert.assertEquals(8, deleteFiles.size());
+    assertThat(deleteFiles).hasSize(8);
 
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
-    Assert.assertEquals(12000, expectedRecords.size());
-    Assert.assertEquals(4000, expectedDeletes.size());
+    assertThat(expectedRecords).hasSize(12000);
+    assertThat(expectedDeletes).hasSize(4000);
 
     SparkActions.get(spark)
         .rewriteDataFiles(table)
@@ -319,7 +318,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
             .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
             .execute();
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    Assert.assertEquals("Should have 0 new delete files", 0, newDeleteFiles.size());
+    assertThat(newDeleteFiles).as("Should have 0 new delete files").size().isZero();
     assertNotContains(deleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, deleteFiles, newDeleteFiles, 4);
@@ -328,24 +327,24 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     List<Object[]> actualRecords = records(table);
     List<Object[]> actualDeletes = deleteRecords(table);
     assertEquals("Rows must match", expectedRecords, actualRecords);
-    Assert.assertEquals("Should be no new position deletes", 0, actualDeletes.size());
+    assertThat(actualDeletes).as("Should be no new position deletes").size().isZero();
   }
 
-  @Test
+  @TestTemplate
   public void testSomePartitionsDanglingDeletes() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
-    Assert.assertEquals(4, dataFiles.size());
+    assertThat(dataFiles).hasSize(4);
 
     List<DeleteFile> deleteFiles = deleteFiles(table);
-    Assert.assertEquals(8, deleteFiles.size());
+    assertThat(deleteFiles).hasSize(8);
 
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
-    Assert.assertEquals(12000, expectedRecords.size());
-    Assert.assertEquals(4000, expectedDeletes.size());
+    assertThat(expectedRecords).hasSize(12000);
+    assertThat(expectedDeletes).hasSize(4000);
 
     // Rewrite half the data files
     Expression filter = Expressions.or(Expressions.equal("c1", 0), Expressions.equal("c1", 1));
@@ -361,7 +360,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
             .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
             .execute();
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    Assert.assertEquals("Should have 2 new delete files", 2, newDeleteFiles.size());
+    assertThat(newDeleteFiles).as("Should have 2 new delete files").hasSize(2);
     assertNotContains(deleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, deleteFiles, newDeleteFiles, 4);
@@ -384,23 +383,23 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertEquals("Position deletes must match", expectedDeletes, actualDeletes);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteFilterRemoveDangling() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
     table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles, true);
-    Assert.assertEquals(4, dataFiles.size());
+    assertThat(dataFiles).hasSize(4);
 
     List<DeleteFile> deleteFiles = deleteFiles(table);
-    Assert.assertEquals(8, deleteFiles.size());
+    assertThat(deleteFiles).hasSize(8);
 
     table.refresh();
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
-    Assert.assertEquals(12000, expectedRecords.size()); // 16000 data - 4000 delete rows
-    Assert.assertEquals(4000, expectedDeletes.size());
+    assertThat(expectedRecords).hasSize(12000); // 16000 data - 4000 delete rows
+    assertThat(expectedDeletes).hasSize(4000);
 
     SparkActions.get(spark)
         .rewriteDataFiles(table)
@@ -417,7 +416,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
             .execute();
 
     List<DeleteFile> newDeleteFiles = except(deleteFiles(table), deleteFiles);
-    Assert.assertEquals("Should have 2 new delete files", 0, newDeleteFiles.size());
+    assertThat(newDeleteFiles).as("Should have 2 new delete files").size().isZero();
 
     List<DeleteFile> expectedRewrittenFiles =
         filterFiles(table, deleteFiles, ImmutableList.of(0), ImmutableList.of(1));
@@ -432,35 +431,35 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertEquals("Position deletes must match", expectedDeletesFiltered, allDeletes);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionEvolutionAdd() throws Exception {
     Table table = createTableUnpartitioned(2, SCALE);
     List<DataFile> unpartitionedDataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, unpartitionedDataFiles);
-    Assert.assertEquals(2, unpartitionedDataFiles.size());
+    assertThat(unpartitionedDataFiles).hasSize(2);
 
     List<DeleteFile> unpartitionedDeleteFiles = deleteFiles(table);
-    Assert.assertEquals(2, unpartitionedDeleteFiles.size());
+    assertThat(unpartitionedDeleteFiles).hasSize(2);
 
     List<Object[]> expectedUnpartitionedDeletes = deleteRecords(table);
     List<Object[]> expectedUnpartitionedRecords = records(table);
-    Assert.assertEquals(2000, expectedUnpartitionedRecords.size());
-    Assert.assertEquals(2000, expectedUnpartitionedDeletes.size());
+    assertThat(expectedUnpartitionedRecords).hasSize(2000);
+    assertThat(expectedUnpartitionedDeletes).hasSize(2000);
 
     table.updateSpec().addField("c1").commit();
     writeRecords(table, 2, SCALE, 2);
     List<DataFile> partitionedDataFiles =
         except(TestHelpers.dataFiles(table), unpartitionedDataFiles);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, partitionedDataFiles);
-    Assert.assertEquals(2, partitionedDataFiles.size());
+    assertThat(partitionedDataFiles).hasSize(2);
 
     List<DeleteFile> partitionedDeleteFiles = except(deleteFiles(table), unpartitionedDeleteFiles);
-    Assert.assertEquals(4, partitionedDeleteFiles.size());
+    assertThat(partitionedDeleteFiles).hasSize(4);
 
     List<Object[]> expectedDeletes = deleteRecords(table);
     List<Object[]> expectedRecords = records(table);
-    Assert.assertEquals(4000, expectedDeletes.size());
-    Assert.assertEquals(8000, expectedRecords.size());
+    assertThat(expectedDeletes).hasSize(4000);
+    assertThat(expectedRecords).hasSize(8000);
 
     Result result =
         SparkActions.get(spark)
@@ -472,7 +471,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
         Stream.concat(unpartitionedDeleteFiles.stream(), partitionedDeleteFiles.stream())
             .collect(Collectors.toList());
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    Assert.assertEquals("Should have 3 new delete files", 3, newDeleteFiles.size());
+    assertThat(newDeleteFiles).as("Should have 3 new delete files").hasSize(3);
     assertNotContains(rewrittenDeleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, rewrittenDeleteFiles, newDeleteFiles, 3);
@@ -484,15 +483,15 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertEquals("Position deletes must match", expectedDeletes, actualDeletes);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionEvolutionRemove() throws Exception {
     Table table = createTablePartitioned(2, 2, SCALE);
     List<DataFile> dataFilesUnpartitioned = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesUnpartitioned);
-    Assert.assertEquals(2, dataFilesUnpartitioned.size());
+    assertThat(dataFilesUnpartitioned).hasSize(2);
 
     List<DeleteFile> deleteFilesUnpartitioned = deleteFiles(table);
-    Assert.assertEquals(4, deleteFilesUnpartitioned.size());
+    assertThat(deleteFilesUnpartitioned).hasSize(4);
 
     table.updateSpec().removeField("c1").commit();
 
@@ -500,18 +499,18 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     List<DataFile> dataFilesPartitioned =
         except(TestHelpers.dataFiles(table), dataFilesUnpartitioned);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesPartitioned);
-    Assert.assertEquals(2, dataFilesPartitioned.size());
+    assertThat(dataFilesPartitioned).hasSize(2);
 
     List<DeleteFile> deleteFilesPartitioned = except(deleteFiles(table), deleteFilesUnpartitioned);
-    Assert.assertEquals(2, deleteFilesPartitioned.size());
+    assertThat(deleteFilesPartitioned).hasSize(2);
 
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
-    Assert.assertEquals(4000, expectedDeletes.size());
-    Assert.assertEquals(8000, expectedRecords.size());
+    assertThat(expectedDeletes).hasSize(4000);
+    assertThat(expectedRecords).hasSize(8000);
 
     List<DeleteFile> expectedRewritten = deleteFiles(table);
-    Assert.assertEquals(6, expectedRewritten.size());
+    assertThat(expectedRewritten).hasSize(6);
 
     Result result =
         SparkActions.get(spark)
@@ -519,7 +518,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
             .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
             .execute();
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    Assert.assertEquals("Should have 3 new delete files", 3, newDeleteFiles.size());
+    assertThat(newDeleteFiles).as("Should have 3 new delete files").hasSize(3);
     assertNotContains(expectedRewritten, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, expectedRewritten, newDeleteFiles, 3);
@@ -531,15 +530,15 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertEquals("Position deletes must match", expectedDeletes, actualDeletes);
   }
 
-  @Test
+  @TestTemplate
   public void testSchemaEvolution() throws Exception {
     Table table = createTablePartitioned(2, 2, SCALE);
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
-    Assert.assertEquals(2, dataFiles.size());
+    assertThat(dataFiles).hasSize(2);
 
     List<DeleteFile> deleteFiles = deleteFiles(table);
-    Assert.assertEquals(4, deleteFiles.size());
+    assertThat(deleteFiles).hasSize(4);
 
     table.updateSchema().addColumn("c4", Types.StringType.get()).commit();
     writeNewSchemaRecords(table, 2, SCALE, 2, 2);
@@ -552,13 +551,13 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     writePosDeletesForFiles(table, 2, DELETES_SCALE, newSchemaDataFiles);
 
     List<DeleteFile> newSchemaDeleteFiles = except(deleteFiles(table), deleteFiles);
-    Assert.assertEquals(4, newSchemaDeleteFiles.size());
+    assertThat(newSchemaDeleteFiles).hasSize(4);
 
     table.refresh();
     List<Object[]> expectedDeletes = deleteRecords(table);
     List<Object[]> expectedRecords = records(table);
-    Assert.assertEquals(4000, expectedDeletes.size()); // 4 files * 1000 per file
-    Assert.assertEquals(12000, expectedRecords.size()); // 4 * 4000 - 4000
+    assertThat(expectedDeletes).hasSize(4000); // 4 files * 1000 per file
+    assertThat(expectedRecords).hasSize(12000); // 4 * 4000 - 4000
 
     Result result =
         SparkActions.get(spark)
@@ -570,7 +569,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
         Stream.concat(deleteFiles.stream(), newSchemaDeleteFiles.stream())
             .collect(Collectors.toList());
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    Assert.assertEquals("Should have 2 new delete files", 4, newDeleteFiles.size());
+    assertThat(newDeleteFiles).as("Should have 2 new delete files").hasSize(4);
     assertNotContains(rewrittenDeleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, rewrittenDeleteFiles, newDeleteFiles, 4);
@@ -627,9 +626,10 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   private void writeRecordsWithPartitions(
       Table table, int files, int numRecords, List<List<Integer>> partitions) {
     int partitionTypeSize = table.spec().partitionType().fields().size();
-    Assert.assertTrue(
-        "This method currently supports only two columns as partition columns",
-        partitionTypeSize <= 2);
+    assertThat(partitionTypeSize)
+        .as("This method currently supports only two columns as partition columns")
+        .isLessThanOrEqualTo(2);
+
     BiFunction<Integer, List<Integer>, ThreeColumnRecord> recordFunction =
         (i, partValues) -> {
           switch (partitionTypeSize) {
@@ -737,13 +737,13 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
       List<DataFile> partitionFiles = filesByPartitionEntry.getValue();
 
       int deletesForPartition = partitionFiles.size() * deletesPerDataFile;
-      Assert.assertEquals(
-          "Number of delete files per partition should be "
-              + "evenly divisible by requested deletes per data file times number of data files in this partition",
-          0,
-          deletesForPartition % deleteFilesPerPartition);
-      int deleteFileSize = deletesForPartition / deleteFilesPerPartition;
+      assertThat(deletesForPartition % deleteFilesPerPartition)
+          .as(
+              "Number of delete files per partition should be "
+                  + "evenly divisible by requested deletes per data file times number of data files in this partition")
+          .isZero();
 
+      int deleteFileSize = deletesForPartition / deleteFilesPerPartition;
       int counter = 0;
       List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
       for (DataFile partitionFile : partitionFiles) {
@@ -752,7 +752,8 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
           counter++;
           if (counter == deleteFileSize) {
             // Dump to file and reset variables
-            OutputFile output = Files.localOutput(temp.newFile());
+            OutputFile output =
+                Files.localOutput(File.createTempFile("junit", null, temp.toFile()));
             deleteFiles.add(FileHelpers.writeDeleteFile(table, output, partition, deletes).first());
             counter = 0;
             deletes.clear();
@@ -797,7 +798,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     Set<String> rewrittenPaths =
         rewritten.stream().map(f -> f.path().toString()).collect(Collectors.toSet());
     rewrittenPaths.retainAll(originalPaths);
-    Assert.assertEquals(0, rewrittenPaths.size());
+    assertThat(rewrittenPaths).size().isZero();
   }
 
   private void assertLocallySorted(List<DeleteFile> deleteFiles) {
@@ -806,16 +807,16 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
           spark.read().format("iceberg").load("default." + TABLE_NAME + ".position_deletes");
       deletes.filter(deletes.col("delete_file_path").equalTo(deleteFile.path().toString()));
       List<Row> rows = deletes.collectAsList();
-      Assert.assertFalse("Empty delete file found", rows.isEmpty());
+      assertThat(rows).as("Empty delete file found").isNotEmpty();
       int lastPos = 0;
       String lastPath = "";
       for (Row row : rows) {
         String path = row.getAs("file_path");
         long pos = row.getAs("pos");
         if (path.compareTo(lastPath) < 0) {
-          Assert.fail(String.format("File_path not sorted, Found %s after %s", path, lastPath));
+          fail(String.format("File_path not sorted, Found %s after %s", path, lastPath));
         } else if (path.equals(lastPath)) {
-          Assert.assertTrue("Pos not sorted", pos >= lastPos);
+          assertThat(pos).as("Pos not sorted").isGreaterThanOrEqualTo(lastPos);
         }
       }
     }
@@ -823,7 +824,8 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
 
   private String name(Table table) {
     String[] splits = table.name().split("\\.");
-    Assert.assertEquals(3, splits.length);
+
+    assertThat(splits).hasSize(3);
     return String.format("%s.%s", splits[1], splits[2]);
   }
 
@@ -901,49 +903,53 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
       List<DeleteFile> rewrittenDeletes,
       List<DeleteFile> newDeletes,
       int expectedGroups) {
-    Assert.assertEquals(
-        "Expected rewritten delete file count does not match",
-        rewrittenDeletes.size(),
-        result.rewrittenDeleteFilesCount());
-    Assert.assertEquals(
-        "Expected new delete file count does not match",
-        newDeletes.size(),
-        result.addedDeleteFilesCount());
-    Assert.assertEquals(
-        "Expected rewritten delete byte count does not match",
-        size(rewrittenDeletes),
-        result.rewrittenBytesCount());
-    Assert.assertEquals(
-        "Expected new delete byte count does not match",
-        size(newDeletes),
-        result.addedBytesCount());
+    assertThat(rewrittenDeletes.size())
+        .as("Expected rewritten delete file count does not match")
+        .isEqualTo(result.rewrittenDeleteFilesCount());
 
-    Assert.assertEquals(
-        "Expected rewrite group count does not match",
-        expectedGroups,
-        result.rewriteResults().size());
-    Assert.assertEquals(
-        "Expected rewritten delete file count in all groups to match",
-        rewrittenDeletes.size(),
-        result.rewriteResults().stream()
-            .mapToInt(FileGroupRewriteResult::rewrittenDeleteFilesCount)
-            .sum());
-    Assert.assertEquals(
-        "Expected added delete file count in all groups to match",
-        newDeletes.size(),
-        result.rewriteResults().stream()
-            .mapToInt(FileGroupRewriteResult::addedDeleteFilesCount)
-            .sum());
-    Assert.assertEquals(
-        "Expected rewritten delete bytes in all groups to match",
-        size(rewrittenDeletes),
-        result.rewriteResults().stream()
-            .mapToLong(FileGroupRewriteResult::rewrittenBytesCount)
-            .sum());
-    Assert.assertEquals(
-        "Expected added delete bytes in all groups to match",
-        size(newDeletes),
-        result.rewriteResults().stream().mapToLong(FileGroupRewriteResult::addedBytesCount).sum());
+    assertThat(newDeletes.size())
+        .as("Expected new delete file count does not match")
+        .isEqualTo(result.addedDeleteFilesCount());
+
+    assertThat(size(rewrittenDeletes))
+        .as("Expected rewritten delete byte count does not match")
+        .isEqualTo(result.rewrittenBytesCount());
+
+    assertThat(size(newDeletes))
+        .as("Expected new delete byte count does not match")
+        .isEqualTo(result.addedBytesCount());
+
+    assertThat(expectedGroups)
+        .as("Expected rewrite group count does not match")
+        .isEqualTo(result.rewriteResults().size());
+
+    assertThat(rewrittenDeletes.size())
+        .as("Expected rewritten delete file count in all groups to match")
+        .isEqualTo(
+            result.rewriteResults().stream()
+                .mapToInt(FileGroupRewriteResult::rewrittenDeleteFilesCount)
+                .sum());
+
+    assertThat(newDeletes.size())
+        .as("Expected added delete file count in all groups to match")
+        .isEqualTo(
+            result.rewriteResults().stream()
+                .mapToInt(FileGroupRewriteResult::addedDeleteFilesCount)
+                .sum());
+
+    assertThat(size(rewrittenDeletes))
+        .as("Expected rewritten delete bytes in all groups to match")
+        .isEqualTo(
+            result.rewriteResults().stream()
+                .mapToLong(FileGroupRewriteResult::rewrittenBytesCount)
+                .sum());
+
+    assertThat(size(newDeletes))
+        .as("Expected added delete bytes in all groups to match")
+        .isEqualTo(
+            result.rewriteResults().stream()
+                .mapToLong(FileGroupRewriteResult::addedBytesCount)
+                .sum());
   }
 
   private void checkSequenceNumbers(
@@ -961,10 +967,9 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
       if (addedPartitionFiles != null) {
         addedPartitionFiles.forEach(
             d ->
-                Assert.assertEquals(
-                    "Sequence number should be max of rewritten set",
-                    d.dataSequenceNumber(),
-                    maxRewrittenSeq));
+                assertThat(d.dataSequenceNumber())
+                    .as("Sequence number should be max of rewritten set")
+                    .isEqualTo(maxRewrittenSeq));
       }
     }
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -155,7 +155,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
             .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
             .execute();
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    assertThat(newDeleteFiles).as("Expected 1 new delete file").size().isOne();
+    assertThat(newDeleteFiles).as("Expected 1 new delete file").hasSize(1);
     assertLocallySorted(newDeleteFiles);
     assertNotContains(deleteFiles, newDeleteFiles);
     checkResult(result, deleteFiles, newDeleteFiles, 1);
@@ -318,7 +318,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
             .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
             .execute();
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    assertThat(newDeleteFiles).as("Should have 0 new delete files").size().isZero();
+    assertThat(newDeleteFiles).as("Should have 0 new delete files").hasSize(0);
     assertNotContains(deleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, deleteFiles, newDeleteFiles, 4);
@@ -327,7 +327,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     List<Object[]> actualRecords = records(table);
     List<Object[]> actualDeletes = deleteRecords(table);
     assertEquals("Rows must match", expectedRecords, actualRecords);
-    assertThat(actualDeletes).as("Should be no new position deletes").size().isZero();
+    assertThat(actualDeletes).as("Should be no new position deletes").hasSize(0);
   }
 
   @TestTemplate
@@ -416,7 +416,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
             .execute();
 
     List<DeleteFile> newDeleteFiles = except(deleteFiles(table), deleteFiles);
-    assertThat(newDeleteFiles).as("Should have 2 new delete files").size().isZero();
+    assertThat(newDeleteFiles).as("Should have 2 new delete files").hasSize(0);
 
     List<DeleteFile> expectedRewrittenFiles =
         filterFiles(table, deleteFiles, ImmutableList.of(0), ImmutableList.of(1));
@@ -798,7 +798,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     Set<String> rewrittenPaths =
         rewritten.stream().map(f -> f.path().toString()).collect(Collectors.toSet());
     rewrittenPaths.retainAll(originalPaths);
-    assertThat(rewrittenPaths).size().isZero();
+    assertThat(rewrittenPaths).hasSize(0);
   }
 
   private void assertLocallySorted(List<DeleteFile> deleteFiles) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkFileRewriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkFileRewriter.java
@@ -109,7 +109,7 @@ public class TestSparkFileRewriter extends TestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assertions.assertThat(groups).as("Must have 1 group").hasSize(1);
+    Assertions.assertThat(groups).as("Must have 1 group").size().isOne();
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
     Assertions.assertThat(group).as("Must rewrite 2 files").hasSize(2);
   }
@@ -128,9 +128,9 @@ public class TestSparkFileRewriter extends TestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assertions.assertThat(groups).as("Must have 1 group").hasSize(1);
+    Assertions.assertThat(groups).as("Must have 1 group").size().isOne();
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
-    Assertions.assertThat(group).as("Must rewrite 1 file").hasSize(1);
+    Assertions.assertThat(group).as("Must rewrite 1 file").size().isOne();
   }
 
   private void checkDataFileGroupWithEnoughFiles(SizeBasedDataRewriter rewriter) {
@@ -151,7 +151,7 @@ public class TestSparkFileRewriter extends TestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assertions.assertThat(groups).as("Must have 1 group").hasSize(1);
+    Assertions.assertThat(groups).as("Must have 1 group").size().isOne();
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
     Assertions.assertThat(group).as("Must rewrite 4 files").hasSize(4);
   }
@@ -171,7 +171,7 @@ public class TestSparkFileRewriter extends TestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assertions.assertThat(groups).as("Must have 1 group").hasSize(1);
+    Assertions.assertThat(groups).as("Must have 1 group").size().isOne();
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
     Assertions.assertThat(group).as("Must rewrite 3 files").hasSize(3);
   }
@@ -189,9 +189,9 @@ public class TestSparkFileRewriter extends TestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assertions.assertThat(groups).as("Must have 1 group").hasSize(1);
+    Assertions.assertThat(groups).as("Must have 1 group").size().isOne();
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
-    Assertions.assertThat(group).as("Must rewrite big file").hasSize(1);
+    Assertions.assertThat(group).as("Must rewrite big file").size().isOne();
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkFileRewriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkFileRewriter.java
@@ -109,7 +109,7 @@ public class TestSparkFileRewriter extends TestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assertions.assertThat(groups).as("Must have 1 group").size().isOne();
+    Assertions.assertThat(groups).as("Must have 1 group").hasSize(1);
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
     Assertions.assertThat(group).as("Must rewrite 2 files").hasSize(2);
   }
@@ -128,9 +128,9 @@ public class TestSparkFileRewriter extends TestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assertions.assertThat(groups).as("Must have 1 group").size().isOne();
+    Assertions.assertThat(groups).as("Must have 1 group").hasSize(1);
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
-    Assertions.assertThat(group).as("Must rewrite 1 file").size().isOne();
+    Assertions.assertThat(group).as("Must rewrite 1 file").hasSize(1);
   }
 
   private void checkDataFileGroupWithEnoughFiles(SizeBasedDataRewriter rewriter) {
@@ -151,7 +151,7 @@ public class TestSparkFileRewriter extends TestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assertions.assertThat(groups).as("Must have 1 group").size().isOne();
+    Assertions.assertThat(groups).as("Must have 1 group").hasSize(1);
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
     Assertions.assertThat(group).as("Must rewrite 4 files").hasSize(4);
   }
@@ -171,7 +171,7 @@ public class TestSparkFileRewriter extends TestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assertions.assertThat(groups).as("Must have 1 group").size().isOne();
+    Assertions.assertThat(groups).as("Must have 1 group").hasSize(1);
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
     Assertions.assertThat(group).as("Must rewrite 3 files").hasSize(3);
   }
@@ -189,9 +189,9 @@ public class TestSparkFileRewriter extends TestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assertions.assertThat(groups).as("Must have 1 group").size().isOne();
+    Assertions.assertThat(groups).as("Must have 1 group").hasSize(1);
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
-    Assertions.assertThat(group).as("Must rewrite big file").size().isOne();
+    Assertions.assertThat(group).as("Must rewrite big file").hasSize(1);
   }
 
   @Test


### PR DESCRIPTION
This PR contains the tests in spark/actions directory, now migrated to JUnit5.

Related to PR : #9341

Issue: #9086