### PR TITLE
Core: Fix setting updated parquet compression property

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -90,10 +90,19 @@ public class TableMetadata implements Serializable {
   private static Map<String, String> persistedProperties(Map<String, String> rawProperties) {
     Map<String, String> persistedProperties = Maps.newHashMap();
 
+    String format =
+        rawProperties.getOrDefault(
+            TableProperties.DEFAULT_FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
+    String deleteFileFormat =
+        rawProperties.getOrDefault(TableProperties.DELETE_DEFAULT_FILE_FORMAT, format);
+
     // explicitly set defaults that apply only to new tables
-    persistedProperties.put(
-        TableProperties.PARQUET_COMPRESSION,
-        TableProperties.PARQUET_COMPRESSION_DEFAULT_SINCE_1_4_0);
+    if (format.equalsIgnoreCase(FileFormat.PARQUET.name())
+        || deleteFileFormat.equalsIgnoreCase(FileFormat.PARQUET.name())) {
+      persistedProperties.put(
+          TableProperties.PARQUET_COMPRESSION,
+          TableProperties.PARQUET_COMPRESSION_DEFAULT_SINCE_1_4_0);
+    }
 
     rawProperties.entrySet().stream()
         .filter(entry -> !TableProperties.RESERVED_PROPERTIES.contains(entry.getKey()))

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -1729,6 +1729,46 @@ public class TestTableMetadata {
         meta.location());
   }
 
+  @Test
+  public void testCompressionDefaultPropertyForParquet() {
+    Map<String, String> properties =
+        ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, FileFormat.PARQUET.name());
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            TEST_SCHEMA, SPEC_5, SORT_ORDER_3, "/some-location/", properties);
+
+    Assertions.assertThat(metadata.property(TableProperties.PARQUET_COMPRESSION, null))
+        .as(
+            "Parquet data files should have the updated Parquet default compression property defined")
+        .isEqualTo(TableProperties.PARQUET_COMPRESSION_DEFAULT_SINCE_1_4_0);
+
+    properties =
+        ImmutableMap.of(
+            TableProperties.DEFAULT_FILE_FORMAT, FileFormat.ORC.name(),
+            TableProperties.DELETE_DEFAULT_FILE_FORMAT, FileFormat.PARQUET.name());
+    metadata =
+        TableMetadata.newTableMetadata(
+            TEST_SCHEMA, SPEC_5, SORT_ORDER_3, "/some-location/", properties);
+    Assertions.assertThat(metadata.property(TableProperties.PARQUET_COMPRESSION, null))
+        .as(
+            "Parquet delete files should have the updated Parquet default compression property defined")
+        .isEqualTo(TableProperties.PARQUET_COMPRESSION_DEFAULT_SINCE_1_4_0);
+  }
+
+  @Test
+  public void testNonParquetTablesNoParquetCompressionProperty() {
+    Map<String, String> properties =
+        ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, FileFormat.ORC.name());
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            TEST_SCHEMA, SPEC_5, SORT_ORDER_3, "/some-location/", properties);
+
+    Assertions.assertThat(metadata.property(TableProperties.PARQUET_COMPRESSION, null))
+        .as(
+            "ORC and other non-parquet files should not have the updated Parquet default compression property defined")
+        .isNull();
+  }
+
   private String createManifestListWithManifestFile(
       long snapshotId, Long parentSnapshotId, String manifestFile) throws IOException {
     File manifestList = temp.newFile("manifests" + UUID.randomUUID());


### PR DESCRIPTION
Fixes #9490 .

As part of 1.4.0 we made the default compression for Parquet to zstd. However, this property is being set for every new table regardless of the underlying file formats (e.g. we wouldn't want to set these properties for Avro or ORC).

This change conditionally sets the property based on the underlying file formats when setting the properties in the TableMetadata for new table creation.