### PR TITLE
Spark 3.5: Set log level to WARN for rewrite task failure with partial progress

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -345,7 +345,7 @@ public class RewriteDataFilesSparkAction
         .noRetry()
         .onFailure(
             (fileGroup, exception) -> {
-              LOG.error("Failure during rewrite group {}", fileGroup.info(), exception);
+              LOG.warn("Failure during rewrite group {}", fileGroup.info(), exception);
               rewriteFailures.add(
                   ImmutableRewriteDataFiles.FileGroupFailureResult.builder()
                       .info(fileGroup.info())

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
@@ -303,7 +303,7 @@ public class RewritePositionDeleteFilesSparkAction
         .noRetry()
         .onFailure(
             (fileGroup, exception) ->
-                LOG.error("Failure during rewrite group {}", fileGroup.info(), exception))
+                LOG.warn("Failure during rewrite group {}", fileGroup.info(), exception))
         .run(fileGroup -> commitService.offer(rewriteDeleteFiles(ctx, fileGroup)));
     rewriteService.shutdown();
 


### PR DESCRIPTION
Even the rewrite task failure without partial progress is logged as a WARN. It shouldn't be an ERROR with partial progress.