### PR TITLE
Core: Add data sequence number as derived column to files metadata table

### DIFF
--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
@@ -45,7 +45,6 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
-import org.apache.iceberg.MetricsUtil;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
@@ -285,7 +284,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> deleteColumns =
         deleteFilesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String deleteNames =
         deleteColumns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
@@ -311,7 +310,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> columns =
         filesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String names = columns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
 
@@ -384,7 +383,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> columns =
         filesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String names = columns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
 
@@ -470,7 +469,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> columns =
         filesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String names = columns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
 
@@ -553,7 +552,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> columns =
         filesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String names = columns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
 

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
@@ -45,7 +45,6 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
-import org.apache.iceberg.MetricsUtil;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
@@ -285,7 +284,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> deleteColumns =
         deleteFilesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String deleteNames =
         deleteColumns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
@@ -311,7 +310,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> columns =
         filesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String names = columns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
 
@@ -384,7 +383,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> columns =
         filesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String names = columns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
 
@@ -470,7 +469,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> columns =
         filesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String names = columns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
 
@@ -553,7 +552,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> columns =
         filesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String names = columns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
 

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
@@ -45,7 +45,6 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
-import org.apache.iceberg.MetricsUtil;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
@@ -285,7 +284,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> deleteColumns =
         deleteFilesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String deleteNames =
         deleteColumns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
@@ -311,7 +310,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> columns =
         filesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String names = columns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
 
@@ -384,7 +383,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> columns =
         filesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String names = columns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
 
@@ -470,7 +469,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> columns =
         filesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String names = columns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
 
@@ -553,7 +552,7 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     List<String> columns =
         filesTableSchema.columns().stream()
             .map(Types.NestedField::name)
