### PR TITLE
Add pagination to open api spec for listing of namespaces, tables, views

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -75,10 +75,10 @@ class Namespace(BaseModel):
     )
 
 
-class NextPageToken(BaseModel):
+class PageToken(BaseModel):
     __root__: str = Field(
         ...,
-        description='An opaque next page token, when non-null and non-empty this indicates that more results can be returned by server. This should be used in the next request for the query parameter of pageToken.',
+        description='An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables) by signaling to the service that they would prefer the response to be paginated.\nClients will initiate the request by sending an empty pageToken e.g. GET /tables?pageToken or /tables?pageToken= For servers that support pagination, they will recognize pageToken and return a next pageToken in response if there are more results available. After initial request, it is expected that the next pageToken from the last response be used in the subsequent request. For servers that do not support pagination, they will ignore the pageToken and return all results.',
     )
 
 
@@ -588,12 +588,12 @@ class GetNamespaceResponse(BaseModel):
 
 
 class ListTablesResponse(BaseModel):
-    next_page_token: Optional[NextPageToken] = Field(None, alias='next-page-token')
+    next_page_token: Optional[PageToken] = Field(None, alias='next-page-token')
     identifiers: Optional[List[TableIdentifier]] = Field(None, unique_items=True)
 
 
 class ListNamespacesResponse(BaseModel):
-    next_page_token: Optional[NextPageToken] = Field(None, alias='next-page-token')
+    next_page_token: Optional[PageToken] = Field(None, alias='next-page-token')
     namespaces: Optional[List[Namespace]] = Field(None, unique_items=True)
 
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -78,7 +78,7 @@ class Namespace(BaseModel):
 class NextPageToken(BaseModel):
     __root__: str = Field(
         ...,
-        description='An opaque next page token, when non-empty this indicates that more results can be returned by server. This should be used in the next request for the query parameter of pageToken.',
+        description='An opaque next page token, when non-null and non-empty this indicates that more results can be returned by server. This should be used in the next request for the query parameter of pageToken.',
     )
 
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -78,7 +78,7 @@ class Namespace(BaseModel):
 class PageToken(BaseModel):
     __root__: str = Field(
         ...,
-        description='An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables). Clients will initiate the first paginated request by sending an empty pageToken e.g. GET /tables?pageToken or GET /tables?pageToken= signaling to the service that the response should be paginated.\nFor servers that support pagination, they will recognize `pageToken` and return a next-page-token in response if there are more results available. After the initial request, it is expected that the next-page-token from the last response, is used in the subsequent request. For servers that do not support pagination, they will ignore the `pageToken` and return all results.',
+        description='An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables). Clients will initiate the first paginated request by sending an empty `pageToken` e.g. `GET /tables?pageToken` or `GET /tables?pageToken=` signaling to the service that the response should be paginated.\nFor servers that support pagination, they will recognize `pageToken` and return a `next-page-token` in response if there are more results available. After the initial request, it is expected that the `next-page-token` from the last response is used in the subsequent request. For servers that do not support pagination, they will ignore the `pageToken` and return all results.',
     )
 
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -78,7 +78,7 @@ class Namespace(BaseModel):
 class PageToken(BaseModel):
     __root__: str = Field(
         ...,
-        description='An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables) by signaling to the service that they would prefer the response to be paginated.\nClients will initiate the request by sending an empty pageToken e.g. GET /tables?pageToken or /tables?pageToken= For servers that support pagination, they will recognize pageToken and return a next pageToken in response if there are more results available. After initial request, it is expected that the next pageToken from the last response be used in the subsequent request. For servers that do not support pagination, they will ignore the pageToken and return all results.',
+        description='An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables). Clients will initiate the first paginated request by sending an empty pageToken e.g. GET /tables?pageToken or GET /tables?pageToken= signaling to the service that the response should be paginated.\nFor servers that support pagination, they will recognize `pageToken` and return a next-page-token in response if there are more results available. After the initial request, it is expected that the next-page-token from the last response, is used in the subsequent request. For servers that do not support pagination, they will ignore the `pageToken` and return all results.',
     )
 
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -75,6 +75,13 @@ class Namespace(BaseModel):
     )
 
 
+class NextPageToken(BaseModel):
+    __root__: str = Field(
+        ...,
+        description='An opaque next page token, when non-empty this indicates that more results can be returned by server, and when empty this indicates the returned results are complete. This should be used in the next request for the query parameter of pageToken.',
+    )
+
+
 class TableIdentifier(BaseModel):
     namespace: Namespace
     name: str
