### PR TITLE
Migrate Read and other sub-classes in spark-extensions to JUnit5 and AssertJ style

### DIFF
--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -239,6 +239,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
     integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}"
     integrationImplementation libs.junit.vintage.engine
+    integrationImplementation libs.junit.jupiter
     integrationImplementation libs.slf4j.simple
     integrationImplementation libs.assertj.core
     integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
@@ -288,6 +289,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
   }
 
   task integrationTest(type: Test) {
+    useJUnitPlatform()
     description = "Test Spark3 Runtime Jar against Spark ${sparkMajorVersion}"
     group = "verification"
     jvmArgs += project.property('extraJvmArgs')

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTableSchema.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTableSchema.java
@@ -24,7 +24,6 @@ import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,8 +73,9 @@ public class TestAlterTableSchema extends ExtensionsTestBase {
   public void testSetInvalidIdentifierFields() {
     sql("CREATE TABLE %s (id bigint NOT NULL, id2 bigint) USING iceberg", tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue(
-        "Table should start without identifier", table.schema().identifierFieldIds().isEmpty());
+    assertThat(table.schema().identifierFieldIds())
+        .as("Table should start without identifier")
+        .isEmpty();
     Assertions.assertThatThrownBy(
             () -> sql("ALTER TABLE %s SET IDENTIFIER FIELDS unknown", tableName))
         .isInstanceOf(IllegalArgumentException.class)

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetaColumnProjectionWithStageScan.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetaColumnProjectionWithStageScan.java
@@ -18,9 +18,12 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterable;
@@ -34,19 +37,14 @@ import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
-import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestMetaColumnProjectionWithStageScan extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestMetaColumnProjectionWithStageScan extends ExtensionsTestBase {
 
-  public TestMetaColumnProjectionWithStageScan(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
       {
@@ -57,7 +55,7 @@ public class TestMetaColumnProjectionWithStageScan extends SparkExtensionsTestBa
     };
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
@@ -68,7 +66,7 @@ public class TestMetaColumnProjectionWithStageScan extends SparkExtensionsTestBa
     taskSetManager.stageTasks(tab, fileSetID, Lists.newArrayList(tasks));
   }
 
-  @Test
+  @TestTemplate
   public void testReadStageTableMeta() throws Exception {
     sql(
         "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES"
@@ -103,7 +101,7 @@ public class TestMetaColumnProjectionWithStageScan extends SparkExtensionsTestBa
               .option(SparkReadOptions.SCAN_TASK_SET_ID, fileSetID)
               .load(tableLocation);
 
-      Assertions.assertThat(scanDF2.columns().length).isEqualTo(2);
+      assertThat(scanDF2.columns()).hasSize(2);
     }
 
     try (CloseableIterable<ScanTask> tasks = table.newBatchScan().planFiles()) {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.avro.generic.GenericData.Record;
@@ -33,6 +32,7 @@ import org.apache.iceberg.FileContent;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
@@ -53,22 +53,19 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.types.StructType;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestMetadataTables extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestMetadataTables extends ExtensionsTestBase {
 
-  public TestMetadataTables(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testUnpartitionedTable() throws Exception {
     sql(
         "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES"
@@ -92,8 +89,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
     List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
     List<ManifestFile> expectedDeleteManifests = TestHelpers.deleteManifests(table);
-    Assert.assertEquals("Should have 1 data manifest", 1, expectedDataManifests.size());
-    Assert.assertEquals("Should have 1 delete manifest", 1, expectedDeleteManifests.size());
+    assertThat(expectedDataManifests).as("Should have 1 data manifest").hasSize(1);
+    assertThat(expectedDeleteManifests).as("Should have 1 delete manifest").hasSize(1);
 
     Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
     Schema filesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".files").schema();
@@ -101,13 +98,12 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     // check delete files table
     Dataset<Row> actualDeleteFilesDs = spark.sql("SELECT * FROM " + tableName + ".delete_files");
     List<Row> actualDeleteFiles = TestHelpers.selectNonDerived(actualDeleteFilesDs).collectAsList();
-    Assert.assertEquals(
-        "Metadata table should return one delete file", 1, actualDeleteFiles.size());
+    assertThat(actualDeleteFiles).as("Metadata table should return one delete file").hasSize(1);
 
     List<Record> expectedDeleteFiles =
         expectedEntries(
             table, FileContent.POSITION_DELETES, entriesTableSchema, expectedDeleteManifests, null);
-    Assert.assertEquals("Should be one delete file manifest entry", 1, expectedDeleteFiles.size());
+    assertThat(expectedDeleteFiles).as("Should be one delete file manifest entry").hasSize(1);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDeleteFilesDs),
         expectedDeleteFiles.get(0),
@@ -116,11 +112,11 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     // check data files table
     Dataset<Row> actualDataFilesDs = spark.sql("SELECT * FROM " + tableName + ".data_files");
     List<Row> actualDataFiles = TestHelpers.selectNonDerived(actualDataFilesDs).collectAsList();
-    Assert.assertEquals("Metadata table should return one data file", 1, actualDataFiles.size());
+    assertThat(actualDataFiles).as("Metadata table should return one data file").hasSize(1);
 
     List<Record> expectedDataFiles =
         expectedEntries(table, FileContent.DATA, entriesTableSchema, expectedDataManifests, null);
-    Assert.assertEquals("Should be one data file manifest entry", 1, expectedDataFiles.size());
+    assertThat(expectedDataFiles).as("Should be one data file manifest entry").hasSize(1);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDataFilesDs),
         expectedDataFiles.get(0),
@@ -131,19 +127,19 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
         spark.sql("SELECT * FROM " + tableName + ".files ORDER BY content");
     List<Row> actualFiles = TestHelpers.selectNonDerived(actualFilesDs).collectAsList();
 
-    Assert.assertEquals("Metadata table should return two files", 2, actualFiles.size());
+    assertThat(actualFiles).as("Metadata table should return two files").hasSize(2);
 
     List<Record> expectedFiles =
         Stream.concat(expectedDataFiles.stream(), expectedDeleteFiles.stream())
             .collect(Collectors.toList());
-    Assert.assertEquals("Should have two files manifest entries", 2, expectedFiles.size());
+    assertThat(expectedFiles).as("Should have two files manifest entries").hasSize(2);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(0), actualFiles.get(0));
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(1), actualFiles.get(1));
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedTable() throws Exception {
     sql(
         "CREATE TABLE %s (id bigint, data string) "
@@ -177,8 +173,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
     List<ManifestFile> expectedDeleteManifests = TestHelpers.deleteManifests(table);
-    Assert.assertEquals("Should have 2 data manifests", 2, expectedDataManifests.size());
-    Assert.assertEquals("Should have 2 delete manifests", 2, expectedDeleteManifests.size());
+    assertThat(expectedDataManifests).as("Should have 2 data manifest").hasSize(2);
+    assertThat(expectedDeleteManifests).as("Should have 2 delete manifest").hasSize(2);
 
     Schema filesTableSchema =
         Spark3Util.loadIcebergTable(spark, tableName + ".delete_files").schema();
@@ -187,15 +183,13 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Record> expectedDeleteFiles =
         expectedEntries(
             table, FileContent.POSITION_DELETES, entriesTableSchema, expectedDeleteManifests, "a");
-    Assert.assertEquals(
-        "Should have one delete file manifest entry", 1, expectedDeleteFiles.size());
+    assertThat(expectedDeleteFiles).as("Should have one delete file manifest entry").hasSize(1);
 
     Dataset<Row> actualDeleteFilesDs =
         spark.sql("SELECT * FROM " + tableName + ".delete_files " + "WHERE partition.data='a'");
     List<Row> actualDeleteFiles = actualDeleteFilesDs.collectAsList();
 
-    Assert.assertEquals(
-        "Metadata table should return one delete file", 1, actualDeleteFiles.size());
+    assertThat(actualDeleteFiles).as("Metadata table should return one delete file").hasSize(1);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDeleteFilesDs),
         expectedDeleteFiles.get(0),
@@ -204,13 +198,13 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     // Check data files table
     List<Record> expectedDataFiles =
         expectedEntries(table, FileContent.DATA, entriesTableSchema, expectedDataManifests, "a");
-    Assert.assertEquals("Should have one data file manifest entry", 1, expectedDataFiles.size());
+    assertThat(expectedDataFiles).as("Should have one data file manifest entry").hasSize(1);
 
     Dataset<Row> actualDataFilesDs =
         spark.sql("SELECT * FROM " + tableName + ".data_files " + "WHERE partition.data='a'");
 
     List<Row> actualDataFiles = TestHelpers.selectNonDerived(actualDataFilesDs).collectAsList();
-    Assert.assertEquals("Metadata table should return one data file", 1, actualDataFiles.size());
+    assertThat(actualDataFiles).as("Metadata table should return one data file").hasSize(1);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDataFilesDs),
         expectedDataFiles.get(0),
@@ -218,32 +212,29 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     List<Row> actualPartitionsWithProjection =
         spark.sql("SELECT file_count FROM " + tableName + ".partitions ").collectAsList();
-    Assert.assertEquals(
-        "Metadata table should return two partitions record",
-        2,
-        actualPartitionsWithProjection.size());
-    for (int i = 0; i < 2; ++i) {
-      Assert.assertEquals(1, actualPartitionsWithProjection.get(i).get(0));
-    }
+    assertThat(actualPartitionsWithProjection)
+        .as("Metadata table should return two partitions record")
+        .hasSize(2)
+        .containsExactly(RowFactory.create(1), RowFactory.create(1));
 
     // Check files table
     List<Record> expectedFiles =
         Stream.concat(expectedDataFiles.stream(), expectedDeleteFiles.stream())
             .collect(Collectors.toList());
-    Assert.assertEquals("Should have two file manifest entries", 2, expectedFiles.size());
+    assertThat(expectedFiles).as("Should have two file manifest entries").hasSize(2);
 
     Dataset<Row> actualFilesDs =
         spark.sql(
             "SELECT * FROM " + tableName + ".files " + "WHERE partition.data='a' ORDER BY content");
     List<Row> actualFiles = TestHelpers.selectNonDerived(actualFilesDs).collectAsList();
-    Assert.assertEquals("Metadata table should return two files", 2, actualFiles.size());
+    assertThat(actualFiles).as("Metadata table should return two files").hasSize(2);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(0), actualFiles.get(0));
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(1), actualFiles.get(1));
   }
 
-  @Test
+  @TestTemplate
   public void testAllFilesUnpartitioned() throws Exception {
     sql(
         "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES"
@@ -267,13 +258,13 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
     List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
-    Assert.assertEquals("Should have 1 data manifest", 1, expectedDataManifests.size());
+    assertThat(expectedDataManifests).as("Should have 1 data manifest").hasSize(1);
     List<ManifestFile> expectedDeleteManifests = TestHelpers.deleteManifests(table);
-    Assert.assertEquals("Should have 1 delete manifest", 1, expectedDeleteManifests.size());
+    assertThat(expectedDeleteManifests).as("Should have 1 delete manifest").hasSize(1);
 
     // Clear table to test whether 'all_files' can read past files
     List<Object[]> results = sql("DELETE FROM %s", tableName);
-    Assert.assertEquals("Table should be cleared", 0, results.size());
+    assertThat(results).as("Table should be cleared").isEmpty();
 
     Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
     Schema filesTableSchema =
@@ -285,8 +276,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     List<Record> expectedDataFiles =
         expectedEntries(table, FileContent.DATA, entriesTableSchema, expectedDataManifests, null);
-    Assert.assertEquals("Should be one data file manifest entry", 1, expectedDataFiles.size());
-    Assert.assertEquals("Metadata table should return one data file", 1, actualDataFiles.size());
+    assertThat(expectedDataFiles).as("Should be one data file manifest entry").hasSize(1);
+    assertThat(actualDataFiles).as("Metadata table should return one data file").hasSize(1);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDataFilesDs),
         expectedDataFiles.get(0),
@@ -299,9 +290,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Record> expectedDeleteFiles =
         expectedEntries(
             table, FileContent.POSITION_DELETES, entriesTableSchema, expectedDeleteManifests, null);
-    Assert.assertEquals("Should be one delete file manifest entry", 1, expectedDeleteFiles.size());
-    Assert.assertEquals(
-        "Metadata table should return one delete file", 1, actualDeleteFiles.size());
+    assertThat(expectedDeleteFiles).as("Should be one delete file manifest entry").hasSize(1);
+    assertThat(actualDeleteFiles).as("Metadata table should return one delete file").hasSize(1);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDeleteFilesDs),
         expectedDeleteFiles.get(0),
@@ -313,12 +303,12 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Row> actualFiles = actualFilesDs.collectAsList();
     List<Record> expectedFiles = ListUtils.union(expectedDataFiles, expectedDeleteFiles);
     expectedFiles.sort(Comparator.comparing(r -> ((Integer) r.get("content"))));
-    Assert.assertEquals("Metadata table should return two files", 2, actualFiles.size());
+    assertThat(actualFiles).as("Metadata table should return two files").hasSize(2);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles, actualFiles);
   }
 
-  @Test
+  @TestTemplate
   public void testAllFilesPartitioned() throws Exception {
     // Create table and insert data
     sql(
@@ -350,13 +340,13 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
     List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
-    Assert.assertEquals("Should have 2 data manifests", 2, expectedDataManifests.size());
+    assertThat(expectedDataManifests).as("Should have 2 data manifests").hasSize(2);
     List<ManifestFile> expectedDeleteManifests = TestHelpers.deleteManifests(table);
-    Assert.assertEquals("Should have 1 delete manifest", 1, expectedDeleteManifests.size());
+    assertThat(expectedDeleteManifests).as("Should have 1 delete manifest").hasSize(1);
 
     // Clear table to test whether 'all_files' can read past files
     List<Object[]> results = sql("DELETE FROM %s", tableName);
-    Assert.assertEquals("Table should be cleared", 0, results.size());
+    assertThat(results).as("Table should be cleared").isEmpty();
 
     Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
     Schema filesTableSchema =
@@ -368,8 +358,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Row> actualDataFiles = TestHelpers.selectNonDerived(actualDataFilesDs).collectAsList();
     List<Record> expectedDataFiles =
         expectedEntries(table, FileContent.DATA, entriesTableSchema, expectedDataManifests, "a");
-    Assert.assertEquals("Should be one data file manifest entry", 1, expectedDataFiles.size());
-    Assert.assertEquals("Metadata table should return one data file", 1, actualDataFiles.size());
+    assertThat(expectedDataFiles).as("Should be one data file manifest entry").hasSize(1);
+    assertThat(actualDataFiles).as("Metadata table should return one data file").hasSize(1);
     TestHelpers.assertEqualsSafe(
         SparkSchemaUtil.convert(TestHelpers.selectNonDerived(actualDataFilesDs).schema())
             .asStruct(),
@@ -384,8 +374,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Record> expectedDeleteFiles =
         expectedEntries(
             table, FileContent.POSITION_DELETES, entriesTableSchema, expectedDeleteManifests, "a");
-    Assert.assertEquals("Should be one data file manifest entry", 1, expectedDeleteFiles.size());
-    Assert.assertEquals("Metadata table should return one data file", 1, actualDeleteFiles.size());
+    assertThat(expectedDeleteFiles).as("Should be one data file manifest entry").hasSize(1);
+    assertThat(actualDeleteFiles).as("Metadata table should return one data file").hasSize(1);
 
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDeleteFilesDs),
@@ -403,12 +393,12 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     List<Record> expectedFiles = ListUtils.union(expectedDataFiles, expectedDeleteFiles);
     expectedFiles.sort(Comparator.comparing(r -> ((Integer) r.get("content"))));
-    Assert.assertEquals("Metadata table should return two files", 2, actualFiles.size());
+    assertThat(actualFiles).as("Metadata table should return two files").hasSize(2);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDataFilesDs), expectedFiles, actualFiles);
   }
 
