### PR TITLE
Spark 3.5: Add an option not to delete files in ExpireSnapshots

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
@@ -118,4 +118,9 @@ public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
    * @return this for method chaining
    */
   ExpireSnapshots cleanExpiredFiles(boolean clean);
+
+  /** Returns number of expired snapshots */
+  default long expiredSnapshotsCount() {
+    return 0L;
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
@@ -99,6 +99,11 @@ public interface ExpireSnapshots extends Action<ExpireSnapshots, ExpireSnapshots
 
   /** The action result that contains a summary of the execution. */
   interface Result {
+    /** Return the number of deleted snapshots. */
+    default long deletedSnapshotsCount() {
+      return 0L;
+    }
+
     /** Returns the number of deleted data files. */
     long deletedDataFilesCount();
 

--- a/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshots.java
@@ -30,6 +30,13 @@ interface BaseExpireSnapshots extends ExpireSnapshots {
 
   @Value.Immutable
   interface Result extends ExpireSnapshots.Result {
+
+    @Override
+    @Value.Default
+    default long deletedSnapshotsCount() {
+      return ExpireSnapshots.Result.super.deletedSnapshotsCount();
+    }
+
     @Override
     @Value.Default
     default long deletedStatisticsFilesCount() {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -74,7 +74,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
 
     List<Object[]> output = sql("CALL %s.system.expire_snapshots('%s')", catalogName, tableIdent);
     assertEquals(
-        "Should not delete any files", ImmutableList.of(row(0L, 0L, 0L, 0L, 0L, 0L)), output);
+        "Should not delete any files", ImmutableList.of(row(0L, 0L, 0L, 0L, 0L, 0L, 0L)), output);
   }
 
   @Test
@@ -103,7 +103,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
             "CALL %s.system.expire_snapshots('%s', TIMESTAMP '%s')",
             catalogName, tableIdent, secondSnapshotTimestamp);
     assertEquals(
-        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 1L, 0L)), output1);
+        "Procedure output must match", ImmutableList.of(row(1L, 0L, 0L, 0L, 0L, 1L, 0L)), output1);
 
     table.refresh();
 
@@ -130,7 +130,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
             "CALL %s.system.expire_snapshots('%s', TIMESTAMP '%s', 2)",
             catalogName, tableIdent, currentTimestamp);
     assertEquals(
-        "Procedure output must match", ImmutableList.of(row(2L, 0L, 0L, 2L, 1L, 0L)), output);
+        "Procedure output must match", ImmutableList.of(row(1L, 2L, 0L, 0L, 2L, 1L, 0L)), output);
   }
 
   @Test
@@ -153,7 +153,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
             "CALL %s.system.expire_snapshots(older_than => TIMESTAMP '%s',table => '%s')",
             catalogName, currentTimestamp, tableIdent);
     assertEquals(
-        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 1L, 0L)), output);
+        "Procedure output must match", ImmutableList.of(row(1L, 0L, 0L, 0L, 0L, 1L, 0L)), output);
   }
 
   @Test
@@ -237,7 +237,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
             catalogName, currentTimestamp, tableIdent, 4);
     assertEquals(
         "Expiring snapshots concurrently should succeed",
-        ImmutableList.of(row(0L, 0L, 0L, 0L, 3L, 0L)),
+        ImmutableList.of(row(3L, 0L, 0L, 0L, 0L, 3L, 0L)),
         output);
   }
 
@@ -322,7 +322,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
 
     assertEquals(
         "Should deleted 1 data and pos delete file and 4 manifests and lists (one for each txn)",
-        ImmutableList.of(row(1L, 1L, 0L, 4L, 4L, 0L)),
+        ImmutableList.of(row(4L, 1L, 1L, 0L, 4L, 4L, 0L)),
         output);
     Assert.assertFalse("Delete manifest should be removed", localFs.exists(deleteManifestPath));
     Assert.assertFalse("Delete file should be removed", localFs.exists(deleteFilePath));
@@ -351,7 +351,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
                 + "stream_results => true)",
             catalogName, currentTimestamp, tableIdent);
     assertEquals(
-        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 1L, 0L)), output);
+        "Procedure output must match", ImmutableList.of(row(1L, 0L, 0L, 0L, 0L, 1L, 0L)), output);
   }
 
   @Test
