### PR TITLE
Make InMemoryFileIO map shared access across instances

### DIFF
--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class InMemoryFileIO implements FileIO {
 
-  static final Map<String, byte[]> IN_MEMORY_FILES = Maps.newConcurrentMap();
+  private static final Map<String, byte[]> IN_MEMORY_FILES = Maps.newConcurrentMap();
   private boolean closed = false;
 
   public void addFile(String location, byte[] contents) {

--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
@@ -28,22 +28,22 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class InMemoryFileIO implements FileIO {
 
-  private static final Map<String, byte[]> inMemoryFiles = Maps.newConcurrentMap();
+  static final Map<String, byte[]> IN_MEMORY_FILES = Maps.newConcurrentMap();
   private boolean closed = false;
 
   public void addFile(String location, byte[] contents) {
     Preconditions.checkState(!closed, "Cannot call addFile after calling close()");
-    inMemoryFiles.put(location, contents);
+    IN_MEMORY_FILES.put(location, contents);
   }
 
   public boolean fileExists(String location) {
-    return inMemoryFiles.containsKey(location);
+    return IN_MEMORY_FILES.containsKey(location);
   }
 
   @Override
   public InputFile newInputFile(String location) {
     Preconditions.checkState(!closed, "Cannot call newInputFile after calling close()");
-    byte[] contents = inMemoryFiles.get(location);
+    byte[] contents = IN_MEMORY_FILES.get(location);
     if (null == contents) {
       throw new NotFoundException("No in-memory file found for location: %s", location);
     }
@@ -59,7 +59,7 @@ public class InMemoryFileIO implements FileIO {
   @Override
   public void deleteFile(String location) {
     Preconditions.checkState(!closed, "Cannot call deleteFile after calling close()");
-    if (null == inMemoryFiles.remove(location)) {
+    if (null == IN_MEMORY_FILES.remove(location)) {
       throw new NotFoundException("No in-memory file found for location: %s", location);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class InMemoryFileIO implements FileIO {
 
-  private final Map<String, byte[]> inMemoryFiles = Maps.newConcurrentMap();
+  private static final Map<String, byte[]> inMemoryFiles = Maps.newConcurrentMap();
   private boolean closed = false;
 
   public void addFile(String location, byte[] contents) {

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
@@ -32,7 +32,7 @@ public class TestInMemoryFileIO {
   @Test
   public void testBasicEndToEnd() throws IOException {
     InMemoryFileIO fileIO = new InMemoryFileIO();
-    String location = "s3://foo/" + UUID.randomUUID();
+    String location = getRandomLocation();
     Assertions.assertThat(fileIO.fileExists(location)).isFalse();
 
     OutputStream outputStream = fileIO.newOutputFile(location).create();
@@ -67,7 +67,7 @@ public class TestInMemoryFileIO {
 
   @Test
   public void testCreateNoOverwrite() {
-    String location = "s3://foo/" + UUID.randomUUID();
+    String location = getRandomLocation();
     InMemoryFileIO fileIO = new InMemoryFileIO();
     fileIO.addFile(location, "hello world".getBytes());
     Assertions.assertThatExceptionOfType(AlreadyExistsException.class)
@@ -76,7 +76,7 @@ public class TestInMemoryFileIO {
 
   @Test
   public void testOverwriteBeforeAndAfterClose() throws IOException {
-    String location = "s3://foo/" + UUID.randomUUID();
+    String location = getRandomLocation();
     byte[] oldData = "old data".getBytes();
     byte[] newData = "new data".getBytes();
 
@@ -114,11 +114,15 @@ public class TestInMemoryFileIO {
 
   @Test
   public void testFilesAreSharedAcrossMultipleInstances() {
-    String location = "s3://foo/" + UUID.randomUUID();
+    String location = getRandomLocation();
     InMemoryFileIO fileIO = new InMemoryFileIO();
     fileIO.addFile(location, "hello world".getBytes());
 
     InMemoryFileIO fileIO2 = new InMemoryFileIO();
     Assertions.assertThat(fileIO2.fileExists(location)).isTrue();
+  }
+
+  private String getRandomLocation() {
+    return "s3://foo/" + UUID.randomUUID();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.inmemory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.UUID;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.assertj.core.api.Assertions;
@@ -31,7 +32,7 @@ public class TestInMemoryFileIO {
   @Test
   public void testBasicEndToEnd() throws IOException {
     InMemoryFileIO fileIO = new InMemoryFileIO();
-    String location = "s3://foo/bar.txt";
+    String location = "s3://foo/" + UUID.randomUUID();
     Assertions.assertThat(fileIO.fileExists(location)).isFalse();
 
     OutputStream outputStream = fileIO.newOutputFile(location).create();
@@ -66,7 +67,7 @@ public class TestInMemoryFileIO {
 
   @Test
   public void testCreateNoOverwrite() {
-    String location = "s3://foo/bar/baz.txt";
+    String location = "s3://foo/" + UUID.randomUUID();
     InMemoryFileIO fileIO = new InMemoryFileIO();
     fileIO.addFile(location, "hello world".getBytes());
     Assertions.assertThatExceptionOfType(AlreadyExistsException.class)
@@ -75,9 +76,9 @@ public class TestInMemoryFileIO {
 
   @Test
   public void testOverwriteBeforeAndAfterClose() throws IOException {
+    String location = "s3://foo/" + UUID.randomUUID();
     byte[] oldData = "old data".getBytes();
     byte[] newData = "new data".getBytes();
-    String location = "s3://foo/bar/baz/qux.txt";
 
     InMemoryFileIO fileIO = new InMemoryFileIO();
     OutputStream outputStream = fileIO.newOutputFile(location).create();
@@ -113,11 +114,11 @@ public class TestInMemoryFileIO {
 
   @Test
   public void testFilesAreSharedAcrossMultipleInstances() {
-    String location = "s3://foo/shared.txt";
+    String location = "s3://foo/" + UUID.randomUUID();
     InMemoryFileIO fileIO = new InMemoryFileIO();
     fileIO.addFile(location, "hello world".getBytes());
 
     InMemoryFileIO fileIO2 = new InMemoryFileIO();
-    Assertions.assertThat(fileIO2.fileExists(location));
+    Assertions.assertThat(fileIO2.fileExists(location)).isTrue();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
@@ -27,11 +27,11 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestInMemoryFileIO {
-  String location = "s3://foo/bar.txt";
 
   @Test
   public void testBasicEndToEnd() throws IOException {
     InMemoryFileIO fileIO = new InMemoryFileIO();
+    String location = "s3://foo/bar.txt";
     Assertions.assertThat(fileIO.fileExists(location)).isFalse();
 
     OutputStream outputStream = fileIO.newOutputFile(location).create();
@@ -66,6 +66,7 @@ public class TestInMemoryFileIO {
 
   @Test
   public void testCreateNoOverwrite() {
+    String location = "s3://foo/bar/baz.txt";
     InMemoryFileIO fileIO = new InMemoryFileIO();
     fileIO.addFile(location, "hello world".getBytes());
     Assertions.assertThatExceptionOfType(AlreadyExistsException.class)
@@ -76,6 +77,7 @@ public class TestInMemoryFileIO {
   public void testOverwriteBeforeAndAfterClose() throws IOException {
     byte[] oldData = "old data".getBytes();
     byte[] newData = "new data".getBytes();
+    String location = "s3://foo/bar/baz/qux.txt";
 
     InMemoryFileIO fileIO = new InMemoryFileIO();
     OutputStream outputStream = fileIO.newOutputFile(location).create();
@@ -107,5 +109,15 @@ public class TestInMemoryFileIO {
     inputStream.read(buf);
     inputStream.close();
     Assertions.assertThat(new String(buf)).isEqualTo("new data");
+  }
+
+  @Test
+  public void testFilesAreSharedAcrossMultipleInstances() {
+    String location = "s3://foo/shared.txt";
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    fileIO.addFile(location, "hello world".getBytes());
+
+    InMemoryFileIO fileIO2 = new InMemoryFileIO();
+    Assertions.assertThat(fileIO2.fileExists(location));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
@@ -119,7 +119,9 @@ public class TestInMemoryFileIO {
     fileIO.addFile(location, "hello world".getBytes());
 
     InMemoryFileIO fileIO2 = new InMemoryFileIO();
-    Assertions.assertThat(fileIO2.fileExists(location)).isTrue();
+    Assertions.assertThat(fileIO2.fileExists(location))
+        .isTrue()
+        .as("Files should be shared across all InMemoryFileIO instances");
   }
 
   private String randomLocation() {

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
@@ -32,7 +32,7 @@ public class TestInMemoryFileIO {
   @Test
   public void testBasicEndToEnd() throws IOException {
     InMemoryFileIO fileIO = new InMemoryFileIO();
-    String location = getRandomLocation();
+    String location = randomLocation();
     Assertions.assertThat(fileIO.fileExists(location)).isFalse();
 
     OutputStream outputStream = fileIO.newOutputFile(location).create();
@@ -67,7 +67,7 @@ public class TestInMemoryFileIO {
 
   @Test
   public void testCreateNoOverwrite() {
-    String location = getRandomLocation();
+    String location = randomLocation();
     InMemoryFileIO fileIO = new InMemoryFileIO();
     fileIO.addFile(location, "hello world".getBytes());
     Assertions.assertThatExceptionOfType(AlreadyExistsException.class)
@@ -76,7 +76,7 @@ public class TestInMemoryFileIO {
 
   @Test
   public void testOverwriteBeforeAndAfterClose() throws IOException {
-    String location = getRandomLocation();
+    String location = randomLocation();
     byte[] oldData = "old data".getBytes();
     byte[] newData = "new data".getBytes();
 
@@ -114,7 +114,7 @@ public class TestInMemoryFileIO {
 
   @Test
   public void testFilesAreSharedAcrossMultipleInstances() {
-    String location = getRandomLocation();
+    String location = randomLocation();
     InMemoryFileIO fileIO = new InMemoryFileIO();
     fileIO.addFile(location, "hello world".getBytes());
 
@@ -122,7 +122,7 @@ public class TestInMemoryFileIO {
     Assertions.assertThat(fileIO2.fileExists(location)).isTrue();
   }
 
-  private String getRandomLocation() {
+  private String randomLocation() {
     return "s3://foo/" + UUID.randomUUID();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -180,7 +180,12 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     restCatalog.initialize(
         "prod",
         ImmutableMap.of(
-            CatalogProperties.URI, httpServer.getURI().toString(), "credential", "catalog:12345"));
+            CatalogProperties.URI,
+            httpServer.getURI().toString(),
+            CatalogProperties.FILE_IO_IMPL,
+            "org.apache.iceberg.inmemory.InMemoryFileIO",
+            "credential",
+            "catalog:12345"));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
This PR addresses the issue with InMemoryFileIO not being resolved by the RESTCatalog Tests identified in #9604.

In the RESTCatalog tests are backed by the `InMemoryCatalog` which uses `InMemoryFileIO`. But the `ResolvingFileIO` can't resolve this FileIO, and if we pass in the FileIO into the `RESTCatalog` there will be two instances of the `InMemoryFileIO`. Therefore, this change will ensure that there is shared access to the files across all the instances of the `InMemoryFileIO`. 


For more information: #9604 

## Testing

Running and setting a break point on this method:
* https://github.com/apache/iceberg/blob/50fb4004d299737fcbae6526e1743dd197c9242d/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java#L1386

### Before
#### InMemoryFileIO files 
<img width="1142" alt="Screenshot 2024-02-13 at 3 08 45 PM" src="https://github.com/apache/iceberg/assets/19402187/2c998db9-6046-4225-83bc-3546ae404013">


#### ResolvingFileIO files
<img width="1326" alt="Screenshot 2024-02-13 at 3 03 49 PM" src="https://github.com/apache/iceberg/assets/19402187/ce30ad09-2fb6-4727-97ff-37eebd40b3b6">


### After
<img width="1235" alt="Screenshot 2024-02-13 at 2 41 44 PM" src="https://github.com/apache/iceberg/assets/19402187/e53fd59d-4b37-4280-8398-4c2fa7ee21c6">


### Build

`./gradlew build`
```
BUILD SUCCESSFUL in 49m 38s
452 actionable tasks: 216 executed, 236 up-to-date
2:32:59 PM: Execution finished 'build'.
```

cc: @nastra @amogh-jahagirdar @jackye1995 