### PR TITLE
New docs switch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -60,3 +60,6 @@ notifications:
     issues:       issues@iceberg.apache.org
     pullrequests: issues@iceberg.apache.org
     jira_options: link label link label
+
+publish:
+    whoami:  asf-site

--- a/site/dev/deploy.sh
+++ b/site/dev/deploy.sh
@@ -20,5 +20,4 @@ set -e
 
 ./dev/setup_env.sh
 
-mkdocs gh-deploy --no-history # --remote-branch asf-site
-
+mkdocs gh-deploy --no-history --remote-branch asf-site


### PR DESCRIPTION
This PR moves us to the updated documentation project to bring the Iceberg website and documentation back to the main repository. Related PRs: #8659, #8912, #8917, and #8919.

1. Revert [adding the ASF site publish indicator](https://github.com/apache/iceberg-docs/pull/36) from the apache/iceberg-docs repository. **This step must happen first!** https://github.com/apache/iceberg-docs/pull/308

1. Merge this PR:
   1. Update the deploy script to [point to the `asf-site` branch](https://github.com/bitsondatadev/iceberg/blob/new-docs-switch/site/dev/deploy.sh#L23) instead of the default `gh-pages` branch.

   1. Revert [removing the ASF site publish indicator](https://github.com/apache/iceberg/pull/4045) from the apache/iceberg repository to indicate ASF infra that this repository's `asf-site` branch is now where the Iceberg site exists.

   1. Delete the current versioned `./docs` and replace those from the current versioned docs location `./site/docs/docs/nightly/`. (This is the majority of the file changes in this PR.

We will move the versioned docs under `site/docs/docs/nightly/` and put them in the top-level `docs` folder. (#9578) This merge will happen afterwards to preserve the history of the versioned documentation in this folder. Stay tuned.

Fixes: https://github.com/apache/iceberg/issues/8151





