### PR TITLE
Spark: Support min/max/count push down for Identity partition columns

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -410,6 +410,12 @@ acceptedBreaks:
       old: "field org.apache.iceberg.actions.RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES_DEFAULT"
       new: "field org.apache.iceberg.actions.RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES_DEFAULT"
       justification: "Update default to align with recommendation and allow more parallelism"
+    - code: "java.generics.formalTypeParameterAdded"
+      old: "class org.apache.iceberg.expressions.BoundAggregate<T extends java.lang.Object,\
+        \ C extends java.lang.Object>"
+      new: "class org.apache.iceberg.expressions.BoundAggregate<T extends java.lang.Object,\
+        \ C extends java.lang.Object, R extends java.lang.Object>"
+      justification: "Allow count distinct push down on partition cols"
     - code: "java.method.addedToInterface"
       new: "method int org.apache.iceberg.view.ViewVersion::schemaId()"
       justification: "Moving SchemaID to ViewVersion. View Spec implementation has\
@@ -421,6 +427,15 @@ acceptedBreaks:
       new: "method java.util.List<org.apache.iceberg.actions.RewritePositionDeleteFiles.FileGroupRewriteResult>\
         \ org.apache.iceberg.actions.RewritePositionDeleteFiles.Result::rewriteResults()"
       justification: "New method added to un-implemented interface"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void org.apache.iceberg.expressions.AggregateEvaluator::update(org.apache.iceberg.DataFile)"
+      new: "method void org.apache.iceberg.expressions.AggregateEvaluator::update(org.apache.iceberg.DataFile,\
+        \ org.apache.iceberg.StructLike)"
+      justification: "Allowing aggregate push down on partition cols"
+    - code: "java.method.removed"
+      old: "method <T, C> R org.apache.iceberg.expressions.ExpressionVisitors.ExpressionVisitor<R>::aggregate(org.apache.iceberg.expressions.BoundAggregate<T,\
+        \ C>)"
+      justification: "Allow count distinct push down on partition cols"
     - code: "java.method.removed"
       old: "method java.lang.Integer org.apache.iceberg.view.ImmutableSQLViewRepresentation::schemaId()"
       justification: "Moving SchemaID to ViewVersion. View Spec implementation has\
@@ -438,7 +453,17 @@ acceptedBreaks:
         \ org.apache.iceberg.view.ImmutableSQLViewRepresentation.Builder::schemaId(java.lang.Integer)"
       justification: "Moving SchemaID to ViewVersion. View Spec implementation has\
         \ not been voted on yet so this break is acceptable"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method java.util.List<org.apache.iceberg.expressions.BoundAggregate<?,\
+        \ ?>> org.apache.iceberg.expressions.AggregateEvaluator::aggregates()"
+      new: "method java.util.List<org.apache.iceberg.expressions.BoundAggregate<?,\
+        \ ?, ?>> org.apache.iceberg.expressions.AggregateEvaluator::aggregates()"
+      justification: "Allow count distinct push down on partition cols"
     org.apache.iceberg:iceberg-core:
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.PartitionData"
+      new: "class org.apache.iceberg.PartitionData"
+      justification: "Add more methods for allowing aggregate push down on partition cols"
     - code: "java.class.removed"
       old: "class org.apache.iceberg.actions.BaseExpireSnapshotsActionResult"
       justification: "Removing deprecations for 1.3.0"

