### PR TITLE
Core: Mark NoSuchViewException as CleanableFailure

### DIFF
--- a/api/src/main/java/org/apache/iceberg/exceptions/NoSuchViewException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/NoSuchViewException.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.exceptions;
 import com.google.errorprone.annotations.FormatMethod;
 
 /** Exception raised when attempting to load a view that does not exist. */
-public class NoSuchViewException extends RuntimeException {
+public class NoSuchViewException extends RuntimeException implements CleanableFailure {
   @FormatMethod
   public NoSuchViewException(String message, Object... args) {
     super(String.format(message, args));


### PR DESCRIPTION
Similar to `NoSuchTableException`, this exception should also be marked as `CleanableFailure`