### PR TITLE
Flink: Backport #9364 to 1.16 and 1.17 for Create CatalogTestBase for migration to JUnit5

### DIFF
--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.util.ArrayUtils;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public abstract class CatalogTestBase extends TestBase {
+
+  protected static final String DATABASE = "db";
+  @TempDir protected File hiveWarehouse;
+  @TempDir protected File hadoopWarehouse;
+
+  @Parameter(index = 0)
+  protected String catalogName;
+
+  @Parameter(index = 1)
+  protected Namespace baseNamespace;
+
+  protected Catalog validationCatalog;
+  protected SupportsNamespaces validationNamespaceCatalog;
+  protected Map<String, String> config = Maps.newHashMap();
+
+  protected String flinkDatabase;
+  protected Namespace icebergNamespace;
+  protected boolean isHadoopCatalog;
+
+  @Parameters(name = "catalogName={0}, baseNamespace={1}")
+  protected static List<Object[]> parameters() {
+    return Arrays.asList(
+        new Object[] {"testhive", Namespace.empty()},
+        new Object[] {"testhadoop", Namespace.empty()},
+        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1")});
+  }
+
+  @BeforeEach
+  public void before() {
+    this.isHadoopCatalog = catalogName.startsWith("testhadoop");
+    this.validationCatalog =
+        isHadoopCatalog
+            ? new HadoopCatalog(hiveConf, "file:" + hadoopWarehouse.getPath())
+            : catalog;
+    this.validationNamespaceCatalog = (SupportsNamespaces) validationCatalog;
+
+    config.put("type", "iceberg");
+    if (!baseNamespace.isEmpty()) {
+      config.put(FlinkCatalogFactory.BASE_NAMESPACE, baseNamespace.toString());
+    }
+    if (isHadoopCatalog) {
+      config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hadoop");
+    } else {
+      config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hive");
+      config.put(CatalogProperties.URI, getURI(hiveConf));
+    }
+    config.put(CatalogProperties.WAREHOUSE_LOCATION, String.format("file://%s", warehouseRoot()));
+
+    this.flinkDatabase = catalogName + "." + DATABASE;
+    this.icebergNamespace =
+        Namespace.of(ArrayUtils.concat(baseNamespace.levels(), new String[] {DATABASE}));
+    sql("CREATE CATALOG %s WITH %s", catalogName, toWithClause(config));
+  }
+
+  @AfterEach
+  public void clean() {
+    dropCatalog(catalogName, true);
+  }
+
+  protected String warehouseRoot() {
+    if (isHadoopCatalog) {
+      return hadoopWarehouse.getAbsolutePath();
+    } else {
+      return hiveWarehouse.getAbsolutePath();
+    }
+  }
+
+  protected String getFullQualifiedTableName(String tableName) {
+    final List<String> levels = Lists.newArrayList(icebergNamespace.levels());
+    levels.add(tableName);
+    return Joiner.on('.').join(levels);
+  }
+
+  static String getURI(HiveConf conf) {
+    return conf.get(HiveConf.ConfVars.METASTOREURIS.varname);
+  }
+
+  static String toWithClause(Map<String, String> props) {
+    StringBuilder builder = new StringBuilder();
+    builder.append("(");
+    int propCount = 0;
+    for (Map.Entry<String, String> entry : props.entrySet()) {
+      if (propCount > 0) {
+        builder.append(",");
+      }
+      builder
+          .append("'")
+          .append(entry.getKey())
+          .append("'")
+          .append("=")
+          .append("'")
+          .append(entry.getValue())
+          .append("'");
+      propCount++;
+    }
+    builder.append(")");
+    return builder.toString();
+  }
+}

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.flink;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.ObjectPath;
@@ -25,25 +27,28 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
 
-public class TestFlinkCatalogTablePartitions extends FlinkCatalogTestBase {
+public class TestFlinkCatalogTablePartitions extends CatalogTestBase {
 
   private String tableName = "test_table";
 
-  private final FileFormat format;
+  @Parameter(index = 2)
+  private FileFormat format;
 
-  @Parameterized.Parameters(
-      name = "catalogName={0}, baseNamespace={1}, format={2}, cacheEnabled={3}")
-  public static Iterable<Object[]> parameters() {
+  @Parameter(index = 3)
+  private Boolean cacheEnabled;
+
+  @Parameters(name = "catalogName={0}, baseNamespace={1}, format={2}, cacheEnabled={3}")
+  protected static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
     for (FileFormat format :
         new FileFormat[] {FileFormat.ORC, FileFormat.AVRO, FileFormat.PARQUET}) {
@@ -58,30 +63,24 @@ public class TestFlinkCatalogTablePartitions extends FlinkCatalogTestBase {
     return parameters;
   }
 
-  public TestFlinkCatalogTablePartitions(
-      String catalogName, Namespace baseNamespace, FileFormat format, boolean cacheEnabled) {
-    super(catalogName, baseNamespace);
-    this.format = format;
-    config.put(CatalogProperties.CACHE_ENABLED, String.valueOf(cacheEnabled));
-  }
-
   @Override
-  @Before
+  @BeforeEach
   public void before() {
     super.before();
+    config.put(CatalogProperties.CACHE_ENABLED, String.valueOf(cacheEnabled));
     sql("CREATE DATABASE %s", flinkDatabase);
     sql("USE CATALOG %s", catalogName);
     sql("USE %s", DATABASE);
   }
 
-  @After
+  @AfterEach
   public void cleanNamespaces() {
     sql("DROP TABLE IF EXISTS %s.%s", flinkDatabase, tableName);
     sql("DROP DATABASE IF EXISTS %s", flinkDatabase);
     super.clean();
   }
 
-  @Test
+  @TestTemplate
   public void testListPartitionsWithUnpartitionedTable() {
     sql(
         "CREATE TABLE %s (id INT, data VARCHAR) with ('write.format.default'='%s')",
@@ -95,7 +94,7 @@ public class TestFlinkCatalogTablePartitions extends FlinkCatalogTestBase {
         .hasMessage("Table " + objectPath + " in catalog " + catalogName + " is not partitioned.");
   }
 
-  @Test
+  @TestTemplate
   public void testListPartitionsWithPartitionedTable()
       throws TableNotExistException, TableNotPartitionedException {
     sql(
@@ -108,13 +107,12 @@ public class TestFlinkCatalogTablePartitions extends FlinkCatalogTestBase {
     ObjectPath objectPath = new ObjectPath(DATABASE, tableName);
     FlinkCatalog flinkCatalog = (FlinkCatalog) getTableEnv().getCatalog(catalogName).get();
     List<CatalogPartitionSpec> list = flinkCatalog.listPartitions(objectPath);
-    Assert.assertEquals("Should have 2 partition", 2, list.size());
-
+    assertThat(list).hasSize(2);
     List<CatalogPartitionSpec> expected = Lists.newArrayList();
     CatalogPartitionSpec partitionSpec1 = new CatalogPartitionSpec(ImmutableMap.of("data", "a"));
     CatalogPartitionSpec partitionSpec2 = new CatalogPartitionSpec(ImmutableMap.of("data", "b"));
     expected.add(partitionSpec1);
     expected.add(partitionSpec2);
-    Assert.assertEquals("Should produce the expected catalog partition specs.", list, expected);
+    assertThat(list).as("Should produce the expected catalog partition specs.").isEqualTo(expected);
   }
 }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestMetadataTableReadableMetrics.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestMetadataTableReadableMetrics.java
@@ -21,9 +21,11 @@ package org.apache.iceberg.flink.source;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
+import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.Base64;
 import java.util.List;
 import org.apache.flink.configuration.Configuration;
@@ -32,6 +34,7 @@ import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.types.Row;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -40,28 +43,22 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.flink.FlinkCatalogTestBase;
+import org.apache.iceberg.flink.CatalogTestBase;
 import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
+public class TestMetadataTableReadableMetrics extends CatalogTestBase {
   private static final String TABLE_NAME = "test_table";
 
-  public TestMetadataTableReadableMetrics(String catalogName, Namespace baseNamespace) {
-    super(catalogName, baseNamespace);
-  }
-
-  @Parameterized.Parameters(name = "catalogName={0}, baseNamespace={1}")
-  public static Iterable<Object[]> parameters() {
+  @Parameters(name = "catalogName={0}, baseNamespace={1}")
+  protected static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
     String catalogName = "testhive";
     Namespace baseNamespace = Namespace.empty();
@@ -76,7 +73,7 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
     return super.getTableEnv();
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  private @TempDir Path temp;
 
   private static final Types.StructType LEAF_STRUCT_TYPE =
       Types.StructType.of(
@@ -134,8 +131,8 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
             createPrimitiveRecord(
                 false, 2, 2L, Float.NaN, 2.0D, new BigDecimal("2.00"), "2", null, null));
 
-    DataFile dataFile =
-        FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), records);
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(testFile), records);
     table.newAppend().appendFile(dataFile).commit();
     return table;
   }
@@ -153,12 +150,13 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
             createNestedRecord(0L, 0.0),
             createNestedRecord(1L, Double.NaN),
             createNestedRecord(null, null));
-    DataFile dataFile =
-        FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), records);
+
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(testFile), records);
     table.newAppend().appendFile(dataFile).commit();
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     super.before();
     sql("USE CATALOG %s", catalogName);
@@ -167,7 +165,7 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
   }
 
   @Override
-  @After
+  @AfterEach
   public void clean() {
     sql("DROP TABLE IF EXISTS %s.%s", flinkDatabase, TABLE_NAME);
     sql("DROP DATABASE IF EXISTS %s", flinkDatabase);
@@ -212,7 +210,7 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
     return values;
   }
 
-  @Test
+  @TestTemplate
   public void testPrimitiveColumns() throws Exception {
     createPrimitiveTable();
     List<Row> result = sql("SELECT readable_metrics FROM %s$files", TABLE_NAME);
@@ -257,7 +255,7 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
     TestHelpers.assertRows(result, expected);
   }
 
-  @Test
+  @TestTemplate
   public void testSelectPrimitiveValues() throws Exception {
     createPrimitiveTable();
 
@@ -276,7 +274,7 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
         ImmutableList.of(Row.of(4L, 0)));
   }
 
