### PR TITLE
Core: Supports limiting the count of manifests to merge when committing

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -118,6 +118,9 @@ public class TableProperties {
   public static final String MANIFEST_MERGE_ENABLED = "commit.manifest-merge.enabled";
   public static final boolean MANIFEST_MERGE_ENABLED_DEFAULT = true;
 
+  public static final String MANIFEST_MERGE_COUNT_LIMIT = "commit.manifest.merge-count-limit";
+  public static final int MANIFEST_MERGE_COUNT_LIMIT_DEFAULT = Integer.MAX_VALUE;
+
   public static final String DEFAULT_FILE_FORMAT = "write.format.default";
   public static final String DELETE_DEFAULT_FILE_FORMAT = "write.delete.format.default";
   public static final String DEFAULT_FILE_FORMAT_DEFAULT = "parquet";


### PR DESCRIPTION
The `MergingSnapshotProducer` will rewrite all the manifests after we change the `commit.manifest.target-size-bytes`. For a larger table, this will block the commit operation for a long time since there are many manifests to rewrite. In this PR, we add a new table property to support limiting the count of manifests to merge when committing. 