-  @Test
+  @TestTemplate
   public void testMetadataLogEntries() throws Exception {
     // Create table and insert data
     sql(
@@ -465,8 +455,9 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
         sql(
             "SELECT * FROM %s.metadata_log_entries WHERE latest_snapshot_id = %s",
             tableName, currentSnapshotId);
-    Assert.assertEquals(
-        "metadataLogEntries table should return 1 row", 1, metadataLogWithFilters.size());
+    assertThat(metadataLogWithFilters)
+        .as("metadataLogEntries table should return 1 row")
+        .hasSize(1);
     assertEquals(
         "Result should match the latest snapshot entry",
         ImmutableList.of(
@@ -487,15 +478,16 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     metadataFiles.add(tableMetadata.metadataFileLocation());
     List<Object[]> metadataLogWithProjection =
         sql("SELECT file FROM %s.metadata_log_entries", tableName);
-    Assert.assertEquals(
-        "metadataLogEntries table should return 3 rows", 3, metadataLogWithProjection.size());
+    assertThat(metadataLogWithProjection)
+        .as("metadataLogEntries table should return 3 rows")
+        .hasSize(3);
     assertEquals(
         "metadataLog entry should be of same file",
         metadataFiles.stream().map(this::row).collect(Collectors.toList()),
         metadataLogWithProjection);
   }
 
-  @Test
+  @TestTemplate
   public void testFilesTableTimeTravelWithSchemaEvolution() throws Exception {
     // Create table and insert data
     sql(
@@ -545,7 +537,7 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Record> expectedFiles =
         expectedEntries(table, FileContent.DATA, entriesTableSchema, expectedDataManifests, null);
 
-    Assert.assertEquals("actualFiles size should be 2", 2, actualFiles.size());
+    assertThat(actualFiles).as("actualFiles size should be 2").hasSize(2);
 
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(0), actualFiles.get(0));
@@ -553,13 +545,12 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(1), actualFiles.get(1));
 
-    Assert.assertEquals(
-        "expectedFiles and actualFiles size should be the same",
-        actualFiles.size(),
-        expectedFiles.size());
+    assertThat(actualFiles)
+        .as("expectedFiles and actualFiles size should be the same")
+        .hasSameSizeAs(expectedFiles);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotReferencesMetatable() throws Exception {
     // Create table and insert data
     sql(
@@ -605,43 +596,64 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
         .commit();
     // Check refs table
     List<Row> references = spark.sql("SELECT * FROM " + tableName + ".refs").collectAsList();
-    Assert.assertEquals("Refs table should return 3 rows", 3, references.size());
+    assertThat(references).as("Refs table should return 3 rows").hasSize(3);
     List<Row> branches =
         spark.sql("SELECT * FROM " + tableName + ".refs WHERE type='BRANCH'").collectAsList();
-    Assert.assertEquals("Refs table should return 2 branches", 2, branches.size());
+    assertThat(branches).as("Refs table should return 2 branches").hasSize(2);
     List<Row> tags =
         spark.sql("SELECT * FROM " + tableName + ".refs WHERE type='TAG'").collectAsList();
-    Assert.assertEquals("Refs table should return 1 tag", 1, tags.size());
+    assertThat(tags).as("Refs table should return 1 tag").hasSize(1);
 
     // Check branch entries in refs table
     List<Row> mainBranch =
         spark
             .sql("SELECT * FROM " + tableName + ".refs WHERE name = 'main' AND type='BRANCH'")
             .collectAsList();
-    Assert.assertEquals("main", mainBranch.get(0).getAs("name"));
-    Assert.assertEquals("BRANCH", mainBranch.get(0).getAs("type"));
-    Assert.assertEquals(currentSnapshotId, mainBranch.get(0).getAs("snapshot_id"));
+    assertThat(mainBranch)
+        .hasSize(1)
+        .containsExactly(RowFactory.create("main", "BRANCH", currentSnapshotId, null, null, null));
+    assertThat(mainBranch.get(0).schema().fieldNames())
+        .containsExactly(
+            "name",
+            "type",
+            "snapshot_id",
+            "max_reference_age_in_ms",
+            "min_snapshots_to_keep",
+            "max_snapshot_age_in_ms");
 
     List<Row> testBranch =
         spark
             .sql("SELECT * FROM " + tableName + ".refs WHERE name = 'testBranch' AND type='BRANCH'")
             .collectAsList();
-    Assert.assertEquals("testBranch", testBranch.get(0).getAs("name"));
-    Assert.assertEquals("BRANCH", testBranch.get(0).getAs("type"));
-    Assert.assertEquals(currentSnapshotId, testBranch.get(0).getAs("snapshot_id"));
-    Assert.assertEquals(Long.valueOf(10), testBranch.get(0).getAs("max_reference_age_in_ms"));
-    Assert.assertEquals(Integer.valueOf(20), testBranch.get(0).getAs("min_snapshots_to_keep"));
-    Assert.assertEquals(Long.valueOf(30), testBranch.get(0).getAs("max_snapshot_age_in_ms"));
+    assertThat(testBranch)
+        .hasSize(1)
+        .containsExactly(
+            RowFactory.create("testBranch", "BRANCH", currentSnapshotId, 10L, 20L, 30L));
+    assertThat(testBranch.get(0).schema().fieldNames())
+        .containsExactly(
+            "name",
+            "type",
+            "snapshot_id",
+            "max_reference_age_in_ms",
+            "min_snapshots_to_keep",
+            "max_snapshot_age_in_ms");
 
     // Check tag entries in refs table
     List<Row> testTag =
         spark
             .sql("SELECT * FROM " + tableName + ".refs WHERE name = 'testTag' AND type='TAG'")
             .collectAsList();
-    Assert.assertEquals("testTag", testTag.get(0).getAs("name"));
-    Assert.assertEquals("TAG", testTag.get(0).getAs("type"));
-    Assert.assertEquals(currentSnapshotId, testTag.get(0).getAs("snapshot_id"));
-    Assert.assertEquals(Long.valueOf(50), testTag.get(0).getAs("max_reference_age_in_ms"));
+    assertThat(testTag)
+        .hasSize(1)
+        .containsExactly(RowFactory.create("testTag", "TAG", currentSnapshotId, 50L, null, null));
+    assertThat(testTag.get(0).schema().fieldNames())
+        .containsExactly(
+            "name",
+            "type",
+            "snapshot_id",
+            "max_reference_age_in_ms",
+            "min_snapshots_to_keep",
+            "max_snapshot_age_in_ms");
 
     // Check projection in refs table
     List<Row> testTagProjection =
@@ -651,12 +663,12 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
                     + tableName
                     + ".refs where type='TAG'")
             .collectAsList();
-    Assert.assertEquals("testTag", testTagProjection.get(0).getAs("name"));
-    Assert.assertEquals("TAG", testTagProjection.get(0).getAs("type"));
-    Assert.assertEquals(currentSnapshotId, testTagProjection.get(0).getAs("snapshot_id"));
-    Assert.assertEquals(
-        Long.valueOf(50), testTagProjection.get(0).getAs("max_reference_age_in_ms"));
-    Assert.assertNull(testTagProjection.get(0).getAs("min_snapshots_to_keep"));
+    assertThat(testTagProjection)
+        .hasSize(1)
+        .containsExactly(RowFactory.create("testTag", "TAG", currentSnapshotId, 50L, null));
+    assertThat(testTagProjection.get(0).schema().fieldNames())
+        .containsExactly(
+            "name", "type", "snapshot_id", "max_reference_age_in_ms", "min_snapshots_to_keep");
 
     List<Row> mainBranchProjection =
         spark
@@ -665,21 +677,23 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
                     + tableName
                     + ".refs WHERE name = 'main' AND type = 'BRANCH'")
             .collectAsList();
-    Assert.assertEquals("main", mainBranchProjection.get(0).getAs("name"));
-    Assert.assertEquals("BRANCH", mainBranchProjection.get(0).getAs("type"));
+    assertThat(mainBranchProjection)
+        .hasSize(1)
+        .containsExactly(RowFactory.create("main", "BRANCH"));
+    assertThat(mainBranchProjection.get(0).schema().fieldNames()).containsExactly("name", "type");
 
     List<Row> testBranchProjection =
         spark
             .sql(
-                "SELECT type, name, max_reference_age_in_ms, snapshot_id FROM "
+                "SELECT name, type, snapshot_id, max_reference_age_in_ms FROM "
                     + tableName
                     + ".refs WHERE name = 'testBranch' AND type = 'BRANCH'")
             .collectAsList();
-    Assert.assertEquals("testBranch", testBranchProjection.get(0).getAs("name"));
-    Assert.assertEquals("BRANCH", testBranchProjection.get(0).getAs("type"));
-    Assert.assertEquals(currentSnapshotId, testBranchProjection.get(0).getAs("snapshot_id"));
-    Assert.assertEquals(
-        Long.valueOf(10), testBranchProjection.get(0).getAs("max_reference_age_in_ms"));
+    assertThat(testBranchProjection)
+        .hasSize(1)
+        .containsExactly(RowFactory.create("testBranch", "BRANCH", currentSnapshotId, 10L));
+    assertThat(testBranchProjection.get(0).schema().fieldNames())
+        .containsExactly("name", "type", "snapshot_id", "max_reference_age_in_ms");
   }
 
   /**
@@ -724,7 +738,7 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     return partValue.equals(partition.get(0).toString());
   }
 
-  @Test
+  @TestTemplate
   public void metadataLogEntriesAfterReplacingTable() throws Exception {
     sql(
         "CREATE TABLE %s (id bigint, data string) "

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestStoragePartitionedJoinsInRowLevelOperations.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestStoragePartitionedJoinsInRowLevelOperations.java
@@ -20,9 +20,12 @@ package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.RowLevelOperationMode.COPY_ON_WRITE;
 import static org.apache.iceberg.RowLevelOperationMode.MERGE_ON_READ;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -31,13 +34,12 @@ import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.internal.SQLConf;
-import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestStoragePartitionedJoinsInRowLevelOperations extends ExtensionsTestBase {
 
   private static final String OTHER_TABLE_NAME = "other_table";
 
@@ -68,7 +70,7 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
           SparkSQLProperties.PRESERVE_DATA_GROUPING,
           "true");
 
-  @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
       {
@@ -79,23 +81,18 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
     };
   }
 
-  public TestStoragePartitionedJoinsInRowLevelOperations(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS %s", tableName(OTHER_TABLE_NAME));
   }
 
-  @Test
+  @TestTemplate
   public void testCopyOnWriteDeleteWithoutShuffles() {
     checkDelete(COPY_ON_WRITE);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeOnReadDeleteWithoutShuffles() {
     checkDelete(MERGE_ON_READ);
   }
@@ -139,10 +136,10 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
           String planAsString = plan.toString();
           if (mode == COPY_ON_WRITE) {
             int actualNumShuffles = StringUtils.countMatches(planAsString, "Exchange");
-            Assert.assertEquals("Should be 1 shuffle with SPJ", 1, actualNumShuffles);
-            Assertions.assertThat(planAsString).contains("Exchange hashpartitioning(_file");
+            assertThat(actualNumShuffles).as("Should be 1 shuffle with SPJ").isEqualTo(1);
+            assertThat(planAsString).contains("Exchange hashpartitioning(_file");
           } else {
-            Assertions.assertThat(planAsString).doesNotContain("Exchange");
+            assertThat(planAsString).doesNotContain("Exchange");
           }
         });
 
@@ -158,12 +155,12 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
         sql("SELECT * FROM %s ORDER BY id, salary", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testCopyOnWriteUpdateWithoutShuffles() {
     checkUpdate(COPY_ON_WRITE);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeOnReadUpdateWithoutShuffles() {
     checkUpdate(MERGE_ON_READ);
   }
@@ -207,10 +204,10 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
           String planAsString = plan.toString();
           if (mode == COPY_ON_WRITE) {
             int actualNumShuffles = StringUtils.countMatches(planAsString, "Exchange");
-            Assert.assertEquals("Should be 1 shuffle with SPJ", 1, actualNumShuffles);
-            Assertions.assertThat(planAsString).contains("Exchange hashpartitioning(_file");
+            assertThat(actualNumShuffles).as("Should be 1 shuffle with SPJ").isEqualTo(1);
+            assertThat(planAsString).contains("Exchange hashpartitioning(_file");
           } else {
-            Assertions.assertThat(planAsString).doesNotContain("Exchange");
+            assertThat(planAsString).doesNotContain("Exchange");
           }
         });
 
@@ -227,22 +224,22 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
         sql("SELECT * FROM %s ORDER BY id, salary", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testCopyOnWriteMergeWithoutShuffles() {
     checkMerge(COPY_ON_WRITE, false /* with ON predicate */);
   }
 