-  @Test
+  @TestTemplate
   public void testSelectNestedValues() throws Exception {
     createNestedTable();
     TestHelpers.assertRows(
@@ -287,7 +285,7 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
         ImmutableList.of(Row.of(0L, 3L)));
   }
 
-  @Test
+  @TestTemplate
   public void testNestedValues() throws Exception {
     createNestedTable();
 

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.util.ArrayUtils;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public abstract class CatalogTestBase extends TestBase {
+
+  protected static final String DATABASE = "db";
+  @TempDir protected File hiveWarehouse;
+  @TempDir protected File hadoopWarehouse;
+
+  @Parameter(index = 0)
+  protected String catalogName;
+
+  @Parameter(index = 1)
+  protected Namespace baseNamespace;
+
+  protected Catalog validationCatalog;
+  protected SupportsNamespaces validationNamespaceCatalog;
+  protected Map<String, String> config = Maps.newHashMap();
+
+  protected String flinkDatabase;
+  protected Namespace icebergNamespace;
+  protected boolean isHadoopCatalog;
+
+  @Parameters(name = "catalogName={0}, baseNamespace={1}")
+  protected static List<Object[]> parameters() {
+    return Arrays.asList(
+        new Object[] {"testhive", Namespace.empty()},
+        new Object[] {"testhadoop", Namespace.empty()},
+        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1")});
+  }
+
+  @BeforeEach
+  public void before() {
+    this.isHadoopCatalog = catalogName.startsWith("testhadoop");
+    this.validationCatalog =
+        isHadoopCatalog
+            ? new HadoopCatalog(hiveConf, "file:" + hadoopWarehouse.getPath())
+            : catalog;
+    this.validationNamespaceCatalog = (SupportsNamespaces) validationCatalog;
+
+    config.put("type", "iceberg");
+    if (!baseNamespace.isEmpty()) {
+      config.put(FlinkCatalogFactory.BASE_NAMESPACE, baseNamespace.toString());
+    }
+    if (isHadoopCatalog) {
+      config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hadoop");
+    } else {
+      config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hive");
+      config.put(CatalogProperties.URI, getURI(hiveConf));
+    }
+    config.put(CatalogProperties.WAREHOUSE_LOCATION, String.format("file://%s", warehouseRoot()));
+
+    this.flinkDatabase = catalogName + "." + DATABASE;
+    this.icebergNamespace =
+        Namespace.of(ArrayUtils.concat(baseNamespace.levels(), new String[] {DATABASE}));
+    sql("CREATE CATALOG %s WITH %s", catalogName, toWithClause(config));
+  }
+
+  @AfterEach
+  public void clean() {
+    dropCatalog(catalogName, true);
+  }
+
+  protected String warehouseRoot() {
+    if (isHadoopCatalog) {
+      return hadoopWarehouse.getAbsolutePath();
+    } else {
+      return hiveWarehouse.getAbsolutePath();
+    }
+  }
+
+  protected String getFullQualifiedTableName(String tableName) {
+    final List<String> levels = Lists.newArrayList(icebergNamespace.levels());
+    levels.add(tableName);
+    return Joiner.on('.').join(levels);
+  }
+
+  static String getURI(HiveConf conf) {
+    return conf.get(HiveConf.ConfVars.METASTOREURIS.varname);
+  }
+
+  static String toWithClause(Map<String, String> props) {
+    StringBuilder builder = new StringBuilder();
+    builder.append("(");
+    int propCount = 0;
+    for (Map.Entry<String, String> entry : props.entrySet()) {
+      if (propCount > 0) {
+        builder.append(",");
+      }
+      builder
+          .append("'")
+          .append(entry.getKey())
+          .append("'")
+          .append("=")
+          .append("'")
+          .append(entry.getValue())
+          .append("'");
+      propCount++;
+    }
+    builder.append(")");
+    return builder.toString();
+  }
+}

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.flink;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.ObjectPath;
@@ -25,25 +27,28 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
 
-public class TestFlinkCatalogTablePartitions extends FlinkCatalogTestBase {
+public class TestFlinkCatalogTablePartitions extends CatalogTestBase {
 
   private String tableName = "test_table";
 
-  private final FileFormat format;
+  @Parameter(index = 2)
+  private FileFormat format;
 
-  @Parameterized.Parameters(
-      name = "catalogName={0}, baseNamespace={1}, format={2}, cacheEnabled={3}")
-  public static Iterable<Object[]> parameters() {
+  @Parameter(index = 3)
+  private Boolean cacheEnabled;
+
+  @Parameters(name = "catalogName={0}, baseNamespace={1}, format={2}, cacheEnabled={3}")
+  protected static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
     for (FileFormat format :
         new FileFormat[] {FileFormat.ORC, FileFormat.AVRO, FileFormat.PARQUET}) {
@@ -58,30 +63,24 @@ public class TestFlinkCatalogTablePartitions extends FlinkCatalogTestBase {
     return parameters;
   }
 
-  public TestFlinkCatalogTablePartitions(
-      String catalogName, Namespace baseNamespace, FileFormat format, boolean cacheEnabled) {
-    super(catalogName, baseNamespace);
-    this.format = format;
-    config.put(CatalogProperties.CACHE_ENABLED, String.valueOf(cacheEnabled));
-  }
-
   @Override
-  @Before
+  @BeforeEach
   public void before() {
     super.before();
+    config.put(CatalogProperties.CACHE_ENABLED, String.valueOf(cacheEnabled));
     sql("CREATE DATABASE %s", flinkDatabase);
     sql("USE CATALOG %s", catalogName);
     sql("USE %s", DATABASE);
   }
 
-  @After
+  @AfterEach
   public void cleanNamespaces() {
     sql("DROP TABLE IF EXISTS %s.%s", flinkDatabase, tableName);
     sql("DROP DATABASE IF EXISTS %s", flinkDatabase);
     super.clean();
   }
 
-  @Test
+  @TestTemplate
   public void testListPartitionsWithUnpartitionedTable() {
     sql(
         "CREATE TABLE %s (id INT, data VARCHAR) with ('write.format.default'='%s')",
@@ -96,7 +95,7 @@ public class TestFlinkCatalogTablePartitions extends FlinkCatalogTestBase {
         .hasMessageEndingWith("is not partitioned.");
   }
 
-  @Test
+  @TestTemplate
   public void testListPartitionsWithPartitionedTable()
       throws TableNotExistException, TableNotPartitionedException {
     sql(
@@ -109,13 +108,12 @@ public class TestFlinkCatalogTablePartitions extends FlinkCatalogTestBase {
     ObjectPath objectPath = new ObjectPath(DATABASE, tableName);
     FlinkCatalog flinkCatalog = (FlinkCatalog) getTableEnv().getCatalog(catalogName).get();
     List<CatalogPartitionSpec> list = flinkCatalog.listPartitions(objectPath);
-    Assert.assertEquals("Should have 2 partition", 2, list.size());
-
+    assertThat(list).hasSize(2);
     List<CatalogPartitionSpec> expected = Lists.newArrayList();
     CatalogPartitionSpec partitionSpec1 = new CatalogPartitionSpec(ImmutableMap.of("data", "a"));
     CatalogPartitionSpec partitionSpec2 = new CatalogPartitionSpec(ImmutableMap.of("data", "b"));
     expected.add(partitionSpec1);
     expected.add(partitionSpec2);
-    Assert.assertEquals("Should produce the expected catalog partition specs.", list, expected);
+    assertThat(list).as("Should produce the expected catalog partition specs.").isEqualTo(expected);
   }
 }

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestMetadataTableReadableMetrics.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestMetadataTableReadableMetrics.java
@@ -21,9 +21,11 @@ package org.apache.iceberg.flink.source;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
+import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.Base64;
 import java.util.List;
 import org.apache.flink.configuration.Configuration;
@@ -32,6 +34,7 @@ import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.types.Row;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -40,28 +43,22 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.flink.FlinkCatalogTestBase;
+import org.apache.iceberg.flink.CatalogTestBase;
 import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
+public class TestMetadataTableReadableMetrics extends CatalogTestBase {
   private static final String TABLE_NAME = "test_table";
 
-  public TestMetadataTableReadableMetrics(String catalogName, Namespace baseNamespace) {
-    super(catalogName, baseNamespace);
-  }
-
-  @Parameterized.Parameters(name = "catalogName={0}, baseNamespace={1}")
-  public static Iterable<Object[]> parameters() {
+  @Parameters(name = "catalogName={0}, baseNamespace={1}")
+  protected static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
     String catalogName = "testhive";
     Namespace baseNamespace = Namespace.empty();
@@ -76,7 +73,7 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
     return super.getTableEnv();
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  private @TempDir Path temp;
 
   private static final Types.StructType LEAF_STRUCT_TYPE =
       Types.StructType.of(
@@ -134,8 +131,8 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
             createPrimitiveRecord(
                 false, 2, 2L, Float.NaN, 2.0D, new BigDecimal("2.00"), "2", null, null));
 
-    DataFile dataFile =
-        FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), records);
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(testFile), records);
     table.newAppend().appendFile(dataFile).commit();
     return table;
   }
@@ -153,12 +150,13 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
             createNestedRecord(0L, 0.0),
             createNestedRecord(1L, Double.NaN),
             createNestedRecord(null, null));
-    DataFile dataFile =
-        FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), records);
+
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(testFile), records);
     table.newAppend().appendFile(dataFile).commit();
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     super.before();
     sql("USE CATALOG %s", catalogName);
@@ -167,7 +165,7 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
   }
 
   @Override
-  @After
+  @AfterEach
   public void clean() {
     sql("DROP TABLE IF EXISTS %s.%s", flinkDatabase, TABLE_NAME);
     sql("DROP DATABASE IF EXISTS %s", flinkDatabase);
@@ -212,7 +210,7 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
     return values;
   }
 
-  @Test
+  @TestTemplate
   public void testPrimitiveColumns() throws Exception {
     createPrimitiveTable();
     List<Row> result = sql("SELECT readable_metrics FROM %s$files", TABLE_NAME);
@@ -257,7 +255,7 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
     TestHelpers.assertRows(result, expected);
   }
 
-  @Test
+  @TestTemplate
   public void testSelectPrimitiveValues() throws Exception {
     createPrimitiveTable();
 
@@ -276,7 +274,7 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
         ImmutableList.of(Row.of(4L, 0)));
   }
 
-  @Test
+  @TestTemplate
   public void testSelectNestedValues() throws Exception {
     createNestedTable();
     TestHelpers.assertRows(
@@ -287,7 +285,7 @@ public class TestMetadataTableReadableMetrics extends FlinkCatalogTestBase {
         ImmutableList.of(Row.of(0L, 3L)));
   }
 
-  @Test
+  @TestTemplate
   public void testNestedValues() throws Exception {
     createNestedTable();
 


### PR DESCRIPTION
Both 1.17 and 1.16 patch came out clean