### PR TITLE
Core: Fix performance issue when combining tasks by partition

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -875,6 +875,10 @@ acceptedBreaks:
   "1.4.0":
     org.apache.iceberg:iceberg-core:
     - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.PartitionData"
+      new: "class org.apache.iceberg.PartitionData"
+      justification: "Serialization across versions is not supported"
+    - code: "java.class.defaultSerializationChanged"
       old: "class org.apache.iceberg.mapping.NameMapping"
       new: "class org.apache.iceberg.mapping.NameMapping"
       justification: "Serialization across versions is not guaranteed"


### PR DESCRIPTION
This PR fixes a substantial performance issue in combining tasks by partition for SPJ, which was caused by repetitive creation of `PartitionData`, which triggered expensive initialization.

**Before**

```
Benchmark                                                    Mode  Cnt   Score   Error  Units
TaskGroupPlanningBenchmark.planTaskGroups                      ss    5   2.879 ± 0.209   s/op
TaskGroupPlanningBenchmark.planTaskGroups:async                ss          NaN            ---
TaskGroupPlanningBenchmark.planTaskGroupsWithGrouping          ss    5  26.564 ± 0.410   s/op
TaskGroupPlanningBenchmark.planTaskGroupsWithGrouping:async    ss          NaN            ---
```

**After**

```
Benchmark                                                    Mode  Cnt  Score   Error  Units
TaskGroupPlanningBenchmark.planTaskGroups                      ss    5  2.830 ± 0.211   s/op
TaskGroupPlanningBenchmark.planTaskGroups:async                ss         NaN            ---
TaskGroupPlanningBenchmark.planTaskGroupsWithGrouping          ss    5  5.167 ± 0.464   s/op
TaskGroupPlanningBenchmark.planTaskGroupsWithGrouping:async    ss         NaN            ---
```