### PR TITLE
Spark 3.4, 3.5: Use current namespace for SHOW VIEWS cmd

### DIFF
--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala
@@ -67,7 +67,8 @@ case class RewriteViewCommands(spark: SparkSession) extends Rule[LogicalPlan] wi
 
     case ShowViews(UnresolvedNamespace(Seq()), pattern, output)
       if ViewUtil.isViewCatalog(catalogManager.currentCatalog) =>
-      ShowIcebergViews(ResolvedNamespace(catalogManager.currentCatalog, Seq.empty), pattern, output)
+      ShowIcebergViews(ResolvedNamespace(catalogManager.currentCatalog, catalogManager.currentNamespace),
+        pattern, output)
 
     case ShowViews(UnresolvedNamespace(CatalogAndNamespace(catalog, ns)), pattern, output)
       if ViewUtil.isViewCatalog(catalog) =>

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -1358,18 +1358,12 @@ public class TestViews extends SparkExtensionsTestBase {
     assertThat(sql("SHOW VIEWS")).contains(v1).doesNotContain(v2);
     assertThat(sql("SHOW VIEWS LIKE 'viewOne*'")).contains(v1).doesNotContain(v2);
 
-    // independently of the currently set namespace, this will contain all views in the catalog
-    assertThat(sql("SHOW VIEWS IN %s", catalogName)).contains(v1, v2);
-
     assertThat(sql("SHOW VIEWS IN %s.%s", catalogName, namespaceTwo))
         .contains(v2)
         .doesNotContain(v1);
     sql("USE %s", namespaceTwo);
     assertThat(sql("SHOW VIEWS")).contains(v2).doesNotContain(v1);
     assertThat(sql("SHOW VIEWS LIKE 'viewTwo*'")).contains(v2).doesNotContain(v1);
-
-    // independently of the currently set namespace, this will contain all views in the catalog
-    assertThat(sql("SHOW VIEWS IN %s", catalogName)).contains(v1, v2);
   }
 
   @Test

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -1336,6 +1336,43 @@ public class TestViews extends SparkExtensionsTestBase {
   }
 
   @Test
