### PR TITLE
Flink 1.18: Fix iceberg source plan parallelism not effective.

### DIFF
--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkReadConf.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/FlinkReadConf.java
@@ -178,6 +178,7 @@ public class FlinkReadConf {
   public int workerPoolSize() {
     return confParser
         .intConf()
+        .option(FlinkConfigOptions.TABLE_EXEC_ICEBERG_WORKER_POOL_SIZE.key())
         .flinkConfig(FlinkConfigOptions.TABLE_EXEC_ICEBERG_WORKER_POOL_SIZE)
         .defaultValue(FlinkConfigOptions.TABLE_EXEC_ICEBERG_WORKER_POOL_SIZE.defaultValue())
         .parse();


### PR DESCRIPTION
https://github.com/apache/iceberg/blob/66e957bd99ff8d11344efda4cb177c2d243eedaa/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java#L399-L404

In `IcebergSource`, we configure the plan parallelism into `readOptions` through the key `FlinkConfigOptions.TABLE_EXEC_ICEBERG_WORKER_POOL_SIZE`. 

However, since `FlinkReadConf.workerPoolSize()` does not parse the `readOptions` configuration based on this key, the parallelism configured through `IcebergSource.planParallelism` will not actually take effect.