@@ -581,12 +588,12 @@ class GetNamespaceResponse(BaseModel):
 
 
 class ListTablesResponse(BaseModel):
-    next_page_token: Optional[str] = Field(None, alias='next-page-token')
+    next_page_token: Optional[NextPageToken] = Field(None, alias='next-page-token')
     identifiers: Optional[List[TableIdentifier]] = Field(None, unique_items=True)
 
 
 class ListNamespacesResponse(BaseModel):
-    next_page_token: Optional[str] = Field(None, alias='next-page-token')
+    next_page_token: Optional[NextPageToken] = Field(None, alias='next-page-token')
     namespaces: Optional[List[Namespace]] = Field(None, unique_items=True)
 
 
@@ -631,7 +638,7 @@ class TransformTerm(BaseModel):
     term: Reference
 
 
-class ReportMetricsRequest2(CommitReport):
+class ReportMetricsRequest1(CommitReport):
     report_type: str = Field(..., alias='report-type')
 
 
@@ -909,8 +916,8 @@ class LoadViewResult(BaseModel):
     config: Optional[Dict[str, str]] = None
 
 
-class ReportMetricsRequest(BaseModel):
-    __root__: Union[ReportMetricsRequest1, ReportMetricsRequest2]
+class ReportMetricsRequest2(BaseModel):
+    __root__: Union[ReportMetricsRequest, ReportMetricsRequest1]
 
 
 class ScanReport(BaseModel):
@@ -936,7 +943,7 @@ class Schema(StructType):
     )
 
 
-class ReportMetricsRequest1(ScanReport):
+class ReportMetricsRequest(ScanReport):
     report_type: str = Field(..., alias='report-type')
 
 
@@ -949,4 +956,4 @@ ViewMetadata.update_forward_refs()
 AddSchemaUpdate.update_forward_refs()
 CreateTableRequest.update_forward_refs()
 CreateViewRequest.update_forward_refs()
-ReportMetricsRequest.update_forward_refs()
+ReportMetricsRequest2.update_forward_refs()

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -78,7 +78,7 @@ class Namespace(BaseModel):
 class NextPageToken(BaseModel):
     __root__: str = Field(
         ...,
-        description='An opaque next page token, when non-empty this indicates that more results can be returned by server, and when empty this indicates the returned results are complete. This should be used in the next request for the query parameter of pageToken.',
+        description='An opaque next page token, when non-empty this indicates that more results can be returned by server. This should be used in the next request for the query parameter of pageToken.',
     )
 
 
@@ -638,7 +638,7 @@ class TransformTerm(BaseModel):
     term: Reference
 
 
-class ReportMetricsRequest1(CommitReport):
+class ReportMetricsRequest2(CommitReport):
     report_type: str = Field(..., alias='report-type')
 
 
@@ -916,8 +916,8 @@ class LoadViewResult(BaseModel):
     config: Optional[Dict[str, str]] = None
 
 
-class ReportMetricsRequest2(BaseModel):
-    __root__: Union[ReportMetricsRequest, ReportMetricsRequest1]
+class ReportMetricsRequest(BaseModel):
+    __root__: Union[ReportMetricsRequest1, ReportMetricsRequest2]
 
 
 class ScanReport(BaseModel):
@@ -943,7 +943,7 @@ class Schema(StructType):
     )
 
 
-class ReportMetricsRequest(ScanReport):
+class ReportMetricsRequest1(ScanReport):
     report_type: str = Field(..., alias='report-type')
 
 
@@ -956,4 +956,4 @@ ViewMetadata.update_forward_refs()
 AddSchemaUpdate.update_forward_refs()
 CreateTableRequest.update_forward_refs()
 CreateViewRequest.update_forward_refs()
