### PR TITLE
HIVE-28021: escape percent symbol

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/MetastoreLock.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/MetastoreLock.java
@@ -130,7 +130,7 @@ class MetastoreLock implements HiveLock {
         Executors.newSingleThreadScheduledExecutor(
             new ThreadFactoryBuilder()
                 .setDaemon(true)
-                .setNameFormat("iceberg-hive-lock-heartbeat-" + fullName + "-%d")
+                .setNameFormat("iceberg-hive-lock-heartbeat-" + fullName.replace("%", "%%") + "-%d")
                 .build());
 
     initTableLevelLockCache(tableLevelLockCacheEvictionTimeout);

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -970,6 +970,9 @@ public class TestHiveIcebergStorageHandlerNoScan {
   @Test
   public void testCreateTableWithPercentInName() throws IOException {
     Assume.assumeTrue("This test requires Hive Version 4.", HiveVersion.min(HiveVersion.HIVE_4));
+    Assume.assumeTrue(
+        "This test is only for hive catalog",
+        testTableType == TestTables.TestTableType.HIVE_CATALOG);
 
     TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
 
@@ -995,9 +998,6 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
     // Check the Iceberg table data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
-    Assume.assumeTrue(
-        "This test is only for hive catalog",
-        testTableType == TestTables.TestTableType.HIVE_CATALOG);
     Assert.assertEquals(
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),
         icebergTable.schema().asStruct());

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -969,7 +969,9 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithPercentInName() throws IOException {
-    Assume.assumeTrue("This test requires Hive Version 4.", HiveVersion.min(HiveVersion.HIVE_4));
+    Assume.assumeTrue(
+        "This test requires Hive Version 4.",
+        HiveVersion.min(HiveVersion.HIVE_4));
     Assume.assumeTrue(
         "This test is only for hive catalog",
         testTableType == TestTables.TestTableType.HIVE_CATALOG);

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -969,9 +969,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithPercentInName() throws IOException {
-    Assume.assumeTrue(
-        "This test requires Hive Version 4.",
-        HiveVersion.min(HiveVersion.HIVE_4));
+    Assume.assumeTrue("This test requires Hive Version 4.", HiveVersion.min(HiveVersion.HIVE_4));
     Assume.assumeTrue(
         "This test is only for hive catalog",
         testTableType == TestTables.TestTableType.HIVE_CATALOG);

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -969,6 +969,10 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithPercentInName() throws IOException {
+    Assume.assumeTrue(
+        "This test requires Hive Version 4.",
+        HiveVersion.min(HiveVersion.HIVE_4);
+
     TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
 
     shell.executeStatement(

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -970,9 +970,6 @@ public class TestHiveIcebergStorageHandlerNoScan {
   @Test
   public void testCreateTableWithPercentInName() throws IOException {
     Assume.assumeTrue("This test requires Hive Version 4.", HiveVersion.min(HiveVersion.HIVE_4));
-    Assume.assumeTrue(
-        "This test is only for hive catalog",
-        testTableType == TestTables.TestTableType.HIVE_CATALOG);
 
     TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
 
@@ -998,6 +995,9 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
     // Check the Iceberg table data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
+    Assume.assumeTrue(
+        "This test is only for hive catalog",
+        testTableType == TestTables.TestTableType.HIVE_CATALOG);
     Assert.assertEquals(
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),
         icebergTable.schema().asStruct());

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -994,7 +994,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     // Check the Iceberg table data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
     Assume.assumeTrue(
-        "This test is only for hive catalog", 
+        "This test is only for hive catalog",
         testTableType == TestTables.TestTableType.HIVE_CATALOG);
     Assert.assertEquals(
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -984,7 +984,8 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
     // Check the Iceberg table data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
-    Assume.assumeTrue("This test is only for hive catalog", testTableType == TestTables.TestTableType.HIVE_CATALOG);
+    Assume.assumeTrue("This test is only for hive catalog", 
+        testTableType == TestTables.TestTableType.HIVE_CATALOG);
     Assert.assertEquals(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),
         icebergTable.schema().asStruct());
     Assert.assertEquals(PartitionSpec.unpartitioned(), icebergTable.spec());

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -966,41 +966,4 @@ public class TestHiveIcebergStorageHandlerNoScan {
     return ((BaseMetastoreTableOperations) ((BaseTable) icebergTable).operations())
         .currentMetadataLocation();
   }
-
-  @Test
-  public void testCreateTableWithPercentInName() throws IOException {
-    Assume.assumeTrue("This test requires Hive Version 4.", HiveVersion.min(HiveVersion.HIVE_4));
-
-    TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
-
-    shell.executeStatement(
-        "CREATE EXTERNAL TABLE `[|]#&%_@` "
-            + "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' "
-            + testTables.locationForCreateTableSQL(identifier)
-            + "TBLPROPERTIES ('"
-            + InputFormatConfig.TABLE_SCHEMA
-            + "'='"
-            + SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-            + "', '"
-            + InputFormatConfig.PARTITION_SPEC
-            + "'='"
-            + PartitionSpecParser.toJson(PartitionSpec.unpartitioned())
-            + "', 'dummy'='test', '"
-            + InputFormatConfig.EXTERNAL_TABLE_PURGE
-            + "'='TRUE', '"
-            + InputFormatConfig.CATALOG_NAME
-            + "'='"
-            + testTables.catalogName()
-            + "')");
-
-    // Check the Iceberg table data
-    org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
-    Assume.assumeTrue(
-        "This test is only for hive catalog",
-        testTableType == TestTables.TestTableType.HIVE_CATALOG);
-    Assert.assertEquals(
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),
-        icebergTable.schema().asStruct());
-    Assert.assertEquals(PartitionSpec.unpartitioned(), icebergTable.spec());
-  }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -971,22 +971,33 @@ public class TestHiveIcebergStorageHandlerNoScan {
   public void testCreateTableWithPercentInName() throws IOException {
     TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
 
-    shell.executeStatement("CREATE EXTERNAL TABLE `[|]#&%_@` " +
-        "STORED BY ICEBERG " +
-        testTables.locationForCreateTableSQL(identifier) +
-        "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
-        SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "', " +
-        "'" + InputFormatConfig.PARTITION_SPEC + "'='" +
-        PartitionSpecParser.toJson(PartitionSpec.unpartitioned()) + "', " +
-        "'dummy'='test', " +
-        "'" + InputFormatConfig.EXTERNAL_TABLE_PURGE + "'='TRUE', " +
-        "'" + InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')");
+    shell.executeStatement(
+        "CREATE EXTERNAL TABLE `[|]#&%_@` "
+            + "STORED BY ICEBERG "
+            + testTables.locationForCreateTableSQL(identifier)
+            + "TBLPROPERTIES ('"
+            + InputFormatConfig.TABLE_SCHEMA
+            + "'='"
+            + SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+            + "', '"
+            + InputFormatConfig.PARTITION_SPEC
+            + "'='"
+            + PartitionSpecParser.toJson(PartitionSpec.unpartitioned())
+            + "', 'dummy'='test', '"
+            + InputFormatConfig.EXTERNAL_TABLE_PURGE
+            + "'='TRUE', '"
+            + InputFormatConfig.CATALOG_NAME
+            + "'='"
+            + testTables.catalogName()
+            + "')");
 
     // Check the Iceberg table data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
-    Assume.assumeTrue("This test is only for hive catalog", 
+    Assume.assumeTrue(
+        "This test is only for hive catalog", 
         testTableType == TestTables.TestTableType.HIVE_CATALOG);
-    Assert.assertEquals(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),
+    Assert.assertEquals(
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),
         icebergTable.schema().asStruct());
     Assert.assertEquals(PartitionSpec.unpartitioned(), icebergTable.spec());
   }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -971,7 +971,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
   public void testCreateTableWithPercentInName() throws IOException {
     Assume.assumeTrue(
         "This test requires Hive Version 4.",
-        HiveVersion.min(HiveVersion.HIVE_4);
+        HiveVersion.min(HiveVersion.HIVE_4));
 
     TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -973,7 +973,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
     shell.executeStatement(
         "CREATE EXTERNAL TABLE `[|]#&%_@` "
-            + "STORED BY ICEBERG "
+            + "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' "
             + testTables.locationForCreateTableSQL(identifier)
             + "TBLPROPERTIES ('"
             + InputFormatConfig.TABLE_SCHEMA

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -969,9 +969,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithPercentInName() throws IOException {
-    Assume.assumeTrue(
-        "This test requires Hive Version 4.",
-        HiveVersion.min(HiveVersion.HIVE_4));
+    Assume.assumeTrue("This test requires Hive Version 4.", HiveVersion.min(HiveVersion.HIVE_4));
 
     TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -966,4 +966,27 @@ public class TestHiveIcebergStorageHandlerNoScan {
     return ((BaseMetastoreTableOperations) ((BaseTable) icebergTable).operations())
         .currentMetadataLocation();
   }
+
+  @Test
+  public void testCreateTableWithPercentInName() throws IOException {
+    TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
+
+    shell.executeStatement("CREATE EXTERNAL TABLE `[|]#&%_@` " +
+        "STORED BY ICEBERG " +
+        testTables.locationForCreateTableSQL(identifier) +
+        "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
+        SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "', " +
+        "'" + InputFormatConfig.PARTITION_SPEC + "'='" +
+        PartitionSpecParser.toJson(PartitionSpec.unpartitioned()) + "', " +
+        "'dummy'='test', " +
+        "'" + InputFormatConfig.EXTERNAL_TABLE_PURGE + "'='TRUE', " +
+        "'" + InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')");
+
+    // Check the Iceberg table data
+    org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
+    Assume.assumeTrue("This test is only for hive catalog", testTableType == TestTables.TestTableType.HIVE_CATALOG);
+    Assert.assertEquals(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),
+        icebergTable.schema().asStruct());
+    Assert.assertEquals(PartitionSpec.unpartitioned(), icebergTable.spec());
+  }
 }


### PR DESCRIPTION
In order to allow the percent symbol to be used as a schema or table name, the percent symbol needs to be escaped.

What changes were proposed in this pull request?

In alpha 2 and earlier, including a percent symbol wouldn't cause exceptions. This change is to make beta 1 and beyond compatible.

Why are the changes needed?

Currently, in the beta 1 code, if the percent symbol is used as a schema or table name, you will get an UnknownFormatConversionException: Conversion = '_'

Does this PR introduce any user-facing change?

No

Is the change a dependency upgrade?

No

How was this patch tested?

Tested it manually by creating a table with a percent, specifically "[|]#&%@"."[|]#&%@"
Added a unit test - https://github.com/apache/hive/pull/5024