### PR TITLE
Pushed filters to Parquet file on best effort basis in Vectorized Reader

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.parquet;
 
 import java.nio.ByteBuffer;
+import java.util.Set;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.And;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.BoundReference;
 import org.apache.iceberg.expressions.Expression;
@@ -28,7 +30,9 @@ import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.ExpressionVisitors.ExpressionVisitor;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.expressions.Not;
 import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
@@ -36,6 +40,17 @@ import org.apache.parquet.filter2.predicate.Operators;
 import org.apache.parquet.io.api.Binary;
 
 class ParquetFilters {
+
+  private static final Set<Operation> SUPPORTED_OPS =
+      ImmutableSet.of(
+          Operation.IS_NULL,
+          Operation.NOT_NULL,
+          Operation.EQ,
+          Operation.NOT_EQ,
+          Operation.GT,
+          Operation.GT_EQ,
+          Operation.LT,
+          Operation.LT_EQ);
 
   private ParquetFilters() {}
 
@@ -171,6 +186,22 @@ class ParquetFilters {
       }
       throw new UnsupportedOperationException("Cannot convert to Parquet filter: " + pred);
     }
+  }
+
+  public static boolean isSupportedFilter(Expression expr) {
+    if (expr.op().equals(Operation.AND)) {
+      return isSupportedFilter(((And) expr).left()) && isSupportedFilter(((And) expr).right());
+    } else if (expr.op().equals(Operation.OR)) {
+      return isSupportedFilter(((And) expr).left()) && isSupportedFilter(((And) expr).right());
+    } else if (expr.op().equals(Operation.NOT)) {
+      return isSupportedFilter(((Not) expr).child());
+    } else {
+      return isSupportedOp(expr);
+    }
+  }
+
+  private static boolean isSupportedOp(Expression expr) {
+    return SUPPORTED_OPS.contains(expr.op());
   }
 
   @SuppressWarnings("checkstyle:MethodTypeParameterName")

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -79,8 +79,7 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
               nameMapping,
               reuseContainers,
               caseSensitive,
-              null,
-              false);
+              null);
       this.conf = readConf.copy();
       return readConf;
     }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -79,7 +79,8 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
               nameMapping,
               reuseContainers,
               caseSensitive,
-              null);
+              null,
+              false);
       this.conf = readConf.copy();
       return readConf;
     }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
@@ -108,8 +108,7 @@ class ReadConf<T> {
 
     LOG.info("Filters pushed status, alreadyPushed: {}", alreadyPushedFilters);
 
-
-    if(!alreadyPushedFilters) {
+    if (!alreadyPushedFilters) {
       LOG.warn("Filters not pushed yet, checking on row groups");
 
       ParquetMetricsRowGroupFilter statsFilter = null;
@@ -124,13 +123,13 @@ class ReadConf<T> {
       for (int i = 0; i < shouldSkip.length; i += 1) {
         BlockMetaData rowGroup = rowGroups.get(i);
         startRowPositions[i] =
-                offsetToStartPos == null ? 0 : offsetToStartPos.get(rowGroup.getStartingPos());
+            offsetToStartPos == null ? 0 : offsetToStartPos.get(rowGroup.getStartingPos());
         boolean shouldRead =
-                filter == null
-                        || (statsFilter.shouldRead(typeWithIds, rowGroup)
-                        && dictFilter.shouldRead(
+            filter == null
+                || (statsFilter.shouldRead(typeWithIds, rowGroup)
+                    && dictFilter.shouldRead(
                         typeWithIds, rowGroup, reader.getDictionaryReader(rowGroup))
-                        && bloomFilter.shouldRead(
+                    && bloomFilter.shouldRead(
                         typeWithIds, rowGroup, reader.getBloomFilterDataReader(rowGroup)));
         this.shouldSkip[i] = !shouldRead;
         if (shouldRead) {


### PR DESCRIPTION
Hi all,

We are planning to onboard Iceberg as our Tableformat stack in our Data Platform. For that purpose, we were doing some benchmarking between Hudi and Iceberg vs Vanilla Parquet based Dataframe reads in spark and we found out that Iceberg is not pushing the filters to the parquet layer and it is relying on row group based filtering which is a customized pattern for Iceberg

However we saw that amount of data read will be higher in that case, we tried to push down filters till the parquet layer also and we saw benefits in some queries.

We wanted to know the comments on this PR whether this makes sense to the community or should this be avoided and rely on only row group filtering for Iceberg