-ReportMetricsRequest2.update_forward_refs()
+ReportMetricsRequest.update_forward_refs()

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -78,7 +78,7 @@ class Namespace(BaseModel):
 class PageToken(BaseModel):
     __root__: str = Field(
         ...,
-        description='An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables). Clients will initiate the first paginated request by sending an empty `pageToken` e.g. `GET /tables?pageToken` or `GET /tables?pageToken=` signaling to the service that the response should be paginated.\nFor servers that support pagination, they will recognize `pageToken` and return a `next-page-token` in response if there are more results available. After the initial request, it is expected that the `next-page-token` from the last response is used in the subsequent request. For servers that do not support pagination, they will ignore the `pageToken` and return all results.',
+        description='An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables). Clients will initiate the first paginated request by sending an empty `pageToken` e.g. `GET /tables?pageToken` or `GET /tables?pageToken=` signaling to the service that the response should be paginated.\nServers that support pagination will recognize `pageToken` and return a `next-page-token` in response if there are more results available. After the initial request, it is expected that the value of `next-page-token` from the last response is used in the subsequent request. Servers that do not support pagination will ignore `next-page-token` and return all results.',
     )
 
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -581,10 +581,12 @@ class GetNamespaceResponse(BaseModel):
 
 
 class ListTablesResponse(BaseModel):
+    next_page_token: Optional[str] = Field(None, alias='next-page-token')
     identifiers: Optional[List[TableIdentifier]] = Field(None, unique_items=True)
 
 
 class ListNamespacesResponse(BaseModel):
+    next_page_token: Optional[str] = Field(None, alias='next-page-token')
     namespaces: Optional[List[Namespace]] = Field(None, unique_items=True)
 
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1497,16 +1497,11 @@ components:
         A unique token which allows clients to make use of pagination by signaling to the service that they would
         prefer requests to be paginated based on the number of items specified by pageSize.
         
-        New Clients always start the request by sending a required empty pageToken e.g. GET /tables?pageToken
+        Clients that support pagination initiate the request by sending an empty pageToken e.g. GET /tables?pageToken
         Servers supporting pagination would recognize pagination is requested due to the presence of the pageToken
         and honor the contracts specified above by returning a non-empty next pageToken 
         if there are more results available, or an empty next pageToken indicating no more results.
-        Servers that are non-pagination aware will ignore the token and return all results as they previously did.
-        
-        Old clients should not be specifying the new parameters
-        For servers that support pagination, they would notice the lack of the pageToken
-        in the query string and return all results at once (mimicking existing behavior).
-        For servers not supporting pagination, this is the current state and they would return all values at once.
+        Servers that are non-pagination aware will ignore the token and return all results.
       required: false
       allowEmptyValue: true
       schema:
@@ -1516,7 +1511,8 @@ components:
       name: pageSize
       in: query
       description:
-        An upper bound on the number of results to return on the next page.
+        The number of results to return on the next page for servers that support pagination.
+        For servers that do not support pagination clients may receive results larger than the indicated pageSize.
       required: false
       allowEmptyValue: true
       schema:
@@ -1620,6 +1616,13 @@ components:
       items:
         type: string
       example: [ "accounting", "tax" ]
+
+    NextPageToken:
+      description:
+        An opaque next page token, when non-empty this indicates that more results can be returned by server,
+        and when empty this indicates the returned results are complete.
+        This should be used in the next request for the query parameter of pageToken.
+      type: string
 
     TableIdentifier:
       type: object
@@ -3210,11 +3213,7 @@ components:
       type: object
       properties:
         next-page-token:
-          description:
-            A unique next page token, when non-empty this indicates that more results can be returned by server,
-            and when empty this indicates the returned results are complete.
-            This should be used in the next request for the query parameter of pageToken.
-          type: string
+          $ref: '#/components/schemas/NextPageToken'
         identifiers:
           type: array
           uniqueItems: true
@@ -3225,11 +3224,7 @@ components:
       type: object
       properties:
         next-page-token:
-          description:
-            A unique next page token, when non-empty this indicates that more results can be returned by server, 
-            and when empty this indicates the returned results are complete.
-            This should be used in the next request for the query parameter of pageToken.
-          type: string
+          $ref: '#/components/schemas/NextPageToken'
         namespaces:
           type: array
           uniqueItems: true

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1494,7 +1494,7 @@ components:
       name: pageToken
       in: query
       description:
-        A unique token which allows clients to make use of pagination by signaling to the service that they would
+        An opaque token which allows clients to make use of pagination by signaling to the service that they would
         prefer requests to be paginated based on the number of items specified by pageSize.
         
         Clients that support pagination initiate the request by sending an empty pageToken e.g. GET /tables?pageToken

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1494,13 +1494,12 @@ components:
       name: pageToken
       in: query
       description:
