### PR TITLE
Docs: Fix listings on Release page / Update Multi-engine support

### DIFF
--- a/site/docs/multi-engine-support.md
+++ b/site/docs/multi-engine-support.md
@@ -67,6 +67,7 @@ Each engine version undergoes the following lifecycle stages:
 | 3.2        | Deprecated         | 0.13.0                  | {{ icebergVersion }} | [iceberg-spark-runtime-3.2_2.12](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/{{ icebergVersion }}/iceberg-spark-runtime-3.2_2.12-{{ icebergVersion }}.jar) |
 | 3.3        | Maintained         | 0.14.0                  | {{ icebergVersion }} | [iceberg-spark-runtime-3.3_2.12](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/{{ icebergVersion }}/iceberg-spark-runtime-3.3_2.12-{{ icebergVersion }}.jar) |
 | 3.4        | Maintained         | 1.3.0                   | {{ icebergVersion }} | [iceberg-spark-runtime-3.4_2.12](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.4_2.12/{{ icebergVersion }}/iceberg-spark-runtime-3.4_2.12-{{ icebergVersion }}.jar) |
+| 3.5        | Maintained         | 1.4.0                   | {{ icebergVersion }} | [iceberg-spark-runtime-3.5_2.12](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/{{ icebergVersion }}/iceberg-spark-runtime-3.5_2.12-{{ icebergVersion }}.jar) |
 
 * [1] Spark 3.1 shares the same runtime jar `iceberg-spark3-runtime` with Spark 3.0 before Iceberg 0.13.0
 

--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -87,7 +87,7 @@ The 1.4.2 patch release addresses fixing a remaining case where split offsets
 should be ignored when they are deemed invalid.
 
 * Core
