### PR TITLE
OpenAPI: Add AppendDataFileUpdate to TableUpdate for rest appends

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -801,6 +801,17 @@ class AddSchemaUpdate(BaseUpdate):
     )
 
 
+class AppendDataFileUpdate(BaseUpdate):
+    action: Literal['append-data-files']
+    added_data_files: List[ContentFile] = Field(
+        ...,
+        alias='added-data-files',
+        description='List of datafiles to be appended to a table',
+    )
+    schema_: Schema = Field(..., alias='schema')
+    spec: PartitionSpec
+
+
 class TableUpdate(BaseModel):
     __root__: Union[
         AssignUUIDUpdate,
@@ -820,6 +831,7 @@ class TableUpdate(BaseModel):
         RemovePropertiesUpdate,
         SetStatisticsUpdate,
         RemoveStatisticsUpdate,
+        AppendDataFileUpdate,
     ]
 
 
@@ -960,6 +972,43 @@ class CommitTableResponse(BaseModel):
     metadata: TableMetadata
 
 
+class TypeValue(BaseModel):
+    __root__: Union[PrimitiveTypeValue, MapTypeValue, StructTypeValue]
+
+
+class MapTypeValue(BaseModel):
+    keys: Optional[List[TypeValue]] = None
+    values: Optional[List[TypeValue]] = None
+
+
+class StructTypeValue(BaseModel):
+    __root__: Optional[Dict[str, TypeValue]] = None
+
+
+class PrimitiveTypeValue(BaseModel):
+    __root__: Union[bool, int, float, str, List[TypeValue]]
+
+
+class ContentFile(BaseModel):
+    spec_id: int = Field(..., alias='spec-id')
+    content: str
+    file_path: str = Field(..., alias='file-path')
+    file_format: str = Field(..., alias='file-format')
+    partition: Optional[StructTypeValue] = None
+    file_size_in_bytes: int = Field(..., alias='file-size-in-bytes')
+    record_count: int = Field(..., alias='record-count')
+    column_sizes: Optional[MapTypeValue] = Field(None, alias='column-sizes')
+    value_counts: Optional[MapTypeValue] = Field(None, alias='value-counts')
+    null_value_counts: Optional[MapTypeValue] = Field(None, alias='null-value-counts')
+    nan_value_counts: Optional[MapTypeValue] = Field(None, alias='nan-value-counts')
+    lower_bounds: Optional[MapTypeValue] = Field(None, alias='lower-bounds')
+    upper_bounds: Optional[MapTypeValue] = Field(None, alias='upper-bounds')
+    key_metadata: Optional[str] = Field(None, alias='key-metadata')
+    split_offsets: Optional[List[int]] = Field(None, alias='split-offsets')
+    equality_ids: Optional[List[int]] = Field(None, alias='equality-ids')
+    sort_order_id: Optional[int] = Field(None, alias='sort-order-id')
+
+
 class Schema(StructType):
     schema_id: Optional[int] = Field(None, alias='schema-id')
     identifier_field_ids: Optional[List[int]] = Field(
@@ -978,6 +1027,8 @@ Expression.update_forward_refs()
 TableMetadata.update_forward_refs()
 ViewMetadata.update_forward_refs()
 AddSchemaUpdate.update_forward_refs()
+AppendDataFileUpdate.update_forward_refs()
 CreateTableRequest.update_forward_refs()
 CreateViewRequest.update_forward_refs()
 ReportMetricsRequest.update_forward_refs()
+TypeValue.update_forward_refs()

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2192,6 +2192,7 @@ components:
           remove-statistics: '#/components/schemas/RemoveStatisticsUpdate'
           set-partition-statistics: '#/components/schemas/SetPartitionStatisticsUpdate'
           remove-partition-statistics: '#/components/schemas/RemovePartitionStatisticsUpdate'
+          append-data-files: '#/components/schemas/AppendDataFileUpdate'
       type: object
       required:
         - action
@@ -2494,6 +2495,28 @@ components:
           type: integer
           format: int64
 
+    AppendDataFileUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+      required:
+        - action
+        - added-data-files
+        - schema
+        - spec
+      properties:
+        action:
+          type: string
+          enum: [ "append-data-files" ]
+        added-data-files:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContentFile'
+          description: List of datafiles to be appended to a table
+        schema:
+          $ref: '#/components/schemas/Schema'
+        spec:
+          $ref: '#/components/schemas/PartitionSpec'
+
     TableUpdate:
       anyOf:
         - $ref: '#/components/schemas/AssignUUIDUpdate'
@@ -2513,6 +2536,7 @@ components:
         - $ref: '#/components/schemas/RemovePropertiesUpdate'
         - $ref: '#/components/schemas/SetStatisticsUpdate'
         - $ref: '#/components/schemas/RemoveStatisticsUpdate'
+        - $ref: '#/components/schemas/AppendDataFileUpdate'
 
     ViewUpdate:
       anyOf:
@@ -3323,6 +3347,97 @@ components:
         file-size-in-bytes:
           type: integer
           format: int64
+
+    TypeValue:
+      oneOf:
+        - $ref: '#/components/schemas/PrimitiveTypeValue'
+        - $ref: '#/components/schemas/MapTypeValue'
+        - $ref: '#/components/schemas/StructTypeValue'
+
+    MapTypeValue:
+      type: object
+      properties:
+        keys:
+          type: array
+          items:
+            $ref: '#/components/schemas/TypeValue'
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/TypeValue'
+
+    StructTypeValue:
+      type: object
+      additionalProperties:
+        oneOf:
+          - $ref: '#/components/schemas/TypeValue'
+
+    PrimitiveTypeValue:
+      oneOf:
+        - type: boolean
+        - type: integer
+        - type: integer
+          format: int64
+        - type: number
+        - type: string
+        - type: string
+          format: byte
+        - type: array
+          items:
+            $ref: '#/components/schemas/TypeValue'
+
+    ContentFile:
+      type: object
+      required:
+        - spec-id
+        - content
+        - file-path
+        - file-format
+        - file-size-in-bytes
+        - record-count
+      properties:
+        spec-id:
+          type: integer
+        content:
+          type: string
+        file-path:
+          type: string
+        file-format:
+          type: string
+        partition:
+          $ref: '#/components/schemas/StructTypeValue'
+        file-size-in-bytes:
+          type: integer
+          format: int64
+        record-count:
+          type: integer
+          format: int64
+        column-sizes:
+          $ref: '#/components/schemas/MapTypeValue'
+        value-counts:
+          $ref: '#/components/schemas/MapTypeValue'
+        null-value-counts:
+          $ref: '#/components/schemas/MapTypeValue'
+        nan-value-counts:
+          $ref: '#/components/schemas/MapTypeValue'
+        lower-bounds:
+          $ref: '#/components/schemas/MapTypeValue'
+        upper-bounds:
+          $ref: '#/components/schemas/MapTypeValue'
+        key-metadata:
+          type: string
+          format: byte
+        split-offsets:
+          type: array
+          items:
+            type: integer
+            format: int64
+        equality-ids:
+          type: array
+          items:
+            type: integer
+        sort-order-id:
+          type: integer
 
 
   #############################


### PR DESCRIPTION
Let's split the REST API changes from the implementation, since there is some overlap with the rest scan API. We are now serializing DataFiles using the [ContentFileParser](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/ContentFileParser.java#L55) and passing them to the service. ContentFileParser requires passing additional information like the `Schema` and `PartitionSpec` of the table to successfully round trip the updates and apply them to a table. With this approach, the updates will follow this structure:

```
{
  "requirements": [
    {
      "type": "assert-table-uuid",
      "uuid": "b9903b7a-aac4-46d3-af55-953b88bebe67"
    }
  ],
  "updates": [
    {
      "action": "append-data-files",
      "added-data-files": [
        {
          "spec-id": 0,
          "content": "DATA",
          "file-path": "/path/to/data-a.parquet",
          "file-format": "PARQUET",
          "partition": {
            "1000": 0
          },
          "file-size-in-bytes": 10,
          "record-count": 2,
          "sort-order-id": 0
        }
      ],
      "schema": {
        "type": "struct",
        "schema-id": 0,
        "fields": [
          {
            "id": 1,
            "name": "id",
            "required": true,
            "type": "int"
          },
          {
            "id": 2,
            "name": "data",
            "required": true,
            "type": "string"
          }
        ]
      },
      "spec": {
        "spec-id": 0,
        "fields": [
          {
            "name": "id_bucket",
            "transform": "bucket[16]",
            "source-id": 1,
            "field-id": 1000
          }
        ]
      }
    }
  ]
}

```

Furthermore, this change includes the models for the [SIngleValueParser](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/SingleValueParser.java#L43) which is used to serialize the partition field of a DataFile.

These model changes are stemming from the conversation here: https://github.com/apache/iceberg/pull/9292

cc @jackye1995 @rdblue @danielcweeks @rahil-c

### Testing
OpenAPI: ran make install, make lint, make generate