### PR TITLE
OpenAPI: Spec updates for statistics

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -347,6 +347,11 @@ class RemoveStatisticsUpdate(BaseUpdate):
     snapshot_id: int = Field(..., alias='snapshot-id')
 
 
+class RemovePartitionStatisticsUpdate(BaseUpdate):
+    action: Literal['remove-partition-statistics']
+    snapshot_id: int = Field(..., alias='snapshot-id')
+
+
 class TableRequirement(BaseModel):
     type: str
 
@@ -618,6 +623,12 @@ class BlobMetadata(BaseModel):
     properties: Optional[Dict[str, Any]] = None
 
 
+class PartitionStatisticsFile(BaseModel):
+    snapshot_id: int = Field(..., alias='snapshot-id')
+    statistics_path: str = Field(..., alias='statistics-path')
+    file_size_in_bytes: int = Field(..., alias='file-size-in-bytes')
+
+
 class CreateNamespaceRequest(BaseModel):
     namespace: Namespace
     properties: Optional[Dict[str, str]] = Field(
@@ -636,6 +647,13 @@ class TransformTerm(BaseModel):
     type: Literal['transform']
     transform: Transform
     term: Reference
+
+
+class SetPartitionStatisticsUpdate(BaseUpdate):
+    action: Literal['set-partition-statistics']
+    partition_statistics: PartitionStatisticsFile = Field(
+        ..., alias='partition-statistics'
+    )
 
 
 class ReportMetricsRequest2(CommitReport):
@@ -756,6 +774,9 @@ class TableMetadata(BaseModel):
     metadata_log: Optional[MetadataLog] = Field(None, alias='metadata-log')
     statistics_files: Optional[List[StatisticsFile]] = Field(
         None, alias='statistics-files'
+    )
+    partition_statistics_files: Optional[List[PartitionStatisticsFile]] = Field(
+        None, alias='partition-statistics-files'
     )
 
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -754,6 +754,9 @@ class TableMetadata(BaseModel):
     last_sequence_number: Optional[int] = Field(None, alias='last-sequence-number')
     snapshot_log: Optional[SnapshotLog] = Field(None, alias='snapshot-log')
     metadata_log: Optional[MetadataLog] = Field(None, alias='metadata-log')
+    statistics_files: Optional[List[StatisticsFile]] = Field(
+        None, alias='statistics-files'
+    )
 
 
 class ViewMetadata(BaseModel):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2058,6 +2058,11 @@ components:
           $ref: '#/components/schemas/SnapshotLog'
         metadata-log:
           $ref: '#/components/schemas/MetadataLog'
+        # statistics
+        statistics-files:
+          type: array
+          items:
+            $ref: '#/components/schemas/StatisticsFile'
 
     SQLViewRepresentation:
       type: object

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2063,6 +2063,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StatisticsFile'
+        partition-statistics-files:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartitionStatisticsFile'
 
     SQLViewRepresentation:
       type: object
@@ -2186,6 +2190,8 @@ components:
           set-current-view-version: '#/components/schemas/SetCurrentViewVersionUpdate'
           set-statistics: '#/components/schemas/SetStatisticsUpdate'
           remove-statistics: '#/components/schemas/RemoveStatisticsUpdate'
+          set-partition-statistics: '#/components/schemas/SetPartitionStatisticsUpdate'
+          remove-partition-statistics: '#/components/schemas/RemovePartitionStatisticsUpdate'
       type: object
       required:
         - action
@@ -2457,6 +2463,33 @@ components:
         action:
           type: string
           enum: [ "remove-statistics" ]
+        snapshot-id:
+          type: integer
+          format: int64
+
+    SetPartitionStatisticsUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+      required:
+        - action
+        - partition-statistics
+      properties:
+        action:
+          type: string
+          enum: [ "set-partition-statistics" ]
+        partition-statistics:
+          $ref: '#/components/schemas/PartitionStatisticsFile'
+
+    RemovePartitionStatisticsUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+      required:
+        - action
+        - snapshot-id
+      properties:
+        action:
+          type: string
+          enum: [ "remove-partition-statistics" ]
         snapshot-id:
           type: integer
           format: int64
@@ -3274,6 +3307,22 @@ components:
             type: integer
         properties:
           type: object
+
+    PartitionStatisticsFile:
+      type: object
+      required:
+        - snapshot-id
+        - statistics-path
+        - file-size-in-bytes
+      properties:
+        snapshot-id:
+          type: integer
+          format: int64
+        statistics-path:
+          type: string
+        file-size-in-bytes:
+          type: integer
+          format: int64
 
 
   #############################


### PR DESCRIPTION
As a follow up for https://github.com/apache/iceberg/pull/9564 I added the statistics files to the table metadata.

Then I noticed the partition statistics files were also missing, so I added them here instead of creating another PR, since the changes are somewhat related.