### PR TITLE
AWS: Add url-connection-client to aws-bundle

### DIFF
--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -35,6 +35,7 @@ project(":iceberg-aws-bundle") {
     implementation "software.amazon.awssdk:sts"
     implementation "software.amazon.awssdk:dynamodb"
     implementation "software.amazon.awssdk:lakeformation"
+    implementation "software.amazon.awssdk:url-connection-client"
   }
 
   shadowJar {


### PR DESCRIPTION
Without this, it's not possible to switch the underlying HTTP client via `http-client.type=urlconnection` (as defined in `HttpClientProperties`)