### PR TITLE
Add support for providing output-spec-id during rewrite - spark 3.5

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -120,6 +120,16 @@ public interface RewriteDataFiles
   String REWRITE_JOB_ORDER_DEFAULT = RewriteJobOrder.NONE.orderName();
 
   /**
+   * Constant representing the target output partition specification ID.
+   *
+   * <p>output-spec-id ID is used by the file rewriter during the rewrite operation to identify the
+   * specific output partition spec. This allows rewriting files into a partitioning which is not
+   * the current schema's partitioning. If not explicitly specified the current partitioning is
+   * used.
+   */
+  String OUTPUT_SPEC_ID = "output-spec-id";
+
+  /**
    * Choose BINPACK as a strategy for this rewrite operation
    *
    * @return this for method chaining

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -120,12 +120,11 @@ public interface RewriteDataFiles
   String REWRITE_JOB_ORDER_DEFAULT = RewriteJobOrder.NONE.orderName();
 
   /**
-   * Constant representing the target output partition specification ID.
+   * The partition specification ID to be used for rewritten files
    *
    * <p>output-spec-id ID is used by the file rewriter during the rewrite operation to identify the
-   * specific output partition spec. This allows rewriting files into a partitioning which is not
-   * the current schema's partitioning. If not explicitly specified the current partitioning is
-   * used.
+   * specific output partition spec. Data will be reorganized during the rewrite to align with the
+   * output partitioning. Defaults to the current table specification used.
    */
   String OUTPUT_SPEC_ID = "output-spec-id";
 

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -124,7 +124,7 @@ public interface RewriteDataFiles
    *
    * <p>output-spec-id ID is used by the file rewriter during the rewrite operation to identify the
    * specific output partition spec. Data will be reorganized during the rewrite to align with the
-   * output partitioning. Defaults to the current table specification used.
+   * output partitioning. Defaults to the current table specification.
    */
   String OUTPUT_SPEC_ID = "output-spec-id";
 

--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewriter.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewriter.java
@@ -263,7 +263,7 @@ public abstract class SizeBasedFileRewriter<T extends ContentScanTask<F>, F exte
 
   /**
    * returns already set outputSpecId rewriter will use, value is set by user using `output-spec-id`
-   * see more {@link #outputSpecId(Map<String, String>)}
+   * see more {@link #outputSpecId(Map)}
    */
   protected int outputSpecId() {
     return outputSpecId;

--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewriter.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewriter.java
@@ -275,7 +275,7 @@ public abstract class SizeBasedFileRewriter<T extends ContentScanTask<F>, F exte
         PropertyUtil.propertyAsInt(options, RewriteDataFiles.OUTPUT_SPEC_ID, table.spec().specId());
     Preconditions.checkArgument(
         table.specs().containsKey(specId),
-        "Cannot use output spec id %d because the table spec does not contain a reference to this spec-id",
+        "Cannot use output spec id %s because the table spec does not contain a reference to this spec-id",
         specId);
     return specId;
   }

--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewriter.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewriter.java
@@ -111,6 +111,8 @@ public abstract class SizeBasedFileRewriter<T extends ContentScanTask<F>, F exte
   private boolean rewriteAll;
   private long maxGroupSize;
 
+  private int outputSpecId;
+
   protected SizeBasedFileRewriter(Table table) {
     this.table = table;
   }
@@ -146,6 +148,7 @@ public abstract class SizeBasedFileRewriter<T extends ContentScanTask<F>, F exte
     this.minInputFiles = minInputFiles(options);
     this.rewriteAll = rewriteAll(options);
     this.maxGroupSize = maxGroupSize(options);
