### PR TITLE
Core: Add view support for JDBC catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.jdbc;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -37,7 +38,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.TableMetadata;
@@ -49,6 +49,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
@@ -60,16 +61,21 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.LocationUtil;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.view.BaseMetastoreViewCatalog;
+import org.apache.iceberg.view.ViewOperations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class JdbcCatalog extends BaseMetastoreCatalog
+public class JdbcCatalog extends BaseMetastoreViewCatalog
     implements Configurable<Object>, SupportsNamespaces {
 
   public static final String PROPERTY_PREFIX = "jdbc.";
   private static final String NAMESPACE_EXISTS_PROPERTY = "exists";
   private static final Logger LOG = LoggerFactory.getLogger(JdbcCatalog.class);
   private static final Joiner SLASH = Joiner.on("/");
+  static final String VIEW_WARNING_LOG_MESSAGE =
+      "JDBC catalog is initialized without view support. To auto-migrate the database's schema and enable view support, set jdbc.add-view-support=true";
 
   private FileIO io;
   private String catalogName = "jdbc";
@@ -81,6 +87,7 @@ public class JdbcCatalog extends BaseMetastoreCatalog
   private final Function<Map<String, String>, JdbcClientPool> clientPoolBuilder;
   private final boolean initializeCatalogTables;
   private CloseableGroup closeableGroup;
+  private JdbcUtil.SchemaVersion schemaVersion = JdbcUtil.SchemaVersion.V1;
 
   public JdbcCatalog() {
     this(null, null, true);
@@ -158,14 +165,17 @@ public class JdbcCatalog extends BaseMetastoreCatalog
               dbMeta.getTables(
                   null /* catalog name */,
                   null /* schemaPattern */,
-                  JdbcUtil.CATALOG_TABLE_NAME /* tableNamePattern */,
+                  JdbcUtil.CATALOG_TABLE_VIEW_NAME /* tableNamePattern */,
                   null /* types */);
           if (tableExists.next()) {
+            updateCatalogTables(conn);
             return true;
           }
 
-          LOG.debug("Creating table {} to store iceberg catalog", JdbcUtil.CATALOG_TABLE_NAME);
-          return conn.prepareStatement(JdbcUtil.CREATE_CATALOG_TABLE).execute();
+          LOG.debug(
+              "Creating table {} to store iceberg catalog tables",
+              JdbcUtil.CATALOG_TABLE_VIEW_NAME);
+          return conn.prepareStatement(JdbcUtil.CREATE_CATALOG_SQL).execute();
         });
 
     connections.run(
@@ -185,14 +195,39 @@ public class JdbcCatalog extends BaseMetastoreCatalog
           LOG.debug(
               "Creating table {} to store iceberg catalog namespace properties",
               JdbcUtil.NAMESPACE_PROPERTIES_TABLE_NAME);
-          return conn.prepareStatement(JdbcUtil.CREATE_NAMESPACE_PROPERTIES_TABLE).execute();
+          return conn.prepareStatement(JdbcUtil.CREATE_NAMESPACE_PROPERTIES_TABLE_SQL).execute();
         });
+  }
+
+  private void updateCatalogTables(Connection connection) throws SQLException {
+    DatabaseMetaData dbMeta = connection.getMetaData();
+    ResultSet typeColumn =
+        dbMeta.getColumns(null, null, JdbcUtil.CATALOG_TABLE_VIEW_NAME, JdbcUtil.RECORD_TYPE);
+    if (typeColumn.next()) {
+      LOG.debug("{} already supports views", JdbcUtil.CATALOG_TABLE_VIEW_NAME);
+    } else {
+      if (PropertyUtil.propertyAsBoolean(
+          catalogProperties, JdbcUtil.ADD_VIEW_SUPPORT_PROPERTY, false)) {
+        connection.prepareStatement(JdbcUtil.UPDATE_CATALOG_SQL).execute();
+      } else {
+        LOG.warn(VIEW_WARNING_LOG_MESSAGE);
+        schemaVersion = JdbcUtil.SchemaVersion.V0;
+      }
+    }
   }
 
   @Override
   protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
     return new JdbcTableOperations(
-        connections, io, catalogName, tableIdentifier, catalogProperties);
+        connections, io, catalogName, tableIdentifier, catalogProperties, schemaVersion);
+  }
+
+  @Override
+  protected ViewOperations newViewOps(TableIdentifier viewIdentifier) {
+    if (schemaVersion != JdbcUtil.SchemaVersion.V1) {
+      throw new UnsupportedOperationException(VIEW_WARNING_LOG_MESSAGE);
+    }
+    return new JdbcViewOperations(connections, io, catalogName, viewIdentifier, catalogProperties);
   }
 
   @Override
@@ -217,7 +252,9 @@ public class JdbcCatalog extends BaseMetastoreCatalog
 
     int deletedRecords =
         execute(
-            JdbcUtil.DROP_TABLE_SQL,
+            (schemaVersion == JdbcUtil.SchemaVersion.V1)
+                ? JdbcUtil.V1_DROP_TABLE_SQL
+                : JdbcUtil.V0_DROP_TABLE_SQL,
             catalogName,
             JdbcUtil.namespaceToString(identifier.namespace()),
             identifier.name());
@@ -245,13 +282,35 @@ public class JdbcCatalog extends BaseMetastoreCatalog
         row ->
             JdbcUtil.stringToTableIdentifier(
                 row.getString(JdbcUtil.TABLE_NAMESPACE), row.getString(JdbcUtil.TABLE_NAME)),
