### PR TITLE
Flink: Supports specifying comment for iceberg fields in create table and addcolumn syntax using flinksql

### DIFF
--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.TableChange;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
@@ -390,23 +391,15 @@ public class FlinkCatalog extends AbstractCatalog {
               + "an iceberg catalog, Please create table with 'connector'='iceberg' property in a non-iceberg catalog or "
               + "create table without 'connector'='iceberg' related properties in an iceberg table.");
     }
-
-    createIcebergTable(tablePath, table, ignoreIfExists);
+    createIcebergTable(tablePath, (ResolvedCatalogTable) table, ignoreIfExists);
   }
 
-  void createIcebergTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
+  void createIcebergTable(ObjectPath tablePath, ResolvedCatalogTable table, boolean ignoreIfExists)
       throws CatalogException, TableAlreadyExistException {
     validateFlinkTable(table);
     Schema icebergSchema;
-    if (table instanceof CatalogTable) {
-      Map<String, String> columnComments = FlinkSchemaUtil.getColumnComments((CatalogTable) table);
-      icebergSchema = FlinkSchemaUtil.convert(table.getSchema(), columnComments);
-    } else {
-      icebergSchema = FlinkSchemaUtil.convert(table.getSchema());
-    }
-
+    icebergSchema = FlinkSchemaUtil.convert(table);
     PartitionSpec spec = toPartitionSpec(((CatalogTable) table).getPartitionKeys(), icebergSchema);
-
     ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
     String location = null;
     for (Map.Entry<String, String> entry : table.getOptions().entrySet()) {

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.flink;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
@@ -391,6 +393,7 @@ public class FlinkCatalog extends AbstractCatalog {
               + "an iceberg catalog, Please create table with 'connector'='iceberg' property in a non-iceberg catalog or "
               + "create table without 'connector'='iceberg' related properties in an iceberg table.");
     }
+    checkArgument(table instanceof ResolvedCatalogTable, "table should be resolved");
     createIcebergTable(tablePath, (ResolvedCatalogTable) table, ignoreIfExists);
   }
 

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg.flink;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
@@ -393,7 +391,7 @@ public class FlinkCatalog extends AbstractCatalog {
               + "an iceberg catalog, Please create table with 'connector'='iceberg' property in a non-iceberg catalog or "
               + "create table without 'connector'='iceberg' related properties in an iceberg table.");
     }