-  @Test
+  @TestTemplate
   public void testCopyOnWriteMergeWithoutShufflesWithPredicate() {
     checkMerge(COPY_ON_WRITE, true /* with ON predicate */);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeOnReadMergeWithoutShuffles() {
     checkMerge(MERGE_ON_READ, false /* with ON predicate */);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeOnReadMergeWithoutShufflesWithPredicate() {
     checkMerge(MERGE_ON_READ, true /* with ON predicate */);
   }
@@ -294,10 +291,10 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
           String planAsString = plan.toString();
           if (mode == COPY_ON_WRITE) {
             int actualNumShuffles = StringUtils.countMatches(planAsString, "Exchange");
-            Assert.assertEquals("Should be 1 shuffle with SPJ", 1, actualNumShuffles);
-            Assertions.assertThat(planAsString).contains("Exchange hashpartitioning(_file");
+            assertThat(actualNumShuffles).as("Should be 1 shuffle with SPJ").isEqualTo(1);
+            assertThat(planAsString).contains("Exchange hashpartitioning(_file");
           } else {
-            Assertions.assertThat(planAsString).doesNotContain("Exchange");
+            assertThat(planAsString).doesNotContain("Exchange");
           }
         });
 

--- a/spark/v3.5/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
+++ b/spark/v3.5/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
@@ -19,22 +19,19 @@
 package org.apache.iceberg.spark;
 
 import java.io.IOException;
