### PR TITLE
Spark 3.4: Improve error msg when function can't be loaded

### DIFF
--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -505,9 +505,8 @@ public class TestViews extends SparkExtensionsTestBase {
     // reading from a view that references a TEMP FUNCTION shouldn't be possible
     assertThatThrownBy(() -> sql("SELECT * FROM %s", viewName))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining("The function")
-        .hasMessageContaining(functionName)
-        .hasMessageContaining("cannot be found");
+        .hasMessageStartingWith(
+            String.format("Cannot load function: %s.%s.%s", catalogName, NAMESPACE, functionName));
   }
 
   @Test

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SupportsFunctions.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SupportsFunctions.java
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.connector.catalog.FunctionCatalog;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
+import scala.Option;
 
 interface SupportsFunctions extends FunctionCatalog {
 
@@ -58,6 +59,7 @@ interface SupportsFunctions extends FunctionCatalog {
       }
     }
 
-    throw new NoSuchFunctionException(ident);
+    throw new NoSuchFunctionException(
+        String.format("Cannot load function: %s.%s", name(), ident), Option.empty());
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestFunctionCatalog.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestFunctionCatalog.java
@@ -89,13 +89,13 @@ public class TestFunctionCatalog extends SparkTestBaseWithCatalog {
                 asFunctionCatalog.loadFunction(Identifier.of(DEFAULT_NAMESPACE, "iceberg_version")))
         .isInstanceOf(NoSuchFunctionException.class)
         .hasMessageStartingWith(
-            "[ROUTINE_NOT_FOUND] The function default.iceberg_version cannot be found.");
+            String.format("Cannot load function: %s.default.iceberg_version", catalogName));
 
     Identifier undefinedFunction = Identifier.of(SYSTEM_NAMESPACE, "undefined_function");
     Assertions.assertThatThrownBy(() -> asFunctionCatalog.loadFunction(undefinedFunction))
         .isInstanceOf(NoSuchFunctionException.class)
         .hasMessageStartingWith(
-            "[ROUTINE_NOT_FOUND] The function system.undefined_function cannot be found.");
+            String.format("Cannot load function: %s.system.undefined_function", catalogName));
 
     Assertions.assertThatThrownBy(() -> sql("SELECT undefined_function(1, 2)"))
         .isInstanceOf(AnalysisException.class)


### PR DESCRIPTION
This backports #9814 to Spark 3.4