### PR TITLE
Add filter pushdown API for contains and endsWith

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
@@ -87,6 +87,14 @@ public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
         return String.valueOf(value).startsWith((String) literal.value());
       case NOT_STARTS_WITH:
         return !String.valueOf(value).startsWith((String) literal.value());
+      case ENDS_WITH:
+        return String.valueOf(value).endsWith((String) literal.value());
+      case NOT_ENDS_WITH:
+        return !String.valueOf(value).endsWith((String) literal.value());
+      case CONTAINS:
+        return String.valueOf(value).contains((String) literal.value());
+      case NOT_CONTAINS:
+        return !String.valueOf(value).contains((String) literal.value());
       default:
         throw new IllegalStateException("Invalid operation for BoundLiteralPredicate: " + op());
     }
@@ -158,6 +166,14 @@ public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
         return term() + " startsWith \"" + literal + "\"";
       case NOT_STARTS_WITH:
         return term() + " notStartsWith \"" + literal + "\"";
+      case ENDS_WITH:
+        return term() + " endsWith \"" + literal + "\"";
+      case NOT_ENDS_WITH:
+        return term() + " notEndsWith \"" + literal + "\"";
+      case CONTAINS:
+        return term() + " contains \"" + literal + "\"";
+      case NOT_CONTAINS:
+        return term() + " notContains \"" + literal + "\"";
       case IN:
         return term() + " in { " + literal + " }";
       case NOT_IN:

