### PR TITLE
Spark: Fix SparkTable to use name and effective snapshotID for comparing

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -409,24 +409,18 @@ public class SparkTable
       return false;
     }
 
-    // use name and effective snapshot id to support time travel
+    // use name only unless branch/snapshotId is given in order to correctly invalidate Spark cache
+    // when branch or snapshotId is given, it's time travel
     SparkTable that = (SparkTable) other;
     return icebergTable.name().equals(that.icebergTable.name())
-        && Objects.equals(effectiveSnapshotId(), that.effectiveSnapshotId());
+        && Objects.equals(lazyFixedSnapshotId, that.lazyFixedSnapshotId);
   }
 
   @Override
   public int hashCode() {
-    // use name and effective snapshot id to support time travel
-    return Objects.hash(icebergTable.name(), effectiveSnapshotId());
-  }
-
-  public Long effectiveSnapshotId() {
-    if (lazyFixedSnapshotId != null) {
-      return lazyFixedSnapshotId;
-    }
-    final Snapshot currentSnapshot = icebergTable.currentSnapshot();
-    return currentSnapshot != null ? currentSnapshot.snapshotId() : null;
+    // use name only unless branch/snapshotId is given in order to correctly invalidate Spark cache
+    // when branch or snapshotId is given, it's time travel
+    return Objects.hash(icebergTable.name(), lazyFixedSnapshotId);
   }
 
   private static CaseInsensitiveStringMap addSnapshotId(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -133,7 +133,7 @@ public class SparkTable
   public SparkTable(Table icebergTable, String branch, boolean refreshEagerly) {
     this(icebergTable, refreshEagerly);
     this.branch = branch;
-    final Snapshot snapshot = icebergTable.snapshot(branch);
+    Snapshot snapshot = icebergTable.snapshot(branch);
     ValidationException.check(
         branch == null || SnapshotRef.MAIN_BRANCH.equals(branch) || snapshot != null,
         "Cannot use branch (does not exist): %s",

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -415,6 +415,7 @@ public class SparkTable
     // when branch or snapshotId is given, it's time travel
     SparkTable that = (SparkTable) other;
     return icebergTable.name().equals(that.icebergTable.name())
+        && normalizedBranch().equals(that.normalizedBranch())
         && Objects.equals(snapshotId, that.snapshotId);
   }
 
@@ -422,7 +423,11 @@ public class SparkTable
   public int hashCode() {
     // use name only unless branch/snapshotId is given in order to correctly invalidate Spark cache
     // when branch or snapshotId is given, it's time travel
-    return Objects.hash(icebergTable.name(), snapshotId);
+    return Objects.hash(icebergTable.name(), normalizedBranch(), snapshotId);
+  }
+
+  private String normalizedBranch() {
+    return branch != null ? branch : SnapshotRef.MAIN_BRANCH;
   }
 
   private static CaseInsensitiveStringMap addSnapshotId(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -64,8 +64,8 @@ public class TestSparkTable extends CatalogTestBase {
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
 
     SparkTable table1 = (SparkTable) catalog.loadTable(identifier);
-    final long version1Snapshot = table1.table().currentSnapshot().snapshotId();
-    final String version1 = "VERSION_1";
+    long version1Snapshot = table1.table().currentSnapshot().snapshotId();
+    String version1 = "VERSION_1";
     table1.table().manageSnapshots().createTag(version1, version1Snapshot).commit();
 
     SparkTable firstSnapshotTable = table1.copyWithSnapshotId(version1Snapshot);
@@ -74,8 +74,8 @@ public class TestSparkTable extends CatalogTestBase {
     sql("UPDATE %s SET data = 'b'", tableName);
 
     SparkTable table2 = (SparkTable) catalog.loadTable(identifier);
-    final long version2Snapshot = table2.table().currentSnapshot().snapshotId();
-    final String version2 = "VERSION_2";
+    long version2Snapshot = table2.table().currentSnapshot().snapshotId();
+    String version2 = "VERSION_2";
     table2.table().manageSnapshots().createTag(version2, version2Snapshot).commit();
 
     SparkTable secondTagTable = table2.copyWithBranch(version2);


### PR DESCRIPTION
Issue: #9450 

I've changed SparkTable to use name and effective snapshot id for checking equality.

With the previous code I mentioned in #9450,
```diff
-    return icebergTable.name().equals(that.icebergTable.name());
+    return icebergTable.name().equals(that.icebergTable.name())
+            && Objects.equals(branch, that.branch)
+            && Objects.equals(snapshotId, that.snapshotId);
```

the two refs with the same effective snapshot id don't get optimized as @ajantha-bhat stated.
```sql
SELECT * FROM iceberg_except_test
UNION
SELECT * FROM iceberg_except_test
VERSION AS OF '2024-01-01';

== Parsed Logical Plan ==
'Distinct
+- 'Union false, false
   :- 'Project [*]
   :  +- 'UnresolvedRelation [iceberg_except_test], [], false
   +- 'Project [*]
      +- 'RelationTimeTravel 'UnresolvedRelation [iceberg_except_test], [], false, 2024-01-01

== Analyzed Logical Plan ==
id: string, a: string, b: timestamp
Distinct
+- Union false, false
   :- Project [id#30, a#31, b#32]
   :  +- SubqueryAlias local.iceberg_except_test
   :     +- RelationV2[id#30, a#31, b#32] local.iceberg_except_test local.iceberg_except_test
   +- Project [id#33, a#34, b#35]
      +- SubqueryAlias local.iceberg_except_test
         +- RelationV2[id#33, a#34, b#35] local.iceberg_except_test local.iceberg_except_test

== Optimized Logical Plan ==
Aggregate [id#30, a#31, b#32], [id#30, a#31, b#32]
+- Union false, false
   :- RelationV2[id#30, a#31, b#32] local.iceberg_except_test
   +- RelationV2[id#33, a#34, b#35] local.iceberg_except_test
```

With this patch, the same query is optimized as below:
```sql
== Parsed Logical Plan ==
'Distinct
+- 'Union false, false
   :- 'Project [*]
   :  +- 'UnresolvedRelation [iceberg_except_test], [], false
   +- 'Project [*]
      +- 'RelationTimeTravel 'UnresolvedRelation [iceberg_except_test], [], false, 2024-01-01

== Analyzed Logical Plan ==
id: string, a: string, b: timestamp
Distinct
+- Union false, false
   :- Project [id#27, a#28, b#29]
   :  +- SubqueryAlias local.iceberg_except_test
   :     +- RelationV2[id#27, a#28, b#29] local.iceberg_except_test local.iceberg_except_test
   +- Project [id#30, a#31, b#32]
      +- SubqueryAlias local.iceberg_except_test
         +- RelationV2[id#30, a#31, b#32] local.iceberg_except_test local.iceberg_except_test

== Optimized Logical Plan ==
Aggregate [id#27, a#28, b#29], [id#27, a#28, b#29]
+- RelationV2[id#27, a#28, b#29] local.iceberg_except_test
```

Closes #9450 