### PR TITLE
Core: Make CatalogHandlers.commit public

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -342,7 +342,7 @@ public class CatalogHandlers {
     return ops.current();
   }
 
-  static TableMetadata commit(TableOperations ops, UpdateTableRequest request) {
+  public static TableMetadata commit(TableOperations ops, UpdateTableRequest request) {
     AtomicBoolean isRetry = new AtomicBoolean(false);
     try {
       Tasks.foreach(ops)


### PR DESCRIPTION
Externalize TableMetadata's commit method so that the TableMetadata class can be used in custom REST catalog implementations