### PR TITLE
Docs: Add Daft into Iceberg documentation

### DIFF
--- a/docs/docs/daft.md
+++ b/docs/docs/daft.md
@@ -42,11 +42,13 @@ pip install getdaft pyiceberg
 
 ## Querying Iceberg using Daft
 
-### Reading PyIceberg tables
+Daft interacts natively with [PyIceberg](https://py.iceberg.apache.org/) to read Iceberg tables.
 
-Daft interacts natively with [PyIceberg](https://py.iceberg.apache.org/) to read from Iceberg.
+### Reading Iceberg tables
 
-Simply load a PyIceberg table and pass it into Daft as follows:
+Create an Iceberg table following [the spark-quickstart tutorial](https://iceberg.apache.org/spark-quickstart/). 
+
+Load the Iceberg table `demo.nyc.taxis` it into Daft, limiting to the first three columns.
 
 ``` py
 import daft

--- a/docs/docs/daft.md
+++ b/docs/docs/daft.md
@@ -86,7 +86,7 @@ df.show()
 (Showing first 8 rows)
 ```
 
-Any subsequent filter operations on the Daft `df` DataFrame object will be correctly optimized to take advantage of Iceberg features such as hidden partitioning and file-level statistics for efficient reads.
+Any filter operations on the Daft dataframe, `df`, will [push down the filters](https://iceberg.apache.org/docs/latest/performance/#data-filtering), effectuate [hidden partitioning](https://iceberg.apache.org/docs/latest/partitioning/), and utilize [table statistics to inform query planning](https://iceberg.apache.org/docs/latest/performance/#scan-planning) for efficient reads.
 
 ``` py
 import datetime

--- a/docs/docs/daft.md
+++ b/docs/docs/daft.md
@@ -44,7 +44,7 @@ Daft interacts natively with [PyIceberg](https://py.iceberg.apache.org/) to read
 
 > **Setup Steps**
 > 
-> To follow along with this code, first create an Iceberg table following [the spark-quickstart tutorial](https://iceberg.apache.org/spark-quickstart/). PyIceberg must then be correctly configured by ensuring that our `~/.pyiceberg.yaml` file contains an appropriate catalog entry:
+> To follow along with this code, first create an Iceberg table following [the Spark Quickstart tutorial](https://iceberg.apache.org/spark-quickstart/). PyIceberg must then be correctly configured by ensuring that the `~/.pyiceberg.yaml` file contains an appropriate catalog entry:
 > 
 > ```
 > catalog:

--- a/docs/docs/daft.md
+++ b/docs/docs/daft.md
@@ -145,4 +145,4 @@ When reading from an Iceberg source into Daft:
 | **Nested Types** |
 | `struct(**fields)` | [`daft.DataType.struct(**fields)`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.struct) |
 | `list(child_type)` | [`daft.DataType.list(child_type)`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.list) |
-| `map(K, V)` | [`daft.DataType.map_(K, V)`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.list) |
+| `map(K, V)` | [`daft.DataType.map(K, V)`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.map) |

--- a/docs/docs/daft.md
+++ b/docs/docs/daft.md
@@ -21,18 +21,14 @@ title: "Daft"
 # Daft
 
 [Daft](www.getdaft.io) is a distributed query engine written in Python and Rust, two fast-growing ecosystems in the data engineering and machine learning industry.
-It exposes it's flavor of the widely adopted [DataFrame API](https://www.getdaft.io/projects/docs/en/latest/api_docs/dataframe.html) akin to many existing Python libraries.
 
-Iceberg supports reading of Iceberg tables into Daft DataFrames by using the Python client library [PyIceberg](https://py.iceberg.apache.org/).
+It exposes its flavor of the familiar [Python DataFrame API](https://www.getdaft.io/projects/docs/en/latest/api_docs/dataframe.html) which is a common abstraction over querying tables of data in the Python data ecosystem.
 
-For Python users, Daft is complementary to PyIceberg as a query engine layer:
-
-* **PyIceberg:** catalog/table management tasks (e.g. creation of tables, modifying table schemas)
-* **Daft:** querying tables (e.g. previewing tables, data ETL and analysis)
-
-In database terms, PyIceberg is the Data Description Language (DDL) for database administration and Daft is the Data Manipulation Language (DML) for querying data.
+Daft DataFrames are a powerful interface to power use-cases across ML/AI training, batch inference, feature engineering and traditional analytics. Daft's tight integration with Iceberg unlocks novel capabilities for both traditional analytics and Pythonic ML workloads on your data catalog.
 
 ## Enabling Iceberg support in Daft
+
+[PyIceberg](https://py.iceberg.apache.org/) supports reading of Iceberg tables into Daft DataFrames. 
 
 To use Iceberg with Daft, ensure that the [PyIceberg](https://py.iceberg.apache.org/) library is also installed in your current Python environment.
 

--- a/docs/docs/daft.md
+++ b/docs/docs/daft.md
@@ -1,0 +1,93 @@
+---
+title: "Daft"
+---
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+
+# Daft
+
+[Daft](www.getdaft.io) is a Python/Rust-based distributed query engine with a Python DataFrame API.
+
+Iceberg supports reading of Iceberg tables into Daft DataFrames by using the Python client library [PyIceberg](https://py.iceberg.apache.org/).
+
+For Python users, Daft is complementary to PyIceberg as a pure query engine layer:
+
+* **PyIceberg:** catalog/table management tasks (e.g. creation of tables, modifying table schemas)
+* **Daft:** querying tables (e.g. previewing tables, data ETL and analysis)
+
+In database terms, PyIceberg is the Data Description Language (DDL) for database administration and Daft is the Data Manipulation Language (DML) for querying data
+
+## Enabling Iceberg support in Daft
+
+To use Iceberg with Daft, simply ensure that the [PyIceberg](https://py.iceberg.apache.org/) library is also installed in your current Python environment.
+
+```
+pip install getdaft pyiceberg
+```
+
+## Querying Iceberg using Daft
+
+### Reading PyIceberg tables
+
+Daft interacts natively with [PyIceberg](https://py.iceberg.apache.org/) to read from Iceberg.
+
+Simply load a PyIceberg table and pass it into Daft as follows:
+
+``` py
+import daft
+from pyiceberg import load_catalog
+
+table = load_catalog("my_catalog").load_table("my_namespace.my_table")
+df = daft.read_iceberg(table)
+df.show()
+```
+
+Any subsequent filter operations on the Daft `df` DataFrame object will be correctly optimized to take advantage of Iceberg features such as hidden partitioning and file-level statistics for efficient reads.
+
+``` py
+# Filter which takes advantage of partition pruning capabilities of Iceberg
+df = df.where(df["partition_key"] < 1000)
+df.show()
+```
+
+### Type compatibility
+
+Daft and Iceberg have compatible type systems. Here are how types are converted across the two systems.
+
+When reading from an Iceberg source into Daft:
+
+| Iceberg | Daft |
+|---------|------|
+| **Primitive Types** |
+| `boolean` | [`daft.DataType.bool()`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.bool) |
+| `int` | [`daft.DataType.int32()`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.int32) |
+| `long` | [`daft.DataType.int64()`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.int64) |
+| `float` | [`daft.DataType.float32()`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.float32) |
+| `double` | [`daft.DataType.float64()`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.float64) |
+| `decimal(precision, scale)` | [`daft.DataType.decimal128(precision, scale)`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.decimal128) |
+| `date` | [`daft.DataType.date()`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.date) |
+| `time` | [`daft.DataType.int64()`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.int64) |
+| `timestamp` | [`daft.DataType.timestamp(timeunit="us", timezone=None)`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.timestamp) |
+| `timestampz` | [`daft.DataType.timestamp(timeunit="us", timezone="UTC")`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.timestamp) |
+| `string` | [`daft.DataType.string()`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.string) |
+| `uuid` | [`daft.DataType.binary()`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.binary) |
+| `fixed(L)` | [`daft.DataType.binary()`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.binary) |
+| `binary` | [`daft.DataType.binary()`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.binary) |
+| **Nested Types** |
+| `struct(**fields)` | [`daft.DataType.struct(**fields)`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.struct) |
+| `list(child_type)` | [`daft.DataType.list(child_type)`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.list) |
+| `map(K, V)` | [`daft.DataType.struct({"key": K, "value": V})`](https://www.getdaft.io/projects/docs/en/latest/api_docs/datatype.html#daft.DataType.struct) |

--- a/docs/docs/daft.md
+++ b/docs/docs/daft.md
@@ -42,20 +42,20 @@ Daft interacts natively with [PyIceberg](https://py.iceberg.apache.org/) to read
 
 ### Reading Iceberg tables
 
-> **Setup Steps**
-> 
-> To follow along with this code, first create an Iceberg table following [the Spark Quickstart tutorial](https://iceberg.apache.org/spark-quickstart/). PyIceberg must then be correctly configured by ensuring that the `~/.pyiceberg.yaml` file contains an appropriate catalog entry:
-> 
-> ```
-> catalog:
->   default:
->     # URL to the Iceberg REST server Docker container
->     uri: http://localhost:8181
->     # URL and credentials for the MinIO Docker container
->     s3.endpoint: http://localhost:9000
->     s3.access-key-id: admin
->     s3.secret-access-key: password
-> ```
+**Setup Steps**
+
+To follow along with this code, first create an Iceberg table following [the Spark Quickstart tutorial](https://iceberg.apache.org/spark-quickstart/). PyIceberg must then be correctly configured by ensuring that the `~/.pyiceberg.yaml` file contains an appropriate catalog entry:
+
+```
+catalog:
+  default:
+    # URL to the Iceberg REST server Docker container
+    uri: http://localhost:8181
+    # URL and credentials for the MinIO Docker container
+    s3.endpoint: http://localhost:9000
+    s3.access-key-id: admin
+    s3.secret-access-key: password
+```
 
 Here is how the Iceberg table `demo.nyc.taxis` can be loaded into Daft:
 
@@ -77,7 +77,6 @@ df.show()
 ```
 
 ```
-WARNING:root:IcebergScanOperator(default.nyc.taxis) has Partitioning Keys: [PartitionField(vendor_id#Int64, src=vendor_id#Int64, tfm=Identity)] but no partition filter was specified. This will result in a full table scan.
 ╭───────────┬─────────┬───────────────┬─────────────┬────────────────────╮
 │ vendor_id ┆ trip_id ┆ trip_distance ┆ fare_amount ┆ store_and_fwd_flag │
 │ ---       ┆ ---     ┆ ---           ┆ ---         ┆ ---                │
@@ -95,7 +94,7 @@ WARNING:root:IcebergScanOperator(default.nyc.taxis) has Partitioning Keys: [Part
 (Showing first 4 of 4 rows)
 ```
 
-Notice that the operation above produced a warning from PyIceberg that "no partition filter was specified". Any filter operations on the Daft dataframe, `df`, will [push down the filters](https://iceberg.apache.org/docs/latest/performance/#data-filtering), correctly account for [hidden partitioning](https://iceberg.apache.org/docs/latest/partitioning/), and utilize [table statistics to inform query planning](https://iceberg.apache.org/docs/latest/performance/#scan-planning) for efficient reads.
+Note that the operation above will produce a warning from PyIceberg that "no partition filter was specified" and that "this will result in a full table scan". Any filter operations on the Daft dataframe, `df`, will [push down the filters](https://iceberg.apache.org/docs/latest/performance/#data-filtering), correctly account for [hidden partitioning](https://iceberg.apache.org/docs/latest/partitioning/), and utilize [table statistics to inform query planning](https://iceberg.apache.org/docs/latest/performance/#scan-planning) for efficient reads.
 
 Let's try the above query again, but this time with a filter applied on the table's partition column `"vendor_id"` which Daft will correctly use to elide a full table scan.
 

--- a/docs/docs/daft.md
+++ b/docs/docs/daft.md
@@ -34,7 +34,7 @@ In database terms, PyIceberg is the Data Description Language (DDL) for database
 
 ## Enabling Iceberg support in Daft
 
-To use Iceberg with Daft, simply ensure that the [PyIceberg](https://py.iceberg.apache.org/) library is also installed in your current Python environment.
+To use Iceberg with Daft, ensure that the [PyIceberg](https://py.iceberg.apache.org/) library is also installed in your current Python environment.
 
 ```
 pip install getdaft pyiceberg

--- a/docs/docs/daft.md
+++ b/docs/docs/daft.md
@@ -29,7 +29,7 @@ For Python users, Daft is complementary to PyIceberg as a pure query engine laye
 * **PyIceberg:** catalog/table management tasks (e.g. creation of tables, modifying table schemas)
 * **Daft:** querying tables (e.g. previewing tables, data ETL and analysis)
 
-In database terms, PyIceberg is the Data Description Language (DDL) for database administration and Daft is the Data Manipulation Language (DML) for querying data
+In database terms, PyIceberg is the Data Description Language (DDL) for database administration and Daft is the Data Manipulation Language (DML) for querying data.
 
 ## Enabling Iceberg support in Daft
 

--- a/docs/docs/daft.md
+++ b/docs/docs/daft.md
@@ -20,7 +20,8 @@ title: "Daft"
 
 # Daft
 
-[Daft](www.getdaft.io) is a Python/Rust-based distributed query engine with a Python DataFrame API.
+[Daft](www.getdaft.io) is a distributed query engine written in Python and Rust, two fast-growing ecosystems in the data engineering and machine learning industry.
+It exposes it's flavor of the widely adopted [DataFrame API](https://www.getdaft.io/projects/docs/en/latest/api_docs/dataframe.html) akin to many existing Python libraries.
 
 Iceberg supports reading of Iceberg tables into Daft DataFrames by using the Python client library [PyIceberg](https://py.iceberg.apache.org/).
 

--- a/docs/docs/daft.md
+++ b/docs/docs/daft.md
@@ -122,7 +122,6 @@ df.show()
 
 Daft and Iceberg have compatible type systems. Here are how types are converted across the two systems.
 
-When reading from an Iceberg source into Daft:
 
 | Iceberg | Daft |
 |---------|------|

--- a/docs/docs/daft.md
+++ b/docs/docs/daft.md
@@ -57,7 +57,7 @@ Daft interacts natively with [PyIceberg](https://py.iceberg.apache.org/) to read
 >     s3.secret-access-key: password
 > ```
 
-Here is how we can load the Iceberg table `demo.nyc.taxis` into Daft:
+Here is how the Iceberg table `demo.nyc.taxis` can be loaded into Daft:
 
 ``` py
 import daft

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - flink-configuration.md
   - hive.md
   - Trino: https://trino.io/docs/current/connector/iceberg.html
+  - Daft: daft.md
   - Clickhouse: https://clickhouse.com/docs/en/engines/table-engines/integrations/iceberg
   - Presto: https://prestodb.io/docs/current/connector/iceberg.html
   - Dremio: https://docs.dremio.com/data-formats/apache-iceberg/


### PR DESCRIPTION
- Adds installation examples
- Adds code examples for getting up and running with Daft + PyIceberg
- Adds a type conversion matrix between Daft and PyIceberg