### PR TITLE
Dynamically support Spark native engine in Iceberg

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowBatchReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowBatchReader.java
@@ -32,6 +32,10 @@ class ArrowBatchReader extends BaseBatchReader<ColumnarBatch> {
 
   ArrowBatchReader() {}
 
+  ArrowBatchReader(List<VectorizedReader<?>> readers) {
+    initialize(readers);
+  }
+
   @Override
   public void initialize(List<VectorizedReader<?>> readers) {
     this.readers =

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
@@ -376,16 +376,20 @@ public class ArrowReader extends CloseableGroup {
      */
     private static ArrowBatchReader buildReader(
         Schema expectedSchema, MessageType fileSchema, boolean setArrowValidityVector) {
+      VectorizedReaderBuilder vectorizedReaderBuilder = new VectorizedReaderBuilder();
+      vectorizedReaderBuilder.initialize(
+          expectedSchema,
+          fileSchema,
+          setArrowValidityVector,
+          ImmutableMap.of(),
+          readers -> {
+            ArrowBatchReader batchReader = new ArrowBatchReader();
+            batchReader.initialize(readers);
+            return batchReader;
+          });
       return (ArrowBatchReader)
           TypeWithSchemaVisitor.visit(
-              expectedSchema.asStruct(),
-              fileSchema,
-              new VectorizedReaderBuilder(
-                  expectedSchema,
-                  fileSchema,
-                  setArrowValidityVector,
-                  ImmutableMap.of(),
-                  ArrowBatchReader::new));
+              expectedSchema.asStruct(), fileSchema, vectorizedReaderBuilder);
     }
   }
 }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
@@ -376,20 +376,16 @@ public class ArrowReader extends CloseableGroup {
      */
     private static ArrowBatchReader buildReader(
         Schema expectedSchema, MessageType fileSchema, boolean setArrowValidityVector) {
-      VectorizedReaderBuilder vectorizedReaderBuilder = new VectorizedReaderBuilder();
-      vectorizedReaderBuilder.initialize(
-          expectedSchema,
-          fileSchema,
-          setArrowValidityVector,
-          ImmutableMap.of(),
-          readers -> {
-            ArrowBatchReader batchReader = new ArrowBatchReader();
-            batchReader.initialize(readers);
-            return batchReader;
-          });
       return (ArrowBatchReader)
           TypeWithSchemaVisitor.visit(
-              expectedSchema.asStruct(), fileSchema, vectorizedReaderBuilder);
+              expectedSchema.asStruct(),
+              fileSchema,
+              new VectorizedReaderBuilder(
+                  expectedSchema,
+                  fileSchema,
+                  setArrowValidityVector,
+                  ImmutableMap.of(),
+                  ArrowBatchReader::new));
     }
   }
 }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
