### PR TITLE
Fix community link

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -81,7 +81,7 @@ extra:
   icebergVersion: '1.4.2'
   social:
     - icon: fontawesome/regular/comments
-      link: './community'
+      link: 'https://iceberg.apache.org/community/'
       title: community
     - icon: fontawesome/brands/github
       link: 'https://github.com/apache/iceberg'


### PR DESCRIPTION
The community link works only on top-level site links. Link this to the static site for now, eventually we need to consider a site-wide variable solution but that's not important for now.