### PR TITLE
Spark: propagate snapshot properties for RewriteDataFiles and RewritePositionDeleteFiles

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -18,12 +18,14 @@
  */
 package org.apache.iceberg.actions;
 
+import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
@@ -36,6 +38,7 @@ public class RewriteDataFilesCommitManager {
   private final Table table;
   private final long startingSnapshotId;
   private final boolean useStartingSequenceNumber;
+  private final Map<String, String> extraCommitSummary;
 
   // constructor used for testing
   public RewriteDataFilesCommitManager(Table table) {
@@ -48,9 +51,18 @@ public class RewriteDataFilesCommitManager {
 
   public RewriteDataFilesCommitManager(
       Table table, long startingSnapshotId, boolean useStartingSequenceNumber) {
+    this(table, startingSnapshotId, useStartingSequenceNumber, ImmutableMap.of());
+  }
+
+  public RewriteDataFilesCommitManager(
+      Table table,
+      long startingSnapshotId,
+      boolean useStartingSequenceNumber,
+      Map<String, String> extraCommitSummary) {
     this.table = table;
     this.startingSnapshotId = startingSnapshotId;
     this.useStartingSequenceNumber = useStartingSequenceNumber;
+    this.extraCommitSummary = extraCommitSummary;
   }
 
   /**
@@ -74,7 +86,9 @@ public class RewriteDataFilesCommitManager {
     } else {
       rewrite.rewriteFiles(rewrittenDataFiles, addedDataFiles);
     }
-
+    if (!extraCommitSummary.isEmpty()) {
+      extraCommitSummary.forEach(rewrite::set);
+    }
     rewrite.commit();
   }
 

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -38,7 +38,7 @@ public class RewriteDataFilesCommitManager {
   private final Table table;
   private final long startingSnapshotId;
   private final boolean useStartingSequenceNumber;
-  private final Map<String, String> extraCommitSummary;
+  private final Map<String, String> snapshotProperties;
 
   // constructor used for testing
   public RewriteDataFilesCommitManager(Table table) {
@@ -58,11 +58,11 @@ public class RewriteDataFilesCommitManager {
       Table table,
       long startingSnapshotId,
       boolean useStartingSequenceNumber,
-      Map<String, String> extraCommitSummary) {
+      Map<String, String> snapshotProperties) {
     this.table = table;
     this.startingSnapshotId = startingSnapshotId;
     this.useStartingSequenceNumber = useStartingSequenceNumber;
-    this.extraCommitSummary = extraCommitSummary;
+    this.snapshotProperties = snapshotProperties;
   }
 
   /**
@@ -87,7 +87,7 @@ public class RewriteDataFilesCommitManager {
       rewrite.rewriteFiles(rewrittenDataFiles, addedDataFiles);
     }
 
-    extraCommitSummary.forEach(rewrite::set);
+    snapshotProperties.forEach(rewrite::set);
 
     rewrite.commit();
   }

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -86,9 +86,9 @@ public class RewriteDataFilesCommitManager {
     } else {
       rewrite.rewriteFiles(rewrittenDataFiles, addedDataFiles);
     }
-    if (!extraCommitSummary.isEmpty()) {
-      extraCommitSummary.forEach(rewrite::set);
-    }
+
+    extraCommitSummary.forEach(rewrite::set);
+
     rewrite.commit();
   }
 

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
@@ -72,9 +72,7 @@ public class RewritePositionDeletesCommitManager {
       }
     }
 
-    if (!extraCommitSummary.isEmpty()) {
-      extraCommitSummary.forEach(rewriteFiles::set);
-    }
+    extraCommitSummary.forEach(rewriteFiles::set);
 
     rewriteFiles.commit();
   }

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
@@ -41,16 +41,16 @@ public class RewritePositionDeletesCommitManager {
 
   private final Table table;
   private final long startingSnapshotId;
-  private final Map<String, String> extraCommitSummary;
+  private final Map<String, String> snapshotProperties;
 
   public RewritePositionDeletesCommitManager(Table table) {
     this(table, ImmutableMap.of());
   }
 
-  public RewritePositionDeletesCommitManager(Table table, Map<String, String> extraCommitSummary) {
+  public RewritePositionDeletesCommitManager(Table table, Map<String, String> snapshotProperties) {
     this.table = table;
     this.startingSnapshotId = table.currentSnapshot().snapshotId();
-    this.extraCommitSummary = extraCommitSummary;
+    this.snapshotProperties = snapshotProperties;
   }
 
   /**
@@ -72,7 +72,7 @@ public class RewritePositionDeletesCommitManager {
       }
     }
 
-    extraCommitSummary.forEach(rewriteFiles::set);
+    snapshotProperties.forEach(rewriteFiles::set);
 
     rewriteFiles.commit();
   }

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.actions;
 
+import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DeleteFile;
@@ -25,6 +26,7 @@ import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,10 +41,16 @@ public class RewritePositionDeletesCommitManager {
 
   private final Table table;
   private final long startingSnapshotId;
+  private final Map<String, String> extraCommitSummary;
 
   public RewritePositionDeletesCommitManager(Table table) {
+    this(table, ImmutableMap.of());
+  }
+
+  public RewritePositionDeletesCommitManager(Table table, Map<String, String> extraCommitSummary) {
     this.table = table;
     this.startingSnapshotId = table.currentSnapshot().snapshotId();
+    this.extraCommitSummary = extraCommitSummary;
   }
 
   /**
@@ -62,6 +70,10 @@ public class RewritePositionDeletesCommitManager {
       for (DeleteFile file : group.addedDeleteFiles()) {
         rewriteFiles.addFile(file, group.maxRewrittenDataSequenceNumber());
       }
+    }
+
+    if (!extraCommitSummary.isEmpty()) {
+      extraCommitSummary.forEach(rewriteFiles::set);
     }
 
     rewriteFiles.commit();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotUpdateSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotUpdateSparkAction.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.actions;
 
 import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.spark.sql.SparkSession;
 
@@ -38,5 +39,9 @@ abstract class BaseSnapshotUpdateSparkAction<ThisT> extends BaseSparkAction<This
   protected void commit(org.apache.iceberg.SnapshotUpdate<?> update) {
     summary.forEach(update::set);
     update.commit();
+  }
+
+  protected Map<String, String> commitSummary() {
+    return ImmutableMap.copyOf(summary);
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -257,7 +257,8 @@ public class RewriteDataFilesSparkAction
 
   @VisibleForTesting
   RewriteDataFilesCommitManager commitManager(long startingSnapshotId) {
-    return new RewriteDataFilesCommitManager(table, startingSnapshotId, useStartingSequenceNumber);
+    return new RewriteDataFilesCommitManager(
+        table, startingSnapshotId, useStartingSequenceNumber, commitSummary());
   }
 
   private Result doExecute(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
@@ -215,7 +215,7 @@ public class RewritePositionDeleteFilesSparkAction
   }
 
   private RewritePositionDeletesCommitManager commitManager() {
-    return new RewritePositionDeletesCommitManager(table);
+    return new RewritePositionDeletesCommitManager(table, commitSummary());
   }
 
   private Result doExecute(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1452,7 +1452,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Result ignored = basicRewrite(table).snapshotProperty("key", "value").execute();
     assertThat(table.currentSnapshot().summary())
         .containsAllEntriesOf(ImmutableMap.of("key", "value"));
-    // make sure internal produced properties is not lost
+    // make sure internal produced properties are not lost
     String[] commitMetricsKeys =
         new String[] {
           SnapshotSummary.ADDED_FILES_PROP,

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1445,6 +1445,14 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(actual).as("Number of files order should not be ascending").isNotEqualTo(expected);
   }
 
+  @Test
+  public void testSnapshotProperty() {
+    Table table = createTable(4);
+    Result ignored = basicRewrite(table).snapshotProperty("key", "value").execute();
+    assertThat(table.currentSnapshot().summary())
+        .containsAllEntriesOf(ImmutableMap.of("key", "value"));
+  }
+
   private Stream<RewriteFileGroup> toGroupStream(Table table, RewriteDataFilesSparkAction rewrite) {
     rewrite.validateAndInitOptions();
     StructLikeMap<List<List<FileScanTask>>> fileGroupsByPartition =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -60,6 +60,7 @@ import org.apache.iceberg.RewriteJobOrder;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
@@ -1451,6 +1452,15 @@ public class TestRewriteDataFilesAction extends TestBase {
     Result ignored = basicRewrite(table).snapshotProperty("key", "value").execute();
     assertThat(table.currentSnapshot().summary())
         .containsAllEntriesOf(ImmutableMap.of("key", "value"));
+    // make sure internal produced properties is not lost
+    String[] commitMetricsKeys =
+        new String[] {
+          SnapshotSummary.ADDED_FILES_PROP,
+          SnapshotSummary.DELETED_FILES_PROP,
+          SnapshotSummary.TOTAL_DATA_FILES_PROP,
+          SnapshotSummary.CHANGED_PARTITION_COUNT_PROP
+        };
+    assertThat(table.currentSnapshot().summary()).containsKeys(commitMetricsKeys);
   }
 
   private Stream<RewriteFileGroup> toGroupStream(Table table, RewriteDataFilesSparkAction rewrite) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -633,7 +633,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     assertThat(table.currentSnapshot().summary())
         .containsAllEntriesOf(ImmutableMap.of("key", "value"));
 
-    // make sure internal produced properties is not lost
+    // make sure internal produced properties are not lost
     String[] commitMetricsKeys =
         new String[] {
           SnapshotSummary.ADDED_DELETE_FILES_PROP,

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.PositionDeletesScanTask;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -631,6 +632,19 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
             .execute();
     assertThat(table.currentSnapshot().summary())
         .containsAllEntriesOf(ImmutableMap.of("key", "value"));
+
+    // make sure internal produced properties is not lost
+    String[] commitMetricsKeys =
+        new String[] {
+          SnapshotSummary.ADDED_DELETE_FILES_PROP,
+          SnapshotSummary.ADDED_POS_DELETES_PROP,
+          SnapshotSummary.CHANGED_PARTITION_COUNT_PROP,
+          SnapshotSummary.REMOVED_DELETE_FILES_PROP,
+          SnapshotSummary.REMOVED_POS_DELETES_PROP,
+          SnapshotSummary.TOTAL_DATA_FILES_PROP,
+          SnapshotSummary.TOTAL_DELETE_FILES_PROP,
+        };
+    assertThat(table.currentSnapshot().summary()).containsKeys(commitMetricsKeys);
   }
 
   private Table createTablePartitioned(int partitions, int files, int numRecords) {


### PR DESCRIPTION
When working with `RewriteDataFiles`, I noticed that the snapshot properties cannot be set via `snapshotProperty(String, String)`.  This PR will fix that issue by propagating snapshot properties into `RewriteDataFilesCommitManager` or `RewritePositionDeletesCommitManager` and all the way down to `RewriteFiles`.