### PR TITLE
Support for pushdown like filter (endsWith and contains)

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
@@ -87,6 +87,14 @@ public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
         return String.valueOf(value).startsWith((String) literal.value());
       case NOT_STARTS_WITH:
         return !String.valueOf(value).startsWith((String) literal.value());
+      case ENDS_WITH:
+        return String.valueOf(value).endsWith((String) literal.value());
+      case NOT_ENDS_WITH:
+        return !String.valueOf(value).endsWith((String) literal.value());
+      case CONTAINS:
+        return String.valueOf(value).contains((String) literal.value());
+      case NOT_CONTAINS:
+        return !String.valueOf(value).contains((String) literal.value());
       default:
         throw new IllegalStateException("Invalid operation for BoundLiteralPredicate: " + op());
     }
@@ -158,6 +166,14 @@ public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
         return term() + " startsWith \"" + literal + "\"";
       case NOT_STARTS_WITH:
         return term() + " notStartsWith \"" + literal + "\"";
+      case ENDS_WITH:
+        return term() + " endsWith \"" + literal + "\"";
+      case NOT_ENDS_WITH:
+        return term() + " notEndsWith \"" + literal + "\"";
+      case CONTAINS:
+        return term() + " contains \"" + literal + "\"";
+      case NOT_CONTAINS:
+        return term() + " notContains \"" + literal + "\"";
       case IN:
         return term() + " in { " + literal + " }";
       case NOT_IN:

