### PR TITLE
Add REST spec for data access mechanisms

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1457,18 +1457,18 @@ components:
       example: "sales"
 
     data-access:
-      name: X-Iceberg-Data-Access
+      name: X-Iceberg-Access-Delegation
       in: header
       description: >
-        Optional signal to the server that the client supports data access via
-        a comma-separated list of access mechanisms.  The server may choose to 
-        supply access via any or none of the requested mechanisms.
+        Optional signal to the server that the client supports delegated access
+        via a comma-separated list of access mechanisms.  The server may choose
+        to supply access via any or none of the requested mechanisms.
       required: false
       schema:
         type: string
         enum:
-          - vended_credentials
-          - remote_signing
+          - vended-credentials
+          - remote-signing
       style: simple
       explode: false
       example: "vended_credentials,remote_signing"

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -491,6 +491,8 @@ paths:
         create operation include changes like AddSchemaUpdate and SetCurrentSchemaUpdate that set the initial
         table state.
       operationId: createTable
+      parameters:
+        - $ref: '#/components/parameters/data-access'
       requestBody:
         content:
           application/json:
@@ -610,6 +612,7 @@ paths:
         for table requests. Otherwise, a token may be passed using a RFC 8693 token type as a configuration
         key. For example, "urn:ietf:params:oauth:token-type:jwt=<JWT-token>".
       parameters:
+        - $ref: '#/components/parameters/data-access'
         - in: query
           name: snapshots
           description:
@@ -1452,6 +1455,23 @@ components:
       schema:
         type: string
       example: "sales"
+
+    data-access:
+      name: X-Iceberg-Data-Access
+      in: header
+      description: >
+        Optional signal to the server that the client supports data access via
+        a comma-separated list of access mechanisms.  The server may choose to 
+        supply access via any or none of the requested mechanisms.
+      required: false
+      schema:
+        type: string
+        enum:
+          - vended_credentials
+          - remote_signing
+      style: simple
+      explode: false
+      example: "vended_credentials,remote_signing"
 
   ##############################
   # Application Schema Objects #

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1463,6 +1463,13 @@ components:
         Optional signal to the server that the client supports delegated access
         via a comma-separated list of access mechanisms.  The server may choose
         to supply access via any or none of the requested mechanisms.
+        
+        Specific properties and handling for `vended-credentials` is documented
+        in the `LoadTableResult` schema section of this spec document.
+        
+        The protocol and specification for `remote-signing` is documented in 
+        the `s3-signer-open-api.yaml` OpenApi spec in the `aws` module.
+
       required: false
       schema:
         type: string
@@ -1471,7 +1478,7 @@ components:
           - remote-signing
       style: simple
       explode: false
-      example: "vended_credentials,remote_signing"
+      example: "vended-credentials,remote-signing"
 
   ##############################
   # Application Schema Objects #

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1464,8 +1464,10 @@ components:
         via a comma-separated list of access mechanisms.  The server may choose
         to supply access via any or none of the requested mechanisms.
         
+        
         Specific properties and handling for `vended-credentials` is documented
         in the `LoadTableResult` schema section of this spec document.
+        
         
         The protocol and specification for `remote-signing` is documented in 
         the `s3-signer-open-api.yaml` OpenApi spec in the `aws` module.


### PR DESCRIPTION
This PR add an optional header so that clients can provide information to the REST server related to which data access mechanisms they support.
