### PR TITLE
Core: Common metadata for TableMetadata and ViewMetadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadata.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.iceberg.util.PropertyUtil;
+
+/** A base class for {@link TableMetadata} and {@link org.apache.iceberg.view.ViewMetadata} */
+public interface BaseMetadata extends Serializable {
+
+  String location();
+
+  Map<String, String> properties();
+
+  @Nullable
+  String metadataFileLocation();
+
+  Schema schema();
+
+  default String property(String property, String defaultValue) {
+    return properties().getOrDefault(property, defaultValue);
+  }
+
+  default boolean propertyAsBoolean(String property, boolean defaultValue) {
+    return PropertyUtil.propertyAsBoolean(properties(), property, defaultValue);
+  }
+
+  default int propertyAsInt(String property, int defaultValue) {
+    return PropertyUtil.propertyAsInt(properties(), property, defaultValue);
+  }
+
+  default long propertyAsLong(String property, long defaultValue) {
+    return PropertyUtil.propertyAsLong(properties(), property, defaultValue);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +46,7 @@ import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SerializableSupplier;
 
 /** Metadata for a table. */
-public class TableMetadata implements Serializable {
+public class TableMetadata implements BaseMetadata {
   static final long INITIAL_SEQUENCE_NUMBER = 0;
   static final long INVALID_SEQUENCE_NUMBER = -1;
   static final int DEFAULT_TABLE_FORMAT_VERSION = 2;
@@ -390,6 +389,7 @@ public class TableMetadata implements Serializable {
     return formatVersion;
   }
 
+  @Override
   public String metadataFileLocation() {
     return metadataFileLocation;
   }
@@ -414,6 +414,7 @@ public class TableMetadata implements Serializable {
     return lastColumnId;
   }
 
+  @Override
   public Schema schema() {
     return schemasById.get(currentSchemaId);
   }
@@ -470,28 +471,14 @@ public class TableMetadata implements Serializable {
     return sortOrdersById;
   }
 
+  @Override
   public String location() {
     return location;
   }
 
+  @Override
   public Map<String, String> properties() {
     return properties;
-  }
-
-  public String property(String property, String defaultValue) {
-    return properties.getOrDefault(property, defaultValue);
-  }
-
-  public boolean propertyAsBoolean(String property, boolean defaultValue) {
-    return PropertyUtil.propertyAsBoolean(properties, property, defaultValue);
-  }
-
-  public int propertyAsInt(String property, int defaultValue) {
-    return PropertyUtil.propertyAsInt(properties, property, defaultValue);
-  }
-
-  public long propertyAsLong(String property, long defaultValue) {
-    return PropertyUtil.propertyAsLong(properties, property, defaultValue);
   }
 
   public Snapshot snapshot(long snapshotId) {

--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.view;
 
-import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +27,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.apache.iceberg.BaseMetadata;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("ImmutablesStyle")
 @Value.Immutable(builder = false)
 @Value.Style(allParameters = true, visibilityString = "PACKAGE")
-public interface ViewMetadata extends Serializable {
+public interface ViewMetadata extends BaseMetadata {
   Logger LOG = LoggerFactory.getLogger(ViewMetadata.class);
   int SUPPORTED_VIEW_FORMAT_VERSION = 1;
   int DEFAULT_VIEW_FORMAT_VERSION = 1;
@@ -53,6 +53,7 @@ public interface ViewMetadata extends Serializable {
 
   int formatVersion();
 
+  @Override
   String location();
 
   default Integer currentSchemaId() {
@@ -76,10 +77,12 @@ public interface ViewMetadata extends Serializable {
 
   List<ViewHistoryEntry> history();
 
+  @Override
   Map<String, String> properties();
 
   List<MetadataUpdate> changes();
 
+  @Override
   @Nullable
   String metadataFileLocation();
 
@@ -119,6 +122,7 @@ public interface ViewMetadata extends Serializable {
     return builder.build();
   }
 
+  @Override
   default Schema schema() {
     return schemasById().get(currentSchemaId());
   }


### PR DESCRIPTION
Ref Issue #9514 

[TableMetadata](https://github.com/apache/iceberg/blob/3b8fd904ea6c3b0f81afdae59b17ab12e45c5faf/core/src/main/java/org/apache/iceberg/TableMetadata.java)  and [ViewMetadata](https://github.com/apache/iceberg/blob/3b8fd904ea6c3b0f81afdae59b17ab12e45c5faf/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java) have some common methods , Which have been abstracted out to IcebergMetadata now. It should help to have common code for Iceberg Table and View implementations with different catalog. 