-        An opaque token which allows clients to make use of pagination by signaling to the service that they would
-        prefer requests to be paginated based on the number of items specified by pageSize.
+        An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables) by signaling to the service that they would
+        that they would prefer response to be paginated. If pageSize is specified, the service should return exactly the number of items specified by it.
         
         Clients that support pagination initiate the request by sending an empty pageToken e.g. GET /tables?pageToken
         Servers supporting pagination would recognize pagination is requested due to the presence of the pageToken
-        and honor the contracts specified above by returning a non-empty next pageToken 
-        if there are more results available, or an empty next pageToken indicating no more results.
+        and honor the contracts specified above by returning a NextPageToken in response if there are more results available.
         Servers that are non-pagination aware will ignore the token and return all results.
       required: false
       allowEmptyValue: true
@@ -1619,8 +1618,7 @@ components:
 
     NextPageToken:
       description:
-        An opaque next page token, when non-empty this indicates that more results can be returned by server,
-        and when empty this indicates the returned results are complete.
+        An opaque next page token, when non-empty this indicates that more results can be returned by server.
         This should be used in the next request for the query parameter of pageToken.
       type: string
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1510,8 +1510,8 @@ components:
       name: pageSize
       in: query
       description:
-        The number of results to return on the next page for servers that support pagination.
-        For servers that do not support pagination clients may receive results larger than the indicated pageSize.
+        For servers that support pagination, this signals an upper bound of the number of results that client will receive. 
+        For servers that do not support pagination, clients may receive results larger than the indicated pageSize.
       required: false
       allowEmptyValue: true
       schema:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1502,8 +1502,8 @@ components:
       name: pageSize
       in: query
       description:
-        For servers that support pagination, this signals an upper bound of the number of results that client will receive. 
-        For servers that do not support pagination, clients may receive results larger than the indicated pageSize.
+        For servers that support pagination, this signals an upper bound of the number of results that a client will receive. 
+        For servers that do not support pagination, clients may receive results larger than the indicated `pageSize`.
       required: false
       schema:
         type: integer
@@ -1609,13 +1609,13 @@ components:
 
     PageToken:
       description:
-        An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables) by signaling to the service
-        that they would prefer the response to be paginated.
+        An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables). 
+        Clients will initiate the first paginated request by sending an empty pageToken e.g. GET /tables?pageToken or GET /tables?pageToken=
+        signaling to the service that the response should be paginated.
 
-        Clients will initiate the request by sending an empty pageToken e.g. GET /tables?pageToken or /tables?pageToken=
-        For servers that support pagination, they will recognize pageToken and return a next pageToken in response if there are more results available.
-        After initial request, it is expected that the next pageToken from the last response be used in the subsequent request.
-        For servers that do not support pagination, they will ignore the pageToken and return all results.
+        For servers that support pagination, they will recognize `pageToken` and return a next-page-token in response if there are more results available.
+        After the initial request, it is expected that the next-page-token from the last response, is used in the subsequent request.
+        For servers that do not support pagination, they will ignore the `pageToken` and return all results.
       type: string
 
     TableIdentifier:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1498,7 +1498,7 @@ components:
         that they would prefer response to be paginated.
         
         Clients will initiate the request by sending an empty pageToken e.g. GET /tables?pageToken or /tables?pageToken=
-        For servers that support pagination, they would recognize pageToken and honor the contracts specified above 
+        For servers that support pagination, they will recognize pageToken and honor the contracts specified above 
         by returning a NextPageToken in response if there are more results available.
         For servers that do not support pagination, they will ignore the token and return all results.
       required: false
@@ -1515,7 +1515,7 @@ components:
       required: false
       allowEmptyValue: true
       schema:
-        type: string
+        type: integer
 
   ##############################
   # Application Schema Objects #
@@ -1618,7 +1618,7 @@ components:
 
     NextPageToken:
       description:
-        An opaque next page token, when non-empty this indicates that more results can be returned by server.
+        An opaque next page token, when non-null and non-empty this indicates that more results can be returned by server.
         This should be used in the next request for the query parameter of pageToken.
       type: string
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1610,11 +1610,11 @@ components:
     PageToken:
       description:
         An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables). 
-        Clients will initiate the first paginated request by sending an empty pageToken e.g. GET /tables?pageToken or GET /tables?pageToken=
+        Clients will initiate the first paginated request by sending an empty `pageToken` e.g. `GET /tables?pageToken` or `GET /tables?pageToken=`
         signaling to the service that the response should be paginated.
 