--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -156,5 +156,27 @@ public class Evaluator implements Serializable {
     public <T> Boolean notStartsWith(Bound<T> valueExpr, Literal<T> lit) {
       return !startsWith(valueExpr, lit);
     }
+
+    @Override
+    public <T> Boolean endsWith(Bound<T> valueExpr, Literal<T> lit) {
+      T evalRes = valueExpr.eval(struct);
+      return evalRes != null && ((String) evalRes).endsWith((String) lit.value());
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(Bound<T> valueExpr, Literal<T> lit) {
+      return !endsWith(valueExpr, lit);
+    }
+
+    @Override
+    public <T> Boolean contains(Bound<T> valueExpr, Literal<T> lit) {
+      T evalRes = valueExpr.eval(struct);
+      return evalRes != null && ((String) evalRes).contains((String) lit.value());
+    }
+
+    @Override
+    public <T> Boolean notContains(Bound<T> valueExpr, Literal<T> lit) {
+      return !contains(valueExpr, lit);
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expression.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expression.java
@@ -44,6 +44,10 @@ public interface Expression extends Serializable {
     OR,
     STARTS_WITH,
     NOT_STARTS_WITH,
+    ENDS_WITH,
+    NOT_ENDS_WITH,
+    CONTAINS,
+    NOT_CONTAINS,
     COUNT,
     COUNT_STAR,
     MAX,
@@ -90,6 +94,14 @@ public interface Expression extends Serializable {
           return Operation.NOT_STARTS_WITH;
         case NOT_STARTS_WITH:
           return Operation.STARTS_WITH;
+        case ENDS_WITH:
+          return Operation.NOT_ENDS_WITH;
+        case NOT_ENDS_WITH:
+          return Operation.ENDS_WITH;
+        case CONTAINS:
+          return Operation.NOT_CONTAINS;
+        case NOT_CONTAINS:
+          return Operation.CONTAINS;
         default:
           throw new IllegalArgumentException("No negation for operation: " + this);
       }

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -325,6 +325,10 @@ public class ExpressionUtil {
         case NOT_EQ:
         case STARTS_WITH:
         case NOT_STARTS_WITH:
+        case ENDS_WITH:
+        case NOT_ENDS_WITH:
+        case CONTAINS:
+        case NOT_CONTAINS:
           return new UnboundPredicate<>(
               pred.op(), pred.term(), (T) sanitize(pred.literal(), now, today));
         case IN:
@@ -425,6 +429,14 @@ public class ExpressionUtil {
           return term + " STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
         case NOT_STARTS_WITH:
           return term + " NOT STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
+        case ENDS_WITH:
+          return term + " ENDS WITH " + value((BoundLiteralPredicate<?>) pred);
+        case NOT_ENDS_WITH:
+          return term + " NOT ENDS WITH " + value((BoundLiteralPredicate<?>) pred);
+        case CONTAINS:
+          return term + " CONTAINS " + value((BoundLiteralPredicate<?>) pred);
+        case NOT_CONTAINS:
+          return term + " NOT CONTAINS " + value((BoundLiteralPredicate<?>) pred);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());
@@ -477,6 +489,14 @@ public class ExpressionUtil {
           return term + " STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
         case NOT_STARTS_WITH:
           return term + " NOT STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
+        case ENDS_WITH:
+          return term + " ENDS WITH " + sanitize(pred.literal(), nowMicros, today);
+        case NOT_ENDS_WITH:
+          return term + " NOT ENDS WITH " + sanitize(pred.literal(), nowMicros, today);
+        case CONTAINS:
+          return term + " CONTAINS " + sanitize(pred.literal(), nowMicros, today);
+        case NOT_CONTAINS:
+          return term + " NOT CONTAINS " + sanitize(pred.literal(), nowMicros, today);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -126,6 +126,26 @@ public class ExpressionVisitors {
           "notStartsWith expression is not supported by the visitor");
     }
 
+    public <T> R endsWith(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "endsWith expression is not supported by the visitor");
+    }
+
+    public <T> R notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "notEndsWith expression is not supported by the visitor");
+    }
+
+    public <T> R contains(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "contains expression is not supported by the visitor");
+    }
+
+    public <T> R notContains(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "notContains expression is not supported by the visitor");
+    }
+
     /**
      * Handle a non-reference value in this visitor.
      *
@@ -166,6 +186,14 @@ public class ExpressionVisitors {
             return startsWith((BoundReference<T>) pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith((BoundReference<T>) pred.term(), literalPred.literal());
+          case ENDS_WITH:
+            return endsWith((BoundReference<T>) pred.term(), literalPred.literal());
+          case NOT_ENDS_WITH:
+            return notEndsWith((BoundReference<T>) pred.term(), literalPred.literal());
+          case CONTAINS:
+            return contains((BoundReference<T>) pred.term(), literalPred.literal());
+          case NOT_CONTAINS:
+            return notContains((BoundReference<T>) pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -266,6 +294,22 @@ public class ExpressionVisitors {
       throw new UnsupportedOperationException("Unsupported operation.");
     }
 
+    public <T> R endsWith(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
+    public <T> R notEndsWith(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
+    public <T> R contains(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
+    public <T> R notContains(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
     @Override
     public <T> R predicate(BoundPredicate<T> pred) {
       if (pred.isLiteralPredicate()) {
@@ -287,6 +331,14 @@ public class ExpressionVisitors {
             return startsWith(pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith(pred.term(), literalPred.literal());
+          case ENDS_WITH:
+            return endsWith(pred.term(), literalPred.literal());
+          case NOT_ENDS_WITH:
+            return notEndsWith(pred.term(), literalPred.literal());
+          case CONTAINS:
+            return contains(pred.term(), literalPred.literal());
+          case NOT_CONTAINS:
+            return notContains(pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -465,6 +517,14 @@ public class ExpressionVisitors {
             return startsWith(pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith(pred.term(), literalPred.literal());
+          case ENDS_WITH:
+            return endsWith(pred.term(), literalPred.literal());
+          case NOT_ENDS_WITH:
+            return notEndsWith(pred.term(), literalPred.literal());
+          case CONTAINS:
+            return contains(pred.term(), literalPred.literal());
+          case NOT_CONTAINS:
+            return notContains(pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -553,6 +613,22 @@ public class ExpressionVisitors {
     }
 
     public <T> R notStartsWith(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R endsWith(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R notEndsWith(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R contains(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R notContains(BoundTerm<T> term, Literal<T> lit) {
       return null;
     }
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -287,27 +287,31 @@ public class ExpressionVisitors {
     }
 
     public <T> R startsWith(Bound<T> expr, Literal<T> lit) {
-      throw new UnsupportedOperationException("Unsupported operation.");
+      throw new UnsupportedOperationException(
+          "startsWith operation is not supported by the visitor");
     }
 
     public <T> R notStartsWith(Bound<T> expr, Literal<T> lit) {
-      throw new UnsupportedOperationException("Unsupported operation.");
+      throw new UnsupportedOperationException(
+          "notStartsWith operation is not supported by the visitor");
     }
 
     public <T> R endsWith(Bound<T> expr, Literal<T> lit) {
-      throw new UnsupportedOperationException("Unsupported operation.");
+      throw new UnsupportedOperationException("endsWith operation is not supported by the visitor");
     }
 
     public <T> R notEndsWith(Bound<T> expr, Literal<T> lit) {
-      throw new UnsupportedOperationException("Unsupported operation.");
+      throw new UnsupportedOperationException(
+          "notEndsWith operation is not supported by the visitor");
     }
 
     public <T> R contains(Bound<T> expr, Literal<T> lit) {
-      throw new UnsupportedOperationException("Unsupported operation.");
+      throw new UnsupportedOperationException("contains operation is not supported by the visitor");
     }
 
     public <T> R notContains(Bound<T> expr, Literal<T> lit) {
-      throw new UnsupportedOperationException("Unsupported operation.");
+      throw new UnsupportedOperationException(
+          "notContains operation is not supported by the visitor");
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -197,6 +197,38 @@ public class Expressions {
     return new UnboundPredicate<>(Expression.Operation.NOT_STARTS_WITH, expr, value);
   }
 
+  public static UnboundPredicate<String> endsWith(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.ENDS_WITH, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> endsWith(UnboundTerm<String> expr, String value) {
+    return new UnboundPredicate<>(Expression.Operation.ENDS_WITH, expr, value);
+  }
+
+  public static UnboundPredicate<String> notEndsWith(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.NOT_ENDS_WITH, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> notEndsWith(UnboundTerm<String> expr, String value) {
+    return new UnboundPredicate<>(Expression.Operation.NOT_ENDS_WITH, expr, value);
+  }
+
+  public static UnboundPredicate<String> contains(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.CONTAINS, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> contains(UnboundTerm<String> expr, String value) {
+    return new UnboundPredicate<>(Expression.Operation.CONTAINS, expr, value);
+  }
+
+  public static UnboundPredicate<String> notContains(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.NOT_CONTAINS, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> notContains(UnboundTerm<String> expr, String value) {
+    return new UnboundPredicate<>(Expression.Operation.NOT_CONTAINS, expr, value);
+  }
+
   public static <T> UnboundPredicate<T> in(String name, T... values) {
     return predicate(Operation.IN, name, Lists.newArrayList(values));
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -470,6 +470,34 @@ public class InclusiveMetricsEvaluator {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it ends with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it not ends with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it contains with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it not contains with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
     private boolean mayContainNull(Integer id) {
       return nullCounts == null || (nullCounts.containsKey(id) && nullCounts.get(id) != 0);
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
@@ -400,6 +400,34 @@ public class ManifestEvaluator {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it ends with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it not ends with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it contains a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      // because we cannot use a min or max value to determine
+      // if it not contains with a certain value.
+      return ROWS_MIGHT_MATCH;
+    }
+
     private boolean allValuesAreNull(PartitionFieldSummary summary, Type.TypeID typeId) {
       // containsNull encodes whether at least one partition value is null,
       // lowerBound is null if all partition values are null

--- a/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
@@ -223,6 +223,34 @@ public class ResidualEvaluator implements Serializable {
     }
 
     @Override
+    public <T> Expression endsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).endsWith((String) lit.value())
+          ? alwaysTrue()
+          : alwaysFalse();
+    }
+
+    @Override
+    public <T> Expression notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).endsWith((String) lit.value())
+          ? alwaysFalse()
+          : alwaysTrue();
+    }
+
+    @Override
+    public <T> Expression contains(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).contains((String) lit.value())
+          ? alwaysTrue()
+          : alwaysFalse();
+    }
+
+    @Override
+    public <T> Expression notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).contains((String) lit.value())
+          ? alwaysFalse()
+          : alwaysTrue();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <T> Expression predicate(BoundPredicate<T> pred) {
       // Get the strict projection and inclusive projection of this predicate in partition data,

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -466,6 +466,26 @@ public class StrictMetricsEvaluator {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
     private boolean canContainNulls(Integer id) {
       return nullCounts == null || (nullCounts.containsKey(id) && nullCounts.get(id) > 0);
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
@@ -263,6 +263,14 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
         return term() + " startsWith \"" + literal() + "\"";
       case NOT_STARTS_WITH:
         return term() + " notStartsWith \"" + literal() + "\"";
+      case ENDS_WITH:
+        return term() + " endsWith \"" + literal() + "\"";
+      case NOT_ENDS_WITH:
+        return term() + " notEndsWith \"" + literal() + "\"";
+      case CONTAINS:
+        return term() + " contains \"" + literal() + "\"";
+      case NOT_CONTAINS:
+        return term() + " notContains \"" + literal() + "\"";
       case IN:
         return term() + " in (" + COMMA.join(literals()) + ")";
       case NOT_IN:

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -196,6 +196,10 @@ class ProjectionUtil {
         return predicate(Expression.Operation.EQ, name, transform.apply(boundary));
       case STARTS_WITH:
         return predicate(Expression.Operation.STARTS_WITH, name, transform.apply(boundary));
+      case ENDS_WITH:
+        return predicate(Expression.Operation.ENDS_WITH, name, transform.apply(boundary));
+      case CONTAINS:
+        return predicate(Expression.Operation.CONTAINS, name, transform.apply(boundary));
         //        case IN: // TODO
         //          return Expressions.predicate(Operation.IN, name, transform.apply(boundary));
       default:

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -326,6 +326,8 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
         BoundLiteralPredicate<CharSequence> pred = predicate.asLiteralPredicate();
         switch (pred.op()) {
           case STARTS_WITH:
+          case ENDS_WITH:
+          case CONTAINS:
             if (pred.literal().value().length() < width()) {
               return Expressions.predicate(pred.op(), name, pred.literal().value());
             } else if (pred.literal().value().length() == width()) {
@@ -335,6 +337,8 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
             return ProjectionUtil.truncateArray(name, pred, this);
 
           case NOT_STARTS_WITH:
+          case NOT_ENDS_WITH:
+          case NOT_CONTAINS:
             if (pred.literal().value().length() < width()) {
               return Expressions.predicate(pred.op(), name, pred.literal().value());
             } else if (pred.literal().value().length() == width()) {
@@ -365,6 +369,8 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
         BoundLiteralPredicate<CharSequence> pred = predicate.asLiteralPredicate();
         switch (pred.op()) {
           case STARTS_WITH:
+          case ENDS_WITH:
+          case CONTAINS:
             if (pred.literal().value().length() < width()) {
               return Expressions.predicate(pred.op(), name, pred.literal().value());
             } else if (pred.literal().value().length() == width()) {
@@ -374,6 +380,8 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
             return null;
 
           case NOT_STARTS_WITH:
+          case NOT_ENDS_WITH:
+          case NOT_CONTAINS:
             if (pred.literal().value().length() < width()) {
               return Expressions.predicate(pred.op(), name, pred.literal().value());
             } else if (pred.literal().value().length() == width()) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.expressions;
 import static org.apache.iceberg.expressions.Expressions.alwaysFalse;
 import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.contains;
+import static org.apache.iceberg.expressions.Expressions.endsWith;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -30,6 +32,8 @@ import static org.apache.iceberg.expressions.Expressions.isNull;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notContains;
+import static org.apache.iceberg.expressions.Expressions.notEndsWith;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
@@ -345,6 +349,102 @@ public class TestEvaluator {
         .isFalse();
     assertThat(evaluator.eval(TestHelpers.Row.of("Abcde")))
         .as("Abcde notStartsWith abc should be true")
+        .isTrue();
+  }
+
+  @Test
+  public void testEndsWith() {
+    StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
+    Evaluator evaluator = new Evaluator(struct, endsWith("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
+        .as("abc endsWith abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("bcx")))
+        .as("bcx endsWith abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("abC")))
+        .as("abC endsWith abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("c")))
+        .as("c endsWith abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("aabc")))
+        .as("aabc endsWith abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of((String) null)))
+        .as("null endsWith abc should be false")
+        .isFalse();
+  }
+
+  @Test
+  public void testNotEndsWith() {
+    StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
+    Evaluator evaluator = new Evaluator(struct, notEndsWith("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
+        .as("abc notEndsWith abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcx")))
+        .as("abcx notEndsWith abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("abC")))
+        .as("abC notEndsWith abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("c")))
+        .as("c notEndsWith abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("ababc")))
+        .as("ababc notEndsWith abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("AbAbc")))
+        .as("AbAbc notEndsWith abc should be true")
+        .isTrue();
+  }
+
+  @Test
+  public void testContains() {
+    StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
+    Evaluator evaluator = new Evaluator(struct, contains("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
+        .as("abc contains abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("bx")))
+        .as("bx contains abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("abC")))
+        .as("abC contains abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("c")))
+        .as("c contains abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("aabca")))
+        .as("aabca contains abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of((String) null)))
+        .as("null contains abc should be false")
+        .isFalse();
+  }
+
+  @Test
+  public void testNotContains() {
+    StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
+    Evaluator evaluator = new Evaluator(struct, notContains("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
+        .as("abc notContains abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("bx")))
+        .as("bx notContains abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("abC")))
+        .as("abC notContains abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("c")))
+        .as("c notContains abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("ababc")))
+        .as("ababc notContains abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("AbAbc")))
+        .as("AbAbc notContains abc should be true")
         .isTrue();
   }
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
@@ -308,6 +308,12 @@ public class TestEvaluator {
   public void testStartsWith() {
     StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
     Evaluator evaluator = new Evaluator(struct, startsWith("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of(new Object[] {null})))
+        .as(" null startsWith abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("")))
+        .as(" '' startsWith abc should be false")
+        .isFalse();
     assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
         .as("abc startsWith abc should be true")
         .isTrue();
@@ -332,6 +338,12 @@ public class TestEvaluator {
   public void testNotStartsWith() {
     StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
     Evaluator evaluator = new Evaluator(struct, notStartsWith("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of(new Object[] {null})))
+        .as(" null notStartsWith abc should be false")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("")))
+        .as(" '' notStartsWith abc should be false")
+        .isTrue();
     assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
         .as("abc notStartsWith abc should be false")
         .isFalse();
@@ -356,6 +368,12 @@ public class TestEvaluator {
   public void testEndsWith() {
     StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
     Evaluator evaluator = new Evaluator(struct, endsWith("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of(new Object[] {null})))
+        .as(" null endsWith abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("")))
+        .as(" '' endsWith abc should be false")
+        .isFalse();
     assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
         .as("abc endsWith abc should be true")
         .isTrue();
@@ -380,6 +398,12 @@ public class TestEvaluator {
   public void testNotEndsWith() {
     StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
     Evaluator evaluator = new Evaluator(struct, notEndsWith("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of(new Object[] {null})))
+        .as(" null notEndsWith abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("")))
+        .as(" '' notEndsWith abc should be true")
+        .isTrue();
     assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
         .as("abc notEndsWith abc should be false")
         .isFalse();
@@ -404,6 +428,12 @@ public class TestEvaluator {
   public void testContains() {
     StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
     Evaluator evaluator = new Evaluator(struct, contains("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of(new Object[] {null})))
+        .as(" null contains abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("")))
+        .as(" '' contains abc should be false")
+        .isFalse();
     assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
         .as("abc contains abc should be true")
         .isTrue();
@@ -428,6 +458,12 @@ public class TestEvaluator {
   public void testNotContains() {
     StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
     Evaluator evaluator = new Evaluator(struct, notContains("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of(new Object[] {null})))
+        .as(" null notContains abc should be false")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("")))
+        .as(" '' notContains abc should be false")
+        .isTrue();
     assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
         .as("abc notContains abc should be false")
         .isFalse();

--- a/api/src/test/java/org/apache/iceberg/transforms/TestContains.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestContains.java
@@ -36,7 +36,7 @@ import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestContains {
+public class TestContains extends TestTransformBase {
 
   private static final String COLUMN = "someStringCol";
   private static final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
@@ -45,18 +45,14 @@ public class TestContains {
   public void testTruncateProjections() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).truncate(COLUMN, 4).build();
 
-    TransformTestHelpers.assertProjectionInclusive(
-        spec, contains(COLUMN, "ab"), "ab", Expression.Operation.CONTAINS);
-    TransformTestHelpers.assertProjectionInclusive(
-        spec, contains(COLUMN, "abab"), "abab", Expression.Operation.EQ);
+    assertProjectionInclusive(spec, contains(COLUMN, "ab"), "ab", Expression.Operation.CONTAINS);
+    assertProjectionInclusive(spec, contains(COLUMN, "abab"), "abab", Expression.Operation.EQ);
     // It will truncate the first 4 characters and then compare contains.
-    TransformTestHelpers.assertProjectionInclusive(
+    assertProjectionInclusive(
         spec, contains(COLUMN, "abcdab"), "abcd", Expression.Operation.CONTAINS);
 
-    TransformTestHelpers.assertProjectionStrict(
-        spec, contains(COLUMN, "ab"), "ab", Expression.Operation.CONTAINS);
-    TransformTestHelpers.assertProjectionStrict(
-        spec, contains(COLUMN, "abab"), "abab", Expression.Operation.EQ);
+    assertProjectionStrict(spec, contains(COLUMN, "ab"), "ab", Expression.Operation.CONTAINS);
+    assertProjectionStrict(spec, contains(COLUMN, "abab"), "abab", Expression.Operation.EQ);
 
     Expression projection = Projections.strict(spec).project(contains(COLUMN, "abcdab"));
     Assertions.assertThat(projection).isInstanceOf(False.class);

--- a/api/src/test/java/org/apache/iceberg/transforms/TestContains.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestContains.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.transforms;
+
+import static org.apache.iceberg.expressions.Expressions.contains;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.expressions.Binder;
+import org.apache.iceberg.expressions.BoundPredicate;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.False;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestContains {
+
+  private static final String COLUMN = "someStringCol";
+  private static final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
+
+  @Test
+  public void testTruncateProjections() {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).truncate(COLUMN, 4).build();
+
+    TransformTestHelpers.assertProjectionInclusive(
+        spec, contains(COLUMN, "ab"), "ab", Expression.Operation.CONTAINS);
+    TransformTestHelpers.assertProjectionInclusive(
+        spec, contains(COLUMN, "abab"), "abab", Expression.Operation.EQ);
+    // It will truncate the first 4 characters and then compare contains.
+    TransformTestHelpers.assertProjectionInclusive(
+        spec, contains(COLUMN, "abcdab"), "abcd", Expression.Operation.CONTAINS);
+
+    TransformTestHelpers.assertProjectionStrict(
+        spec, contains(COLUMN, "ab"), "ab", Expression.Operation.CONTAINS);
+    TransformTestHelpers.assertProjectionStrict(
+        spec, contains(COLUMN, "abab"), "abab", Expression.Operation.EQ);
+
+    Expression projection = Projections.strict(spec).project(contains(COLUMN, "abcdab"));
+    Assertions.assertThat(projection).isInstanceOf(False.class);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testEvaluatorTruncateString() {
+    Truncate<String> trunc = Truncate.get(2);
+    Expression expr = contains(COLUMN, "bcgf");
+    BoundPredicate<String> boundExpr =
+        (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);
+
+    UnboundPredicate<String> projected = trunc.project(COLUMN, boundExpr);
+    Evaluator evaluator = new Evaluator(SCHEMA.asStruct(), projected);
+    // It will truncate the first 2 characters and then compare contains.
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcde")))
+        .as("contains(abcde, truncate(bcgf,2))  => true")
+        .isTrue();
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/transforms/TestEndsWith.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestEndsWith.java
@@ -36,7 +36,7 @@ import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestEndsWith {
+public class TestEndsWith extends TestTransformBase {
 
   private static final String COLUMN = "someStringCol";
   private static final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
@@ -45,18 +45,14 @@ public class TestEndsWith {
   public void testTruncateProjections() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).truncate(COLUMN, 4).build();
 
-    TransformTestHelpers.assertProjectionInclusive(
-        spec, endsWith(COLUMN, "ab"), "ab", Expression.Operation.ENDS_WITH);
-    TransformTestHelpers.assertProjectionInclusive(
-        spec, endsWith(COLUMN, "abab"), "abab", Expression.Operation.EQ);
+    assertProjectionInclusive(spec, endsWith(COLUMN, "ab"), "ab", Expression.Operation.ENDS_WITH);
+    assertProjectionInclusive(spec, endsWith(COLUMN, "abab"), "abab", Expression.Operation.EQ);
     // It will truncate the first 4 characters and then compare from the end.
-    TransformTestHelpers.assertProjectionInclusive(
+    assertProjectionInclusive(
         spec, endsWith(COLUMN, "abcdab"), "abcd", Expression.Operation.ENDS_WITH);
 
-    TransformTestHelpers.assertProjectionStrict(
-        spec, endsWith(COLUMN, "ab"), "ab", Expression.Operation.ENDS_WITH);
-    TransformTestHelpers.assertProjectionStrict(
-        spec, endsWith(COLUMN, "abab"), "abab", Expression.Operation.EQ);
+    assertProjectionStrict(spec, endsWith(COLUMN, "ab"), "ab", Expression.Operation.ENDS_WITH);
+    assertProjectionStrict(spec, endsWith(COLUMN, "abab"), "abab", Expression.Operation.EQ);
 
     Expression projection = Projections.strict(spec).project(endsWith(COLUMN, "abcdab"));
     Assertions.assertThat(projection).isInstanceOf(False.class);

--- a/api/src/test/java/org/apache/iceberg/transforms/TestEndsWith.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestEndsWith.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.transforms;
+
+import static org.apache.iceberg.expressions.Expressions.endsWith;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.expressions.Binder;
+import org.apache.iceberg.expressions.BoundPredicate;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.False;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestEndsWith {
+
+  private static final String COLUMN = "someStringCol";
+  private static final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
+
+  @Test
+  public void testTruncateProjections() {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).truncate(COLUMN, 4).build();
+
+    TransformTestHelpers.assertProjectionInclusive(
+        spec, endsWith(COLUMN, "ab"), "ab", Expression.Operation.ENDS_WITH);
+    TransformTestHelpers.assertProjectionInclusive(
+        spec, endsWith(COLUMN, "abab"), "abab", Expression.Operation.EQ);
+    // It will truncate the first 4 characters and then compare from the end.
+    TransformTestHelpers.assertProjectionInclusive(
+        spec, endsWith(COLUMN, "abcdab"), "abcd", Expression.Operation.ENDS_WITH);
+
+    TransformTestHelpers.assertProjectionStrict(
+        spec, endsWith(COLUMN, "ab"), "ab", Expression.Operation.ENDS_WITH);
+    TransformTestHelpers.assertProjectionStrict(
+        spec, endsWith(COLUMN, "abab"), "abab", Expression.Operation.EQ);
+
+    Expression projection = Projections.strict(spec).project(endsWith(COLUMN, "abcdab"));
+    Assertions.assertThat(projection).isInstanceOf(False.class);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testEvaluatorTruncateString() {
+    Truncate<String> trunc = Truncate.get(2);
+    Expression expr = endsWith(COLUMN, "degf");
+    BoundPredicate<String> boundExpr =
+        (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);
+
+    UnboundPredicate<String> projected = trunc.project(COLUMN, boundExpr);
+    Evaluator evaluator = new Evaluator(SCHEMA.asStruct(), projected);
+    // It will truncate the first 2 characters and then compare from the end.
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcde")))
+        .as("endsWith(abcde, truncate(degf,2))  => true")
+        .isTrue();
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/transforms/TestNotContains.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestNotContains.java
@@ -19,45 +19,40 @@
 package org.apache.iceberg.transforms;
 
 import static org.apache.iceberg.expressions.Expressions.notContains;
-import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
 import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.StrictMetricsEvaluator;
 import org.apache.iceberg.expressions.True;
 import org.apache.iceberg.expressions.UnboundPredicate;
-import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
-public class TestNotContains {
-
-  private static final String COLUMN = "someStringCol";
-  private static final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
+public class TestNotContains extends TestTransformBase {
 
   @Test
   public void testTruncateProjections() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).truncate(COLUMN, 4).build();
 
-    TransformTestHelpers.assertProjectionInclusive(
+    assertProjectionInclusive(
         spec, notContains(COLUMN, "ab"), "ab", Expression.Operation.NOT_CONTAINS);
-    TransformTestHelpers.assertProjectionInclusive(
+    assertProjectionInclusive(
         spec, notContains(COLUMN, "abab"), "abab", Expression.Operation.NOT_EQ);
     // When literal is longer than partition spec's truncation width, we always read for an
-    // inclusive projection when using notStartsWith.
+    // inclusive projection when using notContains.
     Expression projection = Projections.inclusive(spec).project(notContains(COLUMN, "ababab"));
     assertThat(projection).isInstanceOf(True.class);
 
-    TransformTestHelpers.assertProjectionStrict(
+    assertProjectionStrict(
         spec, notContains(COLUMN, "ab"), "ab", Expression.Operation.NOT_CONTAINS);
-    TransformTestHelpers.assertProjectionStrict(
-        spec, notContains(COLUMN, "abab"), "abab", Expression.Operation.NOT_EQ);
-    TransformTestHelpers.assertProjectionStrict(
+    assertProjectionStrict(spec, notContains(COLUMN, "abab"), "abab", Expression.Operation.NOT_EQ);
+    assertProjectionStrict(
         spec, notContains(COLUMN, "abcdab"), "abcd", Expression.Operation.NOT_CONTAINS);
   }
 
@@ -74,6 +69,115 @@ public class TestNotContains {
     // It will truncate the first 2 characters and then compare notContains.
     assertThat(evaluator.eval(TestHelpers.Row.of("abce")))
         .as("notContains(abcde, truncate(cdg,2))  => true")
+        .isTrue();
+  }
+
+  @Test
+  public void testTruncateStringWhenProjectedPredicateTermIsLongerThanWidth() {
+    Truncate<String> trunc = Truncate.get(2);
+    UnboundPredicate<String> expr = notContains(COLUMN, "abcde");
+    BoundPredicate<String> boundExpr =
+        (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);
+
+    UnboundPredicate<String> projected = trunc.projectStrict(COLUMN, boundExpr);
+    Evaluator evaluator = new Evaluator(SCHEMA.asStruct(), projected);
+
+    assertThat(projected.literal().value())
+        .as("The projected literal should be truncated to the truncation width")
+        .isEqualTo("ab");
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("eabcde")))
+        .as("notContains('eabcde', truncate('abcde',2)) => false")
+        .isFalse();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("ab")))
+        .as("notContains('ab', truncate('abcde', 2)) => false")
+        .isFalse();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcdz")))
+        .as("notContains('abcdz', truncate('abcdz', 2)) => false")
+        .isFalse();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("a")))
+        .as("notContains('a', truncate('abcde', 2)) => true")
+        .isTrue();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("aczcde")))
+        .as("notContains('aczcde', truncate('abcde', 2)) => true")
+        .isTrue();
+  }
+
+  @Test
+  public void testTruncateStringWhenProjectedPredicateTermIsShorterThanWidth() {
+    Truncate<String> trunc = Truncate.get(16);
+    UnboundPredicate<String> expr = notContains(COLUMN, "bc");
+    BoundPredicate<String> boundExpr =
+        (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);
+
+    UnboundPredicate<String> projected = trunc.projectStrict(COLUMN, boundExpr);
+    Evaluator evaluator = new Evaluator(SCHEMA.asStruct(), projected);
+
+    assertThat(projected.literal().value())
+        .as(
+            "The projected literal should not be truncated as its size is shorter than truncation width")
+        .isEqualTo("bc");
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcde")))
+        .as("notContains('abcde', truncate('bc', 16)) => false")
+        .isFalse();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("bc")))
+        .as("notContains('bc', truncate('bc', 16)) => false")
+        .isFalse();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("a")))
+        .as("notContains('a', truncate('bc', 16)) => true")
+        .isTrue();
+  }
+
+  @Test
+  public void testTruncateStringWhenProjectedPredicateTermIsEqualToWidth() {
+    Truncate<String> trunc = Truncate.get(7);
+    UnboundPredicate<String> expr = notContains(COLUMN, "abcdefg");
+    BoundPredicate<String> boundExpr =
+        (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);
+
+    UnboundPredicate<String> projected = trunc.projectStrict(COLUMN, boundExpr);
+    Evaluator evaluator = new Evaluator(SCHEMA.asStruct(), projected);
+
+    assertThat(projected.literal().value())
+        .as(
+            "The projected literal should not be truncated as its size is equal to truncation width")
+        .isEqualTo("abcdefg");
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcdefg")))
+        .as("notContains('abcdefg', truncate('abcdefg', 7)) => false")
+        .isFalse();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("ab")))
+        .as("notContains('ab', truncate('abcdefg', 7)) => true")
+        .isTrue();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("a")))
+        .as("notContains('a', truncate('abcdefg', 7)) => true")
+        .isTrue();
+  }
+
+  @Test
+  public void testStrictMetricsEvaluatorForNotContains() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notContains(COLUMN, "bbb")).eval(TEST_FILE);
+    assertThat(shouldRead)
+        .as("Should not match: strict metrics eval is always false for notContains")
+        .isFalse();
+  }
+
+  @Test
+  public void testInclusiveMetricsEvaluatorForNotContains() {
+    boolean shouldRead =
+        new InclusiveMetricsEvaluator(SCHEMA, notContains(COLUMN, "aaa")).eval(TEST_FILE);
+    assertThat(shouldRead)
+        .as("Should match: inclusive metrics evaluator is always true for notContains")
         .isTrue();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestNotContains.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestNotContains.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.transforms;
+
+import static org.apache.iceberg.expressions.Expressions.notContains;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.expressions.Binder;
+import org.apache.iceberg.expressions.BoundPredicate;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.True;
+import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestNotContains {
+
+  private static final String COLUMN = "someStringCol";
+  private static final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
+
+  @Test
+  public void testTruncateProjections() {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).truncate(COLUMN, 4).build();
+
+    TransformTestHelpers.assertProjectionInclusive(
+        spec, notContains(COLUMN, "ab"), "ab", Expression.Operation.NOT_CONTAINS);
+    TransformTestHelpers.assertProjectionInclusive(
+        spec, notContains(COLUMN, "abab"), "abab", Expression.Operation.NOT_EQ);
+    // When literal is longer than partition spec's truncation width, we always read for an
+    // inclusive projection when using notStartsWith.
+    Expression projection = Projections.inclusive(spec).project(notContains(COLUMN, "ababab"));
+    assertThat(projection).isInstanceOf(True.class);
+
+    TransformTestHelpers.assertProjectionStrict(
+        spec, notContains(COLUMN, "ab"), "ab", Expression.Operation.NOT_CONTAINS);
+    TransformTestHelpers.assertProjectionStrict(
+        spec, notContains(COLUMN, "abab"), "abab", Expression.Operation.NOT_EQ);
+    TransformTestHelpers.assertProjectionStrict(
+        spec, notContains(COLUMN, "abcdab"), "abcd", Expression.Operation.NOT_CONTAINS);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testEvaluatorTruncateString() {
+    Truncate<String> trunc = Truncate.get(2);
+    Expression expr = notContains(COLUMN, "cdg");
+    BoundPredicate<String> boundExpr =
+        (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);
+
+    UnboundPredicate<String> projected = trunc.projectStrict(COLUMN, boundExpr);
+    Evaluator evaluator = new Evaluator(SCHEMA.asStruct(), projected);
+    // It will truncate the first 2 characters and then compare notContains.
+    assertThat(evaluator.eval(TestHelpers.Row.of("abce")))
+        .as("notContains(abcde, truncate(cdg,2))  => true")
+        .isTrue();
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/transforms/TestNotEndsWith.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestNotEndsWith.java
@@ -19,45 +19,40 @@
 package org.apache.iceberg.transforms;
 
 import static org.apache.iceberg.expressions.Expressions.notEndsWith;
-import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
 import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.StrictMetricsEvaluator;
 import org.apache.iceberg.expressions.True;
 import org.apache.iceberg.expressions.UnboundPredicate;
-import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
-public class TestNotEndsWith {
-
-  private static final String COLUMN = "someStringCol";
-  private static final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
+public class TestNotEndsWith extends TestTransformBase {
 
   @Test
   public void testTruncateProjections() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).truncate(COLUMN, 4).build();
 
-    TransformTestHelpers.assertProjectionInclusive(
+    assertProjectionInclusive(
         spec, notEndsWith(COLUMN, "ab"), "ab", Expression.Operation.NOT_ENDS_WITH);
-    TransformTestHelpers.assertProjectionInclusive(
+    assertProjectionInclusive(
         spec, notEndsWith(COLUMN, "abab"), "abab", Expression.Operation.NOT_EQ);
     // When literal is longer than partition spec's truncation width, we always read for an
-    // inclusive projection when using notStartsWith.
+    // inclusive projection when using notEndsWith.
     Expression projection = Projections.inclusive(spec).project(notEndsWith(COLUMN, "ababab"));
     assertThat(projection).isInstanceOf(True.class);
 
-    TransformTestHelpers.assertProjectionStrict(
+    assertProjectionStrict(
         spec, notEndsWith(COLUMN, "ab"), "ab", Expression.Operation.NOT_ENDS_WITH);
-    TransformTestHelpers.assertProjectionStrict(
-        spec, notEndsWith(COLUMN, "abab"), "abab", Expression.Operation.NOT_EQ);
-    TransformTestHelpers.assertProjectionStrict(
+    assertProjectionStrict(spec, notEndsWith(COLUMN, "abab"), "abab", Expression.Operation.NOT_EQ);
+    assertProjectionStrict(
         spec, notEndsWith(COLUMN, "abcdab"), "abcd", Expression.Operation.NOT_ENDS_WITH);
   }
 
@@ -73,7 +68,116 @@ public class TestNotEndsWith {
     Evaluator evaluator = new Evaluator(SCHEMA.asStruct(), projected);
     // It will truncate the first 2 characters and then compare from the end.
     assertThat(evaluator.eval(TestHelpers.Row.of("abcde")))
-        .as("notEndsWith(abcde, truncate(cdg,2))  => true")
+        .as("notEndsWith('abcde', truncate('cdg',2))  => true")
+        .isTrue();
+  }
+
+  @Test
+  public void testTruncateStringWhenProjectedPredicateTermIsLongerThanWidth() {
+    Truncate<String> trunc = Truncate.get(2);
+    UnboundPredicate<String> expr = notEndsWith(COLUMN, "abcde");
+    BoundPredicate<String> boundExpr =
+        (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);
+
+    UnboundPredicate<String> projected = trunc.projectStrict(COLUMN, boundExpr);
+    Evaluator evaluator = new Evaluator(SCHEMA.asStruct(), projected);
+
+    assertThat(projected.literal().value())
+        .as("The projected literal should be truncated to the truncation width")
+        .isEqualTo("ab");
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcde")))
+        .as("notEndsWith('abcde', truncate('abcde',2)) => true")
+        .isTrue();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("ab")))
+        .as("notEndsWith('ab', truncate('ab', 2)) => false")
+        .isFalse();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcdz")))
+        .as("notEndsWith('abcdz', truncate('abcde', 2)) => true")
+        .isTrue();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("a")))
+        .as("notEndsWith('a', truncate('abcde', 2)) => true")
+        .isTrue();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("aczcab")))
+        .as("notEndsWith('aczcab', truncate('abcde', 2)) => false")
+        .isFalse();
+  }
+
+  @Test
+  public void testTruncateStringWhenProjectedPredicateTermIsShorterThanWidth() {
+    Truncate<String> trunc = Truncate.get(16);
+    UnboundPredicate<String> expr = notEndsWith(COLUMN, "ab");
+    BoundPredicate<String> boundExpr =
+        (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);
+
+    UnboundPredicate<String> projected = trunc.projectStrict(COLUMN, boundExpr);
+    Evaluator evaluator = new Evaluator(SCHEMA.asStruct(), projected);
+
+    assertThat(projected.literal().value())
+        .as(
+            "The projected literal should not be truncated as its size is shorter than truncation width")
+        .isEqualTo("ab");
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("efcab")))
+        .as("notEndsWith('efcab', truncate('ab', 16)) => false")
+        .isFalse();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("ab")))
+        .as("notEndsWith('ab', truncate('ab', 16)) => false")
+        .isFalse();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("a")))
+        .as("notEndsWith('a', truncate('ab', 16)) => true")
+        .isTrue();
+  }
+
+  @Test
+  public void testTruncateStringWhenProjectedPredicateTermIsEqualToWidth() {
+    Truncate<String> trunc = Truncate.get(7);
+    UnboundPredicate<String> expr = notEndsWith(COLUMN, "abcdefg");
+    BoundPredicate<String> boundExpr =
+        (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);
+
+    UnboundPredicate<String> projected = trunc.projectStrict(COLUMN, boundExpr);
+    Evaluator evaluator = new Evaluator(SCHEMA.asStruct(), projected);
+
+    assertThat(projected.literal().value())
+        .as(
+            "The projected literal should not be truncated as its size is equal to truncation width")
+        .isEqualTo("abcdefg");
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcdefg")))
+        .as("notEndsWith('abcdefg', truncate(abcdefg, 7)) => false")
+        .isFalse();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("ab")))
+        .as("notEndsWith('ab', truncate('abcdefg', 7)) => true")
+        .isTrue();
+
+    assertThat(evaluator.eval(TestHelpers.Row.of("a")))
+        .as("notEndsWith('a', truncate('abcdefg', 7)) => true")
+        .isTrue();
+  }
+
+  @Test
+  public void testStrictMetricsEvaluatorForNotEndsWith() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notEndsWith(COLUMN, "bbb")).eval(TEST_FILE);
+    assertThat(shouldRead)
+        .as("Should not match: strict metrics eval is always false for notEndsWith")
+        .isFalse();
+  }
+
+  @Test
+  public void testInclusiveMetricsEvaluatorForNotEndsWith() {
+    boolean shouldRead =
+        new InclusiveMetricsEvaluator(SCHEMA, notEndsWith(COLUMN, "aaa")).eval(TEST_FILE);
+    assertThat(shouldRead)
+        .as("Should match: inclusive metrics evaluator is always true for notEndsWith")
         .isTrue();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestNotEndsWith.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestNotEndsWith.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.transforms;
+
+import static org.apache.iceberg.expressions.Expressions.notEndsWith;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.expressions.Binder;
+import org.apache.iceberg.expressions.BoundPredicate;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.True;
+import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestNotEndsWith {
+
+  private static final String COLUMN = "someStringCol";
+  private static final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
+
+  @Test
+  public void testTruncateProjections() {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).truncate(COLUMN, 4).build();
+
+    TransformTestHelpers.assertProjectionInclusive(
+        spec, notEndsWith(COLUMN, "ab"), "ab", Expression.Operation.NOT_ENDS_WITH);
+    TransformTestHelpers.assertProjectionInclusive(
+        spec, notEndsWith(COLUMN, "abab"), "abab", Expression.Operation.NOT_EQ);
+    // When literal is longer than partition spec's truncation width, we always read for an
+    // inclusive projection when using notStartsWith.
+    Expression projection = Projections.inclusive(spec).project(notEndsWith(COLUMN, "ababab"));
+    assertThat(projection).isInstanceOf(True.class);
+
+    TransformTestHelpers.assertProjectionStrict(
+        spec, notEndsWith(COLUMN, "ab"), "ab", Expression.Operation.NOT_ENDS_WITH);
+    TransformTestHelpers.assertProjectionStrict(
+        spec, notEndsWith(COLUMN, "abab"), "abab", Expression.Operation.NOT_EQ);
+    TransformTestHelpers.assertProjectionStrict(
+        spec, notEndsWith(COLUMN, "abcdab"), "abcd", Expression.Operation.NOT_ENDS_WITH);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testEvaluatorTruncateString() {
+    Truncate<String> trunc = Truncate.get(2);
+    Expression expr = notEndsWith(COLUMN, "cdg");
+    BoundPredicate<String> boundExpr =
+        (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);
+
+    UnboundPredicate<String> projected = trunc.projectStrict(COLUMN, boundExpr);
+    Evaluator evaluator = new Evaluator(SCHEMA.asStruct(), projected);
+    // It will truncate the first 2 characters and then compare from the end.
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcde")))
+        .as("notEndsWith(abcde, truncate(cdg,2))  => true")
+        .isTrue();
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/transforms/TestNotStartsWith.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestNotStartsWith.java
@@ -75,7 +75,7 @@ public class TestNotStartsWith extends TestTransformBase {
         .isEqualTo("ab");
 
     assertThat(evaluator.eval(TestHelpers.Row.of("abcde")))
-        .as("notStartsWith('abcde', truncate(abcde,2)) => false")
+        .as("notStartsWith('abcde', truncate('abcde',2)) => false")
         .isFalse();
 
     assertThat(evaluator.eval(TestHelpers.Row.of("ab")))

--- a/api/src/test/java/org/apache/iceberg/transforms/TestNotStartsWith.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestNotStartsWith.java
@@ -18,54 +18,23 @@
  */
 package org.apache.iceberg.transforms;
 