-        JdbcUtil.LIST_TABLES_SQL,
+        (schemaVersion == JdbcUtil.SchemaVersion.V1)
+            ? JdbcUtil.V1_LIST_TABLE_SQL
+            : JdbcUtil.V0_LIST_TABLE_SQL,
         catalogName,
         JdbcUtil.namespaceToString(namespace));
   }
 
   @Override
   public void renameTable(TableIdentifier from, TableIdentifier to) {
+    if (from.equals(to)) {
+      return;
+    }
+
+    if (!tableExists(from)) {
+      throw new NoSuchTableException("Table does not exist: %s", from);
+    }
+
+    if (!namespaceExists(to.namespace())) {
+      throw new NoSuchNamespaceException("Namespace does not exist: %s", to.namespace());
+    }
+
+    if (viewExists(to)) {
+      throw new AlreadyExistsException("Cannot rename %s to %s. View already exists", from, to);
+    }
+
+    if (tableExists(to)) {
+      throw new AlreadyExistsException("Table already exists: %s", to);
+    }
+
     int updatedRecords =
         execute(
             err -> {
@@ -261,7 +320,9 @@ public class JdbcCatalog extends BaseMetastoreCatalog
                 throw new AlreadyExistsException("Table already exists: %s", to);
               }
             },
-            JdbcUtil.RENAME_TABLE_SQL,
+            (schemaVersion == JdbcUtil.SchemaVersion.V1)
+                ? JdbcUtil.V1_RENAME_TABLE_SQL
+                : JdbcUtil.V0_RENAME_TABLE_SQL,
             JdbcUtil.namespaceToString(to.namespace()),
             to.name(),
             catalogName,
@@ -315,7 +376,7 @@ public class JdbcCatalog extends BaseMetastoreCatalog
     namespaces.addAll(
         fetch(
             row -> JdbcUtil.stringToNamespace(row.getString(JdbcUtil.TABLE_NAMESPACE)),
-            JdbcUtil.LIST_ALL_TABLE_NAMESPACES_SQL,
+            JdbcUtil.LIST_ALL_NAMESPACES_SQL,
             catalogName));
     namespaces.addAll(
         fetch(
@@ -501,6 +562,101 @@ public class JdbcCatalog extends BaseMetastoreCatalog
   @Override
   public boolean namespaceExists(Namespace namespace) {
     return JdbcUtil.namespaceExists(catalogName, connections, namespace);
+  }
+
+  @Override
+  public boolean dropView(TableIdentifier identifier) {
+    if (schemaVersion != JdbcUtil.SchemaVersion.V1) {
+      throw new UnsupportedOperationException(VIEW_WARNING_LOG_MESSAGE);
+    }
+
+    int deletedRecords =
+        execute(
+            JdbcUtil.DROP_VIEW_SQL,
+            catalogName,
+            JdbcUtil.namespaceToString(identifier.namespace()),
+            identifier.name());
+
+    if (deletedRecords == 0) {
+      LOG.info("Skipping drop, view does not exist: {}", identifier);
+      return false;
+    }
+
+    LOG.info("Dropped view: {}", identifier);
+    return true;
+  }
+
+  @Override
+  public List<TableIdentifier> listViews(Namespace namespace) {
+    if (schemaVersion != JdbcUtil.SchemaVersion.V1) {
+      throw new UnsupportedOperationException(VIEW_WARNING_LOG_MESSAGE);
+    }
+
+    if (!namespaceExists(namespace)) {
+      throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
+    }
+
+    return fetch(
+        row ->
+            JdbcUtil.stringToTableIdentifier(
+                row.getString(JdbcUtil.TABLE_NAMESPACE), row.getString(JdbcUtil.TABLE_NAME)),
+        JdbcUtil.LIST_VIEW_SQL,
+        catalogName,
+        JdbcUtil.namespaceToString(namespace));
+  }
+
+  @Override
+  public void renameView(TableIdentifier from, TableIdentifier to) {
+    if (schemaVersion != JdbcUtil.SchemaVersion.V1) {
+      throw new UnsupportedOperationException(VIEW_WARNING_LOG_MESSAGE);
+    }
+
+    if (from.equals(to)) {
+      return;
+    }
+
+    if (!namespaceExists(to.namespace())) {
+      throw new NoSuchNamespaceException("Namespace does not exist: %s", to.namespace());
+    }
+
+    if (!viewExists(from)) {
+      throw new NoSuchViewException("View does not exist");
+    }
+
+    if (tableExists(to)) {
+      throw new AlreadyExistsException("Cannot rename %s to %s. Table already exists", from, to);
+    }
+
+    if (viewExists(to)) {
+      throw new AlreadyExistsException("Cannot rename %s to %s. View already exists", from, to);
+    }
+
+    int updatedRecords =
+        execute(
+            err -> {
+              // SQLite doesn't set SQLState or throw SQLIntegrityConstraintViolationException
+              if (err instanceof SQLIntegrityConstraintViolationException
+                  || (err.getMessage() != null && err.getMessage().contains("constraint failed"))) {
+                throw new AlreadyExistsException(
+                    "Cannot rename %s to %s. View already exists", from, to);
+              }
+            },
+            JdbcUtil.RENAME_VIEW_SQL,
+            JdbcUtil.namespaceToString(to.namespace()),
+            to.name(),
+            catalogName,
+            JdbcUtil.namespaceToString(from.namespace()),
+            from.name());
+
+    if (updatedRecords == 1) {
+      LOG.info("Renamed view from {}, to {}", from, to);
+    } else if (updatedRecords == 0) {
+      throw new NoSuchViewException("View does not exist: %s", from);
+    } else {
+      LOG.warn(
+          "Rename operation affected {} rows: the catalog view's primary key assumption has been violated",
+          updatedRecords);
+    }
   }
 
   private int execute(String sql, String... args) {

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcTableOperations.java
@@ -19,8 +19,6 @@
 package org.apache.iceberg.jdbc;
 
 import java.sql.DataTruncation;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.SQLNonTransientConnectionException;
@@ -39,7 +37,6 @@ import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,18 +49,21 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
   private final FileIO fileIO;
   private final JdbcClientPool connections;
   private final Map<String, String> catalogProperties;
+  private final JdbcUtil.SchemaVersion schemaVersion;
 
   protected JdbcTableOperations(
       JdbcClientPool dbConnPool,
       FileIO fileIO,
       String catalogName,
       TableIdentifier tableIdentifier,
-      Map<String, String> catalogProperties) {
+      Map<String, String> catalogProperties,
+      JdbcUtil.SchemaVersion schemaVersion) {
     this.catalogName = catalogName;
     this.tableIdentifier = tableIdentifier;
     this.fileIO = fileIO;
     this.connections = dbConnPool;
     this.catalogProperties = catalogProperties;
+    this.schemaVersion = schemaVersion;
   }
 
   @Override
@@ -71,7 +71,7 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
     Map<String, String> table;
 
     try {
-      table = getTable();
+      table = JdbcUtil.loadTable(schemaVersion, connections, catalogName, tableIdentifier);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new UncheckedInterruptedException(e, "Interrupted during refresh");
@@ -105,7 +105,8 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
     boolean newTable = base == null;
     String newMetadataLocation = writeNewMetadataIfRequired(newTable, metadata);
     try {
-      Map<String, String> table = getTable();
+      Map<String, String> table =
+          JdbcUtil.loadTable(schemaVersion, connections, catalogName, tableIdentifier);
 
       if (base != null) {
         validateMetadataLocation(table, base);
@@ -140,6 +141,7 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
       if (e.getMessage().contains("constraint failed")) {
         throw new AlreadyExistsException("Table already exists: %s", tableIdentifier);
       }
+
       throw new UncheckedSQLException(e, "Unknown failure");
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -150,20 +152,13 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
   private void updateTable(String newMetadataLocation, String oldMetadataLocation)
       throws SQLException, InterruptedException {
     int updatedRecords =
-        connections.run(
-            conn -> {
-              try (PreparedStatement sql = conn.prepareStatement(JdbcUtil.DO_COMMIT_SQL)) {
-                // UPDATE
-                sql.setString(1, newMetadataLocation);
-                sql.setString(2, oldMetadataLocation);
-                // WHERE
-                sql.setString(3, catalogName);
-                sql.setString(4, JdbcUtil.namespaceToString(tableIdentifier.namespace()));
-                sql.setString(5, tableIdentifier.name());
-                sql.setString(6, oldMetadataLocation);
-                return sql.executeUpdate();
-              }
-            });
+        JdbcUtil.updateTable(
+            schemaVersion,
+            connections,
+            catalogName,
+            tableIdentifier,
+            newMetadataLocation,
+            oldMetadataLocation);
 
     if (updatedRecords == 1) {
       LOG.debug("Successfully committed to existing table: {}", tableIdentifier);
@@ -182,18 +177,23 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
           tableIdentifier, catalogName, namespace);
     }
 
+    if (schemaVersion == JdbcUtil.SchemaVersion.V1
+        && JdbcUtil.viewExists(catalogName, connections, tableIdentifier)) {
+      throw new AlreadyExistsException("View with same name already exists: %s", tableIdentifier);
+    }
+
+    if (JdbcUtil.tableExists(schemaVersion, catalogName, connections, tableIdentifier)) {
+      throw new AlreadyExistsException("Table already exists: %s", tableIdentifier);
+    }
+
     int insertRecord =
-        connections.run(
-            conn -> {
-              try (PreparedStatement sql =
-                  conn.prepareStatement(JdbcUtil.DO_COMMIT_CREATE_TABLE_SQL)) {
-                sql.setString(1, catalogName);
-                sql.setString(2, JdbcUtil.namespaceToString(namespace));
-                sql.setString(3, tableIdentifier.name());
-                sql.setString(4, newMetadataLocation);
-                return sql.executeUpdate();
-              }
-            });
+        JdbcUtil.doCommitCreateTable(
+            schemaVersion,
+            connections,
+            catalogName,
+            namespace,
+            tableIdentifier,
+            newMetadataLocation);
 
     if (insertRecord == 1) {
       LOG.debug("Successfully committed to new table: {}", tableIdentifier);
@@ -222,33 +222,5 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
   @Override
   protected String tableName() {
     return tableIdentifier.toString();
-  }
-
-  private Map<String, String> getTable()
-      throws UncheckedSQLException, SQLException, InterruptedException {
-    return connections.run(
-        conn -> {
-          Map<String, String> table = Maps.newHashMap();
-
-          try (PreparedStatement sql = conn.prepareStatement(JdbcUtil.GET_TABLE_SQL)) {
-            sql.setString(1, catalogName);
-            sql.setString(2, JdbcUtil.namespaceToString(tableIdentifier.namespace()));
-            sql.setString(3, tableIdentifier.name());
-            ResultSet rs = sql.executeQuery();
-
-            if (rs.next()) {
-              table.put(JdbcUtil.CATALOG_NAME, rs.getString(JdbcUtil.CATALOG_NAME));
-              table.put(JdbcUtil.TABLE_NAMESPACE, rs.getString(JdbcUtil.TABLE_NAMESPACE));
-              table.put(JdbcUtil.TABLE_NAME, rs.getString(JdbcUtil.TABLE_NAME));
-              table.put(METADATA_LOCATION_PROP, rs.getString(METADATA_LOCATION_PROP));
-              table.put(
-                  PREVIOUS_METADATA_LOCATION_PROP, rs.getString(PREVIOUS_METADATA_LOCATION_PROP));
-            }
-
-            rs.close();
-          }
-
-          return table;
-        });
   }
 }

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
@@ -25,31 +25,62 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 final class JdbcUtil {
   // property to control strict-mode (aka check if namespace exists when creating a table)
   static final String STRICT_MODE_PROPERTY = JdbcCatalog.PROPERTY_PREFIX + "strict-mode";
+  // property to control if view support is added to the existing database
+  static final String ADD_VIEW_SUPPORT_PROPERTY = JdbcCatalog.PROPERTY_PREFIX + "add-view-support";
 
-  // Catalog Table
-  static final String CATALOG_TABLE_NAME = "iceberg_tables";
+  enum SchemaVersion {
+    V0,
+    V1
+  }
+
+  // Catalog Table & View
+  static final String CATALOG_TABLE_VIEW_NAME = "iceberg_tables";
   static final String CATALOG_NAME = "catalog_name";
-  static final String TABLE_NAMESPACE = "table_namespace";
   static final String TABLE_NAME = "table_name";
+  static final String TABLE_NAMESPACE = "table_namespace";
+  static final String RECORD_TYPE = "iceberg_type";
+  static final String TABLE_RECORD_TYPE = "TABLE";
+  static final String VIEW_RECORD_TYPE = "VIEW";
 
-  static final String DO_COMMIT_SQL =
+  private static final String V1_DO_COMMIT_SQL =
       "UPDATE "
-          + CATALOG_TABLE_NAME
+          + CATALOG_TABLE_VIEW_NAME
           + " SET "
           + JdbcTableOperations.METADATA_LOCATION_PROP
           + " = ? , "
           + JdbcTableOperations.PREVIOUS_METADATA_LOCATION_PROP
-          + " = ? "
+          + " = ?"
+          + " WHERE "
+          + CATALOG_NAME
+          + " = ? AND "
+          + TABLE_NAMESPACE
+          + " = ? AND "
+          + TABLE_NAME
+          + " = ? AND "
+          + JdbcTableOperations.METADATA_LOCATION_PROP
+          + " = ? AND "
+          + RECORD_TYPE
+          + " = ?";
+  private static final String V0_DO_COMMIT_SQL =
+      "UPDATE "
+          + CATALOG_TABLE_VIEW_NAME
+          + " SET "
+          + JdbcTableOperations.METADATA_LOCATION_PROP
+          + " = ? , "
+          + JdbcTableOperations.PREVIOUS_METADATA_LOCATION_PROP
+          + " = ?"
           + " WHERE "
           + CATALOG_NAME
           + " = ? AND "
@@ -59,9 +90,9 @@ final class JdbcUtil {
           + " = ? AND "
           + JdbcTableOperations.METADATA_LOCATION_PROP
           + " = ?";
-  static final String CREATE_CATALOG_TABLE =
+  static final String CREATE_CATALOG_SQL =
       "CREATE TABLE "
-          + CATALOG_TABLE_NAME
+          + CATALOG_TABLE_VIEW_NAME
           + "("
           + CATALOG_NAME
           + " VARCHAR(255) NOT NULL,"
@@ -73,6 +104,8 @@ final class JdbcUtil {
           + " VARCHAR(1000),"
           + JdbcTableOperations.PREVIOUS_METADATA_LOCATION_PROP
           + " VARCHAR(1000),"
+          + RECORD_TYPE
+          + " VARCHAR(100),"
           + "PRIMARY KEY ("
           + CATALOG_NAME
           + ", "
@@ -81,85 +114,242 @@ final class JdbcUtil {
           + TABLE_NAME
           + ")"
           + ")";
-  static final String GET_TABLE_SQL =
+  static final String UPDATE_CATALOG_SQL =
+      "ALTER TABLE " + CATALOG_TABLE_VIEW_NAME + " ADD COLUMN " + RECORD_TYPE + " VARCHAR(5)";
+
+  private static final String GET_VIEW_SQL =
       "SELECT * FROM "
-          + CATALOG_TABLE_NAME
+          + CATALOG_TABLE_VIEW_NAME
           + " WHERE "
           + CATALOG_NAME
           + " = ? AND "
           + TABLE_NAMESPACE
           + " = ? AND "
           + TABLE_NAME
-          + " = ? ";
-  static final String LIST_TABLES_SQL =
+          + " = ? AND "
+          + RECORD_TYPE
+          + " = "
+          + "'"
+          + VIEW_RECORD_TYPE
+          + "'";
+  private static final String V1_GET_TABLE_SQL =
       "SELECT * FROM "
-          + CATALOG_TABLE_NAME
+          + CATALOG_TABLE_VIEW_NAME
+          + " WHERE "
+          + CATALOG_NAME
+          + " = ? AND "
+          + TABLE_NAMESPACE
+          + " = ? AND "
+          + TABLE_NAME
+          + " = ? AND ("
+          + RECORD_TYPE
+          + " = "
+          + "'"
+          + TABLE_RECORD_TYPE
+          + "'"
+          + " OR "
+          + RECORD_TYPE
+          + " IS NULL)";
+  private static final String V0_GET_TABLE_SQL =
+      "SELECT * FROM "
+          + CATALOG_TABLE_VIEW_NAME
+          + " WHERE "
+          + CATALOG_NAME
+          + " = ? AND "
+          + TABLE_NAMESPACE
+          + " = ? AND "
+          + TABLE_NAME
+          + " = ?";
+  static final String LIST_VIEW_SQL =
+      "SELECT * FROM "
+          + CATALOG_TABLE_VIEW_NAME
+          + " WHERE "
+          + CATALOG_NAME
+          + " = ? AND "
+          + TABLE_NAMESPACE
+          + " = ? AND "
+          + RECORD_TYPE
+          + " = "
+          + "'"
+          + VIEW_RECORD_TYPE
+          + "'";
+  static final String V1_LIST_TABLE_SQL =
+      "SELECT * FROM "
+          + CATALOG_TABLE_VIEW_NAME
+          + " WHERE "
+          + CATALOG_NAME
+          + " = ? AND "
+          + TABLE_NAMESPACE
+          + " = ? AND ("
+          + RECORD_TYPE
+          + " = "
+          + "'"
+          + TABLE_RECORD_TYPE
+          + "'"
+          + " OR "
+          + RECORD_TYPE
+          + " IS NULL)";
+  static final String V0_LIST_TABLE_SQL =
+      "SELECT * FROM "
+          + CATALOG_TABLE_VIEW_NAME
           + " WHERE "
           + CATALOG_NAME
           + " = ? AND "
           + TABLE_NAMESPACE
           + " = ?";
-  static final String RENAME_TABLE_SQL =
+  static final String RENAME_VIEW_SQL =
       "UPDATE "
-          + CATALOG_TABLE_NAME
+          + CATALOG_TABLE_VIEW_NAME
           + " SET "
           + TABLE_NAMESPACE
-          + " = ? , "
+          + " = ?, "
           + TABLE_NAME
-          + " = ? "
+          + " = ?"
           + " WHERE "
           + CATALOG_NAME
           + " = ? AND "
           + TABLE_NAMESPACE
           + " = ? AND "
           + TABLE_NAME
-          + " = ? ";
-  static final String DROP_TABLE_SQL =
+          + " = ? AND "
+          + RECORD_TYPE
+          + " = "
+          + "'"
+          + VIEW_RECORD_TYPE
+          + "'";
+  static final String V1_RENAME_TABLE_SQL =
+      "UPDATE "
+          + CATALOG_TABLE_VIEW_NAME
+          + " SET "
+          + TABLE_NAMESPACE
+          + " = ?, "
+          + TABLE_NAME
+          + " = ?"
+          + " WHERE "
+          + CATALOG_NAME
+          + " = ? AND "
+          + TABLE_NAMESPACE
+          + " = ? AND "
+          + TABLE_NAME
+          + " = ? AND ("
+          + RECORD_TYPE
+          + " = "
+          + "'"
+          + TABLE_RECORD_TYPE
+          + "'"
+          + " OR "
+          + RECORD_TYPE
+          + " IS NULL)";
+  static final String V0_RENAME_TABLE_SQL =
+      "UPDATE "
+          + CATALOG_TABLE_VIEW_NAME
+          + " SET "
+          + TABLE_NAMESPACE
+          + " = ?, "
+          + TABLE_NAME
+          + " = ?"
+          + " WHERE "
+          + CATALOG_NAME
+          + " = ? AND "
+          + TABLE_NAMESPACE
+          + " = ? AND "
+          + TABLE_NAME
+          + " = ?";
+  static final String DROP_VIEW_SQL =
       "DELETE FROM "
-          + CATALOG_TABLE_NAME
+          + CATALOG_TABLE_VIEW_NAME
           + " WHERE "
           + CATALOG_NAME
           + " = ? AND "
           + TABLE_NAMESPACE
-          + " = ? AND "
+          + "  = ? AND "
           + TABLE_NAME
-          + " = ? ";
-  static final String GET_NAMESPACE_SQL =
+          + " = ? AND "
+          + RECORD_TYPE
+          + " = "
+          + "'"
+          + VIEW_RECORD_TYPE
+          + "'";
+  static final String V1_DROP_TABLE_SQL =
+      "DELETE FROM "
+          + CATALOG_TABLE_VIEW_NAME
+          + " WHERE "
+          + CATALOG_NAME
+          + " = ? AND "
+          + TABLE_NAMESPACE
+          + "  = ? AND "
+          + TABLE_NAME
+          + " = ? AND ("
+          + RECORD_TYPE
+          + " = "
+          + "'"
+          + TABLE_RECORD_TYPE
+          + "'"
+          + " OR "
+          + RECORD_TYPE
+          + " IS NULL)";
+  static final String V0_DROP_TABLE_SQL =
+      "DELETE FROM "
+          + CATALOG_TABLE_VIEW_NAME
+          + " WHERE "
+          + CATALOG_NAME
+          + " = ? AND "
+          + TABLE_NAMESPACE
+          + "  = ? AND "
+          + TABLE_NAME
+          + " = ?";
+  private static final String GET_NAMESPACE_SQL =
       "SELECT "
           + TABLE_NAMESPACE
           + " FROM "
-          + CATALOG_TABLE_NAME
+          + CATALOG_TABLE_VIEW_NAME
           + " WHERE "
           + CATALOG_NAME
           + " = ? AND "
-          + " ( "
+          + " ("
           + TABLE_NAMESPACE
           + " = ? OR "
           + TABLE_NAMESPACE
-          + " LIKE ? ESCAPE '\\' "
-          + " ) "
+          + " LIKE ? ESCAPE '\\')"
           + " LIMIT 1";
   static final String LIST_NAMESPACES_SQL =
       "SELECT DISTINCT "
           + TABLE_NAMESPACE
           + " FROM "
-          + CATALOG_TABLE_NAME
+          + CATALOG_TABLE_VIEW_NAME
           + " WHERE "
           + CATALOG_NAME
           + " = ? AND "
           + TABLE_NAMESPACE
           + " LIKE ?";
-  static final String LIST_ALL_TABLE_NAMESPACES_SQL =
+  static final String LIST_ALL_NAMESPACES_SQL =
       "SELECT DISTINCT "
           + TABLE_NAMESPACE
           + " FROM "
-          + CATALOG_TABLE_NAME
+          + CATALOG_TABLE_VIEW_NAME
           + " WHERE "
           + CATALOG_NAME
           + " = ?";
-  static final String DO_COMMIT_CREATE_TABLE_SQL =
+  private static final String V1_DO_COMMIT_CREATE_SQL =
       "INSERT INTO "
-          + CATALOG_TABLE_NAME
+          + CATALOG_TABLE_VIEW_NAME
+          + " ("
+          + CATALOG_NAME
+          + ", "
+          + TABLE_NAMESPACE
+          + ", "
+          + TABLE_NAME
+          + ", "
+          + JdbcTableOperations.METADATA_LOCATION_PROP
+          + ", "
+          + JdbcTableOperations.PREVIOUS_METADATA_LOCATION_PROP
+          + ", "
+          + RECORD_TYPE
+          + ") "
+          + " VALUES (?,?,?,?,null,?)";
+  private static final String V0_DO_COMMIT_CREATE_SQL =
+      "INSERT INTO "
+          + CATALOG_TABLE_VIEW_NAME
           + " ("
           + CATALOG_NAME
           + ", "
@@ -179,7 +369,7 @@ final class JdbcUtil {
   static final String NAMESPACE_PROPERTY_KEY = "property_key";
   static final String NAMESPACE_PROPERTY_VALUE = "property_value";
 
-  static final String CREATE_NAMESPACE_PROPERTIES_TABLE =
+  static final String CREATE_NAMESPACE_PROPERTIES_TABLE_SQL =
       "CREATE TABLE "
           + NAMESPACE_PROPERTIES_TABLE_NAME
           + "("
@@ -278,20 +468,20 @@ final class JdbcUtil {
 
   private JdbcUtil() {}
 
-  public static Namespace stringToNamespace(String namespace) {
+  static Namespace stringToNamespace(String namespace) {
     Preconditions.checkArgument(namespace != null, "Invalid namespace %s", namespace);
     return Namespace.of(Iterables.toArray(SPLITTER_DOT.split(namespace), String.class));
   }
 
-  public static String namespaceToString(Namespace namespace) {
+  static String namespaceToString(Namespace namespace) {
     return JOINER_DOT.join(namespace.levels());
   }
 
-  public static TableIdentifier stringToTableIdentifier(String tableNamespace, String tableName) {
+  static TableIdentifier stringToTableIdentifier(String tableNamespace, String tableName) {
     return TableIdentifier.of(JdbcUtil.stringToNamespace(tableNamespace), tableName);
   }
 
-  public static Properties filterAndRemovePrefix(Map<String, String> properties, String prefix) {
+  static Properties filterAndRemovePrefix(Map<String, String> properties, String prefix) {
     Properties result = new Properties();
     properties.forEach(
         (key, value) -> {
@@ -303,7 +493,218 @@ final class JdbcUtil {
     return result;
   }
 
-  public static String updatePropertiesStatement(int size) {
+  private static int update(
+      boolean isTable,
+      SchemaVersion schemaVersion,
+      JdbcClientPool connections,
+      String catalogName,
+      TableIdentifier identifier,
+      String newMetadataLocation,
+      String oldMetadataLocation)
+      throws SQLException, InterruptedException {
+    return connections.run(
+        conn -> {
+          try (PreparedStatement sql =
+              conn.prepareStatement(
+                  (schemaVersion == SchemaVersion.V1) ? V1_DO_COMMIT_SQL : V0_DO_COMMIT_SQL)) {
+            // UPDATE
+            sql.setString(1, newMetadataLocation);
+            sql.setString(2, oldMetadataLocation);
+            // WHERE
+            sql.setString(3, catalogName);
+            sql.setString(4, namespaceToString(identifier.namespace()));
+            sql.setString(5, identifier.name());
+            sql.setString(6, oldMetadataLocation);
+            if (schemaVersion == SchemaVersion.V1) {
+              sql.setString(7, isTable ? TABLE_RECORD_TYPE : VIEW_RECORD_TYPE);
+            }
+
+            return sql.executeUpdate();
+          }
+        });
+  }
+
+  static int updateTable(
+      SchemaVersion schemaVersion,
+      JdbcClientPool connections,
+      String catalogName,
+      TableIdentifier tableIdentifier,
+      String newMetadataLocation,
+      String oldMetadataLocation)
+      throws SQLException, InterruptedException {
+    return update(
+        true,
+        schemaVersion,
+        connections,
+        catalogName,
+        tableIdentifier,
+        newMetadataLocation,
+        oldMetadataLocation);
+  }
+
+  static int updateView(
+      JdbcClientPool connections,
+      String catalogName,
+      TableIdentifier viewIdentifier,
+      String newMetadataLocation,
+      String oldMetadataLocation)
+      throws SQLException, InterruptedException {
+    return update(
+        false,
+        SchemaVersion.V1,
+        connections,
+        catalogName,
+        viewIdentifier,
+        newMetadataLocation,
+        oldMetadataLocation);
+  }
+
+  private static Map<String, String> tableOrView(
+      boolean isTable,
+      SchemaVersion schemaVersion,
+      JdbcClientPool connections,
+      String catalogName,
+      TableIdentifier identifier)
+      throws SQLException, InterruptedException {
+    return connections.run(
+        conn -> {
+          Map<String, String> tableOrView = Maps.newHashMap();
+
+          try (PreparedStatement sql =
+              conn.prepareStatement(
+                  isTable
+                      ? ((schemaVersion == SchemaVersion.V1) ? V1_GET_TABLE_SQL : V0_GET_TABLE_SQL)
+                      : GET_VIEW_SQL)) {
+            sql.setString(1, catalogName);
+            sql.setString(2, namespaceToString(identifier.namespace()));
+            sql.setString(3, identifier.name());
+            ResultSet rs = sql.executeQuery();
+
+            if (rs.next()) {
+              tableOrView.put(CATALOG_NAME, rs.getString(CATALOG_NAME));
+              tableOrView.put(TABLE_NAMESPACE, rs.getString(TABLE_NAMESPACE));
+              tableOrView.put(TABLE_NAME, rs.getString(TABLE_NAME));
+              tableOrView.put(
+                  BaseMetastoreTableOperations.METADATA_LOCATION_PROP,
+                  rs.getString(BaseMetastoreTableOperations.METADATA_LOCATION_PROP));
+              tableOrView.put(
+                  BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP,
+                  rs.getString(BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP));
+            }
+
+            rs.close();
+          }
+
+          return tableOrView;
+        });
+  }
+
+  static Map<String, String> loadTable(
+      SchemaVersion schemaVersion,
+      JdbcClientPool connections,
+      String catalogName,
+      TableIdentifier identifier)
+      throws SQLException, InterruptedException {
+    return tableOrView(true, schemaVersion, connections, catalogName, identifier);
+  }
+
+  static Map<String, String> loadView(
+      SchemaVersion schemaVersion,
+      JdbcClientPool connections,
+      String catalogName,
+      TableIdentifier identifier)
+      throws SQLException, InterruptedException {
+    return tableOrView(false, schemaVersion, connections, catalogName, identifier);
+  }
+
+  private static int doCommitCreate(
+      boolean isTable,
+      SchemaVersion schemaVersion,
+      JdbcClientPool connections,
+      String catalogName,
+      Namespace namespace,
+      TableIdentifier identifier,
+      String newMetadataLocation)
+      throws SQLException, InterruptedException {
+    return connections.run(
+        conn -> {
+          try (PreparedStatement sql =
+              conn.prepareStatement(
+                  (schemaVersion == SchemaVersion.V1)
+                      ? V1_DO_COMMIT_CREATE_SQL
+                      : V0_DO_COMMIT_CREATE_SQL)) {
+            sql.setString(1, catalogName);
+            sql.setString(2, namespaceToString(namespace));
+            sql.setString(3, identifier.name());
+            sql.setString(4, newMetadataLocation);
+            if (schemaVersion == SchemaVersion.V1) {
+              sql.setString(5, isTable ? TABLE_RECORD_TYPE : VIEW_RECORD_TYPE);
+            }
+
+            return sql.executeUpdate();
+          }
+        });
+  }
+
+  static int doCommitCreateTable(
+      SchemaVersion schemaVersion,
+      JdbcClientPool connections,
+      String catalogName,
+      Namespace namespace,
+      TableIdentifier tableIdentifier,
+      String newMetadataLocation)
+      throws SQLException, InterruptedException {
+    return doCommitCreate(
+        true,
+        schemaVersion,
+        connections,
+        catalogName,
+        namespace,
+        tableIdentifier,
+        newMetadataLocation);
+  }
+
+  static int doCommitCreateView(
+      JdbcClientPool connections,
+      String catalogName,
+      Namespace namespace,
+      TableIdentifier viewIdentifier,
+      String newMetadataLocation)
+      throws SQLException, InterruptedException {
+    return doCommitCreate(
+        false,
+        SchemaVersion.V1,
+        connections,
+        catalogName,
+        namespace,
+        viewIdentifier,
+        newMetadataLocation);
+  }
+
+  static boolean viewExists(
+      String catalogName, JdbcClientPool connections, TableIdentifier viewIdentifier) {
+    return exists(
+        connections,
+        GET_VIEW_SQL,
+        catalogName,
+        namespaceToString(viewIdentifier.namespace()),
+        viewIdentifier.name());
+  }
+
+  static boolean tableExists(
+      SchemaVersion schemaVersion,
+      String catalogName,
+      JdbcClientPool connections,
+      TableIdentifier tableIdentifier) {
+    return exists(
+        connections,
+        (schemaVersion == SchemaVersion.V1) ? V1_GET_TABLE_SQL : V0_GET_TABLE_SQL,
+        catalogName,
+        namespaceToString(tableIdentifier.namespace()),
+        tableIdentifier.name());
+  }
+
+  static String updatePropertiesStatement(int size) {
     StringBuilder sqlStatement =
         new StringBuilder(
             "UPDATE "
@@ -314,6 +715,7 @@ final class JdbcUtil {
     for (int i = 0; i < size; i += 1) {
       sqlStatement.append(" WHEN " + NAMESPACE_PROPERTY_KEY + " = ? THEN ?");
     }
+
     sqlStatement.append(
         " END WHERE "
             + CATALOG_NAME
@@ -329,7 +731,7 @@ final class JdbcUtil {
     return sqlStatement.toString();
   }
 
-  public static String insertPropertiesStatement(int size) {
+  static String insertPropertiesStatement(int size) {
     StringBuilder sqlStatement = new StringBuilder(JdbcUtil.INSERT_NAMESPACE_PROPERTIES_SQL);
 
     for (int i = 0; i < size; i++) {
@@ -342,7 +744,7 @@ final class JdbcUtil {
     return sqlStatement.toString();
   }
 
-  public static String deletePropertiesStatement(Set<String> properties) {
+  static String deletePropertiesStatement(Set<String> properties) {
     StringBuilder sqlStatement = new StringBuilder(JdbcUtil.DELETE_NAMESPACE_PROPERTIES_SQL);
     String values = String.join(",", Collections.nCopies(properties.size(), String.valueOf('?')));
     sqlStatement.append("(").append(values).append(")");
@@ -358,25 +760,16 @@ final class JdbcUtil {
     // catalog.db can exists as: catalog.db.ns1 or catalog.db.ns1.ns2
     String namespaceStartsWith =
         namespaceEquals.replace("\\", "\\\\").replace("_", "\\_").replace("%", "\\%") + ".%";
-    if (exists(
-        connections,
-        JdbcUtil.GET_NAMESPACE_SQL,
-        catalogName,
-        namespaceEquals,
-        namespaceStartsWith)) {
+    if (exists(connections, GET_NAMESPACE_SQL, catalogName, namespaceEquals, namespaceStartsWith)) {
       return true;
     }
 
-    if (exists(
+    return exists(
         connections,
         JdbcUtil.GET_NAMESPACE_PROPERTIES_SQL,
         catalogName,
         namespaceEquals,
-        namespaceStartsWith)) {
-      return true;
-    }
-
-    return false;
+        namespaceStartsWith);
   }
 
   @SuppressWarnings("checkstyle:NestedTryDepth")

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcViewOperations.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcViewOperations.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.jdbc;
+
+import java.sql.DataTruncation;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLTimeoutException;
+import java.sql.SQLTransientConnectionException;
+import java.sql.SQLWarning;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.view.BaseViewOperations;
+import org.apache.iceberg.view.ViewMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** JDBC implementation of Iceberg ViewOperations. */
+public class JdbcViewOperations extends BaseViewOperations {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JdbcViewOperations.class);
+  private final String catalogName;
+  private final TableIdentifier viewIdentifier;
+  private final FileIO fileIO;
+  private final JdbcClientPool connections;
+  private final Map<String, String> catalogProperties;
+
+  protected JdbcViewOperations(
+      JdbcClientPool dbConnPool,
+      FileIO fileIO,
+      String catalogName,
+      TableIdentifier viewIdentifier,
+      Map<String, String> catalogProperties) {
+    this.catalogName = catalogName;
+    this.viewIdentifier = viewIdentifier;
+    this.fileIO = fileIO;
+    this.connections = dbConnPool;
+    this.catalogProperties = catalogProperties;
+  }
+
+  @Override
+  protected void doRefresh() {
+    Map<String, String> view;
+
+    try {
+      view = JdbcUtil.loadView(JdbcUtil.SchemaVersion.V1, connections, catalogName, viewIdentifier);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UncheckedInterruptedException(e, "Interrupted during refresh");
+    } catch (SQLException e) {
+      // SQL exception happened when getting view from catalog
+      throw new UncheckedSQLException(
+          e, "Failed to get view %s from catalog %s", viewIdentifier, catalogName);
+    }
+
+    if (view.isEmpty()) {
+      if (currentMetadataLocation() != null) {
+        throw new NoSuchViewException("View does not exist: %s", viewIdentifier);
+      } else {
+        this.disableRefresh();
+        return;
+      }
+    }
+
+    String newMetadataLocation = view.get(JdbcTableOperations.METADATA_LOCATION_PROP);
+    Preconditions.checkState(
+        newMetadataLocation != null, "Invalid view %s: metadata location is null", viewIdentifier);
+    refreshFromMetadataLocation(newMetadataLocation);
+  }
+
+  @Override
+  protected void doCommit(ViewMetadata base, ViewMetadata metadata) {
+    String newMetadataLocation = writeNewMetadataIfRequired(metadata);
+    try {
+      Map<String, String> view =
+          JdbcUtil.loadView(JdbcUtil.SchemaVersion.V1, connections, catalogName, viewIdentifier);
+      if (base != null) {
+        validateMetadataLocation(view, base);
+        String oldMetadataLocation = base.metadataFileLocation();
+        // Start atomic update
+        LOG.debug("Committing existing view: {}", viewName());
+        updateView(newMetadataLocation, oldMetadataLocation);
+      } else {
+        // view does not exist, create it
+        LOG.debug("Committing new view: {}", viewName());
+        createView(newMetadataLocation);
+      }
+
+    } catch (SQLIntegrityConstraintViolationException e) {
+      if (currentMetadataLocation() == null) {
+        throw new AlreadyExistsException(e, "View already exists: %s", viewIdentifier);
+      } else {
+        throw new UncheckedSQLException(e, "View already exists: %s", viewIdentifier);
+      }
+
+    } catch (SQLTimeoutException e) {
+      throw new UncheckedSQLException(e, "Database Connection timeout");
+    } catch (SQLTransientConnectionException | SQLNonTransientConnectionException e) {
+      throw new UncheckedSQLException(e, "Database Connection failed");
+    } catch (DataTruncation e) {
+      throw new UncheckedSQLException(e, "Database data truncation error");
+    } catch (SQLWarning e) {
+      throw new UncheckedSQLException(e, "Database warning");
+    } catch (SQLException e) {
+      // SQLite doesn't set SQLState or throw SQLIntegrityConstraintViolationException
+      if (e.getMessage().contains("constraint failed")) {
+        throw new AlreadyExistsException("View already exists: %s", viewIdentifier);
+      }
+
+      throw new UncheckedSQLException(e, "Unknown failure");
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UncheckedInterruptedException(e, "Interrupted during commit");
+    }
+  }
+
+  @Override
+  protected String viewName() {
+    return viewIdentifier.toString();
+  }
+
+  @Override
+  protected FileIO io() {
+    return fileIO;
+  }
+
+  private void validateMetadataLocation(Map<String, String> view, ViewMetadata base) {
+    String catalogMetadataLocation = view.get(JdbcTableOperations.METADATA_LOCATION_PROP);
+    String baseMetadataLocation = base != null ? base.metadataFileLocation() : null;
+
+    if (!Objects.equals(baseMetadataLocation, catalogMetadataLocation)) {
+      throw new CommitFailedException(
+          "Cannot commit %s: metadata location %s has changed from %s",
+          viewIdentifier, baseMetadataLocation, catalogMetadataLocation);
+    }
+  }
+
+  private void updateView(String newMetadataLocation, String oldMetadataLocation)
+      throws SQLException, InterruptedException {
+    int updatedRecords =
+        JdbcUtil.updateView(
+            connections, catalogName, viewIdentifier, newMetadataLocation, oldMetadataLocation);
+
+    if (updatedRecords == 1) {
+      LOG.debug("Successfully committed to existing view: {}", viewIdentifier);
+    } else {
+      throw new CommitFailedException(
+          "Failed to update view %s from catalog %s", viewIdentifier, catalogName);
+    }
+  }
+
+  private void createView(String newMetadataLocation) throws SQLException, InterruptedException {
+    Namespace namespace = viewIdentifier.namespace();
+    if (PropertyUtil.propertyAsBoolean(catalogProperties, JdbcUtil.STRICT_MODE_PROPERTY, false)
+        && !JdbcUtil.namespaceExists(catalogName, connections, namespace)) {
+      throw new NoSuchNamespaceException(
+          "Cannot create view %s in catalog %s. Namespace %s does not exist",
+          viewIdentifier, catalogName, namespace);
+    }
+
+    if (JdbcUtil.tableExists(JdbcUtil.SchemaVersion.V1, catalogName, connections, viewIdentifier)) {
+      throw new AlreadyExistsException("Table with same name already exists: %s", viewIdentifier);
+    }
+
+    if (JdbcUtil.viewExists(catalogName, connections, viewIdentifier)) {
+      throw new AlreadyExistsException("View already exists: %s", viewIdentifier);
+    }
+
+    int insertRecord =
+        JdbcUtil.doCommitCreateView(
+            connections, catalogName, namespace, viewIdentifier, newMetadataLocation);
+
+    if (insertRecord == 1) {
+      LOG.debug("Successfully committed to new view: {}", viewIdentifier);
+    } else {
+      throw new CommitFailedException(
+          "Failed to create view %s in catalog %s", viewIdentifier, catalogName);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -77,6 +79,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.sqlite.SQLiteDataSource;
 
 public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
 
@@ -156,6 +159,91 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     // second initialization should not fail even if tables are already created
     jdbcCatalog.initialize("test_jdbc_catalog", properties);
     jdbcCatalog.initialize("test_jdbc_catalog", properties);
+  }
+
+  @Test
+  public void testSchemaIsMigratedToAddViewSupport() throws Exception {
+    // as this test uses different connections, we can't use memory database (as it's per
+    // connection), but a file database instead
+    java.nio.file.Path dbFile = Files.createTempFile("icebergSchemaUpdate", "db");
+    String jdbcUrl = "jdbc:sqlite:" + dbFile.toAbsolutePath();
+
+    initLegacySchema(jdbcUrl);
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(CatalogProperties.WAREHOUSE_LOCATION, this.tableDir.toAbsolutePath().toString());
+    properties.put(CatalogProperties.URI, jdbcUrl);
+    properties.put(JdbcUtil.ADD_VIEW_SUPPORT_PROPERTY, "true");
+    JdbcCatalog jdbcCatalog = new JdbcCatalog();
+    jdbcCatalog.setConf(conf);
+    jdbcCatalog.initialize("TEST", properties);
+
+    TableIdentifier tableOne = TableIdentifier.of("namespace1", "table1");
+    TableIdentifier tableTwo = TableIdentifier.of("namespace2", "table2");
+    assertThat(jdbcCatalog.listTables(Namespace.of("namespace1")))
+        .hasSize(1)
+        .containsExactly(tableOne);
+
+    assertThat(jdbcCatalog.listTables(Namespace.of("namespace2")))
+        .hasSize(1)
+        .containsExactly(tableTwo);
+
+    assertThat(jdbcCatalog.listViews(Namespace.of("namespace1"))).isEmpty();
+
+    TableIdentifier view = TableIdentifier.of("namespace1", "view");
+    jdbcCatalog
+        .buildView(view)
+        .withQuery("spark", "select * from tbl")
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(Namespace.of("namespace1"))
+        .create();
+
+    assertThat(jdbcCatalog.listViews(Namespace.of("namespace1"))).hasSize(1).containsExactly(view);
+  }
+
+  @Test
+  public void testLegacySchemaSupport() throws Exception {
+    // as this test uses different connection, we can't use memory database (as it's per
+    // connection), but a
+    // file database instead
+    java.nio.file.Path dbFile = Files.createTempFile("icebergOldSchema", "db");
+    String jdbcUrl = "jdbc:sqlite:" + dbFile.toAbsolutePath();
+
+    initLegacySchema(jdbcUrl);
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(CatalogProperties.WAREHOUSE_LOCATION, this.tableDir.toAbsolutePath().toString());
+    properties.put(CatalogProperties.URI, jdbcUrl);
+    JdbcCatalog jdbcCatalog = new JdbcCatalog();
+    jdbcCatalog.setConf(conf);
+    jdbcCatalog.initialize("TEST", properties);
+
+    TableIdentifier tableOne = TableIdentifier.of("namespace1", "table1");
+    TableIdentifier tableTwo = TableIdentifier.of("namespace2", "table2");
+
+    assertThat(jdbcCatalog.listTables(Namespace.of("namespace1")))
+        .hasSize(1)
+        .containsExactly(tableOne);
+
+    assertThat(jdbcCatalog.listTables(Namespace.of("namespace2")))
+        .hasSize(1)
+        .containsExactly(tableTwo);
+
+    TableIdentifier newTable = TableIdentifier.of("namespace1", "table2");
+    jdbcCatalog.buildTable(newTable, SCHEMA).create();
+
+    assertThat(jdbcCatalog.listTables(Namespace.of("namespace1")))
+        .hasSize(2)
+        .containsExactly(tableOne, newTable);
+
+    assertThatThrownBy(() -> jdbcCatalog.listViews(Namespace.of("namespace1")))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(JdbcCatalog.VIEW_WARNING_LOG_MESSAGE);
+
+    assertThatThrownBy(
+            () -> jdbcCatalog.buildView(TableIdentifier.of("namespace1", "view")).create())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(JdbcCatalog.VIEW_WARNING_LOG_MESSAGE);
   }
 
   @Test
@@ -852,6 +940,70 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     @Override
     public void report(MetricsReport report) {
       COUNTER.incrementAndGet();
+    }
+  }
+
+  private void initLegacySchema(String jdbcUrl) throws SQLException {
+    SQLiteDataSource dataSource = new SQLiteDataSource();
+    dataSource.setUrl(jdbcUrl);
+
+    try (Connection connection = dataSource.getConnection()) {
+      // create "old style" SQL schema
+      connection
+          .prepareStatement(
+              "CREATE TABLE "
+                  + JdbcUtil.CATALOG_TABLE_VIEW_NAME
+                  + "("
+                  + JdbcUtil.CATALOG_NAME
+                  + " VARCHAR(255) NOT NULL,"
+                  + JdbcUtil.TABLE_NAMESPACE
+                  + " VARCHAR(255) NOT NULL,"
+                  + JdbcUtil.TABLE_NAME
+                  + " VARCHAR(255) NOT NULL,"
+                  + JdbcTableOperations.METADATA_LOCATION_PROP
+                  + " VARCHAR(1000),"
+                  + JdbcTableOperations.PREVIOUS_METADATA_LOCATION_PROP
+                  + " VARCHAR(1000),"
+                  + "PRIMARY KEY("
+                  + JdbcUtil.CATALOG_NAME
+                  + ","
+                  + JdbcUtil.TABLE_NAMESPACE
+                  + ","
+                  + JdbcUtil.TABLE_NAME
+                  + "))")
+          .executeUpdate();
+      connection
+          .prepareStatement(
+              "INSERT INTO "
+                  + JdbcUtil.CATALOG_TABLE_VIEW_NAME
+                  + "("
+                  + JdbcUtil.CATALOG_NAME
+                  + ","
+                  + JdbcUtil.TABLE_NAMESPACE
+                  + ","
+                  + JdbcUtil.TABLE_NAME
+                  + ","
+                  + JdbcTableOperations.METADATA_LOCATION_PROP
+                  + ","
+                  + JdbcTableOperations.PREVIOUS_METADATA_LOCATION_PROP
+                  + ") VALUES('TEST','namespace1','table1',null,null)")
+          .execute();
+      connection
+          .prepareStatement(
+              "INSERT INTO "
+                  + JdbcUtil.CATALOG_TABLE_VIEW_NAME
+                  + "("
+                  + JdbcUtil.CATALOG_NAME
+                  + ","
+                  + JdbcUtil.TABLE_NAMESPACE
+                  + ","
+                  + JdbcUtil.TABLE_NAME
+                  + ","
+                  + JdbcTableOperations.METADATA_LOCATION_PROP
+                  + ","
+                  + JdbcTableOperations.PREVIOUS_METADATA_LOCATION_PROP
+                  + ") VALUES('TEST','namespace2','table2',null,null)")
+          .execute();
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
@@ -18,10 +18,11 @@
  */
 package org.apache.iceberg.jdbc;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Map;
 import java.util.Properties;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestJdbcUtil {
@@ -42,6 +43,6 @@ public class TestJdbcUtil {
 
     Properties actual = JdbcUtil.filterAndRemovePrefix(input, "jdbc.");
 
-    Assertions.assertThat(expected).isEqualTo(actual);
+    assertThat(expected).isEqualTo(actual);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcViewCatalog.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.jdbc;
+
+import java.util.Map;
+import java.util.UUID;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.view.ViewCatalogTests;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestJdbcViewCatalog extends ViewCatalogTests<JdbcCatalog> {
+
+  private JdbcCatalog catalog;
+
+  @TempDir private java.nio.file.Path tableDir;
+
+  @BeforeEach
+  public void before() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(
+        CatalogProperties.URI,
+        "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", ""));
+    properties.put(JdbcCatalog.PROPERTY_PREFIX + "username", "user");
+    properties.put(JdbcCatalog.PROPERTY_PREFIX + "password", "password");
+    properties.put(CatalogProperties.WAREHOUSE_LOCATION, tableDir.toAbsolutePath().toString());
+
+    catalog = new JdbcCatalog();
+    catalog.setConf(new Configuration());
+    catalog.initialize("testCatalog", properties);
+  }
+
+  @Override
+  protected JdbcCatalog catalog() {
+    return catalog;
+  }
+
+  @Override
+  protected Catalog tableCatalog() {
+    return catalog;
+  }
+
+  @Override
+  protected boolean requiresNamespaceCreate() {
+    return true;
+  }
+}


### PR DESCRIPTION
This PR adds view support to the JDBC catalog:
- `JdbcCatalog` extends `BaseMetastoreViewCatalog`
- Introduce `JdbcViewOperations`
- Dedicated JDBC table to store views and associated namespaces
- `JdbcUtil` refactoring to deal with SQL statements common to table and view
- Introduce `TestJdbcViewCatalog` by extending `ViewCatalogTests`

Close #8697 