### PR TITLE
AWS: Update S3FileIO test to run when CLIENT_FACTORY is not set

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -156,16 +156,12 @@ public class TestS3FileIOIntegration {
   }
 
   @Test
-  public void testS3FileIOWithDefaultAwsClientFactoryImpl() throws Exception {
+  public void testS3FileIOWithAwsClientFactoryImpl() throws Exception {
     s3.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO();
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put(
-        S3FileIOProperties.CLIENT_FACTORY,
-        "org.apache.iceberg.aws.s3.DefaultS3FileIOAwsClientFactory");
-    s3FileIO.initialize(properties);
+    s3FileIO.initialize(Maps.newHashMap());
     validateRead(s3FileIO);
   }
 

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -156,7 +156,7 @@ public class TestS3FileIOIntegration {
   }
 
   @Test
-  public void testS3FileIOWithAwsClientFactoryImpl() throws Exception {
+  public void testS3FileIOWithDefaultAwsClientFactoryImpl() throws Exception {
     s3.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));


### PR DESCRIPTION
This PR updates the existing test to check `S3FileIO` works even with the `CLIENT_FACTORY` is not set. This update ensures the two tests below work
- `testS3FileIOWithDefaultAwsClientFactoryImpl` - checks with `DefaultAwsClientFactory` 
- `testS3FileIOWithS3FileIOAwsClientFactoryImpl` - checks with `DefaultS3FileIOAwsClientFactory`

Currently the existing tests `testS3FileIOWithDefaultAwsClientFactoryImpl ` and `testS3FileIOWithS3FileIOAwsClientFactoryImpl` are duplicated. 