### PR TITLE
Docs: Fix typo in tag reading example

### DIFF
--- a/docs/java-api-quickstart.md
+++ b/docs/java-api-quickstart.md
@@ -264,7 +264,7 @@ Reading from a branch or tag can be done as usual via the Table Scan API, by pas
 TableScan branchRead = table.newScan().useRef("test-branch");
 
 // Read from the snapshot referenced by audit-tag
-Table tagRead = table.newScan().useRef("audit-tag");
+TableScan tagRead = table.newScan().useRef("audit-tag");
 ```
 
 ### Replacing and fast forwarding branches and tags


### PR DESCRIPTION
Small fix in the docs