### PR TITLE
Adjust Deprecation Version for DynamoDB Catalog to 1.5.0

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -87,7 +87,7 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 /**
  * DynamoDB implementation of Iceberg catalog
  *
- * @deprecated since 1.6.0, will be removed in 2.0.0
+ * @deprecated since 1.5.0, will be removed in 2.0.0
  */
 @Deprecated
 public class DynamoDbCatalog extends BaseMetastoreCatalog

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -44,7 +44,7 @@ import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
-/** @deprecated since 1.6.0, will be removed in 2.0.0 */
+/** @deprecated since 1.5.0, will be removed in 2.0.0 */
 @Deprecated
 class DynamoDbTableOperations extends BaseMetastoreTableOperations {
 

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -226,7 +226,7 @@ PARTITIONED BY (category);
 ```
 
 ### DynamoDB Catalog
-**Deprecated:** As of version 1.5.0, the DynamoDB Catalog is planned for deprecation in 2.0.0.
+**Deprecated:** As of version 1.5.0, the DynamoDB Catalog is planned for deprecation in version 2.0.0.
 
 Iceberg supports using a [DynamoDB](https://aws.amazon.com/dynamodb) table to record and manage database and table information.
 

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -226,6 +226,7 @@ PARTITIONED BY (category);
 ```
 
 ### DynamoDB Catalog
+**Deprecated:** As of version 1.5.0, the DynamoDB Catalog is planned for deprecation in 2.0.0.
 
 Iceberg supports using a [DynamoDB](https://aws.amazon.com/dynamodb) table to record and manage database and table information.
 


### PR DESCRIPTION
Fast follow update to correct the planned deprecation version for the `DynamoDbCatalog`. The previous PR set the deprecation at version 1.6.0. This change brings it forward to 1.5.0 to account for potential RC's. This change also modifies the docs to include a deprecation notice.

@jackye1995 @nastra