-import static org.apache.iceberg.TestHelpers.assertAndUnwrapUnbound;
 import static org.apache.iceberg.expressions.Expressions.notStartsWith;
-import static org.apache.iceberg.types.Conversions.toByteBuffer;
-import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.iceberg.DataFile;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestHelpers;
-import org.apache.iceberg.TestHelpers.Row;
-import org.apache.iceberg.TestHelpers.TestDataFile;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
-import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.StrictMetricsEvaluator;
 import org.apache.iceberg.expressions.True;
 import org.apache.iceberg.expressions.UnboundPredicate;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.types.Types;
-import org.apache.iceberg.types.Types.StringType;
 import org.junit.jupiter.api.Test;
 
-public class TestNotStartsWith {
-
-  private static final String COLUMN = "someStringCol";
-  private static final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
-
-  // All 50 rows have someStringCol = 'bbb', none are null (despite being optional).
-  private static final DataFile FILE_1 =
-      new TestDataFile(
-          "file_1.avro",
-          Row.of(),
-          50,
-          // any value counts, including nulls
-          ImmutableMap.of(1, 50L),
-          // null value counts
-          ImmutableMap.of(1, 0L),
-          // nan value counts
-          null,
-          // lower bounds
-          ImmutableMap.of(1, toByteBuffer(StringType.get(), "bbb")),
-          // upper bounds
-          ImmutableMap.of(1, toByteBuffer(StringType.get(), "bbb")));
+public class TestNotStartsWith extends TestTransformBase {
 
   @Test
   public void testTruncateProjections() {
@@ -106,23 +75,23 @@ public class TestNotStartsWith {
         .isEqualTo("ab");
 
     assertThat(evaluator.eval(TestHelpers.Row.of("abcde")))
-        .as("notStartsWith(abcde, truncate(abcde,2)) => false")
+        .as("notStartsWith('abcde', truncate(abcde,2)) => false")
         .isFalse();
 
     assertThat(evaluator.eval(TestHelpers.Row.of("ab")))
-        .as("notStartsWith(abcde, truncate(ab, 2)) => false")
+        .as("notStartsWith('ab', truncate('abcde', 2)) => false")
         .isFalse();
 
     assertThat(evaluator.eval(TestHelpers.Row.of("abcdz")))
-        .as("notStartsWith(abcde, truncate(abcdz, 2)) => false")
+        .as("notStartsWith('abcdz', truncate('abcdz', 2)) => false")
         .isFalse();
 
     assertThat(evaluator.eval(TestHelpers.Row.of("a")))
-        .as("notStartsWith(abcde, truncate(a, 2)) => true")
+        .as("notStartsWith('a', truncate('abcde', 2)) => true")
         .isTrue();
 
     assertThat(evaluator.eval(TestHelpers.Row.of("aczcde")))
-        .as("notStartsWith(abcde, truncate(aczcde, 2)) => true")
+        .as("notStartsWith('aczcde', truncate('abcde', 2)) => true")
         .isTrue();
   }
 
@@ -142,15 +111,15 @@ public class TestNotStartsWith {
         .isEqualTo("ab");
 
     assertThat(evaluator.eval(TestHelpers.Row.of("abcde")))
-        .as("notStartsWith(ab, truncate(abcde, 16)) => false")
+        .as("notStartsWith('abcde', truncate('ab', 16)) => false")
         .isFalse();
 
     assertThat(evaluator.eval(TestHelpers.Row.of("ab")))
-        .as("notStartsWith(ab, truncate(ab, 16)) => false")
+        .as("notStartsWith('ab', truncate('ab', 16)) => false")
         .isFalse();
 
     assertThat(evaluator.eval(TestHelpers.Row.of("a")))
-        .as("notStartsWith(ab, truncate(a, 16)) => true")
+        .as("notStartsWith('a', truncate('ab', 16)) => true")
         .isTrue();
   }
 
@@ -174,18 +143,18 @@ public class TestNotStartsWith {
         .isFalse();
 
     assertThat(evaluator.eval(TestHelpers.Row.of("ab")))
-        .as("notStartsWith(abcdefg, truncate(ab, 2)) => true")
+        .as("notStartsWith('ab', truncate('abcdefg', 7)) => true")
         .isTrue();
 
     assertThat(evaluator.eval(TestHelpers.Row.of("a")))
-        .as("notStartsWith(abcdefg, truncate(a, 16)) => true")
+        .as("notStartsWith('a', truncate('abcdefg', 7)) => true")
         .isTrue();
   }
 
   @Test
   public void testStrictMetricsEvaluatorForNotStartsWith() {
     boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith(COLUMN, "bbb")).eval(FILE_1);
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith(COLUMN, "bbb")).eval(TEST_FILE);
     assertThat(shouldRead)
         .as("Should not match: strict metrics eval is always false for notStartsWith")
         .isFalse();
@@ -194,53 +163,21 @@ public class TestNotStartsWith {
   @Test
   public void testInclusiveMetricsEvaluatorForNotStartsWith() {
     boolean shouldRead =
-        new InclusiveMetricsEvaluator(SCHEMA, notStartsWith(COLUMN, "aaa")).eval(FILE_1);
+        new InclusiveMetricsEvaluator(SCHEMA, notStartsWith(COLUMN, "aaa")).eval(TEST_FILE);
     assertThat(shouldRead).as("Should match: some columns meet the filter criteria").isTrue();
 
-    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notStartsWith(COLUMN, "b")).eval(FILE_1);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notStartsWith(COLUMN, "b")).eval(TEST_FILE);
     assertThat(shouldRead).as("Should not match: no columns match the filter criteria").isFalse();
 
-    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notStartsWith(COLUMN, "bb")).eval(FILE_1);
+    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notStartsWith(COLUMN, "bb")).eval(TEST_FILE);
     assertThat(shouldRead).as("Should not match: no columns match the filter criteria").isFalse();
 