--- a/api/src/main/java/org/apache/iceberg/Accessors.java
+++ b/api/src/main/java/org/apache/iceberg/Accessors.java
@@ -57,18 +57,24 @@ public class Accessors {
 
   private static class PositionAccessor implements Accessor<StructLike> {
     private final int position;
+    private final String name;
     private final Type type;
     private final Class<?> javaClass;
 
-    PositionAccessor(int pos, Type type) {
+    PositionAccessor(int pos, String name, Type type) {
       this.position = pos;
+      this.name = name;
       this.type = type;
       this.javaClass = type.typeId().javaClass();
     }
 
     @Override
     public Object get(StructLike row) {
-      return row.get(position, javaClass);
+      Object result = row.get(position, javaClass);
+      if (result == null) {
+        result = row.get(name, javaClass);
+      }
+      return result;
     }
 
     @Override
@@ -183,8 +189,8 @@ public class Accessors {
     }
   }
 
-  private static Accessor<StructLike> newAccessor(int pos, Type type) {
-    return new PositionAccessor(pos, type);
+  private static Accessor<StructLike> newAccessor(int pos, String name, Type type) {
+    return new PositionAccessor(pos, name, type);
   }
 
   private static Accessor<StructLike> newAccessor(
@@ -226,7 +232,7 @@ public class Accessors {
         }
 
         // Add an accessor for this field as an Object (may or may not be primitive).
-        accessors.put(field.fieldId(), newAccessor(i, field.type()));
+        accessors.put(field.fieldId(), newAccessor(i, field.name(), field.type()));
       }
 
       return accessors;

--- a/api/src/main/java/org/apache/iceberg/StructLike.java
+++ b/api/src/main/java/org/apache/iceberg/StructLike.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * Interface for accessing data by position in a schema.
  *
@@ -29,4 +32,12 @@ public interface StructLike {
   <T> T get(int pos, Class<T> javaClass);
 
   <T> void set(int pos, T value);
+
+  default <T> T get(String name, Class<T> javaClass) {
+    return null;
+  }
+
+  default Set<String> getPartitionNames() {
+    return Collections.emptySet();
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Aggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Aggregate.java
@@ -47,6 +47,8 @@ public abstract class Aggregate<C extends Term> implements Expression {
         return "count(" + term() + ")";
       case COUNT_STAR:
         return "count(*)";
+      case COUNT_DISTINCT:
+        return "count(distinct" + term() + ")";
       case MAX:
         return "max(" + term() + ")";
       case MIN:

--- a/api/src/main/java/org/apache/iceberg/expressions/Binder.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Binder.java
@@ -165,7 +165,7 @@ public class Binder {
     }
 
     @Override
-    public <T, C> Expression aggregate(BoundAggregate<T, C> agg) {
+    public <T, C> Expression aggregate(BoundAggregate<T, C, ?> agg) {
       throw new IllegalStateException("Found already bound aggregate: " + agg);
     }
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/CountAggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/CountAggregate.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.expressions;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.StructLike;
 
-public class CountAggregate<T> extends BoundAggregate<T, Long> {
+public class CountAggregate<T> extends BoundAggregate<T, Long, Long> {
   protected CountAggregate(Operation op, BoundTerm<T> term) {
     super(op, term);
   }
@@ -47,14 +47,24 @@ public class CountAggregate<T> extends BoundAggregate<T, Long> {
   }
 
   @Override
+  public Long eval(DataFile file, StructLike struct) {
+    return countFor(file, struct);
+  }
+
+  protected Long countFor(DataFile file, StructLike row) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement countFor(DataFile)");
+  }
+
+  @Override
   public Aggregator<Long> newAggregator() {
     return new CountAggregator<>(this);
   }
 
-  private static class CountAggregator<T> extends NullSafeAggregator<T, Long> {
+  private static class CountAggregator<T> extends NullSafeAggregator<T, Long, Long> {
     private Long count = 0L;
 
-    CountAggregator(BoundAggregate<T, Long> aggregate) {
+    CountAggregator(BoundAggregate<T, Long, Long> aggregate) {
       super(aggregate);
     }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/CountStar.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/CountStar.java
@@ -37,6 +37,16 @@ public class CountStar<T> extends CountAggregate<T> {
   }
 
   @Override
+  protected boolean hasColumnValue(DataFile file) {
+    return file.recordCount() >= 0;
+  }
+
+  @Override
+  protected Long countFor(DataFile file, StructLike row) {
+    return countFor(file);
+  }
+
+  @Override
   protected Long countFor(DataFile file) {
     long count = file.recordCount();
     if (count < 0) {

--- a/api/src/main/java/org/apache/iceberg/expressions/Expression.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expression.java
@@ -45,6 +45,7 @@ public interface Expression extends Serializable {
     STARTS_WITH,
     NOT_STARTS_WITH,
     COUNT,
+    COUNT_DISTINCT,
     COUNT_STAR,
     MAX,
     MIN;

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -56,7 +56,7 @@ public class ExpressionVisitors {
       return null;
     }
 
-    public <T, C> R aggregate(BoundAggregate<T, C> agg) {
+    public <T, C> R aggregate(BoundAggregate<T, C, ?> agg) {
       throw new UnsupportedOperationException("Cannot visit aggregate expression");
     }
 
@@ -348,7 +348,7 @@ public class ExpressionVisitors {
       }
     } else if (expr instanceof Aggregate) {
       if (expr instanceof BoundAggregate) {
-        return visitor.aggregate((BoundAggregate<?, ?>) expr);
+        return visitor.aggregate((BoundAggregate<?, ?, ?>) expr);
       } else {
         return visitor.aggregate((UnboundAggregate<?>) expr);
       }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -324,4 +324,8 @@ public class Expressions {
   public static <T> UnboundAggregate<T> min(String name) {
     return new UnboundAggregate<>(Operation.MIN, ref(name));
   }
+
+  public static <T> UnboundAggregate<T> countDistinct(String name) {
+    return new UnboundAggregate<>(Operation.COUNT_DISTINCT, ref(name));
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/MaxAggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/MaxAggregate.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.expressions;
 
 import java.util.Comparator;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type.PrimitiveType;
@@ -27,6 +28,7 @@ import org.apache.iceberg.types.Types;
 
 public class MaxAggregate<T> extends ValueAggregate<T> {
   private final int fieldId;
+  private final String fieldName;
   private final PrimitiveType type;
   private final Comparator<T> comparator;
 
@@ -34,6 +36,7 @@ public class MaxAggregate<T> extends ValueAggregate<T> {
     super(Operation.MAX, term);
     Types.NestedField field = term.ref().field();
     this.fieldId = field.fieldId();
+    this.fieldName = field.name();
     this.type = field.type().asPrimitiveType();
     this.comparator = Comparators.forType(type);
   }
@@ -52,6 +55,16 @@ public class MaxAggregate<T> extends ValueAggregate<T> {
   }
 
   @Override
+  protected boolean hasColumnValue(DataFile file) {
+    return file.valueCounts().containsKey(fieldId) && file.nullValueCounts().containsKey(fieldId);
+  }
+
+  @Override
+  protected boolean isIdentityPartitionColumn(StructLike struct) {
+    return struct.getPartitionNames().contains(String.valueOf(fieldName));
+  }
+
+  @Override
   protected Object evaluateRef(DataFile file) {
     return Conversions.fromByteBuffer(type, safeGet(file.upperBounds(), fieldId));
   }
@@ -61,7 +74,7 @@ public class MaxAggregate<T> extends ValueAggregate<T> {
     return new MaxAggregator<>(this, comparator);
   }
 
-  private static class MaxAggregator<T> extends NullSafeAggregator<T, T> {
+  private static class MaxAggregator<T> extends NullSafeAggregator<T, T, T> {
     private final Comparator<T> comparator;
     private T max = null;
 
@@ -72,6 +85,10 @@ public class MaxAggregate<T> extends ValueAggregate<T> {
 
     @Override
     protected void update(T value) {
+      if (value == null) {
+        return;
+      }
+
       if (max == null || comparator.compare(value, max) > 0) {
         this.max = value;
       }

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundAggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundAggregate.java
@@ -51,6 +51,8 @@ public class UnboundAggregate<T> extends Aggregate<UnboundTerm<T>>
         return new CountStar<>(null);
       case COUNT:
         return new CountNonNull<>(boundTerm(struct, caseSensitive));
+      case COUNT_DISTINCT:
+        return new CountDistinct<>(boundTerm(struct, caseSensitive));
       case MAX:
         return new MaxAggregate<>(boundTerm(struct, caseSensitive));
       case MIN:

--- a/api/src/main/java/org/apache/iceberg/expressions/ValueAggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ValueAggregate.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.expressions;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.StructLike;
 
-class ValueAggregate<T> extends BoundAggregate<T, T> {
+class ValueAggregate<T> extends BoundAggregate<T, T, T> {
   private final SingleValueStruct valueStruct = new SingleValueStruct();
 
   protected ValueAggregate(Operation op, BoundTerm<T> term) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestAggregateEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestAggregateEvaluator.java
@@ -106,7 +106,7 @@ public class TestAggregateEvaluator {
     AggregateEvaluator aggregateEvaluator = AggregateEvaluator.create(SCHEMA, list);
 
     for (DataFile dataFile : dataFiles) {
-      aggregateEvaluator.update(dataFile);
+      aggregateEvaluator.update(dataFile, dataFile.partition());
     }
 
     assertThat(aggregateEvaluator.allAggregatorsValid()).isTrue();
@@ -126,7 +126,7 @@ public class TestAggregateEvaluator {
     AggregateEvaluator aggregateEvaluator = AggregateEvaluator.create(SCHEMA, list);
 
     for (DataFile dataFile : dataFiles) {
-      aggregateEvaluator.update(dataFile);
+      aggregateEvaluator.update(dataFile, dataFile.partition());
     }
 
     assertThat(aggregateEvaluator.allAggregatorsValid()).isTrue();
@@ -145,7 +145,7 @@ public class TestAggregateEvaluator {
             Expressions.min("some_nulls"));
     AggregateEvaluator aggregateEvaluator = AggregateEvaluator.create(SCHEMA, list);
     for (DataFile dataFile : dataFiles) {
-      aggregateEvaluator.update(dataFile);
+      aggregateEvaluator.update(dataFile, dataFile.partition());
     }
 
     assertThat(aggregateEvaluator.allAggregatorsValid()).isFalse();
@@ -164,7 +164,7 @@ public class TestAggregateEvaluator {
             Expressions.min("no_stats"));
     AggregateEvaluator aggregateEvaluator = AggregateEvaluator.create(SCHEMA, list);
     for (DataFile dataFile : dataFiles) {
-      aggregateEvaluator.update(dataFile);
+      aggregateEvaluator.update(dataFile, dataFile.partition());
     }
 
     assertThat(aggregateEvaluator.allAggregatorsValid()).isFalse();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkAggregates.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkAggregates.java
@@ -47,9 +47,10 @@ public class SparkAggregates {
       switch (op) {
         case COUNT:
           Count countAgg = (Count) aggregate;
-          if (countAgg.isDistinct()) {
-            // manifest file doesn't have count distinct so this can't be pushed down
-            return null;
+          if (countAgg.isDistinct() && countAgg.column() instanceof NamedReference) {
+            // partition info have partition value so this can be converted
+            return Expressions.countDistinct(
+                SparkUtil.toColumnName((NamedReference) countAgg.column()));
           }
 
           if (countAgg.column() instanceof NamedReference) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAggregates.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAggregates.java
@@ -70,8 +70,11 @@ public class TestSparkAggregates {
               .isEqualTo(expectedCount.toString());
 
           Count countDistinct = new Count(namedReference, true);
-          Expression convertedCountDistinct = SparkAggregates.convert(countDistinct);
-          assertThat(convertedCountDistinct).as("Count Distinct is converted to null").isNull();
+          Expression expectedCountDistinct = Expressions.countDistinct(unquoted);
+          Expression actualCountDistinct = SparkAggregates.convert(countDistinct);
+          assertThat(String.valueOf(actualCountDistinct))
+              .as("Count Distinct must match")
+              .isEqualTo(expectedCountDistinct.toString());
 
           CountStar countStar = new CountStar();
           Expression expectedCountStar = Expressions.countStar();


### PR DESCRIPTION
### Notes
Support min/max/count aggregate push down for partition columns

- min/max/count aggregate push down is not working if partition columns don't present as data columns(the stats won't be present in avro files), so even the aggregate has been push down to data source, `AggregateEvaluator` will fail, it still go through full table scan
- add support by updating evaluator based on PartitionData 

### Testing
Creating a hive table: 
CREATE EXTERNAL TABLE store_sales (id int, data INT) PARTITIONED BY (ss_sold_date_sk INT)
then registered as Iceberg table

Tested on Spark 3.5, verified count/min/max been successfully pushdown, and simple queries (`select count(ss_sold_date_sk) from store_sales` , `select min(ss_sold_date_sk) from store_sales` and `select max(ss_sold_date_sk) from store_sales`) has been speed up with the change