### PR TITLE
Spark 3.5: Remaining tests migrated to Junit5 

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
@@ -18,10 +18,11 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Assert;
 
 public final class TaskCheckHelper {
   private TaskCheckHelper() {}
@@ -31,8 +32,9 @@ public final class TaskCheckHelper {
     List<FileScanTask> expectedTasks = getFileScanTasksInFilePathOrder(expected);
     List<FileScanTask> actualTasks = getFileScanTasksInFilePathOrder(actual);
 
-    Assert.assertEquals(
-        "The number of file scan tasks should match", expectedTasks.size(), actualTasks.size());
+    assertThat(actualTasks)
+        .as("The number of file scan tasks should match")
+        .hasSameSizeAs(expectedTasks);
 
     for (int i = 0; i < expectedTasks.size(); i++) {
       FileScanTask expectedTask = expectedTasks.get(i);
@@ -45,60 +47,57 @@ public final class TaskCheckHelper {
     assertEquals(expected.file(), actual.file());
 
     // PartitionSpec implements its own equals method
-    Assert.assertEquals("PartitionSpec doesn't match", expected.spec(), actual.spec());
+    assertThat(actual.spec()).as("PartitionSpec doesn't match").isEqualTo(expected.spec());
 
-    Assert.assertEquals("starting position doesn't match", expected.start(), actual.start());
+    assertThat(actual.start()).as("starting position doesn't match").isEqualTo(expected.start());
 
-    Assert.assertEquals(
-        "the number of bytes to scan doesn't match", expected.start(), actual.start());
+    assertThat(actual.start())
+        .as("the number of bytes to scan doesn't match")
+        .isEqualTo(expected.start());
 
     // simplify comparison on residual expression via comparing toString
-    Assert.assertEquals(
-        "Residual expression doesn't match",
-        expected.residual().toString(),
-        actual.residual().toString());
+    assertThat(actual.residual().toString())
+        .as("Residual expression doesn't match")
+        .isEqualTo(expected.residual().toString());
   }
 
   public static void assertEquals(DataFile expected, DataFile actual) {
-    Assert.assertEquals("Should match the serialized record path", expected.path(), actual.path());
-    Assert.assertEquals(
-        "Should match the serialized record format", expected.format(), actual.format());
-    Assert.assertEquals(
-        "Should match the serialized record partition",
-        expected.partition().get(0, Object.class),
-        actual.partition().get(0, Object.class));
-    Assert.assertEquals(
-        "Should match the serialized record count", expected.recordCount(), actual.recordCount());
-    Assert.assertEquals(
-        "Should match the serialized record size",
-        expected.fileSizeInBytes(),
-        actual.fileSizeInBytes());
-    Assert.assertEquals(
-        "Should match the serialized record value counts",
-        expected.valueCounts(),
-        actual.valueCounts());
-    Assert.assertEquals(
-        "Should match the serialized record null value counts",
-        expected.nullValueCounts(),
-        actual.nullValueCounts());
-    Assert.assertEquals(
-        "Should match the serialized record lower bounds",
-        expected.lowerBounds(),
-        actual.lowerBounds());
-    Assert.assertEquals(
-        "Should match the serialized record upper bounds",
-        expected.upperBounds(),
-        actual.upperBounds());
-    Assert.assertEquals(
-        "Should match the serialized record key metadata",
-        expected.keyMetadata(),
-        actual.keyMetadata());
-    Assert.assertEquals(
-        "Should match the serialized record offsets",
-        expected.splitOffsets(),
-        actual.splitOffsets());
-    Assert.assertEquals(
-        "Should match the serialized record offsets", expected.keyMetadata(), actual.keyMetadata());
+    assertThat(actual.path())
+        .as("Should match the serialized record path")
+        .isEqualTo(expected.path());
+    assertThat(actual.format())
+        .as("Should match the serialized record format")
+        .isEqualTo(expected.format());
+    assertThat(actual.partition().get(0, Object.class))
+        .as("Should match the serialized record partition")
+        .isEqualTo(expected.partition().get(0, Object.class));
+    assertThat(actual.recordCount())
+        .as("Should match the serialized record count")
+        .isEqualTo(expected.recordCount());
+    assertThat(actual.fileSizeInBytes())
+        .as("Should match the serialized record size")
+        .isEqualTo(expected.fileSizeInBytes());
+    assertThat(actual.valueCounts())
+        .as("Should match the serialized record value counts")
+        .isEqualTo(expected.valueCounts());
+    assertThat(actual.nullValueCounts())
+        .as("Should match the serialized record null value counts")
+        .isEqualTo(expected.nullValueCounts());
+    assertThat(actual.lowerBounds())
+        .as("Should match the serialized record lower bounds")
+        .isEqualTo(expected.lowerBounds());
+    assertThat(actual.upperBounds())
+        .as("Should match the serialized record upper bounds")
+        .isEqualTo(expected.upperBounds());
+    assertThat(actual.keyMetadata())
+        .as("Should match the serialized record key metadata")
+        .isEqualTo(expected.keyMetadata());
+    assertThat(actual.splitOffsets())
+        .as("Should match the serialized record offsets")
+        .isEqualTo(expected.splitOffsets());
+    assertThat(actual.keyMetadata())
+        .as("Should match the serialized record offsets")
+        .isEqualTo(expected.keyMetadata());
   }
 
   private static List<FileScanTask> getFileScanTasksInFilePathOrder(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestHadoopMetricsContextSerialization.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestHadoopMetricsContextSerialization.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.hadoop.HadoopMetricsContext;
 import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestHadoopMetricsContextSerialization {
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
@@ -31,6 +32,7 @@ import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -39,21 +41,18 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TestScanTaskSerialization extends SparkTestBase {
+public class TestScanTaskSerialization extends TestBase {
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
@@ -62,13 +61,13 @@ public class TestScanTaskSerialization extends SparkTestBase {
           optional(2, "c2", Types.StringType.get()),
           optional(3, "c3", Types.StringType.get()));
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private String tableLocation = null;
 
-  @Before
+  @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.newFolder();
+    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.tableLocation = tableDir.toURI().toString();
   }
 
@@ -76,8 +75,8 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseCombinedScanTaskKryoSerialization() throws Exception {
     BaseCombinedScanTask scanTask = prepareBaseCombinedScanTaskForSerDeTest();
 
-    File data = temp.newFile();
-    Assert.assertTrue(data.delete());
+    File data = File.createTempFile("junit", null, temp.toFile());
+    assertThat(data.delete()).isTrue();
     Kryo kryo = new KryoSerializer(new SparkConf()).newKryo();
 
     try (Output out = new Output(new FileOutputStream(data))) {
@@ -86,7 +85,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
 
     try (Input in = new Input(new FileInputStream(data))) {
       Object obj = kryo.readClassAndObject(in);
-      Assertions.assertThat(obj)
+      assertThat(obj)
           .as("Should be a BaseCombinedScanTask")
           .isInstanceOf(BaseCombinedScanTask.class);
       TaskCheckHelper.assertEquals(scanTask, (BaseCombinedScanTask) obj);
@@ -105,7 +104,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
     try (ObjectInputStream in =
         new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       Object obj = in.readObject();
-      Assertions.assertThat(obj)
+      assertThat(obj)
           .as("Should be a BaseCombinedScanTask")
           .isInstanceOf(BaseCombinedScanTask.class);
       TaskCheckHelper.assertEquals(scanTask, (BaseCombinedScanTask) obj);
@@ -117,10 +116,10 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseScanTaskGroupKryoSerialization() throws Exception {
     BaseScanTaskGroup<FileScanTask> taskGroup = prepareBaseScanTaskGroupForSerDeTest();
 
-    Assert.assertTrue("Task group can't be empty", !taskGroup.tasks().isEmpty());
+    assertThat(taskGroup.tasks()).as("Task group can't be empty").isNotEmpty();
 
-    File data = temp.newFile();
-    Assert.assertTrue(data.delete());
+    File data = File.createTempFile("junit", null, temp.toFile());
+    assertThat(data.delete()).isTrue();
     Kryo kryo = new KryoSerializer(new SparkConf()).newKryo();
 
     try (Output out = new Output(Files.newOutputStream(data.toPath()))) {
@@ -129,9 +128,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
 
     try (Input in = new Input(Files.newInputStream(data.toPath()))) {
       Object obj = kryo.readClassAndObject(in);
-      Assertions.assertThat(obj)
-          .as("should be a BaseScanTaskGroup")
-          .isInstanceOf(BaseScanTaskGroup.class);
+      assertThat(obj).as("should be a BaseScanTaskGroup").isInstanceOf(BaseScanTaskGroup.class);
       TaskCheckHelper.assertEquals(taskGroup, (BaseScanTaskGroup<FileScanTask>) obj);
     }
   }
@@ -141,7 +138,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseScanTaskGroupJavaSerialization() throws Exception {
     BaseScanTaskGroup<FileScanTask> taskGroup = prepareBaseScanTaskGroupForSerDeTest();
 
-    Assert.assertTrue("Task group can't be empty", !taskGroup.tasks().isEmpty());
+    assertThat(taskGroup.tasks()).as("Task group can't be empty").isNotEmpty();
 
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
@@ -151,9 +148,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
     try (ObjectInputStream in =
         new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       Object obj = in.readObject();
-      Assertions.assertThat(obj)
-          .as("should be a BaseScanTaskGroup")
-          .isInstanceOf(BaseScanTaskGroup.class);
+      assertThat(obj).as("should be a BaseScanTaskGroup").isInstanceOf(BaseScanTaskGroup.class);
       TaskCheckHelper.assertEquals(taskGroup, (BaseScanTaskGroup<FileScanTask>) obj);
     }
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.hadoop.HadoopTables;
@@ -48,14 +49,13 @@ import org.junit.jupiter.api.io.TempDir;
 public class TestTableSerialization {
 
   @Parameters(name = "isObjectStoreEnabled = {0}")
-  public static Object[][] parameters() {
-    return new Object[][] {{"true"}, {"false"}};
+  public static List<String> parameters() {
+    return Arrays.asList("true", "false");
   }
 
   private static final HadoopTables TABLES = new HadoopTables();
 
-  @Parameter
-  private String isObjectStoreEnabled;
+  @Parameter private String isObjectStoreEnabled;
 
   private static final Schema SCHEMA =
       new Schema(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -54,7 +54,7 @@ public class TestTableSerialization {
 
   private static final HadoopTables TABLES = new HadoopTables();
 
-  @Parameter(index = 0)
+  @Parameter
   private String isObjectStoreEnabled;
 
   private static final Schema SCHEMA =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/ValidationHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/ValidationHelpers.java
@@ -18,11 +18,12 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.assertj.core.api.Assertions;
 
 public class ValidationHelpers {
 
@@ -72,6 +73,6 @@ public class ValidationHelpers {
 
   private static <T> void assertSameElements(String context, List<T> actual, List<T> expected) {
     String errorMessage = String.format("%s must match", context);
-    Assertions.assertThat(actual).as(errorMessage).hasSameElementsAs(expected);
+    assertThat(actual).as(errorMessage).hasSameElementsAs(expected);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -53,7 +54,6 @@ import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.util.QueryExecutionListener;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -127,9 +127,9 @@ public abstract class TestBase extends SparkTestHelperBase {
 
   protected Object scalarSql(String query, Object... args) {
     List<Object[]> rows = sql(query, args);
-    Assertions.assertThat(rows.size()).as("Scalar SQL should return one row").isEqualTo(1);
+    assertThat(rows.size()).as("Scalar SQL should return one row").isEqualTo(1);
     Object[] row = Iterables.getOnlyElement(rows);
-    Assertions.assertThat(row.length).as("Scalar SQL should return one value").isEqualTo(1);
+    assertThat(row.length).as("Scalar SQL should return one value").isEqualTo(1);
     return row[0];
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBaseWithCatalog.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBaseWithCatalog.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
@@ -35,7 +37,6 @@ import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.util.PropertyUtil;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,7 +61,7 @@ public abstract class TestBaseWithCatalog extends TestBase {
   @BeforeAll
   public static void createWarehouse() throws IOException {
     TestBaseWithCatalog.warehouse = File.createTempFile("warehouse", null);
-    Assertions.assertThat(warehouse.delete()).isTrue();
+    assertThat(warehouse.delete()).isTrue();
   }
 
   @AfterAll
@@ -68,9 +69,7 @@ public abstract class TestBaseWithCatalog extends TestBase {
     if (warehouse != null && warehouse.exists()) {
       Path warehousePath = new Path(warehouse.getAbsolutePath());
       FileSystem fs = warehousePath.getFileSystem(hiveConf);
-      Assertions.assertThat(fs.delete(warehousePath, true))
-          .as("Failed to delete " + warehousePath)
-          .isTrue();
+      assertThat(fs.delete(warehousePath, true)).as("Failed to delete " + warehousePath).isTrue();
     }
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
@@ -197,9 +197,9 @@ public class TestChangelogIterator extends SparkTestHelperBase {
         ChangelogIterator.computeUpdates(rowsWithDuplication.iterator(), SCHEMA, IDENTIFIER_FIELDS);
 
     assertThatThrownBy(() -> Lists.newArrayList(iterator))
-        .as(
-            "Cannot compute updates because there are multiple rows with the same identifier fields([id, name]). Please make sure the rows are unique.")
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Cannot compute updates because there are multiple rows with the same identifier fields([id,name]). Please make sure the rows are unique.");
 
     // still allow extra insert rows
     rowsWithDuplication =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
@@ -18,7 +18,8 @@
  */
 package org.apache.iceberg.spark;
 
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,8 +34,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestChangelogIterator extends SparkTestHelperBase {
   private static final String DELETE = ChangelogOperation.DELETE.name();
@@ -78,7 +78,7 @@ public class TestChangelogIterator extends SparkTestHelperBase {
         Arrays.asList(RowType.DELETED, RowType.INSERTED, RowType.CARRY_OVER, RowType.UPDATED),
         0,
         permutations);
-    Assert.assertEquals(24, permutations.size());
+    assertThat(permutations).hasSize(24);
 
     for (Object[] permutation : permutations) {
       validate(permutation);
@@ -196,10 +196,10 @@ public class TestChangelogIterator extends SparkTestHelperBase {
     Iterator<Row> iterator =
         ChangelogIterator.computeUpdates(rowsWithDuplication.iterator(), SCHEMA, IDENTIFIER_FIELDS);
 
-    assertThrows(
-        "Cannot compute updates because there are multiple rows with the same identifier fields([id, name]). Please make sure the rows are unique.",
-        IllegalStateException.class,
-        () -> Lists.newArrayList(iterator));
+    assertThatThrownBy(() -> Lists.newArrayList(iterator))
+        .as(
+            "Cannot compute updates because there are multiple rows with the same identifier fields([id, name]). Please make sure the rows are unique.")
+        .isInstanceOf(IllegalStateException.class);
 
     // still allow extra insert rows
     rowsWithDuplication =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestFunctionCatalog.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestFunctionCatalog.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.spark;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.functions.IcebergVersionFunction;
@@ -27,64 +30,63 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.connector.catalog.FunctionCatalog;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
-import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
 
-public class TestFunctionCatalog extends SparkTestBaseWithCatalog {
+public class TestFunctionCatalog extends TestBaseWithCatalog {
   private static final String[] EMPTY_NAMESPACE = new String[] {};
   private static final String[] SYSTEM_NAMESPACE = new String[] {"system"};
   private static final String[] DEFAULT_NAMESPACE = new String[] {"default"};
   private static final String[] DB_NAMESPACE = new String[] {"db"};
-  private final FunctionCatalog asFunctionCatalog;
+  private FunctionCatalog asFunctionCatalog;
 
-  public TestFunctionCatalog() {
+  @BeforeEach
+  public void before() {
+    super.before();
     this.asFunctionCatalog = castToFunctionCatalog(catalogName);
+    createDefaultNamespace();
   }
 
-  @Before
   public void createDefaultNamespace() {
     sql("CREATE NAMESPACE IF NOT EXISTS %s", catalogName + ".default");
   }
 
-  @After
+  @AfterEach
   public void dropDefaultNamespace() {
     sql("DROP NAMESPACE IF EXISTS %s", catalogName + ".default");
   }
 
-  @Test
+  @TestTemplate
   public void testListFunctionsViaCatalog() throws NoSuchNamespaceException {
-    Assertions.assertThat(asFunctionCatalog.listFunctions(EMPTY_NAMESPACE))
+    assertThat(asFunctionCatalog.listFunctions(EMPTY_NAMESPACE))
         .anyMatch(func -> "iceberg_version".equals(func.name()));
 
-    Assertions.assertThat(asFunctionCatalog.listFunctions(SYSTEM_NAMESPACE))
+    assertThat(asFunctionCatalog.listFunctions(SYSTEM_NAMESPACE))
         .anyMatch(func -> "iceberg_version".equals(func.name()));
 
-    Assert.assertArrayEquals(
-        "Listing functions in an existing namespace that's not system should not throw",
-        new Identifier[0],
-        asFunctionCatalog.listFunctions(DEFAULT_NAMESPACE));
+    assertThat(asFunctionCatalog.listFunctions(DEFAULT_NAMESPACE))
+        .as("Listing functions in an existing namespace that's not system should not throw")
+        .isEqualTo(new Identifier[0]);
 
-    Assertions.assertThatThrownBy(() -> asFunctionCatalog.listFunctions(DB_NAMESPACE))
+    assertThatThrownBy(() -> asFunctionCatalog.listFunctions(DB_NAMESPACE))
         .isInstanceOf(NoSuchNamespaceException.class)
         .hasMessageStartingWith("[SCHEMA_NOT_FOUND] The schema `db` cannot be found.");
   }
 
-  @Test
+  @TestTemplate
   public void testLoadFunctions() throws NoSuchFunctionException {
     for (String[] namespace : ImmutableList.of(EMPTY_NAMESPACE, SYSTEM_NAMESPACE)) {
       Identifier identifier = Identifier.of(namespace, "iceberg_version");
       UnboundFunction func = asFunctionCatalog.loadFunction(identifier);
 
-      Assertions.assertThat(func)
+      assertThat(func)
           .isNotNull()
           .isInstanceOf(UnboundFunction.class)
           .isExactlyInstanceOf(IcebergVersionFunction.class);
     }
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 asFunctionCatalog.loadFunction(Identifier.of(DEFAULT_NAMESPACE, "iceberg_version")))
         .isInstanceOf(NoSuchFunctionException.class)
@@ -92,42 +94,42 @@ public class TestFunctionCatalog extends SparkTestBaseWithCatalog {
             "[ROUTINE_NOT_FOUND] The function default.iceberg_version cannot be found.");
 
     Identifier undefinedFunction = Identifier.of(SYSTEM_NAMESPACE, "undefined_function");
-    Assertions.assertThatThrownBy(() -> asFunctionCatalog.loadFunction(undefinedFunction))
+    assertThatThrownBy(() -> asFunctionCatalog.loadFunction(undefinedFunction))
         .isInstanceOf(NoSuchFunctionException.class)
         .hasMessageStartingWith(
             "[ROUTINE_NOT_FOUND] The function system.undefined_function cannot be found.");
 
-    Assertions.assertThatThrownBy(() -> sql("SELECT undefined_function(1, 2)"))
+    assertThatThrownBy(() -> sql("SELECT undefined_function(1, 2)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
             "[UNRESOLVED_ROUTINE] Cannot resolve function `undefined_function` on search path");
   }
 
-  @Test
+  @TestTemplate
   public void testCallingFunctionInSQLEndToEnd() {
     String buildVersion = IcebergBuild.version();
 
-    Assert.assertEquals(
-        "Should be able to use the Iceberg version function from the fully qualified system namespace",
-        buildVersion,
-        scalarSql("SELECT %s.system.iceberg_version()", catalogName));
+    assertThat(scalarSql("SELECT %s.system.iceberg_version()", catalogName))
+        .as(
+            "Should be able to use the Iceberg version function from the fully qualified system namespace")
+        .isEqualTo(buildVersion);
 
-    Assert.assertEquals(
-        "Should be able to use the Iceberg version function when fully qualified without specifying a namespace",
-        buildVersion,
-        scalarSql("SELECT %s.iceberg_version()", catalogName));
+    assertThat(scalarSql("SELECT %s.iceberg_version()", catalogName))
+        .as(
+            "Should be able to use the Iceberg version function when fully qualified without specifying a namespace")
+        .isEqualTo(buildVersion);
 
     sql("USE %s", catalogName);
 
-    Assert.assertEquals(
-        "Should be able to call iceberg_version from system namespace without fully qualified name when using Iceberg catalog",
-        buildVersion,
-        scalarSql("SELECT system.iceberg_version()"));
+    assertThat(scalarSql("SELECT system.iceberg_version()"))
+        .as(
+            "Should be able to call iceberg_version from system namespace without fully qualified name when using Iceberg catalog")
+        .isEqualTo(buildVersion);
 
-    Assert.assertEquals(
-        "Should be able to call iceberg_version from empty namespace without fully qualified name when using Iceberg catalog",
-        buildVersion,
-        scalarSql("SELECT iceberg_version()"));
+    assertThat(scalarSql("SELECT iceberg_version()"))
+        .as(
+            "Should be able to call iceberg_version from empty namespace without fully qualified name when using Iceberg catalog")
+        .isEqualTo(buildVersion);
   }
 
   private FunctionCatalog castToFunctionCatalog(String name) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestFunctionCatalog.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestFunctionCatalog.java
@@ -45,10 +45,6 @@ public class TestFunctionCatalog extends TestBaseWithCatalog {
   public void before() {
     super.before();
     this.asFunctionCatalog = castToFunctionCatalog(catalogName);
-    createDefaultNamespace();
-  }
-
-  public void createDefaultNamespace() {
     sql("CREATE NAMESPACE IF NOT EXISTS %s", catalogName + ".default");
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
@@ -46,10 +46,10 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.types.Types;
-import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.Test;
 
 public class TestSpark3Util extends TestBase {
-  @TestTemplate
+  @Test
   public void testDescribeSortOrder() {
     Schema schema =
         new Schema(
@@ -96,7 +96,7 @@ public class TestSpark3Util extends TestBase {
         .isEqualTo("time ASC NULLS FIRST, data ASC NULLS LAST");
   }
 
-  @TestTemplate
+  @Test
   public void testDescribeSchema() {
     Schema schema =
         new Schema(
@@ -113,7 +113,7 @@ public class TestSpark3Util extends TestBase {
             "struct<data: list<string> not null,pairs: map<string, bigint>,time: timestamp not null>");
   }
 
-  @TestTemplate
+  @Test
   public void testLoadIcebergTable() throws Exception {
     spark.conf().set("spark.sql.catalog.hive", SparkCatalog.class.getName());
     spark.conf().set("spark.sql.catalog.hive.type", "hive");
@@ -126,7 +126,7 @@ public class TestSpark3Util extends TestBase {
     assertThat(table.name()).isEqualTo(tableFullName);
   }
 
-  @TestTemplate
+  @Test
   public void testLoadIcebergCatalog() throws Exception {
     spark.conf().set("spark.sql.catalog.test_cat", SparkCatalog.class.getName());
     spark.conf().set("spark.sql.catalog.test_cat.type", "hive");
@@ -136,7 +136,7 @@ public class TestSpark3Util extends TestBase {
         .isInstanceOf(CachingCatalog.class);
   }
 
-  @TestTemplate
+  @Test
   public void testDescribeExpression() {
     Expression refExpression = equal("id", 1);
     assertThat(Spark3Util.describe(refExpression)).isEqualTo("id = 1");

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
@@ -36,6 +36,7 @@ import static org.apache.iceberg.expressions.Expressions.truncate;
 import static org.apache.iceberg.expressions.Expressions.year;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.Schema;
@@ -45,61 +46,57 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.TestTemplate;
 
-public class TestSpark3Util extends SparkTestBase {
-  @Test
+public class TestSpark3Util extends TestBase {
+  @TestTemplate
   public void testDescribeSortOrder() {
     Schema schema =
         new Schema(
             required(1, "data", Types.StringType.get()),
             required(2, "time", Types.TimestampType.withoutZone()));
 
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "data DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("Identity", schema, 1)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "bucket(1, data) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("bucket[1]", schema, 1)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "truncate(data, 3) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("truncate[3]", schema, 1)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "years(time) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("year", schema, 2)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "months(time) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("month", schema, 2)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "days(time) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("day", schema, 2)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "hours(time) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("hour", schema, 2)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "unknown(data) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("unknown", schema, 1)));
+    assertThat(Spark3Util.describe(buildSortOrder("Identity", schema, 1)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("data DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("bucket[1]", schema, 1)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("bucket(1, data) DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("truncate[3]", schema, 1)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("truncate(data, 3) DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("year", schema, 2)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("years(time) DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("month", schema, 2)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("months(time) DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("day", schema, 2)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("days(time) DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("hour", schema, 2)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("hours(time) DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("unknown", schema, 1)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("unknown(data) DESC NULLS FIRST");
 
     // multiple sort orders
     SortOrder multiOrder =
         SortOrder.builderFor(schema).asc("time", NULLS_FIRST).asc("data", NULLS_LAST).build();
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "time ASC NULLS FIRST, data ASC NULLS LAST",
-        Spark3Util.describe(multiOrder));
+    assertThat(Spark3Util.describe(multiOrder))
+        .as("Sort order isn't correct.")
+        .isEqualTo("time ASC NULLS FIRST, data ASC NULLS LAST");
   }
 
-  @Test
+  @TestTemplate
   public void testDescribeSchema() {
     Schema schema =
         new Schema(
@@ -110,13 +107,13 @@ public class TestSpark3Util extends SparkTestBase {
                 Types.MapType.ofOptional(4, 5, Types.StringType.get(), Types.LongType.get())),
             required(6, "time", Types.TimestampType.withoutZone()));
 
-    Assert.assertEquals(
-        "Schema description isn't correct.",
-        "struct<data: list<string> not null,pairs: map<string, bigint>,time: timestamp not null>",
-        Spark3Util.describe(schema));
+    assertThat(Spark3Util.describe(schema))
+        .as("Schema description isn't correct.")
+        .isEqualTo(
+            "struct<data: list<string> not null,pairs: map<string, bigint>,time: timestamp not null>");
   }
 
-  @Test
+  @TestTemplate
   public void testLoadIcebergTable() throws Exception {
     spark.conf().set("spark.sql.catalog.hive", SparkCatalog.class.getName());
     spark.conf().set("spark.sql.catalog.hive.type", "hive");
@@ -126,45 +123,45 @@ public class TestSpark3Util extends SparkTestBase {
     sql("CREATE TABLE %s (c1 bigint, c2 string, c3 string) USING iceberg", tableFullName);
 
     Table table = Spark3Util.loadIcebergTable(spark, tableFullName);
-    Assert.assertTrue(table.name().equals(tableFullName));
+    assertThat(table.name()).isEqualTo(tableFullName);
   }
 
-  @Test
+  @TestTemplate
   public void testLoadIcebergCatalog() throws Exception {
     spark.conf().set("spark.sql.catalog.test_cat", SparkCatalog.class.getName());
     spark.conf().set("spark.sql.catalog.test_cat.type", "hive");
     Catalog catalog = Spark3Util.loadIcebergCatalog(spark, "test_cat");
-    Assert.assertTrue(
-        "Should retrieve underlying catalog class", catalog instanceof CachingCatalog);
+    assertThat(catalog)
+        .as("Should retrieve underlying catalog class")
+        .isInstanceOf(CachingCatalog.class);
   }
 
-  @Test
+  @TestTemplate
   public void testDescribeExpression() {
     Expression refExpression = equal("id", 1);
-    Assertions.assertThat(Spark3Util.describe(refExpression)).isEqualTo("id = 1");
+    assertThat(Spark3Util.describe(refExpression)).isEqualTo("id = 1");
 
     Expression yearExpression = greaterThan(year("ts"), 10);
-    Assertions.assertThat(Spark3Util.describe(yearExpression)).isEqualTo("year(ts) > 10");
+    assertThat(Spark3Util.describe(yearExpression)).isEqualTo("year(ts) > 10");
 
     Expression monthExpression = greaterThanOrEqual(month("ts"), 10);
-    Assertions.assertThat(Spark3Util.describe(monthExpression)).isEqualTo("month(ts) >= 10");
+    assertThat(Spark3Util.describe(monthExpression)).isEqualTo("month(ts) >= 10");
 
     Expression dayExpression = lessThan(day("ts"), 10);
-    Assertions.assertThat(Spark3Util.describe(dayExpression)).isEqualTo("day(ts) < 10");
+    assertThat(Spark3Util.describe(dayExpression)).isEqualTo("day(ts) < 10");
 
     Expression hourExpression = lessThanOrEqual(hour("ts"), 10);
-    Assertions.assertThat(Spark3Util.describe(hourExpression)).isEqualTo("hour(ts) <= 10");
+    assertThat(Spark3Util.describe(hourExpression)).isEqualTo("hour(ts) <= 10");
 
     Expression bucketExpression = in(bucket("id", 5), 3);
-    Assertions.assertThat(Spark3Util.describe(bucketExpression)).isEqualTo("bucket[5](id) IN (3)");
+    assertThat(Spark3Util.describe(bucketExpression)).isEqualTo("bucket[5](id) IN (3)");
 
     Expression truncateExpression = notIn(truncate("name", 3), "abc");
-    Assertions.assertThat(Spark3Util.describe(truncateExpression))
+    assertThat(Spark3Util.describe(truncateExpression))
         .isEqualTo("truncate[3](name) NOT IN ('abc')");
 
     Expression andExpression = and(refExpression, yearExpression);
-    Assertions.assertThat(Spark3Util.describe(andExpression))
-        .isEqualTo("(id = 1 AND year(ts) > 10)");
+    assertThat(Spark3Util.describe(andExpression)).isEqualTo("(id = 1 AND year(ts) > 10)");
   }
 
   private SortOrder buildSortOrder(String transform, Schema schema, int sourceId) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkCachedTableCatalog.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkCachedTableCatalog.java
@@ -18,32 +18,40 @@
  */
 package org.apache.iceberg.spark;
 
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
 
-public class TestSparkCachedTableCatalog extends SparkTestBaseWithCatalog {
+public class TestSparkCachedTableCatalog extends TestBaseWithCatalog {
 
   private static final SparkTableCache TABLE_CACHE = SparkTableCache.get();
 
-  @BeforeClass
+  @BeforeAll
   public static void setupCachedTableCatalog() {
     spark.conf().set("spark.sql.catalog.testcache", SparkCachedTableCatalog.class.getName());
   }
 
-  @AfterClass
+  @AfterAll
   public static void unsetCachedTableCatalog() {
     spark.conf().unset("spark.sql.catalog.testcache");
   }
 
-  public TestSparkCachedTableCatalog() {
-    super(SparkCatalogConfig.HIVE);
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  protected static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        SparkCatalogConfig.HIVE.properties()
+      },
+    };
   }
 
-  @Test
+  @TestTemplate
   public void testTimeTravel() {
     sql("CREATE TABLE %s (id INT, dep STRING) USING iceberg", tableName);
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkCompressionUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkCompressionUtil.java
@@ -34,15 +34,15 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.internal.config.package$;
 import org.apache.spark.sql.SparkSession;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkCompressionUtil {
 
   private SparkSession spark;
   private SparkConf sparkConf;
 
-  @Before
+  @BeforeEach
   public void initSpark() {
     this.spark = mock(SparkSession.class);
     this.sparkConf = mock(SparkConf.class);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
@@ -29,6 +29,7 @@ import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
 import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.DELETE;
 import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.MERGE;
 import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.UPDATE;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Table;
@@ -40,11 +41,10 @@ import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.expressions.SortDirection;
 import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
 
-public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatalog {
+public class TestSparkDistributionAndOrderingUtil extends TestBaseWithCatalog {
 
   private static final Distribution UNSPECIFIED_DISTRIBUTION = Distributions.unspecified();
   private static final Distribution FILE_CLUSTERED_DISTRIBUTION =
@@ -100,7 +100,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
             Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
       };
 
-  @After
+  @AfterEach
   public void dropTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
@@ -141,7 +141,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
   // write mode is HASH -> CLUSTER BY date + LOCALLY ORDER BY date, id
   // write mode is RANGE -> ORDER BY date, id
 
-  @Test
+  @TestTemplate
   public void testDefaultWriteUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -150,7 +150,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkWriteDistributionAndOrdering(table, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashWriteUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -161,7 +161,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkWriteDistributionAndOrdering(table, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeWriteUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -172,7 +172,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkWriteDistributionAndOrdering(table, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultWriteUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -191,7 +191,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testHashWriteUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -210,7 +210,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkWriteDistributionAndOrdering(table, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeWriteUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -231,7 +231,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultWritePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -260,7 +260,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkWriteDistributionAndOrdering(table, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashWritePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -291,7 +291,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkWriteDistributionAndOrdering(table, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeWritePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -320,7 +320,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkWriteDistributionAndOrdering(table, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultWritePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -343,7 +343,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testHashWritePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -371,7 +371,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeWritePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -436,7 +436,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
   // delete mode is HASH -> CLUSTER BY date + LOCALLY ORDER BY date, id
   // delete mode is RANGE -> ORDER BY date, id
 
-  @Test
+  @TestTemplate
   public void testDefaultCopyOnWriteDeleteUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -446,7 +446,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, FILE_CLUSTERED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneCopyOnWriteDeleteUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -458,7 +458,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashCopyOnWriteDeleteUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -470,7 +470,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, FILE_CLUSTERED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeCopyOnWriteDeleteUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -483,7 +483,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultCopyOnWriteDeleteUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -501,7 +501,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneCopyOnWriteDeleteUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -521,7 +521,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testHashCopyOnWriteDeleteUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -541,7 +541,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeCopyOnWriteDeleteUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -562,7 +562,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultCopyOnWriteDeletePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -591,7 +591,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneCopyOnWriteDeletePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -620,7 +620,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashCopyOnWriteDeletePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -651,7 +651,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeCopyOnWriteDeletePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -680,7 +680,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultCopyOnWriteDeletePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -704,7 +704,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneCopyOnWriteDeletePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -728,7 +728,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testHashCopyOnWriteDeletePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -756,7 +756,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeCopyOnWriteDeletePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -817,7 +817,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
   // update mode is HASH -> CLUSTER BY date + LOCALLY ORDER BY date, id
   // update mode is RANGE -> ORDER BY date, id
 
-  @Test
+  @TestTemplate
   public void testDefaultCopyOnWriteUpdateUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -827,7 +827,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, FILE_CLUSTERED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneCopyOnWriteUpdateUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -839,7 +839,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashCopyOnWriteUpdateUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -851,7 +851,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, FILE_CLUSTERED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeCopyOnWriteUpdateUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -864,7 +864,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultCopyOnWriteUpdateUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -882,7 +882,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneCopyOnWriteUpdateUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -902,7 +902,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testHashCopyOnWriteUpdateUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -922,7 +922,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeCopyOnWriteUpdateUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -943,7 +943,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultCopyOnWriteUpdatePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -972,7 +972,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneCopyOnWriteUpdatePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1001,7 +1001,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashCopyOnWriteUpdatePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1032,7 +1032,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeCopyOnWriteUpdatePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1061,7 +1061,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultCopyOnWriteUpdatePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1085,7 +1085,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneCopyOnWriteUpdatePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1109,7 +1109,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testHashCopyOnWriteUpdatePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1137,7 +1137,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeCopyOnWriteUpdatePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1198,7 +1198,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
   // merge mode is HASH -> CLUSTER BY date + LOCALLY ORDER BY date, id
   // merge mode is RANGE -> ORDERED BY date, id
 
-  @Test
+  @TestTemplate
   public void testDefaultCopyOnWriteMergeUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1207,7 +1207,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneCopyOnWriteMergeUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1218,7 +1218,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashCopyOnWriteMergeUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1229,7 +1229,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeCopyOnWriteMergeUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1240,7 +1240,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultCopyOnWriteMergeUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1259,7 +1259,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneCopyOnWriteMergeUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1279,7 +1279,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, MERGE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testHashCopyOnWriteMergeUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1299,7 +1299,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, MERGE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeCopyOnWriteMergeUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1320,7 +1320,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultCopyOnWriteMergePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1349,7 +1349,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneCopyOnWriteMergePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1377,7 +1377,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashCopyOnWriteMergePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1408,7 +1408,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeCopyOnWriteMergePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1437,7 +1437,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultCopyOnWriteMergePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1461,7 +1461,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneCopyOnWriteMergePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1485,7 +1485,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, MERGE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testHashCopyOnWriteMergePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1513,7 +1513,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testRangeCopyOnWriteMergePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1573,7 +1573,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
   //                         LOCALLY ORDERED BY _spec_id, _partition, _file, _pos
   // delete mode is RANGE (fanout) -> RANGE DISTRIBUTE BY _spec_id, _partition + empty ordering
 
-  @Test
+  @TestTemplate
   public void testDefaultPositionDeltaDeleteUnpartitionedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1593,7 +1593,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, SPEC_ID_PARTITION_FILE_CLUSTERED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNonePositionDeltaDeleteUnpartitionedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1612,7 +1612,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashPositionDeltaDeleteUnpartitionedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1634,7 +1634,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, SPEC_ID_PARTITION_FILE_CLUSTERED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangePositionDeltaDeleteUnpartitionedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1654,7 +1654,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, DELETE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultPositionDeltaDeletePartitionedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1678,7 +1678,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, SPEC_ID_PARTITION_CLUSTERED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNonePositionDeltaDeletePartitionedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1701,7 +1701,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashPositionDeltaDeletePartitionedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1727,7 +1727,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, DELETE, SPEC_ID_PARTITION_CLUSTERED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangePositionDeltaDeletePartitionedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -1814,7 +1814,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
   // update mode is RANGE -> RANGE DISTRIBUTE BY _spec_id, _partition, date, id +
   //                         LOCALLY ORDERED BY _spec_id, _partition, _file, _pos, date, id
 
-  @Test
+  @TestTemplate
   public void testDefaultPositionDeltaUpdateUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1834,7 +1834,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, SPEC_ID_PARTITION_FILE_CLUSTERED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNonePositionDeltaUpdateUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1853,7 +1853,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashPositionDeltaUpdateUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1875,7 +1875,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, SPEC_ID_PARTITION_FILE_CLUSTERED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangePositionDeltaUpdateUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1895,7 +1895,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, UPDATE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultPositionDeltaUpdateUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1921,7 +1921,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, SPEC_ID_PARTITION_FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testNonePositionDeltaUpdateUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1949,7 +1949,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testHashPositionDeltaUpdateUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -1977,7 +1977,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, SPEC_ID_PARTITION_FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testRangePositionDeltaUpdateUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -2018,7 +2018,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultPositionDeltaUpdatePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2061,7 +2061,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, UPDATE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNonePositionDeltaUpdatePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2098,7 +2098,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashPositionDeltaUpdatePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2143,7 +2143,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, UPDATE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangePositionDeltaUpdatePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2190,7 +2190,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, UPDATE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultPositionDeltaUpdatePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2230,7 +2230,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testNonePositionDeltaUpdatePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2263,7 +2263,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testHashPositionDeltaUpdatePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2305,7 +2305,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, UPDATE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testRangePositionDeltaUpdatePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2414,7 +2414,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
   // merge mode is RANGE -> RANGE DISTRIBUTE BY _spec_id, _partition, date, id
   //                        LOCALLY ORDERED BY _spec_id, _partition, _file, _pos, date, id
 
-  @Test
+  @TestTemplate
   public void testDefaultPositionDeltaMergeUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -2438,7 +2438,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, MERGE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNonePositionDeltaMergeUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -2457,7 +2457,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, MERGE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashPositionDeltaMergeUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -2483,7 +2483,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, MERGE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangePositionDeltaMergeUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -2512,7 +2512,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, MERGE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultPositionDeltaMergeUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -2545,7 +2545,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testNonePositionDeltaMergeUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -2573,7 +2573,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, MERGE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testHashPositionDeltaMergeUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -2608,7 +2608,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testRangePositionDeltaMergeUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -2648,7 +2648,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultPositionDeltaMergePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2690,7 +2690,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, MERGE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNonePositionDeltaMergePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2727,7 +2727,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, MERGE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testHashPositionDeltaMergePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2771,7 +2771,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, MERGE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testRangePositionDeltaMergePartitionedUnsortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2817,7 +2817,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, MERGE, expectedDistribution, EMPTY_ORDERING);
   }
 
-  @Test
+  @TestTemplate
   public void testNonePositionDeltaMergePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2849,7 +2849,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         table, MERGE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultPositionDeltaMergePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2888,7 +2888,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testHashPositionDeltaMergePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2929,7 +2929,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkPositionDeltaDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
   }
 
-  @Test
+  @TestTemplate
   public void testRangePositionDeltaMergePartitionedSortedTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
@@ -2978,10 +2978,10 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     SparkWriteRequirements requirements = writeConf.writeRequirements();
 
     Distribution distribution = requirements.distribution();
-    Assert.assertEquals("Distribution must match", expectedDistribution, distribution);
+    assertThat(distribution).as("Distribution must match").isEqualTo(expectedDistribution);
 
     SortOrder[] ordering = requirements.ordering();
-    Assert.assertArrayEquals("Ordering must match", expectedOrdering, ordering);
+    assertThat(ordering).as("Ordering must match").isEqualTo(expectedOrdering);
   }
 
   private void checkCopyOnWriteDistributionAndOrdering(
@@ -2994,10 +2994,10 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     SparkWriteRequirements requirements = writeConf.copyOnWriteRequirements(command);
 
     Distribution distribution = requirements.distribution();
-    Assert.assertEquals("Distribution must match", expectedDistribution, distribution);
+    assertThat(distribution).as("Distribution must match").isEqualTo(expectedDistribution);
 
     SortOrder[] ordering = requirements.ordering();
-    Assert.assertArrayEquals("Ordering must match", expectedOrdering, ordering);
+    assertThat(ordering).as("Ordering must match").isEqualTo(expectedOrdering);
   }
 
   private void checkPositionDeltaDistributionAndOrdering(
@@ -3010,10 +3010,10 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     SparkWriteRequirements requirements = writeConf.positionDeltaRequirements(command);
 
     Distribution distribution = requirements.distribution();
-    Assert.assertEquals("Distribution must match", expectedDistribution, distribution);
+    assertThat(distribution).as("Distribution must match").isEqualTo(expectedDistribution);
 
     SortOrder[] ordering = requirements.ordering();
-    Assert.assertArrayEquals("Ordering must match", expectedOrdering, ordering);
+    assertThat(ordering).as("Ordering must match").isEqualTo(expectedOrdering);
   }
 
   private void disableFanoutWriters(Table table) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -40,8 +42,7 @@ import org.apache.spark.sql.sources.IsNull;
 import org.apache.spark.sql.sources.LessThan;
 import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkFilters {
 
@@ -59,54 +60,61 @@ public class TestSparkFilters {
           IsNull isNull = IsNull.apply(quoted);
           Expression expectedIsNull = Expressions.isNull(unquoted);
           Expression actualIsNull = SparkFilters.convert(isNull);
-          Assert.assertEquals(
-              "IsNull must match", expectedIsNull.toString(), actualIsNull.toString());
+          assertThat(actualIsNull.toString())
+              .as("IsNull must match")
+              .isEqualTo(expectedIsNull.toString());
 
           IsNotNull isNotNull = IsNotNull.apply(quoted);
           Expression expectedIsNotNull = Expressions.notNull(unquoted);
           Expression actualIsNotNull = SparkFilters.convert(isNotNull);
-          Assert.assertEquals(
-              "IsNotNull must match", expectedIsNotNull.toString(), actualIsNotNull.toString());
+          assertThat(actualIsNotNull.toString())
+              .as("IsNotNull must match")
+              .isEqualTo(expectedIsNotNull.toString());
 
           LessThan lt = LessThan.apply(quoted, 1);
           Expression expectedLt = Expressions.lessThan(unquoted, 1);
           Expression actualLt = SparkFilters.convert(lt);
-          Assert.assertEquals("LessThan must match", expectedLt.toString(), actualLt.toString());
+          assertThat(actualLt.toString())
+              .as("LessThan must match")
+              .isEqualTo(expectedLt.toString());
 
           LessThanOrEqual ltEq = LessThanOrEqual.apply(quoted, 1);
           Expression expectedLtEq = Expressions.lessThanOrEqual(unquoted, 1);
           Expression actualLtEq = SparkFilters.convert(ltEq);
-          Assert.assertEquals(
-              "LessThanOrEqual must match", expectedLtEq.toString(), actualLtEq.toString());
+          assertThat(actualLtEq.toString())
+              .as("LessThanOrEqual must match")
+              .isEqualTo(expectedLtEq.toString());
 
           GreaterThan gt = GreaterThan.apply(quoted, 1);
           Expression expectedGt = Expressions.greaterThan(unquoted, 1);
           Expression actualGt = SparkFilters.convert(gt);
-          Assert.assertEquals("GreaterThan must match", expectedGt.toString(), actualGt.toString());
+          assertThat(actualGt.toString())
+              .as("GreaterThan must match")
+              .isEqualTo(expectedGt.toString());
 
           GreaterThanOrEqual gtEq = GreaterThanOrEqual.apply(quoted, 1);
           Expression expectedGtEq = Expressions.greaterThanOrEqual(unquoted, 1);
           Expression actualGtEq = SparkFilters.convert(gtEq);
-          Assert.assertEquals(
-              "GreaterThanOrEqual must match", expectedGtEq.toString(), actualGtEq.toString());
+          assertThat(actualGtEq.toString())
+              .as("GreaterThanOrEqual must match")
+              .isEqualTo(expectedGtEq.toString());
 
           EqualTo eq = EqualTo.apply(quoted, 1);
           Expression expectedEq = Expressions.equal(unquoted, 1);
           Expression actualEq = SparkFilters.convert(eq);
-          Assert.assertEquals("EqualTo must match", expectedEq.toString(), actualEq.toString());
+          assertThat(actualEq.toString()).as("EqualTo must match").isEqualTo(expectedEq.toString());
 
           EqualNullSafe eqNullSafe = EqualNullSafe.apply(quoted, 1);
           Expression expectedEqNullSafe = Expressions.equal(unquoted, 1);
           Expression actualEqNullSafe = SparkFilters.convert(eqNullSafe);
-          Assert.assertEquals(
-              "EqualNullSafe must match",
-              expectedEqNullSafe.toString(),
-              actualEqNullSafe.toString());
+          assertThat(actualEqNullSafe.toString())
+              .as("EqualNullSafe must match")
+              .isEqualTo(expectedEqNullSafe.toString());
 
           In in = In.apply(quoted, new Integer[] {1});
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkFilters.convert(in);
-          Assert.assertEquals("In must match", expectedIn.toString(), actualIn.toString());
+          assertThat(actualIn.toString()).as("In must match").isEqualTo(expectedIn.toString());
         });
   }
 
@@ -120,14 +128,13 @@ public class TestSparkFilters {
     Expression timestampExpression = SparkFilters.convert(GreaterThan.apply("x", timestamp));
     Expression rawExpression = Expressions.greaterThan("x", epochMicros);
 
-    Assert.assertEquals(
-        "Generated Timestamp expression should be correct",
-        rawExpression.toString(),
-        timestampExpression.toString());
-    Assert.assertEquals(
-        "Generated Instant expression should be correct",
-        rawExpression.toString(),
-        instantExpression.toString());
+    assertThat(timestampExpression.toString())
+        .as("Generated Timestamp expression should be correct")
+        .isEqualTo(rawExpression.toString());
+
+    assertThat(instantExpression.toString())
+        .as("Generated Instant expression should be correct")
+        .isEqualTo(rawExpression.toString());
   }
 
   @Test
@@ -139,10 +146,9 @@ public class TestSparkFilters {
     Expression instantExpression = SparkFilters.convert(GreaterThan.apply("x", ldt));
     Expression rawExpression = Expressions.greaterThan("x", epochMicros);
 
-    Assert.assertEquals(
-        "Generated Instant expression should be correct",
-        rawExpression.toString(),
-        instantExpression.toString());
+    assertThat(instantExpression.toString())
+        .as("Generated Instant expression should be correct")
+        .isEqualTo(rawExpression.toString());
   }
 
   @Test
@@ -155,15 +161,13 @@ public class TestSparkFilters {
     Expression dateExpression = SparkFilters.convert(GreaterThan.apply("x", date));
     Expression rawExpression = Expressions.greaterThan("x", epochDay);
 
-    Assert.assertEquals(
-        "Generated localdate expression should be correct",
-        rawExpression.toString(),
-        localDateExpression.toString());
+    assertThat(localDateExpression.toString())
+        .as("Generated localdate expression should be correct")
+        .isEqualTo(rawExpression.toString());
 
-    Assert.assertEquals(
-        "Generated date expression should be correct",
-        rawExpression.toString(),
-        dateExpression.toString());
+    assertThat(dateExpression.toString())
+        .as("Generated date expression should be correct")
+        .isEqualTo(rawExpression.toString());
   }
 
   @Test
@@ -171,7 +175,7 @@ public class TestSparkFilters {
     Not filter =
         Not.apply(And.apply(EqualTo.apply("col1", 1), In.apply("col2", new Integer[] {1, 2})));
     Expression converted = SparkFilters.convert(filter);
-    Assert.assertNull("Expression should not be converted", converted);
+    assertThat(converted).as("Expression should not be converted").isNull();
   }
 
   @Test
@@ -180,6 +184,6 @@ public class TestSparkFilters {
     Expression actual = SparkFilters.convert(filter);
     Expression expected =
         Expressions.and(Expressions.notNull("col"), Expressions.notIn("col", 1, 2));
-    Assert.assertEquals("Expressions should match", expected.toString(), actual.toString());
+    assertThat(actual.toString()).as("Expressions should match").isEqualTo(expected.toString());
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -29,8 +30,7 @@ import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.MetadataAttribute;
 import org.apache.spark.sql.catalyst.types.DataTypeUtils;
 import org.apache.spark.sql.types.StructType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkSchemaUtil {
   private static final Schema TEST_SCHEMA =
@@ -46,23 +46,22 @@ public class TestSparkSchemaUtil {
 
   @Test
   public void testEstimateSizeMaxValue() throws IOException {
-    Assert.assertEquals(
-        "estimateSize returns Long max value",
-        Long.MAX_VALUE,
-        SparkSchemaUtil.estimateSize(null, Long.MAX_VALUE));
+    assertThat(SparkSchemaUtil.estimateSize(null, Long.MAX_VALUE))
+        .as("estimateSize returns Long max value")
+        .isEqualTo(Long.MAX_VALUE);
   }
 
   @Test
   public void testEstimateSizeWithOverflow() throws IOException {
     long tableSize =
         SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(TEST_SCHEMA), Long.MAX_VALUE - 1);
-    Assert.assertEquals("estimateSize handles overflow", Long.MAX_VALUE, tableSize);
+    assertThat(tableSize).as("estimateSize handles overflow").isEqualTo(Long.MAX_VALUE);
   }
 
   @Test
   public void testEstimateSize() throws IOException {
     long tableSize = SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(TEST_SCHEMA), 1);
-    Assert.assertEquals("estimateSize matches with expected approximation", 24, tableSize);
+    assertThat(tableSize).as("estimateSize matches with expected approximation").isEqualTo(24);
   }
 
   @Test
@@ -72,13 +71,13 @@ public class TestSparkSchemaUtil {
         scala.collection.JavaConverters.seqAsJavaList(DataTypeUtils.toAttributes(structType));
     for (AttributeReference attrRef : attrRefs) {
       if (MetadataColumns.isMetadataColumn(attrRef.name())) {
-        Assert.assertTrue(
-            "metadata columns should have __metadata_col in attribute metadata",
-            MetadataAttribute.unapply(attrRef).isDefined());
+        assertThat(MetadataAttribute.unapply(attrRef).isDefined())
+            .as("metadata columns should have __metadata_col in attribute metadata")
+            .isTrue();
       } else {
-        Assert.assertFalse(
-            "non metadata columns should not have __metadata_col in attribute metadata",
-            MetadataAttribute.unapply(attrRef).isDefined());
+        assertThat(MetadataAttribute.unapply(attrRef).isDefined())
+            .as("non metadata columns should not have __metadata_col in attribute metadata")
+            .isFalse();
       }
     }
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.KryoHelpers;
@@ -27,9 +29,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkTableUtil {
   @Test
@@ -40,7 +40,7 @@ public class TestSparkTableUtil {
     SparkPartition sparkPartition = new SparkPartition(values, uri, format);
 
     SparkPartition deserialized = KryoHelpers.roundTripSerialize(sparkPartition);
-    Assertions.assertThat(sparkPartition).isEqualTo(deserialized);
+    assertThat(sparkPartition).isEqualTo(deserialized);
   }
 
   @Test
@@ -51,7 +51,7 @@ public class TestSparkTableUtil {
     SparkPartition sparkPartition = new SparkPartition(values, uri, format);
 
     SparkPartition deserialized = TestHelpers.roundTripSerialize(sparkPartition);
-    Assertions.assertThat(sparkPartition).isEqualTo(deserialized);
+    assertThat(sparkPartition).isEqualTo(deserialized);
   }
 
   @Test
@@ -68,13 +68,12 @@ public class TestSparkTableUtil {
     MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
     MetricsConfig deserialized = KryoHelpers.roundTripSerialize(config);
 
-    Assert.assertEquals(
-        MetricsModes.Full.get().toString(), deserialized.columnMode("col1").toString());
-    Assert.assertEquals(
-        MetricsModes.Truncate.withLength(16).toString(),
-        deserialized.columnMode("col2").toString());
-    Assert.assertEquals(
-        MetricsModes.Counts.get().toString(), deserialized.columnMode("col3").toString());
+    assertThat(deserialized.columnMode("col1").toString())
+        .isEqualTo(MetricsModes.Full.get().toString());
+    assertThat(deserialized.columnMode("col2").toString())
+        .isEqualTo(MetricsModes.Truncate.withLength(16).toString());
+    assertThat(deserialized.columnMode("col3").toString())
+        .isEqualTo(MetricsModes.Counts.get().toString());
   }
 
   @Test
@@ -91,12 +90,11 @@ public class TestSparkTableUtil {
     MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
     MetricsConfig deserialized = TestHelpers.roundTripSerialize(config);
 
-    Assert.assertEquals(
-        MetricsModes.Full.get().toString(), deserialized.columnMode("col1").toString());
-    Assert.assertEquals(
-        MetricsModes.Truncate.withLength(16).toString(),
-        deserialized.columnMode("col2").toString());
-    Assert.assertEquals(
-        MetricsModes.Counts.get().toString(), deserialized.columnMode("col3").toString());
+    assertThat(deserialized.columnMode("col1").toString())
+        .isEqualTo(MetricsModes.Full.get().toString());
+    assertThat(deserialized.columnMode("col2").toString())
+        .isEqualTo(MetricsModes.Truncate.withLength(16).toString());
+    assertThat(deserialized.columnMode("col3").toString())
+        .isEqualTo(MetricsModes.Counts.get().toString());
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.spark;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -49,9 +52,7 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkV2Filters {
 
@@ -88,98 +89,114 @@ public class TestSparkV2Filters {
           Predicate isNull = new Predicate("IS_NULL", attrOnly);
           Expression expectedIsNull = Expressions.isNull(unquoted);
           Expression actualIsNull = SparkV2Filters.convert(isNull);
-          Assert.assertEquals(
-              "IsNull must match", expectedIsNull.toString(), actualIsNull.toString());
+          assertThat(actualIsNull.toString())
+              .as("IsNull must match")
+              .isEqualTo(expectedIsNull.toString());
 
           Predicate isNotNull = new Predicate("IS_NOT_NULL", attrOnly);
           Expression expectedIsNotNull = Expressions.notNull(unquoted);
           Expression actualIsNotNull = SparkV2Filters.convert(isNotNull);
-          Assert.assertEquals(
-              "IsNotNull must match", expectedIsNotNull.toString(), actualIsNotNull.toString());
+          assertThat(actualIsNotNull.toString())
+              .as("IsNotNull must match")
+              .isEqualTo(expectedIsNotNull.toString());
 
           Predicate lt1 = new Predicate("<", attrAndValue);
           Expression expectedLt1 = Expressions.lessThan(unquoted, 1);
           Expression actualLt1 = SparkV2Filters.convert(lt1);
-          Assert.assertEquals("LessThan must match", expectedLt1.toString(), actualLt1.toString());
+          assertThat(actualLt1.toString())
+              .as("LessThan must match")
+              .isEqualTo(expectedLt1.toString());
 
           Predicate lt2 = new Predicate("<", valueAndAttr);
           Expression expectedLt2 = Expressions.greaterThan(unquoted, 1);
           Expression actualLt2 = SparkV2Filters.convert(lt2);
-          Assert.assertEquals("LessThan must match", expectedLt2.toString(), actualLt2.toString());
+          assertThat(actualLt2.toString())
+              .as("LessThan must match")
+              .isEqualTo(expectedLt2.toString());
 
           Predicate ltEq1 = new Predicate("<=", attrAndValue);
           Expression expectedLtEq1 = Expressions.lessThanOrEqual(unquoted, 1);
           Expression actualLtEq1 = SparkV2Filters.convert(ltEq1);
-          Assert.assertEquals(
-              "LessThanOrEqual must match", expectedLtEq1.toString(), actualLtEq1.toString());
+          assertThat(actualLtEq1.toString())
+              .as("LessThanOrEqual must match")
+              .isEqualTo(expectedLtEq1.toString());
 
           Predicate ltEq2 = new Predicate("<=", valueAndAttr);
           Expression expectedLtEq2 = Expressions.greaterThanOrEqual(unquoted, 1);
           Expression actualLtEq2 = SparkV2Filters.convert(ltEq2);
-          Assert.assertEquals(
-              "LessThanOrEqual must match", expectedLtEq2.toString(), actualLtEq2.toString());
+          assertThat(actualLtEq2.toString())
+              .as("LessThanOrEqual must match")
+              .isEqualTo(expectedLtEq2.toString());
 
           Predicate gt1 = new Predicate(">", attrAndValue);
           Expression expectedGt1 = Expressions.greaterThan(unquoted, 1);
           Expression actualGt1 = SparkV2Filters.convert(gt1);
-          Assert.assertEquals(
-              "GreaterThan must match", expectedGt1.toString(), actualGt1.toString());
+          assertThat(actualGt1.toString())
+              .as("GreaterThan must match")
+              .isEqualTo(expectedGt1.toString());
 
           Predicate gt2 = new Predicate(">", valueAndAttr);
           Expression expectedGt2 = Expressions.lessThan(unquoted, 1);
           Expression actualGt2 = SparkV2Filters.convert(gt2);
-          Assert.assertEquals(
-              "GreaterThan must match", expectedGt2.toString(), actualGt2.toString());
+          assertThat(actualGt2.toString())
+              .as("GreaterThan must match")
+              .isEqualTo(expectedGt2.toString());
 
           Predicate gtEq1 = new Predicate(">=", attrAndValue);
           Expression expectedGtEq1 = Expressions.greaterThanOrEqual(unquoted, 1);
           Expression actualGtEq1 = SparkV2Filters.convert(gtEq1);
-          Assert.assertEquals(
-              "GreaterThanOrEqual must match", expectedGtEq1.toString(), actualGtEq1.toString());
+          assertThat(actualGtEq1.toString())
+              .as("GreaterThanOrEqual must match")
+              .isEqualTo(expectedGtEq1.toString());
 
           Predicate gtEq2 = new Predicate(">=", valueAndAttr);
           Expression expectedGtEq2 = Expressions.lessThanOrEqual(unquoted, 1);
           Expression actualGtEq2 = SparkV2Filters.convert(gtEq2);
-          Assert.assertEquals(
-              "GreaterThanOrEqual must match", expectedGtEq2.toString(), actualGtEq2.toString());
+          assertThat(actualGtEq2.toString())
+              .as("GreaterThanOrEqual must match")
+              .isEqualTo(expectedGtEq2.toString());
 
           Predicate eq1 = new Predicate("=", attrAndValue);
           Expression expectedEq1 = Expressions.equal(unquoted, 1);
           Expression actualEq1 = SparkV2Filters.convert(eq1);
-          Assert.assertEquals("EqualTo must match", expectedEq1.toString(), actualEq1.toString());
+          assertThat(actualEq1.toString())
+              .as("EqualTo must match")
+              .isEqualTo(expectedEq1.toString());
 
           Predicate eq2 = new Predicate("=", valueAndAttr);
           Expression expectedEq2 = Expressions.equal(unquoted, 1);
           Expression actualEq2 = SparkV2Filters.convert(eq2);
-          Assert.assertEquals("EqualTo must match", expectedEq2.toString(), actualEq2.toString());
+          assertThat(actualEq2.toString())
+              .as("EqualTo must match")
+              .isEqualTo(expectedEq2.toString());
 
           Predicate notEq1 = new Predicate("<>", attrAndValue);
           Expression expectedNotEq1 = Expressions.notEqual(unquoted, 1);
           Expression actualNotEq1 = SparkV2Filters.convert(notEq1);
-          Assert.assertEquals(
-              "NotEqualTo must match", expectedNotEq1.toString(), actualNotEq1.toString());
+          assertThat(actualNotEq1.toString())
+              .as("NotEqualTo must match")
+              .isEqualTo(expectedNotEq1.toString());
 
           Predicate notEq2 = new Predicate("<>", valueAndAttr);
           Expression expectedNotEq2 = Expressions.notEqual(unquoted, 1);
           Expression actualNotEq2 = SparkV2Filters.convert(notEq2);
-          Assert.assertEquals(
-              "NotEqualTo must match", expectedNotEq2.toString(), actualNotEq2.toString());
+          assertThat(actualNotEq2.toString())
+              .as("NotEqualTo must match")
+              .isEqualTo(expectedNotEq2.toString());
 
           Predicate eqNullSafe1 = new Predicate("<=>", attrAndValue);
           Expression expectedEqNullSafe1 = Expressions.equal(unquoted, 1);
           Expression actualEqNullSafe1 = SparkV2Filters.convert(eqNullSafe1);
-          Assert.assertEquals(
-              "EqualNullSafe must match",
-              expectedEqNullSafe1.toString(),
-              actualEqNullSafe1.toString());
+          assertThat(actualEqNullSafe1.toString())
+              .as("EqualNullSafe must match")
+              .isEqualTo(expectedEqNullSafe1.toString());
 
           Predicate eqNullSafe2 = new Predicate("<=>", valueAndAttr);
           Expression expectedEqNullSafe2 = Expressions.equal(unquoted, 1);
           Expression actualEqNullSafe2 = SparkV2Filters.convert(eqNullSafe2);
-          Assert.assertEquals(
-              "EqualNullSafe must match",
-              expectedEqNullSafe2.toString(),
-              actualEqNullSafe2.toString());
+          assertThat(actualEqNullSafe2.toString())
+              .as("EqualNullSafe must match")
+              .isEqualTo(expectedEqNullSafe2.toString());
 
           LiteralValue str =
               new LiteralValue(UTF8String.fromString("iceberg"), DataTypes.StringType);
@@ -188,18 +205,19 @@ public class TestSparkV2Filters {
           Predicate startsWith = new Predicate("STARTS_WITH", attrAndStr);
           Expression expectedStartsWith = Expressions.startsWith(unquoted, "iceberg");
           Expression actualStartsWith = SparkV2Filters.convert(startsWith);
-          Assert.assertEquals(
-              "StartsWith must match", expectedStartsWith.toString(), actualStartsWith.toString());
+          assertThat(actualStartsWith.toString())
+              .as("StartsWith must match")
+              .isEqualTo(expectedStartsWith.toString());
 
           Predicate in = new Predicate("IN", attrAndValue);
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkV2Filters.convert(in);
-          Assert.assertEquals("In must match", expectedIn.toString(), actualIn.toString());
+          assertThat(actualIn.toString()).as("In must match").isEqualTo(expectedIn.toString());
 
           Predicate and = new And(lt1, eq1);
           Expression expectedAnd = Expressions.and(expectedLt1, expectedEq1);
           Expression actualAnd = SparkV2Filters.convert(and);
-          Assert.assertEquals("And must match", expectedAnd.toString(), actualAnd.toString());
+          assertThat(actualAnd.toString()).as("And must match").isEqualTo(expectedAnd.toString());
 
           org.apache.spark.sql.connector.expressions.Expression[] attrAndAttr =
               new org.apache.spark.sql.connector.expressions.Expression[] {
@@ -208,21 +226,21 @@ public class TestSparkV2Filters {
           Predicate invalid = new Predicate("<", attrAndAttr);
           Predicate andWithInvalidLeft = new And(invalid, eq1);
           Expression convertedAnd = SparkV2Filters.convert(andWithInvalidLeft);
-          Assert.assertEquals("And must match", convertedAnd, null);
+          assertThat(convertedAnd).as("And must match").isNull();
 
           Predicate or = new Or(lt1, eq1);
           Expression expectedOr = Expressions.or(expectedLt1, expectedEq1);
           Expression actualOr = SparkV2Filters.convert(or);
-          Assert.assertEquals("Or must match", expectedOr.toString(), actualOr.toString());
+          assertThat(actualOr.toString()).as("Or must match").isEqualTo(expectedOr.toString());
 
           Predicate orWithInvalidLeft = new Or(invalid, eq1);
           Expression convertedOr = SparkV2Filters.convert(orWithInvalidLeft);
-          Assert.assertEquals("Or must match", convertedOr, null);
+          assertThat(convertedOr).as("Or must match").isNull();
 
           Predicate not = new Not(lt1);
           Expression expectedNot = Expressions.not(expectedLt1);
           Expression actualNot = SparkV2Filters.convert(not);
-          Assert.assertEquals("Not must match", expectedNot.toString(), actualNot.toString());
+          assertThat(actualNot.toString()).as("Not must match").isEqualTo(expectedNot.toString());
         });
   }
 
@@ -238,23 +256,23 @@ public class TestSparkV2Filters {
         new org.apache.spark.sql.connector.expressions.Expression[] {value, namedReference};
 
     Predicate eq1 = new Predicate("=", attrAndValue);
-    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(eq1))
+    assertThatThrownBy(() -> SparkV2Filters.convert(eq1))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("Expression is always false");
 
     Predicate eq2 = new Predicate("=", valueAndAttr);
-    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(eq2))
+    assertThatThrownBy(() -> SparkV2Filters.convert(eq2))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("Expression is always false");
 
     Predicate eqNullSafe1 = new Predicate("<=>", attrAndValue);
     Expression expectedEqNullSafe = Expressions.isNull(col);
     Expression actualEqNullSafe1 = SparkV2Filters.convert(eqNullSafe1);
-    Assertions.assertThat(actualEqNullSafe1.toString()).isEqualTo(expectedEqNullSafe.toString());
+    assertThat(actualEqNullSafe1.toString()).isEqualTo(expectedEqNullSafe.toString());
 
     Predicate eqNullSafe2 = new Predicate("<=>", valueAndAttr);
     Expression actualEqNullSafe2 = SparkV2Filters.convert(eqNullSafe2);
-    Assertions.assertThat(actualEqNullSafe2.toString()).isEqualTo(expectedEqNullSafe.toString());
+    assertThat(actualEqNullSafe2.toString()).isEqualTo(expectedEqNullSafe.toString());
   }
 
   @Test
@@ -271,11 +289,11 @@ public class TestSparkV2Filters {
     Predicate eqNaN1 = new Predicate("=", attrAndValue);
     Expression expectedEqNaN = Expressions.isNaN(col);
     Expression actualEqNaN1 = SparkV2Filters.convert(eqNaN1);
-    Assertions.assertThat(actualEqNaN1.toString()).isEqualTo(expectedEqNaN.toString());
+    assertThat(actualEqNaN1.toString()).isEqualTo(expectedEqNaN.toString());
 
     Predicate eqNaN2 = new Predicate("=", valueAndAttr);
     Expression actualEqNaN2 = SparkV2Filters.convert(eqNaN2);
-    Assertions.assertThat(actualEqNaN2.toString()).isEqualTo(expectedEqNaN.toString());
+    assertThat(actualEqNaN2.toString()).isEqualTo(expectedEqNaN.toString());
   }
 
   @Test
@@ -290,12 +308,12 @@ public class TestSparkV2Filters {
         new org.apache.spark.sql.connector.expressions.Expression[] {value, namedReference};
 
     Predicate notEq1 = new Predicate("<>", attrAndValue);
-    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(notEq1))
+    assertThatThrownBy(() -> SparkV2Filters.convert(notEq1))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("Expression is always false");
 
     Predicate notEq2 = new Predicate("<>", valueAndAttr);
-    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(notEq2))
+    assertThatThrownBy(() -> SparkV2Filters.convert(notEq2))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("Expression is always false");
   }
@@ -314,11 +332,11 @@ public class TestSparkV2Filters {
     Predicate notEqNaN1 = new Predicate("<>", attrAndValue);
     Expression expectedNotEqNaN = Expressions.notNaN(col);
     Expression actualNotEqNaN1 = SparkV2Filters.convert(notEqNaN1);
-    Assertions.assertThat(actualNotEqNaN1.toString()).isEqualTo(expectedNotEqNaN.toString());
+    assertThat(actualNotEqNaN1.toString()).isEqualTo(expectedNotEqNaN.toString());
 
     Predicate notEqNaN2 = new Predicate("<>", valueAndAttr);
     Expression actualNotEqNaN2 = SparkV2Filters.convert(notEqNaN2);
-    Assertions.assertThat(actualNotEqNaN2.toString()).isEqualTo(expectedNotEqNaN.toString());
+    assertThat(actualNotEqNaN2.toString()).isEqualTo(expectedNotEqNaN.toString());
   }
 
   @Test
@@ -378,10 +396,9 @@ public class TestSparkV2Filters {
     Expression tsExpression = SparkV2Filters.convert(predicate);
     Expression rawExpression = Expressions.greaterThan("x", epochMicros);
 
-    Assert.assertEquals(
-        "Generated Timestamp expression should be correct",
-        rawExpression.toString(),
-        tsExpression.toString());
+    assertThat(tsExpression.toString())
+        .as("Generated Timestamp expression should be correct")
+        .isEqualTo(rawExpression.toString());
   }
 
   @Test
@@ -398,10 +415,9 @@ public class TestSparkV2Filters {
     Expression dateExpression = SparkV2Filters.convert(predicate);
     Expression rawExpression = Expressions.greaterThan("x", epochDay);
 
-    Assert.assertEquals(
-        "Generated date expression should be correct",
-        rawExpression.toString(),
-        dateExpression.toString());
+    assertThat(dateExpression.toString())
+        .as("Generated date expression should be correct")
+        .isEqualTo(rawExpression.toString());
   }
 
   @Test
@@ -420,7 +436,7 @@ public class TestSparkV2Filters {
 
     Not filter = new Not(new And(equal, in));
     Expression converted = SparkV2Filters.convert(filter);
-    Assert.assertNull("Expression should not be converted", converted);
+    assertThat(converted).as("Expression should not be converted").isNull();
   }
 
   @Test
@@ -437,7 +453,7 @@ public class TestSparkV2Filters {
     Expression actual = SparkV2Filters.convert(not);
     Expression expected =
         Expressions.and(Expressions.notNull("col"), Expressions.notIn("col", 1, 2));
-    Assert.assertEquals("Expressions should match", expected.toString(), actual.toString());
+    assertThat(actual.toString()).as("Expressions should match").isEqualTo(expected.toString());
   }
 
   @Test
@@ -630,7 +646,7 @@ public class TestSparkV2Filters {
     Predicate predicate = new Predicate("=", expressions(udf, literalValue));
 
     Expression icebergExpr = SparkV2Filters.convert(predicate);
-    Assertions.assertThat(icebergExpr).isNull();
+    assertThat(icebergExpr).isNull();
   }
 
   private <T> void testUDF(
@@ -746,7 +762,7 @@ public class TestSparkV2Filters {
     Predicate invalid = new Predicate("<", attrAndAttr);
     Predicate andWithInvalidLeft = new And(invalid, eq1);
     Expression convertedAnd = SparkV2Filters.convert(andWithInvalidLeft);
-    Assertions.assertThat(convertedAnd).isNull();
+    assertThat(convertedAnd).isNull();
 
     Predicate or = new Or(lt1, eq1);
     Expression expectedOr = Expressions.or(expectedLt1, expectedEq1);
@@ -755,7 +771,7 @@ public class TestSparkV2Filters {
 
     Predicate orWithInvalidLeft = new Or(invalid, eq1);
     Expression convertedOr = SparkV2Filters.convert(orWithInvalidLeft);
-    Assertions.assertThat(convertedOr).isNull();
+    assertThat(convertedOr).isNull();
 
     Predicate not = new Not(lt1);
     Expression expectedNot = Expressions.not(expectedLt1);
@@ -764,7 +780,7 @@ public class TestSparkV2Filters {
   }
 
   private static void assertEquals(Expression expected, Expression actual) {
-    Assertions.assertThat(ExpressionUtil.equivalent(expected, actual, STRUCT, true)).isTrue();
+    assertThat(ExpressionUtil.equivalent(expected, actual, STRUCT, true)).isTrue();
   }
 
   private org.apache.spark.sql.connector.expressions.Expression[] expressions(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
@@ -18,14 +18,15 @@
  */
 package org.apache.iceberg.spark;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkValueConverter {
   @Test
@@ -86,9 +87,8 @@ public class TestSparkValueConverter {
     Row sparkRow = RowFactory.create(1, null);
     Record record = GenericRecord.create(schema);
     record.set(0, 1);
-    Assert.assertEquals(
-        "Round-trip conversion should produce original value",
-        record,
-        SparkValueConverter.convert(schema, sparkRow));
+    assertThat(SparkValueConverter.convert(schema, sparkRow))
+        .as("Round-trip conversion should produce original value")
+        .isEqualTo(record);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -57,15 +57,15 @@ import org.apache.iceberg.deletes.DeleteGranularity;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.spark.sql.internal.SQLConf;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
 
-public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
+public class TestSparkWriteConf extends TestBaseWithCatalog {
 
-  @Before
+  @BeforeEach
   public void before() {
+    super.before();
     sql(
         "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
             + "USING iceberg "
@@ -73,12 +73,12 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
         tableName);
   }
 
-  @After
+  @AfterEach
   public void after() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteGranularityDefault() {
     Table table = validationCatalog.loadTable(tableIdent);
     SparkWriteConf writeConf = new SparkWriteConf(spark, table, ImmutableMap.of());
@@ -87,7 +87,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
     assertThat(value).isEqualTo(DeleteGranularity.PARTITION);
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteGranularityTableProperty() {
     Table table = validationCatalog.loadTable(tableIdent);
 
@@ -102,7 +102,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
     assertThat(value).isEqualTo(DeleteGranularity.FILE);
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteGranularityWriteOption() {
     Table table = validationCatalog.loadTable(tableIdent);
 
@@ -120,7 +120,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
     assertThat(value).isEqualTo(DeleteGranularity.FILE);
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteGranularityInvalidValue() {
     Table table = validationCatalog.loadTable(tableIdent);
 
@@ -133,7 +133,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
         .hasMessageContaining("Unknown delete granularity");
   }
 
-  @Test
+  @TestTemplate
   public void testAdvisoryPartitionSize() {
     Table table = validationCatalog.loadTable(tableIdent);
 
@@ -151,7 +151,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
     assertThat(value3).isGreaterThan(10L * 1024 * 1024);
   }
 
-  @Test
+  @TestTemplate
   public void testSparkWriteConfDistributionDefault() {
     Table table = validationCatalog.loadTable(tableIdent);
 
@@ -160,7 +160,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
     checkMode(DistributionMode.HASH, writeConf);
   }
 
-  @Test
+  @TestTemplate
   public void testSparkWriteConfDistributionModeWithWriteOption() {
     Table table = validationCatalog.loadTable(tableIdent);
 
@@ -171,7 +171,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
     checkMode(DistributionMode.NONE, writeConf);
   }
 
-  @Test
+  @TestTemplate
   public void testSparkWriteConfDistributionModeWithSessionConfig() {
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.DISTRIBUTION_MODE, DistributionMode.NONE.modeName()),
@@ -182,7 +182,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testSparkWriteConfDistributionModeWithTableProperties() {
     Table table = validationCatalog.loadTable(tableIdent);
 
@@ -198,7 +198,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
     checkMode(DistributionMode.NONE, writeConf);
   }
 
-  @Test
+  @TestTemplate
   public void testSparkWriteConfDistributionModeWithTblPropAndSessionConfig() {
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.DISTRIBUTION_MODE, DistributionMode.NONE.modeName()),
@@ -219,7 +219,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testSparkWriteConfDistributionModeWithWriteOptionAndSessionConfig() {
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.DISTRIBUTION_MODE, DistributionMode.RANGE.modeName()),
@@ -236,7 +236,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testSparkWriteConfDistributionModeWithEverything() {
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.DISTRIBUTION_MODE, DistributionMode.RANGE.modeName()),
@@ -261,7 +261,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testSparkConfOverride() {
     List<List<Map<String, String>>> propertiesSuites =
         Lists.newArrayList(
@@ -334,7 +334,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testDataPropsDefaultsAsDeleteProps() {
     List<List<Map<String, String>>> propertiesSuites =
         Lists.newArrayList(
@@ -403,7 +403,7 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteFileWriteConf() {
     List<List<Map<String, String>>> propertiesSuites =
         Lists.newArrayList(
@@ -498,9 +498,9 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
           SparkWriteConf writeConf = new SparkWriteConf(spark, table, ImmutableMap.of());
           Map<String, String> writeProperties = writeConf.writeProperties();
           Map<String, String> expectedProperties = propertiesSuite.get(2);
-          Assert.assertEquals(expectedProperties.size(), writeConf.writeProperties().size());
+          assertThat(writeConf.writeProperties()).hasSameSizeAs(expectedProperties);
           for (Map.Entry<String, String> entry : writeProperties.entrySet()) {
-            Assert.assertEquals(entry.getValue(), expectedProperties.get(entry.getKey()));
+            assertThat(expectedProperties).containsEntry(entry.getKey(), entry.getValue());
           }
 
           table.refresh();
@@ -514,12 +514,12 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
   }
 
   private void checkMode(DistributionMode expectedMode, SparkWriteConf writeConf) {
-    Assert.assertEquals(expectedMode, writeConf.distributionMode());
-    Assert.assertEquals(expectedMode, writeConf.copyOnWriteDistributionMode(DELETE));
-    Assert.assertEquals(expectedMode, writeConf.positionDeltaDistributionMode(DELETE));
-    Assert.assertEquals(expectedMode, writeConf.copyOnWriteDistributionMode(UPDATE));
-    Assert.assertEquals(expectedMode, writeConf.positionDeltaDistributionMode(UPDATE));
-    Assert.assertEquals(expectedMode, writeConf.copyOnWriteDistributionMode(MERGE));
-    Assert.assertEquals(expectedMode, writeConf.positionDeltaDistributionMode(MERGE));
+    assertThat(writeConf.distributionMode()).isEqualTo(expectedMode);
+    assertThat(writeConf.copyOnWriteDistributionMode(DELETE)).isEqualTo(expectedMode);
+    assertThat(writeConf.positionDeltaDistributionMode(DELETE)).isEqualTo(expectedMode);
+    assertThat(writeConf.copyOnWriteDistributionMode(UPDATE)).isEqualTo(expectedMode);
+    assertThat(writeConf.positionDeltaDistributionMode(UPDATE)).isEqualTo(expectedMode);
+    assertThat(writeConf.copyOnWriteDistributionMode(MERGE)).isEqualTo(expectedMode);
+    assertThat(writeConf.positionDeltaDistributionMode(MERGE)).isEqualTo(expectedMode);
   }
 }


### PR DESCRIPTION
This PR migrates remaining tests in Spark3.5 to JUnit5. 

Issue: #9086 