### PR TITLE
Spark 3.5: Support filtering with buckets in RewriteDataFilesProcedure

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -873,6 +873,19 @@ acceptedBreaks:
       new: "method void org.apache.iceberg.encryption.Ciphers::<init>()"
       justification: "Static utility class - should not have public constructor"
   "1.4.0":
+    org.apache.iceberg:iceberg-api:
+    - code: "java.method.addedToInterface"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::partitionFilter(org.apache.iceberg.expressions.Expression)"
+      justification: "add partitionFilter interface"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.actions.RewriteDataFiles org.apache.iceberg.actions.RewriteDataFiles::partitionFilter(org.apache.iceberg.expressions.Expression)"
+      justification: "add partitionFilter interface"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.expressions.Expression org.apache.iceberg.Scan<ThisT,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::partitionFilter()"
+      justification: "add partitionFilter interface"
     org.apache.iceberg:iceberg-core:
     - code: "java.class.defaultSerializationChanged"
       old: "class org.apache.iceberg.mapping.NameMapping"

--- a/api/src/main/java/org/apache/iceberg/BatchScanAdapter.java
+++ b/api/src/main/java/org/apache/iceberg/BatchScanAdapter.java
@@ -104,6 +104,16 @@ class BatchScanAdapter implements BatchScan {
   }
 
   @Override
+  public BatchScan partitionFilter(Expression expr) {
+    return new BatchScanAdapter(scan.partitionFilter(expr));
+  }
+
+  @Override
+  public Expression partitionFilter() {
+    return scan.partitionFilter();
+  }
+
+  @Override
   public BatchScan ignoreResiduals() {
     return new BatchScanAdapter(scan.ignoreResiduals());
   }

--- a/api/src/main/java/org/apache/iceberg/Scan.java
+++ b/api/src/main/java/org/apache/iceberg/Scan.java
@@ -127,6 +127,10 @@ public interface Scan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>> {
    */
   Expression filter();
 
+  ThisT partitionFilter(Expression expr);
+
+  Expression partitionFilter();
+
   /**
    * Create a new scan from this that applies data filtering to files but not to rows in those
    * files.

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -171,6 +171,10 @@ public interface RewriteDataFiles
    */
   RewriteDataFiles filter(Expression expression);
 
+  default RewriteDataFiles partitionFilter(Expression expression) {
+    throw new UnsupportedOperationException("Partition Filter not implemented for this framework");
+  }
+
   /**
    * A map of file group information to the results of rewriting that file group. If the results are
    * null then that particular file group failed. We should only have failed groups if partial

--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -201,6 +201,17 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
   }
 
   @Override
+  public ThisT partitionFilter(Expression expr) {
+    return newRefinedScan(
+        table, schema, context.filterPartitions(Expressions.and(context.partitionFilter(), expr)));
+  }
+
+  @Override
+  public Expression partitionFilter() {
+    return context().partitionFilter();
+  }
+
+  @Override
   public ThisT ignoreResiduals() {
     return newRefinedScan(table, schema, context.ignoreResiduals(true));
   }

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -74,6 +74,7 @@ public class DataTableScan extends BaseTableScan {
             .caseSensitive(isCaseSensitive())
             .select(scanColumns())
             .filterData(filter())
+            .filterPartitions(partitionFilter())
             .specsById(table().specs())
             .scanMetrics(scanMetrics())
             .ignoreDeleted()

--- a/core/src/main/java/org/apache/iceberg/TableScanContext.java
+++ b/core/src/main/java/org/apache/iceberg/TableScanContext.java
@@ -46,6 +46,11 @@ abstract class TableScanContext {
   }
 
   @Value.Default
+  public Expression partitionFilter() {
+    return Expressions.alwaysTrue();
+  }
+
+  @Value.Default
   public boolean ignoreResiduals() {
     return false;
   }
@@ -109,6 +114,10 @@ abstract class TableScanContext {
 
   TableScanContext filterRows(Expression filter) {
     return ImmutableTableScanContext.builder().from(this).rowFilter(filter).build();
+  }
+
+  TableScanContext filterPartitions(Expression filter) {
+    return ImmutableTableScanContext.builder().from(this).partitionFilter(filter).build();
   }
 
   TableScanContext ignoreResiduals(boolean shouldIgnoreResiduals) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -89,6 +89,7 @@ public class RewriteDataFilesSparkAction
   private final Table table;
 
   private Expression filter = Expressions.alwaysTrue();
+  private Expression partitionFilter = Expressions.alwaysTrue();
   private int maxConcurrentFileGroupRewrites;
   private int maxCommits;
   private boolean partialProgressEnabled;
@@ -147,6 +148,12 @@ public class RewriteDataFilesSparkAction
   }
 
   @Override
+  public RewriteDataFilesSparkAction partitionFilter(Expression expression) {
+    partitionFilter = Expressions.and(partitionFilter, expression);
+    return this;
+  }
+
+  @Override
   public RewriteDataFiles.Result execute() {
     if (table.currentSnapshot() == null) {
       return EMPTY_RESULT;
@@ -185,6 +192,7 @@ public class RewriteDataFilesSparkAction
             .newScan()
             .useSnapshot(startingSnapshotId)
             .filter(filter)
+            .partitionFilter(partitionFilter)
             .ignoreResiduals()
             .planFiles();
 


### PR DESCRIPTION
This adds support of filtering with buckets in RewriteDataFilesProcedure. For this support, I add a method `partitionFilter` to the `Scan` interface, which can be submitted in a separate PR if you think it's a good approach.