@@ -432,7 +432,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
             + "   table => '%s')";
     List<Object[]> output = sql(callStatement, catalogName, currentTimestamp, tableIdent);
     assertEquals(
-        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 1L, 0L)), output);
+        "Procedure output must match", ImmutableList.of(row(1L, 0L, 0L, 0L, 0L, 1L, 0L)), output);
 
     table.refresh();
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -79,6 +79,7 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
   private Consumer<String> deleteFunc = null;
   private ExecutorService deleteExecutorService = null;
   private Dataset<FileInfo> expiredFileDS = null;
+  private long expiredSnapshotsCount = 0;
 
   ExpireSnapshotsSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -159,6 +160,8 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
       }
 
       expireSnapshots.cleanExpiredFiles(false).commit();
+
+      this.expiredSnapshotsCount = expireSnapshots.expiredSnapshotsCount();
 
       // fetch valid files after expiration
       TableMetadata updatedMetadata = ops.refresh();
@@ -259,6 +262,7 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
     LOG.info("Deleted {} total files", summary.totalFilesCount());
 
     return ImmutableExpireSnapshots.Result.builder()
+        .deletedSnapshotsCount(expiredSnapshotsCount)
         .deletedDataFilesCount(summary.dataFilesCount())
         .deletedPositionDeleteFilesCount(summary.positionDeleteFilesCount())
         .deletedEqualityDeleteFilesCount(summary.equalityDeleteFilesCount())

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -59,6 +59,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
   private static final StructType OUTPUT_TYPE =
       new StructType(
           new StructField[] {
+            new StructField("deleted_snapshots_count", DataTypes.LongType, true, Metadata.empty()),
             new StructField("deleted_data_files_count", DataTypes.LongType, true, Metadata.empty()),
             new StructField(
                 "deleted_position_delete_files_count", DataTypes.LongType, true, Metadata.empty()),
@@ -157,6 +158,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
   private InternalRow[] toOutputRows(ExpireSnapshots.Result result) {
     InternalRow row =
         newInternalRow(
+            result.deletedSnapshotsCount(),
             result.deletedDataFilesCount(),
             result.deletedPositionDeleteFilesCount(),
             result.deletedEqualityDeleteFilesCount(),
@@ -168,6 +170,6 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
 
   @Override
   public String description() {
-    return "ExpireSnapshotProcedure";
+    return "ExpireSnapshotsProcedure";
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -53,7 +53,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
         ProcedureParameter.optional("retain_last", DataTypes.IntegerType),
         ProcedureParameter.optional("max_concurrent_deletes", DataTypes.IntegerType),
         ProcedureParameter.optional("stream_results", DataTypes.BooleanType),
-        ProcedureParameter.optional("snapshot_ids", DataTypes.createArrayType(DataTypes.LongType))
+        ProcedureParameter.optional("snapshot_ids", DataTypes.createArrayType(DataTypes.LongType)),
+        ProcedureParameter.optional("delete_files", DataTypes.BooleanType)
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -105,6 +106,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     Integer maxConcurrentDeletes = args.isNullAt(3) ? null : args.getInt(3);
     Boolean streamResult = args.isNullAt(4) ? null : args.getBoolean(4);
     long[] snapshotIds = args.isNullAt(5) ? null : args.getArray(5).toLongArray();
+    Boolean deleteFiles = args.isNullAt(6) ? null : args.getBoolean(6);
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
@@ -147,6 +149,10 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
           if (streamResult != null) {
             action.option(
                 ExpireSnapshotsSparkAction.STREAM_RESULTS, Boolean.toString(streamResult));
+          }
+
+          if (deleteFiles != null) {
+            action.option(ExpireSnapshotsSparkAction.DELETE_FILES, Boolean.toString(deleteFiles));
           }
 
           ExpireSnapshots.Result result = action.execute();


### PR DESCRIPTION
In some cases, manifest list files of past snapshots might have been corrupted or deleted. It has no impact on the current table state but fails `ExpireSnapshotsProcedure` when it's checking the existence of manifest list files. In this PR, 

1. An option `delete_files` is added to `ExpireSnapshotsProcedure` such that it's possible not to check files but to only  update metadata.
2. `deleted_snapshots_count` is added to `ExpireSnapshotsProcedure` result to report the changes when `delete_files => false`.