@@ -40,15 +40,18 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 
+@SuppressWarnings({"VisibilityModifier", "checkstyle:HiddenField"})
 public class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedReader<?>> {
-  private final MessageType parquetSchema;
-  private final Schema icebergSchema;
-  private final BufferAllocator rootAllocator;
-  private final Map<Integer, ?> idToConstant;
-  private final boolean setArrowValidityVector;
-  private final Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory;
+  protected MessageType parquetSchema;
+  protected Schema icebergSchema;
+  protected BufferAllocator rootAllocator;
+  protected Map<Integer, ?> idToConstant;
+  protected boolean setArrowValidityVector;
+  protected Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory;
 
-  public VectorizedReaderBuilder(
+  public VectorizedReaderBuilder() {}
+
+  public void initialize(
       Schema expectedSchema,
       MessageType parquetSchema,
       boolean setArrowValidityVector,

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
@@ -51,6 +51,15 @@ public class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedRea
 
   public VectorizedReaderBuilder() {}
 
+  public VectorizedReaderBuilder(
+      Schema expectedSchema,
+      MessageType parquetSchema,
+      boolean setArrowValidityVector,
+      Map<Integer, ?> idToConstant,
+      Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory) {
+    initialize(expectedSchema, parquetSchema, setArrowValidityVector, idToConstant, readerFactory);
+  }
+
   public void initialize(
       Schema expectedSchema,
       MessageType parquetSchema,

--- a/parquet/src/main/java/org/apache/iceberg/parquet/BaseBatchReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/BaseBatchReader.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+/** A base BatchReader class that contains common functionality */
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public abstract class BaseBatchReader<T> implements VectorizedReader<T> {
+  protected VectorizedReader[] readers;
+
+  public BaseBatchReader() {}
+
+  public void initialize(List<VectorizedReader<?>> readerList) {}
+
+  @Override
+  public void setRowGroupInfo(
+      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData, long rowPosition) {
+    for (VectorizedReader reader : readers) {
+      if (reader != null) {
+        reader.setRowGroupInfo(pageStore, metaData, rowPosition);
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    for (VectorizedReader<?> reader : readers) {
+      if (reader != null) {
+        reader.close();
+      }
+    }
+  }
+
+  @Override
+  public void setBatchSize(int batchSize) {
+    for (VectorizedReader reader : readers) {
+      if (reader != null) {
+        reader.setBatchSize(batchSize);
+      }
+    }
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkConfParser.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkConfParser.java
@@ -50,6 +50,10 @@ class SparkConfParser {
     this.options = options;
   }
 
+  public RuntimeConfig getSessionConf() {
+    return sessionConf;
+  }
+
   public BooleanConfParser booleanConf() {
     return new BooleanConfParser();
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark;
 import static org.apache.iceberg.PlanningMode.LOCAL;
 
 import java.util.Map;
+import java.util.Properties;
 import org.apache.iceberg.PlanningMode;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -268,6 +269,38 @@ public class SparkReadConf {
         .sessionConf(SparkSQLProperties.PRESERVE_DATA_GROUPING)
         .defaultValue(SparkSQLProperties.PRESERVE_DATA_GROUPING_DEFAULT)
         .parse();
+  }
+
+  public String getCustomizedVectorizationImpl() {
+    return confParser
+        .stringConf()
+        .sessionConf(SparkSQLProperties.CUSTOMIZED_VECTORIZATION_IMPL)
+        .defaultValue("")
+        .parse();
+  }
+
+  public String getCustomizedVectorizationPropertyPrefix() {
+    return confParser
+        .stringConf()
+        .sessionConf(SparkSQLProperties.CUSTOMIZED_VECTORIZATION_PROPERTY_PREFIX)
+        .defaultValue("")
+        .parse();
+  }
+
+  public Properties getCustomizedVectorizationProperties() {
+    Properties properties = new Properties();
+
+    java.util.Map<String, String> map =
+        scala.collection.JavaConverters.mapAsJavaMapConverter(confParser.getSessionConf().getAll())
+            .asJava();
+
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      if (entry.getKey().contains(getCustomizedVectorizationPropertyPrefix())) {
+        properties.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    return properties;
   }
 
   public boolean aggregatePushDownEnabled() {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -27,6 +27,12 @@ public class SparkSQLProperties {
   // Controls whether vectorized reads are enabled
   public static final String VECTORIZATION_ENABLED = "spark.sql.iceberg.vectorization.enabled";
 
+  public static final String CUSTOMIZED_VECTORIZATION_IMPL =
+      "spark.sql.iceberg.customized.vectorization.impl";
+
+  public static final String CUSTOMIZED_VECTORIZATION_PROPERTY_PREFIX =
+      "spark.sql.iceberg.customized.vectorization.property.prefix";
+
   // Controls whether to perform the nullability check during writes
   public static final String CHECK_NULLABILITY = "spark.sql.iceberg.check-nullability";
   public static final boolean CHECK_NULLABILITY_DEFAULT = true;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/BaseColumnarBatchReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/BaseColumnarBatchReader.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data.vectorized;
+
+import java.util.List;
+import java.util.Properties;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.DeleteFilter;
+import org.apache.iceberg.parquet.BaseBatchReader;
+import org.apache.iceberg.parquet.VectorizedReader;
+import org.apache.spark.sql.catalyst.InternalRow;
+
+/** A base ColumnBatchReader class that contains common functionality */
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public abstract class BaseColumnarBatchReader<T> extends BaseBatchReader<T> {
+  protected boolean hasIsDeletedColumn;
+  protected DeleteFilter<InternalRow> deletes = null;
+  protected long rowStartPosInBatch = 0;
+
+  protected Schema schema;
+
+  public BaseColumnarBatchReader() {}
+
+  public void initialize(
+      List<VectorizedReader<?>> readers, Schema schema1, Properties properties) {}
+
+  public void setDeleteFilter(DeleteFilter<InternalRow> deleteFilter) {
+    this.deletes = deleteFilter;
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/SparkVectorizedReaderBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/SparkVectorizedReaderBuilder.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data.vectorized;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Function;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.arrow.ArrowAllocation;
+import org.apache.iceberg.arrow.vectorized.VectorizedReaderBuilder;
+import org.apache.iceberg.data.DeleteFilter;
+import org.apache.iceberg.parquet.VectorizedReader;
+import org.apache.parquet.schema.MessageType;
+import org.apache.spark.sql.catalyst.InternalRow;
+
+@SuppressWarnings({"VisibilityModifier", "checkstyle:HiddenField"})
+public class SparkVectorizedReaderBuilder extends VectorizedReaderBuilder {
+  protected DeleteFilter<InternalRow> deleteFilter;
+
+  public SparkVectorizedReaderBuilder() {}
+
+  public void initialize(
+      Schema expectedSchema,
+      MessageType parquetSchema,
+      boolean setArrowValidityVector,
+      Map<Integer, ?> idToConstant,
+      Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory,
+      DeleteFilter<InternalRow> deleteFilter,
+      Properties customizedVectorizationProperties) {
+    this.parquetSchema = parquetSchema;
+    this.icebergSchema = expectedSchema;
+    this.rootAllocator =
+        ArrowAllocation.rootAllocator()
+            .newChildAllocator("VectorizedReadBuilder", 0, Long.MAX_VALUE);
+    this.setArrowValidityVector = setArrowValidityVector;
+    this.idToConstant = idToConstant;
+    this.readerFactory = readerFactory;
+    this.deleteFilter = deleteFilter;
+  }
+
+  protected VectorizedReader<?> vectorizedReader(List<VectorizedReader<?>> reorderedFields) {
+    VectorizedReader<?> reader = readerFactory.apply(reorderedFields);
+    if (deleteFilter != null) {
+      ((ColumnarBatchReader) reader).setDeleteFilter(deleteFilter);
+    }
+    return reader;
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedUtil.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data.vectorized;
+
+import org.apache.iceberg.common.DynConstructors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class VectorizedUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(VectorizedUtil.class);
+
+  private VectorizedUtil() {}
+
+  public static SparkVectorizedReaderBuilder getSparkVectorizedReaderBuilder(String impl) {
+    LOG.info("Loading SparkVectorizedReaderBuilder implementation: {}", impl);
+    DynConstructors.Ctor<SparkVectorizedReaderBuilder> ctor;
+    try {
+      ctor =
+          DynConstructors.builder(SparkVectorizedReaderBuilder.class)
+              .loader(VectorizedUtil.class.getClassLoader())
+              .impl(impl)
+              .buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize SparkVectorizedReaderBuilder, missing no-arg constructor: %s",
+              impl),
+          e);
+    }
+
+    SparkVectorizedReaderBuilder vectorizedReaderBuilder;
+    try {
+      vectorizedReaderBuilder = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize SparkVectorizedReaderBuilder, %s does not implement SparkVectorizedReaderBuilder.",
+              impl),
+          e);
+    }
+
+    return vectorizedReaderBuilder;
+  }
+
+  public static BaseColumnarBatchReader getBaseColumnarBatchReader(String impl) {
+    LOG.info("Loading BaseColumnarBatchReader implementation: {}", impl);
+    DynConstructors.Ctor<BaseColumnarBatchReader> ctor;
+    try {
+      ctor =
+          DynConstructors.builder(BaseColumnarBatchReader.class)
+              .loader(VectorizedUtil.class.getClassLoader())
+              .impl(impl)
+              .buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize BaseColumnarBatchReader, missing no-arg constructor: %s", impl),
+          e);
+    }
+
+    BaseColumnarBatchReader baseColumnarBatchReader;
+    try {
+      baseColumnarBatchReader = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize BaseColumnarBatchReader, %s does not implement BaseColumnarBatchReader.",
+              impl),
+          e);
+    }
+
+    return baseColumnarBatchReader;
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.source;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Properties;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataColumns;
@@ -115,11 +116,14 @@ class SparkBatch implements Batch {
   public PartitionReaderFactory createReaderFactory() {
     if (useParquetBatchReads()) {
       int batchSize = readConf.parquetBatchSize();
-      return new SparkColumnarReaderFactory(batchSize);
+      return new SparkColumnarReaderFactory(
+          batchSize,
+          readConf.getCustomizedVectorizationImpl(),
+          readConf.getCustomizedVectorizationProperties());
 
     } else if (useOrcBatchReads()) {
       int batchSize = readConf.orcBatchSize();
-      return new SparkColumnarReaderFactory(batchSize);
+      return new SparkColumnarReaderFactory(batchSize, "", new Properties());
 
     } else {
       return new SparkRowReaderFactory();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -190,7 +191,12 @@ public class TestSparkParquetReadMetadataColumns {
     builder.createBatchedReaderFunc(
         fileSchema ->
             VectorizedSparkParquetReaders.buildReader(
-                PROJECTION_SCHEMA, fileSchema, Maps.newHashMap(), deleteFilter));
+                PROJECTION_SCHEMA,
+                fileSchema,
+                Maps.newHashMap(),
+                deleteFilter,
+                "",
+                new Properties()));
     builder.recordsPerBatch(RECORDS_PER_BATCH);
 
     validate(expectedRowsAfterDelete, builder);
@@ -266,7 +272,7 @@ public class TestSparkParquetReadMetadataColumns {
       builder.createBatchedReaderFunc(
           fileSchema ->
               VectorizedSparkParquetReaders.buildReader(
-                  PROJECTION_SCHEMA, fileSchema, Maps.newHashMap(), null));
+                  PROJECTION_SCHEMA, fileSchema, Maps.newHashMap(), null, "", new Properties()));
       builder.recordsPerBatch(RECORDS_PER_BATCH);
     } else {
       builder =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Properties;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
@@ -144,7 +145,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
             .createBatchedReaderFunc(
                 type ->
                     VectorizedSparkParquetReaders.buildReader(
-                        schema, type, Maps.newHashMap(), null));
+                        schema, type, Maps.newHashMap(), null, "", new Properties()));
     if (reuseContainers) {
       readBuilder.reuseContainers();
     }
@@ -207,7 +208,9 @@ public class TestParquetVectorizedReads extends AvroDataTest {
                     new MessageType(
                         "struct", new GroupType(Type.Repetition.OPTIONAL, "struct").withId(1)),
                     Maps.newHashMap(),
-                    null))
+                    null,
+                    "",
+                    new Properties()))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("Vectorized reads are not supported yet for struct fields");
   }


### PR DESCRIPTION
This PR is to introduce a dynamic plugin mechanism to support Spark native execution engines, e.g. [Comet](https://github.com/apache/arrow-datafusion-comet)

Currently in Iceberg, when vectorization is activated, Iceberg employs the `VectorizedReaderBuilder` to generate `VectorizedArrowReader` and `ColumnarBatchReader`, which are then used for batch reading. I propose to introduce a customized `VectorizedReaderBuilder` and a customized `ColumnarBatchReader`. At runtime, if the customized `VectorizedReaderBuilder` and `ColumnarBatchReader` are accessible, the system will leverage the native vectorized execution engines. In cases where these customized components are not available, Iceberg's standard `VectorizedReaderBuilder` and `ColumnarBatchReader` will be utilized for batch reading. 

A new `SparkSQLProperties.CUSTOMIZED_VECTORIZATION_IMPL` is added to specify the customized vectorization implementation.  If `CUSTOMIZED_VECTORIZATION_IMPL` is not set, the default iceberg `SparkVectorizedReaderBuilder` and `ColumnarBatchReader` are used for batch reading. If `VECTORIZATION_IMPL` is set, the customized `SparkVectorizedReaderBuilder` and `ColumnarBatchReader`are used for batch reading. In addition, a new `SparkSQLProperties.CUSTOMIZED_VECTORIZATION_PROPERTY_PREFIX` is added to specify the prefix of the customized vectorization property keys. Using Apache Comet as an example, 
```
 SparkSession spark =
   SparkSession.builder()
       .master("local[2]")
       .config(
           SparkSQLProperties.CUSTOMIZED_VECTORIZATION_IMPL,
           "org.apache.comet.Comet")
       // CometConfig keys start with ‘spark.comet’. For example,
       // CometConf.COMET_USE_DECIMAL_128.key is ‘spark.comet.use.decimal128’
       // CometConf.COMET_USE_LAZY_MATERIALIZATION’.key is 
       // ‘spark.comet.use.lazyMaterialization’
       // so we set SparkSQLProperties.CUSTOMIZED_VECTORIZATION_PROPERTY_PREFIX to
       // ‘spark.comet’
       .config(SparkSQLProperties.CUSTOMIZED_VECTORIZATION_PROPERTY_PREFIX, "spark.comet")
       .config(CometConf.COMET_USE_DECIMAL_128().key(), "true")
       .config(CometConf.COMET_USE_LAZY_MATERIALIZATION().key(), "true")
       .enableHiveSupport()
       .getOrCreate();
```
`A VectorizedUtil` class is added to dynamically load `SparkVectorizedReaderBuilder` and `BaseColumnarBatchReader`.

The customized `VectorizedReaderBuilder` and a customized `ColumnarBatchReader` need to be implemented in the native engine (e.g. Comet).
