### PR TITLE
Spark 3.5: Add a procedure to remove corrupt snapshots

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveSnapshotsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveSnapshotsProcedure.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+
+public class TestRemoveSnapshotsProcedure extends ExtensionsTestBase {
+
+  @AfterEach
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void testRemoveCorruptSnapshots() throws IOException {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    long firstSnapshotId = table.currentSnapshot().parentId();
+    FileSystem localFs = FileSystem.getLocal(new Configuration());
+    Path manifestListPath = new Path(table.snapshot(firstSnapshotId).manifestListLocation());
+    assertThat(localFs.exists(manifestListPath)).isTrue();
+    localFs.delete(manifestListPath, false);
+    assertThat(localFs.exists(manifestListPath)).isFalse();
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.expire_snapshots(table => '%s', snapshot_ids => ARRAY(%d))",
+                    catalogName, tableIdent, firstSnapshotId))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageStartingWith("File does not exist");
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.remove_snapshots(" + "table => '%s'," + "snapshot_ids => ARRAY(%d))",
+            catalogName, tableIdent, firstSnapshotId);
+    assertEquals("Procedure output must match", ImmutableList.of(row(1L)), output);
+
+    // There should only be one single snapshot left.
+    table.refresh();
+    assertThat(table.snapshots()).as("Should be 1 snapshots").hasSize(1);
+    assertThat(
+            Iterables.filter(
+                table.snapshots(), snapshot -> snapshot.snapshotId() == firstSnapshotId))
+        .as("Snapshot ID should not be present")
+        .hasSize(0);
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveSnapshotsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveSnapshotsProcedure.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.procedures;
+
+import org.apache.iceberg.ExpireSnapshots;
+import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A procedure that removes corrupt snapshots whose ManifestList files are missing. To expire
+ * healthy snapshots, use ExpireSnapshotsProcedure.
+ */
+public class RemoveSnapshotsProcedure extends BaseProcedure {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RemoveSnapshotsProcedure.class);
+
+  private static final ProcedureParameter[] PARAMETERS =
+      new ProcedureParameter[] {
+        ProcedureParameter.required("table", DataTypes.StringType),
+        ProcedureParameter.required("snapshot_ids", DataTypes.createArrayType(DataTypes.LongType))
+      };
+
+  private static final StructType OUTPUT_TYPE =
+      new StructType(
+          new StructField[] {
+            new StructField("deleted_snapshots_count", DataTypes.LongType, true, Metadata.empty())
+          });
+
+  public static ProcedureBuilder builder() {
+    return new BaseProcedure.Builder<RemoveSnapshotsProcedure>() {
+      @Override
+      protected RemoveSnapshotsProcedure doBuild() {
+        return new RemoveSnapshotsProcedure(tableCatalog());
+      }
+    };
+  }
+
+  private RemoveSnapshotsProcedure(TableCatalog tableCatalog) {
+    super(tableCatalog);
+  }
+
+  @Override
+  public ProcedureParameter[] parameters() {
+    return PARAMETERS;
+  }
+
+  @Override
+  public StructType outputType() {
+    return OUTPUT_TYPE;
+  }
+
+  @Override
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  public InternalRow[] call(InternalRow args) {
+    Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
+    long[] snapshotIds = args.getArray(1).toLongArray();
+
+    return modifyIcebergTable(
+        tableIdent,
+        table -> {
+          ExpireSnapshots expireSnapshots = table.expireSnapshots();
+
+          expireSnapshots.expireOlderThan(0L);
+          if (snapshotIds != null) {
+            for (long snapshotId : snapshotIds) {
+              expireSnapshots.expireSnapshotId(snapshotId);
+            }
+            expireSnapshots.cleanExpiredFiles(false).commit();
+            return toOutputRows(snapshotIds.length);
+          } else {
+            return toOutputRows(0);
+          }
+        });
+  }
+
+  private InternalRow[] toOutputRows(long deletedSnapshotsCount) {
+    InternalRow row = newInternalRow(deletedSnapshotsCount);
+
+    return new InternalRow[] {row};
+  }
+
+  @Override
+  public String description() {
+    return "RemoveSnapshotsProcedure";
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -56,6 +56,7 @@ public class SparkProcedures {
     mapBuilder.put("create_changelog_view", CreateChangelogViewProcedure::builder);
     mapBuilder.put("rewrite_position_delete_files", RewritePositionDeleteFilesProcedure::builder);
     mapBuilder.put("fast_forward", FastForwardBranchProcedure::builder);
+    mapBuilder.put("remove_snapshots", RemoveSnapshotsProcedure::builder);
     return mapBuilder.build();
   }
 


### PR DESCRIPTION
This PR adds a procedure that removes corrupt snapshots whose ManifestList files are missing. `expire_snapshots` procedure will be blocked by missing ManifestList files.