### PR TITLE
Spark 3.4: Cleanup the code branch for merge distribution mode conf which is no longer needed

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -354,10 +354,6 @@ public class SparkWriteConf {
     if (mergeModeName != null) {
       DistributionMode mergeMode = DistributionMode.fromName(mergeModeName);
       return adjustWriteDistributionMode(mergeMode);
-
-    } else if (table.spec().isPartitioned()) {
-      return HASH;
-
     } else {
       return distributionMode();
     }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
@@ -1708,14 +1708,12 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.replaceSortOrder().desc("id").commit();
 
-    Expression[] expectedClustering = new Expression[] {Expressions.identity("date")};
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
-
     SortOrder[] expectedOrdering =
         new SortOrder[] {
           Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
           Expressions.sort(Expressions.column("id"), SortDirection.DESCENDING)
         };
+    Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
 
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -122,6 +122,16 @@ public class TestSparkWriteConf extends SparkTestBaseWithCatalog {
   }
 
   @Test
+  public void testSparkWriteConfDistributionModeWithWriteDistributionModeTablePropertyOnly() {
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties().set(WRITE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE).commit();
+
+    SparkWriteConf writeConf = new SparkWriteConf(spark, table, ImmutableMap.of());
+    Assert.assertEquals(DistributionMode.RANGE, writeConf.copyOnWriteDistributionMode(MERGE));
+  }
+
+  @Test
   public void testSparkWriteConfDistributionModeWithTblPropAndSessionConfig() {
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.DISTRIBUTION_MODE, DistributionMode.NONE.modeName()),


### PR DESCRIPTION
Fix for `SparkWriteConf` where Iceberg table has `write.distribution-mode=range` set in the table properties but MERGE operation incorrectly resolves distribution mode as `HASH` for partitioned tables instead of `RANGE`.

It seems that the code branch for partitioned tables in `SparkWriteConf.copyOnWriteMergeDistributionMode` is no longer needed as this is already covered by `distributionMode()`