### PR TITLE
Flink: Optionally Overwrite All Partitions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic",
+    "java.home": "/opt/homebrew/Cellar/openjdk@11/11.0.22/libexec/openjdk.jdk/Contents/Home"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "automatic",
-    "java.home": "/opt/homebrew/Cellar/openjdk@11/11.0.22/libexec/openjdk.jdk/Contents/Home"
-}

--- a/docs/docs/flink-configuration.md
+++ b/docs/docs/flink-configuration.md
@@ -152,6 +152,7 @@ INSERT INTO tableName /*+ OPTIONS('upsert-enabled'='true') */
 | target-file-size-bytes | As per table property                      | Overrides this table's write.target-file-size-bytes          |
 | upsert-enabled         | Table write.upsert.enabled                 | Overrides this table's write.upsert.enabled                  |
 | overwrite-enabled      | false                                      | Overwrite the table's data, overwrite mode shouldn't be enable when configuring to use UPSERT data stream. |
+| overwrite_all_partitions | false                                    | Overwrite all partitions instead of just effected partitions. Only works when overwrite-enabled is turned on
 | distribution-mode      | Table write.distribution-mode              | Overrides this table's write.distribution-mode               |
 | compression-codec      | Table write.(fileformat).compression-codec | Overrides this table's compression codec for this write      |
 | compression-level      | Table write.(fileformat).compression-level | Overrides this table's compression level for Parquet and Avro tables for this write |

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -63,6 +63,15 @@ public class FlinkWriteConf {
         .parse();
   }
 
