### PR TITLE
Spark 3.5: Support executor cache locality

### DIFF
--- a/core/src/test/java/org/apache/iceberg/MockFileScanTask.java
+++ b/core/src/test/java/org/apache/iceberg/MockFileScanTask.java
@@ -44,6 +44,17 @@ public class MockFileScanTask extends BaseFileScanTask {
     this.length = file.fileSizeInBytes();
   }
 
+  public MockFileScanTask(DataFile file, Schema schema, PartitionSpec spec) {
+    super(file, null, SchemaParser.toJson(schema), PartitionSpecParser.toJson(spec), null);
+    this.length = file.fileSizeInBytes();
+  }
+
+  public MockFileScanTask(
+      DataFile file, DeleteFile[] deleteFiles, Schema schema, PartitionSpec spec) {
+    super(file, deleteFiles, SchemaParser.toJson(schema), PartitionSpecParser.toJson(spec), null);
+    this.length = file.fileSizeInBytes();
+  }
+
   public static MockFileScanTask mockTask(long length, int sortOrderId) {
     DataFile mockFile = Mockito.mock(DataFile.class);
     Mockito.when(mockFile.fileSizeInBytes()).thenReturn(length);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -331,4 +331,24 @@ public class SparkReadConf {
     SparkConf sparkConf = spark.sparkContext().conf();
     return sparkConf.getSizeAsBytes(DRIVER_MAX_RESULT_SIZE, DRIVER_MAX_RESULT_SIZE_DEFAULT);
   }
+
+  public boolean executorCacheLocalityEnabled() {
+    return executorCacheEnabled() && executorCacheLocalityEnabledInternal();
+  }
+
+  private boolean executorCacheEnabled() {
+    return confParser
+        .booleanConf()
+        .sessionConf(SparkSQLProperties.EXECUTOR_CACHE_ENABLED)
+        .defaultValue(SparkSQLProperties.EXECUTOR_CACHE_ENABLED_DEFAULT)
+        .parse();
+  }
+
+  private boolean executorCacheLocalityEnabledInternal() {
+    return confParser
+        .booleanConf()
+        .sessionConf(SparkSQLProperties.EXECUTOR_CACHE_LOCALITY_ENABLED)
+        .defaultValue(SparkSQLProperties.EXECUTOR_CACHE_LOCALITY_ENABLED_DEFAULT)
+        .parse();
+  }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -86,4 +86,8 @@ public class SparkSQLProperties {
   public static final String EXECUTOR_CACHE_MAX_TOTAL_SIZE =
       "spark.sql.iceberg.executor-cache.max-total-size";
   public static final long EXECUTOR_CACHE_MAX_TOTAL_SIZE_DEFAULT = 128 * 1024 * 1024; // 128 MB
+
+  public static final String EXECUTOR_CACHE_LOCALITY_ENABLED =
+      "spark.sql.iceberg.executor-cache.locality.enabled";
+  public static final boolean EXECUTOR_CACHE_LOCALITY_ENABLED_DEFAULT = false;
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -29,9 +29,8 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.Tasks;
-import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.connector.read.Batch;
@@ -49,6 +48,7 @@ class SparkBatch implements Batch {
   private final Schema expectedSchema;
   private final boolean caseSensitive;
   private final boolean localityEnabled;
+  private final boolean executorCacheLocalityEnabled;
   private final int scanHashCode;
 
   SparkBatch(
@@ -68,6 +68,7 @@ class SparkBatch implements Batch {
     this.expectedSchema = expectedSchema;
     this.caseSensitive = readConf.caseSensitive();
     this.localityEnabled = readConf.localityEnabled();
+    this.executorCacheLocalityEnabled = readConf.executorCacheLocalityEnabled();
     this.scanHashCode = scanHashCode;
   }
 
@@ -77,25 +78,37 @@ class SparkBatch implements Batch {
     Broadcast<Table> tableBroadcast =
         sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     String expectedSchemaString = SchemaParser.toJson(expectedSchema);
+    String[][] locations = computePreferredLocations();
 
     InputPartition[] partitions = new InputPartition[taskGroups.size()];
 
-    Tasks.range(partitions.length)
-        .stopOnFailure()
-        .executeWith(localityEnabled ? ThreadPools.getWorkerPool() : null)
-        .run(
-            index ->
-                partitions[index] =
-                    new SparkInputPartition(
-                        groupingKeyType,
-                        taskGroups.get(index),
-                        tableBroadcast,
-                        branch,
-                        expectedSchemaString,
-                        caseSensitive,
-                        localityEnabled));
+    for (int index = 0; index < taskGroups.size(); index++) {
+      partitions[index] =
+          new SparkInputPartition(
+              groupingKeyType,
+              taskGroups.get(index),
+              tableBroadcast,
+              branch,
+              expectedSchemaString,
+              caseSensitive,
+              locations != null ? locations[index] : SparkPlanningUtil.NO_LOCATION_PREFERENCE);
+    }
 
     return partitions;
+  }
+
+  private String[][] computePreferredLocations() {
+    if (localityEnabled) {
+      return SparkPlanningUtil.fetchBlockLocations(table.io(), taskGroups);
+
+    } else if (executorCacheLocalityEnabled) {
+      List<String> executorLocations = SparkUtil.executorLocations();
+      if (!executorLocations.isEmpty()) {
+        return SparkPlanningUtil.assignExecutors(taskGroups, executorLocations);
+      }
+    }
+
+    return null;
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPlanningUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPlanningUtil.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.ScanTask;
+import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.hadoop.Util;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.JavaHash;
+import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.ThreadPools;
+
+class SparkPlanningUtil {
+
+  public static final String[] NO_LOCATION_PREFERENCE = new String[0];
+
+  private SparkPlanningUtil() {}
+
+  public static String[][] fetchBlockLocations(
+      FileIO io, List<? extends ScanTaskGroup<?>> taskGroups) {
+    String[][] locations = new String[taskGroups.size()][];
+
+    Tasks.range(taskGroups.size())
+        .stopOnFailure()
+        .executeWith(ThreadPools.getWorkerPool())
+        .run(index -> locations[index] = Util.blockLocations(io, taskGroups.get(index)));
+
+    return locations;
+  }
+
+  public static String[][] assignExecutors(
+      List<? extends ScanTaskGroup<?>> taskGroups, List<String> executorLocations) {
+    Map<Integer, JavaHash<StructLike>> partitionHashes = Maps.newHashMap();
+    String[][] locations = new String[taskGroups.size()][];
+
+    for (int index = 0; index < taskGroups.size(); index++) {
+      locations[index] = assign(taskGroups.get(index), executorLocations, partitionHashes);
+    }
+
+    return locations;
+  }
+
+  private static String[] assign(
+      ScanTaskGroup<?> taskGroup,
+      List<String> executorLocations,
+      Map<Integer, JavaHash<StructLike>> partitionHashes) {
+    List<String> locations = Lists.newArrayList();
+
+    for (ScanTask task : taskGroup.tasks()) {
+      if (task.isFileScanTask()) {
+        FileScanTask fileTask = task.asFileScanTask();
+        PartitionSpec spec = fileTask.spec();
+        if (spec.isPartitioned() && !fileTask.deletes().isEmpty()) {
+          JavaHash<StructLike> partitionHash =
+              partitionHashes.computeIfAbsent(spec.specId(), key -> partitionHash(spec));
+          int partitionHashCode = partitionHash.hash(fileTask.partition());
+          int index = Math.floorMod(partitionHashCode, executorLocations.size());
+          String executorLocation = executorLocations.get(index);
+          locations.add(executorLocation);
+        }
+      }
+    }
+
+    return locations.toArray(NO_LOCATION_PREFERENCE);
+  }
+
+  private static JavaHash<StructLike> partitionHash(PartitionSpec spec) {
+    return JavaHash.forType(spec.partitionType());
+  }
+}

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkPlanningUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkPlanningUtil.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.iceberg.BaseScanTaskGroup;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.MockFileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.ScanTask;
+import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.TestHelpers.Row;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.TestTemplate;
+import org.mockito.Mockito;
+
+public class TestSparkPlanningUtil extends TestBaseWithCatalog {
+
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "id", Types.IntegerType.get()),
+          required(2, "data", Types.StringType.get()),
+          required(3, "category", Types.StringType.get()));
+  private static final PartitionSpec SPEC_1 =
+      PartitionSpec.builderFor(SCHEMA).withSpecId(1).bucket("id", 16).identity("data").build();
+  private static final PartitionSpec SPEC_2 =
+      PartitionSpec.builderFor(SCHEMA).withSpecId(2).identity("data").build();
+  private static final List<String> EXECUTOR_LOCATIONS =
+      ImmutableList.of("host1_exec1", "host1_exec2", "host1_exec3", "host2_exec1", "host2_exec2");
+
+  @TestTemplate
+  public void testFileScanTaskWithoutDeletes() {
+    List<ScanTask> tasks =
+        ImmutableList.of(
+            new MockFileScanTask(mockDataFile(Row.of(1, "a")), SCHEMA, SPEC_1),
+            new MockFileScanTask(mockDataFile(Row.of(2, "b")), SCHEMA, SPEC_1),
+            new MockFileScanTask(mockDataFile(Row.of(3, "c")), SCHEMA, SPEC_1));
+    ScanTaskGroup<ScanTask> taskGroup = new BaseScanTaskGroup<>(tasks);
+    List<ScanTaskGroup<ScanTask>> taskGroups = ImmutableList.of(taskGroup);
+
+    String[][] locations = SparkPlanningUtil.assignExecutors(taskGroups, EXECUTOR_LOCATIONS);
+
+    // should not assign executors if there are no deletes
+    assertThat(locations.length).isEqualTo(1);
+    assertThat(locations[0]).isEmpty();
+  }
+
+  @TestTemplate
+  public void testFileScanTaskWithDeletes() {
+    StructLike partition1 = Row.of("k2", null);
+    StructLike partition2 = Row.of("k1");
+    List<ScanTask> tasks =
+        ImmutableList.of(
+            new MockFileScanTask(
+                mockDataFile(partition1), mockDeleteFiles(1, partition1), SCHEMA, SPEC_1),
+            new MockFileScanTask(
+                mockDataFile(partition2), mockDeleteFiles(3, partition2), SCHEMA, SPEC_2),
+            new MockFileScanTask(
+                mockDataFile(partition1), mockDeleteFiles(2, partition1), SCHEMA, SPEC_1));
+    ScanTaskGroup<ScanTask> taskGroup = new BaseScanTaskGroup<>(tasks);
+    List<ScanTaskGroup<ScanTask>> taskGroups = ImmutableList.of(taskGroup);
+
+    String[][] locations = SparkPlanningUtil.assignExecutors(taskGroups, EXECUTOR_LOCATIONS);
+
+    // should assign executors and handle different size of partitions
+    assertThat(locations.length).isEqualTo(1);
+    assertThat(locations[0].length).isGreaterThanOrEqualTo(1);
+  }
+
+  @TestTemplate
+  public void testFileScanTaskWithUnpartitionedDeletes() {
+    List<ScanTask> tasks1 =
+        ImmutableList.of(
+            new MockFileScanTask(
+                mockDataFile(Row.of()),
+                mockDeleteFiles(2, Row.of()),
+                SCHEMA,
+                PartitionSpec.unpartitioned()),
+            new MockFileScanTask(
+                mockDataFile(Row.of()),
+                mockDeleteFiles(2, Row.of()),
+                SCHEMA,
+                PartitionSpec.unpartitioned()),
+            new MockFileScanTask(
+                mockDataFile(Row.of()),
+                mockDeleteFiles(2, Row.of()),
+                SCHEMA,
+                PartitionSpec.unpartitioned()));
+    ScanTaskGroup<ScanTask> taskGroup1 = new BaseScanTaskGroup<>(tasks1);
+    List<ScanTask> tasks2 =
+        ImmutableList.of(
+            new MockFileScanTask(
+                mockDataFile(null),
+                mockDeleteFiles(2, null),
+                SCHEMA,
+                PartitionSpec.unpartitioned()),
+            new MockFileScanTask(
+                mockDataFile(null),
+                mockDeleteFiles(2, null),
+                SCHEMA,
+                PartitionSpec.unpartitioned()),
+            new MockFileScanTask(
+                mockDataFile(null),
+                mockDeleteFiles(2, null),
+                SCHEMA,
+                PartitionSpec.unpartitioned()));
+    ScanTaskGroup<ScanTask> taskGroup2 = new BaseScanTaskGroup<>(tasks2);
+    List<ScanTaskGroup<ScanTask>> taskGroups = ImmutableList.of(taskGroup1, taskGroup2);
+
+    String[][] locations = SparkPlanningUtil.assignExecutors(taskGroups, EXECUTOR_LOCATIONS);
+
+    // should not assign executors if the table is unpartitioned
+    assertThat(locations.length).isEqualTo(2);
+    assertThat(locations[0]).isEmpty();
+    assertThat(locations[1]).isEmpty();
+  }
+
+  @TestTemplate
+  public void testDataTasks() {
+    List<ScanTask> tasks =
+        ImmutableList.of(
+            new MockDataTask(mockDataFile(Row.of(1, "a"))),
+            new MockDataTask(mockDataFile(Row.of(2, "b"))),
+            new MockDataTask(mockDataFile(Row.of(3, "c"))));
+    ScanTaskGroup<ScanTask> taskGroup = new BaseScanTaskGroup<>(tasks);
+    List<ScanTaskGroup<ScanTask>> taskGroups = ImmutableList.of(taskGroup);
+
+    String[][] locations = SparkPlanningUtil.assignExecutors(taskGroups, EXECUTOR_LOCATIONS);
+
+    // should not assign executors for data tasks
+    assertThat(locations.length).isEqualTo(1);
+    assertThat(locations[0]).isEmpty();
+  }
+
+  @TestTemplate
+  public void testUnknownTasks() {
+    List<ScanTask> tasks = ImmutableList.of(new UnknownScanTask(), new UnknownScanTask());
+    ScanTaskGroup<ScanTask> taskGroup = new BaseScanTaskGroup<>(tasks);
+    List<ScanTaskGroup<ScanTask>> taskGroups = ImmutableList.of(taskGroup);
+
+    String[][] locations = SparkPlanningUtil.assignExecutors(taskGroups, EXECUTOR_LOCATIONS);
+
+    // should not assign executors for unknown tasks
+    assertThat(locations.length).isEqualTo(1);
+    assertThat(locations[0]).isEmpty();
+  }
+
+  private static DataFile mockDataFile(StructLike partition) {
+    DataFile file = Mockito.mock(DataFile.class);
+    when(file.partition()).thenReturn(partition);
+    return file;
+  }
+
+  private static DeleteFile[] mockDeleteFiles(int count, StructLike partition) {
+    DeleteFile[] files = new DeleteFile[count];
+    for (int index = 0; index < count; index++) {
+      files[index] = mockDeleteFile(partition);
+    }
+    return files;
+  }
+
+  private static DeleteFile mockDeleteFile(StructLike partition) {
+    DeleteFile file = Mockito.mock(DeleteFile.class);
+    when(file.partition()).thenReturn(partition);
+    return file;
+  }
+
+  private static class MockDataTask extends MockFileScanTask implements DataTask {
+
+    MockDataTask(DataFile file) {
+      super(file);
+    }
+
+    @Override
+    public PartitionSpec spec() {
+      return PartitionSpec.unpartitioned();
+    }
+
+    @Override
+    public CloseableIterable<StructLike> rows() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class UnknownScanTask implements ScanTask {}
+}


### PR DESCRIPTION
This PR adds an ability to enable executor cache locality. The new SQL property is off by default as it does not make sense in all cases and may introduce unnecessary task waits. When enabled and there are deletes, this logic will try to co-locate tasks for one partition to the same executors to increase the probability of the cache reuse.