### PR TITLE
Dynamically support Spark native engine in Iceberg

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -287,6 +287,14 @@ public class SparkReadConf {
         .parse();
   }
 
+  public String getCustomizedColumnarReaderFactoryImpl() {
+    return confParser
+        .stringConf()
+        .sessionConf(SparkSQLProperties.CUSTOMIZED_COLUMNAR_READER_FACTORY_IMPL)
+        .defaultValue("")
+        .parse();
+  }
+
   public int parallelism() {
     int defaultParallelism = spark.sparkContext().defaultParallelism();
     int numShufflePartitions = spark.sessionState().conf().numShufflePartitions();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -90,4 +90,7 @@ public class SparkSQLProperties {
   public static final String EXECUTOR_CACHE_LOCALITY_ENABLED =
       "spark.sql.iceberg.executor-cache.locality.enabled";
   public static final boolean EXECUTOR_CACHE_LOCALITY_ENABLED_DEFAULT = false;
+
+  public static final String CUSTOMIZED_COLUMNAR_READER_FACTORY_IMPL =
+      "spark.sql.iceberg.customized.columnar-reader-factory-impl";
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
@@ -38,7 +38,7 @@ import org.apache.iceberg.types.TypeUtil;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBatch, T> {
-  private final int batchSize;
+  protected final int batchSize;
 
   BaseBatchReader(
       Table table,

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
+@SuppressWarnings("checkstyle:VisibilityModifier")
 abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBatch, T> {
   protected final int batchSize;
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -249,6 +249,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
   public class SparkDeleteFilter extends DeleteFilter<InternalRow> {
     private final InternalRowWrapper asStructLike;
 
+    @SuppressWarnings("checkstyle:RedundantModifier")
     public SparkDeleteFilter(String filePath, List<DeleteFile> deletes, DeleteCounter counter) {
       super(filePath, deletes, tableSchema, expectedSchema, counter);
       this.asStructLike = new InternalRowWrapper(SparkSchemaUtil.convert(requiredSchema()));

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -246,10 +246,10 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
     return value;
   }
 
-  protected class SparkDeleteFilter extends DeleteFilter<InternalRow> {
+  public class SparkDeleteFilter extends DeleteFilter<InternalRow> {
     private final InternalRowWrapper asStructLike;
 
-    SparkDeleteFilter(String filePath, List<DeleteFile> deletes, DeleteCounter counter) {
+    public SparkDeleteFilter(String filePath, List<DeleteFile> deletes, DeleteCounter counter) {
       super(filePath, deletes, tableSchema, expectedSchema, counter);
       this.asStructLike = new InternalRowWrapper(SparkSchemaUtil.convert(requiredSchema()));
     }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -38,14 +38,14 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class BatchDataReader extends BaseBatchReader<FileScanTask>
+public class BatchDataReader extends BaseBatchReader<FileScanTask>
     implements PartitionReader<ColumnarBatch> {
 
   private static final Logger LOG = LoggerFactory.getLogger(BatchDataReader.class);
 
   private final long numSplits;
 
-  BatchDataReader(SparkInputPartition partition, int batchSize) {
+  public BatchDataReader(SparkInputPartition partition, int batchSize) {
     this(
         partition.table(),
         partition.taskGroup(),

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkColumnarReaderFactory.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkColumnarReaderFactory.java
@@ -26,10 +26,12 @@ import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
-class SparkColumnarReaderFactory implements PartitionReaderFactory {
-  private final int batchSize;
+public class SparkColumnarReaderFactory implements PartitionReaderFactory {
+  protected int batchSize;
 
-  SparkColumnarReaderFactory(int batchSize) {
+  public SparkColumnarReaderFactory() {}
+
+  public void initialize(int batchSize) {
     Preconditions.checkArgument(batchSize > 1, "Batch size must be > 1");
     this.batchSize = batchSize;
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkColumnarReaderFactory.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkColumnarReaderFactory.java
@@ -26,14 +26,15 @@ import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
+@SuppressWarnings("checkstyle:VisibilityModifier")
 public class SparkColumnarReaderFactory implements PartitionReaderFactory {
   protected int batchSize;
 
   public SparkColumnarReaderFactory() {}
 
-  public void initialize(int batchSize) {
-    Preconditions.checkArgument(batchSize > 1, "Batch size must be > 1");
-    this.batchSize = batchSize;
+  public void initialize(int size) {
+    Preconditions.checkArgument(size > 1, "Batch size must be > 1");
+    this.batchSize = size;
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkColumnarReaderFactoryUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkColumnarReaderFactoryUtil.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.common.DynConstructors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SparkColumnarReaderFactoryUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SparkColumnarReaderFactoryUtil.class);
+
+  private SparkColumnarReaderFactoryUtil() {}
+
+  public static SparkColumnarReaderFactory getSparkColumnarReaderFactory(String impl) {
+    LOG.info("Loading SparkColumnarReaderFactory implementation: {}", impl);
+    DynConstructors.Ctor<SparkColumnarReaderFactory> ctor;
+    try {
+      ctor =
+          DynConstructors.builder(SparkColumnarReaderFactory.class)
+              .loader(SparkColumnarReaderFactoryUtil.class.getClassLoader())
+              .impl(impl)
+              .buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize SparkColumnarReaderFactory, missing no-arg constructor: %s", impl),
+          e);
+    }
+
+    SparkColumnarReaderFactory readerFactory;
+    try {
+      readerFactory = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize SparkColumnarReaderFactory, %s does not implement SparkColumnarReaderFactory.",
+              impl),
+          e);
+    }
+
+    return readerFactory;
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkInputPartition.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkInputPartition.java
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.HasPartitionKey;
 import org.apache.spark.sql.connector.read.InputPartition;
 
-class SparkInputPartition implements InputPartition, HasPartitionKey, Serializable {
+public class SparkInputPartition implements InputPartition, HasPartitionKey, Serializable {
   private final Types.StructType groupingKeyType;
   private final ScanTaskGroup<?> taskGroup;
   private final Broadcast<Table> tableBroadcast;


### PR DESCRIPTION
This PR tries the approach of injecting a customized `PartitionReaderFactory` to support Spark native execution engines, e.g. [Comet](https://github.com/apache/arrow-datafusion-comet)

Example usage:

```
 SparkSession spark =
   SparkSession.builder()
       .master("local[2]")
       .config("spark.sql.iceberg.customized.columnar-reader-factory.impl",
           "org.apache.comet.CometCustomizedSparkColumnarReaderFactory")
       .enableHiveSupport()
       .getOrCreate();
```