### PR TITLE
Docs: Fix broken strike-through markup

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -68,6 +68,7 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true 
   - pymdownx.mark
+  - pymdownx.tilde
   - attr_list
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji


### PR DESCRIPTION
This commit should fix broken strike-through markup on https://iceberg.apache.org/spec/ page

![strikethroughfix](https://github.com/apache/iceberg/assets/45054928/2bcbe93d-2b7b-4cb9-84fb-a39ed7472996)


Closes #9693