### PR TITLE
Backporting Flink: Watermark Read Options to 1.17 and 1.16

### DIFF
--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkReadConf.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkReadConf.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.util.TimeUtils;
 import org.apache.iceberg.Table;
@@ -188,6 +189,24 @@ public class FlinkReadConf {
         .option(FlinkReadOptions.MAX_ALLOWED_PLANNING_FAILURES)
         .flinkConfig(FlinkReadOptions.MAX_ALLOWED_PLANNING_FAILURES_OPTION)
         .defaultValue(FlinkReadOptions.MAX_ALLOWED_PLANNING_FAILURES_OPTION.defaultValue())
+        .parse();
+  }
+
+  public String watermarkColumn() {
+    return confParser
+        .stringConf()
+        .option(FlinkReadOptions.WATERMARK_COLUMN)
+        .flinkConfig(FlinkReadOptions.WATERMARK_COLUMN_OPTION)
+        .defaultValue(FlinkReadOptions.WATERMARK_COLUMN_OPTION.defaultValue())
+        .parseOptional();
+  }
+
+  public TimeUnit watermarkColumnTimeUnit() {
+    return confParser
+        .enumConfParser(TimeUnit.class)
+        .option(FlinkReadOptions.WATERMARK_COLUMN_TIME_UNIT)
+        .flinkConfig(FlinkReadOptions.WATERMARK_COLUMN_TIME_UNIT_OPTION)
+        .defaultValue(FlinkReadOptions.WATERMARK_COLUMN_TIME_UNIT_OPTION.defaultValue())
         .parse();
   }
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkReadOptions.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkReadOptions.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.TableProperties;
@@ -109,4 +110,14 @@ public class FlinkReadOptions {
   public static final String MAX_ALLOWED_PLANNING_FAILURES = "max-allowed-planning-failures";
   public static final ConfigOption<Integer> MAX_ALLOWED_PLANNING_FAILURES_OPTION =
       ConfigOptions.key(PREFIX + MAX_ALLOWED_PLANNING_FAILURES).intType().defaultValue(3);
+
+  public static final String WATERMARK_COLUMN = "watermark-column";
+  public static final ConfigOption<String> WATERMARK_COLUMN_OPTION =
+      ConfigOptions.key(PREFIX + WATERMARK_COLUMN).stringType().noDefaultValue();
+
+  public static final String WATERMARK_COLUMN_TIME_UNIT = "watermark-column-time-unit";
+  public static final ConfigOption<TimeUnit> WATERMARK_COLUMN_TIME_UNIT_OPTION =
+      ConfigOptions.key(PREFIX + WATERMARK_COLUMN_TIME_UNIT)
+          .enumType(TimeUnit.class)
+          .defaultValue(TimeUnit.MICROSECONDS);
 }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestHelpers.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestHelpers.java
@@ -126,7 +126,7 @@ public class TestHelpers {
         .collect(Collectors.toList());
   }
 
