### PR TITLE
Spark 3.4, 3.5: Enable drop table with purge in tests

### DIFF
--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -82,9 +82,7 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
 
   @After
   public void removeTable() {
-    // TODO: use the Iceberg catalog to drop the table until SPARK-43203 is fixed
-    validationCatalog.dropTable(tableIdent, true /* purge */);
-    sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP TABLE IF EXISTS %s PURGE", tableName);
     sql("DROP TABLE IF EXISTS p PURGE");
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestDropTable.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestDropTable.java
@@ -33,7 +33,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestDropTable extends SparkCatalogTestBase {
@@ -86,8 +85,7 @@ public class TestDropTable extends SparkCatalogTestBase {
     }
   }
 
-  // TODO: enable once SPARK-43203 is fixed
-  @Ignore
+  @Test
   public void testPurgeTable() throws IOException {
     assertEquals(
         "Should have expected rows",
@@ -104,8 +102,7 @@ public class TestDropTable extends SparkCatalogTestBase {
     Assert.assertTrue("All files should be deleted", checkFilesExist(manifestAndFiles, false));
   }
 
-  // TODO: enable once SPARK-43203 is fixed
-  @Ignore
+  @Test
   public void testPurgeTableGCDisabled() throws IOException {
     sql("ALTER TABLE %s SET TBLPROPERTIES (gc.enabled = false)", tableName);
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -82,9 +82,7 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
 
   @After
   public void removeTable() {
-    // TODO: use the Iceberg catalog to drop the table until SPARK-43203 is fixed
-    validationCatalog.dropTable(tableIdent, true /* purge */);
-    sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP TABLE IF EXISTS %s PURGE", tableName);
     sql("DROP TABLE IF EXISTS p PURGE");
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestDropTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestDropTable.java
@@ -33,7 +33,6 @@ import org.apache.iceberg.spark.CatalogTestBase;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestTemplate;
 
 public class TestDropTable extends CatalogTestBase {
@@ -85,8 +84,7 @@ public class TestDropTable extends CatalogTestBase {
     }
   }
 
-  // TODO: enable once SPARK-43203 is fixed
-  @Disabled
+  @TestTemplate
   public void testPurgeTable() throws IOException {
     assertEquals(
         "Should have expected rows",
@@ -102,8 +100,7 @@ public class TestDropTable extends CatalogTestBase {
     assertThat(checkFilesExist(manifestAndFiles, false)).as("All files should be deleted").isTrue();
   }
 
-  // TODO: enable once SPARK-43203 is fixed
-  @Disabled
+  @TestTemplate
   public void testPurgeTableGCDisabled() throws IOException {
     sql("ALTER TABLE %s SET TBLPROPERTIES (gc.enabled = false)", tableName);
 


### PR DESCRIPTION
Since https://issues.apache.org/jira/browse/SPARK-43203 has been fixed in Spark 3.4.2 and 3.5.0, we can enable drop table with purge in tests now.