### PR TITLE
Aliyun: Add security token to OSS client properties

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunClientFactories.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunClientFactories.java
@@ -23,6 +23,7 @@ import com.aliyun.oss.OSSClientBuilder;
 import java.util.Map;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.util.PropertyUtil;
 
 public class AliyunClientFactories {
@@ -90,11 +91,20 @@ public class AliyunClientFactories {
           aliyunProperties,
           "Cannot create aliyun oss client before initializing the AliyunClientFactory.");
 
-      return new OSSClientBuilder()
-          .build(
-              aliyunProperties.ossEndpoint(),
-              aliyunProperties.accessKeyId(),
-              aliyunProperties.accessKeySecret());
+      if (Strings.isNullOrEmpty(aliyunProperties.securityToken())) {
+        return new OSSClientBuilder()
+            .build(
+                aliyunProperties.ossEndpoint(),
+                aliyunProperties.accessKeyId(),
+                aliyunProperties.accessKeySecret());
+      } else {
+        return new OSSClientBuilder()
+            .build(
+                aliyunProperties.ossEndpoint(),
+                aliyunProperties.accessKeyId(),
+                aliyunProperties.accessKeySecret(),
+                aliyunProperties.securityToken());
+      }
     }
 
     @Override

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
@@ -53,6 +53,17 @@ public class AliyunProperties implements Serializable {
   public static final String CLIENT_ACCESS_KEY_SECRET = "client.access-key-secret";
 
   /**
+   * Aliyun supports Security Token Service (STS) to generate temporary access credentials to
+   * authorize a user to access the Object Storage Service (OSS) resources within a specific period
+   * of time. In this way, user does not have to share the AccessKey pair and ensures higher level
+   * of data security.
+   *
+   * <p>For more information about how to obtain a security token, see:
+   * https://www.alibabacloud.com/help/en/vod/user-guide/sts-tokens
+   */
+  public static final String CLIENT_SECURITY_TOKEN = "client.security-token";
+
+  /**
    * The implementation class of {@link AliyunClientFactory} to customize Aliyun client
    * configurations. If set, all Aliyun clients will be initialized by the specified factory. If not
    * set, {@link AliyunClientFactories#defaultFactory()} is used as default factory.
@@ -68,6 +79,7 @@ public class AliyunProperties implements Serializable {
   private final String ossEndpoint;
   private final String accessKeyId;
   private final String accessKeySecret;
+  private final String securityToken;
   private final String ossStagingDirectory;
 
   public AliyunProperties() {
@@ -79,6 +91,7 @@ public class AliyunProperties implements Serializable {
     this.ossEndpoint = properties.get(OSS_ENDPOINT);
     this.accessKeyId = properties.get(CLIENT_ACCESS_KEY_ID);
     this.accessKeySecret = properties.get(CLIENT_ACCESS_KEY_SECRET);
+    this.securityToken = properties.get(CLIENT_SECURITY_TOKEN);
 
     this.ossStagingDirectory =
         PropertyUtil.propertyAsString(
@@ -95,6 +108,10 @@ public class AliyunProperties implements Serializable {
 
   public String accessKeySecret() {
     return accessKeySecret;
+  }
+
+  public String securityToken() {
+    return securityToken;
   }
 
   public String ossStagingDirectory() {

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/TestAliyunClientFactories.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/TestAliyunClientFactories.java
@@ -42,8 +42,17 @@ public class TestAliyunClientFactories {
         .as("Should have no Aliyun properties set")
         .isNull();
 
+    Assertions.assertThat(defaultFactory.aliyunProperties().securityToken())
+        .as("Should have no security token")
+        .isNull();
+
     AliyunClientFactory defaultFactoryWithConfig =
-        AliyunClientFactories.from(ImmutableMap.of(AliyunProperties.CLIENT_ACCESS_KEY_ID, "key"));
+        AliyunClientFactories.from(
+            ImmutableMap.of(
+                AliyunProperties.CLIENT_ACCESS_KEY_ID,
+                "key",
+                AliyunProperties.CLIENT_SECURITY_TOKEN,
+                "token"));
     Assertions.assertThat(defaultFactoryWithConfig)
         .as("Should load default when factory impl not configured")
         .isInstanceOf(AliyunClientFactories.DefaultAliyunClientFactory.class);
@@ -51,6 +60,10 @@ public class TestAliyunClientFactories {
     Assertions.assertThat(defaultFactoryWithConfig.aliyunProperties().accessKeyId())
         .as("Should have access key set")
         .isEqualTo("key");
+
+    Assertions.assertThat(defaultFactoryWithConfig.aliyunProperties().securityToken())
+        .as("Should have security token set")
+        .isEqualTo("token");
   }
 
   @Test

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSFileIO.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSFileIO.java
@@ -158,6 +158,9 @@ public class TestOSSFileIO extends AliyunOSSTestBase {
     Assertions.assertThat(oss.getCredentialsProvider().getCredentials().getSecretAccessKey())
         .as("Should have expected secret key")
         .isEqualTo(accessSecret);
+    Assertions.assertThat(oss.getCredentialsProvider().getCredentials().getSecurityToken())
+        .as("Should have no security token")
+        .isNull();
   }
 
   private FileIO fileIO() {


### PR DESCRIPTION
Currently the default DefaultAliyunClientFactory requires users to pass AccessKey pair to have access to OSS. However, in many cases organizations use Security Token Service (STS) to generate temporary access credentials to authorize a user to access the Object Storage Service (OSS) resources within a specific period of time. See https://www.alibabacloud.com/help/en/oss/developer-reference/use-temporary-access-credentials-provided-by-sts-to-access-oss for detail. It would be good to support passing a security token to create an OSS client by DefaultAliyunClientFactory.