### PR TITLE
Core: Fix EncryptingFileIO factory method.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
@@ -35,9 +35,14 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 
 public class EncryptingFileIO implements FileIO, Serializable {
-  public static EncryptingFileIO create(FileIO io, EncryptionManager em) {
+  public static EncryptingFileIO combine(FileIO io, EncryptionManager em) {
     if (io instanceof EncryptingFileIO) {
-      return (EncryptingFileIO) io;
+      EncryptingFileIO encryptingIO = (EncryptingFileIO) io;
+      if (encryptingIO.em == em) {
+        return encryptingIO;
+      }
+
+      return combine(encryptingIO.io, em);
     }
 
     return new EncryptingFileIO(io, em);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -182,7 +182,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
   private Map<String, InputFile> inputFiles() {
     if (lazyInputFiles == null) {
       this.lazyInputFiles =
-          EncryptingFileIO.create(table().io(), table().encryption())
+          EncryptingFileIO.combine(table().io(), table().encryption())
               .bulkDecrypt(
                   () -> taskGroup.tasks().stream().flatMap(this::referencedFiles).iterator());
     }


### PR DESCRIPTION
This implements @RussellSpitzer's suggestion to make `EncryptingFileIO.create` more defensive.