-    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notStartsWith(COLUMN, "bbb")).eval(FILE_1);
+    shouldRead =
+        new InclusiveMetricsEvaluator(SCHEMA, notStartsWith(COLUMN, "bbb")).eval(TEST_FILE);
     assertThat(shouldRead).as("Should not match: no columns match the filter criteria").isFalse();
 
-    shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notStartsWith(COLUMN, "bbbb")).eval(FILE_1);
+    shouldRead =
+        new InclusiveMetricsEvaluator(SCHEMA, notStartsWith(COLUMN, "bbbb")).eval(TEST_FILE);
     assertThat(shouldRead).as("Should match: some columns match the filter criteria").isTrue();
-  }
-
-  private void assertProjectionInclusive(
-      PartitionSpec spec,
-      UnboundPredicate<?> filter,
-      String expectedLiteral,
-      Expression.Operation expectedOp) {
-    Expression projection = Projections.inclusive(spec).project(filter);
-    assertProjection(spec, expectedLiteral, projection, expectedOp);
-  }
-
-  private void assertProjectionStrict(
-      PartitionSpec spec,
-      UnboundPredicate<?> filter,
-      String expectedLiteral,
-      Expression.Operation expectedOp) {
-    Expression projection = Projections.strict(spec).project(filter);
-    assertProjection(spec, expectedLiteral, projection, expectedOp);
-  }
-
-  @SuppressWarnings("unchecked")
-  private void assertProjection(
-      PartitionSpec spec,
-      String expectedLiteral,
-      Expression projection,
-      Expression.Operation expectedOp) {
-    UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
-    Literal<?> literal = predicate.literal();
-    Truncate<CharSequence> transform =
-        (Truncate<CharSequence>) spec.getFieldsBySourceId(1).get(0).transform();
-    String output = transform.toHumanString(Types.StringType.get(), (String) literal.value());
-
-    assertThat(predicate.op()).isEqualTo(expectedOp);
-    assertThat(output).isEqualTo(expectedLiteral);
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestStartsWith.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestStartsWith.java
@@ -18,30 +18,22 @@
  */
 package org.apache.iceberg.transforms;
 
-import static org.apache.iceberg.TestHelpers.assertAndUnwrapUnbound;
 import static org.apache.iceberg.expressions.Expressions.startsWith;
-import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.False;
-import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.UnboundPredicate;
-import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestStartsWith {
-
-  private static final String COLUMN = "someStringCol";
-  private static final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
+public class TestStartsWith extends TestTransformBase {
 
   @Test
   public void testTruncateProjections() {
@@ -74,39 +66,5 @@ public class TestStartsWith {
     assertThat(evaluator.eval(TestHelpers.Row.of("abcdg")))
         .as("startsWith(abcde, truncate(abcdg,2))  => true")
         .isTrue();
-  }
-
-  private void assertProjectionInclusive(
-      PartitionSpec spec,
-      UnboundPredicate<?> filter,
-      String expectedLiteral,
-      Expression.Operation expectedOp) {
-    Expression projection = Projections.inclusive(spec).project(filter);
-    assertProjection(spec, expectedLiteral, projection, expectedOp);
-  }
-
-  private void assertProjectionStrict(
-      PartitionSpec spec,
-      UnboundPredicate<?> filter,
-      String expectedLiteral,
-      Expression.Operation expectedOp) {
-    Expression projection = Projections.strict(spec).project(filter);
-    assertProjection(spec, expectedLiteral, projection, expectedOp);
-  }
-
-  @SuppressWarnings("unchecked")
-  private void assertProjection(
-      PartitionSpec spec,
-      String expectedLiteral,
-      Expression projection,
-      Expression.Operation expectedOp) {
-    UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
-    Literal<?> literal = predicate.literal();
-    Truncate<CharSequence> transform =
-        (Truncate<CharSequence>) spec.getFieldsBySourceId(1).get(0).transform();
-    String output = transform.toHumanString(Types.StringType.get(), (String) literal.value());
-
-    assertThat(predicate.op()).isEqualTo(expectedOp);
-    assertThat(output).isEqualTo(expectedLiteral);
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTransformBase.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTransformBase.java
@@ -19,20 +19,45 @@
 package org.apache.iceberg.transforms;
 
 import static org.apache.iceberg.TestHelpers.assertAndUnwrapUnbound;
+import static org.apache.iceberg.types.Conversions.toByteBuffer;
+import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 
-public class TransformTestHelpers {
+public class TestTransformBase {
 
-  private TransformTestHelpers() {}
+  public final String COLUMN = "someStringCol";
 
-  public static void assertProjectionInclusive(
+  public final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
+
+  // All 50 rows have someStringCol = 'bbb', none are null (despite being optional).
+  public final DataFile TEST_FILE =
+      new TestHelpers.TestDataFile(
+          "file_1.avro",
+          TestHelpers.Row.of(),
+          50,
+          // any value counts, including nulls
+          ImmutableMap.of(1, 50L),
+          // null value counts
+          ImmutableMap.of(1, 0L),
+          // nan value counts
+          null,
+          // lower bounds
+          ImmutableMap.of(1, toByteBuffer(Types.StringType.get(), "bbb")),
+          // upper bounds
+          ImmutableMap.of(1, toByteBuffer(Types.StringType.get(), "bbb")));
+
+  public void assertProjectionInclusive(
       PartitionSpec spec,
       UnboundPredicate<?> filter,
       String expectedLiteral,
@@ -41,7 +66,7 @@ public class TransformTestHelpers {
     assertProjection(spec, expectedLiteral, projection, expectedOp);
   }
 
-  public static void assertProjectionStrict(
+  public void assertProjectionStrict(
       PartitionSpec spec,
       UnboundPredicate<?> filter,
       String expectedLiteral,
@@ -51,7 +76,7 @@ public class TransformTestHelpers {
   }
 
   @SuppressWarnings("unchecked")
-  public static void assertProjection(
+  public void assertProjection(
       PartitionSpec spec,
       String expectedLiteral,
       Expression projection,

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTransformBase.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTransformBase.java
@@ -36,12 +36,12 @@ import org.apache.iceberg.types.Types;
 
 public class TestTransformBase {
 
-  public final String COLUMN = "someStringCol";
+  public static final String COLUMN = "someStringCol";
 
-  public final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
+  public static final Schema SCHEMA = new Schema(optional(1, COLUMN, Types.StringType.get()));
 
   // All 50 rows have someStringCol = 'bbb', none are null (despite being optional).
-  public final DataFile TEST_FILE =
+  public static final DataFile TEST_FILE =
       new TestHelpers.TestDataFile(
           "file_1.avro",
           TestHelpers.Row.of(),

--- a/api/src/test/java/org/apache/iceberg/transforms/TransformTestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TransformTestHelpers.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.transforms;
+
+import static org.apache.iceberg.TestHelpers.assertAndUnwrapUnbound;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.types.Types;
+
+public class TransformTestHelpers {
+
+  private TransformTestHelpers() {}
+
+  public static void assertProjectionInclusive(
+      PartitionSpec spec,
+      UnboundPredicate<?> filter,
+      String expectedLiteral,
+      Expression.Operation expectedOp) {
+    Expression projection = Projections.inclusive(spec).project(filter);
+    assertProjection(spec, expectedLiteral, projection, expectedOp);
+  }
+
+  public static void assertProjectionStrict(
+      PartitionSpec spec,
+      UnboundPredicate<?> filter,
+      String expectedLiteral,
+      Expression.Operation expectedOp) {
+    Expression projection = Projections.strict(spec).project(filter);
+    assertProjection(spec, expectedLiteral, projection, expectedOp);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static void assertProjection(
+      PartitionSpec spec,
+      String expectedLiteral,
+      Expression projection,
+      Expression.Operation expectedOp) {
+    UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
+    Literal<?> literal = predicate.literal();
+    Truncate<CharSequence> transform =
+        (Truncate<CharSequence>) spec.getFieldsBySourceId(1).get(0).transform();
+    String output = transform.toHumanString(Types.StringType.get(), (String) literal.value());
+
+    assertThat(predicate.op()).isEqualTo(expectedOp);
+    assertThat(output).isEqualTo(expectedLiteral);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -400,6 +400,26 @@ public class AllManifestsTable extends BaseMetadataTable {
         return ROWS_MIGHT_MATCH;
       }
 
+      @Override
+      public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
       /**
        * Comparison of snapshot reference and literal, using long comparator.
        *

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -347,6 +347,10 @@ public class ExpressionParser {
       case NOT_EQ:
       case STARTS_WITH:
       case NOT_STARTS_WITH:
+      case ENDS_WITH:
+      case NOT_ENDS_WITH:
+      case CONTAINS:
+      case NOT_CONTAINS:
         // literal predicates
         Preconditions.checkArgument(
             node.has(VALUE), "Cannot parse %s predicate: missing value", op);


### PR DESCRIPTION
This PR adds filter pushing down api for `endsWith` (`like %x`) and `contains` (`like %x%`). Before this PR, iceberg only support pushdown startWith filter. Spark parquet supports pushdown `endWiths` and `contains`.
This PR is the first part, the next PR will complete the related implementation of spark and fileFormat