+  public void showViewsWithCurrentNamespace() {
+    String namespaceOne = "show_views_ns1";
+    String namespaceTwo = "show_views_ns2";
+    String viewOne = viewName("viewOne");
+    String viewTwo = viewName("viewTwo");
+    sql("CREATE NAMESPACE IF NOT EXISTS %s", namespaceOne);
+    sql("CREATE NAMESPACE IF NOT EXISTS %s", namespaceTwo);
+
+    // create one view in each namespace
+    sql("CREATE VIEW %s.%s AS SELECT * FROM %s.%s", namespaceOne, viewOne, NAMESPACE, tableName);
+    sql("CREATE VIEW %s.%s AS SELECT * FROM %s.%s", namespaceTwo, viewTwo, NAMESPACE, tableName);
+
+    Object[] v1 = row(namespaceOne, viewOne, false);
+    Object[] v2 = row(namespaceTwo, viewTwo, false);
+
+    assertThat(sql("SHOW VIEWS IN %s.%s", catalogName, namespaceOne))
+        .contains(v1)
+        .doesNotContain(v2);
+    sql("USE %s", namespaceOne);
+    assertThat(sql("SHOW VIEWS")).contains(v1).doesNotContain(v2);
+    assertThat(sql("SHOW VIEWS LIKE 'viewOne*'")).contains(v1).doesNotContain(v2);
+
+    // independently of the currently set namespace, this will contain all views in the catalog
+    assertThat(sql("SHOW VIEWS IN %s", catalogName)).contains(v1, v2);
+
+    assertThat(sql("SHOW VIEWS IN %s.%s", catalogName, namespaceTwo))
+        .contains(v2)
+        .doesNotContain(v1);
+    sql("USE %s", namespaceTwo);
+    assertThat(sql("SHOW VIEWS")).contains(v2).doesNotContain(v1);
+    assertThat(sql("SHOW VIEWS LIKE 'viewTwo*'")).contains(v2).doesNotContain(v1);
+
+    // independently of the currently set namespace, this will contain all views in the catalog
+    assertThat(sql("SHOW VIEWS IN %s", catalogName)).contains(v1, v2);
+  }
+
+  @Test
   public void showCreateSimpleView() {
     String viewName = "showCreateSimpleView";
     String sql = String.format("SELECT id, data FROM %s WHERE id <= 3", tableName);

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala
@@ -69,7 +69,8 @@ case class RewriteViewCommands(spark: SparkSession) extends Rule[LogicalPlan] wi
 
     case ShowViews(UnresolvedNamespace(Seq()), pattern, output)
       if ViewUtil.isViewCatalog(catalogManager.currentCatalog) =>
-      ShowIcebergViews(ResolvedNamespace(catalogManager.currentCatalog, Seq.empty), pattern, output)
+      ShowIcebergViews(ResolvedNamespace(catalogManager.currentCatalog, catalogManager.currentNamespace),
+        pattern, output)
 
     case ShowViews(UnresolvedNamespace(CatalogAndNamespace(catalog, ns)), pattern, output)
       if ViewUtil.isViewCatalog(catalog) =>

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -1457,6 +1457,43 @@ public class TestViews extends SparkExtensionsTestBase {
   }
 
   @Test
+  public void showViewsWithCurrentNamespace() {
+    String namespaceOne = "show_views_ns1";
+    String namespaceTwo = "show_views_ns2";
+    String viewOne = viewName("viewOne");
+    String viewTwo = viewName("viewTwo");
+    sql("CREATE NAMESPACE IF NOT EXISTS %s", namespaceOne);
+    sql("CREATE NAMESPACE IF NOT EXISTS %s", namespaceTwo);
+
+    // create one view in each namespace
+    sql("CREATE VIEW %s.%s AS SELECT * FROM %s.%s", namespaceOne, viewOne, NAMESPACE, tableName);
+    sql("CREATE VIEW %s.%s AS SELECT * FROM %s.%s", namespaceTwo, viewTwo, NAMESPACE, tableName);
+
+    Object[] v1 = row(namespaceOne, viewOne, false);
+    Object[] v2 = row(namespaceTwo, viewTwo, false);
+
+    assertThat(sql("SHOW VIEWS IN %s.%s", catalogName, namespaceOne))
+        .contains(v1)
+        .doesNotContain(v2);
+    sql("USE %s", namespaceOne);
+    assertThat(sql("SHOW VIEWS")).contains(v1).doesNotContain(v2);
+    assertThat(sql("SHOW VIEWS LIKE 'viewOne*'")).contains(v1).doesNotContain(v2);
+
+    // independently of the currently set namespace, this will contain all views in the catalog
+    assertThat(sql("SHOW VIEWS IN %s", catalogName)).contains(v1, v2);
+
+    assertThat(sql("SHOW VIEWS IN %s.%s", catalogName, namespaceTwo))
+        .contains(v2)
+        .doesNotContain(v1);
+    sql("USE %s", namespaceTwo);
+    assertThat(sql("SHOW VIEWS")).contains(v2).doesNotContain(v1);
+    assertThat(sql("SHOW VIEWS LIKE 'viewTwo*'")).contains(v2).doesNotContain(v1);
+
+    // independently of the currently set namespace, this will contain all views in the catalog
+    assertThat(sql("SHOW VIEWS IN %s", catalogName)).contains(v1, v2);
+  }
+
+  @Test
   public void showCreateSimpleView() {
     String viewName = "showCreateSimpleView";
     String sql = String.format("SELECT id, data FROM %s WHERE id <= 3", tableName);

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -1479,18 +1479,12 @@ public class TestViews extends SparkExtensionsTestBase {
     assertThat(sql("SHOW VIEWS")).contains(v1).doesNotContain(v2);
     assertThat(sql("SHOW VIEWS LIKE 'viewOne*'")).contains(v1).doesNotContain(v2);
 
-    // independently of the currently set namespace, this will contain all views in the catalog
-    assertThat(sql("SHOW VIEWS IN %s", catalogName)).contains(v1, v2);
-
     assertThat(sql("SHOW VIEWS IN %s.%s", catalogName, namespaceTwo))
         .contains(v2)
         .doesNotContain(v1);
     sql("USE %s", namespaceTwo);
     assertThat(sql("SHOW VIEWS")).contains(v2).doesNotContain(v1);
     assertThat(sql("SHOW VIEWS LIKE 'viewTwo*'")).contains(v2).doesNotContain(v1);
-
-    // independently of the currently set namespace, this will contain all views in the catalog
-    assertThat(sql("SHOW VIEWS IN %s", catalogName)).contains(v1, v2);
   }
 
   @Test


### PR DESCRIPTION
This uses the current namespace when executing `USE <namespace>` and then `SHOW VIEWS` (without specifying a namespace) 

This behavior is similar to what's being done for V1 `ShowViews` in https://github.com/apache/spark/blob/branch-3.5/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala#L43-L44

This reproduces the issue and shows that there's a different behavior for `SHOW TABLES` vs `SHOW VIEWS` when the current namespace is set:
```
spark-sql (default)> use iceberg1;
Time taken: 0.015 seconds
spark-sql (iceberg1)> show tables;
foo
foo2
Time taken: 0.044 seconds, Fetched 2 row(s)
spark-sql (iceberg1)> show views;
24/02/24 08:24:25 ERROR SparkSQLDriver: Failed in [show views]
org.apache.iceberg.exceptions.NoSuchNamespaceException: Invalid namespace: 
	at org.apache.iceberg.rest.RESTSessionCatalog.checkNamespaceIsValid(RESTSessionCatalog.java:993)
	at org.apache.iceberg.rest.RESTSessionCatalog.listViews(RESTSessionCatalog.java:1046)
	at org.apache.iceberg.catalog.BaseViewSessionCatalog$AsViewCatalog.listViews(BaseViewSessionCatalog.java:53)
	at org.apache.iceberg.rest.RESTCatalog.listViews(RESTCatalog.java:273)
	at org.apache.iceberg.spark.SparkCatalog.listViews(SparkCatalog.java:545)
	at org.apache.spark.sql.execution.datasources.v2.ShowV2ViewsExec.run(ShowV2ViewsExec.scala:47)
	at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result$lzycompute(V2CommandExec.scala:43)
	at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result(V2CommandExec.scala:43)
	at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.executeCollect(V2CommandExec.scala:49)
	at ...

```

With this fix, the behavior is now correct and both `SHOW TABLES` / `SHOW VIEWS` list the tables/views in the currently set namespace:
```
spark-sql (default)> use iceberg1;
Time taken: 0.02 seconds
spark-sql (iceberg1)> show tables;
foo
foo2
Time taken: 0.06 seconds, Fetched 2 row(s)
spark-sql (iceberg1)> show views;
iceberg1	v1	false
iceberg1	v2	false
Time taken: 0.035 seconds, Fetched 2 row(s)
```