### PR TITLE
Spark: Avoid NPE when catalog config doesn't have "type" set

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBaseWithCatalog.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBaseWithCatalog.java
@@ -101,7 +101,7 @@ public abstract class TestBaseWithCatalog extends TestBase {
     catalogConfig.forEach(
         (key, value) -> spark.conf().set("spark.sql.catalog." + catalogName + "." + key, value));
 
-    if (catalogConfig.get("type").equalsIgnoreCase("hadoop")) {
+    if ("hadoop".equalsIgnoreCase(catalogConfig.get("type"))) {
       spark.conf().set("spark.sql.catalog." + catalogName + ".warehouse", "file:" + warehouse);
     }
 


### PR DESCRIPTION
We do the same check in [`SparkTestBaseWithCatalog`](https://github.com/apache/iceberg/blob/1a9c3f78f5e2d0b831aadd4636eeb70975463e78/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java#L90) to avoid a potential NPE when a catalog configuration doesn't have the `type` set