+    this.outputSpecId = outputSpecId(options);
 
     if (rewriteAll) {
       LOG.info("Configured to rewrite all provided files in table {}", table.name());
@@ -256,6 +259,24 @@ public abstract class SizeBasedFileRewriter<T extends ContentScanTask<F>, F exte
    */
   protected long writeMaxFileSize() {
     return (long) (targetFileSize + ((maxFileSize - targetFileSize) * 0.5));
+  }
+
+  /**
+   * returns already set outputSpecId rewriter will use, value is set by user using `output-spec-id`
+   * see more {@link #outputSpecId(Map<String, String>)}
+   */
+  protected int outputSpecId() {
+    return outputSpecId;
+  }
+
+  private int outputSpecId(Map<String, String> options) {
+    int specId =
+        PropertyUtil.propertyAsInt(options, RewriteDataFiles.OUTPUT_SPEC_ID, table.spec().specId());
+    Preconditions.checkArgument(
+        table.specs().containsKey(specId),
+        "Output spec id %s is not a valid spec id for table",
+        specId);
+    return specId;
   }
 
   private Map<String, Long> sizeThresholds(Map<String, String> options) {

--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewriter.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewriter.java
@@ -275,7 +275,7 @@ public abstract class SizeBasedFileRewriter<T extends ContentScanTask<F>, F exte
         PropertyUtil.propertyAsInt(options, RewriteDataFiles.OUTPUT_SPEC_ID, table.spec().specId());
     Preconditions.checkArgument(
         table.specs().containsKey(specId),
-        "Cannot use output spec id %s because the table spec does not contain a reference to this spec-id",
+        "Cannot use output spec id %s because the table does not contain a reference to this spec-id.",
         specId);
     return specId;
   }

--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewriter.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewriter.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -261,10 +262,10 @@ public abstract class SizeBasedFileRewriter<T extends ContentScanTask<F>, F exte
     return (long) (targetFileSize + ((maxFileSize - targetFileSize) * 0.5));
   }
 
-  /**
-   * returns already set outputSpecId rewriter will use, value is set by user using `output-spec-id`
-   * see more {@link #outputSpecId(Map)}
-   */
+  protected PartitionSpec outputSpec() {
+    return table.specs().get(outputSpecId);
+  }
+
   protected int outputSpecId() {
     return outputSpecId;
   }
@@ -274,7 +275,7 @@ public abstract class SizeBasedFileRewriter<T extends ContentScanTask<F>, F exte
         PropertyUtil.propertyAsInt(options, RewriteDataFiles.OUTPUT_SPEC_ID, table.spec().specId());
     Preconditions.checkArgument(
         table.specs().containsKey(specId),
-        "Output spec id %s is not a valid spec id for table",
+        "Cannot use output spec id %d because the table spec does not contain a reference to this spec-id",
         specId);
     return specId;
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -81,7 +81,8 @@ public class RewriteDataFilesSparkAction
           PARTIAL_PROGRESS_MAX_COMMITS,
           TARGET_FILE_SIZE_BYTES,
           USE_STARTING_SEQUENCE_NUMBER,
-          REWRITE_JOB_ORDER);
+          REWRITE_JOB_ORDER,
+          OUTPUT_SPEC_ID);
 
   private static final RewriteDataFilesSparkAction.Result EMPTY_RESULT =
       ImmutableRewriteDataFiles.Result.builder().rewriteResults(ImmutableList.of()).build();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackDataRewriter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackDataRewriter.java
@@ -58,13 +58,14 @@ class SparkBinPackDataRewriter extends SparkSizeBasedDataRewriter {
         .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, groupId)
         .option(SparkWriteOptions.TARGET_FILE_SIZE_BYTES, writeMaxFileSize())
         .option(SparkWriteOptions.DISTRIBUTION_MODE, distributionMode(group).modeName())
