### PR TITLE
Core: Fix ParallelIterable memory leak where queue continues to be populated even after iterator close 

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
+++ b/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
@@ -67,6 +67,12 @@ public class ParallelIterable<T> extends CloseableGroup implements CloseableIter
                             try (Closeable ignored =
                                 (iterable instanceof Closeable) ? (Closeable) iterable : () -> {}) {
                               for (T item : iterable) {
+                                // exit manually because `ConcurrentLinkedQueue` can't be
+                                // interrupted
+                                if (closed) {
+                                  return;
+                                }
+
                                 queue.add(item);
                               }
                             } catch (IOException e) {


### PR DESCRIPTION
This patch is a part for fix #7843 , we will need to add `BlockingParallelIterable` to fix the whole problem.