### PR TITLE
Flink: Flag Driven Dynamic Loading of Partition Spec From Table During Commits

### DIFF
--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -140,6 +140,7 @@ public class FlinkSink {
     private ReadableConfig readableConfig = new Configuration();
     private final Map<String, String> writeOptions = Maps.newHashMap();
     private FlinkWriteConf flinkWriteConf = null;
+    private boolean useDynamicSpecLoading = false;
 
     private Builder() {}
 
@@ -276,6 +277,11 @@ public class FlinkSink {
      */
     public Builder equalityFieldColumns(List<String> columns) {
       this.equalityFieldColumns = columns;
+      return this;
+    }
+
+    public Builder enableDynamicSpecLoading(boolean enable) {
+      this.useDynamicSpecLoading = enable;
       return this;
     }
 
@@ -434,7 +440,8 @@ public class FlinkSink {
               snapshotProperties,
               flinkWriteConf.workerPoolSize(),
               flinkWriteConf.branch(),
-              table.spec());
+              table.spec(),
+              useDynamicSpecLoading);
       SingleOutputStreamOperator<Void> committerStream =
           writerStream
               .transform(operatorName(ICEBERG_FILES_COMMITTER_NAME), Types.VOID, filesCommitter)


### PR DESCRIPTION
In Flink File Committer operator, partition spec is taken as input. While table is loaded regularly after each checkpoint, partition spec will never be updated unless the job is stopped and started again. This PR takes a flag to enable dynamic spec usage from table. If the flag is set, while writing manifest most updated spec from table will be used rather than the spec with which operator was instantiated. 