-    checkArgument(table instanceof ResolvedCatalogTable, "table should be resolved");
+    Preconditions.checkArgument(table instanceof ResolvedCatalogTable, "table should be resolved");
     createIcebergTable(tablePath, (ResolvedCatalogTable) table, ignoreIfExists);
   }
 

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -399,7 +399,7 @@ public class FlinkCatalog extends AbstractCatalog {
       throws CatalogException, TableAlreadyExistException {
     validateFlinkTable(table);
 
-    Schema icebergSchema = FlinkSchemaUtil.convert(table);
+    Schema icebergSchema = FlinkSchemaUtil.convert(table.getResolvedSchema());
     PartitionSpec spec = toPartitionSpec(((CatalogTable) table).getPartitionKeys(), icebergSchema);
     ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
     String location = null;

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -398,8 +398,8 @@ public class FlinkCatalog extends AbstractCatalog {
   void createIcebergTable(ObjectPath tablePath, ResolvedCatalogTable table, boolean ignoreIfExists)
       throws CatalogException, TableAlreadyExistException {
     validateFlinkTable(table);
-    Schema icebergSchema;
-    icebergSchema = FlinkSchemaUtil.convert(table);
+
+    Schema icebergSchema = FlinkSchemaUtil.convert(table);
     PartitionSpec spec = toPartitionSpec(((CatalogTable) table).getPartitionKeys(), icebergSchema);
     ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
     String location = null;

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -397,8 +397,14 @@ public class FlinkCatalog extends AbstractCatalog {
   void createIcebergTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
       throws CatalogException, TableAlreadyExistException {
     validateFlinkTable(table);
+    Schema icebergSchema;
+    if (table instanceof CatalogTable) {
+      Map<String, String> columnComments = FlinkSchemaUtil.getColumnComments((CatalogTable) table);
+      icebergSchema = FlinkSchemaUtil.convert(table.getSchema(), columnComments);
+    } else {
+      icebergSchema = FlinkSchemaUtil.convert(table.getSchema());
+    }
 
-    Schema icebergSchema = FlinkSchemaUtil.convert(table.getSchema());
     PartitionSpec spec = toPartitionSpec(((CatalogTable) table).getPartitionKeys(), icebergSchema);
 
     ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -24,9 +24,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
@@ -85,9 +83,9 @@ public class FlinkDynamicTableFactory
   @Override
   public DynamicTableSource createDynamicTableSource(Context context) {
     ObjectIdentifier objectIdentifier = context.getObjectIdentifier();
-    CatalogTable catalogTable = context.getCatalogTable();
-    Map<String, String> tableProps = catalogTable.getOptions();
-    TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
+    ResolvedCatalogTable resolvedCatalogTable = context.getCatalogTable();
+    Map<String, String> tableProps = resolvedCatalogTable.getOptions();
+    TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(resolvedCatalogTable.getSchema());
 
     TableLoader tableLoader;
     if (catalog != null) {
@@ -95,7 +93,7 @@ public class FlinkDynamicTableFactory
     } else {
       tableLoader =
           createTableLoader(
-              catalogTable,
+              resolvedCatalogTable,
               tableProps,
               objectIdentifier.getDatabaseName(),
               objectIdentifier.getObjectName());
@@ -107,9 +105,9 @@ public class FlinkDynamicTableFactory
   @Override
   public DynamicTableSink createDynamicTableSink(Context context) {
     ObjectIdentifier objectIdentifier = context.getObjectIdentifier();
-    CatalogTable catalogTable = context.getCatalogTable();
-    Map<String, String> writeProps = catalogTable.getOptions();
-    TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
+    ResolvedCatalogTable resolvedCatalogTable = context.getCatalogTable();
+    Map<String, String> writeProps = resolvedCatalogTable.getOptions();
+    TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(resolvedCatalogTable.getSchema());
 
     TableLoader tableLoader;
     if (catalog != null) {
@@ -117,7 +115,7 @@ public class FlinkDynamicTableFactory
     } else {
       tableLoader =
           createTableLoader(
-              catalogTable,
+              resolvedCatalogTable,
               writeProps,
               objectIdentifier.getDatabaseName(),
               objectIdentifier.getObjectName());
@@ -148,7 +146,7 @@ public class FlinkDynamicTableFactory
   }
 
   private static TableLoader createTableLoader(
-      CatalogBaseTable catalogBaseTable,
+      ResolvedCatalogTable resolvedCatalogTable,
       Map<String, String> tableProps,
       String databaseName,
       String tableName) {
@@ -188,7 +186,7 @@ public class FlinkDynamicTableFactory
     // Create table if not exists in the external catalog.
     if (!flinkCatalog.tableExists(objectPath)) {
       try {
-        flinkCatalog.createIcebergTable(objectPath, (ResolvedCatalogTable) catalogBaseTable, true);
+        flinkCatalog.createIcebergTable(objectPath, resolvedCatalogTable, true);
       } catch (TableAlreadyExistException e) {
         throw new AlreadyExistsException(
             e,

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -187,7 +188,7 @@ public class FlinkDynamicTableFactory
     // Create table if not exists in the external catalog.
     if (!flinkCatalog.tableExists(objectPath)) {
       try {
-        flinkCatalog.createIcebergTable(objectPath, catalogBaseTable, true);
+        flinkCatalog.createIcebergTable(objectPath, (ResolvedCatalogTable) catalogBaseTable, true);
       } catch (TableAlreadyExistException e) {
         throw new AlreadyExistsException(
             e,

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -19,12 +19,9 @@
 package org.apache.iceberg.flink;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -100,15 +97,6 @@ public class FlinkSchemaUtil {
     Type converted = root.accept(new FlinkTypeToType(root));
     Schema iSchema = new Schema(converted.asStructType().fields());
     return freshIdentifierFieldIds(iSchema, catalogTable.getSchema());
-  }
-
-  public static Map<String, String> getColumnComments(CatalogTable catalogTable) {
-    return catalogTable.getUnresolvedSchema().getColumns().stream()
-        .filter(c -> c.getComment().isPresent())
-        .collect(
-            Collectors.toMap(
-                org.apache.flink.table.api.Schema.UnresolvedColumn::getName,
-                c -> c.getComment().get()));
   }
 
   private static Schema freshIdentifierFieldIds(Schema iSchema, TableSchema schema) {

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -63,7 +63,7 @@ public class FlinkSchemaUtil {
   public static Schema convert(TableSchema schema) {
     LogicalType schemaType = schema.toRowDataType().getLogicalType();
     Preconditions.checkArgument(
-        schemaType instanceof RowType, "Schema logical type should be RowType.");
+        schemaType instanceof RowType, "Schema logical type should be row type.");
 
     RowType root = (RowType) schemaType;
     Type converted = root.accept(new FlinkTypeToType(root));
@@ -95,7 +95,7 @@ public class FlinkSchemaUtil {
 
     LogicalType schemaType = DataTypes.ROW(fields).notNull().getLogicalType();
     Preconditions.checkArgument(
-        schemaType instanceof RowType, "Schema logical type should be RowType.");
+        schemaType instanceof RowType, "Schema logical type should be row type.");
 
     RowType root = (RowType) schemaType;
     Type converted = root.accept(new FlinkTypeToType(root));
@@ -114,7 +114,7 @@ public class FlinkSchemaUtil {
       Types.NestedField field = icebergSchema.findField(primaryKey);
       Preconditions.checkNotNull(
           field,
-          "Cannot find field ID for the primary key column %s in Schema %s",
+          "Cannot find field ID for the primary key column %s in schema %s",
           primaryKey,
           icebergSchema);
       identifierFieldIds.add(field.fieldId());

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -18,9 +18,6 @@
  */
 package org.apache.iceberg.flink;
 
-import static org.apache.flink.table.api.DataTypes.FIELD;
-import static org.apache.flink.table.api.DataTypes.ROW;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -86,14 +83,14 @@ public class FlinkSchemaUtil {
                 column -> {
                   String columnComment = columnComments.get(column.getName());
                   if (columnComment != null) {
-                    return FIELD(column.getName(), column.getType(), columnComment);
+                    return DataTypes.FIELD(column.getName(), column.getType(), columnComment);
                   } else {
-                    return FIELD(column.getName(), column.getType());
+                    return DataTypes.FIELD(column.getName(), column.getType());
                   }
                 })
             .toArray(DataTypes.Field[]::new);
 
-    LogicalType schemaType = ROW(fields).notNull().getLogicalType();
+    LogicalType schemaType = DataTypes.ROW(fields).notNull().getLogicalType();
     Preconditions.checkArgument(
         schemaType instanceof RowType, "Schema logical type should be RowType.");
 

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/util/FlinkAlterTableUtil.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/util/FlinkAlterTableUtil.java
@@ -132,9 +132,11 @@ public class FlinkAlterTableUtil {
             flinkColumn.getName());
         Type icebergType = FlinkSchemaUtil.convert(flinkColumn.getDataType().getLogicalType());
         if (flinkColumn.getDataType().getLogicalType().isNullable()) {
-          pendingUpdate.addColumn(flinkColumn.getName(), icebergType);
+          pendingUpdate.addColumn(
+              flinkColumn.getName(), icebergType, flinkColumn.getComment().orElse(null));
         } else {
-          pendingUpdate.addRequiredColumn(flinkColumn.getName(), icebergType);
+          pendingUpdate.addRequiredColumn(
+              flinkColumn.getName(), icebergType, flinkColumn.getComment().orElse(null));
         }
       } else if (change instanceof TableChange.ModifyColumn) {
         TableChange.ModifyColumn modifyColumn = (TableChange.ModifyColumn) change;

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -320,23 +320,24 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     assertThat(schemaBefore.asStruct())
         .isEqualTo(
             new Schema(Types.NestedField.optional(1, "id", Types.LongType.get())).asStruct());
-    sql("ALTER TABLE tl ADD (dt STRING COMMENT 'comment for dt')");
+    sql("ALTER TABLE tl ADD (dt STRING)");
     Schema schemaAfter1 = table("tl").schema();
     assertThat(schemaAfter1.asStruct())
         .isEqualTo(
             new Schema(
                     Types.NestedField.optional(1, "id", Types.LongType.get()),
-                    Types.NestedField.optional(2, "dt", Types.StringType.get(), "comment for dt"))
+                    Types.NestedField.optional(2, "dt", Types.StringType.get()))
                 .asStruct());
     // Add multiple columns
-    sql("ALTER TABLE tl ADD (col1 STRING, col2 BIGINT)");
+    sql("ALTER TABLE tl ADD (col1 STRING COMMENT 'comment for col1', col2 BIGINT)");
     Schema schemaAfter2 = table("tl").schema();
     assertThat(schemaAfter2.asStruct())
         .isEqualTo(
             new Schema(
                     Types.NestedField.optional(1, "id", Types.LongType.get()),
-                    Types.NestedField.optional(2, "dt", Types.StringType.get(), "comment for dt"),
-                    Types.NestedField.optional(3, "col1", Types.StringType.get()),
+                    Types.NestedField.optional(2, "dt", Types.StringType.get()),
+                    Types.NestedField.optional(
+                        3, "col1", Types.StringType.get(), "comment for col1"),
                     Types.NestedField.optional(4, "col2", Types.LongType.get()))
                 .asStruct());
     // Adding a required field should fail because Iceberg's SchemaUpdate does not allow

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -227,6 +227,19 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testCreateTableWithColumnComment() {
+    sql("CREATE TABLE tl(id BIGINT COMMENT 'comment - id', data STRING COMMENT 'comment - data')");
+
+    Table table = table("tl");
+    assertThat(table.schema().asStruct())
+        .isEqualTo(
+            new Schema(
+                    Types.NestedField.optional(1, "id", Types.LongType.get(), "comment - id"),
+                    Types.NestedField.optional(2, "data", Types.StringType.get(), "comment - data"))
+                .asStruct());
+  }
+
+  @TestTemplate
   public void testCreateTableWithFormatV2ThroughTableProperty() throws Exception {
     sql("CREATE TABLE tl(id BIGINT) WITH ('format-version'='2')");
 
@@ -307,13 +320,13 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     assertThat(schemaBefore.asStruct())
         .isEqualTo(
             new Schema(Types.NestedField.optional(1, "id", Types.LongType.get())).asStruct());
-    sql("ALTER TABLE tl ADD (dt STRING)");
+    sql("ALTER TABLE tl ADD (dt STRING COMMENT 'comment for dt')");
     Schema schemaAfter1 = table("tl").schema();
     assertThat(schemaAfter1.asStruct())
         .isEqualTo(
             new Schema(
                     Types.NestedField.optional(1, "id", Types.LongType.get()),
-                    Types.NestedField.optional(2, "dt", Types.StringType.get()))
+                    Types.NestedField.optional(2, "dt", Types.StringType.get(), "comment for dt"))
                 .asStruct());
     // Add multiple columns
     sql("ALTER TABLE tl ADD (col1 STRING, col2 BIGINT)");
@@ -322,7 +335,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
         .isEqualTo(
             new Schema(
                     Types.NestedField.optional(1, "id", Types.LongType.get()),
-                    Types.NestedField.optional(2, "dt", Types.StringType.get()),
+                    Types.NestedField.optional(2, "dt", Types.StringType.get(), "comment for dt"),
                     Types.NestedField.optional(3, "col1", Types.StringType.get()),
                     Types.NestedField.optional(4, "col2", Types.LongType.get()))
                 .asStruct());


### PR DESCRIPTION
If we use flinksql to create the iceberg table, even if I specify field comments, there are no field comments in the final iceberg table. #8511

In order to solve this problem, this PR parses field comments when creating tables and adding fields in flinksql, and finally adds them to iceberg field comments.