-            .filter(c -> !c.equals(MetricsUtil.READABLE_METRICS))
+            .filter(c -> !MetadataTableUtils.DERIVED_FIELDS.contains(c))
             .collect(Collectors.toList());
     String names = columns.stream().map(n -> "`" + n + "`").collect(Collectors.joining(","));
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
@@ -828,7 +829,7 @@ public class TestHelpers {
     StructField[] fields = metadataTable.schema().fields();
     return metadataTable.select(
         Stream.of(fields)
-            .filter(f -> !f.name().equals("readable_metrics")) // derived field
+            .filter(f -> !MetadataTableUtils.DERIVED_FIELDS.contains(f.name())) // derived field
             .map(f -> new Column(f.name()))
             .toArray(Column[]::new));
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
@@ -844,7 +845,7 @@ public class TestHelpers {
     StructField[] fields = metadataTable.schema().fields();
     return metadataTable.select(
         Stream.of(fields)
-            .filter(f -> !f.name().equals("readable_metrics")) // derived field
+            .filter(f -> !MetadataTableUtils.DERIVED_FIELDS.contains(f.name())) // derived field
             .map(f -> new Column(f.name()))
             .toArray(Column[]::new));
   }

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -276,8 +276,6 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     Assert.assertEquals("Table should be cleared", 0, results.size());
 
     Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
-    Schema filesTableSchema =
-        Spark3Util.loadIcebergTable(spark, tableName + ".all_data_files").schema();
 
     // Check all data files table
     Dataset<Row> actualDataFilesDs = spark.sql("SELECT * FROM " + tableName + ".all_data_files");

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
@@ -817,7 +818,7 @@ public class TestHelpers {
     StructField[] fields = metadataTable.schema().fields();
     return metadataTable.select(
         Stream.of(fields)
-            .filter(f -> !f.name().equals("readable_metrics")) // derived field
+            .filter(f -> !MetadataTableUtils.DERIVED_FIELDS.contains(f.name())) // derived field
             .map(f -> new Column(f.name()))
             .toArray(Column[]::new));
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadDerivedColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadDerivedColumns.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestMetadataTableReadDerivedColumns extends TestBaseWithCatalog {
+
+  @TempDir private Path temp;
+
+  private Long appendSnapshotId0;
+  private Long appendSnapshotId1;
+  private Long eqDeleteSnapshotId;
+  private Long posDeleteSnapshotId;
+
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "booleanCol", Types.BooleanType.get()),
+          required(2, "intCol", Types.IntegerType.get()));
+
+  private static final PartitionSpec SPEC =
+      PartitionSpec.builderFor(SCHEMA).identity("intCol").build();
+
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  protected static Object[][] parameters() {
+    return new Object[][] {
+      {
+        // only SparkCatalog supports metadata table sql queries
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        SparkCatalogConfig.HIVE.properties()
+      },
+    };
+  }
+
+  protected String tableName() {
+    return tableName.split("\\.")[2];
+  }
+
+  protected String database() {
+    return tableName.split("\\.")[1];
+  }
+
+  private Table createPrimitiveTable() throws IOException {
+    Table table =
+        catalog.createTable(
+            TableIdentifier.of(Namespace.of(database()), tableName()),
+            SCHEMA,
+            SPEC,
+            Collections.singletonMap(TableProperties.FORMAT_VERSION, "2"));
+
+    // write 2 data files
+    List<Record> records0 = Lists.newArrayList(createRecord(true, 0), createRecord(false, 0));
+    List<Record> records1 = Lists.newArrayList(createRecord(true, 1), createRecord(false, 1));
+    DataFile dataFile0 =
+        FileHelpers.writeDataFile(
+            table, Files.localOutput(temp.toFile()), TestHelpers.Row.of(0), records0);
+    DataFile dataFile1 =
+        FileHelpers.writeDataFile(
+            table, Files.localOutput(temp.toFile()), TestHelpers.Row.of(1), records1);
+    table.newAppend().appendFile(dataFile0).commit();
+    table.refresh();
+    appendSnapshotId0 = table.currentSnapshot().snapshotId();
+    table.newAppend().appendFile(dataFile1).commit();
+    table.refresh();
+    appendSnapshotId1 = table.currentSnapshot().snapshotId();
+
+    // write equality deletes
+    List<Record> eqDeletes = Lists.newArrayList();
+    Schema deleteRowSchema = SCHEMA.select("intCol");
+    Record delete = GenericRecord.create(deleteRowSchema);
+    eqDeletes.add(delete.copy("intCol", 1));
+    DeleteFile equalityDeletes =
+        FileHelpers.writeDeleteFile(
+            table,
+            Files.localOutput(temp.toFile()),
+            TestHelpers.Row.of(1),
+            eqDeletes,
+            deleteRowSchema);
+    table.newRowDelta().addDeletes(equalityDeletes).commit();
+    table.refresh();
+    eqDeleteSnapshotId = table.currentSnapshot().snapshotId();
+
+    // write position deletes
+    List<PositionDelete<?>> posDeletes =
+        Lists.newArrayList(positionDelete(table.schema(), dataFile0.path(), 0L, true, 0));
+
+    DeleteFile posDeleteFiles =
+        FileHelpers.writePosDeleteFile(
+            table, Files.localOutput(temp.toFile()), TestHelpers.Row.of(0), posDeletes);
+    table.newRowDelta().addDeletes(posDeleteFiles).commit();
+    table.refresh();
+    posDeleteSnapshotId = table.currentSnapshot().snapshotId();
+
+    return table;
+  }
+
+  @AfterEach
+  public void dropTable() {
+    sql("DROP TABLE %s", tableName);
+  }
+
+  protected GenericRecord createRecord(boolean booleanCol, int intCol) {
+    GenericRecord record = GenericRecord.create(SCHEMA);
+    record.set(0, booleanCol);
+    record.set(1, intCol);
+    return record;
+  }
+
+  private PositionDelete<GenericRecord> positionDelete(
+      Schema tableSchema, CharSequence path, Long position, boolean boolValue, int intValue) {
+    PositionDelete<GenericRecord> posDelete = PositionDelete.create();
+    GenericRecord nested = GenericRecord.create(tableSchema);
+    nested.set(0, boolValue);
+    nested.set(1, intValue);
+    posDelete.set(path, position, nested);
+    return posDelete;
+  }
+
+  @TestTemplate
+  public void testDataSequenceNumberOnDeleteFiles() throws Exception {
+    Table table = createPrimitiveTable();
+    DeleteFile equalityDelete =
+        table.snapshot(eqDeleteSnapshotId).addedDeleteFiles(table.io()).iterator().next();
+    DeleteFile positionDelete =
+        table.snapshot(posDeleteSnapshotId).addedDeleteFiles(table.io()).iterator().next();
+
+    List<Object[]> expected =
+        ImmutableList.of(
+            row(equalityDelete.dataSequenceNumber()), row(positionDelete.dataSequenceNumber()));
+    String deleteSql = "SELECT  data_sequence_number FROM %s.%s order by data_sequence_number";
+    List<Object[]> actual = sql(String.format(deleteSql, tableName, "delete_files"));
+    assertEquals(
+        "Select of data sequence number only should match record for delete_files table",
+        expected,
+        actual);
+  }
+
+  @TestTemplate
+  public void testMixedColumnsOnFiles() throws Exception {
+    Table table = createPrimitiveTable();
+    DataFile dataFileFirst =
+        table.snapshot(appendSnapshotId0).addedDataFiles(table.io()).iterator().next();
+    DataFile dataFileSecond =
+        table.snapshot(appendSnapshotId1).addedDataFiles(table.io()).iterator().next();
+    DeleteFile equalityDelete =
+        table.snapshot(eqDeleteSnapshotId).addedDeleteFiles(table.io()).iterator().next();
+    DeleteFile positionDelete =
+        table.snapshot(posDeleteSnapshotId).addedDeleteFiles(table.io()).iterator().next();
+
+    List<Object[]> expected =
+        ImmutableList.of(
+            row(dataFileFirst.path(), dataFileFirst.dataSequenceNumber()),
+            row(dataFileSecond.path(), dataFileSecond.dataSequenceNumber()),
+            row(equalityDelete.path(), equalityDelete.dataSequenceNumber()),
+            row(positionDelete.path(), positionDelete.dataSequenceNumber()));
+    String sql = "SELECT file_path, data_sequence_number FROM %s.%s order by data_sequence_number";
+    List<Object[]> actual = sql(String.format(sql, tableName, "files"));
+    assertEquals(
+        "Select of derived and non-derived column should match record for files table",
+        expected,
+        actual);
+  }
+
+  @TestTemplate
+  public void testVirtualColumnsOnDataFiles() throws Exception {
+    Table table = createPrimitiveTable();
+    DataFile dataFileFirst =
+        table.snapshot(appendSnapshotId0).addedDataFiles(table.io()).iterator().next();
+    DataFile dataFileSecond =
+        table.snapshot(appendSnapshotId1).addedDataFiles(table.io()).iterator().next();
+
+    List<Object[]> expected =
+        ImmutableList.of(
+            row(dataFileFirst.dataSequenceNumber(), 0, true, dataFileFirst.recordCount()),
+            row(dataFileSecond.dataSequenceNumber(), 1, true, dataFileSecond.recordCount()));
+
+    String dataFileSql =
+        "SELECT data_sequence_number,"
+            + "readable_metrics.intCol.lower_bound, readable_metrics.booleanCol.upper_bound,"
+            + "record_count FROM %s.%s order by data_sequence_number";
+    List<Object[]> result = sql(String.format(dataFileSql, tableName, "data_files"));
+    assertEquals(
+        "Select of data sequence number, readable metrcics and record count should match record for data_files table",
+        expected,
+        result);
+  }
+}


### PR DESCRIPTION
This PR add data_sequence_number as derived/virtual column on all files metadata table, enables query like
```
SELECT  data_sequence_number FROM iceberg.db.table.files
```
without change the avro schema for files.