### PR TITLE
Core: Remove unused sourceTransform parameter in helper method

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -156,8 +156,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     return addField(null, term);
   }
 
-  private BaseUpdatePartitionSpec rewriteDeleteAndAddField(
-      PartitionField existing, String name, Pair<Integer, Transform<?, ?>> sourceTransform) {
+  private BaseUpdatePartitionSpec rewriteDeleteAndAddField(PartitionField existing, String name) {
     deletes.remove(existing.fieldId());
     if (name == null || existing.name().equals(name)) {
       return this;
@@ -180,7 +179,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     if (existing != null
         && deletes.contains(existing.fieldId())
         && existing.transform().equals(sourceTransform.second())) {
-      return rewriteDeleteAndAddField(existing, name, sourceTransform);
+      return rewriteDeleteAndAddField(existing, name);
     }
 
     Preconditions.checkArgument(


### PR DESCRIPTION
This change removes an unused `sourceTransform` parameter in a helper method in the implementation of `UpdatePartitionSpec`.