### PR TITLE
AWS: Add Option to don't write non current columns in glue schema closes #7584

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -295,7 +295,11 @@ public class AwsProperties implements Serializable {
     this.glueLakeFormationEnabled =
         PropertyUtil.propertyAsBoolean(
             properties, GLUE_LAKEFORMATION_ENABLED, GLUE_LAKEFORMATION_ENABLED_DEFAULT);
-
+    this.glueCatalogWriteNonCurrentColumns =
+            PropertyUtil.propertyAsBoolean(
+                properties,
+                GLUE_WRITE_NON_CURRENT_COLUMNS,
+                GLUE_WRITE_NON_CURRENT_COLUMNS_DEFAULT);
     this.dynamoDbEndpoint = properties.get(DYNAMODB_ENDPOINT);
     this.dynamoDbTableName =
         PropertyUtil.propertyAsString(properties, DYNAMODB_TABLE_NAME, DYNAMODB_TABLE_NAME_DEFAULT);

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -102,6 +102,11 @@ public class AwsProperties implements Serializable {
    */
   public static final String GLUE_CATALOG_ENDPOINT = "glue.endpoint";
 
+  /** Enable or disable writing non current columns in glue schema */
+  public static final String GLUE_WRITE_NON_CURRENT_COLUMNS = "glue.write-non-current-columns";
+
+  public static final boolean GLUE_WRITE_NON_CURRENT_COLUMNS_DEFAULT = false;
+
   /** Configure an alternative endpoint of the DynamoDB service to access. */
   public static final String DYNAMODB_ENDPOINT = "dynamodb.endpoint";
 
@@ -226,6 +231,7 @@ public class AwsProperties implements Serializable {
   private boolean glueCatalogSkipArchive;
   private boolean glueCatalogSkipNameValidation;
   private boolean glueLakeFormationEnabled;
+  private boolean glueCatalogWriteNonCurrentColumns;
 
   private String dynamoDbTableName;
   private String dynamoDbEndpoint;
@@ -252,6 +258,7 @@ public class AwsProperties implements Serializable {
     this.glueCatalogSkipArchive = GLUE_CATALOG_SKIP_ARCHIVE_DEFAULT;
     this.glueCatalogSkipNameValidation = GLUE_CATALOG_SKIP_NAME_VALIDATION_DEFAULT;
     this.glueLakeFormationEnabled = GLUE_LAKEFORMATION_ENABLED_DEFAULT;
+    this.glueCatalogWriteNonCurrentColumns = GLUE_WRITE_NON_CURRENT_COLUMNS_DEFAULT;
 
     this.dynamoDbEndpoint = null;
     this.dynamoDbTableName = DYNAMODB_TABLE_NAME_DEFAULT;
@@ -336,6 +343,10 @@ public class AwsProperties implements Serializable {
     return glueCatalogSkipArchive;
   }
 
+  public boolean glueCatalogWriteNonCurrentColumns() {
+    return glueCatalogWriteNonCurrentColumns;
+  }
+
   public void setGlueCatalogSkipArchive(boolean skipArchive) {
     this.glueCatalogSkipArchive = skipArchive;
   }
@@ -354,6 +365,10 @@ public class AwsProperties implements Serializable {
 
   public void setGlueLakeFormationEnabled(boolean glueLakeFormationEnabled) {
     this.glueLakeFormationEnabled = glueLakeFormationEnabled;
+  }
+
+  public void setGlueCatalogWriteNonCurrentColumns(boolean glueCatalogWriteNonCurrentColumns) {
+    this.glueCatalogWriteNonCurrentColumns = glueCatalogWriteNonCurrentColumns;
   }
 
   public String dynamoDbTableName() {

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -118,6 +118,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
   public void initialize(String name, Map<String, String> properties) {
     this.catalogProperties = ImmutableMap.copyOf(properties);
     AwsClientFactory awsClientFactory;
+
     if (PropertyUtil.propertyAsBoolean(
         properties,
         AwsProperties.GLUE_LAKEFORMATION_ENABLED,
@@ -129,7 +130,12 @@ public class GlueCatalog extends BaseMetastoreCatalog
       if (factoryImpl == null) {
         builder.put(AwsProperties.CLIENT_FACTORY, LakeFormationAwsClientFactory.class.getName());
       }
-
+      builder.put(
+          AwsProperties.GLUE_WRITE_NON_CURRENT_COLUMNS,
+          PropertyUtil.propertyAsBoolean(
+              properties,
+              AwsProperties.GLUE_WRITE_NON_CURRENT_COLUMNS,
+              AwsProperties.GLUE_WRITE_NON_CURRENT_COLUMNS_DEFAULT));
       this.catalogProperties = builder.buildOrThrow();
       awsClientFactory = AwsClientFactories.from(catalogProperties);
       Preconditions.checkArgument(

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -132,10 +132,8 @@ public class GlueCatalog extends BaseMetastoreCatalog
       }
       builder.put(
           AwsProperties.GLUE_WRITE_NON_CURRENT_COLUMNS,
-          PropertyUtil.propertyAsBoolean(
-              properties,
-              AwsProperties.GLUE_WRITE_NON_CURRENT_COLUMNS,
-              AwsProperties.GLUE_WRITE_NON_CURRENT_COLUMNS_DEFAULT));
+          String.valueOf(AwsProperties.GLUE_WRITE_NON_CURRENT_COLUMNS_DEFAULT)
+      );
       this.catalogProperties = builder.buildOrThrow();
       awsClientFactory = AwsClientFactories.from(catalogProperties);
       Preconditions.checkArgument(

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -318,7 +318,10 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
                   TableInput.builder()
                       .applyMutation(
                           builder ->
-                              IcebergToGlueConverter.setTableInputInformation(builder, metadata))
+                              IcebergToGlueConverter.setTableInputInformation(
+                                  builder,
+                                  metadata,
+                                  awsProperties.glueCatalogWriteNonCurrentColumns()))
                       .name(tableName)
                       .tableType(GLUE_EXTERNAL_TABLE_TYPE)
                       .parameters(parameters)
@@ -340,7 +343,10 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
                   TableInput.builder()
                       .applyMutation(
                           builder ->
-                              IcebergToGlueConverter.setTableInputInformation(builder, metadata))
+                              IcebergToGlueConverter.setTableInputInformation(
+                                  builder,
+                                  metadata,
+                                  awsProperties.glueCatalogWriteNonCurrentColumns()))
                       .name(tableName)
                       .tableType(GLUE_EXTERNAL_TABLE_TYPE)
                       .parameters(parameters)

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -313,10 +313,6 @@ class IcebergToGlueConverter {
         for (NestedField field : schema.columns()) {
           if (addNonCurrentColumn) {
             addColumnWithDedupe(columns, addedNames, field, false /* is not current */);
-          } else {
-            for (int i = 0; i <= columns.size(); i++) {
-              LOG.info("Omitting column " + columns.get(i).name());
-            }
           }
         }
       }

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
@@ -177,7 +177,7 @@ public class TestIcebergToGlueConverter {
         PartitionSpec.builderFor(schema).identity("x").withSpecId(1000).build();
     TableMetadata tableMetadata =
         TableMetadata.newTableMetadata(schema, partitionSpec, "s3://test", tableLocationProperties);
-    IcebergToGlueConverter.setTableInputInformation(actualTableInputBuilder, tableMetadata);
+    IcebergToGlueConverter.setTableInputInformation(actualTableInputBuilder, tableMetadata, true);
     TableInput actualTableInput = actualTableInputBuilder.build();
 
     // Expected TableInput
@@ -243,7 +243,7 @@ public class TestIcebergToGlueConverter {
     Schema newSchema =
         new Schema(Types.NestedField.required(1, "x", Types.StringType.get(), "comment1"));
     tableMetadata = tableMetadata.updateSchema(newSchema, 3);
-    IcebergToGlueConverter.setTableInputInformation(actualTableInputBuilder, tableMetadata);
+    IcebergToGlueConverter.setTableInputInformation(actualTableInputBuilder, tableMetadata, true);
     TableInput actualTableInput = actualTableInputBuilder.build();
 
     // Expected TableInput


### PR DESCRIPTION
This PR aims to close this [issue](https://github.com/apache/iceberg/issues/7584) and would resolve this [issue](https://github.com/apache/iceberg/issues/6340)  too.

We want to provide an optional parameter to `IcebergToGlueConverter` 's `setTableInputInformation` method (set to false by default) named     `glueCatalogWriteNonCurrentColumns`  . It will allow to skip writing columns that were deleted in previous version of the Glue Schema instead of writing and setting the `iceberg.filed.current` value to false.