### PR TITLE
Core: API to add manifest file with OverwriteFiles.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/OverwriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/OverwriteFiles.java
@@ -154,4 +154,18 @@ public interface OverwriteFiles extends SnapshotUpdate<OverwriteFiles> {
    * @return this for method chaining
    */
   OverwriteFiles validateNoConflictingDeletes();
+
+  /**
+   * Append a {@link ManifestFile} to the table. Similar to {@link
+   * AppendFiles#appendManifest(ManifestFile)} Having this with {@link OverwriteFiles} too, helps to
+   * Use manifestFile with data files. It will put less pressure on memory in case of thousands of
+   * data files together.
+   *
+   * @param file a manifest file
+   * @return this for method chaining
+   */
+  default OverwriteFiles appendManifest(ManifestFile file) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement deleteFile");
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -113,6 +113,21 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles>
   }
 
   @Override
+  public OverwriteFiles appendManifest(ManifestFile manifest) {
+    Preconditions.checkArgument(
+        !manifest.hasExistingFiles(), "Cannot append manifest with existing files");
+    Preconditions.checkArgument(
+        !manifest.hasDeletedFiles(), "Cannot append manifest with deleted files");
+    Preconditions.checkArgument(
+        manifest.snapshotId() == null || manifest.snapshotId() == -1,
+        "Snapshot id must be assigned during commit");
+    Preconditions.checkArgument(
+        manifest.sequenceNumber() == -1, "Sequence must be assigned during commit");
+    add(manifest);
+    return this;
+  }
+
+  @Override
   public BaseOverwriteFiles toBranch(String branch) {
     targetBranch(branch);
     return this;

--- a/core/src/test/java/org/apache/iceberg/TestOverwrite.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwrite.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
+import static org.apache.iceberg.relocated.com.google.common.collect.Iterators.concat;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.apache.iceberg.util.SnapshotUtil.latestSnapshot;
@@ -337,5 +338,155 @@ public class TestOverwrite extends TestBase {
         .hasMessageStartingWith("Cannot append file with rows that do not match filter");
 
     assertThat(latestSnapshot(base, branch).snapshotId()).isEqualTo(baseId);
+  }
+
+  @Test
+  public void testOverwriteWithEmptyTableAppendManifest() throws IOException {
+    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+
+    TableMetadata base = readMetadata();
+    Assert.assertNull("Should not have a current snapshot", latestSnapshot(base, branch));
+    Assert.assertEquals("Last sequence number should be 0", 0, base.lastSequenceNumber());
+
+    ManifestFile manifest = writeManifest(FILE_A, FILE_B);
+
+    commit(super.table, super.table.newOverwrite().appendManifest(manifest), branch);
+
+    Snapshot committedSnapshot = latestSnapshot(super.table, branch);
+    Assert.assertNotNull("Should create a snapshot", latestSnapshot(super.table, branch));
+    V1Assert.assertEquals(
+        "Last sequence number should be 0", 0, super.table.ops().current().lastSequenceNumber());
+    V2Assert.assertEquals(
+        "Last sequence number should be 1", 1, super.table.ops().current().lastSequenceNumber());
+    Assert.assertEquals(
+        "Should create 1 manifest for initial write",
+        1,
+        committedSnapshot.allManifests(super.table.io()).size());
+
+    long overwriteId = committedSnapshot.snapshotId();
+    validateManifest(
+        committedSnapshot.allManifests(table.io()).get(0),
+        dataSeqs(1L, 1L),
+        fileSeqs(1L, 1L),
+        ids(overwriteId, overwriteId),
+        files(FILE_A, FILE_B),
+        statuses(Status.ADDED, Status.ADDED));
+
+    // validate that the metadata summary is correct when using appendManifest
+    Assert.assertEquals(
+        "Summary metadata should include 2 added files",
+        "2",
+        committedSnapshot.summary().get("added-data-files"));
+  }
+
+  @Test
+  public void testOverwriteWithAddFileAndAppendManifest() throws IOException {
+    // merge all manifests for this test
+    super.table.updateProperties().set("commit.manifest.min-count-to-merge", "1").commit();
+
+    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+
+    TableMetadata base = readMetadata();
+    Assert.assertNull("Should not have a current snapshot", latestSnapshot(base, branch));
+    Assert.assertEquals("Last sequence number should be 0", 0, base.lastSequenceNumber());
+
+    ManifestFile manifest = writeManifest(FILE_A, FILE_B);
+
+    commit(
+        super.table,
+        super.table.newOverwrite().addFile(FILE_C).addFile(FILE_D).appendManifest(manifest),
+        branch);
+
+    Snapshot committedSnapshot = latestSnapshot(super.table, branch);
+    Assert.assertNotNull("Should create a snapshot", latestSnapshot(super.table, branch));
+    V1Assert.assertEquals(
+        "Last sequence number should be 0", 0, super.table.ops().current().lastSequenceNumber());
+    V2Assert.assertEquals(
+        "Last sequence number should be 1", 1, super.table.ops().current().lastSequenceNumber());
+
+    long snapshotId = committedSnapshot.snapshotId();
+
+    Assert.assertEquals(
+        "Should create 1 merged manifest",
+        1,
+        committedSnapshot.allManifests(super.table.io()).size());
+
+    validateManifest(
+        committedSnapshot.allManifests(super.table.io()).get(0),
+        dataSeqs(1L, 1L, 1L, 1L),
+        fileSeqs(1L, 1L, 1L, 1L),
+        ids(snapshotId, snapshotId, snapshotId, snapshotId),
+        files(FILE_C, FILE_D, FILE_A, FILE_B),
+        statuses(Status.ADDED, Status.ADDED, Status.ADDED, Status.ADDED));
+  }
+
+  @Test
+  public void testOverwriteWithDeleteFileAndAppendManifest() throws IOException {
+    // merge all manifests for this test
+    super.table.updateProperties().set("commit.manifest.min-count-to-merge", "1").commit();
+
+    Assert.assertNull("Should not have a current snapshot", latestSnapshot(readMetadata(), branch));
+    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+
+    commit(
+        super.table,
+        super.table.newOverwrite().addFile(FILE_C).addFile(FILE_D),
+        branch); // Added data file , FILE_C and FILE_D
+
+    Assert.assertNotNull("Should create a snapshot", latestSnapshot(super.table, branch));
+    V1Assert.assertEquals(
+        "Last sequence number should be 0", 0, super.table.ops().current().lastSequenceNumber());
+    V2Assert.assertEquals(
+        "Last sequence number should be 1", 1, super.table.ops().current().lastSequenceNumber());
+
+    Snapshot commitBefore = latestSnapshot(super.table, branch);
+    long baseId = commitBefore.snapshotId();
+    validateSnapshot(null, commitBefore, 1, FILE_C, FILE_D);
+
+    Assert.assertEquals(
+        "Should create 1 manifest for initial write",
+        1,
+        commitBefore.allManifests(table.io()).size());
+    ManifestFile initialManifest = commitBefore.allManifests(table.io()).get(0);
+    validateManifest(
+        initialManifest,
+        dataSeqs(1L, 1L),
+        fileSeqs(1L, 1L),
+        ids(baseId, baseId),
+        files(FILE_C, FILE_D),
+        statuses(Status.ADDED, Status.ADDED));
+
+    ManifestFile manifest = writeManifest(FILE_A, FILE_B); // Added Data File FILE_A, FILE_B
+    commit(
+        super.table,
+        super.table
+            .newOverwrite()
+            .appendManifest(manifest)
+            .deleteFile(FILE_C), // Delete Data File FILE_C
+        branch);
+
+    V1Assert.assertEquals(
+        "Last sequence number should be 0", 0, super.table.ops().current().lastSequenceNumber());
+    V2Assert.assertEquals(
+        "Last sequence number should be 2", 2, super.table.ops().current().lastSequenceNumber());
+
+    Snapshot committedAfter = latestSnapshot(super.table, branch);
+    Assert.assertEquals(
+        "Should contain 1 merged manifest for second write",
+        1,
+        committedAfter.allManifests(super.table.io()).size());
+    ManifestFile newManifest = committedAfter.allManifests(super.table.io()).get(0);
+    Assert.assertNotEquals(
+        "Should not contain manifest from initial write", initialManifest, newManifest);
+
+    long snapshotId = committedAfter.snapshotId();
+
+    validateManifest(
+        newManifest,
+        dataSeqs(2L, 2L, 1L, 1L),
+        fileSeqs(2L, 2L, 1L, 1L),
+        ids(snapshotId, snapshotId, snapshotId, baseId),
+        concat(files(FILE_A, FILE_B), files(initialManifest)), // FILE_A, FILE_B, FILE_C, FILE_D
+        statuses(Status.ADDED, Status.ADDED, Status.DELETED, Status.EXISTING)); // FILE_C - DELETED
   }
 }


### PR DESCRIPTION
Currently [OverwriteFiles](https://github.com/apache/iceberg/blob/6a3b2d7c153412b01c746debb018c544516f2bbd/api/src/main/java/org/apache/iceberg/OverwriteFiles.java) only support to add/delete file. In case of thousands of data files. It can add heap pressure with [add(DataFile f)](https://github.com/apache/iceberg/blob/6a3b2d7c153412b01c746debb018c544516f2bbd/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java#L226). This change is to support appending manifest directly instead of chaining multiple `addFile(DataFile file)`. This API is similar to [AppendFiles](https://github.com/apache/iceberg/blob/6a3b2d7c153412b01c746debb018c544516f2bbd/api/src/main/java/org/apache/iceberg/AppendFiles.java#L59). 

CC: @ajantha-bhat , @nastra 