### PR TITLE
Spark 3.4: Bypass Spark's ViewCatalog API when replacing a view

### DIFF
--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2ViewExec.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2ViewExec.scala
@@ -19,6 +19,7 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import org.apache.iceberg.spark.SupportsReplaceView
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.ViewAlreadyExistsException
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -56,20 +57,34 @@ case class CreateV2ViewExec(
 
     if (replace) {
       // CREATE OR REPLACE VIEW
-      if (catalog.viewExists(ident)) {
-        catalog.dropView(ident)
+      catalog match {
+        case c: SupportsReplaceView =>
+          c.replaceView(
+            ident,
+            queryText,
+            currentCatalog,
+            currentNamespace,
+            viewSchema,
+            queryColumnNames.toArray,
+            columnAliases.toArray,
+            columnComments.map(c => c.orNull).toArray,
+            newProperties.asJava)
+        case _ =>
+          if (catalog.viewExists(ident)) {
+            catalog.dropView(ident)
+          }
+
+          catalog.createView(
+            ident,
+            queryText,
+            currentCatalog,
+            currentNamespace,
+            viewSchema,
+            queryColumnNames.toArray,
+            columnAliases.toArray,
+            columnComments.map(c => c.orNull).toArray,
+            newProperties.asJava)
       }
-      // FIXME: replaceView API doesn't exist in Spark 3.5
-      catalog.createView(
-        ident,
-        queryText,
-        currentCatalog,
-        currentNamespace,
-        viewSchema,
-        queryColumnNames.toArray,
-        columnAliases.toArray,
-        columnComments.map(c => c.orNull).toArray,
-        newProperties.asJava)
     } else {
       try {
         // CREATE VIEW [IF NOT EXISTS]

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SupportsReplaceView.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SupportsReplaceView.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.util.Map;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchViewException;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.View;
+import org.apache.spark.sql.connector.catalog.ViewCatalog;
+import org.apache.spark.sql.types.StructType;
+
+public interface SupportsReplaceView extends ViewCatalog {
+  /**
+   * Replace a view in the catalog
+   *
+   * @param ident a view identifier
+   * @param sql the SQL text that defines the view
+   * @param currentCatalog the current catalog
+   * @param currentNamespace the current namespace
+   * @param schema the view query output schema
+   * @param queryColumnNames the query column names
+   * @param columnAliases the column aliases
+   * @param columnComments the column comments
+   * @param properties the view properties
+   * @throws NoSuchViewException If the view doesn't exist or is a table
+   * @throws NoSuchNamespaceException If the identifier namespace does not exist (optional)
+   */
+  View replaceView(
+      Identifier ident,
+      String sql,
+      String currentCatalog,
+      String[] currentNamespace,
+      StructType schema,
+      String[] queryColumnNames,
+      String[] columnAliases,
+      String[] columnComments,
+      Map<String, String> properties)
+      throws NoSuchViewException, NoSuchNamespaceException;
+}

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkView.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkView.java
@@ -35,7 +35,7 @@ import org.apache.spark.sql.types.StructType;
 
 public class SparkView implements org.apache.spark.sql.connector.catalog.View {
 
-  private static final String QUERY_COLUMN_NAMES = "spark.query-column-names";
+  public static final String QUERY_COLUMN_NAMES = "spark.query-column-names";
   public static final Set<String> RESERVED_PROPERTIES =
       ImmutableSet.of("provider", "location", FORMAT_VERSION, QUERY_COLUMN_NAMES);
 

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2ViewExec.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2ViewExec.scala
@@ -23,7 +23,6 @@ import org.apache.iceberg.spark.SupportsReplaceView
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.ViewAlreadyExistsException
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.catalog.ViewCatalog
 import org.apache.spark.sql.types.StructType


### PR DESCRIPTION
This backports #9596 to Spark 3.4