### PR TITLE
API: Extend FileIO and add EncryptingFileIO.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
@@ -36,6 +36,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 
 public class EncryptingFileIO implements FileIO, Serializable {
   public static EncryptingFileIO create(FileIO io, EncryptionManager em) {
+    if (io instanceof EncryptingFileIO) {
+      return (EncryptingFileIO) io;
+    }
+
     return new EncryptingFileIO(io, em);
   }
 

--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.encryption;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+
+public class EncryptingFileIO implements FileIO, Serializable {
+  public static EncryptingFileIO create(FileIO io, EncryptionManager em) {
+    return new EncryptingFileIO(io, em);
+  }
+
+  private final FileIO io;
+  private final EncryptionManager em;
+
+  EncryptingFileIO(FileIO io, EncryptionManager em) {
+    this.io = io;
+    this.em = em;
+  }
+
+  public Map<String, InputFile> bulkDecrypt(Iterable<? extends ContentFile<?>> files) {
+    Iterable<InputFile> decrypted = em.decrypt(Iterables.transform(files, this::wrap));
+
+    ImmutableMap.Builder<String, InputFile> builder = ImmutableMap.builder();
+    for (InputFile in : decrypted) {
+      builder.put(in.location(), in);
+    }
+
+    return builder.buildKeepingLast();
+  }
+
+  public EncryptionManager encryptionManager() {
+    return em;
+  }
+
+  @Override
+  public InputFile newInputFile(String path) {
+    return io.newInputFile(path);
+  }
+
+  @Override
+  public InputFile newInputFile(String path, long length) {
+    return io.newInputFile(path, length);
+  }
+
+  @Override
+  public InputFile newInputFile(DataFile file) {
+    return newInputFile((ContentFile<?>) file);
+  }
+
+  @Override
+  public InputFile newInputFile(DeleteFile file) {
+    return newInputFile((ContentFile<?>) file);
+  }
+
+  private InputFile newInputFile(ContentFile<?> file) {
+    if (file.keyMetadata() != null) {
+      return newDecryptingInputFile(
+          file.path().toString(), file.fileSizeInBytes(), file.keyMetadata());
+    } else {
+      return newInputFile(file.path().toString(), file.fileSizeInBytes());
+    }
+  }
+
+  @Override
+  public InputFile newInputFile(ManifestFile manifest) {
+    if (manifest.keyMetadata() != null) {
+      return newDecryptingInputFile(manifest.path(), manifest.length(), manifest.keyMetadata());
+    } else {
+      return newInputFile(manifest.path(), manifest.length());
+    }
+  }
+
+  public InputFile newDecryptingInputFile(String path, ByteBuffer buffer) {
+    return em.decrypt(wrap(io.newInputFile(path), buffer));
+  }
+
+  public InputFile newDecryptingInputFile(String path, long length, ByteBuffer buffer) {
+    // TODO: is the length correct for the encrypted file? It may be the length of the plaintext
+    // stream
+    return em.decrypt(wrap(io.newInputFile(path, length), buffer));
+  }
+
+  @Override
+  public OutputFile newOutputFile(String path) {
+    return io.newOutputFile(path);
+  }
+
+  public EncryptedOutputFile newEncryptingOutputFile(String path) {
+    OutputFile plainOutputFile = io.newOutputFile(path);
+    return em.encrypt(plainOutputFile);
+  }
+
+  @Override
+  public void deleteFile(String path) {
+    io.deleteFile(path);
+  }
+
+  @Override
+  public void close() {
+    io.close();
+
+    if (em instanceof Closeable) {
+      try {
+        ((Closeable) em).close();
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to close encryption manager", e);
+      }
+    }
+  }
+
+  private SimpleEncryptedInputFile wrap(ContentFile<?> file) {
+    InputFile encryptedInputFile = io.newInputFile(file.path().toString(), file.fileSizeInBytes());
+    return new SimpleEncryptedInputFile(encryptedInputFile, toKeyMetadata(file.keyMetadata()));
+  }
+
+  private static SimpleEncryptedInputFile wrap(InputFile encryptedInputFile, ByteBuffer buffer) {
+    return new SimpleEncryptedInputFile(encryptedInputFile, toKeyMetadata(buffer));
+  }
+
+  private static EncryptionKeyMetadata toKeyMetadata(ByteBuffer buffer) {
+    return buffer != null ? new SimpleKeyMetadata(buffer) : EmptyKeyMetadata.get();
+  }
+
+  private static class SimpleEncryptedInputFile implements EncryptedInputFile {
+    private final InputFile encryptedInputFile;
+    private final EncryptionKeyMetadata keyMetadata;
+
+    private SimpleEncryptedInputFile(
+        InputFile encryptedInputFile, EncryptionKeyMetadata keyMetadata) {
+      this.encryptedInputFile = encryptedInputFile;
+      this.keyMetadata = keyMetadata;
+    }
+
+    @Override
+    public InputFile encryptedInputFile() {
+      return encryptedInputFile;
+    }
+
+    @Override
+    public EncryptionKeyMetadata keyMetadata() {
+      return keyMetadata;
+    }
+  }
+
+  private static class SimpleKeyMetadata implements EncryptionKeyMetadata {
+    private final ByteBuffer metadataBuffer;
+
+    private SimpleKeyMetadata(ByteBuffer metadataBuffer) {
+      this.metadataBuffer = metadataBuffer;
+    }
+
+    @Override
+    public ByteBuffer buffer() {
+      return metadataBuffer;
+    }
+
+    @Override
+    public EncryptionKeyMetadata copy() {
+      return new SimpleKeyMetadata(metadataBuffer.duplicate());
+    }
+  }
+
+  private static class EmptyKeyMetadata implements EncryptionKeyMetadata {
+    private static final EmptyKeyMetadata INSTANCE = new EmptyKeyMetadata();
+
+    private static EmptyKeyMetadata get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public ByteBuffer buffer() {
+      return null;
+    }
+
+    @Override
+    public EncryptionKeyMetadata copy() {
+      return this;
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/io/FileIO.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileIO.java
@@ -21,6 +21,10 @@ package org.apache.iceberg.io;
 import java.io.Closeable;
 import java.io.Serializable;
 import java.util.Map;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
  * Pluggable module for reading, writing, and deleting files.
@@ -40,6 +44,30 @@ public interface FileIO extends Serializable, Closeable {
    */
   default InputFile newInputFile(String path, long length) {
     return newInputFile(path);
+  }
+
+  default InputFile newInputFile(DataFile file) {
+    Preconditions.checkArgument(
+        file.keyMetadata() == null,
+        "Cannot decrypt data file: {} (use DecryptingFileIO)",
+        file.path());
+    return newInputFile(file.path().toString());
+  }
+
+  default InputFile newInputFile(DeleteFile file) {
+    Preconditions.checkArgument(
+        file.keyMetadata() == null,
+        "Cannot decrypt delete file: {} (use DecryptingFileIO)",
+        file.path());
+    return newInputFile(file.path().toString());
+  }
+
+  default InputFile newInputFile(ManifestFile manifest) {
+    Preconditions.checkArgument(
+        manifest.keyMetadata() == null,
+        "Cannot decrypt manifest: {} (use DecryptingFileIO)",
+        manifest.path());
+    return newInputFile(manifest.path());
   }
 
   /** Get a {@link OutputFile} instance to write bytes to the file at the given path. */

--- a/api/src/main/java/org/apache/iceberg/io/FileIO.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileIO.java
@@ -49,7 +49,7 @@ public interface FileIO extends Serializable, Closeable {
   default InputFile newInputFile(DataFile file) {
     Preconditions.checkArgument(
         file.keyMetadata() == null,
-        "Cannot decrypt data file: {} (use DecryptingFileIO)",
+        "Cannot decrypt data file: {} (use EncryptingFileIO)",
         file.path());
     return newInputFile(file.path().toString());
   }
@@ -57,7 +57,7 @@ public interface FileIO extends Serializable, Closeable {
   default InputFile newInputFile(DeleteFile file) {
     Preconditions.checkArgument(
         file.keyMetadata() == null,
-        "Cannot decrypt delete file: {} (use DecryptingFileIO)",
+        "Cannot decrypt delete file: {} (use EncryptingFileIO)",
         file.path());
     return newInputFile(file.path().toString());
   }
@@ -65,7 +65,7 @@ public interface FileIO extends Serializable, Closeable {
   default InputFile newInputFile(ManifestFile manifest) {
     Preconditions.checkArgument(
         manifest.keyMetadata() == null,
-        "Cannot decrypt manifest: {} (use DecryptingFileIO)",
+        "Cannot decrypt manifest: {} (use EncryptingFileIO)",
         manifest.path());
     return newInputFile(manifest.path());
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -356,10 +356,10 @@ public class ManifestFiles {
 
   static boolean cachingEnabled(FileIO io) {
     try {
-    return PropertyUtil.propertyAsBoolean(
-        io.properties(),
-        CatalogProperties.IO_MANIFEST_CACHE_ENABLED,
-        CatalogProperties.IO_MANIFEST_CACHE_ENABLED_DEFAULT);
+      return PropertyUtil.propertyAsBoolean(
+          io.properties(),
+          CatalogProperties.IO_MANIFEST_CACHE_ENABLED,
+          CatalogProperties.IO_MANIFEST_CACHE_ENABLED_DEFAULT);
     } catch (UnsupportedOperationException e) {
       return false;
     }

--- a/core/src/main/java/org/apache/iceberg/encryption/NativeEncryptionOutputFile.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/NativeEncryptionOutputFile.java
@@ -18,13 +18,35 @@
  */
 package org.apache.iceberg.encryption;
 
+import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
 
 /** An {@link EncryptedOutputFile} that can be used for format-native encryption. */
-public interface NativeEncryptionOutputFile extends EncryptedOutputFile {
+public interface NativeEncryptionOutputFile extends EncryptedOutputFile, OutputFile {
   @Override
   NativeEncryptionKeyMetadata keyMetadata();
 
   /** An {@link OutputFile} instance for the underlying (plaintext) output stream. */
   OutputFile plainOutputFile();
+
+  @Override
+  default PositionOutputStream create() {
+    return encryptingOutputFile().create();
+  }
+
+  @Override
+  default PositionOutputStream createOrOverwrite() {
+    return encryptingOutputFile().createOrOverwrite();
+  }
+
+  @Override
+  default String location() {
+    return encryptingOutputFile().location();
+  }
+
+  @Override
+  default InputFile toInputFile() {
+    return encryptingOutputFile().toInputFile();
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -61,6 +61,10 @@ public class StandardEncryptionManager implements EncryptionManager {
   @Override
   public NativeEncryptionInputFile decrypt(EncryptedInputFile encrypted) {
     // this input file will lazily parse key metadata in case the file is not an AES GCM stream.
+    if (encrypted instanceof NativeEncryptionInputFile) {
+      return (NativeEncryptionInputFile) encrypted;
+    }
+
     return new StandardDecryptedInputFile(encrypted);
   }
 

--- a/core/src/main/java/org/apache/iceberg/io/ContentCache.java
+++ b/core/src/main/java/org/apache/iceberg/io/ContentCache.java
@@ -207,7 +207,7 @@ public class ContentCache {
 
     @Override
     public long getLength() {
-      FileContent buf = contentCache.getIfPresent(input.location());
+      FileContent buf = contentCache.cache.getIfPresent(input.location());
       if (buf != null) {
         return buf.length;
       } else {
@@ -244,13 +244,13 @@ public class ContentCache {
 
     @Override
     public boolean exists() {
-      FileContent buf = contentCache.getIfPresent(input.location());
+      FileContent buf = contentCache.cache.getIfPresent(input.location());
       return buf != null || input.exists();
     }
 
     private SeekableInputStream cachedStream() throws IOException {
       try {
-        FileContent content = contentCache.get(input.location(), k -> download(input));
+        FileContent content = contentCache.cache.get(input.location(), k -> download(input));
         return ByteBufferInputStream.wrap(content.buffers);
       } catch (UncheckedIOException ex) {
         throw ex.getCause();

--- a/core/src/main/java/org/apache/iceberg/io/ContentCache.java
+++ b/core/src/main/java/org/apache/iceberg/io/ContentCache.java
@@ -126,6 +126,25 @@ public class ContentCache {
    * and no caching will be done for that file. Otherwise, this method will return a {@link
    * CachingInputFile} that serve file reads backed by ContentCache.
    *
+   * @param io a FileIO associated with the location.
+   * @param location URL/path of a file accessible by io.
+   * @param length the known length of such file.
+   * @return a {@link CachingInputFile} if length is within allowed limit. Otherwise, a regular
+   *     {@link InputFile} for given location.
+   * @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead
+   */
+  @Deprecated
+  public InputFile tryCache(FileIO io, String location, long length) {
+    return tryCache(io.newInputFile(location, length));
+  }
+
+  /**
+   * Try cache the file-content of file in the given location upon stream reading.
+   *
+   * <p>If length is longer than maximum length allowed by ContentCache, a regular {@link InputFile}
+   * and no caching will be done for that file. Otherwise, this method will return a {@link
+   * CachingInputFile} that serve file reads backed by ContentCache.
+   *
    * @param input an InputFile to cache
    * @return a {@link CachingInputFile} if length is within allowed limit. Otherwise, a regular
    *     {@link InputFile} for given location.

--- a/core/src/main/java/org/apache/iceberg/io/ContentCache.java
+++ b/core/src/main/java/org/apache/iceberg/io/ContentCache.java
@@ -182,7 +182,13 @@ public class ContentCache {
         .toString();
   }
 
-  private static class FileContent {
+  /**
+   * @deprecated will be removed in 1.7; use {@link FileContent} instead.
+   */
+  @Deprecated
+  private static class CacheEntry {}
+
+  private static class FileContent extends CacheEntry {
     private final long length;
     private final List<ByteBuffer> buffers;
 

--- a/core/src/main/java/org/apache/iceberg/io/ContentCache.java
+++ b/core/src/main/java/org/apache/iceberg/io/ContentCache.java
@@ -111,25 +111,19 @@ public class ContentCache {
     return cache.stats();
   }
 
-  /**
-   * @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead
-   */
+  /** @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead */
   @Deprecated
   public FileContent get(String key, Function<String, FileContent> mappingFunction) {
     return cache.get(key, mappingFunction);
   }
 
-  /**
-   * @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead
-   */
+  /** @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead */
   @Deprecated
   public FileContent getIfPresent(String location) {
     return cache.getIfPresent(location);
   }
 
-  /**
-   * @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead
-   */
+  /** @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead */
   @Deprecated
   public InputFile tryCache(FileIO io, String location, long length) {
     return tryCache(io.newInputFile(location, length));
@@ -179,9 +173,7 @@ public class ContentCache {
         .toString();
   }
 
-  /**
-   * @deprecated will be removed in 1.7; use {@link FileContent} instead.
-   */
+  /** @deprecated will be removed in 1.7; use {@link FileContent} instead. */
   @Deprecated
   private static class CacheEntry {}
 

--- a/core/src/main/java/org/apache/iceberg/io/ContentCache.java
+++ b/core/src/main/java/org/apache/iceberg/io/ContentCache.java
@@ -113,13 +113,13 @@ public class ContentCache {
 
   /** @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead */
   @Deprecated
-  public FileContent get(String key, Function<String, FileContent> mappingFunction) {
+  public CacheEntry get(String key, Function<String, FileContent> mappingFunction) {
     return cache.get(key, mappingFunction);
   }
 
   /** @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead */
   @Deprecated
-  public FileContent getIfPresent(String location) {
+  public CacheEntry getIfPresent(String location) {
     return cache.getIfPresent(location);
   }
 

--- a/core/src/main/java/org/apache/iceberg/io/ContentCache.java
+++ b/core/src/main/java/org/apache/iceberg/io/ContentCache.java
@@ -32,7 +32,6 @@ import java.util.function.Function;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,8 +39,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Class that provides file-content caching during reading.
  *
- * <p>The file-content caching is initiated by calling {@link ContentCache#tryCache(FileIO, String,
- * long)}. Given a FileIO, a file location string, and file length that is within allowed limit,
+ * <p>The file-content caching is initiated by calling {@link ContentCache#tryCache(InputFile)}.
+ * Given a FileIO, a file location string, and file length that is within allowed limit,
  * ContentCache will return a {@link CachingInputFile} that is backed by the cache. Calling {@link
  * CachingInputFile#newStream()} will return a {@link ByteBufferInputStream} backed by list of
  * {@link ByteBuffer} from the cache if such file-content exist in the cache. If the file-content
@@ -56,7 +55,7 @@ public class ContentCache {
   private final long expireAfterAccessMs;
   private final long maxTotalBytes;
   private final long maxContentLength;
-  private final Cache<String, CacheEntry> cache;
+  private final Cache<String, FileContent> cache;
 
   /**
    * Constructor for ContentCache class.
@@ -86,11 +85,11 @@ public class ContentCache {
         builder
             .maximumWeight(maxTotalBytes)
             .weigher(
-                (Weigher<String, CacheEntry>)
+                (Weigher<String, FileContent>)
                     (key, value) -> (int) Math.min(value.length, Integer.MAX_VALUE))
             .softValues()
             .removalListener(
-                (location, cacheEntry, cause) ->
+                (location, fileContent, cause) ->
                     LOG.debug("Evicted {} from ContentCache ({})", location, cause))
             .recordStats()
             .build();
@@ -112,11 +111,11 @@ public class ContentCache {
     return cache.stats();
   }
 
-  public CacheEntry get(String key, Function<String, CacheEntry> mappingFunction) {
+  public FileContent get(String key, Function<String, FileContent> mappingFunction) {
     return cache.get(key, mappingFunction);
   }
 
-  public CacheEntry getIfPresent(String location) {
+  public FileContent getIfPresent(String location) {
     return cache.getIfPresent(location);
   }
 
@@ -127,17 +126,15 @@ public class ContentCache {
    * and no caching will be done for that file. Otherwise, this method will return a {@link
    * CachingInputFile} that serve file reads backed by ContentCache.
    *
-   * @param io a FileIO associated with the location.
-   * @param location URL/path of a file accessible by io.
-   * @param length the known length of such file.
+   * @param input an InputFile to cache
    * @return a {@link CachingInputFile} if length is within allowed limit. Otherwise, a regular
    *     {@link InputFile} for given location.
    */
-  public InputFile tryCache(FileIO io, String location, long length) {
-    if (length <= maxContentLength) {
-      return new CachingInputFile(this, io, location, length);
+  public InputFile tryCache(InputFile input) {
+    if (input.getLength() <= maxContentLength) {
+      return new CachingInputFile(this, input);
     }
-    return io.newInputFile(location, length);
+    return input;
   }
 
   public void invalidate(String key) {
@@ -166,11 +163,11 @@ public class ContentCache {
         .toString();
   }
 
-  private static class CacheEntry {
+  private static class FileContent {
     private final long length;
     private final List<ByteBuffer> buffers;
 
-    private CacheEntry(long length, List<ByteBuffer> buffers) {
+    private FileContent(long length, List<ByteBuffer> buffers) {
       this.length = length;
       this.buffers = buffers;
     }
@@ -187,34 +184,20 @@ public class ContentCache {
    */
   private static class CachingInputFile implements InputFile {
     private final ContentCache contentCache;
-    private final FileIO io;
-    private final String location;
-    private final long length;
-    private InputFile fallbackInputFile = null;
+    private final InputFile input;
 
-    private CachingInputFile(ContentCache cache, FileIO io, String location, long length) {
+    private CachingInputFile(ContentCache cache, InputFile input) {
       this.contentCache = cache;
-      this.io = io;
-      this.location = location;
-      this.length = length;
-    }
-
-    private InputFile wrappedInputFile() {
-      if (fallbackInputFile == null) {
-        fallbackInputFile = io.newInputFile(location, length);
-      }
-      return fallbackInputFile;
+      this.input = input;
     }
 
     @Override
     public long getLength() {
-      CacheEntry buf = contentCache.getIfPresent(location);
+      FileContent buf = contentCache.getIfPresent(input.location());
       if (buf != null) {
         return buf.length;
-      } else if (fallbackInputFile != null) {
-        return fallbackInputFile.getLength();
       } else {
-        return length;
+        return input.getLength();
       }
     }
 
@@ -232,80 +215,63 @@ public class ContentCache {
     @Override
     public SeekableInputStream newStream() {
       try {
-        // read from cache if file length is less than or equal to maximum length allowed to
-        // cache.
-        if (getLength() <= contentCache.maxContentLength()) {
-          return cachedStream();
-        }
-
-        // fallback to non-caching input stream.
-        return wrappedInputFile().newStream();
+        return cachedStream();
       } catch (FileNotFoundException e) {
-        throw new NotFoundException(
-            e, "Failed to open input stream for file %s: %s", location, e.toString());
+        throw new NotFoundException(e, "Failed to open file: %s", input.location());
       } catch (IOException e) {
-        throw new UncheckedIOException(
-            String.format("Failed to open input stream for file %s: %s", location, e), e);
+        return input.newStream();
       }
     }
 
     @Override
     public String location() {
-      return location;
+      return input.location();
     }
 
     @Override
     public boolean exists() {
-      CacheEntry buf = contentCache.getIfPresent(location);
-      return buf != null || wrappedInputFile().exists();
-    }
-
-    private CacheEntry cacheEntry() {
-      long start = System.currentTimeMillis();
-      try (SeekableInputStream stream = wrappedInputFile().newStream()) {
-        long fileLength = getLength();
-        long totalBytesToRead = fileLength;
-        List<ByteBuffer> buffers = Lists.newArrayList();
-
-        while (totalBytesToRead > 0) {
-          // read the stream in 4MB chunk
-          int bytesToRead = (int) Math.min(BUFFER_CHUNK_SIZE, totalBytesToRead);
-          byte[] buf = new byte[bytesToRead];
-          int bytesRead = IOUtil.readRemaining(stream, buf, 0, bytesToRead);
-          totalBytesToRead -= bytesRead;
-
-          if (bytesRead < bytesToRead) {
-            // Read less than it should be, possibly hitting EOF. Abandon caching by throwing
-            // IOException and let the caller fallback to non-caching input file.
-            throw new IOException(
-                String.format(
-                    "Expected to read %d bytes, but only %d bytes read.",
-                    fileLength, fileLength - totalBytesToRead));
-          } else {
-            buffers.add(ByteBuffer.wrap(buf));
-          }
-        }
-
-        CacheEntry newEntry = new CacheEntry(fileLength, buffers);
-        LOG.debug("cacheEntry took {} ms for {}", (System.currentTimeMillis() - start), location);
-        return newEntry;
-      } catch (IOException ex) {
-        throw new UncheckedIOException(ex);
-      }
+      FileContent buf = contentCache.getIfPresent(input.location());
+      return buf != null || input.exists();
     }
 
     private SeekableInputStream cachedStream() throws IOException {
       try {
-        CacheEntry entry = contentCache.get(location, k -> cacheEntry());
-        Preconditions.checkNotNull(
-            entry, "CacheEntry should not be null when there is no RuntimeException occurs");
-        LOG.debug("Cache stats: {}", contentCache.stats());
-        return ByteBufferInputStream.wrap(entry.buffers);
+        FileContent content = contentCache.get(input.location(), k -> download(input));
+        return ByteBufferInputStream.wrap(content.buffers);
       } catch (UncheckedIOException ex) {
         throw ex.getCause();
-      } catch (RuntimeException ex) {
-        throw new IOException("Caught an error while reading from cache", ex);
       }
+    }
+  }
+
+  private static FileContent download(InputFile input) {
+    try (SeekableInputStream stream = input.newStream()) {
+      long fileLength = input.getLength();
+      long totalBytesToRead = fileLength;
+      List<ByteBuffer> buffers = Lists.newArrayList();
+
+      while (totalBytesToRead > 0) {
+        // read the stream in chunks
+        int bytesToRead = (int) Math.min(BUFFER_CHUNK_SIZE, totalBytesToRead);
+        byte[] buf = new byte[bytesToRead];
+        int bytesRead = IOUtil.readRemaining(stream, buf, 0, bytesToRead);
+        totalBytesToRead -= bytesRead;
+
+        if (bytesRead < bytesToRead) {
+          // Read less than it should be, possibly hitting EOF. Abandon caching by throwing
+          // IOException and let the caller fallback to non-caching input file.
+          throw new IOException(
+              String.format(
+                  "Failed to read %d bytes: %d bytes in stream",
+                  fileLength, fileLength - totalBytesToRead));
+        } else {
+          buffers.add(ByteBuffer.wrap(buf));
+        }
+      }
+
+      return new FileContent(fileLength, buffers);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/io/ContentCache.java
+++ b/core/src/main/java/org/apache/iceberg/io/ContentCache.java
@@ -111,26 +111,23 @@ public class ContentCache {
     return cache.stats();
   }
 
+  /**
+   * @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead
+   */
+  @Deprecated
   public FileContent get(String key, Function<String, FileContent> mappingFunction) {
     return cache.get(key, mappingFunction);
   }
 
+  /**
+   * @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead
+   */
+  @Deprecated
   public FileContent getIfPresent(String location) {
     return cache.getIfPresent(location);
   }
 
   /**
-   * Try cache the file-content of file in the given location upon stream reading.
-   *
-   * <p>If length is longer than maximum length allowed by ContentCache, a regular {@link InputFile}
-   * and no caching will be done for that file. Otherwise, this method will return a {@link
-   * CachingInputFile} that serve file reads backed by ContentCache.
-   *
-   * @param io a FileIO associated with the location.
-   * @param location URL/path of a file accessible by io.
-   * @param length the known length of such file.
-   * @return a {@link CachingInputFile} if length is within allowed limit. Otherwise, a regular
-   *     {@link InputFile} for given location.
    * @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead
    */
   @Deprecated


### PR DESCRIPTION
This adds `EncryptingFileIO` to handle metadata file encryption without breaking existing interfaces that pass `FileIO` without an `EncryptionManager`. It also updates `FileIO` to have methods for opening `ManifestFile`, `DataFile`, and `DeleteFile` directly to avoid needing to check whether a given `FileIO` supports encryption. The default implementation in `FileIO` fails if metadata files are encrypted.