### PR TITLE
Spark 3.5: Remove constructor from parameterized base class

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/CatalogTestBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/CatalogTestBase.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.spark;
 
 import java.nio.file.Path;
-import java.util.Map;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,7 +29,7 @@ public abstract class CatalogTestBase extends TestBaseWithCatalog {
 
   // these parameters are broken out to avoid changes that need to modify lots of test suites
   @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
-  public static Object[][] parameters() {
+  protected static Object[][] parameters() {
     return new Object[][] {
       {
         SparkCatalogConfig.HIVE.catalogName(),
@@ -51,12 +50,4 @@ public abstract class CatalogTestBase extends TestBaseWithCatalog {
   }
 
   @TempDir protected Path temp;
-
-  public CatalogTestBase(SparkCatalogConfig config) {
-    super(config);
-  }
-
-  public CatalogTestBase(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -37,7 +37,7 @@ import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 
 public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   @BeforeEach
@@ -50,7 +50,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeSchemaFailsWithoutWriterOption() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
@@ -82,7 +82,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
         .hasMessage("Field new_col not found in source schema");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeSchemaWithoutAcceptAnySchema() throws Exception {
     Dataset<Row> twoColDF =
         jsonToDF(
@@ -109,7 +109,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
             "Cannot write to `testhadoop`.`default`.`table`, the reason is too many data columns");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeSchemaSparkProperty() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
@@ -143,7 +143,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
         sql("select * from %s order by id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeSchemaIcebergProperty() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
@@ -177,7 +177,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
         sql("select * from %s order by id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testWriteWithCaseSensitiveOption() throws NoSuchTableException, ParseException {
     SparkSession sparkSession = spark.cloneSession();
     sparkSession

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -59,7 +59,7 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.io.TempDir;
 
 public class TestDataSourceOptions extends TestBaseWithCatalog {
@@ -84,7 +84,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
     currentSpark.stop();
   }
 
-  @Test
+  @TestTemplate
   public void testWriteFormatOptionOverridesTableProperties() throws IOException {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
@@ -114,7 +114,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testNoWriteFormatOption() throws IOException {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
@@ -139,7 +139,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testHadoopOptions() throws IOException {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
     Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
@@ -181,7 +181,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testSplitOptionsOverridesTableProperties() throws IOException {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
@@ -224,7 +224,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
         .isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testIncrementalScanOptions() throws IOException {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
@@ -315,7 +315,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
     assertThat(resultDf.count()).as("Unprocessed count should match record count").isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void testMetadataSplitSizeOptionOverrideTableProperties() throws IOException {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
@@ -355,7 +355,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
     assertThat(entriesDf.javaRDD().getNumPartitions()).as("Num partitions must match").isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultMetadataSplitSize() throws IOException {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
@@ -389,7 +389,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
     assertThat(partitionNum).as("Spark partitions should match").isEqualTo(expectedSplits);
   }
 
-  @Test
+  @TestTemplate
   public void testExtraSnapshotMetadata() throws IOException {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
     HadoopTables tables = new HadoopTables(CONF);
@@ -414,7 +414,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
         .containsEntry("another-key", "anotherValue");
   }
 
-  @Test
+  @TestTemplate
   public void testExtraSnapshotMetadataWithSQL() throws InterruptedException, IOException {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
     HadoopTables tables = new HadoopTables(CONF);
@@ -459,7 +459,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
         .containsEntry("another-key", "anotherValue");
   }
 
-  @Test
+  @TestTemplate
   public void testExtraSnapshotMetadataWithDelete()
       throws InterruptedException, NoSuchTableException {
     spark.sessionState().conf().setConfString("spark.sql.shuffle.partitions", "1");

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -48,7 +49,7 @@ import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.io.TempDir;
 
 public class TestMetadataTableReadableMetrics extends TestBaseWithCatalog {
@@ -78,9 +79,16 @@ public class TestMetadataTableReadableMetrics extends TestBaseWithCatalog {
           optional(8, "fixedCol", Types.FixedType.ofLength(3)),
           optional(9, "binaryCol", Types.BinaryType.get()));
 
-  public TestMetadataTableReadableMetrics() {
-    // only SparkCatalog supports metadata table sql queries
-    super(SparkCatalogConfig.HIVE);
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  protected static Object[][] parameters() {
+    return new Object[][] {
+      {
+        // only SparkCatalog supports metadata table sql queries
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        SparkCatalogConfig.HIVE.properties()
+      },
+    };
   }
 
   protected String tableName() {
@@ -190,7 +198,7 @@ public class TestMetadataTableReadableMetrics extends TestBaseWithCatalog {
     return record;
   }
 
-  @Test
+  @TestTemplate
   public void testPrimitiveColumns() throws Exception {
     Table table = createPrimitiveTable();
     DataFile dataFile = table.currentSnapshot().addedDataFiles(table.io()).iterator().next();
@@ -289,7 +297,7 @@ public class TestMetadataTableReadableMetrics extends TestBaseWithCatalog {
     assertEquals("Row should match for entries table", expected, entriesReadableMetrics);
   }
 
-  @Test
+  @TestTemplate
   public void testSelectPrimitiveValues() throws Exception {
     createPrimitiveTable();
 
@@ -328,7 +336,7 @@ public class TestMetadataTableReadableMetrics extends TestBaseWithCatalog {
         sql("SELECT readable_metrics.longCol.value_count, status FROM %s.entries", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testSelectNestedValues() throws Exception {
     createNestedTable();
 
@@ -349,7 +357,7 @@ public class TestMetadataTableReadableMetrics extends TestBaseWithCatalog {
         entriesReadableMetrics);
   }
 
-  @Test
+  @TestTemplate
   public void testNestedValues() throws Exception {
     Pair<Table, DataFile> table = createNestedTable();
     int longColId =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadMetrics.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadMetrics.java
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.execution.metric.SQLMetric;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import scala.collection.JavaConverters;
 
 public class TestSparkReadMetrics extends TestBaseWithCatalog {
@@ -40,7 +40,7 @@ public class TestSparkReadMetrics extends TestBaseWithCatalog {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testReadMetricsForV1Table() throws NoSuchTableException {
     sql(
         "CREATE TABLE %s (id BIGINT) USING iceberg TBLPROPERTIES ('format-version'='1')",
@@ -83,7 +83,7 @@ public class TestSparkReadMetrics extends TestBaseWithCatalog {
     assertThat(metricsMap.get("skippedDeleteFiles").value()).isEqualTo(0);
   }
 
-  @Test
+  @TestTemplate
   public void testReadMetricsForV2Table() throws NoSuchTableException {
     sql(
         "CREATE TABLE %s (id BIGINT) USING iceberg TBLPROPERTIES ('format-version'='2')",
@@ -127,7 +127,7 @@ public class TestSparkReadMetrics extends TestBaseWithCatalog {
     assertThat(metricsMap.get("skippedDeleteFiles").value()).isEqualTo(0);
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteMetrics() throws NoSuchTableException {
     sql(
         "CREATE TABLE %s (id BIGINT)"

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkStagedScan.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkStagedScan.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Table;
@@ -38,11 +37,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
 
 public class TestSparkStagedScan extends CatalogTestBase {
-
-  public TestSparkStagedScan(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
 
   @AfterEach
   public void removeTables() {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.spark.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Map;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
@@ -31,10 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 
 public class TestSparkTable extends CatalogTestBase {
-
-  public TestSparkTable(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
 
   @BeforeEach
   public void createTable() {


### PR DESCRIPTION
After reviewing/merging https://github.com/apache/iceberg/pull/9342 I realized that parameterized base classes should not have a constructor but rather have their parameters set via `@Parameter`. All other setup code should go into a `@BeforeEach` method to properly initialize the test environment