### PR TITLE
API, Core: Fix errorprone warnings

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
@@ -166,6 +166,7 @@ public class CharSequenceSet implements Set<CharSequence>, Serializable {
     wrapperSet.clear();
   }
 
+  @SuppressWarnings("CollectionUndefinedEquality")
   @Override
   public boolean equals(Object other) {
     if (this == other) {

--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
@@ -54,7 +54,7 @@ public class CharSequenceWrapper implements CharSequence, Serializable {
     CharSequenceWrapper that = (CharSequenceWrapper) other;
 
     if (wrapped instanceof String && that.wrapped instanceof String) {
-      return wrapped.equals(that.wrapped);
+      return wrapped.toString().contentEquals(that.wrapped);
     }
 
     if (length() != that.length()) {

--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
@@ -44,7 +44,6 @@ public class CharSequenceWrapper implements CharSequence, Serializable {
   }
 
   @Override
-  // Suppressed errorprone warning due to performance reasons.
   @SuppressWarnings("UndefinedEquals")
   public boolean equals(Object other) {
     if (this == other) {

--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
@@ -44,6 +44,8 @@ public class CharSequenceWrapper implements CharSequence, Serializable {
   }
 
   @Override
+  // Suppressed errorprone warning due to performance reasons.
+  @SuppressWarnings("UndefinedEquals")
   public boolean equals(Object other) {
     if (this == other) {
       return true;
@@ -54,7 +56,7 @@ public class CharSequenceWrapper implements CharSequence, Serializable {
     CharSequenceWrapper that = (CharSequenceWrapper) other;
 
     if (wrapped instanceof String && that.wrapped instanceof String) {
-      return wrapped.toString().contentEquals(that.wrapped);
+      return wrapped.equals(that.wrapped);
     }
 
     if (length() != that.length()) {

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -161,6 +161,7 @@ class DeleteFileIndex {
     return deletes == null ? EMPTY_DELETES : deletes.filter(seq, dataFile);
   }
 
+  @SuppressWarnings("CollectionUndefinedEquality")
   private DeleteFile[] findPathDeletes(long seq, DataFile dataFile) {
     if (posDeletesByPath == null) {
       return EMPTY_DELETES;

--- a/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerByStructureVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerByStructureVisitor.java
@@ -109,7 +109,7 @@ public abstract class AvroWithPartnerByStructureVisitor<P, T> {
         // types match according to the following pattern:
         // Before NULL, branch type i in the union maps to struct field i + 1.
         // After NULL, branch type i in the union maps to struct field i.
-        int structFieldIndex = (encounteredNull) ? i : i + 1;
+        int structFieldIndex = encounteredNull ? i : i + 1;
         if (types.get(i).getType() == Schema.Type.NULL) {
           visit(visitor.nullType(), types.get(i), visitor);
           encounteredNull = true;

--- a/core/src/main/java/org/apache/iceberg/deletes/SortingPositionOnlyDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/SortingPositionOnlyDeleteWriter.java
@@ -116,6 +116,7 @@ public class SortingPositionOnlyDeleteWriter<T>
     return new DeleteWriteResult(deleteFiles, referencedDataFiles);
   }
 
+  @SuppressWarnings("CollectionUndefinedEquality")
   private DeleteWriteResult writeDeletes(Collection<CharSequence> paths) throws IOException {
     FileWriter<PositionDelete<T>, DeleteWriteResult> writer = writers.get();
 


### PR DESCRIPTION
`./gradlew clean build -x test` is reporting some warnings as seen below. 

<img width="769" alt="Screenshot 2024-01-05 at 2 28 46 PM" src="https://github.com/apache/iceberg/assets/5889404/e64c76c4-29d3-42cf-b3e0-c1d9f847200b">

After this PR, `./gradlew clean build -x test` is green.