### PR TITLE
Build: Free disk space before running action in Spark CI

### DIFF
--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -86,6 +86,9 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DscalaVersion=2.12 -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}_2.12:check :iceberg-spark:iceberg-spark-extensions-${{ matrix.spark }}_2.12:check :iceberg-spark:iceberg-spark-runtime-${{ matrix.spark }}_2.12:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@v4
@@ -116,6 +119,9 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DscalaVersion=2.13 -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}_2.13:check :iceberg-spark:iceberg-spark-extensions-${{ matrix.spark }}_2.13:check :iceberg-spark:iceberg-spark-runtime-${{ matrix.spark }}_2.13:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@v4
@@ -146,6 +152,9 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DscalaVersion=${{ matrix.scala-version }} -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}_${{ matrix.scala-version }}:check :iceberg-spark:iceberg-spark-extensions-${{ matrix.spark }}_${{ matrix.scala-version }}:check :iceberg-spark:iceberg-spark-runtime-${{ matrix.spark }}_${{ matrix.scala-version }}:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@v4

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ calcite = "1.10.0"
 delta-standalone = "3.1.0"
 delta-spark = "3.1.0"
 esotericsoftware-kryo = "4.0.2"
-errorprone-annotations = "2.25.0"
+errorprone-annotations = "2.24.1"
 findbugs-jsr305 = "3.0.2"
 flink116 = { strictly = "1.16.2"}
 flink117 = { strictly = "1.17.1"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ calcite = "1.10.0"
 delta-standalone = "3.1.0"
 delta-spark = "3.1.0"
 esotericsoftware-kryo = "4.0.2"
-errorprone-annotations = "2.24.1"
+errorprone-annotations = "2.25.0"
 findbugs-jsr305 = "3.0.2"
 flink116 = { strictly = "1.16.2"}
 flink117 = { strictly = "1.17.1"}


### PR DESCRIPTION
I've seen [Spark CI failure due to no disk space](https://github.com/apache/iceberg/actions/runs/7946611346/job/21694529729?pr=9746) 

```
org.apache.iceberg.spark.extensions.TestCopyOnWriteMerge > testMergeWithConcurrentTableRefresh[catalogName = testhive, implementation = org.apache.iceberg.spark.SparkCatalog, config = {type=hive, default-namespace=default}, format = parquet, vectorized = true, distributionMode = none, branch = test] FAILED
    java.lang.AssertionError: 
    Expecting actual throwable to be an instance of:
      java.lang.IllegalStateException
    but was:
      org.apache.spark.SparkException: Writing job aborted
    	at org.apache.spark.sql.errors.QueryExecutionErrors$.writingJobAbortedError(QueryExecutionErrors.scala:767)
    	at org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec.writeWithV2(WriteToDataSourceV2Exec.scala:409)
    	at org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec.writeWithV2$(WriteToDataSourceV2Exec.scala:353)
    	...(41 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
        at org.apache.iceberg.spark.extensions.TestCopyOnWriteMerge.testMergeWithConcurrentTableRefresh(TestCopyOnWriteMerge.java:148)

org.apache.iceberg.spark.extensions.TestCopyOnWriteMerge > testMergeWithMultipleUpdatesForTargetRowSmallTargetLargeSource[catalogName = testhive, implementation = org.apache.iceberg.spark.SparkCatalog, config = {type=hive, default-namespace=default}, format = parquet, vectorized = true, distributionMode = none, branch = test] FAILED
Error: a.lang.AssertionError: [Should 2024-02-18T05:06:00.9975674Z ##[error]No space left on device : '/home/runner/runners/2.313.0/_diag/pages/943a8a72-7ff9-49d1-b4cb-09d7db8a44a1_80d440e4-f54b-5560-0192-53fee83660bc_1.log'
```

This PR attempts to free unneeded disk space with [free-disk-space action](https://github.com/jlumbroso/free-disk-space).

With this action, it [saved 27GiB in one Spark CI build](https://github.com/apache/iceberg/actions/runs/8038874456/job/21955279770?pr=9786).
```
Run jlumbroso/free-disk-space@v1.3.1
Run # ======
================================================================================
BEFORE CLEAN-UP:

$ dh -h /

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   56G   17G  77% /
...
================================================================================
AFTER CLEAN-UP:

$ dh -h /

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   32G   41G  45% /
...
overall:

********************************************************************************
=> Saved 27GiB

```