-        For servers that support pagination, they will recognize `pageToken` and return a next-page-token in response if there are more results available.
-        After the initial request, it is expected that the next-page-token from the last response, is used in the subsequent request.
+        For servers that support pagination, they will recognize `pageToken` and return a `next-page-token` in response if there are more results available.
+        After the initial request, it is expected that the `next-page-token` from the last response is used in the subsequent request.
         For servers that do not support pagination, they will ignore the `pageToken` and return all results.
       type: string
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1495,12 +1495,12 @@ components:
       in: query
       description:
         An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables) by signaling to the service
-        that they would prefer response to be paginated.
+        that they would prefer the response to be paginated.
         
         Clients will initiate the request by sending an empty pageToken e.g. GET /tables?pageToken or /tables?pageToken=
-        For servers that support pagination, they will recognize pageToken and honor the contracts specified above 
-        by returning a NextPageToken in response if there are more results available.
-        For servers that do not support pagination, they will ignore the token and return all results.
+        For servers that support pagination, they will recognize pageToken and return a NextPageToken in response if there are more results available.
+        After initial request, it is expected that the NextPageToken from the last response be used as the pageToken in the subsequent request.
+        For servers that do not support pagination, they will ignore the pageToken and return all results.
       required: false
       allowEmptyValue: true
       schema:
@@ -1513,7 +1513,6 @@ components:
         For servers that support pagination, this signals an upper bound of the number of results that client will receive. 
         For servers that do not support pagination, clients may receive results larger than the indicated pageSize.
       required: false
-      allowEmptyValue: true
       schema:
         type: integer
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1494,13 +1494,13 @@ components:
       name: pageToken
       in: query
       description:
-        An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables) by signaling to the service that they would
-        that they would prefer response to be paginated. If pageSize is specified, the service should return exactly the number of items specified by it.
+        An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables) by signaling to the service
+        that they would prefer response to be paginated.
         
-        Clients that support pagination initiate the request by sending an empty pageToken e.g. GET /tables?pageToken
-        Servers supporting pagination would recognize pagination is requested due to the presence of the pageToken
-        and honor the contracts specified above by returning a NextPageToken in response if there are more results available.
-        Servers that are non-pagination aware will ignore the token and return all results.
+        Clients will initiate the request by sending an empty pageToken e.g. GET /tables?pageToken or /tables?pageToken=
+        For servers that support pagination, they would recognize pageToken and honor the contracts specified above 
+        by returning a NextPageToken in response if there are more results available.
+        For servers that do not support pagination, they will ignore the token and return all results.
       required: false
       allowEmptyValue: true
       schema:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1493,18 +1493,10 @@ components:
     page-token:
       name: pageToken
       in: query
-      description:
-        An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables) by signaling to the service
-        that they would prefer the response to be paginated.
-        
-        Clients will initiate the request by sending an empty pageToken e.g. GET /tables?pageToken or /tables?pageToken=
-        For servers that support pagination, they will recognize pageToken and return a NextPageToken in response if there are more results available.
-        After initial request, it is expected that the NextPageToken from the last response be used as the pageToken in the subsequent request.
-        For servers that do not support pagination, they will ignore the pageToken and return all results.
       required: false
       allowEmptyValue: true
       schema:
-        type: string
+        $ref: '#/components/schemas/PageToken'
 
     page-size:
       name: pageSize
@@ -1615,10 +1607,15 @@ components:
         type: string
       example: [ "accounting", "tax" ]
 
-    NextPageToken:
+    PageToken:
       description:
-        An opaque next page token, when non-null and non-empty this indicates that more results can be returned by server.
-        This should be used in the next request for the query parameter of pageToken.
+        An opaque token which allows clients to make use of pagination for a list API (e.g. ListTables) by signaling to the service
+        that they would prefer the response to be paginated.
+
+        Clients will initiate the request by sending an empty pageToken e.g. GET /tables?pageToken or /tables?pageToken=
+        For servers that support pagination, they will recognize pageToken and return a next pageToken in response if there are more results available.
+        After initial request, it is expected that the next pageToken from the last response be used in the subsequent request.
+        For servers that do not support pagination, they will ignore the pageToken and return all results.
       type: string
 
     TableIdentifier:
