### PR TITLE
Spark: Fix reading 2 level array issue

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -198,9 +198,17 @@ public class SparkParquetReaders {
         Types.ListType expectedList, GroupType array, ParquetValueReader<?> elementReader) {
       String[] repeatedPath = currentPath();
 
-      int repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
-      int repeatedR = type.getMaxRepetitionLevel(repeatedPath) - 1;
+      int repeatedD;
+      int repeatedR;
 
+      if (type.isRepetition(Type.Repetition.REPEATED)) {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath);
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath);
+      } else {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath) - 1;
+      }
+      
       Type elementType = ParquetSchemaUtil.determineListElementType(array);
       int elementD = type.getMaxDefinitionLevel(path(elementType.getName())) - 1;
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -198,8 +198,16 @@ public class SparkParquetReaders {
         Types.ListType expectedList, GroupType array, ParquetValueReader<?> elementReader) {
       String[] repeatedPath = currentPath();
 
-      int repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
-      int repeatedR = type.getMaxRepetitionLevel(repeatedPath) - 1;
+      int repeatedD;
+      int repeatedR;
+
+      if (type.isRepetition(Type.Repetition.REPEATED)) {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath);
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath);
+      } else {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath) - 1;
+      }
 
       Type elementType = ParquetSchemaUtil.determineListElementType(array);
       int elementD = type.getMaxDefinitionLevel(path(elementType.getName())) - 1;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -198,8 +198,16 @@ public class SparkParquetReaders {
         Types.ListType expectedList, GroupType array, ParquetValueReader<?> elementReader) {
       String[] repeatedPath = currentPath();
 
-      int repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
-      int repeatedR = type.getMaxRepetitionLevel(repeatedPath) - 1;
+      int repeatedD;
+      int repeatedR;
+
+      if (type.isRepetition(Type.Repetition.REPEATED)) {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath);
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath);
+      } else {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath) - 1;
+      }
 
       Type elementType = ParquetSchemaUtil.determineListElementType(array);
       int elementD = type.getMaxDefinitionLevel(path(elementType.getName())) - 1;


### PR DESCRIPTION
Trying to fix the issue:
https://github.com/apache/iceberg/issues/9497

Basically, the RL and DL were 1 level lower than expected. Add an if/else to avoid impacting 3 level array representation.