-  public static void assertRecords(List<Row> results, List<Record> expectedRecords, Schema schema) {
+  private static List<Row> convertRecordToRow(List<Record> expectedRecords, Schema schema) {
     List<Row> expected = Lists.newArrayList();
     @SuppressWarnings("unchecked")
     DataStructureConverter<RowData, Row> converter =
@@ -135,6 +135,17 @@ public class TestHelpers {
                 TypeConversions.fromLogicalToDataType(FlinkSchemaUtil.convert(schema)));
     expectedRecords.forEach(
         r -> expected.add(converter.toExternal(RowDataConverter.convert(schema, r))));
+    return expected;
+  }
+
+  public static void assertRecordsWithOrder(
+      List<Row> results, List<Record> expectedRecords, Schema schema) {
+    List<Row> expected = convertRecordToRow(expectedRecords, schema);
+    assertRowsWithOrder(results, expected);
+  }
+
+  public static void assertRecords(List<Row> results, List<Record> expectedRecords, Schema schema) {
+    List<Row> expected = convertRecordToRow(expectedRecords, schema);
     assertRows(results, expected);
   }
 
@@ -144,6 +155,10 @@ public class TestHelpers {
 
   public static void assertRows(List<Row> results, List<Row> expected) {
     Assertions.assertThat(results).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  public static void assertRowsWithOrder(List<Row> results, List<Row> expected) {
+    Assertions.assertThat(results).containsExactlyElementsOf(expected);
   }
 
   public static void assertRowData(Schema schema, StructLike expected, RowData actual) {

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceSql.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceSql.java
@@ -18,25 +18,141 @@
  */
 package org.apache.iceberg.flink.source;
 
+import static org.apache.iceberg.types.Types.NestedField.required;
+
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.FlinkConfigOptions;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.junit.Test;
 
 /** Use the IcebergSource (FLIP-27) */
 public class TestIcebergSourceSql extends TestSqlBase {
+  private static final Schema SCHEMA_TS =
+      new Schema(
+          required(1, "t1", Types.TimestampType.withoutZone()),
+          required(2, "t2", Types.LongType.get()));
+
   @Override
   public void before() throws IOException {
-    Configuration tableConf = getTableEnv().getConfig().getConfiguration();
+    TableEnvironment tableEnvironment = getTableEnv();
+    Configuration tableConf = tableEnvironment.getConfig().getConfiguration();
     tableConf.setBoolean(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_FLIP27_SOURCE.key(), true);
+
+    tableEnvironment.getConfig().set("table.exec.resource.default-parallelism", "1");
     SqlHelpers.sql(
-        getTableEnv(),
+        tableEnvironment,
         "create catalog iceberg_catalog with ('type'='iceberg', 'catalog-type'='hadoop', 'warehouse'='%s')",
         catalogResource.warehouse());
-    SqlHelpers.sql(getTableEnv(), "use catalog iceberg_catalog");
-    getTableEnv()
-        .getConfig()
-        .getConfiguration()
-        .set(TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED, true);
+    SqlHelpers.sql(tableEnvironment, "use catalog iceberg_catalog");
+
+    tableConf.set(TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED, true);
+  }
+
+  private Record generateRecord(Instant t1, long t2) {
+    Record record = GenericRecord.create(SCHEMA_TS);
+    record.setField("t1", t1.atZone(ZoneId.systemDefault()).toLocalDateTime());
+    record.setField("t2", t2);
+    return record;
+  }
+
+  /** Generates the records in the expected order, with respect to their datafile */
+  private List<Record> generateExpectedRecords(boolean ascending) throws Exception {
+    Table table = catalogResource.catalog().createTable(TestFixtures.TABLE_IDENTIFIER, SCHEMA_TS);
+    long baseTime = 1702382109000L;
+
+    GenericAppenderHelper helper =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, TEMPORARY_FOLDER);
+
+    Record file1Record1 =
+        generateRecord(Instant.ofEpochMilli(baseTime), baseTime + (1000 * 60 * 60 * 24 * 30L));
+    Record file1Record2 =
+        generateRecord(
+            Instant.ofEpochMilli(baseTime - 10 * 1000L), baseTime + (1000 * 60 * 60 * 24 * 35L));
+
+    List<Record> recordsDataFile1 = Lists.newArrayList();
+    recordsDataFile1.add(file1Record1);
+    recordsDataFile1.add(file1Record2);
+    DataFile dataFile1 = helper.writeFile(recordsDataFile1);
+
+    Record file2Record1 =
+        generateRecord(
+            Instant.ofEpochMilli(baseTime + 14 * 1000L), baseTime - (1000 * 60 * 60 * 24 * 30L));
+    Record file2Record2 =
+        generateRecord(
+            Instant.ofEpochMilli(baseTime + 12 * 1000L), baseTime - (1000 * 60 * 61 * 24 * 35L));
+
+    List<Record> recordsDataFile2 = Lists.newArrayList();
+    recordsDataFile2.add(file2Record1);
+    recordsDataFile2.add(file2Record2);
+
+    DataFile dataFile2 = helper.writeFile(recordsDataFile2);
+    helper.appendToTable(dataFile1, dataFile2);
+
+    // Expected records if the splits are ordered
+    //     - ascending (watermark from t1) - records from the split with early timestamps, then
+    // records from the split with late timestamps
+    //     - descending (watermark from t2) - records from the split with old longs, then records
+    // from the split with new longs
+    List<Record> expected = Lists.newArrayList();
+    if (ascending) {
+      expected.addAll(recordsDataFile1);
+      expected.addAll(recordsDataFile2);
+    } else {
+      expected.addAll(recordsDataFile2);
+      expected.addAll(recordsDataFile1);
+    }
+    return expected;
+  }
+
+  /** Tests the order of splits returned when setting the watermark-column options */
+  @Test
+  public void testWatermarkOptionsAscending() throws Exception {
+    List<Record> expected = generateExpectedRecords(true);
+    TestHelpers.assertRecordsWithOrder(
+        run(
+            ImmutableMap.of("watermark-column", "t1", "split-file-open-cost", "128000000"),
+            "",
+            "*"),
+        expected,
+        SCHEMA_TS);
+  }
+
+  /**
+   * Tests the order of splits returned when setting the watermark-column and
+   * watermark-column-time-unit" options
+   */
+  @Test
+  public void testWatermarkOptionsDescending() throws Exception {
+    List<Record> expected = generateExpectedRecords(false);
+    TestHelpers.assertRecordsWithOrder(
+        run(
+            ImmutableMap.of(
+                "watermark-column",
+                "t2",
+                "watermark-column-time-unit",
+                "MILLISECONDS",
+                "split-file-open-cost",
+                "128000000"),
+            "",
+            "*"),
+        expected,
+        SCHEMA_TS);
   }
 }

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkReadConf.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkReadConf.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.util.TimeUtils;
 import org.apache.iceberg.Table;
@@ -188,6 +189,24 @@ public class FlinkReadConf {
         .option(FlinkReadOptions.MAX_ALLOWED_PLANNING_FAILURES)
         .flinkConfig(FlinkReadOptions.MAX_ALLOWED_PLANNING_FAILURES_OPTION)
         .defaultValue(FlinkReadOptions.MAX_ALLOWED_PLANNING_FAILURES_OPTION.defaultValue())
+        .parse();
+  }
+
+  public String watermarkColumn() {
+    return confParser
+        .stringConf()
+        .option(FlinkReadOptions.WATERMARK_COLUMN)
+        .flinkConfig(FlinkReadOptions.WATERMARK_COLUMN_OPTION)
+        .defaultValue(FlinkReadOptions.WATERMARK_COLUMN_OPTION.defaultValue())
+        .parseOptional();
+  }
+
+  public TimeUnit watermarkColumnTimeUnit() {
+    return confParser
+        .enumConfParser(TimeUnit.class)
+        .option(FlinkReadOptions.WATERMARK_COLUMN_TIME_UNIT)
+        .flinkConfig(FlinkReadOptions.WATERMARK_COLUMN_TIME_UNIT_OPTION)
+        .defaultValue(FlinkReadOptions.WATERMARK_COLUMN_TIME_UNIT_OPTION.defaultValue())
         .parse();
   }
 }

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkReadOptions.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkReadOptions.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.TableProperties;
@@ -109,4 +110,14 @@ public class FlinkReadOptions {
   public static final String MAX_ALLOWED_PLANNING_FAILURES = "max-allowed-planning-failures";
   public static final ConfigOption<Integer> MAX_ALLOWED_PLANNING_FAILURES_OPTION =
       ConfigOptions.key(PREFIX + MAX_ALLOWED_PLANNING_FAILURES).intType().defaultValue(3);
+
+  public static final String WATERMARK_COLUMN = "watermark-column";
+  public static final ConfigOption<String> WATERMARK_COLUMN_OPTION =
+      ConfigOptions.key(PREFIX + WATERMARK_COLUMN).stringType().noDefaultValue();
+
+  public static final String WATERMARK_COLUMN_TIME_UNIT = "watermark-column-time-unit";
+  public static final ConfigOption<TimeUnit> WATERMARK_COLUMN_TIME_UNIT_OPTION =
+      ConfigOptions.key(PREFIX + WATERMARK_COLUMN_TIME_UNIT)
+          .enumType(TimeUnit.class)
+          .defaultValue(TimeUnit.MICROSECONDS);
 }

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceSql.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceSql.java
@@ -18,25 +18,141 @@
  */
 package org.apache.iceberg.flink.source;
 
+import static org.apache.iceberg.types.Types.NestedField.required;
+
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.FlinkConfigOptions;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.junit.Test;
 
 /** Use the IcebergSource (FLIP-27) */
 public class TestIcebergSourceSql extends TestSqlBase {
+  private static final Schema SCHEMA_TS =
+      new Schema(
+          required(1, "t1", Types.TimestampType.withoutZone()),
+          required(2, "t2", Types.LongType.get()));
+
   @Override
   public void before() throws IOException {
-    Configuration tableConf = getTableEnv().getConfig().getConfiguration();
+    TableEnvironment tableEnvironment = getTableEnv();
+    Configuration tableConf = tableEnvironment.getConfig().getConfiguration();
     tableConf.setBoolean(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_FLIP27_SOURCE.key(), true);
+
+    tableEnvironment.getConfig().set("table.exec.resource.default-parallelism", "1");
     SqlHelpers.sql(
-        getTableEnv(),
+        tableEnvironment,
         "create catalog iceberg_catalog with ('type'='iceberg', 'catalog-type'='hadoop', 'warehouse'='%s')",
         catalogResource.warehouse());
-    SqlHelpers.sql(getTableEnv(), "use catalog iceberg_catalog");
-    getTableEnv()
-        .getConfig()
-        .getConfiguration()
-        .set(TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED, true);
+    SqlHelpers.sql(tableEnvironment, "use catalog iceberg_catalog");
+
+    tableConf.set(TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED, true);
+  }
+
+  private Record generateRecord(Instant t1, long t2) {
+    Record record = GenericRecord.create(SCHEMA_TS);
+    record.setField("t1", t1.atZone(ZoneId.systemDefault()).toLocalDateTime());
+    record.setField("t2", t2);
+    return record;
+  }
+
+  /** Generates the records in the expected order, with respect to their datafile */
+  private List<Record> generateExpectedRecords(boolean ascending) throws Exception {
+    Table table = catalogResource.catalog().createTable(TestFixtures.TABLE_IDENTIFIER, SCHEMA_TS);
+    long baseTime = 1702382109000L;
+
+    GenericAppenderHelper helper =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, TEMPORARY_FOLDER);
+
+    Record file1Record1 =
+        generateRecord(Instant.ofEpochMilli(baseTime), baseTime + (1000 * 60 * 60 * 24 * 30L));
+    Record file1Record2 =
+        generateRecord(
+            Instant.ofEpochMilli(baseTime - 10 * 1000L), baseTime + (1000 * 60 * 60 * 24 * 35L));
+
+    List<Record> recordsDataFile1 = Lists.newArrayList();
+    recordsDataFile1.add(file1Record1);
+    recordsDataFile1.add(file1Record2);
+    DataFile dataFile1 = helper.writeFile(recordsDataFile1);
+
+    Record file2Record1 =
+        generateRecord(
+            Instant.ofEpochMilli(baseTime + 14 * 1000L), baseTime - (1000 * 60 * 60 * 24 * 30L));
+    Record file2Record2 =
+        generateRecord(
+            Instant.ofEpochMilli(baseTime + 12 * 1000L), baseTime - (1000 * 60 * 61 * 24 * 35L));
+
+    List<Record> recordsDataFile2 = Lists.newArrayList();
+    recordsDataFile2.add(file2Record1);
+    recordsDataFile2.add(file2Record2);
+
+    DataFile dataFile2 = helper.writeFile(recordsDataFile2);
+    helper.appendToTable(dataFile1, dataFile2);
+
+    // Expected records if the splits are ordered
+    //     - ascending (watermark from t1) - records from the split with early timestamps, then
+    // records from the split with late timestamps
+    //     - descending (watermark from t2) - records from the split with old longs, then records
+    // from the split with new longs
+    List<Record> expected = Lists.newArrayList();
+    if (ascending) {
+      expected.addAll(recordsDataFile1);
+      expected.addAll(recordsDataFile2);
+    } else {
+      expected.addAll(recordsDataFile2);
+      expected.addAll(recordsDataFile1);
+    }
+    return expected;
+  }
+
+  /** Tests the order of splits returned when setting the watermark-column options */
+  @Test
+  public void testWatermarkOptionsAscending() throws Exception {
+    List<Record> expected = generateExpectedRecords(true);
+    TestHelpers.assertRecordsWithOrder(
+        run(
+            ImmutableMap.of("watermark-column", "t1", "split-file-open-cost", "128000000"),
+            "",
+            "*"),
+        expected,
+        SCHEMA_TS);
+  }
+
+  /**
+   * Tests the order of splits returned when setting the watermark-column and
+   * watermark-column-time-unit" options
+   */
+  @Test
+  public void testWatermarkOptionsDescending() throws Exception {
+    List<Record> expected = generateExpectedRecords(false);
+    TestHelpers.assertRecordsWithOrder(
+        run(
+            ImmutableMap.of(
+                "watermark-column",
+                "t2",
+                "watermark-column-time-unit",
+                "MILLISECONDS",
+                "split-file-open-cost",
+                "128000000"),
+            "",
+            "*"),
+        expected,
+        SCHEMA_TS);
   }
 }


### PR DESCRIPTION
Flink: Backports the Watermark Read Options to 1.17 and 1.16

The patch was cleanly applied to both 1.17 and 1.16
<b>source:</b>
``` git diff --no-index  flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source  flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source```
brings some changes unrelated to this PR
```git diff --no-index  flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source  flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source```
came out clean

<b>test:</b>
``` git diff --no-index  flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source  flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source```
brings some changes on unrelated to this PR
```git diff --no-index  flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source  flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source```
brings changes, some of them specifically related to junit Version