@@ -3210,7 +3207,7 @@ components:
       type: object
       properties:
         next-page-token:
-          $ref: '#/components/schemas/NextPageToken'
+          $ref: '#/components/schemas/PageToken'
         identifiers:
           type: array
           uniqueItems: true
@@ -3221,7 +3218,7 @@ components:
       type: object
       properties:
         next-page-token:
-          $ref: '#/components/schemas/NextPageToken'
+          $ref: '#/components/schemas/PageToken'
         namespaces:
           type: array
           uniqueItems: true

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -201,6 +201,8 @@ paths:
         If `parent` is not provided, all top-level namespaces should be listed.
       operationId: listNamespaces
       parameters:
+        - $ref: '#/components/parameters/page-token'
+        - $ref: '#/components/parameters/page-size'
         - name: parent
           in: query
           description:
@@ -212,34 +214,6 @@ paths:
           schema:
             type: string
           example: "accounting%1Ftax"
-        - name: pageToken
-          in: query
-          description:
-            Allows clients to make use of pagination by signaling to the service that they would
-            prefer requests to be paginated to a “reasonable” number of results.
-            
-            New Clients always start the request by sending a required empty “pageToken” e.g. GET /tables?continuationToken=””
-            Servers supporting pagination would recognize pagination is requested due to the presence of the pageToken
-            and honor the contracts specified above by returning a non-empty continuation token
-            if there are more results available, or an empty token or missing field indicating no more results.
-            Servers that are non-pagination aware will ignore the token and return all results as they previously did.
-            
-            Old clients should not be specifying the new parameters
-            For servers that support pagination, they would notice the lack of “continuationToken”
-            in the query string and return all results at once (mimicking existing behavior).
-            For servers not supporting pagination, this is the current state and they would return all values at once.
-          required: false
-          allowEmptyValue: true
-          schema:
-            type: string
-        - name: pageSize
-          in: query
-          description:
-            An upper bound on the number of results to return on the next page.
-          required: false
-          allowEmptyValue: true
-          schema:
-            type: string
       responses:
         200:
           $ref: '#/components/responses/ListNamespacesResponse'
@@ -477,34 +451,8 @@ paths:
       description: Return all table identifiers under this namespace
       operationId: listTables
       parameters:
-        - name: pageToken
-          in: query
-          description:
-            Allows clients to make use of pagination by signaling to the service that they would
-            prefer requests to be paginated to a “reasonable” number of results.
-  
-            New Clients always start the request by sending a required empty “pageToken” e.g. GET /tables?continuationToken=””
-            Servers supporting pagination would recognize pagination is requested due to the presence of the pageToken
-            and honor the contracts specified above by returning a non-empty continuation token
-            if there are more results available, or an empty token or missing field indicating no more results.
-            Servers that are non-pagination aware will ignore the token and return all results as they previously did.
-  
-            Old clients should not be specifying the new parameters
-            For servers that support pagination, they would notice the lack of “continuationToken”
-            in the query string and return all results at once (mimicking existing behavior).
-            For servers not supporting pagination, this is the current state and they would return all values at once.
-          required: false
-          allowEmptyValue: true
-          schema:
-            type: string
-        - name: pageSize
-          in: query
-          description:
-            An upper bound on the number of results to return on the next page.
-          required: false
-          allowEmptyValue: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/page-token'
+        - $ref: '#/components/parameters/page-size'
       responses:
         200:
           $ref: '#/components/responses/ListTablesResponse'
@@ -1128,34 +1076,8 @@ paths:
       description: Return all view identifiers under this namespace
       operationId: listViews
       parameters:
-        - name: pageToken
-          in: query
-          description:
-            Allows clients to make use of pagination by signaling to the service that they would
-            prefer requests to be paginated to a “reasonable” number of results.
-            
-            New Clients always start the request by sending a required empty “pageToken” e.g. GET /tables?continuationToken=””
-            Servers supporting pagination would recognize pagination is requested due to the presence of the pageToken
-            and honor the contracts specified above by returning a non-empty continuation token
-            if there are more results available, or an empty token or missing field indicating no more results.
-            Servers that are non-pagination aware will ignore the token and return all results as they previously did.
-            
-            Old clients should not be specifying the new parameters
-            For servers that support pagination, they would notice the lack of “continuationToken”
-            in the query string and return all results at once (mimicking existing behavior).
-            For servers not supporting pagination, this is the current state and they would return all values at once.
-          required: false
-          allowEmptyValue: true
-          schema:
-            type: string
-        - name: pageSize
-          in: query
-          description:
-            An upper bound on the number of results to return on the next page.
-          required: false
-          allowEmptyValue: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/page-token'
+        - $ref: '#/components/parameters/page-size'
       responses:
         200:
           $ref: '#/components/responses/ListTablesResponse'
