### PR TITLE
Parquet, Arrow: Rename BagePageReader to BasePageReader in VectorizedPageIterator

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPageIterator.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPageIterator.java
@@ -170,7 +170,7 @@ public class VectorizedPageIterator extends BasePageIterator {
     return actualBatchSize;
   }
 
-  abstract class BagePageReader {
+  abstract class BasePageReader {
     public int nextBatch(
         FieldVector vector,
         int expectedBatchSize,
@@ -199,7 +199,7 @@ public class VectorizedPageIterator extends BasePageIterator {
   }
 
   /** Method for reading a batch of values of INT32 data type */
-  class IntPageReader extends BagePageReader {
+  class IntPageReader extends BasePageReader {
     @Override
     protected void nextVal(
         FieldVector vector, int batchSize, int numVals, int typeWidth, NullabilityHolder holder) {
@@ -225,7 +225,7 @@ public class VectorizedPageIterator extends BasePageIterator {
   }
 
   /** Method for reading a batch of values of INT64 data type */
-  class LongPageReader extends BagePageReader {
+  class LongPageReader extends BasePageReader {
 
     @Override
     protected void nextVal(
@@ -256,7 +256,7 @@ public class VectorizedPageIterator extends BasePageIterator {
    * always represented in micro-seconds. So we multiply values stored in millis with 1000 before
    * writing them to the vector.
    */
-  class TimestampMillisPageReader extends BagePageReader {
+  class TimestampMillisPageReader extends BasePageReader {
 
     @Override
     protected void nextVal(
@@ -283,7 +283,7 @@ public class VectorizedPageIterator extends BasePageIterator {
   }
 
   /** Method for reading a batch of values of TimestampInt96 data type. */
-  class TimestampInt96PageReader extends BagePageReader {
+  class TimestampInt96PageReader extends BasePageReader {
     @Override
     protected void nextVal(
         FieldVector vector, int batchSize, int numVals, int typeWidth, NullabilityHolder holder) {
@@ -309,7 +309,7 @@ public class VectorizedPageIterator extends BasePageIterator {
   }
 
   /** Method for reading a batch of values of FLOAT data type. */
-  class FloatPageReader extends BagePageReader {
+  class FloatPageReader extends BasePageReader {
 
     @Override
     protected void nextVal(
@@ -336,7 +336,7 @@ public class VectorizedPageIterator extends BasePageIterator {
   }
 
   /** Method for reading a batch of values of DOUBLE data type */
-  class DoublePageReader extends BagePageReader {
+  class DoublePageReader extends BasePageReader {
 
     @Override
     protected void nextVal(
@@ -366,7 +366,7 @@ public class VectorizedPageIterator extends BasePageIterator {
     return Math.min(expectedBatchSize, triplesCount - triplesRead);
   }
 
-  class FixedSizeBinaryPageReader extends BagePageReader {
+  class FixedSizeBinaryPageReader extends BasePageReader {
     @Override
     protected void nextVal(
         FieldVector vector, int batchSize, int numVals, int typeWidth, NullabilityHolder holder) {
@@ -392,7 +392,7 @@ public class VectorizedPageIterator extends BasePageIterator {
   }
 
   /** Method for reading a batch of variable width data type (ENUM, JSON, UTF8, BSON). */
-  class VarWidthTypePageReader extends BagePageReader {
+  class VarWidthTypePageReader extends BasePageReader {
     @Override
     protected void nextVal(
         FieldVector vector, int batchSize, int numVals, int typeWidth, NullabilityHolder holder) {
@@ -422,7 +422,7 @@ public class VectorizedPageIterator extends BasePageIterator {
    * fixed width binary data type. To work around this limitation, the data is read as fixed width
    * binary from parquet and stored in a {@link VarBinaryVector} in Arrow.
    */
-  class FixedWidthBinaryPageReader extends BagePageReader {
+  class FixedWidthBinaryPageReader extends BasePageReader {
     @Override
     protected void nextVal(
         FieldVector vector, int batchSize, int numVals, int typeWidth, NullabilityHolder holder) {
@@ -448,7 +448,7 @@ public class VectorizedPageIterator extends BasePageIterator {
   }
 
   /** Method for reading batches of booleans. */
-  class BooleanPageReader extends BagePageReader {
+  class BooleanPageReader extends BasePageReader {
     @Override
     protected void nextVal(
         FieldVector vector, int batchSize, int numVals, int typeWidth, NullabilityHolder holder) {


### PR DESCRIPTION
I believe the BagePageReader class got its name due to a typo. Fortunately it is not a public class so we have the chance to fix it to BasePageReader.