--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -156,5 +156,27 @@ public class Evaluator implements Serializable {
     public <T> Boolean notStartsWith(Bound<T> valueExpr, Literal<T> lit) {
       return !startsWith(valueExpr, lit);
     }
+
+    @Override
+    public <T> Boolean endsWith(Bound<T> valueExpr, Literal<T> lit) {
+      T evalRes = valueExpr.eval(struct);
+      return evalRes != null && ((String) evalRes).endsWith((String) lit.value());
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(Bound<T> valueExpr, Literal<T> lit) {
+      return !endsWith(valueExpr, lit);
+    }
+
+    @Override
+    public <T> Boolean contains(Bound<T> valueExpr, Literal<T> lit) {
+      T evalRes = valueExpr.eval(struct);
+      return evalRes != null && ((String) evalRes).contains((String) lit.value());
+    }
+
+    @Override
+    public <T> Boolean notContains(Bound<T> valueExpr, Literal<T> lit) {
+      return !contains(valueExpr, lit);
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expression.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expression.java
@@ -44,6 +44,10 @@ public interface Expression extends Serializable {
     OR,
     STARTS_WITH,
     NOT_STARTS_WITH,
+    ENDS_WITH,
+    NOT_ENDS_WITH,
+    CONTAINS,
+    NOT_CONTAINS,
     COUNT,
     COUNT_STAR,
     MAX,
@@ -90,6 +94,14 @@ public interface Expression extends Serializable {
           return Operation.NOT_STARTS_WITH;
         case NOT_STARTS_WITH:
           return Operation.STARTS_WITH;
+        case ENDS_WITH:
+          return Operation.NOT_ENDS_WITH;
+        case NOT_ENDS_WITH:
+          return Operation.ENDS_WITH;
+        case CONTAINS:
+          return Operation.NOT_CONTAINS;
+        case NOT_CONTAINS:
+          return Operation.CONTAINS;
         default:
           throw new IllegalArgumentException("No negation for operation: " + this);
       }

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -325,6 +325,10 @@ public class ExpressionUtil {
         case NOT_EQ:
         case STARTS_WITH:
         case NOT_STARTS_WITH:
+        case ENDS_WITH:
+        case NOT_ENDS_WITH:
+        case CONTAINS:
+        case NOT_CONTAINS:
           return new UnboundPredicate<>(
               pred.op(), pred.term(), (T) sanitize(pred.literal(), now, today));
         case IN:
@@ -425,6 +429,14 @@ public class ExpressionUtil {
           return term + " STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
         case NOT_STARTS_WITH:
           return term + " NOT STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
+        case ENDS_WITH:
+          return term + " ENDS WITH " + value((BoundLiteralPredicate<?>) pred);
+        case NOT_ENDS_WITH:
+          return term + " NOT ENDS WITH " + value((BoundLiteralPredicate<?>) pred);
+        case CONTAINS:
+          return term + " CONTAINS " + value((BoundLiteralPredicate<?>) pred);
+        case NOT_CONTAINS:
+          return term + " NOT CONTAINS " + value((BoundLiteralPredicate<?>) pred);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());
@@ -477,6 +489,14 @@ public class ExpressionUtil {
           return term + " STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
         case NOT_STARTS_WITH:
           return term + " NOT STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
+        case ENDS_WITH:
+          return term + " ENDS WITH " + sanitize(pred.literal(), nowMicros, today);
+        case NOT_ENDS_WITH:
+          return term + " NOT ENDS WITH " + sanitize(pred.literal(), nowMicros, today);
+        case CONTAINS:
+          return term + " CONTAINS " + sanitize(pred.literal(), nowMicros, today);
+        case NOT_CONTAINS:
+          return term + " NOT CONTAINS " + sanitize(pred.literal(), nowMicros, today);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -335,6 +335,10 @@ public class ExpressionVisitors {
             return endsWith(pred.term(), literalPred.literal());
           case NOT_ENDS_WITH:
             return notEndsWith(pred.term(), literalPred.literal());
+          case CONTAINS:
+            return contains(pred.term(), literalPred.literal());
+          case NOT_CONTAINS:
+            return notContains(pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -126,6 +126,26 @@ public class ExpressionVisitors {
           "notStartsWith expression is not supported by the visitor");
     }
 
+    public <T> R endsWith(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "endsWith expression is not supported by the visitor");
+    }
+
+    public <T> R notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "notEndsWith expression is not supported by the visitor");
+    }
+
+    public <T> R contains(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "contains expression is not supported by the visitor");
+    }
+
+    public <T> R notContains(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "notContains expression is not supported by the visitor");
+    }
+
     /**
      * Handle a non-reference value in this visitor.
      *
@@ -166,6 +186,14 @@ public class ExpressionVisitors {
             return startsWith((BoundReference<T>) pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith((BoundReference<T>) pred.term(), literalPred.literal());
+          case ENDS_WITH:
+            return endsWith((BoundReference<T>) pred.term(), literalPred.literal());
+          case NOT_ENDS_WITH:
+            return notEndsWith((BoundReference<T>) pred.term(), literalPred.literal());
+          case CONTAINS:
+            return contains((BoundReference<T>) pred.term(), literalPred.literal());
+          case NOT_CONTAINS:
+            return notContains((BoundReference<T>) pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -266,6 +294,22 @@ public class ExpressionVisitors {
       throw new UnsupportedOperationException("Unsupported operation.");
     }
 
+    public <T> R endsWith(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
+    public <T> R notEndsWith(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
+    public <T> R contains(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
+    public <T> R notContains(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
     @Override
     public <T> R predicate(BoundPredicate<T> pred) {
       if (pred.isLiteralPredicate()) {
@@ -287,6 +331,10 @@ public class ExpressionVisitors {
             return startsWith(pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith(pred.term(), literalPred.literal());
+          case ENDS_WITH:
+            return endsWith(pred.term(), literalPred.literal());
+          case NOT_ENDS_WITH:
+            return notEndsWith(pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -465,6 +513,14 @@ public class ExpressionVisitors {
             return startsWith(pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith(pred.term(), literalPred.literal());
+          case ENDS_WITH:
+            return endsWith(pred.term(), literalPred.literal());
+          case NOT_ENDS_WITH:
+            return notEndsWith(pred.term(), literalPred.literal());
+          case CONTAINS:
+            return contains(pred.term(), literalPred.literal());
+          case NOT_CONTAINS:
+            return notContains(pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -553,6 +609,22 @@ public class ExpressionVisitors {
     }
 
     public <T> R notStartsWith(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R endsWith(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R notEndsWith(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R contains(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R notContains(BoundTerm<T> term, Literal<T> lit) {
       return null;
     }
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -197,6 +197,38 @@ public class Expressions {
     return new UnboundPredicate<>(Expression.Operation.NOT_STARTS_WITH, expr, value);
   }
 
+  public static UnboundPredicate<String> endsWith(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.ENDS_WITH, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> endsWith(UnboundTerm<String> expr, String value) {
+    return new UnboundPredicate<>(Expression.Operation.ENDS_WITH, expr, value);
+  }
+
+  public static UnboundPredicate<String> notEndsWith(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.NOT_ENDS_WITH, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> notEndsWith(UnboundTerm<String> expr, String value) {
+    return new UnboundPredicate<>(Expression.Operation.NOT_ENDS_WITH, expr, value);
+  }
+
+  public static UnboundPredicate<String> contains(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.CONTAINS, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> contains(UnboundTerm<String> expr, String value) {
+    return new UnboundPredicate<>(Expression.Operation.CONTAINS, expr, value);
+  }
+
+  public static UnboundPredicate<String> notContains(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.NOT_CONTAINS, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> notContains(UnboundTerm<String> expr, String value) {
+    return new UnboundPredicate<>(Expression.Operation.NOT_CONTAINS, expr, value);
+  }
+
   public static <T> UnboundPredicate<T> in(String name, T... values) {
     return predicate(Operation.IN, name, Lists.newArrayList(values));
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -470,6 +470,34 @@ public class InclusiveMetricsEvaluator {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it ends with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it not ends with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it contains with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it not contains with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
     private boolean mayContainNull(Integer id) {
       return nullCounts == null || (nullCounts.containsKey(id) && nullCounts.get(id) != 0);
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
@@ -400,6 +400,34 @@ public class ManifestEvaluator {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it ends with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it not ends with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it contains a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it not contains with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
     private boolean allValuesAreNull(PartitionFieldSummary summary, Type.TypeID typeId) {
       // containsNull encodes whether at least one partition value is null,
       // lowerBound is null if all partition values are null

--- a/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
@@ -223,6 +223,34 @@ public class ResidualEvaluator implements Serializable {
     }
 
     @Override
+    public <T> Expression endsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).endsWith((String) lit.value())
+          ? alwaysTrue()
+          : alwaysFalse();
+    }
+
+    @Override
+    public <T> Expression notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).endsWith((String) lit.value())
+          ? alwaysFalse()
+          : alwaysTrue();
+    }
+
+    @Override
+    public <T> Expression contains(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).contains((String) lit.value())
+          ? alwaysTrue()
+          : alwaysFalse();
+    }
+
+    @Override
+    public <T> Expression notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).contains((String) lit.value())
+          ? alwaysFalse()
+          : alwaysTrue();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <T> Expression predicate(BoundPredicate<T> pred) {
       // Get the strict projection and inclusive projection of this predicate in partition data,

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -466,6 +466,26 @@ public class StrictMetricsEvaluator {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
     private boolean canContainNulls(Integer id) {
       return nullCounts == null || (nullCounts.containsKey(id) && nullCounts.get(id) > 0);
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
@@ -263,6 +263,14 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
         return term() + " startsWith \"" + literal() + "\"";
       case NOT_STARTS_WITH:
         return term() + " notStartsWith \"" + literal() + "\"";
+      case ENDS_WITH:
+        return term() + " endsWith \"" + literal() + "\"";
+      case NOT_ENDS_WITH:
+        return term() + " notEndsWith \"" + literal() + "\"";
+      case CONTAINS:
+        return term() + " contains \"" + literal() + "\"";
+      case NOT_CONTAINS:
+        return term() + " notContains \"" + literal() + "\"";
       case IN:
         return term() + " in (" + COMMA.join(literals()) + ")";
       case NOT_IN:

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -196,6 +196,10 @@ class ProjectionUtil {
         return predicate(Expression.Operation.EQ, name, transform.apply(boundary));
       case STARTS_WITH:
         return predicate(Expression.Operation.STARTS_WITH, name, transform.apply(boundary));
+      case ENDS_WITH:
+        return predicate(Expression.Operation.ENDS_WITH, name, transform.apply(boundary));
+      case CONTAINS:
+        return predicate(Expression.Operation.CONTAINS, name, transform.apply(boundary));
         //        case IN: // TODO
         //          return Expressions.predicate(Operation.IN, name, transform.apply(boundary));
       default:

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -326,6 +326,8 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
         BoundLiteralPredicate<CharSequence> pred = predicate.asLiteralPredicate();
         switch (pred.op()) {
           case STARTS_WITH:
+          case ENDS_WITH:
+          case CONTAINS:
             if (pred.literal().value().length() < width()) {
               return Expressions.predicate(pred.op(), name, pred.literal().value());
             } else if (pred.literal().value().length() == width()) {
@@ -335,6 +337,8 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
             return ProjectionUtil.truncateArray(name, pred, this);
 
           case NOT_STARTS_WITH:
+          case NOT_ENDS_WITH:
+          case NOT_CONTAINS:
             if (pred.literal().value().length() < width()) {
               return Expressions.predicate(pred.op(), name, pred.literal().value());
             } else if (pred.literal().value().length() == width()) {

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -400,6 +400,26 @@ public class AllManifestsTable extends BaseMetadataTable {
         return ROWS_MIGHT_MATCH;
       }
 
+      @Override
+      public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
       /**
        * Comparison of snapshot reference and literal, using long comparator.
        *

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -347,6 +347,10 @@ public class ExpressionParser {
       case NOT_EQ:
       case STARTS_WITH:
       case NOT_STARTS_WITH:
+      case ENDS_WITH:
+      case NOT_ENDS_WITH:
+      case CONTAINS:
+      case NOT_CONTAINS:
         // literal predicates
         Preconditions.checkArgument(
             node.has(VALUE), "Cannot parse %s predicate: missing value", op);

--- a/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
@@ -270,6 +270,35 @@ class ExpressionToSearchArgument
   }
 
   @Override
+  public <T> Action endsWith(Bound<T> expr, Literal<T> lit) {
+    // Cannot push down ENDS_WITH operator to ORC, so return TruthValue.YES_NO_NULL which
+    // signifies that this predicate cannot help with filtering
+    return () -> this.builder.literal(TruthValue.YES_NO_NULL);
+  }
+
+  @Override
+  public <T> Action notEndsWith(Bound<T> expr, Literal<T> lit) {
+    // Cannot push down NOT_ENDS_WITH operator to ORC, so return TruthValue.YES_NO_NULL which
+    // signifies that this predicate cannot help with filtering
+    return () -> this.builder.literal(TruthValue.YES_NO_NULL);
+  }
+
+  @Override
+  public <T> Action contains(Bound<T> expr, Literal<T> lit) {
+    // Cannot push down CONTAINS operator to ORC, so return TruthValue.YES_NO_NULL which
+    // signifies
+    // that this predicate cannot help with filtering
+    return () -> this.builder.literal(TruthValue.YES_NO_NULL);
+  }
+
+  @Override
+  public <T> Action notContains(Bound<T> expr, Literal<T> lit) {
+    // Cannot push down NOT_CONTAINS operator to ORC, so return TruthValue.YES_NO_NULL which
+    // signifies that this predicate cannot help with filtering
+    return () -> this.builder.literal(TruthValue.YES_NO_NULL);
+  }
+
+  @Override
   public <T> Action predicate(BoundPredicate<T> pred) {
     if (UNSUPPORTED_TYPES.contains(pred.ref().type().typeId())
         || !(pred.term() instanceof BoundReference)) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
@@ -259,6 +259,26 @@ public class ParquetBloomRowGroupFilter {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
     private BloomFilter loadBloomFilter(int id) {
       if (bloomCache.containsKey(id)) {
         return bloomCache.get(id);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -406,6 +406,82 @@ public class ParquetDictionaryRowGroupFilter {
       return ROWS_CANNOT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      int id = ref.fieldId();
+
+      Boolean hasNonDictPage = isFallback.get(id);
+      if (hasNonDictPage == null || hasNonDictPage) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      Set<T> dictionary = dict(id, lit.comparator());
+      for (T item : dictionary) {
+        if (item.toString().endsWith(lit.value().toString())) {
+          return ROWS_MIGHT_MATCH;
+        }
+      }
+
+      return ROWS_CANNOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      int id = ref.fieldId();
+
+      Boolean hasNonDictPage = isFallback.get(id);
+      if (hasNonDictPage == null || hasNonDictPage) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      Set<T> dictionary = dict(id, lit.comparator());
+      for (T item : dictionary) {
+        if (!item.toString().endsWith(lit.value().toString())) {
+          return ROWS_MIGHT_MATCH;
+        }
+      }
+
+      return ROWS_CANNOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      int id = ref.fieldId();
+
+      Boolean hasNonDictPage = isFallback.get(id);
+      if (hasNonDictPage == null || hasNonDictPage) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      Set<T> dictionary = dict(id, lit.comparator());
+      for (T item : dictionary) {
+        if (item.toString().contains(lit.value().toString())) {
+          return ROWS_MIGHT_MATCH;
+        }
+      }
+
+      return ROWS_CANNOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      int id = ref.fieldId();
+
+      Boolean hasNonDictPage = isFallback.get(id);
+      if (hasNonDictPage == null || hasNonDictPage) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      Set<T> dictionary = dict(id, lit.comparator());
+      for (T item : dictionary) {
+        if (!item.toString().contains(lit.value().toString())) {
+          return ROWS_MIGHT_MATCH;
+        }
+      }
+
+      return ROWS_CANNOT_MATCH;
+    }
+
     @SuppressWarnings("unchecked")
     private <T> Set<T> dict(int id, Comparator<T> comparator) {
       Preconditions.checkNotNull(dictionaries, "Dictionary is required");

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -549,6 +549,34 @@ public class ParquetMetricsRowGroupFilter {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it ends with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it not ends with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it contains a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it not contains with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
     @SuppressWarnings("unchecked")
     private <T> T min(Statistics<?> statistics, int id) {
       return (T) conversions.get(id).apply(statistics.genericGetMin());

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.parquet;
 
 import static org.apache.iceberg.avro.AvroSchemaUtil.convert;
 import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.contains;
+import static org.apache.iceberg.expressions.Expressions.endsWith;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -29,6 +31,8 @@ import static org.apache.iceberg.expressions.Expressions.isNull;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notContains;
+import static org.apache.iceberg.expressions.Expressions.notEndsWith;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
@@ -460,6 +464,192 @@ public class TestDictionaryRowGroupFilter {
 
     shouldRead =
         new ParquetDictionaryRowGroupFilter(SCHEMA, notStartsWith("no_nulls", "xxx"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+  }
+
+  @TestTemplate
+  public void testEndsWith() {
+    boolean shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, endsWith("non_dict", "eq"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: no dictionary").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, endsWith("required", "req"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, endsWith("required", "eq"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, endsWith("some_nulls", "me"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(
+                SCHEMA, endsWith("no_stats", UUID.randomUUID().toString()))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no stats but dictionary is present").isFalse();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, endsWith("required", "reqs"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, endsWith("some_nulls", "mes"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, endsWith("no_nulls", "xxx"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+  }
+
+  @TestTemplate
+  public void testNotEndsWith() {
+    boolean shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notEndsWith("non_dict", "eq"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: no dictionary").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notEndsWith("required", "req"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notEndsWith("required", "eq"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notEndsWith("some_nulls", "ome!"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(
+                SCHEMA, notEndsWith("no_stats", UUID.randomUUID().toString()))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: no stats but dictionary is present").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notEndsWith("required", "reqs"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notEndsWith("some_nulls", "mex"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notEndsWith("some_nulls", "some"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notEndsWith("no_nulls", "xxx"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+  }
+
+  @TestTemplate
+  public void testContains() {
+    boolean shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, contains("non_dict", "e"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: no dictionary").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, contains("required", "req"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, contains("required", "eq"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, contains("some_nulls", "om"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(
+                SCHEMA, contains("no_stats", UUID.randomUUID().toString()))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no stats but dictionary is present").isFalse();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, contains("required", "eqs"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, contains("some_nulls", "mes"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, contains("no_nulls", "xxx"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+  }
+
+  @TestTemplate
+  public void testNotContains() {
+    boolean shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notContains("non_dict", "e"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: no dictionary").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notContains("required", "req"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notContains("required", "e"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notContains("some_nulls", "ome!"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(
+                SCHEMA, notContains("no_stats", UUID.randomUUID().toString()))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: no stats but dictionary is present").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notContains("required", "reqs"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notContains("some_nulls", "mx"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notContains("some_nulls", "some"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notContains("no_nulls", "xxx"))
             .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
     assertThat(shouldRead).as("Should read: dictionary contains a matching entry").isTrue();
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -659,6 +659,14 @@ public class Spark3Util {
           return sqlString(pred.term()) + " LIKE '" + pred.literal().value() + "%'";
         case NOT_STARTS_WITH:
           return sqlString(pred.term()) + " NOT LIKE '" + pred.literal().value() + "%'";
+        case ENDS_WITH:
+          return sqlString(pred.term()) + " LIKE '%" + pred.literal().value() + "'";
+        case NOT_ENDS_WITH:
+          return sqlString(pred.term()) + " NOT LIKE '%" + pred.literal().value() + "'";
+        case CONTAINS:
+          return sqlString(pred.term()) + " LIKE '%" + pred.literal().value() + "%'";
+        case NOT_CONTAINS:
+          return sqlString(pred.term()) + " NOT LIKE '%" + pred.literal().value() + "%'";
         case IN:
           return sqlString(pred.term()) + " IN (" + sqlString(pred.literals()) + ")";
         case NOT_IN:

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.spark;
 
 import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.contains;
+import static org.apache.iceberg.expressions.Expressions.endsWith;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -68,6 +70,8 @@ import org.apache.spark.sql.sources.LessThan;
 import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
 import org.apache.spark.sql.sources.Or;
+import org.apache.spark.sql.sources.StringContains;
+import org.apache.spark.sql.sources.StringEndsWith;
 import org.apache.spark.sql.sources.StringStartsWith;
 
 public class SparkFilters {
@@ -95,6 +99,8 @@ public class SparkFilters {
           .put(Or.class, Operation.OR)
           .put(Not.class, Operation.NOT)
           .put(StringStartsWith.class, Operation.STARTS_WITH)
+          .put(StringEndsWith.class, Operation.ENDS_WITH)
+          .put(StringContains.class, Operation.CONTAINS)
           .buildOrThrow();
 
   public static Expression convert(Filter[] filters) {
@@ -219,6 +225,18 @@ public class SparkFilters {
           {
             StringStartsWith stringStartsWith = (StringStartsWith) filter;
             return startsWith(unquote(stringStartsWith.attribute()), stringStartsWith.value());
+          }
+
+        case ENDS_WITH:
+          {
+            StringEndsWith stringEndsWith = (StringEndsWith) filter;
+            return endsWith(unquote(stringEndsWith.attribute()), stringEndsWith.value());
+          }
+
+        case CONTAINS:
+          {
+            StringContains stringContains = (StringContains) filter;
+            return contains(unquote(stringContains.attribute()), stringContains.value());
           }
       }
     }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.spark;
 
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.bucket;
+import static org.apache.iceberg.expressions.Expressions.contains;
 import static org.apache.iceberg.expressions.Expressions.day;
+import static org.apache.iceberg.expressions.Expressions.endsWith;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -88,6 +90,8 @@ public class SparkV2Filters {
   private static final String OR = "OR";
   private static final String NOT = "NOT";
   private static final String STARTS_WITH = "STARTS_WITH";
+  private static final String ENDS_WITH = "ENDS_WITH";
+  private static final String CONTAINS = "CONTAINS";
 
   private static final Map<String, Operation> FILTERS =
       ImmutableMap.<String, Operation>builder()
@@ -107,6 +111,8 @@ public class SparkV2Filters {
           .put(OR, Operation.OR)
           .put(NOT, Operation.NOT)
           .put(STARTS_WITH, Operation.STARTS_WITH)
+          .put(ENDS_WITH, Operation.ENDS_WITH)
+          .put(CONTAINS, Operation.CONTAINS)
           .buildOrThrow();
 
   private SparkV2Filters() {}
@@ -301,8 +307,20 @@ public class SparkV2Filters {
           }
 
         case STARTS_WITH:
-          String colName = SparkUtil.toColumnName(leftChild(predicate));
-          return startsWith(colName, convertLiteral(rightChild(predicate)).toString());
+          {
+            String colName = SparkUtil.toColumnName(leftChild(predicate));
+            return startsWith(colName, convertLiteral(rightChild(predicate)).toString());
+          }
+        case ENDS_WITH:
+          {
+            String colName = SparkUtil.toColumnName(leftChild(predicate));
+            return endsWith(colName, convertLiteral(rightChild(predicate)).toString());
+          }
+        case CONTAINS:
+          {
+            String colName = SparkUtil.toColumnName(leftChild(predicate));
+            return contains(colName, convertLiteral(rightChild(predicate)).toString());
+          }
       }
     }
 


### PR DESCRIPTION
This PR supports pushing down `endsWith` (like %x) and `contains` (like %x%) to Iceberg. The benefits are:
1. Support for early filtering of partition columns in partitioned tables, before this PR iceberg needs to scan the entire table.
2. Support for pushdown agg  under certain scenarios (before `endWiths` or `contains` could not be pushed down, so it could not pushdown agg).
3. Support for filtering files using Parquet dictionaries for regular columns in tables.

Before this PR, iceberg only support startWith.