### PR TITLE
Build: Ignore major version update in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,4 +36,7 @@ updates:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 5
+  - ignore:
+    dependency-name: "*"
+    update-types: ["version-update:semver-major"]
 


### PR DESCRIPTION
Major version updates like https://github.com/apache/iceberg/pull/9799 and https://github.com/apache/iceberg/pull/9798 are usually breaking and can't be auto merged with dependabot. 

This PR proposes to ignore major version update to have fewer noise.