### PR TITLE
Spark 3.5: Add max allowed failed commits to RewriteDataFiles when partial progress is enabled

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -53,6 +53,13 @@ public interface RewriteDataFiles
   int PARTIAL_PROGRESS_MAX_COMMITS_DEFAULT = 10;
 
   /**
+   * The maximum amount of failed commits that this rewrite is allowed if partial progress is
+   * enabled. By default, all commits are allowed to fail. This setting has no effect if partial
+   * progress is disabled.
+   */
+  String PARTIAL_PROGRESS_MAX_FAILED_COMMITS = "partial-progress.max-failed-commits";
+
+  /**
    * The entire rewrite operation is broken down into pieces based on partitioning and within
    * partitions based on size into groups. These sub-units of the rewrite are referred to as file
    * groups. The largest amount of data that should be compacted in a single group is controlled by

--- a/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
@@ -60,6 +60,7 @@ abstract class BaseCommitService<T> implements Closeable {
   private final int rewritesPerCommit;
   private final AtomicBoolean running = new AtomicBoolean(false);
   private final long timeoutInMS;
+  private int succeededCommits = 0;
 
   /**
    * Constructs a {@link BaseCommitService}
@@ -227,11 +228,16 @@ abstract class BaseCommitService<T> implements Closeable {
       try {
         commitOrClean(batch);
         committedRewrites.addAll(batch);
+        succeededCommits++;
       } catch (Exception e) {
         LOG.error("Failure during rewrite commit process, partial progress enabled. Ignoring", e);
       }
       inProgressCommits.remove(inProgressCommitToken);
     }
+  }
+
+  public int succeededCommits() {
+    return succeededCommits;
   }
 
   @VisibleForTesting

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -79,6 +79,7 @@ public class RewriteDataFilesSparkAction
           MAX_FILE_GROUP_SIZE_BYTES,
           PARTIAL_PROGRESS_ENABLED,
           PARTIAL_PROGRESS_MAX_COMMITS,
+          PARTIAL_PROGRESS_MAX_FAILED_COMMITS,
           TARGET_FILE_SIZE_BYTES,
           USE_STARTING_SEQUENCE_NUMBER,
           REWRITE_JOB_ORDER,
@@ -92,6 +93,7 @@ public class RewriteDataFilesSparkAction
   private Expression filter = Expressions.alwaysTrue();
   private int maxConcurrentFileGroupRewrites;
   private int maxCommits;
+  private int maxFailedCommits;
   private boolean partialProgressEnabled;
   private boolean useStartingSequenceNumber;
   private RewriteJobOrder rewriteJobOrder;
@@ -359,20 +361,31 @@ public class RewriteDataFilesSparkAction
 
     // stop commit service
     commitService.close();
-    List<RewriteFileGroup> commitResults = commitService.results();
-    if (commitResults.size() == 0) {
-      LOG.error(
-          "{} is true but no rewrite commits succeeded. Check the logs to determine why the individual "
-              + "commits failed. If this is persistent it may help to increase {} which will break the rewrite operation "
+
+    int failedCommits = maxCommits - commitService.succeededCommits();
+    if (failedCommits > 0 && failedCommits <= maxFailedCommits) {
+      LOG.warn(
+          "{} is true but {} rewrite commits failed. Check the logs to determine why the individual "
+              + "commits failed. If this is persistent it may help to increase {} which will split the rewrite operation "
               + "into smaller commits.",
           PARTIAL_PROGRESS_ENABLED,
+          failedCommits,
           PARTIAL_PROGRESS_MAX_COMMITS);
+    } else if (failedCommits > maxFailedCommits) {
+      String errorMessage =
+          String.format(
+              "%s is true but %d rewrite commits failed. This is more than the maximum allowed failures of %d. "
+                  + "Check the logs to determine why the individual commits failed. If this is persistent it may help to "
+                  + "increase %s which will split the rewrite operation into smaller commits.",
+              PARTIAL_PROGRESS_ENABLED,
+              failedCommits,
+              maxFailedCommits,
+              PARTIAL_PROGRESS_MAX_COMMITS);
+      throw new RuntimeException(errorMessage);
     }
 
-    List<FileGroupRewriteResult> rewriteResults =
-        commitResults.stream().map(RewriteFileGroup::asResult).collect(Collectors.toList());
     return ImmutableRewriteDataFiles.Result.builder()
-        .rewriteResults(rewriteResults)
+        .rewriteResults(toRewriteResults(commitService.results()))
         .rewriteFailures(rewriteFailures)
         .build();
   }
@@ -403,6 +416,10 @@ public class RewriteDataFilesSparkAction
     return new RewriteFileGroup(info, tasks);
   }
 
+  private Iterable<FileGroupRewriteResult> toRewriteResults(List<RewriteFileGroup> commitResults) {
+    return commitResults.stream().map(RewriteFileGroup::asResult).collect(Collectors.toList());
+  }
+
   void validateAndInitOptions() {
     Set<String> validOptions = Sets.newHashSet(rewriter.validOptions());
     validOptions.addAll(VALID_OPTIONS);
@@ -427,6 +444,9 @@ public class RewriteDataFilesSparkAction
     maxCommits =
         PropertyUtil.propertyAsInt(
             options(), PARTIAL_PROGRESS_MAX_COMMITS, PARTIAL_PROGRESS_MAX_COMMITS_DEFAULT);
+
+    maxFailedCommits =
+        PropertyUtil.propertyAsInt(options(), PARTIAL_PROGRESS_MAX_FAILED_COMMITS, maxCommits);
 
     partialProgressEnabled =
         PropertyUtil.propertyAsBoolean(


### PR DESCRIPTION
When partial progress is enabled, `rewrite_data_files` Spark app can succeed without any "progress" (commits). This PR adds an option `partial-progress.max-failed-commits` and a RuntimeException will be thrown if the number of failed commits exceed it. The default value is `partital-progress.max-commits` to be consistent with current behavior.