@@ -1567,6 +1489,38 @@ components:
       style: simple
       explode: false
       example: "vended-credentials,remote-signing"
+
+    page-token:
+      name: pageToken
+      in: query
+      description:
+        A unique token which allows clients to make use of pagination by signaling to the service that they would
+        prefer requests to be paginated based on the number of items specified by pageSize.
+        
+        New Clients always start the request by sending a required empty pageToken e.g. GET /tables?pageToken
+        Servers supporting pagination would recognize pagination is requested due to the presence of the pageToken
+        and honor the contracts specified above by returning a non-empty next pageToken 
+        if there are more results available, or an empty next pageToken indicating no more results.
+        Servers that are non-pagination aware will ignore the token and return all results as they previously did.
+        
+        Old clients should not be specifying the new parameters
+        For servers that support pagination, they would notice the lack of the pageToken
+        in the query string and return all results at once (mimicking existing behavior).
+        For servers not supporting pagination, this is the current state and they would return all values at once.
+      required: false
+      allowEmptyValue: true
+      schema:
+        type: string
+
+    page-size:
+      name: pageSize
+      in: query
+      description:
+        An upper bound on the number of results to return on the next page.
+      required: false
+      allowEmptyValue: true
+      schema:
+        type: string
 
   ##############################
   # Application Schema Objects #
@@ -3257,8 +3211,9 @@ components:
       properties:
         next-page-token:
           description:
-            A non-empty next page token indicates more results. An absent or emptyPageToken indicates the returned results are complete.
-            This should be used in the next request for the query parameter “pageToken"
+            A unique next page token, when non-empty this indicates that more results can be returned by server,
+            and when empty this indicates the returned results are complete.
+            This should be used in the next request for the query parameter of pageToken.
           type: string
         identifiers:
           type: array
@@ -3271,8 +3226,9 @@ components:
       properties:
         next-page-token:
           description:
-            A non-empty next page token indicates more results. An absent or emptyPageToken indicates the returned results are complete.
-            This should be used in the next request for the query parameter “pageToken"
+            A unique next page token, when non-empty this indicates that more results can be returned by server, 
+            and when empty this indicates the returned results are complete.
+            This should be used in the next request for the query parameter of pageToken.
           type: string
         namespaces:
           type: array

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1507,6 +1507,7 @@ components:
       required: false
       schema:
         type: integer
+        minimum: 1
 
   ##############################
   # Application Schema Objects #
@@ -1613,9 +1614,9 @@ components:
         Clients will initiate the first paginated request by sending an empty `pageToken` e.g. `GET /tables?pageToken` or `GET /tables?pageToken=`
         signaling to the service that the response should be paginated.
 
-        For servers that support pagination, they will recognize `pageToken` and return a `next-page-token` in response if there are more results available.
-        After the initial request, it is expected that the `next-page-token` from the last response is used in the subsequent request.
-        For servers that do not support pagination, they will ignore the `pageToken` and return all results.
+        Servers that support pagination will recognize `pageToken` and return a `next-page-token` in response if there are more results available.
+        After the initial request, it is expected that the value of `next-page-token` from the last response is used in the subsequent request.
+        Servers that do not support pagination will ignore `next-page-token` and return all results.
       type: string
 
     TableIdentifier:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -212,6 +212,34 @@ paths:
           schema:
             type: string
           example: "accounting%1Ftax"
+        - name: pageToken
+          in: query
+          description:
+            Allows clients to make use of pagination by signaling to the service that they would
+            prefer requests to be paginated to a “reasonable” number of results.
+            
+            New Clients always start the request by sending a required empty “pageToken” e.g. GET /tables?continuationToken=””
+            Servers supporting pagination would recognize pagination is requested due to the presence of the pageToken
+            and honor the contracts specified above by returning a non-empty continuation token
+            if there are more results available, or an empty token or missing field indicating no more results.
+            Servers that are non-pagination aware will ignore the token and return all results as they previously did.
+            
+            Old clients should not be specifying the new parameters
+            For servers that support pagination, they would notice the lack of “continuationToken”
+            in the query string and return all results at once (mimicking existing behavior).
+            For servers not supporting pagination, this is the current state and they would return all values at once.
+          required: false
+          allowEmptyValue: true
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description:
+            An upper bound on the number of results to return on the next page.
+          required: false
+          allowEmptyValue: true
+          schema:
+            type: string
       responses:
         200:
           $ref: '#/components/responses/ListNamespacesResponse'
