### PR TITLE
AWS: Revert DynamoDb deprecation for 1.5.0

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -84,12 +84,7 @@ import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItemsRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
-/**
- * DynamoDB implementation of Iceberg catalog
- *
- * @deprecated since 1.5.0, will be removed in 2.0.0
- */
-@Deprecated
+/** DynamoDB implementation of Iceberg catalog */
 public class DynamoDbCatalog extends BaseMetastoreCatalog
     implements SupportsNamespaces, Configurable {
 

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -44,8 +44,6 @@ import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
-/** @deprecated since 1.5.0, will be removed in 2.0.0 */
-@Deprecated
 class DynamoDbTableOperations extends BaseMetastoreTableOperations {
 
   private static final Logger LOG = LoggerFactory.getLogger(DynamoDbTableOperations.class);

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -226,7 +226,6 @@ PARTITIONED BY (category);
 ```
 
 ### DynamoDB Catalog
-**Deprecated:** As of version 1.5.0, the DynamoDB Catalog is planned for deprecation in version 2.0.0.
 
 Iceberg supports using a [DynamoDB](https://aws.amazon.com/dynamodb) table to record and manage database and table information.
 


### PR DESCRIPTION
We might have taken the decision too early and let us discuss more and properly conclude after 1.5.0. 
https://github.com/apache/iceberg/pull/9783#issuecomment-1965781361

We don't want to delay the 1.5.0 RC. Hence, reverting this change. 
