### PR TITLE
Flink 1.18: Fix continuous enumerator lost enumeration history state when restore from checkpoint.

### DIFF
--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
@@ -83,6 +83,7 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
 
     if (enumState != null) {
       this.enumeratorPosition.set(enumState.lastEnumeratedPosition());
+      this.enumerationHistory.restore(enumState.enumerationSplitCountHistory());
     }
   }
 


### PR DESCRIPTION
`ContinuousIcebergEnumerator` ignore the enumeration history state when restore from checkpoint.