### PR TITLE
Flink: Don't fail to serialize IcebergSourceSplit when there is too many delete files

### DIFF
--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
@@ -147,6 +147,32 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
 
       for (FileScanTask fileScanTask : fileScanTasks) {
         String taskJson = FileScanTaskParser.toJson(fileScanTask);
+        out.writeUTF(taskJson);
+      }
+
+      serializedBytesCache = out.getCopyOfBuffer();
+      out.clear();
+    }
+
+    return serializedBytesCache;
+  }
+
+  byte[] serializeV3() throws IOException {
+    if (serializedBytesCache == null) {
+      DataOutputSerializer out = SERIALIZER_CACHE.get();
+      Collection<FileScanTask> fileScanTasks = task.tasks();
+      Preconditions.checkArgument(
+          fileOffset >= 0 && fileOffset < fileScanTasks.size(),
+          "Invalid file offset: %s. Should be within the range of [0, %s)",
+          fileOffset,
+          fileScanTasks.size());
+
+      out.writeInt(fileOffset);
+      out.writeLong(recordOffset);
+      out.writeInt(fileScanTasks.size());
+
+      for (FileScanTask fileScanTask : fileScanTasks) {
+        String taskJson = FileScanTaskParser.toJson(fileScanTask);
         SerializerHelper.writeLongUTF(out, taskJson);
       }
 
@@ -158,6 +184,24 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
   }
 
   static IcebergSourceSplit deserializeV2(byte[] serialized, boolean caseSensitive)
+      throws IOException {
+    DataInputDeserializer in = new DataInputDeserializer(serialized);
+    int fileOffset = in.readInt();
+    long recordOffset = in.readLong();
+    int taskCount = in.readInt();
+
+    List<FileScanTask> tasks = Lists.newArrayListWithCapacity(taskCount);
+    for (int i = 0; i < taskCount; ++i) {
+      String taskJson = in.readUTF();
+      FileScanTask task = FileScanTaskParser.fromJson(taskJson, caseSensitive);
+      tasks.add(task);
+    }
+
+    CombinedScanTask combinedScanTask = new BaseCombinedScanTask(tasks);
+    return IcebergSourceSplit.fromCombinedScanTask(combinedScanTask, fileOffset, recordOffset);
+  }
+
+  static IcebergSourceSplit deserializeV3(byte[] serialized, boolean caseSensitive)
       throws IOException {
     DataInputDeserializer in = new DataInputDeserializer(serialized);
     int fileOffset = in.readInt();

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
@@ -155,7 +155,7 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
 
       for (FileScanTask fileScanTask : fileScanTasks) {
         String taskJson = FileScanTaskParser.toJson(fileScanTask);
-        writeLongUTF(out, taskJson, version);
+        writeTaskJson(out, taskJson, version);
       }
 
       serializedBytesCache = out.getCopyOfBuffer();
@@ -165,7 +165,7 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
     return serializedBytesCache;
   }
 
-  private static void writeLongUTF(DataOutputSerializer out, String taskJson, int version)
+  private static void writeTaskJson(DataOutputSerializer out, String taskJson, int version)
       throws IOException {
     switch (version) {
       case 2:

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
@@ -147,7 +147,7 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
 
       for (FileScanTask fileScanTask : fileScanTasks) {
         String taskJson = FileScanTaskParser.toJson(fileScanTask);
-        out.writeUTF(taskJson);
+        writeBytes(out, taskJson);
       }
 
       serializedBytesCache = out.getCopyOfBuffer();
@@ -166,12 +166,19 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
 
     List<FileScanTask> tasks = Lists.newArrayListWithCapacity(taskCount);
     for (int i = 0; i < taskCount; ++i) {
-      String taskJson = in.readUTF();
+      String taskJson = in.readLine();
       FileScanTask task = FileScanTaskParser.fromJson(taskJson, caseSensitive);
       tasks.add(task);
     }
 
     CombinedScanTask combinedScanTask = new BaseCombinedScanTask(tasks);
     return IcebergSourceSplit.fromCombinedScanTask(combinedScanTask, fileOffset, recordOffset);
+  }
+
+  private static void writeBytes(DataOutputSerializer out, String s) throws IOException {
+    for (int i = 0; i < s.length(); i++) {
+      out.writeByte(s.charAt(i));
+    }
+    out.writeByte('\n');
   }
 }

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
@@ -147,7 +147,7 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
 
       for (FileScanTask fileScanTask : fileScanTasks) {
         String taskJson = FileScanTaskParser.toJson(fileScanTask);
-        writeBytes(out, taskJson);
+        SerializerHelper.writeLongUTF(out, taskJson);
       }
 
       serializedBytesCache = out.getCopyOfBuffer();
@@ -166,19 +166,12 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
 
     List<FileScanTask> tasks = Lists.newArrayListWithCapacity(taskCount);
     for (int i = 0; i < taskCount; ++i) {
-      String taskJson = in.readLine();
+      String taskJson = SerializerHelper.readLongUTF(in);
       FileScanTask task = FileScanTaskParser.fromJson(taskJson, caseSensitive);
       tasks.add(task);
     }
 
     CombinedScanTask combinedScanTask = new BaseCombinedScanTask(tasks);
     return IcebergSourceSplit.fromCombinedScanTask(combinedScanTask, fileOffset, recordOffset);
-  }
-
-  private static void writeBytes(DataOutputSerializer out, String s) throws IOException {
-    for (int i = 0; i < s.length(); i++) {
-      out.writeByte(s.charAt(i));
-    }
-    out.writeByte('\n');
   }
 }

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
@@ -24,7 +24,7 @@ import org.apache.flink.core.io.SimpleVersionedSerializer;
 
 @Internal
 public class IcebergSourceSplitSerializer implements SimpleVersionedSerializer<IcebergSourceSplit> {
-  private static final int VERSION = 2;
+  private static final int VERSION = 3;
 
   private final boolean caseSensitive;
 
@@ -49,6 +49,8 @@ public class IcebergSourceSplitSerializer implements SimpleVersionedSerializer<I
         return IcebergSourceSplit.deserializeV1(serialized);
       case 2:
         return IcebergSourceSplit.deserializeV2(serialized, caseSensitive);
+      case 3:
+        return IcebergSourceSplit.deserializeV3(serialized, caseSensitive);
       default:
         throw new IOException(
             String.format(

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
@@ -39,7 +39,7 @@ public class IcebergSourceSplitSerializer implements SimpleVersionedSerializer<I
 
   @Override
   public byte[] serialize(IcebergSourceSplit split) throws IOException {
-    return split.serializeV2();
+    return split.serializeV3();
   }
 
   @Override

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/SerializerHelper.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/SerializerHelper.java
@@ -33,8 +33,8 @@ import org.apache.flink.core.memory.DataOutputSerializer;
 public class SerializerHelper implements Serializable {
 
   /**
-   * Similar to {@link DataOutputSerializer#writeUTF(String)}. The size is only limited by the
-   * maximum java array size of the buffer.
+   * Similar to {@link DataOutputSerializer#writeUTF(String)}. Except this supports larger payloads
+   * which is up to max integer value.
    *
    * @param out the output stream to write the string to.
    * @param str the string value to be written.
@@ -67,6 +67,20 @@ public class SerializerHelper implements Serializable {
     writeUTFBytes(out, str, (int) utflen);
   }
 
+  /**
+   * Similar to {@link DataInputDeserializer#readUTF()}. Except this supports larger payloads which
+   * is up to max integer value.
+   *
+   * @param in the input stream to read the string from.
+   * @return the string value read from the input stream.
+   * @throws IOException if an I/O error occurs when reading from the input stream.
+   * @deprecated This method is deprecated because there will be a method within the {@link
+   *     DataInputDeserializer} already which does the same thing, so use that one instead once that
+   *     is released on Flink version 1.20.
+   *     <p>See * <a href="https://issues.apache.org/jira/browse/FLINK-34228">FLINK-34228</a> * <a
+   *     href="https://github.com/apache/flink/pull/24191">https://github.com/apache/flink/pull/24191</a>
+   */
+  @Deprecated
   public static String readLongUTF(DataInputDeserializer in) throws IOException {
     int utflen = in.readInt();
     byte[] bytearr = new byte[utflen];

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/SerializerHelper.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/SerializerHelper.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.flink.source.split;
 
 import java.io.IOException;
@@ -30,21 +29,22 @@ import org.apache.flink.core.memory.DataOutputSerializer;
  * taken from the class org.apache.flink.core.memory.DataInputSerializer.readUTF and
  * org.apache.flink.core.memory.DataOutputSerializer.writeUTF.
  */
-public class SerializerHelper implements Serializable {
+class SerializerHelper implements Serializable {
 
   /**
    * Similar to {@link DataOutputSerializer#writeUTF(String)}. Except this supports larger payloads
    * which is up to max integer value.
    *
+   * <p>Note: This method is deprecated because there will be a method within the {@link
+   * DataOutputSerializer} already which does the same thing, so use that one instead once that is
+   * released on Flink version 1.20.
+   *
+   * <p>See * <a href="https://issues.apache.org/jira/browse/FLINK-34228">FLINK-34228</a> * <a
+   * href="https://github.com/apache/flink/pull/24191">https://github.com/apache/flink/pull/24191</a>
+   *
    * @param out the output stream to write the string to.
    * @param str the string value to be written.
-   * @deprecated This method is deprecated because there will be a method within the {@link
-   *     DataOutputSerializer} already which does the same thing, so use that one instead once that
-   *     is released on Flink version 1.20.
-   *     <p>See * <a href="https://issues.apache.org/jira/browse/FLINK-34228">FLINK-34228</a> * <a
-   *     href="https://github.com/apache/flink/pull/24191">https://github.com/apache/flink/pull/24191</a>
    */
-  @Deprecated
   public static void writeLongUTF(DataOutputSerializer out, String str) throws IOException {
     int strlen = str.length();
     long utflen = 0;
@@ -59,6 +59,7 @@ public class SerializerHelper implements Serializable {
         throw new UTFDataFormatException("Encoded string reached maximum length: " + utflen);
       }
     }
+
     if (utflen > Integer.MAX_VALUE - 4) {
       throw new UTFDataFormatException("Encoded string is too long: " + utflen);
     }
@@ -71,16 +72,17 @@ public class SerializerHelper implements Serializable {
    * Similar to {@link DataInputDeserializer#readUTF()}. Except this supports larger payloads which
    * is up to max integer value.
    *
+   * <p>This method is deprecated because there will be a method within the {@link *
+   * DataInputDeserializer} already which does the same thing, so use that one instead once that *
+   * is released on Flink version 1.20. *
+   *
+   * <p>See * <a href="https://issues.apache.org/jira/browse/FLINK-34228">FLINK-34228</a> * <a *
+   * href="https://github.com/apache/flink/pull/24191">https://github.com/apache/flink/pull/24191</a>
+   *
    * @param in the input stream to read the string from.
    * @return the string value read from the input stream.
    * @throws IOException if an I/O error occurs when reading from the input stream.
-   * @deprecated This method is deprecated because there will be a method within the {@link
-   *     DataInputDeserializer} already which does the same thing, so use that one instead once that
-   *     is released on Flink version 1.20.
-   *     <p>See * <a href="https://issues.apache.org/jira/browse/FLINK-34228">FLINK-34228</a> * <a
-   *     href="https://github.com/apache/flink/pull/24191">https://github.com/apache/flink/pull/24191</a>
    */
-  @Deprecated
   public static String readLongUTF(DataInputDeserializer in) throws IOException {
     int utflen = in.readInt();
     byte[] bytearr = new byte[utflen];

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/SerializerHelper.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/SerializerHelper.java
@@ -35,7 +35,7 @@ class SerializerHelper implements Serializable {
    * Similar to {@link DataOutputSerializer#writeUTF(String)}. Except this supports larger payloads
    * which is up to max integer value.
    *
-   * <p>Note: This method is deprecated because there will be a method within the {@link
+   * <p>Note: This method can be removed when the method which does similar thing within the {@link
    * DataOutputSerializer} already which does the same thing, so use that one instead once that is
    * released on Flink version 1.20.
    *
@@ -72,11 +72,11 @@ class SerializerHelper implements Serializable {
    * Similar to {@link DataInputDeserializer#readUTF()}. Except this supports larger payloads which
    * is up to max integer value.
    *
-   * <p>This method is deprecated because there will be a method within the {@link *
-   * DataInputDeserializer} already which does the same thing, so use that one instead once that *
-   * is released on Flink version 1.20. *
+   * <p>Note: This method can be removed when the method which does similar thing within the {@link
+   * DataOutputSerializer} already which does the same thing, so use that one instead once that is
+   * released on Flink version 1.20.
    *
-   * <p>See * <a href="https://issues.apache.org/jira/browse/FLINK-34228">FLINK-34228</a> * <a *
+   * <p>See * <a href="https://issues.apache.org/jira/browse/FLINK-34228">FLINK-34228</a> * <a
    * href="https://github.com/apache/flink/pull/24191">https://github.com/apache/flink/pull/24191</a>
    *
    * @param in the input stream to read the string from.

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/SerializerHelper.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/SerializerHelper.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.split;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UTFDataFormatException;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+
+/**
+ * Helper class to serialize and deserialize strings longer than 65K. The inspiration is mostly
+ * taken from the class org.apache.flink.core.memory.DataInputSerializer.readUTF and
+ * org.apache.flink.core.memory.DataOutputSerializer.writeUTF.
+ */
+public class SerializerHelper implements Serializable {
+
+  public static void writeLongUTF(DataOutputSerializer out, String str) throws IOException {
+    int strlen = str.length();
+    int utflen = 0;
+    int c;
+
+    /* use charAt instead of copying String to char array */
+    for (int i = 0; i < strlen; i++) {
+      c = str.charAt(i);
+      if ((c >= 0x0001) && (c <= 0x007F)) {
+        utflen++;
+      } else if (c > 0x07FF) {
+        utflen += 3;
+      } else {
+        utflen += 2;
+      }
+    }
+    out.writeInt(utflen);
+
+    int len = Math.max(1024, utflen);
+
+    byte[] bytearr = new byte[len];
+    int count = 0;
+
+    int i;
+    for (i = 0; i < strlen; i++) {
+      c = str.charAt(i);
+      if (!((c >= 0x0001) && (c <= 0x007F))) {
+        break;
+      }
+      bytearr[count++] = (byte) c;
+    }
+
+    for (; i < strlen; i++) {
+      c = str.charAt(i);
+      if ((c >= 0x0001) && (c <= 0x007F)) {
+        bytearr[count++] = (byte) c;
+
+      } else if (c > 0x07FF) {
+        bytearr[count++] = (byte) (0xE0 | ((c >> 12) & 0x0F));
+        bytearr[count++] = (byte) (0x80 | ((c >> 6) & 0x3F));
+        bytearr[count++] = (byte) (0x80 | (c & 0x3F));
+      } else {
+        bytearr[count++] = (byte) (0xC0 | ((c >> 6) & 0x1F));
+        bytearr[count++] = (byte) (0x80 | (c & 0x3F));
+      }
+    }
+
+    out.write(bytearr, 0, count);
+  }
+
+  public static String readLongUTF(DataInputDeserializer in) throws IOException {
+    int utflen = in.readInt();
+    byte[] bytearr = new byte[utflen];
+    char[] chararr = new char[utflen];
+
+    int c, char2, char3;
+    int count = 0;
+    int chararrCount = 0;
+
+    in.readFully(bytearr, 0, utflen);
+
+    while (count < utflen) {
+      c = (int) bytearr[count] & 0xff;
+      if (c > 127) {
+        break;
+      }
+      count++;
+      chararr[chararrCount++] = (char) c;
+    }
+
+    while (count < utflen) {
+      c = (int) bytearr[count] & 0xff;
+      switch (c >> 4) {
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+          /* 0xxxxxxx */
+          count++;
+          chararr[chararrCount++] = (char) c;
+          break;
+        case 12:
+        case 13:
+          /* 110x xxxx 10xx xxxx */
+          count += 2;
+          if (count > utflen) {
+            throw new UTFDataFormatException("malformed input: partial character at end");
+          }
+          char2 = (int) bytearr[count - 1];
+          if ((char2 & 0xC0) != 0x80) {
+            throw new UTFDataFormatException("malformed input around byte " + count);
+          }
+          chararr[chararrCount++] = (char) (((c & 0x1F) << 6) | (char2 & 0x3F));
+          break;
+        case 14:
+          /* 1110 xxxx 10xx xxxx 10xx xxxx */
+          count += 3;
+          if (count > utflen) {
+            throw new UTFDataFormatException("malformed input: partial character at end");
+          }
+          char2 = (int) bytearr[count - 2];
+          char3 = (int) bytearr[count - 1];
+          if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80)) {
+            throw new UTFDataFormatException("malformed input around byte " + (count - 1));
+          }
+          chararr[chararrCount++] =
+              (char) (((c & 0x0F) << 12) | ((char2 & 0x3F) << 6) | (char3 & 0x3F));
+          break;
+        default:
+          /* 10xx xxxx, 1111 xxxx */
+          throw new UTFDataFormatException("malformed input around byte " + count);
+      }
+    }
+    // The number of chars produced may be less than utflen
+    return new String(chararr, 0, chararrCount);
+  }
+}

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/SplitHelpers.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/SplitHelpers.java
@@ -19,18 +19,27 @@
 package org.apache.iceberg.flink.source;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseCombinedScanTask;
+import org.apache.iceberg.BaseFileScanTask;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.hadoop.HadoopCatalog;
@@ -39,6 +48,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.ThreadPools;
 import org.junit.Assert;
 import org.junit.rules.TemporaryFolder;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 public class SplitHelpers {
 
@@ -128,5 +140,65 @@ public class SplitHelpers {
       catalog.dropTable(TestFixtures.TABLE_IDENTIFIER);
       catalog.close();
     }
+  }
+
+  /**
+   * This method will equip the {@code icebergSourceSplits} with mock delete files.
+   * <li>For each split, create {@code deleteFilesPerSplit} number of delete files
+   * <li>Replace the original {@code FileScanTask} with the new {@code FileScanTask} with mock
+   * <li>Caller should not attempt to read the deleted files since they are created as mock, and
+   *     they are not real files
+   *
+   * @param icebergSourceSplits The real splits to equip with mock delete files
+   * @param temporaryFolder The temporary folder to create the mock delete files with
+   * @param deleteFilesPerSplit The number of delete files to create for each split
+   * @return The list of re-created splits with mock delete files
+   * @throws IOException If there is any error creating the mock delete files
+   */
+  public static List<IcebergSourceSplit> equipSplitsWithMockDeleteFiles(
+      List<IcebergSourceSplit> icebergSourceSplits,
+      TemporaryFolder temporaryFolder,
+      int deleteFilesPerSplit)
+      throws IOException {
+    List<IcebergSourceSplit> icebergSourceSplitsWithMockDeleteFiles = new ArrayList<>();
+    for (IcebergSourceSplit split : icebergSourceSplits) {
+      final CombinedScanTask combinedScanTask = spy(split.task());
+
+      final List<DeleteFile> deleteFiles = new ArrayList<>();
+      final PartitionSpec spec =
+          PartitionSpec.builderFor(TestFixtures.SCHEMA).withSpecId(0).build();
+
+      for (int i = 0; i < deleteFilesPerSplit; ++i) {
+        final DeleteFile deleteFile =
+            FileMetadata.deleteFileBuilder(spec)
+                .withFormat(FileFormat.PARQUET)
+                .withPath(temporaryFolder.newFile().getPath())
+                .ofPositionDeletes()
+                .withFileSizeInBytes(1000)
+                .withRecordCount(1000)
+                .build();
+        deleteFiles.add(deleteFile);
+      }
+
+      List<FileScanTask> newFileScanTasks = new ArrayList<>();
+      for (FileScanTask task : combinedScanTask.tasks()) {
+        String schemaString = SchemaParser.toJson(task.schema());
+        String specString = PartitionSpecParser.toJson(task.spec());
+
+        BaseFileScanTask baseFileScanTask =
+            new BaseFileScanTask(
+                task.file(),
+                deleteFiles.toArray(new DeleteFile[] {}),
+                schemaString,
+                specString,
+                ResidualEvaluator.unpartitioned(task.residual()));
+        newFileScanTasks.add(baseFileScanTask);
+      }
+      doReturn(newFileScanTasks).when(combinedScanTask).tasks();
+      icebergSourceSplitsWithMockDeleteFiles.add(
+          IcebergSourceSplit.fromCombinedScanTask(
+              combinedScanTask, split.fileOffset(), split.recordOffset()));
+    }
+    return icebergSourceSplitsWithMockDeleteFiles;
   }
 }

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/SplitHelpers.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/SplitHelpers.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.spy;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
@@ -160,11 +159,11 @@ public class SplitHelpers {
       TemporaryFolder temporaryFolder,
       int deleteFilesPerSplit)
       throws IOException {
-    List<IcebergSourceSplit> icebergSourceSplitsWithMockDeleteFiles = new ArrayList<>();
+    List<IcebergSourceSplit> icebergSourceSplitsWithMockDeleteFiles = Lists.newArrayList();
     for (IcebergSourceSplit split : icebergSourceSplits) {
       final CombinedScanTask combinedScanTask = spy(split.task());
 
-      final List<DeleteFile> deleteFiles = new ArrayList<>();
+      final List<DeleteFile> deleteFiles = Lists.newArrayList();
       final PartitionSpec spec =
           PartitionSpec.builderFor(TestFixtures.SCHEMA).withSpecId(0).build();
 
@@ -180,7 +179,7 @@ public class SplitHelpers {
         deleteFiles.add(deleteFile);
       }
 
-      List<FileScanTask> newFileScanTasks = new ArrayList<>();
+      List<FileScanTask> newFileScanTasks = Lists.newArrayList();
       for (FileScanTask task : combinedScanTask.tasks()) {
         String schemaString = SchemaParser.toJson(task.schema());
         String specString = PartitionSpecParser.toJson(task.spec());

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/SplitHelpers.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/SplitHelpers.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.flink.source;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,9 +51,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.ThreadPools;
 import org.junit.Assert;
 import org.junit.rules.TemporaryFolder;
-
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 
 public class SplitHelpers {
 

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
@@ -101,26 +101,24 @@ public class TestIcebergSourceSplitSerializer {
   }
 
   @Test
-  public void testV2WithTooManyDeleteFiles() throws Exception {
-    serializeAndDeserializeV2(1, 1, 5000);
+  public void testV3WithTooManyDeleteFiles() throws Exception {
+    serializeAndDeserializeV3(1, 1, 5000);
   }
 
-  private void serializeAndDeserializeV2(int splitCount, int filesPerSplit, int mockDeletesPerSplit) throws Exception {
-    final List<IcebergSourceSplit> splits = SplitHelpers.createSplitsFromTransientHadoopTable(
+  private void serializeAndDeserializeV3(int splitCount, int filesPerSplit, int mockDeletesPerSplit)
+      throws Exception {
+    final List<IcebergSourceSplit> splits =
+        SplitHelpers.createSplitsFromTransientHadoopTable(
             TEMPORARY_FOLDER, splitCount, filesPerSplit);
     final List<IcebergSourceSplit> splitsWithMockDeleteFiles =
-        SplitHelpers.equipSplitsWithMockDeleteFiles(splits,
-            TEMPORARY_FOLDER, mockDeletesPerSplit);
+        SplitHelpers.equipSplitsWithMockDeleteFiles(splits, TEMPORARY_FOLDER, mockDeletesPerSplit);
 
     for (IcebergSourceSplit split : splitsWithMockDeleteFiles) {
-      byte[] result = split.serializeV2();
-      IcebergSourceSplit deserialized = IcebergSourceSplit.deserializeV2(result, true);
+      byte[] result = split.serializeV3();
+      IcebergSourceSplit deserialized = IcebergSourceSplit.deserializeV3(result, true);
       assertSplitEquals(split, deserialized);
     }
   }
-
-
-
 
   @Test
   public void testDeserializeV1() throws Exception {

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
@@ -105,13 +105,12 @@ public class TestIcebergSourceSplitSerializer {
     serializeAndDeserializeV2(1, 1, 5000);
   }
 
-  private void serializeAndDeserializeV2(int splitCount, int filesPerSplit, int mockDeletesPerSplit)
-      throws Exception {
-    final List<IcebergSourceSplit> splits =
-        SplitHelpers.createSplitsFromTransientHadoopTable(
+  private void serializeAndDeserializeV2(int splitCount, int filesPerSplit, int mockDeletesPerSplit) throws Exception {
+    final List<IcebergSourceSplit> splits = SplitHelpers.createSplitsFromTransientHadoopTable(
             TEMPORARY_FOLDER, splitCount, filesPerSplit);
     final List<IcebergSourceSplit> splitsWithMockDeleteFiles =
-        SplitHelpers.equipSplitsWithMockDeleteFiles(splits, TEMPORARY_FOLDER, mockDeletesPerSplit);
+        SplitHelpers.equipSplitsWithMockDeleteFiles(splits,
+            TEMPORARY_FOLDER, mockDeletesPerSplit);
 
     for (IcebergSourceSplit split : splitsWithMockDeleteFiles) {
       byte[] result = split.serializeV2();
@@ -119,6 +118,9 @@ public class TestIcebergSourceSplitSerializer {
       assertSplitEquals(split, deserialized);
     }
   }
+
+
+
 
   @Test
   public void testDeserializeV1() throws Exception {

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
@@ -101,6 +101,26 @@ public class TestIcebergSourceSplitSerializer {
   }
 
   @Test
+  public void testV2WithTooManyDeleteFiles() throws Exception {
+    serializeAndDeserializeV2(1, 1, 5000);
+  }
+
+  private void serializeAndDeserializeV2(int splitCount, int filesPerSplit, int mockDeletesPerSplit)
+      throws Exception {
+    final List<IcebergSourceSplit> splits =
+        SplitHelpers.createSplitsFromTransientHadoopTable(
+            TEMPORARY_FOLDER, splitCount, filesPerSplit);
+    final List<IcebergSourceSplit> splitsWithMockDeleteFiles =
+        SplitHelpers.equipSplitsWithMockDeleteFiles(splits, TEMPORARY_FOLDER, mockDeletesPerSplit);
+
+    for (IcebergSourceSplit split : splitsWithMockDeleteFiles) {
+      byte[] result = split.serializeV2();
+      IcebergSourceSplit deserialized = IcebergSourceSplit.deserializeV2(result, true);
+      assertSplitEquals(split, deserialized);
+    }
+  }
+
+  @Test
   public void testDeserializeV1() throws Exception {
     final List<IcebergSourceSplit> splits =
         SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 1, 1);


### PR DESCRIPTION
The changes in this PR is addressing the problem in #9410 which makes it problematic to consume from an Iceberg table which is getting regular upserts. 

The problem occurs [on this line](https://github.com/apache/flink/blob/master/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java#L257) with Flink's DataOutputserializer object when the size of an object which is being serialized is above 65kb and that limit is easily exceeded for those tables which are having too many deleted files due to regular upserts.

