### PR TITLE
Open-API: Add table updates for statistics

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -342,6 +342,11 @@ class SetCurrentViewVersionUpdate(BaseUpdate):
     )
 
 
+class RemoveStatisticsUpdate(BaseUpdate):
+    action: Literal['remove-statistics']
+    snapshot_id: int = Field(..., alias='snapshot-id')
+
+
 class TableRequirement(BaseModel):
     type: str
 
@@ -596,6 +601,14 @@ class UpdateNamespacePropertiesResponse(BaseModel):
     )
 
 
+class BlobMetadata(BaseModel):
+    type: str
+    snapshot_id: int = Field(..., alias='snapshot-id')
+    sequence_number: int = Field(..., alias='sequence-number')
+    fields: List[int]
+    properties: Dict[str, Any]
+
+
 class CreateNamespaceRequest(BaseModel):
     namespace: Namespace
     properties: Optional[Dict[str, str]] = Field(
@@ -620,8 +633,22 @@ class ReportMetricsRequest2(CommitReport):
     report_type: str = Field(..., alias='report-type')
 
 
+class StatisticsFile(BaseModel):
+    snapshot_id: int = Field(..., alias='snapshot-id')
+    statistics_path: str = Field(..., alias='statistics-path')
+    file_size_in_bytes: int = Field(..., alias='file-size-in-bytes')
+    file_footer_size_in_bytes: int = Field(..., alias='file-footer-size-in-bytes')
+    blob_metadata: List[BlobMetadata] = Field(..., alias='blob-metadata')
+
+
 class Term(BaseModel):
     __root__: Union[Reference, TransformTerm]
+
+
+class SetStatisticsUpdate(BaseUpdate):
+    action: Literal['set-statistics']
+    snapshot_id: int = Field(..., alias='snapshot-id')
+    statistics: StatisticsFile
 
 
 class UnaryExpression(BaseModel):
@@ -758,6 +785,8 @@ class TableUpdate(BaseModel):
         SetLocationUpdate,
         SetPropertiesUpdate,
         RemovePropertiesUpdate,
+        SetStatisticsUpdate,
+        RemoveStatisticsUpdate,
     ]
 
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -606,7 +606,7 @@ class BlobMetadata(BaseModel):
     snapshot_id: int = Field(..., alias='snapshot-id')
     sequence_number: int = Field(..., alias='sequence-number')
     fields: List[int]
-    properties: Dict[str, Any]
+    properties: Optional[Dict[str, Any]] = None
 
 
 class CreateNamespaceRequest(BaseModel):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3225,7 +3225,6 @@ components:
         - snapshot-id
         - sequence-number
         - fields
-        - properties
       properties:
         type:
           type: string

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2150,6 +2150,8 @@ components:
           remove-properties: '#/components/schemas/RemovePropertiesUpdate'
           add-view-version: '#/components/schemas/AddViewVersionUpdate'
           set-current-view-version: '#/components/schemas/SetCurrentViewVersionUpdate'
+          set-statistics: '#/components/schemas/SetStatisticsUpdate'
+          remove-statistics: '#/components/schemas/RemoveStatisticsUpdate'
       type: object
       required:
         - action
@@ -2394,6 +2396,37 @@ components:
           type: integer
           description: The view version id to set as current, or -1 to set last added view version id
 
+    SetStatisticsUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+      required:
+        - action
+        - snapshot-id
+        - statistics
+      properties:
+        action:
+          type: string
+          enum: [ "set-statistics" ]
+        snapshot-id:
+          type: integer
+          format: int64
+        statistics:
+          $ref: '#/components/schemas/StatisticsFile'
+
+    RemoveStatisticsUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+      required:
+        - action
+        - snapshot-id
+      properties:
+        action:
+          type: string
+          enum: [ "remove-statistics" ]
+        snapshot-id:
+          type: integer
+          format: int64
+
     TableUpdate:
       anyOf:
         - $ref: '#/components/schemas/AssignUUIDUpdate'
@@ -2411,6 +2444,8 @@ components:
         - $ref: '#/components/schemas/SetLocationUpdate'
         - $ref: '#/components/schemas/SetPropertiesUpdate'
         - $ref: '#/components/schemas/RemovePropertiesUpdate'
+        - $ref: '#/components/schemas/SetStatisticsUpdate'
+        - $ref: '#/components/schemas/RemoveStatisticsUpdate'
 
     ViewUpdate:
       anyOf:
@@ -3157,6 +3192,55 @@ components:
           type: string
         metadata:
           $ref: '#/components/schemas/TableMetadata'
+
+    StatisticsFile:
+      type: object
+      required:
+        - snapshot-id
+        - statistics-path
+        - file-size-in-bytes
+        - file-footer-size-in-bytes
+        - blob-metadata
+      properties:
+        snapshot-id:
+          type: integer
+          format: int64
+        statistics-path:
+          type: string
+        file-size-in-bytes:
+          type: integer
+          format: int64
+        file-footer-size-in-bytes:
+          type: integer
+          format: int64
+        blob-metadata:
+          type: array
+          items:
+            $ref: '#/components/schemas/BlobMetadata'
+
+    BlobMetadata:
+      type: object
+      required:
+        - type
+        - snapshot-id
+        - sequence-number
+        - fields
+        - properties
+      properties:
+        type:
+          type: string
+        snapshot-id:
+          type: integer
+          format: int64
+        sequence-number:
+          type: integer
+          format: int64
+        fields:
+          type: array
+          items:
+            type: integer
+        properties:
+          type: object
 
 
   #############################


### PR DESCRIPTION
Table statistics were added in https://github.com/apache/iceberg/pull/5450 and it would be helpful to have them in the OpenAPI spec for REST catalog implementations that don't use the Java parsers from Iceberg.