### PR TITLE
Deprecate DynamoDB Catalog to Reduce Catalog Scope

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -87,7 +87,7 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 /**
  * DynamoDB implementation of Iceberg catalog
  *
- * @deprecated since version 1.6.0, will be removed after two full releases.
+ * @deprecated since version 1.6.0, will be removed in 2.0.0 release
  */
 @Deprecated
 public class DynamoDbCatalog extends BaseMetastoreCatalog

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -87,7 +87,7 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 /**
  * DynamoDB implementation of Iceberg catalog
  *
- * @deprecated since version 1.6.0, will be removed in 2.0.0 release
+ * @deprecated since 1.6.0, will be removed in 2.0.0
  */
 @Deprecated
 public class DynamoDbCatalog extends BaseMetastoreCatalog

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -84,7 +84,11 @@ import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItemsRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
-/** DynamoDB implementation of Iceberg catalog */
+/**
+ * DynamoDB implementation of Iceberg catalog
+ * @deprecated since version 1.6.0, will be removed after two full releases.
+ * */
+@Deprecated
 public class DynamoDbCatalog extends BaseMetastoreCatalog
     implements SupportsNamespaces, Configurable {
 

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -86,8 +86,9 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
 /**
  * DynamoDB implementation of Iceberg catalog
+ *
  * @deprecated since version 1.6.0, will be removed after two full releases.
- * */
+ */
 @Deprecated
 public class DynamoDbCatalog extends BaseMetastoreCatalog
     implements SupportsNamespaces, Configurable {

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -44,6 +44,10 @@ import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
+/**
+ * @deprecated since version 1.6.0, will be removed after two full releases.
+ * */
+@Deprecated
 class DynamoDbTableOperations extends BaseMetastoreTableOperations {
 
   private static final Logger LOG = LoggerFactory.getLogger(DynamoDbTableOperations.class);

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -44,7 +44,7 @@ import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
-/** @deprecated since version 1.6.0, will be removed in 2.0.0 release */
+/** @deprecated since 1.6.0, will be removed in 2.0.0 */
 @Deprecated
 class DynamoDbTableOperations extends BaseMetastoreTableOperations {
 

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -44,7 +44,7 @@ import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
-/** @deprecated since version 1.6.0, will be removed after two full releases. */
+/** @deprecated since version 1.6.0, will be removed in 2.0.0 release */
 @Deprecated
 class DynamoDbTableOperations extends BaseMetastoreTableOperations {
 

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -44,9 +44,7 @@ import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
-/**
- * @deprecated since version 1.6.0, will be removed after two full releases.
- * */
+/** @deprecated since version 1.6.0, will be removed after two full releases. */
 @Deprecated
 class DynamoDbTableOperations extends BaseMetastoreTableOperations {
 


### PR DESCRIPTION
As discussed in the [community sync](https://youtu.be/uAQVGd5zV4I?si=cj0xpfprgvJIGYIm&t=1323), we want to reduce the scope of supported catalogs in Iceberg. There are currently many options, which creates confusion and makes it difficult to properly test and upgrade each one.

The `DynamoDBCatalog` specifically has seen little adoption. It provides similar functionality to other catalogs we already support better like the `GlueCatalog`. As we look to simplify our catalog selection, the DynamoDB catalog makes sense as one to deprecate. 

This PR marks the DynamoDB catalog as deprecated. It will be removed entirely in two releases, starting from Iceberg 1.6.0.

Please comment If you have any concerns or a hard dependency on this catalog. 