### PR TITLE
Core: FileIO Reflection Error Message is Misleading

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -334,7 +334,7 @@ public class CatalogUtil {
               .buildChecked();
     } catch (NoSuchMethodException e) {
       throw new IllegalArgumentException(
-          String.format("Cannot initialize FileIO, missing no-arg constructor: %s", impl), e);
+          String.format("Cannot initialize FileIO implementation %s: %s", impl, e.getMessage()), e);
     }
 
     FileIO fileIO;

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -160,7 +160,8 @@ public class TestCatalogUtil {
     Assertions.assertThatThrownBy(
             () -> CatalogUtil.loadFileIO(TestFileIOBadArg.class.getName(), Maps.newHashMap(), null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Cannot initialize FileIO, missing no-arg constructor");
+        .hasMessageStartingWith("Cannot initialize FileIO implementation " +
+                "org.apache.iceberg.TestCatalogUtil$TestFileIOBadArg: Cannot find constructor");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -160,8 +160,9 @@ public class TestCatalogUtil {
     Assertions.assertThatThrownBy(
             () -> CatalogUtil.loadFileIO(TestFileIOBadArg.class.getName(), Maps.newHashMap(), null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Cannot initialize FileIO implementation " +
-                "org.apache.iceberg.TestCatalogUtil$TestFileIOBadArg: Cannot find constructor");
+        .hasMessageStartingWith(
+            "Cannot initialize FileIO implementation "
+                + "org.apache.iceberg.TestCatalogUtil$TestFileIOBadArg: Cannot find constructor");
   }
 
   @Test


### PR DESCRIPTION
The current error message always says FileIO "missing no-arg constructor: " whenever a NoSuchMethod is thrown but we've seen several instances of the underlying exception being completely unrelated to the existence of a no arg constructor and actually a NSM exception being thrown from a dependent class. 

The biggest culprit of this is S3FileIO, for example if you have a bad AWS SDK you can see something like

#7396

```java
Exception in thread "main" java.lang.IllegalArgumentException: Cannot initialize FileIO, missing no-arg constructor: org.apache.iceberg.aws.s3.S3FileIO
Caused by: java.lang.NoSuchMethodException: Cannot find constructor for interface org.apache.iceberg.io.FileIO
	Missing org.apache.iceberg.aws.s3.S3FileIO [java.lang.NoClassDefFoundError: software/amazon/awssdk/services/s3/model/S3Exception]
	Suppressed: java.lang.NoClassDefFoundError: software/amazon/awssdk/services/s3/model/S3Exception
	Caused by: java.lang.ClassNotFoundException: software.amazon.awssdk.services.s3.model.S3Exception
```

While our error message says it's missing a no-arg constructor the ACTUAL issue is that the AWS SDK is not on the classpath.


To fix this I've changed the error message to mirror the one for the LoadCatalog code which doesn't insert a statement about it missing a no-arg constructor. I think we have similar issues with the class cast error message but I haven't seen that been wrong in the wild yet.