### PR TITLE
Nessie: Add table() and view() API to NessieIcebergClient

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -195,6 +195,16 @@ public class NessieIcebergClient implements AutoCloseable {
     return TableIdentifier.of(elements.toArray(new String[elements.size()]));
   }
 
+  public IcebergTable table(TableIdentifier tableIdentifier) {
+    IcebergContent icebergContent = fetchContent(tableIdentifier);
+    return icebergContent == null ? null : icebergContent.unwrap(IcebergTable.class).orElse(null);
+  }
+
+  public IcebergView view(TableIdentifier tableIdentifier) {
+    IcebergContent icebergContent = fetchContent(tableIdentifier);
+    return icebergContent == null ? null : icebergContent.unwrap(IcebergView.class).orElse(null);
+  }
+
   public IcebergContent fetchContent(TableIdentifier tableIdentifier) {
     try {
       ContentKey key = NessieUtil.toKey(tableIdentifier);


### PR DESCRIPTION
`table()` in `NessieIcebergClient` was renamed to `fetchContent()` with generic functionality while adding the view support for NessieCatalog. 
Nessie doesn't have to maintain compatibility as per https://iceberg.apache.org/contribute/#minor-version-deprecations-discretionary. 

But while bumping Iceberg version at Trino side (https://github.com/trinodb/trino/pull/20308), we concluded that it will be cleaner to have these table() and view() API.