### PR TITLE
Spark 3.5: Support specifying filter in RewriteManifestsProcedure

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -167,6 +167,10 @@ public class RewriteManifestsSparkAction
     return withJobGroupInfo(info, this::doExecute);
   }
 
+  public PartitionSpec spec() {
+    return this.spec;
+  }
+
   private RewriteManifests.Result doExecute() {
     List<ManifestFile> rewrittenManifests = Lists.newArrayList();
     List<ManifestFile> addedManifests = Lists.newArrayList();


### PR DESCRIPTION
This patch add `where` args in `RewritingManifestsProcedure`, It allows us to only rewrite the manifest file of the specified conditions. When we optimize the manifests of a large table, rewriting the manifests of the entire table will cost time, sometimes we only want to rewrite the manifests of the most recent partitions, then specifying the filter for rewriting manifests procedure will be helpful.

Like `RewritingDatafilesProcedure`, `where` args is predicate as a string used for filtering the manifests. All manifests that may contain entry matching the filter will be selected for rewriting (the filter will be always true if it don't contain any partition field)