### PR TITLE
Core: Pass input file into iterators to get the file name

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
@@ -110,7 +110,6 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
     private final long end;
     private final InputFile file;
 
-
     AvroRangeIterator(FileReader<D> reader, InputFile file, long start, long end) {
       this.reader = reader;
       this.file = file;
@@ -119,7 +118,8 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
       try {
         reader.sync(start);
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to find sync past position %d at file: %s", start, file);
+        throw new RuntimeIOException(
+            e, "Failed to find sync past position %d at file: %s", start, file);
       }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/apache/iceberg/issues/9458

Summary:
There are several places in our code currently where a failure while reading a file will throw an exception but the exception will not contain any information related to which file was being read during the failure. The Avro reader is an example of this.