### PR TITLE
OpenAPI: Point to latest doc in rest catalog

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -99,7 +99,7 @@ paths:
 
 
         Common catalog configuration settings are documented at
-        https://iceberg.apache.org/configuration/#catalog-properties
+        https://iceberg.apache.org/docs/latest/configuration/#catalog-properties
         "
       responses:
         200:


### PR DESCRIPTION
This PR simply updates to point to the correct doc url