### PR TITLE
Core: RowDelta should conflict with RewriteFiles operation

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -139,8 +139,7 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles>
     }
 
     if (validateNewDataFiles) {
-      validateAddedDataFiles(
-          base, startingSnapshotId, dataConflictDetectionFilter(), parent, /*newDataOnly=*/ true);
+      validateAddedDataFiles(base, startingSnapshotId, dataConflictDetectionFilter(), parent, true);
     }
 
     if (validateNewDeletes) {

--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -139,7 +139,8 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles>
     }
 
     if (validateNewDataFiles) {
-      validateAddedDataFiles(base, startingSnapshotId, dataConflictDetectionFilter(), parent);
+      validateAddedDataFiles(base, startingSnapshotId, dataConflictDetectionFilter(), parent,
+          /*newDataOnly=*/true);
     }
 
     if (validateNewDeletes) {

--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -139,8 +139,8 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles>
     }
 
     if (validateNewDataFiles) {
-      validateAddedDataFiles(base, startingSnapshotId, dataConflictDetectionFilter(), parent,
-          /*newDataOnly=*/true);
+      validateAddedDataFiles(
+          base, startingSnapshotId, dataConflictDetectionFilter(), parent, /*newDataOnly=*/ true);
     }
 
     if (validateNewDeletes) {

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -302,7 +302,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   protected void validateAddedDataFiles(
       TableMetadata base, Long startingSnapshotId, PartitionSet partitionSet, Snapshot parent) {
     CloseableIterable<ManifestEntry<DataFile>> conflictEntries =
-        addedDataFiles(base, startingSnapshotId, null, partitionSet, parent, /*newDataOnly=*/false);
+        addedDataFiles(
+            base, startingSnapshotId, null, partitionSet, parent, /*newDataOnly=*/ false);
 
     try (CloseableIterator<ManifestEntry<DataFile>> conflicts = conflictEntries.iterator()) {
       if (conflicts.hasNext()) {
@@ -332,8 +333,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       Long startingSnapshotId,
       Expression conflictDetectionFilter,
       Snapshot parent) {
-    validateAddedDataFiles(base, startingSnapshotId, conflictDetectionFilter, parent,
-        /*newDataOnly=*/false);
+    validateAddedDataFiles(
+        base, startingSnapshotId, conflictDetectionFilter, parent, /*newDataOnly=*/ false);
   }
 
   /**
@@ -352,7 +353,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       Snapshot parent,
       boolean newDataOnly) {
     CloseableIterable<ManifestEntry<DataFile>> conflictEntries =
-        addedDataFiles(base, startingSnapshotId, conflictDetectionFilter, null, parent, newDataOnly);
+        addedDataFiles(
+            base, startingSnapshotId, conflictDetectionFilter, null, parent, newDataOnly);
 
     try (CloseableIterator<ManifestEntry<DataFile>> conflicts = conflictEntries.iterator()) {
       if (conflicts.hasNext()) {
@@ -378,7 +380,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
    * @param dataFilter an expression used to find new data files
    * @param partitionSet a set of partitions to find new data files
    * @param parent ending snapshot of the branch
-   * @param newDataOnly if true, only validate data files from operations that write new data records
+   * @param newDataOnly if true, only validate data files from operations that write new data
+   *     records
    */
   private CloseableIterable<ManifestEntry<DataFile>> addedDataFiles(
       TableMetadata base,
@@ -392,16 +395,12 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       return CloseableIterable.empty();
     }
 
-    Set<String> matchingOperations = newDataOnly ? VALIDATE_NEW_DATA_OPERATIONS :
-                                                   VALIDATE_ADDED_FILES_OPERATIONS;
+    Set<String> matchingOperations =
+        newDataOnly ? VALIDATE_NEW_DATA_OPERATIONS : VALIDATE_ADDED_FILES_OPERATIONS;
 
     Pair<List<ManifestFile>, Set<Long>> history =
         validationHistory(
-            base,
-            startingSnapshotId,
-            matchingOperations,
-            ManifestContent.DATA,
-            parent);
+            base, startingSnapshotId, matchingOperations, ManifestContent.DATA, parent);
     List<ManifestFile> manifests = history.first();
     Set<Long> newSnapshots = history.second();
 

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -302,8 +302,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   protected void validateAddedDataFiles(
       TableMetadata base, Long startingSnapshotId, PartitionSet partitionSet, Snapshot parent) {
     CloseableIterable<ManifestEntry<DataFile>> conflictEntries =
-        addedDataFiles(
-            base, startingSnapshotId, null, partitionSet, parent, /*newDataOnly=*/ false);
+        addedDataFiles(base, startingSnapshotId, null, partitionSet, parent, false);
 
     try (CloseableIterator<ManifestEntry<DataFile>> conflicts = conflictEntries.iterator()) {
       if (conflicts.hasNext()) {
@@ -333,8 +332,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       Long startingSnapshotId,
       Expression conflictDetectionFilter,
       Snapshot parent) {
-    validateAddedDataFiles(
-        base, startingSnapshotId, conflictDetectionFilter, parent, /*newDataOnly=*/ false);
+    validateAddedDataFiles(base, startingSnapshotId, conflictDetectionFilter, parent, false);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -58,9 +58,9 @@ import org.slf4j.LoggerFactory;
 abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   private static final Logger LOG = LoggerFactory.getLogger(MergingSnapshotProducer.class);
 
-  // data is only added in "append" and "overwrite" operations
+  // data is only added in "append", "overwrite", and "replace" operations
   private static final Set<String> VALIDATE_ADDED_FILES_OPERATIONS =
-      ImmutableSet.of(DataOperations.APPEND, DataOperations.OVERWRITE);
+      ImmutableSet.of(DataOperations.APPEND, DataOperations.OVERWRITE, DataOperations.REPLACE);
   // data files are removed in "overwrite", "replace", and "delete"
   private static final Set<String> VALIDATE_DATA_FILES_EXIST_OPERATIONS =
       ImmutableSet.of(DataOperations.OVERWRITE, DataOperations.REPLACE, DataOperations.DELETE);

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -1469,7 +1469,6 @@ public class TestRowDelta extends V2TableTestBase {
             .validateNoConflictingDataFiles()
             .validateNoConflictingDeleteFiles();
 
-
     commit(table, rewriteFiles, branch);
 
     Assertions.assertThatThrownBy(() -> commit(table, rowDelta, branch))


### PR DESCRIPTION
RewriteFiles might be used to compact a table, e.g. it can replace lots of small files with a few big files. Concurrent RowDelta (DELETE/ UPDATE) operations must fail, because they can put the table in an inconsistent state.

I.e. the followings can happen without this fix:
A successful DELETE (with merge-on-read) can become a no-op as the position delete files refer to the replaced small files.

A successful UPDATE (with merge-on-read) can duplicate rows as the delete files refer to the replaced small files, and it also adds its own data files.

OverwriteFiles is expected to be compatible with concurrent RewriteFiles if they:

- operate on separate files
- rewriteFiles removes and re-adds the same file (possibly to fix its metadata)

To not break concurrent OverwriteFiles/RewriteFiles compatibility this change also adds some extra logic for them.