### PR TITLE
Infra: Fix issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
@@ -20,7 +20,7 @@
 ---
 name: Iceberg Bug report 🐞
 description: Problems, bugs and issues with Apache Iceberg
-labels: ["kind:bug"]
+labels: ["bug"]
 body:
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/iceberg_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_improvement.yml
@@ -20,7 +20,7 @@
 ---
 name: Iceberg Improvement / Feature Request
 description: New features with Apache Iceberg
-labels: ["kind:feature request"]
+labels: ["improvement"]
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/iceberg_question.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_question.yml
@@ -20,7 +20,7 @@
 ---
 name: Iceberg Question
 description: Questions around Apache Iceberg
-labels: ["kind:question"]
+labels: ["question"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Currently, issues are not automatically labeled because the specified labels in the issue template don't exist.