### PR TITLE
Infra: Increase operations-per-run in stale action to 100

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -48,3 +48,5 @@ jobs:
             This issue has been closed because it has not received any activity in the last 14 days
             since being marked as 'stale'
           ascending: true
+          operations-per-run: 100
+          

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -49,4 +49,3 @@ jobs:
             since being marked as 'stale'
           ascending: true
           operations-per-run: 100
-          


### PR DESCRIPTION
With the default value 30 of  `operations-per-run`, actually only 15 issues can be checked daily for staleness. 

```
Starting the stale action process...
Processing the batch of issues  #1  containing  100  issues...
[#41] Issue #41
[#44] Issue #44
[#76] Issue #76
[#81] Issue #81
[#96] Issue #96
[#116] Issue #116
[#118] Issue #118
[#127] Issue #127
[#128] Issue #128
[#168] Issue #168
[#189] Issue #189
[#193] Issue #193
[#257] Issue #257
[#274] Issue #274
[#345] Issue #345
Warning: No more operations left! Exiting...
Warning: If you think that not enough issues were processed you could try to increase the quantity related to the  operations-per-run (​[https://github.com/actions/stale#operations-per-run​)](https://github.com/actions/stale#operations-per-run%E2%80%8B))  option which is currently set to  30
Statistics:
Processed issues: 15
New stale issues: 2
Added issues labels: 2
Added issues comments: 2
Fetched items: 100
Fetched items events: 14
Fetched items comments: 14
Operations performed: 33
Github API rate used: 33
Github API rate remaining: 14966; reset at: Sat Jan 20 2024 01:11:25 GMT+0000 (Coordinated Universal Time)
```

Given the large amount of backlog and we are still checking issues in 2019, I propose to increase `operations-per-run` to 100 to accelerate the process.