+        .option(SparkWriteOptions.OUTPUT_SPEC_ID, outputSpecId())
         .mode("append")
         .save(groupId);
   }
 
   // invoke a shuffle if the original spec does not match the output spec
   private DistributionMode distributionMode(List<FileScanTask> group) {
-    boolean requiresRepartition = !group.get(0).spec().equals(table().spec());
+    boolean requiresRepartition = !group.get(0).spec().equals(table().specs().get(outputSpecId()));
     return requiresRepartition ? DistributionMode.RANGE : DistributionMode.NONE;
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackDataRewriter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackDataRewriter.java
@@ -65,7 +65,7 @@ class SparkBinPackDataRewriter extends SparkSizeBasedDataRewriter {
 
   // invoke a shuffle if the original spec does not match the output spec
   private DistributionMode distributionMode(List<FileScanTask> group) {
-    boolean requiresRepartition = !group.get(0).spec().equals(table().specs().get(outputSpecId()));
+    boolean requiresRepartition = !group.get(0).spec().equals(outputSpec());
     return requiresRepartition ? DistributionMode.RANGE : DistributionMode.NONE;
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkShufflingDataRewriter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkShufflingDataRewriter.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -86,6 +88,16 @@ abstract class SparkShufflingDataRewriter extends SparkSizeBasedDataRewriter {
 
   protected abstract org.apache.iceberg.SortOrder sortOrder();
 
+  /**
+   * Retrieves and returns the schema for the rewrite using the current table schema.
+   *
+   * <p>The schema with all columns required for correctly sorting the table. This may include
+   * additional computed columns which are not written to the table but are used for sorting.
+   */
+  protected Schema sortSchema() {
+    return table().schema();
+  }
+
   protected abstract Dataset<Row> sortedDF(
       Dataset<Row> df, Function<Dataset<Row>, Dataset<Row>> sortFunc);
 
@@ -122,6 +134,7 @@ abstract class SparkShufflingDataRewriter extends SparkSizeBasedDataRewriter {
         .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, groupId)
         .option(SparkWriteOptions.TARGET_FILE_SIZE_BYTES, writeMaxFileSize())
         .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING, "false")
+        .option(SparkWriteOptions.OUTPUT_SPEC_ID, outputSpecId())
         .mode("append")
         .save(groupId);
   }
@@ -152,11 +165,12 @@ abstract class SparkShufflingDataRewriter extends SparkSizeBasedDataRewriter {
   }
 
   private org.apache.iceberg.SortOrder outputSortOrder(List<FileScanTask> group) {
-    boolean includePartitionColumns = !group.get(0).spec().equals(table().spec());
-    if (includePartitionColumns) {
+    PartitionSpec spec = table().specs().get(outputSpecId());
+    boolean requiresRepartitioning = !group.get(0).spec().equals(spec);
+    if (requiresRepartitioning) {
       // build in the requirement for partition sorting into our sort order
       // as the original spec for this group does not match the output spec
-      return SortOrderUtil.buildSortOrder(table(), sortOrder());
+      return SortOrderUtil.buildSortOrder(sortSchema(), spec, sortOrder());
     } else {
       return sortOrder();
     }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkShufflingDataRewriter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkShufflingDataRewriter.java
@@ -165,7 +165,7 @@ abstract class SparkShufflingDataRewriter extends SparkSizeBasedDataRewriter {
   }
 
   private org.apache.iceberg.SortOrder outputSortOrder(List<FileScanTask> group) {
-    PartitionSpec spec = table().specs().get(outputSpecId());
+    PartitionSpec spec = outputSpec();
     boolean requiresRepartitioning = !group.get(0).spec().equals(spec);
     if (requiresRepartitioning) {
       // build in the requirement for partition sorting into our sort order

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderDataRewriter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderDataRewriter.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkUtil;
@@ -106,6 +107,21 @@ class SparkZOrderDataRewriter extends SparkShufflingDataRewriter {
   @Override
   protected SortOrder sortOrder() {
     return Z_SORT_ORDER;
+  }
+
+  /**
+   * Overrides the sortSchema method to include columns from Z_SCHEMA.
+   *
+   * <p>This method generates a new Schema object which consists of columns from the original table
+   * schema and Z_SCHEMA.
+   */
+  @Override
+  protected Schema sortSchema() {
+    return new Schema(
+        new ImmutableList.Builder<Types.NestedField>()
+            .addAll(table().schema().columns())
+            .addAll(Z_SCHEMA.columns())
+            .build());
   }
 
   @Override

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1518,10 +1518,6 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testBinpackRewriteWithInvalidOutputSpecId() {
     Table table = createTable(10);
     shouldHaveFiles(table, 10);
-    int previousSpecId = table.spec().specId();
-    // simulate multiple partition specs with different commit
-    table.updateSpec().addField(Expressions.truncate("c2", 2)).commit();
-    table.updateSpec().addField(Expressions.bucket("c3", 2)).commit();
     Assertions.assertThatThrownBy(
             () ->
                 actions()

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -49,7 +49,23 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.*;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RewriteJobOrder;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.actions.RewriteDataFiles.Result;
 import org.apache.iceberg.actions.RewriteDataFilesCommitManager;
@@ -1517,7 +1533,8 @@ public class TestRewriteDataFilesAction extends TestBase {
                     .binPack()
                     .execute())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Output spec id 1234 is not a valid spec id for table");
+        .hasMessage(
+            "Cannot use output spec id 1234 because the table does not contain a reference to this spec-id.");
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1470,7 +1470,8 @@ public class TestRewriteDataFilesAction extends TestBase {
         1001: c3_bucket_2: bucket[2](3)
       ]
      */
-    Integer outputSpecId = table.specs().size() - 2;
+    // rewrite to the truncate("c2", 2)
+    int outputSpecId = table.specs().size() - 2;
 
     long dataSizeBefore = testDataSize(table);
     long count = currentData().size();
@@ -1491,11 +1492,10 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testBinpackRewriteWithInvalidOutputSpecId() {
     Table table = createTable(10);
     shouldHaveFiles(table, 10);
-    Integer previousSpecId = table.spec().specId();
+    int previousSpecId = table.spec().specId();
     // simulate multiple partition specs with different commit
     table.updateSpec().addField(Expressions.truncate("c2", 2)).commit();
     table.updateSpec().addField(Expressions.bucket("c3", 2)).commit();
-
     /*
     This is how the table.specs() look like
      specId :: ParitionSpec
@@ -1541,7 +1541,8 @@ public class TestRewriteDataFilesAction extends TestBase {
         1001: c3_bucket_2: bucket[2](3)
       ]
      */
-    Integer outputSpecId = table.specs().size() - 2;
+    // rewrite to the truncate("c2", 2)
+    int outputSpecId = table.specs().size() - 2;
 
     long dataSizeBefore = testDataSize(table);
     long count = currentData().size();
@@ -1559,7 +1560,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @Test
-  public void testzOrderRewriteWithSpecificOutputSpecId() {
+  public void testZOrderRewriteWithSpecificOutputSpecId() {
     Table table = createTable(10);
     shouldHaveFiles(table, 10);
     Integer previousSpecId = table.spec().specId();
@@ -1579,7 +1580,8 @@ public class TestRewriteDataFilesAction extends TestBase {
         1001: c3_bucket_2: bucket[2](3)
       ]
      */
-    Integer outputSpecId = table.specs().size() - 2;
+    // rewrite to the truncate("c2", 2)
+    int outputSpecId = table.specs().size() - 2;
 
     long dataSizeBefore = testDataSize(table);
     long count = currentData().size();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1486,7 +1486,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
     assertThat(currentData().size()).isEqualTo(count);
-    shouldHaveProvidedPartitionSpec(table, outputSpecId);
+    shouldRewriteDataFilesWithPartitionSpec(table, outputSpecId);
   }
 
   @Test
@@ -1511,7 +1511,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
     assertThat(currentData().size()).isEqualTo(count);
-    shouldHaveProvidedPartitionSpec(table, outputSpecId);
+    shouldRewriteDataFilesWithPartitionSpec(table, outputSpecId);
   }
 
   @Test
@@ -1557,7 +1557,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
     assertThat(currentData().size()).isEqualTo(count);
-    shouldHaveProvidedPartitionSpec(table, outputSpecId);
+    shouldRewriteDataFilesWithPartitionSpec(table, outputSpecId);
   }
 
   @Test
@@ -1583,10 +1583,10 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
     assertThat(currentData().size()).isEqualTo(count);
-    shouldHaveProvidedPartitionSpec(table, outputSpecId);
+    shouldRewriteDataFilesWithPartitionSpec(table, outputSpecId);
   }
 
-  protected void shouldHaveProvidedPartitionSpec(Table table, int outputSpecId) {
+  protected void shouldRewriteDataFilesWithPartitionSpec(Table table, int outputSpecId) {
     List<DataFile> rewrittenFiles = currentDataFiles(table);
     // check specId matches outputSpecId
     rewrittenFiles.stream()


### PR DESCRIPTION
#7557 Support Rewrite Datafiles into a custom Partition Spec