### PR TITLE
Core: only trim slash when warehouse location is not root path

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -110,7 +110,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog
     this.catalogName = name;
     this.warehouseLocation = inputWarehouseLocation;
     if (!warehouseLocation.endsWith("://")) {
-        warehouseLocation = LocationUtil.stripTrailingSlash(warehouseLocation);
+      warehouseLocation = LocationUtil.stripTrailingSlash(warehouseLocation);
     }
     this.fs = Util.getFs(new Path(warehouseLocation), conf);
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -108,10 +108,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog
         "Cannot initialize HadoopCatalog because warehousePath must not be null or empty");
 
     this.catalogName = name;
-    this.warehouseLocation = inputWarehouseLocation;
-    if (!warehouseLocation.endsWith("://")) {
-      warehouseLocation = LocationUtil.stripTrailingSlash(warehouseLocation);
-    }
+    this.warehouseLocation = LocationUtil.stripTrailingSlash(inputWarehouseLocation);
     this.fs = Util.getFs(new Path(warehouseLocation), conf);
 
     String fileIOImpl =

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -108,7 +108,10 @@ public class HadoopCatalog extends BaseMetastoreCatalog
         "Cannot initialize HadoopCatalog because warehousePath must not be null or empty");
 
     this.catalogName = name;
-    this.warehouseLocation = LocationUtil.stripTrailingSlash(inputWarehouseLocation);
+    this.warehouseLocation = inputWarehouseLocation;
+    if (!warehouseLocation.endsWith("://")) {
+        warehouseLocation = LocationUtil.stripTrailingSlash(warehouseLocation);
+    }
     this.fs = Util.getFs(new Path(warehouseLocation), conf);
 
     String fileIOImpl =

--- a/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
@@ -28,7 +28,7 @@ public class LocationUtil {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(path), "path must not be null or empty");
 
     String result = path;
-    while (result.endsWith("/")) {
+    while (!result.endsWith("://") && result.endsWith("/")) {
       result = result.substring(0, result.length() - 1);
     }
     return result;

--- a/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
@@ -46,6 +46,21 @@ public class TestLocationUtil {
     assertThat(LocationUtil.stripTrailingSlash(pathWithOnlySlash))
         .as("Should have no trailing slashes")
         .isEmpty();
+
+    String rootPath = "blobstore://";
+    assertThat(LocationUtil.stripTrailingSlash(rootPath))
+        .as("Should be root path")
+        .isEqualTo(rootPath);
+
+    String rootPathWithTrailingSlash = rootPath + "/";
+    assertThat(LocationUtil.stripTrailingSlash(rootPathWithTrailingSlash))
+        .as("Should be root path")
+        .isEqualTo(rootPath);
+
+    String rootPathWithMultipleTrailingSlash = rootPath + "///";
+    assertThat(LocationUtil.stripTrailingSlash(rootPathWithMultipleTrailingSlash))
+        .as("Should be root path")
+        .isEqualTo(rootPath);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
@@ -60,17 +60,25 @@ public class TestLocationUtil {
   }
 
   @Test
-  void testStripTrailingSlashForRootPaths() {
+  void testStripTrailingSlashForRootPath() {
     String rootPath = "blobstore://";
     assertThat(LocationUtil.stripTrailingSlash(rootPath))
         .as("Should be root path")
         .isEqualTo(rootPath);
+  }
 
+  @Test
+  void testStripTrailingSlashForRootPathWithTrailingSlash() {
+    String rootPath = "blobstore://";
     String rootPathWithTrailingSlash = rootPath + "/";
     assertThat(LocationUtil.stripTrailingSlash(rootPathWithTrailingSlash))
         .as("Should be root path")
         .isEqualTo(rootPath);
+  }
 
+  @Test
+  void testStripTrailingSlashForRootPathWithTrailingSlashes() {
+    String rootPath = "blobstore://";
     String rootPathWithMultipleTrailingSlash = rootPath + "///";
     assertThat(LocationUtil.stripTrailingSlash(rootPathWithMultipleTrailingSlash))
         .as("Should be root path")

--- a/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
@@ -60,7 +60,7 @@ public class TestLocationUtil {
   }
 
   @Test
-  void testStripTrailingSlashForRootPath() {
+  void testDoNotStripTrailingSlashForRootPath() {
     String rootPath = "blobstore://";
     assertThat(LocationUtil.stripTrailingSlash(rootPath))
         .as("Should be root path")

--- a/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
@@ -46,7 +46,21 @@ public class TestLocationUtil {
     assertThat(LocationUtil.stripTrailingSlash(pathWithOnlySlash))
         .as("Should have no trailing slashes")
         .isEmpty();
+  }
 
+  @Test
+  public void testStripTrailingSlashWithInvalidPath() {
+    String[] invalidPaths = new String[] {null, ""};
+
+    for (String invalidPath : invalidPaths) {
+      Assertions.assertThatThrownBy(() -> LocationUtil.stripTrailingSlash(invalidPath))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("path must not be null or empty");
+    }
+  }
+
+  @Test
+  void testStripTrailingSlashForRootPaths() {
     String rootPath = "blobstore://";
     assertThat(LocationUtil.stripTrailingSlash(rootPath))
         .as("Should be root path")
@@ -61,16 +75,5 @@ public class TestLocationUtil {
     assertThat(LocationUtil.stripTrailingSlash(rootPathWithMultipleTrailingSlash))
         .as("Should be root path")
         .isEqualTo(rootPath);
-  }
-
-  @Test
-  public void testStripTrailingSlashWithInvalidPath() {
-    String[] invalidPaths = new String[] {null, ""};
-
-    for (String invalidPath : invalidPaths) {
-      Assertions.assertThatThrownBy(() -> LocationUtil.stripTrailingSlash(invalidPath))
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("path must not be null or empty");
-    }
   }
 }


### PR DESCRIPTION
currently root paths like 'scheme://' get trimmed to 'scheme:' making them unusable.