-import java.util.Map;
+import java.nio.file.Files;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.spark.extensions.SparkExtensionsTestBase;
-import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.iceberg.spark.extensions.ExtensionsTestBase;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class SmokeTest extends SparkExtensionsTestBase {
-
-  public SmokeTest(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @Before
+@ExtendWith(ParameterizedTestExtension.class)
+public class SmokeTest extends ExtensionsTestBase {
+  @AfterEach
   public void dropTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
@@ -42,30 +39,32 @@ public class SmokeTest extends SparkExtensionsTestBase {
   // Run through our Doc's Getting Started Example
   // TODO Update doc example so that it can actually be run, modifications were required for this
   // test suite to run
-  @Test
+  @TestTemplate
   public void testGettingStarted() throws IOException {
     // Creating a table
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
     // Writing
     sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
-    Assert.assertEquals(
-        "Should have inserted 3 rows", 3L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assertions.assertThat(scalarSql("SELECT COUNT(*) FROM %s", tableName))
+        .as("Should have inserted 3 rows")
+        .isEqualTo(3L);
 
     sql("DROP TABLE IF EXISTS source PURGE");
     sql(
         "CREATE TABLE source (id bigint, data string) USING parquet LOCATION '%s'",
-        temp.newFolder());
+        Files.createTempDirectory(temp, "junit"));
     sql("INSERT INTO source VALUES (10, 'd'), (11, 'ee')");
 
     sql("INSERT INTO %s SELECT id, data FROM source WHERE length(data) = 1", tableName);
-    Assert.assertEquals(
-        "Table should now have 4 rows", 4L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assertions.assertThat(scalarSql("SELECT COUNT(*) FROM %s", tableName))
+        .as("Table should now have 4 rows")
+        .isEqualTo(4L);
 
     sql("DROP TABLE IF EXISTS updates PURGE");
     sql(
         "CREATE TABLE updates (id bigint, data string) USING parquet LOCATION '%s'",
-        temp.newFolder());
+        Files.createTempDirectory(temp, "junit"));
     sql("INSERT INTO updates VALUES (1, 'x'), (2, 'x'), (4, 'z')");
 
     sql(
@@ -73,31 +72,31 @@ public class SmokeTest extends SparkExtensionsTestBase {
             + "WHEN MATCHED THEN UPDATE SET t.data = u.data\n"
             + "WHEN NOT MATCHED THEN INSERT *",
         tableName);
-    Assert.assertEquals(
-        "Table should now have 5 rows", 5L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
-    Assert.assertEquals(
-        "Record 1 should now have data x",
-        "x",
-        scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
+    Assertions.assertThat(scalarSql("SELECT COUNT(*) FROM %s", tableName))
+        .as("Table should now have 5 rows")
+        .isEqualTo(5L);
+    Assertions.assertThat(scalarSql("SELECT data FROM %s WHERE id = 1", tableName))
+        .as("Record 1 should now have data x")
+        .isEqualTo("x");
 
     // Reading
-    Assert.assertEquals(
-        "There should be 2 records with data x",
-        2L,
-        scalarSql("SELECT count(1) as count FROM %s WHERE data = 'x' GROUP BY data ", tableName));
+    Assertions.assertThat(
+            scalarSql(
+                "SELECT count(1) as count FROM %s WHERE data = 'x' GROUP BY data ", tableName))
+        .as("There should be 2 records with data x")
+        .isEqualTo(2L);
 
     // Not supported because of Spark limitation
     if (!catalogName.equals("spark_catalog")) {
-      Assert.assertEquals(
-          "There should be 3 snapshots",
-          3L,
-          scalarSql("SELECT COUNT(*) FROM %s.snapshots", tableName));
+      Assertions.assertThat(scalarSql("SELECT COUNT(*) FROM %s.snapshots", tableName))
+          .as("There should be 3 snapshots")
+          .isEqualTo(3L);
     }
   }
 
   // From Spark DDL Docs section
-  @Test
-  public void testAlterTable() throws NoSuchTableException {
+  @TestTemplate
+  public void testAlterTable() {
     sql(
         "CREATE TABLE %s (category int, id bigint, data string, ts timestamp) USING iceberg",
         tableName);
@@ -108,7 +107,9 @@ public class SmokeTest extends SparkExtensionsTestBase {
     sql("ALTER TABLE %s ADD PARTITION FIELD years(ts)", tableName);
     sql("ALTER TABLE %s ADD PARTITION FIELD bucket(16, category) AS shard", tableName);
     table = getTable();
-    Assert.assertEquals("Table should have 4 partition fields", 4, table.spec().fields().size());
+    Assertions.assertThat(table.spec().fields())
+        .as("Table should have 4 partition fields")
+        .hasSize(4);
 
     // Drop Examples
     sql("ALTER TABLE %s DROP PARTITION FIELD bucket(16, id)", tableName);
@@ -117,17 +118,21 @@ public class SmokeTest extends SparkExtensionsTestBase {
     sql("ALTER TABLE %s DROP PARTITION FIELD shard", tableName);
 
     table = getTable();
-    Assert.assertTrue("Table should be unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should be unpartitioned")
+        .isTrue();
 
     // Sort order examples
     sql("ALTER TABLE %s WRITE ORDERED BY category, id", tableName);
     sql("ALTER TABLE %s WRITE ORDERED BY category ASC, id DESC", tableName);
     sql("ALTER TABLE %s WRITE ORDERED BY category ASC NULLS LAST, id DESC NULLS FIRST", tableName);
     table = getTable();
-    Assert.assertEquals("Table should be sorted on 2 fields", 2, table.sortOrder().fields().size());
+    Assertions.assertThat(table.sortOrder().fields())
+        .as("Table should be sorted on 2 fields")
+        .hasSize(2);
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTable() {
     sql("DROP TABLE IF EXISTS %s", tableName("first"));
     sql("DROP TABLE IF EXISTS %s", tableName("second"));
@@ -150,7 +155,9 @@ public class SmokeTest extends SparkExtensionsTestBase {
             + "PARTITIONED BY (category)",
         tableName("second"));
     Table second = getTable("second");
-    Assert.assertEquals("Should be partitioned on 1 column", 1, second.spec().fields().size());
+    Assertions.assertThat(second.spec().fields())
+        .as("Should be partitioned on 1 column")
+        .hasSize(1);
 
     sql(
         "CREATE TABLE %s (\n"
@@ -162,7 +169,9 @@ public class SmokeTest extends SparkExtensionsTestBase {
             + "PARTITIONED BY (bucket(16, id), days(ts), category)",
         tableName("third"));
     Table third = getTable("third");
-    Assert.assertEquals("Should be partitioned on 3 columns", 3, third.spec().fields().size());
+    Assertions.assertThat(third.spec().fields())
+        .as("Should be partitioned on 3 columns")
+        .hasSize(3);
   }
 
   private Table getTable(String name) {


### PR DESCRIPTION
Migrate the following "Read" and other sub-classes in spark-extensions to JUnit 5 and AssertJ style along with https://github.com/apache/iceberg/pull/9613, and https://github.com/apache/iceberg/issues/9086.

### Current Progress
- [x] TestMetaColumnProjectionWithStageScan
- [x] TestMetadataTables
- [x] TestStroragePartitionedJoinsInRowLevelOperations
- [x] TestSystemFunctionPushDownDQL
- [x] TestViews
- [x] TestAlterTableSchema (`testSetInvalidIdentifierFields` still has `Assert`.)
- [x] SmokeTest