@@ -448,6 +476,35 @@ paths:
       summary: List all table identifiers underneath a given namespace
       description: Return all table identifiers under this namespace
       operationId: listTables
+      parameters:
+        - name: pageToken
+          in: query
+          description:
+            Allows clients to make use of pagination by signaling to the service that they would
+            prefer requests to be paginated to a “reasonable” number of results.
+  
+            New Clients always start the request by sending a required empty “pageToken” e.g. GET /tables?continuationToken=””
+            Servers supporting pagination would recognize pagination is requested due to the presence of the pageToken
+            and honor the contracts specified above by returning a non-empty continuation token
+            if there are more results available, or an empty token or missing field indicating no more results.
+            Servers that are non-pagination aware will ignore the token and return all results as they previously did.
+  
+            Old clients should not be specifying the new parameters
+            For servers that support pagination, they would notice the lack of “continuationToken”
+            in the query string and return all results at once (mimicking existing behavior).
+            For servers not supporting pagination, this is the current state and they would return all values at once.
+          required: false
+          allowEmptyValue: true
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description:
+            An upper bound on the number of results to return on the next page.
+          required: false
+          allowEmptyValue: true
+          schema:
+            type: string
       responses:
         200:
           $ref: '#/components/responses/ListTablesResponse'
@@ -1070,6 +1127,35 @@ paths:
       summary: List all view identifiers underneath a given namespace
       description: Return all view identifiers under this namespace
       operationId: listViews
+      parameters:
+        - name: pageToken
+          in: query
+          description:
+            Allows clients to make use of pagination by signaling to the service that they would
+            prefer requests to be paginated to a “reasonable” number of results.
+            
+            New Clients always start the request by sending a required empty “pageToken” e.g. GET /tables?continuationToken=””
+            Servers supporting pagination would recognize pagination is requested due to the presence of the pageToken
+            and honor the contracts specified above by returning a non-empty continuation token
+            if there are more results available, or an empty token or missing field indicating no more results.
+            Servers that are non-pagination aware will ignore the token and return all results as they previously did.
+            
+            Old clients should not be specifying the new parameters
+            For servers that support pagination, they would notice the lack of “continuationToken”
+            in the query string and return all results at once (mimicking existing behavior).
+            For servers not supporting pagination, this is the current state and they would return all values at once.
+          required: false
+          allowEmptyValue: true
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description:
+            An upper bound on the number of results to return on the next page.
+          required: false
+          allowEmptyValue: true
+          schema:
+            type: string
       responses:
         200:
           $ref: '#/components/responses/ListTablesResponse'
@@ -3169,6 +3255,11 @@ components:
     ListTablesResponse:
       type: object
       properties:
+        next-page-token:
+          description:
+            A non-empty next page token indicates more results. An absent or emptyPageToken indicates the returned results are complete.
+            This should be used in the next request for the query parameter “pageToken"
+          type: string
         identifiers:
           type: array
           uniqueItems: true
@@ -3178,6 +3269,11 @@ components:
     ListNamespacesResponse:
       type: object
       properties:
+        next-page-token:
+          description:
+            A non-empty next page token indicates more results. An absent or emptyPageToken indicates the returned results are complete.
+            This should be used in the next request for the query parameter “pageToken"
+          type: string
         namespaces:
           type: array
           uniqueItems: true


### PR DESCRIPTION
Dev List discussion thread around adding support for pagination in list namespaces, tables, and views: https://lists.apache.org/thread/lql05h02qtp8mgq74ovhb0ndd76ck4f3 

Credit to @emkornfield for creating this google doc for listing all cases which this change is based off: https://docs.google.com/document/d/1bbfoLssY1szCO_Hm3_93ZcN0UAMpf7kjmpwHQngqQJ0/edit

cc @jackye1995 @rdblue @danielcweeks

## Testing

Ran `make install, make lint, and python3 rest-catalog-open-api.py` without issues.`