-  - Core: Ignore split offsets array when split offset is past file length ([\#8925](https://github.com/apache/iceberg/pull/8925))
+    - Ignore split offsets array when split offset is past file length ([\#8925](https://github.com/apache/iceberg/pull/8925))
 
 ### 1.4.1 Release
 
@@ -95,12 +95,12 @@ Apache Iceberg 1.4.1 was released on October 23, 2023.
 The 1.4.1 release addresses various issues identified in the 1.4.0 release.
 
 * Core
-  - Core: Do not use a lazy split offset list in manifests ([\#8834](https://github.com/apache/iceberg/pull/8834))
-  - Core: Ignore split offsets when the last split offset is past the file length ([\#8860](https://github.com/apache/iceberg/pull/8860))
+    - Do not use a lazy split offset list in manifests ([\#8834](https://github.com/apache/iceberg/pull/8834))
+    - Ignore split offsets when the last split offset is past the file length ([\#8860](https://github.com/apache/iceberg/pull/8860))
 * AWS
-  - Avoid static global credentials provider which doesn't play well with lifecycle management ([\#8677](https://github.com/apache/iceberg/pull/8677))
+    - Avoid static global credentials provider which doesn't play well with lifecycle management ([\#8677](https://github.com/apache/iceberg/pull/8677))
 * Flink
-  - Reverting the default custom partitioner for bucket column ([\#8848](https://github.com/apache/iceberg/pull/8848))
+    - Reverting the default custom partitioner for bucket column ([\#8848](https://github.com/apache/iceberg/pull/8848))
 
 ### 1.4.0 release
 
@@ -108,96 +108,96 @@ Apache Iceberg 1.4.0 was released on October 4, 2023.
 The 1.4.0 release adds a variety of new features and bug fixes.
 
 * API
-  - Implement bound expression sanitization ([\#8149](https://github.com/apache/iceberg/pull/8149))
-  - Remove overflow checks in `DefaultCounter` causing performance issues ([\#8297](https://github.com/apache/iceberg/pull/8297))
-  - Support incremental scanning with branch ([\#5984](https://github.com/apache/iceberg/pull/5984))
-  - Add a validation API to `DeleteFiles` which validates files exist ([\#8525](https://github.com/apache/iceberg/pull/8525))
+    - Implement bound expression sanitization ([\#8149](https://github.com/apache/iceberg/pull/8149))
+    - Remove overflow checks in `DefaultCounter` causing performance issues ([\#8297](https://github.com/apache/iceberg/pull/8297))
+    - Support incremental scanning with branch ([\#5984](https://github.com/apache/iceberg/pull/5984))
+    - Add a validation API to `DeleteFiles` which validates files exist ([\#8525](https://github.com/apache/iceberg/pull/8525))
 * Core
-  - Use V2 format by default in new tables ([\#8381](https://github.com/apache/iceberg/pull/8381))
-  - Use `zstd` compression for Parquet by default in new tables ([\#8593](https://github.com/apache/iceberg/pull/8593))
-  - Add strict metadata cleanup mode and enable it by default ([\#8397](https://github.com/apache/iceberg/pull/8397)) ([\#8599](https://github.com/apache/iceberg/pull/8599))
-  - Avoid generating huge manifests during commits ([\#6335](https://github.com/apache/iceberg/pull/6335))
-  - Add a writer for unordered position deletes ([\#7692](https://github.com/apache/iceberg/pull/7692))
-  - Optimize `DeleteFileIndex` ([\#8157](https://github.com/apache/iceberg/pull/8157))
-  - Optimize lookup in `DeleteFileIndex` without useful bounds ([\#8278](https://github.com/apache/iceberg/pull/8278))
-  - Optimize split offsets handling ([\#8336](https://github.com/apache/iceberg/pull/8336))
-  - Optimize computing user-facing state in data tasks ([\#8346](https://github.com/apache/iceberg/pull/8346))
-  - Don't persist useless file and position bounds for deletes ([\#8360](https://github.com/apache/iceberg/pull/8360))
-  - Don't persist counts for paths and positions in position delete files ([\#8590](https://github.com/apache/iceberg/pull/8590))
-  - Support setting system-level properties via environmental variables ([\#5659](https://github.com/apache/iceberg/pull/5659))
-  - Add JSON parser for `ContentFile` and `FileScanTask` ([\#6934](https://github.com/apache/iceberg/pull/6934))
-  - Add REST spec and request for commits to multiple tables ([\#7741](https://github.com/apache/iceberg/pull/7741))
-  - Add REST API for committing changes against multiple tables ([\#7569](https://github.com/apache/iceberg/pull/7569))
-  - Default to exponential retry strategy in REST client ([\#8366](https://github.com/apache/iceberg/pull/8366))
-  - Support registering tables with REST session catalog ([\#6512](https://github.com/apache/iceberg/pull/6512))
-  - Add last updated timestamp and snapshot ID to partitions metadata table ([\#7581](https://github.com/apache/iceberg/pull/7581))
-  - Add total data size to partitions metadata table ([\#7920](https://github.com/apache/iceberg/pull/7920))
-  - Extend `ResolvingFileIO` to support bulk operations ([\#7976](https://github.com/apache/iceberg/pull/7976))
-  - Key metadata in Avro format ([\#6450](https://github.com/apache/iceberg/pull/6450))
-  - Add AES GCM encryption stream ([\#3231](https://github.com/apache/iceberg/pull/3231))
-  - Fix a connection leak in streaming delete filters ([\#8132](https://github.com/apache/iceberg/pull/8132))
-  - Fix lazy snapshot loading history ([\#8470](https://github.com/apache/iceberg/pull/8470))
-  - Fix unicode handling in HTTPClient ([\#8046](https://github.com/apache/iceberg/pull/8046))
-  - Fix paths for unpartitioned specs in writers ([\#7685](https://github.com/apache/iceberg/pull/7685))
-  - Fix OOM caused by Avro decoder caching ([\#7791](https://github.com/apache/iceberg/pull/7791))
+    - Use V2 format by default in new tables ([\#8381](https://github.com/apache/iceberg/pull/8381))
+    - Use `zstd` compression for Parquet by default in new tables ([\#8593](https://github.com/apache/iceberg/pull/8593))
+    - Add strict metadata cleanup mode and enable it by default ([\#8397](https://github.com/apache/iceberg/pull/8397)) ([\#8599](https://github.com/apache/iceberg/pull/8599))
+    - Avoid generating huge manifests during commits ([\#6335](https://github.com/apache/iceberg/pull/6335))
+    - Add a writer for unordered position deletes ([\#7692](https://github.com/apache/iceberg/pull/7692))
+    - Optimize `DeleteFileIndex` ([\#8157](https://github.com/apache/iceberg/pull/8157))
+    - Optimize lookup in `DeleteFileIndex` without useful bounds ([\#8278](https://github.com/apache/iceberg/pull/8278))
+    - Optimize split offsets handling ([\#8336](https://github.com/apache/iceberg/pull/8336))
+    - Optimize computing user-facing state in data tasks ([\#8346](https://github.com/apache/iceberg/pull/8346))
+    - Don't persist useless file and position bounds for deletes ([\#8360](https://github.com/apache/iceberg/pull/8360))
+    - Don't persist counts for paths and positions in position delete files ([\#8590](https://github.com/apache/iceberg/pull/8590))
+    - Support setting system-level properties via environmental variables ([\#5659](https://github.com/apache/iceberg/pull/5659))
+    - Add JSON parser for `ContentFile` and `FileScanTask` ([\#6934](https://github.com/apache/iceberg/pull/6934))
+    - Add REST spec and request for commits to multiple tables ([\#7741](https://github.com/apache/iceberg/pull/7741))
+    - Add REST API for committing changes against multiple tables ([\#7569](https://github.com/apache/iceberg/pull/7569))
+    - Default to exponential retry strategy in REST client ([\#8366](https://github.com/apache/iceberg/pull/8366))
+    - Support registering tables with REST session catalog ([\#6512](https://github.com/apache/iceberg/pull/6512))
+    - Add last updated timestamp and snapshot ID to partitions metadata table ([\#7581](https://github.com/apache/iceberg/pull/7581))
+    - Add total data size to partitions metadata table ([\#7920](https://github.com/apache/iceberg/pull/7920))
+    - Extend `ResolvingFileIO` to support bulk operations ([\#7976](https://github.com/apache/iceberg/pull/7976))
+    - Key metadata in Avro format ([\#6450](https://github.com/apache/iceberg/pull/6450))
+    - Add AES GCM encryption stream ([\#3231](https://github.com/apache/iceberg/pull/3231))
+    - Fix a connection leak in streaming delete filters ([\#8132](https://github.com/apache/iceberg/pull/8132))
+    - Fix lazy snapshot loading history ([\#8470](https://github.com/apache/iceberg/pull/8470))
+    - Fix unicode handling in HTTPClient ([\#8046](https://github.com/apache/iceberg/pull/8046))
+    - Fix paths for unpartitioned specs in writers ([\#7685](https://github.com/apache/iceberg/pull/7685))
+    - Fix OOM caused by Avro decoder caching ([\#7791](https://github.com/apache/iceberg/pull/7791))
 * Spark
-  - Added support for Spark 3.5
-    - Code for DELETE, UPDATE, and MERGE commands has moved to Spark, and all related extensions have been dropped from Iceberg.
-    - Support for WHEN NOT MATCHED BY SOURCE clause in MERGE.
-    - Column pruning in merge-on-read operations.
-    - Ability to request a bigger advisory partition size for the final write to produce well-sized output files without harming the job parallelism.
-  - Dropped support for Spark 3.1
-  - Deprecated support for Spark 3.2
-  - Support vectorized reads for merge-on-read operations in Spark 3.4 and 3.5 ([\#8466](https://github.com/apache/iceberg/pull/8466))
-  - Increase default advisory partition size for writes in Spark 3.5 ([\#8660](https://github.com/apache/iceberg/pull/8660))
-  - Support distributed planning in Spark 3.4 and 3.5 ([\#8123](https://github.com/apache/iceberg/pull/8123))
-  - Support pushing down system functions by V2 filters in Spark 3.4 and 3.5 ([\#7886](https://github.com/apache/iceberg/pull/7886))
-  - Support fanout position delta writers in Spark 3.4 and 3.5 ([\#7703](https://github.com/apache/iceberg/pull/7703))
-  - Use fanout writers for unsorted tables by default in Spark 3.5 ([\#8621](https://github.com/apache/iceberg/pull/8621))
-  - Support multiple shuffle partitions per file in compaction in Spark 3.4 and 3.5 ([\#7897](https://github.com/apache/iceberg/pull/7897))
-  - Output net changes across snapshots for carryover rows in CDC ([\#7326](https://github.com/apache/iceberg/pull/7326))
-  - Display read metrics on Spark SQL UI ([\#7447](https://github.com/apache/iceberg/pull/7447)) ([\#8445](https://github.com/apache/iceberg/pull/8445))
-  - Adjust split size to benefit from cluster parallelism in Spark 3.4 and 3.5 ([\#7714](https://github.com/apache/iceberg/pull/7714))
-  - Add `fast_forward` procedure ([\#8081](https://github.com/apache/iceberg/pull/8081))
-  - Support filters when rewriting position deletes ([\#7582](https://github.com/apache/iceberg/pull/7582))
-  - Support setting current snapshot with ref ([\#8163](https://github.com/apache/iceberg/pull/8163))
-  - Make backup table name configurable during migration ([\#8227](https://github.com/apache/iceberg/pull/8227))
-  - Add write and SQL options to override compression config ([\#8313](https://github.com/apache/iceberg/pull/8313))
-  - Correct partition transform functions to match the spec ([\#8192](https://github.com/apache/iceberg/pull/8192))
-  - Enable extra commit properties with metadata delete ([\#7649](https://github.com/apache/iceberg/pull/7649))
+    - Added support for Spark 3.5
+        - Code for DELETE, UPDATE, and MERGE commands has moved to Spark, and all related extensions have been dropped from Iceberg.
+        - Support for WHEN NOT MATCHED BY SOURCE clause in MERGE.
+        - Column pruning in merge-on-read operations.
+        - Ability to request a bigger advisory partition size for the final write to produce well-sized output files without harming the job parallelism.
+    - Dropped support for Spark 3.1
+    - Deprecated support for Spark 3.2
+    - Support vectorized reads for merge-on-read operations in Spark 3.4 and 3.5 ([\#8466](https://github.com/apache/iceberg/pull/8466))
+    - Increase default advisory partition size for writes in Spark 3.5 ([\#8660](https://github.com/apache/iceberg/pull/8660))
+    - Support distributed planning in Spark 3.4 and 3.5 ([\#8123](https://github.com/apache/iceberg/pull/8123))
+    - Support pushing down system functions by V2 filters in Spark 3.4 and 3.5 ([\#7886](https://github.com/apache/iceberg/pull/7886))
+    - Support fanout position delta writers in Spark 3.4 and 3.5 ([\#7703](https://github.com/apache/iceberg/pull/7703))
+    - Use fanout writers for unsorted tables by default in Spark 3.5 ([\#8621](https://github.com/apache/iceberg/pull/8621))
+    - Support multiple shuffle partitions per file in compaction in Spark 3.4 and 3.5 ([\#7897](https://github.com/apache/iceberg/pull/7897))
+    - Output net changes across snapshots for carryover rows in CDC ([\#7326](https://github.com/apache/iceberg/pull/7326))
+    - Display read metrics on Spark SQL UI ([\#7447](https://github.com/apache/iceberg/pull/7447)) ([\#8445](https://github.com/apache/iceberg/pull/8445))
+    - Adjust split size to benefit from cluster parallelism in Spark 3.4 and 3.5 ([\#7714](https://github.com/apache/iceberg/pull/7714))
+    - Add `fast_forward` procedure ([\#8081](https://github.com/apache/iceberg/pull/8081))
+    - Support filters when rewriting position deletes ([\#7582](https://github.com/apache/iceberg/pull/7582))
+    - Support setting current snapshot with ref ([\#8163](https://github.com/apache/iceberg/pull/8163))
+    - Make backup table name configurable during migration ([\#8227](https://github.com/apache/iceberg/pull/8227))
+    - Add write and SQL options to override compression config ([\#8313](https://github.com/apache/iceberg/pull/8313))
+    - Correct partition transform functions to match the spec ([\#8192](https://github.com/apache/iceberg/pull/8192))
+    - Enable extra commit properties with metadata delete ([\#7649](https://github.com/apache/iceberg/pull/7649))
 * Flink
-  - Add possibility of ordering the splits based on the file sequence number ([\#7661](https://github.com/apache/iceberg/pull/7661))
-  - Fix serialization in `TableSink` with anonymous object ([\#7866](https://github.com/apache/iceberg/pull/7866))
-  - Switch to `FileScanTaskParser` for JSON serialization of `IcebergSourceSplit` ([\#7978](https://github.com/apache/iceberg/pull/7978))
-  - Custom partitioner for bucket partitions ([\#7161](https://github.com/apache/iceberg/pull/7161))
-  - Implement data statistics coordinator to aggregate data statistics from operator subtasks ([\#7360](https://github.com/apache/iceberg/pull/7360))
-  - Support alter table column ([\#7628](https://github.com/apache/iceberg/pull/7628))
+    - Add possibility of ordering the splits based on the file sequence number ([\#7661](https://github.com/apache/iceberg/pull/7661))
+    - Fix serialization in `TableSink` with anonymous object ([\#7866](https://github.com/apache/iceberg/pull/7866))
+    - Switch to `FileScanTaskParser` for JSON serialization of `IcebergSourceSplit` ([\#7978](https://github.com/apache/iceberg/pull/7978))
+    - Custom partitioner for bucket partitions ([\#7161](https://github.com/apache/iceberg/pull/7161))
+    - Implement data statistics coordinator to aggregate data statistics from operator subtasks ([\#7360](https://github.com/apache/iceberg/pull/7360))
+    - Support alter table column ([\#7628](https://github.com/apache/iceberg/pull/7628))
 * Parquet
-  - Add encryption config to read and write builders ([\#2639](https://github.com/apache/iceberg/pull/2639))
-  - Skip writing bloom filters for deletes ([\#7617](https://github.com/apache/iceberg/pull/7617))
-  - Cache codecs by name and level ([\#8182](https://github.com/apache/iceberg/pull/8182))
-  - Fix decimal data reading from `ParquetAvroValueReaders` ([\#8246](https://github.com/apache/iceberg/pull/8246))
-  - Handle filters with transforms by assuming data must be scanned ([\#8243](https://github.com/apache/iceberg/pull/8243))
+    - Add encryption config to read and write builders ([\#2639](https://github.com/apache/iceberg/pull/2639))
+    - Skip writing bloom filters for deletes ([\#7617](https://github.com/apache/iceberg/pull/7617))
+    - Cache codecs by name and level ([\#8182](https://github.com/apache/iceberg/pull/8182))
+    - Fix decimal data reading from `ParquetAvroValueReaders` ([\#8246](https://github.com/apache/iceberg/pull/8246))
+    - Handle filters with transforms by assuming data must be scanned ([\#8243](https://github.com/apache/iceberg/pull/8243))
 * ORC
-  - Handle filters with transforms by assuming the filter matches ([\#8244](https://github.com/apache/iceberg/pull/8244))
+    - Handle filters with transforms by assuming the filter matches ([\#8244](https://github.com/apache/iceberg/pull/8244))
 * Vendor Integrations 
-  - GCP: Fix single byte read in `GCSInputStream` ([\#8071](https://github.com/apache/iceberg/pull/8071))
-  - GCP: Add properties for OAtuh2 and update library ([\#8073](https://github.com/apache/iceberg/pull/8073))
-  - GCP: Add prefix and bulk operations to `GCSFileIO` ([\#8168](https://github.com/apache/iceberg/pull/8168))
-  - GCP: Add bundle jar for GCP-related dependencies ([\#8231](https://github.com/apache/iceberg/pull/8231))
-  - GCP: Add range reads to `GCSInputStream` ([\#8301](https://github.com/apache/iceberg/pull/8301))
-  - AWS: Add bundle jar for AWS-related dependencies ([\#8261](https://github.com/apache/iceberg/pull/8261))
-  - AWS: support config storage class for `S3FileIO` ([\#8154](https://github.com/apache/iceberg/pull/8154))
-  - AWS: Add `FileIO` tracker/closer to Glue catalog ([\#8315](https://github.com/apache/iceberg/pull/8315))
-  - AWS: Update S3 signer spec to allow an optional string body in `S3SignRequest` ([\#8361](https://github.com/apache/iceberg/pull/8361))
-  - Azure: Add `FileIO` that supports ADLSv2 storage ([\#8303](https://github.com/apache/iceberg/pull/8303))
-  - Azure: Make `ADLSFileIO` implement `DelegateFileIO` ([\#8563](https://github.com/apache/iceberg/pull/8563))
-  - Nessie: Provide better commit message on table registration ([\#8385](https://github.com/apache/iceberg/pull/8385))
+    - GCP: Fix single byte read in `GCSInputStream` ([\#8071](https://github.com/apache/iceberg/pull/8071))
+    - GCP: Add properties for OAtuh2 and update library ([\#8073](https://github.com/apache/iceberg/pull/8073))
+    - GCP: Add prefix and bulk operations to `GCSFileIO` ([\#8168](https://github.com/apache/iceberg/pull/8168))
+    - GCP: Add bundle jar for GCP-related dependencies ([\#8231](https://github.com/apache/iceberg/pull/8231))
+    - GCP: Add range reads to `GCSInputStream` ([\#8301](https://github.com/apache/iceberg/pull/8301))
+    - AWS: Add bundle jar for AWS-related dependencies ([\#8261](https://github.com/apache/iceberg/pull/8261))
+    - AWS: support config storage class for `S3FileIO` ([\#8154](https://github.com/apache/iceberg/pull/8154))
+    - AWS: Add `FileIO` tracker/closer to Glue catalog ([\#8315](https://github.com/apache/iceberg/pull/8315))
+    - AWS: Update S3 signer spec to allow an optional string body in `S3SignRequest` ([\#8361](https://github.com/apache/iceberg/pull/8361))
+    - Azure: Add `FileIO` that supports ADLSv2 storage ([\#8303](https://github.com/apache/iceberg/pull/8303))
+    - Azure: Make `ADLSFileIO` implement `DelegateFileIO` ([\#8563](https://github.com/apache/iceberg/pull/8563))
+    - Nessie: Provide better commit message on table registration ([\#8385](https://github.com/apache/iceberg/pull/8385))
 * Dependencies
-  - Bump Nessie to 0.71.0
-  - Bump ORC to 1.9.1
-  - Bump Arrow to 12.0.1
-  - Bump AWS Java SDK to 2.20.131
+    - Bump Nessie to 0.71.0
+    - Bump ORC to 1.9.1
+    - Bump Arrow to 12.0.1
+    - Bump AWS Java SDK to 2.20.131
 
 
 ### 1.3.1 release
@@ -206,15 +206,15 @@ Apache Iceberg 1.3.1 was released on July 25, 2023.
 The 1.3.1 release addresses various issues identified in the 1.3.0 release.
 
 * Core
-  - Table Metadata parser now accepts null for fields: current-snapshot-id, properties, and snapshots ([\#8064](https://github.com/apache/iceberg/pull/8064))
+    - Table Metadata parser now accepts null for fields: current-snapshot-id, properties, and snapshots ([\#8064](https://github.com/apache/iceberg/pull/8064))
 * Hive
-  - Fix HiveCatalog deleting metadata on failures in checking lock status ([\#7931](https://github.com/apache/iceberg/pull/7931))
+    - Fix HiveCatalog deleting metadata on failures in checking lock status ([\#7931](https://github.com/apache/iceberg/pull/7931))
 * Spark
-  - Fix RewritePositionDeleteFiles failure for certain partition types ([\#8059](https://github.com/apache/iceberg/pull/8059))
-  - Fix RewriteDataFiles concurrency edge-case on commit timeouts ([\#7933](https://github.com/apache/iceberg/pull/7933))
-  - Fix partition-level DELETE operations for WAP branches ([\#7900](https://github.com/apache/iceberg/pull/7900))
+    - Fix RewritePositionDeleteFiles failure for certain partition types ([\#8059](https://github.com/apache/iceberg/pull/8059))
+    - Fix RewriteDataFiles concurrency edge-case on commit timeouts ([\#7933](https://github.com/apache/iceberg/pull/7933))
+    - Fix partition-level DELETE operations for WAP branches ([\#7900](https://github.com/apache/iceberg/pull/7900))
 * Flink
-  - FlinkCatalog creation no longer creates the default database ([\#8039](https://github.com/apache/iceberg/pull/8039))
+    - FlinkCatalog creation no longer creates the default database ([\#8039](https://github.com/apache/iceberg/pull/8039))
 
 ### 1.3.0 release
 
@@ -222,50 +222,50 @@ Apache Iceberg 1.3.0 was released on May 30th, 2023.
 The 1.3.0 release adds a variety of new features and bug fixes.
 
 * Core
-  - Expose file and data sequence numbers in ContentFile ([\#7555](https://github.com/apache/iceberg/pull/7555))
-  - Improve bit density in object storage layout ([\#7128](https://github.com/apache/iceberg/pull/7128))
-  - Store split offsets for delete files ([\#7011](https://github.com/apache/iceberg/pull/7011))
-  - Readable metrics in entries metadata table ([\#7539](https://github.com/apache/iceberg/pull/7539))
-  - Delete file stats in partitions metadata table ([\#6661](https://github.com/apache/iceberg/pull/6661))
-  - Optimized vectorized reads for Parquet Decimal ([\#3249](https://github.com/apache/iceberg/pull/3249))
-  - Vectorized reads for Parquet INT96 timestamps in imported data ([\#6962](https://github.com/apache/iceberg/pull/6962))
-  - Support selected vector with ORC row and batch readers ([\#7197](https://github.com/apache/iceberg/pull/7197))
-  - Clean up expired metastore clients ([\#7310](https://github.com/apache/iceberg/pull/7310))
-  - Support for deleting old partition spec columns in V1 tables ([\#7398](https://github.com/apache/iceberg/pull/7398))
+    - Expose file and data sequence numbers in ContentFile ([\#7555](https://github.com/apache/iceberg/pull/7555))
+    - Improve bit density in object storage layout ([\#7128](https://github.com/apache/iceberg/pull/7128))
+    - Store split offsets for delete files ([\#7011](https://github.com/apache/iceberg/pull/7011))
+    - Readable metrics in entries metadata table ([\#7539](https://github.com/apache/iceberg/pull/7539))
+    - Delete file stats in partitions metadata table ([\#6661](https://github.com/apache/iceberg/pull/6661))
+    - Optimized vectorized reads for Parquet Decimal ([\#3249](https://github.com/apache/iceberg/pull/3249))
+    - Vectorized reads for Parquet INT96 timestamps in imported data ([\#6962](https://github.com/apache/iceberg/pull/6962))
+    - Support selected vector with ORC row and batch readers ([\#7197](https://github.com/apache/iceberg/pull/7197))
+    - Clean up expired metastore clients ([\#7310](https://github.com/apache/iceberg/pull/7310))
+    - Support for deleting old partition spec columns in V1 tables ([\#7398](https://github.com/apache/iceberg/pull/7398))
 * Spark
-  - Initial support for Spark 3.4
-  - Removed integration for Spark 2.4
-  - Support for storage-partitioned joins with mismatching keys in Spark 3.4 (MERGE commands) ([\#7424](https://github.com/apache/iceberg/pull/7424))
-  - Support for TimestampNTZ in Spark 3.4 ([\#7553](https://github.com/apache/iceberg/pull/7553))
-  - Ability to handle skew during writes in Spark 3.4 ([\#7520](https://github.com/apache/iceberg/pull/7520))
-  - Ability to coalesce small tasks during writes in Spark 3.4 ([\#7532](https://github.com/apache/iceberg/pull/7532))
-  - Distribution and ordering enhancements in Spark 3.4 ([\#7637](https://github.com/apache/iceberg/pull/7637))
-  - Action for rewriting position deletes ([\#7389](https://github.com/apache/iceberg/pull/7389))
-  - Procedure for rewriting position deletes ([\#7572](https://github.com/apache/iceberg/pull/7572))
-  - Avoid local sort for MERGE cardinality check ([\#7558](https://github.com/apache/iceberg/pull/7558))
-  - Support for rate limits in Structured Streaming ([\#4479](https://github.com/apache/iceberg/pull/4479))
-  - Read and write support for UUIDs ([\#7399](https://github.com/apache/iceberg/pull/7399))
-  - Concurrent compaction is enabled by default ([\#6907](https://github.com/apache/iceberg/pull/6907))
-  - Support for metadata columns in changelog tables ([\#7152](https://github.com/apache/iceberg/pull/7152))
-  - Add file group failure info for data compaction ([\#7361](https://github.com/apache/iceberg/pull/7361))
+    - Initial support for Spark 3.4
+    - Removed integration for Spark 2.4
+    - Support for storage-partitioned joins with mismatching keys in Spark 3.4 (MERGE commands) ([\#7424](https://github.com/apache/iceberg/pull/7424))
+    - Support for TimestampNTZ in Spark 3.4 ([\#7553](https://github.com/apache/iceberg/pull/7553))
+    - Ability to handle skew during writes in Spark 3.4 ([\#7520](https://github.com/apache/iceberg/pull/7520))
+    - Ability to coalesce small tasks during writes in Spark 3.4 ([\#7532](https://github.com/apache/iceberg/pull/7532))
+    - Distribution and ordering enhancements in Spark 3.4 ([\#7637](https://github.com/apache/iceberg/pull/7637))
+    - Action for rewriting position deletes ([\#7389](https://github.com/apache/iceberg/pull/7389))
+    - Procedure for rewriting position deletes ([\#7572](https://github.com/apache/iceberg/pull/7572))
+    - Avoid local sort for MERGE cardinality check ([\#7558](https://github.com/apache/iceberg/pull/7558))
+    - Support for rate limits in Structured Streaming ([\#4479](https://github.com/apache/iceberg/pull/4479))
+    - Read and write support for UUIDs ([\#7399](https://github.com/apache/iceberg/pull/7399))
+    - Concurrent compaction is enabled by default ([\#6907](https://github.com/apache/iceberg/pull/6907))
+    - Support for metadata columns in changelog tables ([\#7152](https://github.com/apache/iceberg/pull/7152))
+    - Add file group failure info for data compaction ([\#7361](https://github.com/apache/iceberg/pull/7361))
 * Flink
-  - Initial support for Flink 1.17
-  - Removed integration for Flink 1.14
-  - Data statistics operator to collect traffic distribution for guiding smart shuffling ([\#6382](https://github.com/apache/iceberg/pull/6382))
-  - Data statistics operator sends local data statistics to coordinator and receives aggregated data statistics from coordinator for smart shuffling ([\#7269](https://github.com/apache/iceberg/pull/7269))
-  - Exposed write parallelism in SQL hints ([\#7039](https://github.com/apache/iceberg/pull/7039))
-  - Row-level filtering ([\#7109](https://github.com/apache/iceberg/pull/7109))
-  - Use starting sequence number by default when rewriting data files ([\#7218](https://github.com/apache/iceberg/pull/7218))
-  - Config for max allowed consecutive planning failures in IcebergSource before failing the job ([\#7571](https://github.com/apache/iceberg/pull/7571))
+    - Initial support for Flink 1.17
+    - Removed integration for Flink 1.14
+    - Data statistics operator to collect traffic distribution for guiding smart shuffling ([\#6382](https://github.com/apache/iceberg/pull/6382))
+    - Data statistics operator sends local data statistics to coordinator and receives aggregated data statistics from coordinator for smart shuffling ([\#7269](https://github.com/apache/iceberg/pull/7269))
+    - Exposed write parallelism in SQL hints ([\#7039](https://github.com/apache/iceberg/pull/7039))
+    - Row-level filtering ([\#7109](https://github.com/apache/iceberg/pull/7109))
+    - Use starting sequence number by default when rewriting data files ([\#7218](https://github.com/apache/iceberg/pull/7218))
+    - Config for max allowed consecutive planning failures in IcebergSource before failing the job ([\#7571](https://github.com/apache/iceberg/pull/7571))
 * Vendor Integrations
-  - AWS: Use Apache HTTP client as default AWS HTTP client ([\#7119](https://github.com/apache/iceberg/pull/7119))
-  - AWS: Prevent token refresh scheduling on every sign request ([\#7270](https://github.com/apache/iceberg/pull/7270))
-  - AWS: Disable local credentials if remote signing is enabled ([\#7230](https://github.com/apache/iceberg/pull/7230))
+    - AWS: Use Apache HTTP client as default AWS HTTP client ([\#7119](https://github.com/apache/iceberg/pull/7119))
+    - AWS: Prevent token refresh scheduling on every sign request ([\#7270](https://github.com/apache/iceberg/pull/7270))
+    - AWS: Disable local credentials if remote signing is enabled ([\#7230](https://github.com/apache/iceberg/pull/7230))
 * Dependencies
-  - Bump Arrow to 12.0.0
-  - Bump ORC to 1.8.3
-  - Bump Parquet to 1.13.1
-  - Bump Nessie to 0.59.0
+    - Bump Arrow to 12.0.0
+    - Bump ORC to 1.8.3
+    - Bump Parquet to 1.13.1
+    - Bump Nessie to 0.59.0
 
 ### 1.2.1 release
 
@@ -274,17 +274,17 @@ The 1.2.1 release is a patch release to address various issues identified in the
 Here is an overview:
 
 * CORE
-  - REST: fix previous locations for refs-only load [\#7284](https://github.com/apache/iceberg/pull/7284)
-  - Parse snapshot-id as long in remove-statistics update [\#7235](https://github.com/apache/iceberg/pull/7235)
+    - REST: fix previous locations for refs-only load [\#7284](https://github.com/apache/iceberg/pull/7284)
+    - Parse snapshot-id as long in remove-statistics update [\#7235](https://github.com/apache/iceberg/pull/7235)
 * Spark
-  - Broadcast table instead of file IO in rewrite manifests [\#7263](https://github.com/apache/iceberg/pull/7263)
-  - Revert "Spark: Add "Iceberg" prefix to SparkTable name string for SparkUI [\#7273](https://github.com/apache/iceberg/pull/7273)
+    - Broadcast table instead of file IO in rewrite manifests [\#7263](https://github.com/apache/iceberg/pull/7263)
+    - Revert "Spark: Add "Iceberg" prefix to SparkTable name string for SparkUI [\#7273](https://github.com/apache/iceberg/pull/7273)
 * AWS
-  - Make AuthSession cache static [\#7289](https://github.com/apache/iceberg/pull/7289)
-  - Abort S3 input stream on close if not EOS [\#7262](https://github.com/apache/iceberg/pull/7262)
-  - Disable local credentials if remote signing is enabled [\#7230](https://github.com/apache/iceberg/pull/7230)
-  - Prevent token refresh scheduling on every sign request [\#7270](https://github.com/apache/iceberg/pull/7270)
-  - S3 Credentials provider support in DefaultAwsClientFactory [\#7066](https://github.com/apache/iceberg/pull/7066)
+    - Make AuthSession cache static [\#7289](https://github.com/apache/iceberg/pull/7289)
+    - Abort S3 input stream on close if not EOS [\#7262](https://github.com/apache/iceberg/pull/7262)
+    - Disable local credentials if remote signing is enabled [\#7230](https://github.com/apache/iceberg/pull/7230)
+    - Prevent token refresh scheduling on every sign request [\#7270](https://github.com/apache/iceberg/pull/7270)
+    - S3 Credentials provider support in DefaultAwsClientFactory [\#7066](https://github.com/apache/iceberg/pull/7066)
 
 ### 1.2.0 release
 
@@ -293,57 +293,57 @@ The 1.2.0 release adds a variety of new features and bug fixes.
 Here is an overview:
 
 * Core
-  - Added AES GCM encrpytion stream spec ([\#5432](https://github.com/apache/iceberg/pull/5432))
-  - Added support for Delta Lake to Iceberg table conversion ([\#6449](https://github.com/apache/iceberg/pull/6449), [\#6880](https://github.com/apache/iceberg/pull/6880))
-  - Added support for `position_deletes` metadata table ([\#6365](https://github.com/apache/iceberg/pull/6365), [\#6716](https://github.com/apache/iceberg/pull/6716))
-  - Added support for scan and commit metrics reporter that is pluggable through catalog ([\#6404](https://github.com/apache/iceberg/pull/6404), [\#6246](https://github.com/apache/iceberg/pull/6246), [\#6410](https://github.com/apache/iceberg/pull/6410)) 
-  - Added support for branch commit for all operations ([\#4926](https://github.com/apache/iceberg/pull/4926), [\#5010](https://github.com/apache/iceberg/pull/5010))
-  - Added `FileIO` support for ORC readers and writers ([\#6293](https://github.com/apache/iceberg/pull/6293))
-  - Updated all actions to leverage bulk delete whenever possible ([\#6682](https://github.com/apache/iceberg/pull/6682))
-  - Updated snapshot ID definition in Puffin spec to support statistics file reuse ([\#6272](https://github.com/apache/iceberg/pull/6267))
-  - Added human-readable metrics information in `files` metadata table ([\#5376](https://github.com/apache/iceberg/pull/5376))
-  - Fixed incorrect Parquet row group skipping when min and max values are `NaN` ([\#6517](https://github.com/apache/iceberg/pull/6517))
-  - Fixed a bug that location provider could generate paths with double slash (`//`) which is not compatible in a Hadoop file system ([\#6777](https://github.com/apache/iceberg/pull/6777))
-  - Fixed metadata table time travel failure for tables that performed schema evolution ([\#6980](https://github.com/apache/iceberg/pull/6980))
+    - Added AES GCM encrpytion stream spec ([\#5432](https://github.com/apache/iceberg/pull/5432))
+    - Added support for Delta Lake to Iceberg table conversion ([\#6449](https://github.com/apache/iceberg/pull/6449), [\#6880](https://github.com/apache/iceberg/pull/6880))
+    - Added support for `position_deletes` metadata table ([\#6365](https://github.com/apache/iceberg/pull/6365), [\#6716](https://github.com/apache/iceberg/pull/6716))
+    - Added support for scan and commit metrics reporter that is pluggable through catalog ([\#6404](https://github.com/apache/iceberg/pull/6404), [\#6246](https://github.com/apache/iceberg/pull/6246), [\#6410](https://github.com/apache/iceberg/pull/6410)) 
+    - Added support for branch commit for all operations ([\#4926](https://github.com/apache/iceberg/pull/4926), [\#5010](https://github.com/apache/iceberg/pull/5010))
+    - Added `FileIO` support for ORC readers and writers ([\#6293](https://github.com/apache/iceberg/pull/6293))
+    - Updated all actions to leverage bulk delete whenever possible ([\#6682](https://github.com/apache/iceberg/pull/6682))
+    - Updated snapshot ID definition in Puffin spec to support statistics file reuse ([\#6272](https://github.com/apache/iceberg/pull/6267))
+    - Added human-readable metrics information in `files` metadata table ([\#5376](https://github.com/apache/iceberg/pull/5376))
+    - Fixed incorrect Parquet row group skipping when min and max values are `NaN` ([\#6517](https://github.com/apache/iceberg/pull/6517))
+    - Fixed a bug that location provider could generate paths with double slash (`//`) which is not compatible in a Hadoop file system ([\#6777](https://github.com/apache/iceberg/pull/6777))
+    - Fixed metadata table time travel failure for tables that performed schema evolution ([\#6980](https://github.com/apache/iceberg/pull/6980))
 * Spark
-  - Added time range query support for changelog table ([\#6350](https://github.com/apache/iceberg/pull/6350))
-  - Added changelog view procedure for v1 table ([\#6012](https://github.com/apache/iceberg/pull/6012))
-  - Added support for storage partition joins to improve read and write performance ([\#6371](https://github.com/apache/iceberg/pull/6371))
-  - Updated default Arrow environment settings to improve read performance ([\#6550](https://github.com/apache/iceberg/pull/6550))
-  - Added aggregate pushdown support for `min`, `max` and `count` to improve read performance ([\#6622](https://github.com/apache/iceberg/pull/6622))
-  - Updated default distribution mode settings to improve write performance ([\#6828](https://github.com/apache/iceberg/pull/6828), [\#6838](https://github.com/apache/iceberg/pull/6838))
-  - Updated DELETE to perform metadata-only update whenever possible to improve write performance ([\#6899](https://github.com/apache/iceberg/pull/6899))
-  - Improved predicate pushdown support for write operations ([\#6636](https://github.com/apache/iceberg/pull/6633))
-  - Added support for reading a branch or tag through table identifier and `VERSION AS OF` (a.k.a. `FOR SYSTEM_VERSION AS OF`) SQL syntax ([\#6717](https://github.com/apache/iceberg/pull/6717), [\#6575](https://github.com/apache/iceberg/pull/6575))
-  - Added support for writing to a branch through identifier or through write-audit-publish (WAP) workflow settings ([\#6965](https://github.com/apache/iceberg/pull/6965), [\#7050](https://github.com/apache/iceberg/pull/7050))
-  - Added DDL SQL extensions to create, replace and drop a branch or tag ([\#6638](https://github.com/apache/iceberg/pull/6638), [\#6637](https://github.com/apache/iceberg/pull/6637), [\#6752](https://github.com/apache/iceberg/pull/6752), [\#6807](https://github.com/apache/iceberg/pull/6807))
-  - Added UDFs for `years`, `months`, `days` and `hours` transforms ([\#6207](https://github.com/apache/iceberg/pull/6207), [\#6261](https://github.com/apache/iceberg/pull/6261), [\#6300](https://github.com/apache/iceberg/pull/6300), [\#6339](https://github.com/apache/iceberg/pull/6339))
-  - Added partition related stats for `add_files` procedure result ([\#6797](https://github.com/apache/iceberg/pull/6797))
-  - Fixed a bug that `rewrite_manifests` procedure produced a new manifest even when there was no rewrite performed ([\#6659](https://github.com/apache/iceberg/pull/6695))
-  - Fixed a bug that statistics files were not cleaned up in `expire_snapshots` procedure ([\#6090](https://github.com/apache/iceberg/pull/6090))
+    - Added time range query support for changelog table ([\#6350](https://github.com/apache/iceberg/pull/6350))
+    - Added changelog view procedure for v1 table ([\#6012](https://github.com/apache/iceberg/pull/6012))
+    - Added support for storage partition joins to improve read and write performance ([\#6371](https://github.com/apache/iceberg/pull/6371))
+    - Updated default Arrow environment settings to improve read performance ([\#6550](https://github.com/apache/iceberg/pull/6550))
+    - Added aggregate pushdown support for `min`, `max` and `count` to improve read performance ([\#6622](https://github.com/apache/iceberg/pull/6622))
+    - Updated default distribution mode settings to improve write performance ([\#6828](https://github.com/apache/iceberg/pull/6828), [\#6838](https://github.com/apache/iceberg/pull/6838))
+    - Updated DELETE to perform metadata-only update whenever possible to improve write performance ([\#6899](https://github.com/apache/iceberg/pull/6899))
+    - Improved predicate pushdown support for write operations ([\#6636](https://github.com/apache/iceberg/pull/6633))
+    - Added support for reading a branch or tag through table identifier and `VERSION AS OF` (a.k.a. `FOR SYSTEM_VERSION AS OF`) SQL syntax ([\#6717](https://github.com/apache/iceberg/pull/6717), [\#6575](https://github.com/apache/iceberg/pull/6575))
+    - Added support for writing to a branch through identifier or through write-audit-publish (WAP) workflow settings ([\#6965](https://github.com/apache/iceberg/pull/6965), [\#7050](https://github.com/apache/iceberg/pull/7050))
+    - Added DDL SQL extensions to create, replace and drop a branch or tag ([\#6638](https://github.com/apache/iceberg/pull/6638), [\#6637](https://github.com/apache/iceberg/pull/6637), [\#6752](https://github.com/apache/iceberg/pull/6752), [\#6807](https://github.com/apache/iceberg/pull/6807))
+    - Added UDFs for `years`, `months`, `days` and `hours` transforms ([\#6207](https://github.com/apache/iceberg/pull/6207), [\#6261](https://github.com/apache/iceberg/pull/6261), [\#6300](https://github.com/apache/iceberg/pull/6300), [\#6339](https://github.com/apache/iceberg/pull/6339))
+    - Added partition related stats for `add_files` procedure result ([\#6797](https://github.com/apache/iceberg/pull/6797))
+    - Fixed a bug that `rewrite_manifests` procedure produced a new manifest even when there was no rewrite performed ([\#6659](https://github.com/apache/iceberg/pull/6695))
+    - Fixed a bug that statistics files were not cleaned up in `expire_snapshots` procedure ([\#6090](https://github.com/apache/iceberg/pull/6090))
 * Flink
-  - Added support for metadata tables ([\#6222](https://github.com/apache/iceberg/pull/6222))
-  - Added support for read options in Flink source ([\#5967](https://github.com/apache/iceberg/pull/5967))
-  - Added support for reading and writing Avro `GenericRecord` ([\#6557](https://github.com/apache/iceberg/pull/6557), [\#6584](https://github.com/apache/iceberg/pull/6584))
-  - Added support for reading a branch or tag and write to a branch ([\#6660](https://github.com/apache/iceberg/pull/6660), [\#5029](https://github.com/apache/iceberg/pull/5029))
-  - Added throttling support for streaming read ([\#6299](https://github.com/apache/iceberg/pull/6299))
-  - Added support for multiple sinks for the same table in the same job ([\#6528](https://github.com/apache/iceberg/pull/6528))
-  - Fixed a bug that metrics config was not applied to equality and position deletes ([\#6271](https://github.com/apache/iceberg/pull/6271), [\#6313](https://github.com/apache/iceberg/pull/6313))
+    - Added support for metadata tables ([\#6222](https://github.com/apache/iceberg/pull/6222))
+    - Added support for read options in Flink source ([\#5967](https://github.com/apache/iceberg/pull/5967))
+    - Added support for reading and writing Avro `GenericRecord` ([\#6557](https://github.com/apache/iceberg/pull/6557), [\#6584](https://github.com/apache/iceberg/pull/6584))
+    - Added support for reading a branch or tag and write to a branch ([\#6660](https://github.com/apache/iceberg/pull/6660), [\#5029](https://github.com/apache/iceberg/pull/5029))
+    - Added throttling support for streaming read ([\#6299](https://github.com/apache/iceberg/pull/6299))
+    - Added support for multiple sinks for the same table in the same job ([\#6528](https://github.com/apache/iceberg/pull/6528))
+    - Fixed a bug that metrics config was not applied to equality and position deletes ([\#6271](https://github.com/apache/iceberg/pull/6271), [\#6313](https://github.com/apache/iceberg/pull/6313))
 * Vendor Integrations
-  - Added Snowflake catalog integration ([\#6428](https://github.com/apache/iceberg/pull/6428))
-  - Added AWS sigV4 authentication support for REST catalog ([\#6951](https://github.com/apache/iceberg/pull/6951))
-  - Added support for AWS S3 remote signing ([\#6169](https://github.com/apache/iceberg/pull/6169), [\#6835](https://github.com/apache/iceberg/pull/6835), [\#7080](https://github.com/apache/iceberg/pull/7080))
-  - Updated AWS Glue catalog to skip table version archive by default ([\#6919](https://github.com/apache/iceberg/pull/6916))
-  - Updated AWS Glue catalog to not require a warehouse location ([\#6586](https://github.com/apache/iceberg/pull/6586))
-  - Fixed a bug that a bucket-only AWS S3 location such as `s3://my-bucket` could not be parsed ([\#6352](https://github.com/apache/iceberg/pull/6352))
-  - Fixed a bug that unnecessary HTTP client dependencies had to be included to use any AWS integration ([\#6746](https://github.com/apache/iceberg/pull/6746))
-  - Fixed a bug that AWS Glue catalog did not respect custom catalog ID when determining default warehouse location ([\#6223](https://github.com/apache/iceberg/pull/6223))
-  - Fixes a bug that AWS DynamoDB catalog namespace listing result was incomplete ([\#6823](https://github.com/apache/iceberg/pull/6823))
+    - Added Snowflake catalog integration ([\#6428](https://github.com/apache/iceberg/pull/6428))
+    - Added AWS sigV4 authentication support for REST catalog ([\#6951](https://github.com/apache/iceberg/pull/6951))
+    - Added support for AWS S3 remote signing ([\#6169](https://github.com/apache/iceberg/pull/6169), [\#6835](https://github.com/apache/iceberg/pull/6835), [\#7080](https://github.com/apache/iceberg/pull/7080))
+    - Updated AWS Glue catalog to skip table version archive by default ([\#6919](https://github.com/apache/iceberg/pull/6916))
+    - Updated AWS Glue catalog to not require a warehouse location ([\#6586](https://github.com/apache/iceberg/pull/6586))
+    - Fixed a bug that a bucket-only AWS S3 location such as `s3://my-bucket` could not be parsed ([\#6352](https://github.com/apache/iceberg/pull/6352))
+    - Fixed a bug that unnecessary HTTP client dependencies had to be included to use any AWS integration ([\#6746](https://github.com/apache/iceberg/pull/6746))
+    - Fixed a bug that AWS Glue catalog did not respect custom catalog ID when determining default warehouse location ([\#6223](https://github.com/apache/iceberg/pull/6223))
+    - Fixes a bug that AWS DynamoDB catalog namespace listing result was incomplete ([\#6823](https://github.com/apache/iceberg/pull/6823))
 * Dependencies
-  - Upgraded ORC to 1.8.1 ([\#6349](https://github.com/apache/iceberg/pull/6349))
-  - Upgraded Jackson to 2.14.1 ([\#6168](https://github.com/apache/iceberg/pull/6168))
-  - Upgraded AWS SDK V2 to 2.20.18 ([\#7003](https://github.com/apache/iceberg/pull/7003))
-  - Upgraded Nessie to 0.50.0 ([\#6875](https://github.com/apache/iceberg/pull/6875))
+    - Upgraded ORC to 1.8.1 ([\#6349](https://github.com/apache/iceberg/pull/6349))
+    - Upgraded Jackson to 2.14.1 ([\#6168](https://github.com/apache/iceberg/pull/6168))
+    - Upgraded AWS SDK V2 to 2.20.18 ([\#7003](https://github.com/apache/iceberg/pull/7003))
+    - Upgraded Nessie to 0.50.0 ([\#6875](https://github.com/apache/iceberg/pull/6875))
 
 For more details, please visit [Github](https://github.com/apache/iceberg/releases/tag/apache-iceberg-1.2.0).
 
@@ -356,24 +356,24 @@ and adds a variety of new features.
 Here is an overview:
 
 * Core
-  - Puffin statistics have been [added to the Table API](https://github.com/apache/iceberg/pull/4945)
-  - Support for [Table scan reporting](https://github.com/apache/iceberg/pull/5268), which enables collection of statistics of the table scans.
-  - [Add file sequence number to ManifestEntry](https://github.com/apache/iceberg/pull/6002)
-  - [Support register table](https://github.com/apache/iceberg/pull/5037) for all the catalogs (previously it was only for Hive)
-  - [Support performing merge appends and delete files on branches](https://github.com/apache/iceberg/pull/5618)
-  - [Improved Expire Snapshots FileCleanupStrategy](https://github.com/apache/iceberg/pull/5669)
-  - [SnapshotProducer supports branch writes](https://github.com/apache/iceberg/pull/4926)
+    - Puffin statistics have been [added to the Table API](https://github.com/apache/iceberg/pull/4945)
+    - Support for [Table scan reporting](https://github.com/apache/iceberg/pull/5268), which enables collection of statistics of the table scans.
+    - [Add file sequence number to ManifestEntry](https://github.com/apache/iceberg/pull/6002)
+    - [Support register table](https://github.com/apache/iceberg/pull/5037) for all the catalogs (previously it was only for Hive)
+    - [Support performing merge appends and delete files on branches](https://github.com/apache/iceberg/pull/5618)
+    - [Improved Expire Snapshots FileCleanupStrategy](https://github.com/apache/iceberg/pull/5669)
+    - [SnapshotProducer supports branch writes](https://github.com/apache/iceberg/pull/4926)
 * Spark
-  - [Support for aggregate expressions](https://github.com/apache/iceberg/pull/5961)
-  - [SparkChangelogTable for querying changelogs](https://github.com/apache/iceberg/pull/5740)
-  - Dropped support for Apache Spark 3.0
+    - [Support for aggregate expressions](https://github.com/apache/iceberg/pull/5961)
+    - [SparkChangelogTable for querying changelogs](https://github.com/apache/iceberg/pull/5740)
+    - Dropped support for Apache Spark 3.0
 * Flink
-  - [FLIP-27 reader is supported in SQL](https://github.com/apache/iceberg/pull/5318)
-  - Added support for Flink 1.16, dropped support for Flink 1.13
+    - [FLIP-27 reader is supported in SQL](https://github.com/apache/iceberg/pull/5318)
+    - Added support for Flink 1.16, dropped support for Flink 1.13
 * Dependencies
-  - [AWS SDK: 2.17.257](https://github.com/apache/iceberg/pull/5612)
-  - [Nessie: 0.44](https://github.com/apache/iceberg/pull/6008)
-  - [Apache ORC: 1.8.0](https://github.com/apache/iceberg/pull/5699) (Also, supports [setting bloom filters on row groups](https://github.com/apache/iceberg/pull/5313/files))
+    - [AWS SDK: 2.17.257](https://github.com/apache/iceberg/pull/5612)
+    - [Nessie: 0.44](https://github.com/apache/iceberg/pull/6008)
+    - [Apache ORC: 1.8.0](https://github.com/apache/iceberg/pull/5699) (Also, supports [setting bloom filters on row groups](https://github.com/apache/iceberg/pull/5313/files))
 
 For more details, please visit [Github](https://github.com/apache/iceberg/releases/tag/apache-iceberg-1.1.0).
 
@@ -396,19 +396,19 @@ This release includes all bug fixes from the 0.14.x patch releases.
 #### Notable bug fixes
 
 * API
-  - API: Fix ID assignment in schema merging ([#5395](https://github.com/apache/iceberg/pull/5395))
+    - API: Fix ID assignment in schema merging ([#5395](https://github.com/apache/iceberg/pull/5395))
 * Core
-  - Core: Fix snapshot log with intermediate transaction snapshots ([#5568](https://github.com/apache/iceberg/pull/5568))
-  - Core: Fix exception handling in BaseTaskWriter ([#5683](https://github.com/apache/iceberg/pull/5683))
-  - Core: Support deleting tables without metadata files ([#5510](https://github.com/apache/iceberg/pull/5510))
-  - Core: Add CommitStateUnknownException handling to REST ([#5694](https://github.com/apache/iceberg/pull/5694))
+    - Fix snapshot log with intermediate transaction snapshots ([#5568](https://github.com/apache/iceberg/pull/5568))
+    - Fix exception handling in BaseTaskWriter ([#5683](https://github.com/apache/iceberg/pull/5683))
+    - Support deleting tables without metadata files ([#5510](https://github.com/apache/iceberg/pull/5510))
+    - Add CommitStateUnknownException handling to REST ([#5694](https://github.com/apache/iceberg/pull/5694))
 * Spark
-  - Spark: Fix stats in rewrite metadata action ([#5691](https://github.com/apache/iceberg/pull/5691))
+    - Spark: Fix stats in rewrite metadata action ([#5691](https://github.com/apache/iceberg/pull/5691))
 * File Formats
-  - Parquet: Close zstd input stream early to avoid memory pressure ([#5681](https://github.com/apache/iceberg/pull/5681))
+    - Parquet: Close zstd input stream early to avoid memory pressure ([#5681](https://github.com/apache/iceberg/pull/5681))
 * Vendor Integrations
-  - Core, AWS: Fix Kryo serialization failure for FileIO ([#5437](https://github.com/apache/iceberg/pull/5437))
-  - AWS: S3OutputStream - failure to close should persist on subsequent close calls ([#5311](https://github.com/apache/iceberg/pull/5311))
+    - Core, AWS: Fix Kryo serialization failure for FileIO ([#5437](https://github.com/apache/iceberg/pull/5437))
+    - AWS: S3OutputStream - failure to close should persist on subsequent close calls ([#5311](https://github.com/apache/iceberg/pull/5311))
 
 ### 0.14.0 release
 
@@ -431,109 +431,109 @@ Apache Iceberg 0.14.0 was released on 16 July 2022.
 #### High-level features
 
 * API
-  - Added IcebergBuild to expose Iceberg version and build information
-  - Added binary compatibility checking to the build ([#4638](https://github.com/apache/iceberg/pull/4638), [#4798](https://github.com/apache/iceberg/pull/4798))
-  - Added a new IncrementalAppendScan interface and planner implementation ([#4580](https://github.com/apache/iceberg/pull/4580))
-  - Added a new IncrementalChangelogScan interface ([#4870](https://github.com/apache/iceberg/pull/4870))
-  - Refactored the ScanTask hierarchy to create new task types for changelog scans ([#5077](https://github.com/apache/iceberg/pull/5077))
-  - Added expression sanitizer ([#4672](https://github.com/apache/iceberg/pull/4672))
-  - Added utility to check expression equivalence ([#4947](https://github.com/apache/iceberg/pull/4947))
-  - Added support for serializing FileIO instances using initialization properties ([#5178](https://github.com/apache/iceberg/pull/5178))
-  - Updated Snapshot methods to accept a FileIO to read metadata files, deprecated old methods ([#4873](https://github.com/apache/iceberg/pull/4873))
-  - Added optional interfaces to FileIO, for batch deletes ([#4052](https://github.com/apache/iceberg/pull/4052)), prefix operations ([#5096](https://github.com/apache/iceberg/pull/5096)), and ranged reads ([#4608](https://github.com/apache/iceberg/pull/4608))
+    - Added IcebergBuild to expose Iceberg version and build information
+    - Added binary compatibility checking to the build ([#4638](https://github.com/apache/iceberg/pull/4638), [#4798](https://github.com/apache/iceberg/pull/4798))
+    - Added a new IncrementalAppendScan interface and planner implementation ([#4580](https://github.com/apache/iceberg/pull/4580))
+    - Added a new IncrementalChangelogScan interface ([#4870](https://github.com/apache/iceberg/pull/4870))
+    - Refactored the ScanTask hierarchy to create new task types for changelog scans ([#5077](https://github.com/apache/iceberg/pull/5077))
+    - Added expression sanitizer ([#4672](https://github.com/apache/iceberg/pull/4672))
+    - Added utility to check expression equivalence ([#4947](https://github.com/apache/iceberg/pull/4947))
+    - Added support for serializing FileIO instances using initialization properties ([#5178](https://github.com/apache/iceberg/pull/5178))
+    - Updated Snapshot methods to accept a FileIO to read metadata files, deprecated old methods ([#4873](https://github.com/apache/iceberg/pull/4873))
+    - Added optional interfaces to FileIO, for batch deletes ([#4052](https://github.com/apache/iceberg/pull/4052)), prefix operations ([#5096](https://github.com/apache/iceberg/pull/5096)), and ranged reads ([#4608](https://github.com/apache/iceberg/pull/4608))
 * Core
-  - Added a common client for REST-based catalog services that uses a change-based protocol ([#4320](https://github.com/apache/iceberg/pull/4320), [#4319](https://github.com/apache/iceberg/pull/4319))
-  - Added Puffin, a file format for statistics and index payloads or sketches ([#4944](https://github.com/apache/iceberg/pull/4944), [#4537](https://github.com/apache/iceberg/pull/4537))
-  - Added snapshot references to track tags and branches ([#4019](https://github.com/apache/iceberg/pull/4019))
-  - ManageSnapshots now supports multiple operations using transactions, and added branch and tag operations ([#4128](https://github.com/apache/iceberg/pull/4128), [#4071](https://github.com/apache/iceberg/pull/4071))
-  - ReplacePartitions and OverwriteFiles now support serializable isolation ([#2925](https://github.com/apache/iceberg/pull/2925), [#4052](https://github.com/apache/iceberg/pull/4052))
-  - Added new metadata tables: `data_files` ([#4336](https://github.com/apache/iceberg/pull/4336)), `delete_files` ([#4243](https://github.com/apache/iceberg/pull/4243)), `all_delete_files`, and `all_files` ([#4694](https://github.com/apache/iceberg/pull/4694))
-  - Added deleted files to the `files` metadata table ([#4336](https://github.com/apache/iceberg/pull/4336)) and delete file counts to the `manifests` table ([#4764](https://github.com/apache/iceberg/pull/4764))
-  - Added support for predicate pushdown for the `all_data_files` metadata table ([#4382](https://github.com/apache/iceberg/pull/4382)) and the `all_manifests` table ([#4736](https://github.com/apache/iceberg/pull/4736))
-  - Added support for catalogs to default table properties on creation ([#4011](https://github.com/apache/iceberg/pull/4011))
-  - Updated sort order construction to ensure all partition fields are added to avoid partition closed failures ([#5131](https://github.com/apache/iceberg/pull/5131))
+    - Added a common client for REST-based catalog services that uses a change-based protocol ([#4320](https://github.com/apache/iceberg/pull/4320), [#4319](https://github.com/apache/iceberg/pull/4319))
+    - Added Puffin, a file format for statistics and index payloads or sketches ([#4944](https://github.com/apache/iceberg/pull/4944), [#4537](https://github.com/apache/iceberg/pull/4537))
+    - Added snapshot references to track tags and branches ([#4019](https://github.com/apache/iceberg/pull/4019))
+    - ManageSnapshots now supports multiple operations using transactions, and added branch and tag operations ([#4128](https://github.com/apache/iceberg/pull/4128), [#4071](https://github.com/apache/iceberg/pull/4071))
+    - ReplacePartitions and OverwriteFiles now support serializable isolation ([#2925](https://github.com/apache/iceberg/pull/2925), [#4052](https://github.com/apache/iceberg/pull/4052))
+    - Added new metadata tables: `data_files` ([#4336](https://github.com/apache/iceberg/pull/4336)), `delete_files` ([#4243](https://github.com/apache/iceberg/pull/4243)), `all_delete_files`, and `all_files` ([#4694](https://github.com/apache/iceberg/pull/4694))
+    - Added deleted files to the `files` metadata table ([#4336](https://github.com/apache/iceberg/pull/4336)) and delete file counts to the `manifests` table ([#4764](https://github.com/apache/iceberg/pull/4764))
+    - Added support for predicate pushdown for the `all_data_files` metadata table ([#4382](https://github.com/apache/iceberg/pull/4382)) and the `all_manifests` table ([#4736](https://github.com/apache/iceberg/pull/4736))
+    - Added support for catalogs to default table properties on creation ([#4011](https://github.com/apache/iceberg/pull/4011))
+    - Updated sort order construction to ensure all partition fields are added to avoid partition closed failures ([#5131](https://github.com/apache/iceberg/pull/5131))
 * Spark
-  - Spark 3.3 is now supported ([#5056](https://github.com/apache/iceberg/pull/5056))
-  - Added SQL time travel using `AS OF` syntax in Spark 3.3 ([#5156](https://github.com/apache/iceberg/pull/5156))
-  - Scala 2.13 is now supported for Spark 3.2 and 3.3 ([#4009](https://github.com/apache/iceberg/pull/4009))
-  - Added support for the `mergeSchema` option for DataFrame writes ([#4154](https://github.com/apache/iceberg/pull/4154))
-  - MERGE and UPDATE queries now support the lazy / merge-on-read strategy ([#3984](https://github.com/apache/iceberg/pull/3984), [#4047](https://github.com/apache/iceberg/pull/4047))
-  - Added zorder rewrite strategy to the `rewrite_data_files` stored procedure and action ([#3983](https://github.com/apache/iceberg/pull/3983), [#4902](https://github.com/apache/iceberg/pull/4902))
-  - Added a `register_table` stored procedure to create tables from metadata JSON files ([#4810](https://github.com/apache/iceberg/pull/4810))
-  - Added a `publish_changes` stored procedure to publish staged commits by ID ([#4715](https://github.com/apache/iceberg/pull/4715))
-  - Added `CommitMetadata` helper class to set snapshot summary properties from SQL ([#4956](https://github.com/apache/iceberg/pull/4956))
-  - Added support to supply a file listing to remove orphan data files procedure and action ([#4503](https://github.com/apache/iceberg/pull/4503))
-  - Added FileIO metrics to the Spark UI ([#4030](https://github.com/apache/iceberg/pull/4030), [#4050](https://github.com/apache/iceberg/pull/4050))
-  - DROP TABLE now supports the PURGE flag ([#3056](https://github.com/apache/iceberg/pull/3056))
-  - Added support for custom isolation level for dynamic partition overwrites ([#2925](https://github.com/apache/iceberg/pull/2925)) and filter overwrites ([#4293](https://github.com/apache/iceberg/pull/4293))
-  - Schema identifier fields are now shown in table properties ([#4475](https://github.com/apache/iceberg/pull/4475))
-  - Abort cleanup now supports parallel execution ([#4704](https://github.com/apache/iceberg/pull/4704))
+    - Spark 3.3 is now supported ([#5056](https://github.com/apache/iceberg/pull/5056))
+    - Added SQL time travel using `AS OF` syntax in Spark 3.3 ([#5156](https://github.com/apache/iceberg/pull/5156))
+    - Scala 2.13 is now supported for Spark 3.2 and 3.3 ([#4009](https://github.com/apache/iceberg/pull/4009))
+    - Added support for the `mergeSchema` option for DataFrame writes ([#4154](https://github.com/apache/iceberg/pull/4154))
+    - MERGE and UPDATE queries now support the lazy / merge-on-read strategy ([#3984](https://github.com/apache/iceberg/pull/3984), [#4047](https://github.com/apache/iceberg/pull/4047))
+    - Added zorder rewrite strategy to the `rewrite_data_files` stored procedure and action ([#3983](https://github.com/apache/iceberg/pull/3983), [#4902](https://github.com/apache/iceberg/pull/4902))
+    - Added a `register_table` stored procedure to create tables from metadata JSON files ([#4810](https://github.com/apache/iceberg/pull/4810))
+    - Added a `publish_changes` stored procedure to publish staged commits by ID ([#4715](https://github.com/apache/iceberg/pull/4715))
+    - Added `CommitMetadata` helper class to set snapshot summary properties from SQL ([#4956](https://github.com/apache/iceberg/pull/4956))
+    - Added support to supply a file listing to remove orphan data files procedure and action ([#4503](https://github.com/apache/iceberg/pull/4503))
+    - Added FileIO metrics to the Spark UI ([#4030](https://github.com/apache/iceberg/pull/4030), [#4050](https://github.com/apache/iceberg/pull/4050))
+    - DROP TABLE now supports the PURGE flag ([#3056](https://github.com/apache/iceberg/pull/3056))
+    - Added support for custom isolation level for dynamic partition overwrites ([#2925](https://github.com/apache/iceberg/pull/2925)) and filter overwrites ([#4293](https://github.com/apache/iceberg/pull/4293))
+    - Schema identifier fields are now shown in table properties ([#4475](https://github.com/apache/iceberg/pull/4475))
+    - Abort cleanup now supports parallel execution ([#4704](https://github.com/apache/iceberg/pull/4704))
 * Flink
-  - Flink 1.15 is now supported ([#4553](https://github.com/apache/iceberg/pull/4553))
-  - Flink 1.12 support was removed ([#4551](https://github.com/apache/iceberg/pull/4551))
-  - Added a FLIP-27 source and builder to 1.14 and 1.15 ([#5109](https://github.com/apache/iceberg/pull/5109))
-  - Added an option to set the monitor interval ([#4887](https://github.com/apache/iceberg/pull/4887)) and an option to limit the number of snapshots in a streaming read planning operation ([#4943](https://github.com/apache/iceberg/pull/4943))
-  - Added support for write options, like `write-format` to Flink sink builder ([#3998](https://github.com/apache/iceberg/pull/3998))
-  - Added support for task locality when reading from HDFS ([#3817](https://github.com/apache/iceberg/pull/3817))
-  - Use Hadoop configuration files from `hadoop-conf-dir` property ([#4622](https://github.com/apache/iceberg/pull/4622))
+    - Flink 1.15 is now supported ([#4553](https://github.com/apache/iceberg/pull/4553))
+    - Flink 1.12 support was removed ([#4551](https://github.com/apache/iceberg/pull/4551))
+    - Added a FLIP-27 source and builder to 1.14 and 1.15 ([#5109](https://github.com/apache/iceberg/pull/5109))
+    - Added an option to set the monitor interval ([#4887](https://github.com/apache/iceberg/pull/4887)) and an option to limit the number of snapshots in a streaming read planning operation ([#4943](https://github.com/apache/iceberg/pull/4943))
+    - Added support for write options, like `write-format` to Flink sink builder ([#3998](https://github.com/apache/iceberg/pull/3998))
+    - Added support for task locality when reading from HDFS ([#3817](https://github.com/apache/iceberg/pull/3817))
+    - Use Hadoop configuration files from `hadoop-conf-dir` property ([#4622](https://github.com/apache/iceberg/pull/4622))
 * Vendor integrations
-  - Added Dell ECS integration ([#3376](https://github.com/apache/iceberg/pull/3376), [#4221](https://github.com/apache/iceberg/pull/4221))
-  - JDBC catalog now supports namespace properties ([#3275](https://github.com/apache/iceberg/pull/3275))
-  - AWS Glue catalog supports native Glue locking ([#4166](https://github.com/apache/iceberg/pull/4166))
-  - AWS S3FileIO supports using S3 access points ([#4334](https://github.com/apache/iceberg/pull/4334)), bulk operations ([#4052](https://github.com/apache/iceberg/pull/4052), [#5096](https://github.com/apache/iceberg/pull/5096)), ranged reads ([#4608](https://github.com/apache/iceberg/pull/4608)), and tagging at write time or in place of deletes ([#4259](https://github.com/apache/iceberg/pull/4259), [#4342](https://github.com/apache/iceberg/pull/4342))
-  - AWS GlueCatalog supports passing LakeFormation credentials ([#4280](https://github.com/apache/iceberg/pull/4280)) 
-  - AWS DynamoDB catalog and lock supports overriding the DynamoDB endpoint ([#4726](https://github.com/apache/iceberg/pull/4726))
-  - Nessie now supports namespaces and namespace properties ([#4385](https://github.com/apache/iceberg/pull/4385), [#4610](https://github.com/apache/iceberg/pull/4610))
-  - Nessie now passes most common catalog tests ([#4392](https://github.com/apache/iceberg/pull/4392))
+    - Added Dell ECS integration ([#3376](https://github.com/apache/iceberg/pull/3376), [#4221](https://github.com/apache/iceberg/pull/4221))
+    - JDBC catalog now supports namespace properties ([#3275](https://github.com/apache/iceberg/pull/3275))
+    - AWS Glue catalog supports native Glue locking ([#4166](https://github.com/apache/iceberg/pull/4166))
+    - AWS S3FileIO supports using S3 access points ([#4334](https://github.com/apache/iceberg/pull/4334)), bulk operations ([#4052](https://github.com/apache/iceberg/pull/4052), [#5096](https://github.com/apache/iceberg/pull/5096)), ranged reads ([#4608](https://github.com/apache/iceberg/pull/4608)), and tagging at write time or in place of deletes ([#4259](https://github.com/apache/iceberg/pull/4259), [#4342](https://github.com/apache/iceberg/pull/4342))
+    - AWS GlueCatalog supports passing LakeFormation credentials ([#4280](https://github.com/apache/iceberg/pull/4280)) 
+    - AWS DynamoDB catalog and lock supports overriding the DynamoDB endpoint ([#4726](https://github.com/apache/iceberg/pull/4726))
+    - Nessie now supports namespaces and namespace properties ([#4385](https://github.com/apache/iceberg/pull/4385), [#4610](https://github.com/apache/iceberg/pull/4610))
+    - Nessie now passes most common catalog tests ([#4392](https://github.com/apache/iceberg/pull/4392))
 * Parquet
-  - Added support for row group skipping using Parquet bloom filters ([#4938](https://github.com/apache/iceberg/pull/4938))
-  - Added table configuration options for writing Parquet bloom filters ([#5035](https://github.com/apache/iceberg/pull/5035))
+    - Added support for row group skipping using Parquet bloom filters ([#4938](https://github.com/apache/iceberg/pull/4938))
+    - Added table configuration options for writing Parquet bloom filters ([#5035](https://github.com/apache/iceberg/pull/5035))
 * ORC
-  - Support file rolling at a target file size ([#4419](https://github.com/apache/iceberg/pull/4419))
-  - Support table compression settings, `write.orc.compression-codec` and `write.orc.compression-strategy` ([#4273](https://github.com/apache/iceberg/pull/4273))
+    - Support file rolling at a target file size ([#4419](https://github.com/apache/iceberg/pull/4419))
+    - Support table compression settings, `write.orc.compression-codec` and `write.orc.compression-strategy` ([#4273](https://github.com/apache/iceberg/pull/4273))
 
 #### Performance improvements
 
 * Core
-  - Fixed manifest file handling in scan planning to open manifests in the planning threadpool ([#5206](https://github.com/apache/iceberg/pull/5206))
-  - Avoided an extra S3 HEAD request by passing file length when opening manifest files ([#5207](https://github.com/apache/iceberg/pull/5207))
-  - Refactored Arrow vectorized readers to avoid extra dictionary copies ([#5137](https://github.com/apache/iceberg/pull/5137))
-  - Improved Arrow decimal handling to improve decimal performance ([#5168](https://github.com/apache/iceberg/pull/5168), [#5198](https://github.com/apache/iceberg/pull/5198))
-  - Added support for Avro files with Zstd compression ([#4083](https://github.com/apache/iceberg/pull/4083))
-  - Column metrics are now disabled by default after the first 32 columns ([#3959](https://github.com/apache/iceberg/pull/3959), [#5215](https://github.com/apache/iceberg/pull/5215))
-  - Updated delete filters to copy row wrappers to avoid expensive type analysis ([#5249](https://github.com/apache/iceberg/pull/5249))
-  - Snapshot expiration supports parallel execution ([#4148](https://github.com/apache/iceberg/pull/4148))
-  - Manifest updates can use a custom thread pool ([#4146](https://github.com/apache/iceberg/pull/4146))
+    - Fixed manifest file handling in scan planning to open manifests in the planning threadpool ([#5206](https://github.com/apache/iceberg/pull/5206))
+    - Avoided an extra S3 HEAD request by passing file length when opening manifest files ([#5207](https://github.com/apache/iceberg/pull/5207))
+    - Refactored Arrow vectorized readers to avoid extra dictionary copies ([#5137](https://github.com/apache/iceberg/pull/5137))
+    - Improved Arrow decimal handling to improve decimal performance ([#5168](https://github.com/apache/iceberg/pull/5168), [#5198](https://github.com/apache/iceberg/pull/5198))
+    - Added support for Avro files with Zstd compression ([#4083](https://github.com/apache/iceberg/pull/4083))
+    - Column metrics are now disabled by default after the first 32 columns ([#3959](https://github.com/apache/iceberg/pull/3959), [#5215](https://github.com/apache/iceberg/pull/5215))
+    - Updated delete filters to copy row wrappers to avoid expensive type analysis ([#5249](https://github.com/apache/iceberg/pull/5249))
+    - Snapshot expiration supports parallel execution ([#4148](https://github.com/apache/iceberg/pull/4148))
+    - Manifest updates can use a custom thread pool ([#4146](https://github.com/apache/iceberg/pull/4146))
 * Spark
-  - Parquet vectorized reads are enabled by default ([#4196](https://github.com/apache/iceberg/pull/4196))
-  - Scan statistics now adjust row counts for split data files ([#4446](https://github.com/apache/iceberg/pull/4446))
-  - Implemented `SupportsReportStatistics` in `ScanBuilder` to work around SPARK-38962 ([#5136](https://github.com/apache/iceberg/pull/5136))
-  - Updated Spark tables to avoid expensive (and inaccurate) size estimation ([#5225](https://github.com/apache/iceberg/pull/5225))
+    - Parquet vectorized reads are enabled by default ([#4196](https://github.com/apache/iceberg/pull/4196))
+    - Scan statistics now adjust row counts for split data files ([#4446](https://github.com/apache/iceberg/pull/4446))
+    - Implemented `SupportsReportStatistics` in `ScanBuilder` to work around SPARK-38962 ([#5136](https://github.com/apache/iceberg/pull/5136))
+    - Updated Spark tables to avoid expensive (and inaccurate) size estimation ([#5225](https://github.com/apache/iceberg/pull/5225))
 * Flink
-  - Operators will now use a worker pool per job ([#4177](https://github.com/apache/iceberg/pull/4177))
-  - Fixed `ClassCastException` thrown when reading arrays from Parquet ([#4432](https://github.com/apache/iceberg/pull/4432))
+    - Operators will now use a worker pool per job ([#4177](https://github.com/apache/iceberg/pull/4177))
+    - Fixed `ClassCastException` thrown when reading arrays from Parquet ([#4432](https://github.com/apache/iceberg/pull/4432))
 * Hive
-  - Added vectorized Parquet reads for Hive 3 ([#3980](https://github.com/apache/iceberg/pull/3980))
-  - Improved generic reader performance using copy instead of create ([#4218](https://github.com/apache/iceberg/pull/4218))
+    - Added vectorized Parquet reads for Hive 3 ([#3980](https://github.com/apache/iceberg/pull/3980))
+    - Improved generic reader performance using copy instead of create ([#4218](https://github.com/apache/iceberg/pull/4218))
 
 #### Notable bug fixes
 
 This release includes all bug fixes from the 0.13.x patch releases.
 
 * Core
-  - Fixed an exception thrown when metadata-only deletes encounter delete files that are partially matched ([#4304](https://github.com/apache/iceberg/pull/4304))
-  - Fixed transaction retries for changes without validations, like schema updates, that could ignore an update ([#4464](https://github.com/apache/iceberg/pull/4464))
-  - Fixed failures when reading metadata tables with evolved partition specs ([#4520](https://github.com/apache/iceberg/pull/4520), [#4560](https://github.com/apache/iceberg/pull/4560))
-  - Fixed delete files dropped when a manifest is rewritten following a format version upgrade ([#4514](https://github.com/apache/iceberg/pull/4514))
-  - Fixed missing metadata files resulting from an OOM during commit cleanup ([#4673](https://github.com/apache/iceberg/pull/4673))
-  - Updated logging to use sanitized expressions to avoid leaking values ([#4672](https://github.com/apache/iceberg/pull/4672))
+    - Fixed an exception thrown when metadata-only deletes encounter delete files that are partially matched ([#4304](https://github.com/apache/iceberg/pull/4304))
+    - Fixed transaction retries for changes without validations, like schema updates, that could ignore an update ([#4464](https://github.com/apache/iceberg/pull/4464))
+    - Fixed failures when reading metadata tables with evolved partition specs ([#4520](https://github.com/apache/iceberg/pull/4520), [#4560](https://github.com/apache/iceberg/pull/4560))
+    - Fixed delete files dropped when a manifest is rewritten following a format version upgrade ([#4514](https://github.com/apache/iceberg/pull/4514))
+    - Fixed missing metadata files resulting from an OOM during commit cleanup ([#4673](https://github.com/apache/iceberg/pull/4673))
+    - Updated logging to use sanitized expressions to avoid leaking values ([#4672](https://github.com/apache/iceberg/pull/4672))
 * Spark
-  - Fixed Spark to skip calling abort when CommitStateUnknownException is thrown ([#4687](https://github.com/apache/iceberg/pull/4687))
-  - Fixed MERGE commands with mixed case identifiers ([#4848](https://github.com/apache/iceberg/pull/4848))
+    - Fixed Spark to skip calling abort when CommitStateUnknownException is thrown ([#4687](https://github.com/apache/iceberg/pull/4687))
+    - Fixed MERGE commands with mixed case identifiers ([#4848](https://github.com/apache/iceberg/pull/4848))
 * Flink
-  - Fixed table property update failures when tables have a primary key ([#4561](https://github.com/apache/iceberg/pull/4561))
+    - Fixed table property update failures when tables have a primary key ([#4561](https://github.com/apache/iceberg/pull/4561))
 * Integrations
-  - JDBC catalog behavior has been updated to pass common catalog tests ([#4220](https://github.com/apache/iceberg/pull/4220), [#4231](https://github.com/apache/iceberg/pull/4231))
+    - JDBC catalog behavior has been updated to pass common catalog tests ([#4220](https://github.com/apache/iceberg/pull/4220), [#4231](https://github.com/apache/iceberg/pull/4231))
 
 #### Dependency changes
 
@@ -624,59 +624,59 @@ Apache Iceberg 0.13.0 was released on February 4th, 2022.
 **High-level features:**
 
 * **Core**
-  * Catalog caching now supports cache expiration through catalog property `cache.expiration-interval-ms` [[\#3543](https://github.com/apache/iceberg/pull/3543)]
-  * Catalog now supports registration of Iceberg table from a given metadata file location [[\#3851](https://github.com/apache/iceberg/pull/3851)]
-  * Hadoop catalog can be used with S3 and other file systems safely by using a lock manager [[\#3663](https://github.com/apache/iceberg/pull/3663)]
+    * Catalog caching now supports cache expiration through catalog property `cache.expiration-interval-ms` [[\#3543](https://github.com/apache/iceberg/pull/3543)]
+    * Catalog now supports registration of Iceberg table from a given metadata file location [[\#3851](https://github.com/apache/iceberg/pull/3851)]
+    * Hadoop catalog can be used with S3 and other file systems safely by using a lock manager [[\#3663](https://github.com/apache/iceberg/pull/3663)]
 * **Vendor Integrations**
-  * Google Cloud Storage (GCS) `FileIO` is supported with optimized read and write using GCS streaming transfer [[\#3711](https://github.com/apache/iceberg/pull/3711)]
-  * Aliyun Object Storage Service (OSS) `FileIO` is supported [[\#3553](https://github.com/apache/iceberg/pull/3553)]
-  * Any S3-compatible storage (e.g. MinIO) can now be accessed through AWS `S3FileIO` with custom endpoint and credential configurations [[\#3656](https://github.com/apache/iceberg/pull/3656)] [[\#3658](https://github.com/apache/iceberg/pull/3658)]
-  * AWS `S3FileIO` now supports server-side checksum validation [[\#3813](https://github.com/apache/iceberg/pull/3813)]
-  * AWS `GlueCatalog` now displays more table information including table location, description [[\#3467](https://github.com/apache/iceberg/pull/3467)] and columns [[\#3888](https://github.com/apache/iceberg/pull/3888)]
-  * Using multiple `FileIO`s based on file path scheme is supported by configuring a `ResolvingFileIO` [[\#3593](https://github.com/apache/iceberg/pull/3593)]
+    * Google Cloud Storage (GCS) `FileIO` is supported with optimized read and write using GCS streaming transfer [[\#3711](https://github.com/apache/iceberg/pull/3711)]
+    * Aliyun Object Storage Service (OSS) `FileIO` is supported [[\#3553](https://github.com/apache/iceberg/pull/3553)]
+    * Any S3-compatible storage (e.g. MinIO) can now be accessed through AWS `S3FileIO` with custom endpoint and credential configurations [[\#3656](https://github.com/apache/iceberg/pull/3656)] [[\#3658](https://github.com/apache/iceberg/pull/3658)]
+    * AWS `S3FileIO` now supports server-side checksum validation [[\#3813](https://github.com/apache/iceberg/pull/3813)]
+    * AWS `GlueCatalog` now displays more table information including table location, description [[\#3467](https://github.com/apache/iceberg/pull/3467)] and columns [[\#3888](https://github.com/apache/iceberg/pull/3888)]
+    * Using multiple `FileIO`s based on file path scheme is supported by configuring a `ResolvingFileIO` [[\#3593](https://github.com/apache/iceberg/pull/3593)]
 * **Spark**
-  * Spark 3.2 is supported [[\#3335](https://github.com/apache/iceberg/pull/3335)] with merge-on-read `DELETE` [[\#3970](https://github.com/apache/iceberg/pull/3970)]
-  * `RewriteDataFiles` action now supports sort-based table optimization [[\#2829](https://github.com/apache/iceberg/pull/2829)] and merge-on-read delete compaction [[\#3454](https://github.com/apache/iceberg/pull/3454)]. The corresponding Spark call procedure `rewrite_data_files` is also supported [[\#3375](https://github.com/apache/iceberg/pull/3375)]
-  * Time travel queries now use snapshot schema instead of the table's latest schema [[\#3722](https://github.com/apache/iceberg/pull/3722)]
-  * Spark vectorized reads now support row-level deletes [[\#3557](https://github.com/apache/iceberg/pull/3557)] [[\#3287](https://github.com/apache/iceberg/pull/3287)]
-  * `add_files` procedure now skips duplicated files by default (can be turned off with the `check_duplicate_files` flag) [[\#2895](https://github.com/apache/iceberg/issues/2779)], skips folder without file [[\#2895](https://github.com/apache/iceberg/issues/3455)] and partitions with `null` values [[\#2895](https://github.com/apache/iceberg/issues/3778)] instead of throwing exception, and supports partition pruning for faster table import [[\#3745](https://github.com/apache/iceberg/issues/3745)]
+    * Spark 3.2 is supported [[\#3335](https://github.com/apache/iceberg/pull/3335)] with merge-on-read `DELETE` [[\#3970](https://github.com/apache/iceberg/pull/3970)]
+    * `RewriteDataFiles` action now supports sort-based table optimization [[\#2829](https://github.com/apache/iceberg/pull/2829)] and merge-on-read delete compaction [[\#3454](https://github.com/apache/iceberg/pull/3454)]. The corresponding Spark call procedure `rewrite_data_files` is also supported [[\#3375](https://github.com/apache/iceberg/pull/3375)]
+    * Time travel queries now use snapshot schema instead of the table's latest schema [[\#3722](https://github.com/apache/iceberg/pull/3722)]
+    * Spark vectorized reads now support row-level deletes [[\#3557](https://github.com/apache/iceberg/pull/3557)] [[\#3287](https://github.com/apache/iceberg/pull/3287)]
+    * `add_files` procedure now skips duplicated files by default (can be turned off with the `check_duplicate_files` flag) [[\#2895](https://github.com/apache/iceberg/issues/2779)], skips folder without file [[\#2895](https://github.com/apache/iceberg/issues/3455)] and partitions with `null` values [[\#2895](https://github.com/apache/iceberg/issues/3778)] instead of throwing exception, and supports partition pruning for faster table import [[\#3745](https://github.com/apache/iceberg/issues/3745)]
 * **Flink**
-  * Flink 1.13 and 1.14 are supported [[\#3116](https://github.com/apache/iceberg/pull/3116)] [[\#3434](https://github.com/apache/iceberg/pull/3434)]
-  * Flink connector support is supported [[\#2666](https://github.com/apache/iceberg/pull/2666)]
-  * Upsert write option is supported [[\#2863](https://github.com/apache/iceberg/pull/2863)]
+    * Flink 1.13 and 1.14 are supported [[\#3116](https://github.com/apache/iceberg/pull/3116)] [[\#3434](https://github.com/apache/iceberg/pull/3434)]
+    * Flink connector support is supported [[\#2666](https://github.com/apache/iceberg/pull/2666)]
+    * Upsert write option is supported [[\#2863](https://github.com/apache/iceberg/pull/2863)]
 * **Hive**
-  * Table listing in Hive catalog can now skip non-Iceberg tables by disabling flag `list-all-tables` [[\#3908](https://github.com/apache/iceberg/pull/3908)]
-  * Hive tables imported to Iceberg can now be read by `IcebergInputFormat` [[\#3312](https://github.com/apache/iceberg/pull/3312)]
+    * Table listing in Hive catalog can now skip non-Iceberg tables by disabling flag `list-all-tables` [[\#3908](https://github.com/apache/iceberg/pull/3908)]
+    * Hive tables imported to Iceberg can now be read by `IcebergInputFormat` [[\#3312](https://github.com/apache/iceberg/pull/3312)]
 * **File Formats**
-  * ORC now supports writing delete file [[\#3248](https://github.com/apache/iceberg/pull/3248)] [[\#3250](https://github.com/apache/iceberg/pull/3250)] [[\#3366](https://github.com/apache/iceberg/pull/3366)]
+    * ORC now supports writing delete file [[\#3248](https://github.com/apache/iceberg/pull/3248)] [[\#3250](https://github.com/apache/iceberg/pull/3250)] [[\#3366](https://github.com/apache/iceberg/pull/3366)]
 
 **Important bug fixes:**
 
 * **Core**
-  * Iceberg new data file root path is configured through `write.data.path` going forward. `write.folder-storage.path` and `write.object-storage.path` are deprecated [[\#3094](https://github.com/apache/iceberg/pull/3094)]
-  * Catalog commit status is `UNKNOWN` instead of `FAILURE` when new metadata location cannot be found in snapshot history [[\#3717](https://github.com/apache/iceberg/pull/3717)]
-  * Dropping table now also deletes old metadata files instead of leaving them strained [[\#3622](https://github.com/apache/iceberg/pull/3622)]
-  * `history` and `snapshots` metadata tables can now query tables with no current snapshot instead of returning empty [[\#3812](https://github.com/apache/iceberg/pull/3812)]
+    * Iceberg new data file root path is configured through `write.data.path` going forward. `write.folder-storage.path` and `write.object-storage.path` are deprecated [[\#3094](https://github.com/apache/iceberg/pull/3094)]
+    * Catalog commit status is `UNKNOWN` instead of `FAILURE` when new metadata location cannot be found in snapshot history [[\#3717](https://github.com/apache/iceberg/pull/3717)]
+    * Dropping table now also deletes old metadata files instead of leaving them strained [[\#3622](https://github.com/apache/iceberg/pull/3622)]
+    * `history` and `snapshots` metadata tables can now query tables with no current snapshot instead of returning empty [[\#3812](https://github.com/apache/iceberg/pull/3812)]
 * **Vendor Integrations**
-  * Using cloud service integrations such as AWS `GlueCatalog` and `S3FileIO` no longer fail when missing Hadoop dependencies in the execution environment [[\#3590](https://github.com/apache/iceberg/pull/3590)]
-  * AWS clients are now auto-closed when related `FileIO` or `Catalog` is closed. There is no need to close the AWS clients separately [[\#2878](https://github.com/apache/iceberg/pull/2878)]
+    * Using cloud service integrations such as AWS `GlueCatalog` and `S3FileIO` no longer fail when missing Hadoop dependencies in the execution environment [[\#3590](https://github.com/apache/iceberg/pull/3590)]
+    * AWS clients are now auto-closed when related `FileIO` or `Catalog` is closed. There is no need to close the AWS clients separately [[\#2878](https://github.com/apache/iceberg/pull/2878)]
 * **Spark**
-  * For Spark >= 3.1, `REFRESH TABLE` can now be used with Spark session catalog instead of throwing exception [[\#3072](https://github.com/apache/iceberg/pull/3072)]
-  * Insert overwrite mode now skips partition with 0 record instead of failing the write operation [[\#2895](https://github.com/apache/iceberg/issues/2895)]
-  * Spark snapshot expiration action now supports custom `FileIO` instead of just `HadoopFileIO` [[\#3089](https://github.com/apache/iceberg/pull/3089)]
-  * `REPLACE TABLE AS SELECT` can now work with tables with columns that have changed partition transform. Each old partition field of the same column is converted to a void transform with a different name [[\#3421](https://github.com/apache/iceberg/issues/3421)]
-  * Spark SQL filters containing binary or fixed literals can now be pushed down instead of throwing exception [[\#3728](https://github.com/apache/iceberg/pull/3728)]
+    * For Spark >= 3.1, `REFRESH TABLE` can now be used with Spark session catalog instead of throwing exception [[\#3072](https://github.com/apache/iceberg/pull/3072)]
+    * Insert overwrite mode now skips partition with 0 record instead of failing the write operation [[\#2895](https://github.com/apache/iceberg/issues/2895)]
+    * Spark snapshot expiration action now supports custom `FileIO` instead of just `HadoopFileIO` [[\#3089](https://github.com/apache/iceberg/pull/3089)]
+    * `REPLACE TABLE AS SELECT` can now work with tables with columns that have changed partition transform. Each old partition field of the same column is converted to a void transform with a different name [[\#3421](https://github.com/apache/iceberg/issues/3421)]
+    * Spark SQL filters containing binary or fixed literals can now be pushed down instead of throwing exception [[\#3728](https://github.com/apache/iceberg/pull/3728)]
 * **Flink**
-  * A `ValidationException` will be thrown if a user configures both `catalog-type` and `catalog-impl`. Previously it chose to use `catalog-type`. The new behavior brings Flink consistent with Spark and Hive [[\#3308](https://github.com/apache/iceberg/issues/3308)]
-  * Changelog tables can now be queried without `RowData` serialization issues [[\#3240](https://github.com/apache/iceberg/pull/3240)]
-  * `java.sql.Time` data type can now be written without data overflow problem [[\#3740](https://github.com/apache/iceberg/pull/3740)]
-  * Avro position delete files can now be read without encountering `NullPointerException` [[\#3540](https://github.com/apache/iceberg/pull/3540)]
+    * A `ValidationException` will be thrown if a user configures both `catalog-type` and `catalog-impl`. Previously it chose to use `catalog-type`. The new behavior brings Flink consistent with Spark and Hive [[\#3308](https://github.com/apache/iceberg/issues/3308)]
+    * Changelog tables can now be queried without `RowData` serialization issues [[\#3240](https://github.com/apache/iceberg/pull/3240)]
+    * `java.sql.Time` data type can now be written without data overflow problem [[\#3740](https://github.com/apache/iceberg/pull/3740)]
+    * Avro position delete files can now be read without encountering `NullPointerException` [[\#3540](https://github.com/apache/iceberg/pull/3540)]
 * **Hive**
-  * Hive catalog can now be initialized with a `null` Hadoop configuration instead of throwing exception [[\#3252](https://github.com/apache/iceberg/pull/3252)]
-  * Table creation can now succeed instead of throwing exception when some columns do not have comments [[\#3531](https://github.com/apache/iceberg/pull/3531)]
+    * Hive catalog can now be initialized with a `null` Hadoop configuration instead of throwing exception [[\#3252](https://github.com/apache/iceberg/pull/3252)]
+    * Table creation can now succeed instead of throwing exception when some columns do not have comments [[\#3531](https://github.com/apache/iceberg/pull/3531)]
 * **File Formats**
-  * Parquet file writing issue is fixed for string data with over 16 unparseable chars (e.g. high/low surrogates) [[\#3760](https://github.com/apache/iceberg/pull/3760)]
-  * ORC vectorized read is now configured using `read.orc.vectorization.batch-size` instead of `read.parquet.vectorization.batch-size`  [[\#3133](https://github.com/apache/iceberg/pull/3133)]
+    * Parquet file writing issue is fixed for string data with over 16 unparseable chars (e.g. high/low surrogates) [[\#3760](https://github.com/apache/iceberg/pull/3760)]
+    * ORC vectorized read is now configured using `read.orc.vectorization.batch-size` instead of `read.parquet.vectorization.batch-size`  [[\#3133](https://github.com/apache/iceberg/pull/3133)]
 
 **Other notable changes:**
 


### PR DESCRIPTION
The current list item layout on https://iceberg.apache.org/releases/ is wrongly intended, which is being fixed by this PR. Additionally, this adds Spark 3.5 to the supported engine page.

/cc @bitsondatadev @Fokko 