+  public boolean overwriteAllPartitions() {
+    return confParser
+        .booleanConf()
+        .option(FlinkWriteOptions.OVERWRITE_ALL_PARTITIONS.key())
+        .flinkConfig(FlinkWriteOptions.OVERWRITE_ALL_PARTITIONS)
+        .defaultValue(FlinkWriteOptions.OVERWRITE_ALL_PARTITIONS.defaultValue())
+        .parse();
+  }
+
   public boolean upsertMode() {
     return confParser
         .booleanConf()

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -56,6 +56,9 @@ public class FlinkWriteOptions {
   public static final ConfigOption<Boolean> OVERWRITE_MODE =
       ConfigOptions.key("overwrite-enabled").booleanType().defaultValue(false);
 
+  public static final ConfigOption<Boolean> OVERWRITE_ALL_PARTITIONS =
+      ConfigOptions.key("overwrite-all-partitions").booleanType().defaultValue(false);
+
   // Overrides the table's write.distribution-mode
   public static final ConfigOption<String> DISTRIBUTION_MODE =
       ConfigOptions.key("distribution-mode").stringType().noDefaultValue();

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -220,6 +220,13 @@ public class FlinkSink {
       return this;
     }
 
+    public Builder overwriteAllPartitions(boolean newOverwriteAllPartitions) {
+      writeOptions.put(
+          FlinkWriteOptions.OVERWRITE_ALL_PARTITIONS.key(),
+          Boolean.toString(newOverwriteAllPartitions));
+      return this;
+    }
+
     public Builder flinkConf(ReadableConfig config) {
       this.readableConfig = config;
       return this;
@@ -431,6 +438,7 @@ public class FlinkSink {
           new IcebergFilesCommitter(
               tableLoader,
               flinkWriteConf.overwriteMode(),
+              flinkWriteConf.overwriteAllPartitions(),
               snapshotProperties,
               flinkWriteConf.workerPoolSize(),
               flinkWriteConf.branch(),

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -41,6 +41,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.runtime.typeutils.SortedMapTypeInfo;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.OverwriteFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.RowDelta;
@@ -83,6 +84,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
   // TableLoader to load iceberg table lazily.
   private final TableLoader tableLoader;
   private final boolean replacePartitions;
+  private final boolean replaceAllPartitions;
   private final Map<String, String> snapshotProperties;
 
   // A sorted map to maintain the completed data files for each pending checkpointId (which have not
@@ -128,12 +130,14 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
   IcebergFilesCommitter(
       TableLoader tableLoader,
       boolean replacePartitions,
+      boolean replaceAllPartitions,
       Map<String, String> snapshotProperties,
       Integer workerPoolSize,
       String branch,
       PartitionSpec spec) {
     this.tableLoader = tableLoader;
     this.replacePartitions = replacePartitions;
+    this.replaceAllPartitions = replaceAllPartitions;
     this.snapshotProperties = snapshotProperties;
     this.workerPoolSize = workerPoolSize;
     this.branch = branch;
@@ -325,28 +329,38 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
   }
 
   private void replacePartitions(
-      NavigableMap<Long, WriteResult> pendingResults,
-      CommitSummary summary,
-      String newFlinkJobId,
-      String operatorId,
-      long checkpointId) {
-    Preconditions.checkState(
-        summary.deleteFilesCount() == 0, "Cannot overwrite partitions with delete files.");
-    // Commit the overwrite transaction.
-    ReplacePartitions dynamicOverwrite = table.newReplacePartitions().scanManifestsWith(workerPool);
-    for (WriteResult result : pendingResults.values()) {
-      Preconditions.checkState(
-          result.referencedDataFiles().length == 0, "Should have no referenced data files.");
-      Arrays.stream(result.dataFiles()).forEach(dynamicOverwrite::addFile);
+    NavigableMap<Long, WriteResult> pendingResults,
+    CommitSummary summary,
+    String newFlinkJobId,
+    String operatorId,
+    long checkpointId) {
+  Preconditions.checkState(
+      summary.deleteFilesCount() == 0, "Cannot overwrite partitions with delete files.");
+  // Commit the overwrite transaction.
+    SnapshotUpdate<?> update;
+    if (replaceAllPartitions) {
+      OverwriteFiles overwrite = table.newOverwrite().scanManifestsWith(workerPool);
+      // mark all existing files as deleted
+      table.newScan().planFiles().forEach(file -> overwrite.deleteFile(file.file()));
+      for (WriteResult result : pendingResults.values()) {
+        Preconditions.checkState(
+            result.referencedDataFiles().length == 0, "Should have no referenced data files.");
+        Arrays.stream(result.dataFiles()).forEach(overwrite::addFile);
+      }
+      update = overwrite;
+    } else {
+      ReplacePartitions dynamicOverwrite =
+          table.newReplacePartitions().scanManifestsWith(workerPool);
+      for (WriteResult result : pendingResults.values()) {
+        Preconditions.checkState(
+            result.referencedDataFiles().length == 0, "Should have no referenced data files.");
+        Arrays.stream(result.dataFiles()).forEach(dynamicOverwrite::addFile);
+      }
+      update = dynamicOverwrite;
     }
 
     commitOperation(
-        dynamicOverwrite,
-        summary,
-        "dynamic partition overwrite",
-        newFlinkJobId,
-        operatorId,
-        checkpointId);
+        update, summary, "dynamic partition overwrite", newFlinkJobId, operatorId, checkpointId);
   }
 
   private void commitDeltaTxn(

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -1136,6 +1136,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
           new IcebergFilesCommitter(
               new TestTableLoader(tablePath),
               false,
+              false,
               Collections.singletonMap("flink.test", TestIcebergFilesCommitter.class.getName()),
               ThreadPools.WORKER_THREAD_POOL_SIZE,
               branch,

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -63,6 +63,15 @@ public class FlinkWriteConf {
         .parse();
   }
 
+  public boolean overwriteAllPartitions() {
+    return confParser
+        .booleanConf()
+        .option(FlinkWriteOptions.OVERWRITE_ALL_PARTITIONS.key())
+        .flinkConfig(FlinkWriteOptions.OVERWRITE_ALL_PARTITIONS)
+        .defaultValue(FlinkWriteOptions.OVERWRITE_ALL_PARTITIONS.defaultValue())
+        .parse();
+  }
+
   public boolean upsertMode() {
     return confParser
         .booleanConf()

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -56,6 +56,9 @@ public class FlinkWriteOptions {
   public static final ConfigOption<Boolean> OVERWRITE_MODE =
       ConfigOptions.key("overwrite-enabled").booleanType().defaultValue(false);
 
+  public static final ConfigOption<Boolean> OVERWRITE_ALL_PARTITIONS =
+      ConfigOptions.key("overwrite-all-partitions").booleanType().defaultValue(false);
+
   // Overrides the table's write.distribution-mode
   public static final ConfigOption<String> DISTRIBUTION_MODE =
       ConfigOptions.key("distribution-mode").stringType().noDefaultValue();

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -220,6 +220,13 @@ public class FlinkSink {
       return this;
     }
 
+    public Builder overwriteAllPartitions(boolean newOverwriteAllPartitions) {
+      writeOptions.put(
+          FlinkWriteOptions.OVERWRITE_ALL_PARTITIONS.key(),
+          Boolean.toString(newOverwriteAllPartitions));
+      return this;
+    }
+
     public Builder flinkConf(ReadableConfig config) {
       this.readableConfig = config;
       return this;
@@ -431,6 +438,7 @@ public class FlinkSink {
           new IcebergFilesCommitter(
               tableLoader,
               flinkWriteConf.overwriteMode(),
+              flinkWriteConf.overwriteAllPartitions(),
               snapshotProperties,
               flinkWriteConf.workerPoolSize(),
               flinkWriteConf.branch(),

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -1136,6 +1136,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
           new IcebergFilesCommitter(
               new TestTableLoader(tablePath),
               false,
+              false,
               Collections.singletonMap("flink.test", TestIcebergFilesCommitter.class.getName()),
               ThreadPools.WORKER_THREAD_POOL_SIZE,
               branch,


### PR DESCRIPTION
By default when the Flink Sink does Insert Overwrite it only overwrites the partitions that have had data changed in the insert. However there are certain situations where a user might want to overwrite all data in the table and not just the partitions that were effected, to guarantee that the insert is only data left in the table. To accomplish this, first find all files currently active in the table, and then delete those, and then add the the new data in the same commit. 