### PR TITLE
Migrate Read in Core to JUnit5

### DIFF
--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -72,7 +72,7 @@ public abstract class MetadataTableScanTestBase extends TestBase {
           } else {
             assertThat(fileScanTask.residual())
                 .as("Residuals must be preserved")
-                .isEqualTo(Expressions.alwaysTrue());
+                .isNotEqualTo(Expressions.alwaysTrue());
           }
         }
       }

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -88,7 +88,7 @@ public abstract class MetadataTableScanTestBase extends TestBase {
       CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries,
       int position,
       int partitionValue) {
-    assertThat(StreamSupport.stream(entries.spliterator(), false))
+    assertThat(entries)
         .as("File scan tasks do not include correct file")
         .anyMatch(
             entry -> {
@@ -96,6 +96,7 @@ public abstract class MetadataTableScanTestBase extends TestBase {
               if (position >= partition.size()) {
                 return false;
               }
+
               return Objects.equals(partitionValue, partition.get(position, Object.class));
             });
   }

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -18,7 +18,11 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -26,24 +30,17 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.PartitionUtil;
-import org.junit.Assert;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public abstract class MetadataTableScanTestBase extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public abstract class MetadataTableScanTestBase extends TestBase {
 
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
-  }
-
-  public MetadataTableScanTestBase(int formatVersion) {
-    super(formatVersion);
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
   protected Set<String> actualManifestListPaths(TableScan allManifestsTableScan) {
@@ -65,15 +62,17 @@ public abstract class MetadataTableScanTestBase extends TableTestBase {
   protected void validateTaskScanResiduals(TableScan scan, boolean ignoreResiduals)
       throws IOException {
     try (CloseableIterable<CombinedScanTask> tasks = scan.planTasks()) {
-      Assert.assertTrue("Tasks should not be empty", Iterables.size(tasks) > 0);
+      assertThat(tasks).as("Tasks should not be empty").hasSizeGreaterThan(0);
       for (CombinedScanTask combinedScanTask : tasks) {
         for (FileScanTask fileScanTask : combinedScanTask.files()) {
           if (ignoreResiduals) {
-            Assert.assertEquals(
-                "Residuals must be ignored", Expressions.alwaysTrue(), fileScanTask.residual());
+            assertThat(fileScanTask.residual())
+                .as("Residuals must be ignored")
+                .isEqualTo(Expressions.alwaysTrue());
           } else {
-            Assert.assertNotEquals(
-                "Residuals must be preserved", Expressions.alwaysTrue(), fileScanTask.residual());
+            assertThat(fileScanTask.residual())
+                .as("Residuals must be preserved")
+                .isEqualTo(Expressions.alwaysTrue());
           }
         }
       }
@@ -89,18 +88,16 @@ public abstract class MetadataTableScanTestBase extends TableTestBase {
       CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries,
       int position,
       int partitionValue) {
-    Assert.assertTrue(
-        "File scan tasks do not include correct file",
-        StreamSupport.stream(entries.spliterator(), false)
-            .anyMatch(
-                entry -> {
-                  StructLike partition = entry.file().partition();
-                  if (position >= partition.size()) {
-                    return false;
-                  }
-
-                  return Objects.equals(partitionValue, partition.get(position, Object.class));
-                }));
+    assertThat(StreamSupport.stream(entries.spliterator(), false))
+        .as("File scan tasks do not include correct file")
+        .anyMatch(
+            entry -> {
+              StructLike partition = entry.file().partition();
+              if (position >= partition.size()) {
+                return false;
+              }
+              return Objects.equals(partitionValue, partition.get(position, Object.class));
+            });
   }
 
   protected Map<Integer, ?> constantsMap(

--- a/core/src/test/java/org/apache/iceberg/TestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TestBase.java
@@ -745,6 +745,12 @@ public class TestBase {
         assertThat(actual).as(context).isEqualTo(expected);
       }
     }
+
+    void assertHasSize(String context, int expected, List<?> actualList) {
+      if (enabled) {
+        assertThat(actualList).as(context).hasSize(expected);
+      }
+    }
   }
 
   @FunctionalInterface

--- a/core/src/test/java/org/apache/iceberg/TestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TestBase.java
@@ -745,12 +745,6 @@ public class TestBase {
         assertThat(actual).as(context).isEqualTo(expected);
       }
     }
-
-    void assertHasSize(String context, int expected, List<?> actualList) {
-      if (enabled) {
-        assertThat(actualList).as(context).hasSize(expected);
-      }
-    }
   }
 
   @FunctionalInterface

--- a/core/src/test/java/org/apache/iceberg/TestBatchScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestBatchScans.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class TestBatchScans extends TestBase {
 
   @Parameters(name = "formatVersion = {0}")
-  public static List<Object> parameters() {
+  protected static List<Object> parameters() {
     return Arrays.asList(1, 2);
   }
 
@@ -52,8 +52,8 @@ public class TestBatchScans extends TestBase {
 
     FileScanTask t1 = tasks.get(0).asFileScanTask();
     assertThat(FILE_A.path()).as("Task file must match").isEqualTo(t1.file().path());
-    V1Assert.assertHasSize("Task deletes size must match", 0, t1.deletes());
-    V2Assert.assertHasSize("Task deletes size must match", 1, t1.deletes());
+    V1Assert.assertEquals("Task deletes size must match", 0, t1.deletes().size());
+    V2Assert.assertEquals("Task deletes size must match", 1, t1.deletes().size());
 
     FileScanTask t2 = tasks.get(1).asFileScanTask();
     assertThat(FILE_B.path()).as("Task file must match").isEqualTo(t2.file().path());

--- a/core/src/test/java/org/apache/iceberg/TestBatchScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestBatchScans.java
@@ -18,29 +18,26 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestBatchScans extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestBatchScans extends TestBase {
 
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+  @Parameters(name = "formatVersion = {0}")
+  public static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestBatchScans(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testDataTableScan() {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -51,27 +48,27 @@ public class TestBatchScans extends TableTestBase {
     BatchScan scan = table.newBatchScan();
 
     List<ScanTask> tasks = planTasks(scan);
-    Assert.assertEquals("Expected 2 tasks", 2, tasks.size());
+    assertThat(tasks).hasSize(2);
 
     FileScanTask t1 = tasks.get(0).asFileScanTask();
-    Assert.assertEquals("Task file must match", t1.file().path(), FILE_A.path());
-    V1Assert.assertEquals("Task deletes size must match", 0, t1.deletes().size());
-    V2Assert.assertEquals("Task deletes size must match", 1, t1.deletes().size());
+    assertThat(FILE_A.path()).as("Task file must match").isEqualTo(t1.file().path());
+    V1Assert.assertHasSize("Task deletes size must match", 0, t1.deletes());
+    V2Assert.assertHasSize("Task deletes size must match", 1, t1.deletes());
 
     FileScanTask t2 = tasks.get(1).asFileScanTask();
-    Assert.assertEquals("Task file must match", t2.file().path(), FILE_B.path());
-    Assert.assertEquals("Task deletes size must match", 0, t2.deletes().size());
+    assertThat(FILE_B.path()).as("Task file must match").isEqualTo(t2.file().path());
+    assertThat(t2.deletes()).as("Task deletes size must match").hasSize(0);
 
     List<ScanTaskGroup<ScanTask>> taskGroups = planTaskGroups(scan);
-    Assert.assertEquals("Expected 1 task group", 1, taskGroups.size());
+    assertThat(taskGroups).as("Expected 1 task group").hasSize(1);
 
     ScanTaskGroup<ScanTask> tg = taskGroups.get(0);
-    Assert.assertEquals("Task number must match", 2, tg.tasks().size());
+    assertThat(tg.tasks()).as("Task number must match").hasSize(2);
     V1Assert.assertEquals("Files count must match", 2, tg.filesCount());
     V2Assert.assertEquals("Files count must match", 3, tg.filesCount());
   }
 
-  @Test
+  @TestTemplate
   public void testFilesTableScan() {
     table.newFastAppend().appendFile(FILE_A).commit();
     table.newFastAppend().appendFile(FILE_B).commit();
@@ -81,26 +78,26 @@ public class TestBatchScans extends TableTestBase {
             .map(ManifestFile::path)
             .sorted()
             .collect(Collectors.toList());
-    Assert.assertEquals("Must have 2 manifests", 2, manifestPaths.size());
+    assertThat(manifestPaths).as("Must have 2 manifests").hasSize(2);
 
     FilesTable filesTable = new FilesTable(table);
 
     BatchScan scan = filesTable.newBatchScan();
 
     List<ScanTask> tasks = planTasks(scan);
-    Assert.assertEquals("Expected 2 tasks", 2, tasks.size());
+    assertThat(tasks).as("Expected 2 tasks").hasSize(2);
 
     FileScanTask t1 = tasks.get(0).asFileScanTask();
-    Assert.assertEquals("Task file must match", t1.file().path(), manifestPaths.get(0));
+    assertThat(manifestPaths).first().as("Task file must match").isEqualTo(t1.file().path());
 
     FileScanTask t2 = tasks.get(1).asFileScanTask();
-    Assert.assertEquals("Task file must match", t2.file().path(), manifestPaths.get(1));
+    assertThat(manifestPaths).element(1).as("Task file must match").isEqualTo(t2.file().path());
 
     List<ScanTaskGroup<ScanTask>> taskGroups = planTaskGroups(scan);
-    Assert.assertEquals("Expected 1 task group", 1, taskGroups.size());
+    assertThat(taskGroups).as("Expected 1 task group").hasSize(1);
 
     ScanTaskGroup<ScanTask> tg = taskGroups.get(0);
-    Assert.assertEquals("Task number must match", 2, tg.tasks().size());
+    assertThat(tg.tasks()).as("Task number must match").hasSize(2);
   }
 
   // plans tasks and reorders them by file name to have deterministic order

--- a/core/src/test/java/org/apache/iceberg/TestEntriesMetadataTable.java
+++ b/core/src/test/java/org/apache/iceberg/TestEntriesMetadataTable.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class TestEntriesMetadataTable extends TestBase {
 
   @Parameters(name = "formatVersion = {0}")
-  public static List<Object> parameters() {
+  protected static List<Object> parameters() {
     return Arrays.asList(1, 2);
   }
 
@@ -70,8 +70,8 @@ public class TestEntriesMetadataTable extends TestBase {
     FileScanTask file = Iterables.getOnlyElement(scan.planFiles());
     assertThat(file.file().path())
         .as("Data file should be the table's manifest")
-        .isEqualTo(
-            Iterables.getOnlyElement(table.currentSnapshot().allManifests(table.io())).path());
+        .isEqualTo(table.currentSnapshot().allManifests(table.io()).get(0).path());
+
     assertThat(file.file().recordCount()).as("Should contain 2 data file records").isEqualTo(2);
   }
 
@@ -147,15 +147,13 @@ public class TestEntriesMetadataTable extends TestBase {
     List<FileScanTask> files = ImmutableList.copyOf(scan.planFiles());
     assertThat(files.get(0).file().path())
         .as("Data file should be the table's manifest")
-        .isEqualTo(
-            Iterables.getOnlyElement(table.currentSnapshot().dataManifests(table.io())).path());
+        .isEqualTo(table.currentSnapshot().dataManifests(table.io()).get(0).path());
     assertThat(files.get(0).file().recordCount())
         .as("Should contain 2 data file records")
         .isEqualTo(2);
     assertThat(files.get(1).file().path())
         .as("Delete file should be in the table manifest")
-        .isEqualTo(
-            Iterables.getOnlyElement(table.currentSnapshot().deleteManifests(table.io())).path());
+        .isEqualTo(table.currentSnapshot().deleteManifests(table.io()).get(0).path());
     assertThat(files.get(1).file().recordCount())
         .as("Should contain 1 delete file record")
         .isEqualTo(1);

--- a/core/src/test/java/org/apache/iceberg/TestFindFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestFindFiles.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestFindFiles extends TestBase {
   @Parameters(name = "formatVersion = {0}")
-  public static List<Object> parameters() {
+  protected static List<Object> parameters() {
     return Arrays.asList(1, 2);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestFindFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestFindFiles.java
@@ -207,7 +207,7 @@ public class TestFindFiles extends TestBase {
     Iterable<DataFile> files = FindFiles.in(table).collect();
 
     // verify an empty collection of data file is returned
-    assertThat(Sets.newHashSet(files)).hasSize(0);
+    assertThat(files).hasSize(0);
   }
 
   private Set<String> pathSet(DataFile... files) {

--- a/core/src/test/java/org/apache/iceberg/TestFindFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestFindFiles.java
@@ -18,7 +18,10 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -26,32 +29,26 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestFindFiles extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestFindFiles extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  public static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestFindFiles(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testBasicBehavior() {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Iterable<DataFile> files = FindFiles.in(table).collect();
 
-    Assert.assertEquals(pathSet(FILE_A, FILE_B), pathSet(files));
+    assertThat(pathSet(files)).isEqualTo(pathSet(FILE_A, FILE_B));
   }
 
-  @Test
+  @TestTemplate
   public void testWithMetadataMatching() {
     table
         .newAppend()
@@ -66,10 +63,10 @@ public class TestFindFiles extends TableTestBase {
             .withMetadataMatching(Expressions.startsWith("file_path", "/path/to/data-a"))
             .collect();
 
-    Assert.assertEquals(pathSet(FILE_A), pathSet(files));
+    assertThat(pathSet(files)).isEqualTo(pathSet(FILE_A));
   }
 
-  @Test
+  @TestTemplate
   public void testWithRecordsMatching() {
     table
         .newAppend()
@@ -96,10 +93,10 @@ public class TestFindFiles extends TableTestBase {
     final Iterable<DataFile> files =
         FindFiles.in(table).withRecordsMatching(Expressions.equal("id", 1)).collect();
 
-    Assert.assertEquals(Sets.newHashSet("/path/to/data-e.parquet"), pathSet(files));
+    assertThat(pathSet(files)).containsExactly("/path/to/data-e.parquet");
   }
 
-  @Test
+  @TestTemplate
   public void testInPartition() {
     table
         .newAppend()
@@ -115,10 +112,10 @@ public class TestFindFiles extends TableTestBase {
             .inPartition(table.spec(), StaticDataTask.Row.of(2))
             .collect();
 
-    Assert.assertEquals(pathSet(FILE_B, FILE_C), pathSet(files));
+    assertThat(pathSet(files)).isEqualTo(pathSet(FILE_B, FILE_C));
   }
 
-  @Test
+  @TestTemplate
   public void testInPartitions() {
     table
         .newAppend()
@@ -133,10 +130,10 @@ public class TestFindFiles extends TableTestBase {
             .inPartitions(table.spec(), StaticDataTask.Row.of(1), StaticDataTask.Row.of(2))
             .collect();
 
-    Assert.assertEquals(pathSet(FILE_B, FILE_C), pathSet(files));
+    assertThat(pathSet(files)).isEqualTo(pathSet(FILE_B, FILE_C));
   }
 
-  @Test
+  @TestTemplate
   public void testAsOfTimestamp() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -150,10 +147,10 @@ public class TestFindFiles extends TableTestBase {
 
     Iterable<DataFile> files = FindFiles.in(table).asOfTime(timestamp).collect();
 
-    Assert.assertEquals(pathSet(FILE_A, FILE_B), pathSet(files));
+    assertThat(pathSet(files)).isEqualTo(pathSet(FILE_A, FILE_B));
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotId() {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -165,10 +162,10 @@ public class TestFindFiles extends TableTestBase {
 
     Iterable<DataFile> files = FindFiles.in(table).inSnapshot(snapshotId).collect();
 
-    Assert.assertEquals(pathSet(FILE_A, FILE_B, FILE_C), pathSet(files));
+    assertThat(pathSet(files)).isEqualTo(pathSet(FILE_A, FILE_B, FILE_C));
   }
 
-  @Test
+  @TestTemplate
   public void testCaseSensitivity() {
     table
         .newAppend()
@@ -184,25 +181,25 @@ public class TestFindFiles extends TableTestBase {
             .withMetadataMatching(Expressions.startsWith("FILE_PATH", "/path/to/data-a"))
             .collect();
 
-    Assert.assertEquals(pathSet(FILE_A), pathSet(files));
+    assertThat(pathSet(files)).isEqualTo(pathSet(FILE_A));
   }
 
-  @Test
+  @TestTemplate
   public void testIncludeColumnStats() {
     table.newAppend().appendFile(FILE_WITH_STATS).commit();
 
     Iterable<DataFile> files = FindFiles.in(table).includeColumnStats().collect();
     final DataFile file = files.iterator().next();
 
-    Assert.assertEquals(FILE_WITH_STATS.columnSizes(), file.columnSizes());
-    Assert.assertEquals(FILE_WITH_STATS.valueCounts(), file.valueCounts());
-    Assert.assertEquals(FILE_WITH_STATS.nullValueCounts(), file.nullValueCounts());
-    Assert.assertEquals(FILE_WITH_STATS.nanValueCounts(), file.nanValueCounts());
-    Assert.assertEquals(FILE_WITH_STATS.lowerBounds(), file.lowerBounds());
-    Assert.assertEquals(FILE_WITH_STATS.upperBounds(), file.upperBounds());
+    assertThat(file.columnSizes()).isEqualTo(FILE_WITH_STATS.columnSizes());
+    assertThat(file.valueCounts()).isEqualTo(FILE_WITH_STATS.valueCounts());
+    assertThat(file.nullValueCounts()).isEqualTo(FILE_WITH_STATS.nullValueCounts());
+    assertThat(file.nanValueCounts()).isEqualTo(FILE_WITH_STATS.nanValueCounts());
+    assertThat(file.lowerBounds()).isEqualTo(FILE_WITH_STATS.lowerBounds());
+    assertThat(file.upperBounds()).isEqualTo(FILE_WITH_STATS.upperBounds());
   }
 
-  @Test
+  @TestTemplate
   public void testNoSnapshot() {
     // a table has no snapshot when it just gets created and no data is loaded yet
 
@@ -210,7 +207,7 @@ public class TestFindFiles extends TableTestBase {
     Iterable<DataFile> files = FindFiles.in(table).collect();
 
     // verify an empty collection of data file is returned
-    Assert.assertEquals(0, Sets.newHashSet(files).size());
+    assertThat(Sets.newHashSet(files)).hasSize(0);
   }
 
   private Set<String> pathSet(DataFile... files) {

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -358,9 +359,9 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanNoFilter);
     if (formatVersion == 2) {
-      assertThat(entries.iterator()).toIterable().hasSize(8);
+      assertThat(entries).hasSize(8);
     } else {
-      assertThat(entries.iterator()).toIterable().hasSize(4);
+      assertThat(entries).hasSize(4);
     }
 
     validateSingleFieldPartition(entries, 0);
@@ -383,9 +384,9 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanWithProjection);
     if (formatVersion == 2) {
-      assertThat(entries.iterator()).toIterable().hasSize(8);
+      assertThat(entries).hasSize(8);
     } else {
-      assertThat(entries.iterator()).toIterable().hasSize(4);
+      assertThat(entries).hasSize(4);
     }
 
     validateSingleFieldPartition(entries, 0);
@@ -425,9 +426,9 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanAndEq);
     if (formatVersion == 2) {
-      assertThat(entries.iterator()).toIterable().hasSize(2);
+      assertThat(entries).hasSize(2);
     } else {
-      assertThat(entries.iterator()).toIterable().hasSize(1);
+      assertThat(entries).hasSize(1);
     }
 
     validateSingleFieldPartition(entries, 0);
@@ -447,9 +448,9 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanLtAnd);
     if (formatVersion == 2) {
-      assertThat(entries.iterator()).toIterable().hasSize(4);
+      assertThat(entries).hasSize(4);
     } else {
-      assertThat(entries.iterator()).toIterable().hasSize(2);
+      assertThat(entries).hasSize(2);
     }
 
     validateSingleFieldPartition(entries, 0);
@@ -471,9 +472,9 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanOr);
     if (formatVersion == 2) {
-      assertThat(entries.iterator()).toIterable().hasSize(8);
+      assertThat(entries).hasSize(8);
     } else {
-      assertThat(entries.iterator()).toIterable().hasSize(4);
+      assertThat(entries).hasSize(4);
     }
 
     validateSingleFieldPartition(entries, 0);
@@ -492,9 +493,9 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanNot);
     if (formatVersion == 2) {
-      assertThat(entries.iterator()).toIterable().hasSize(4);
+      assertThat(entries).hasSize(4);
     } else {
-      assertThat(entries.iterator()).toIterable().hasSize(2);
+      assertThat(entries).hasSize(2);
     }
 
     validateSingleFieldPartition(entries, 2);
@@ -512,7 +513,6 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanSet);
     if (formatVersion == 2) {
-      assertThat(entries.iterator()).toIterable().hasSize(4);
       assertThat(entries).hasSize(4);
     } else {
       assertThat(entries).hasSize(2);
@@ -533,9 +533,9 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanUnary);
     if (formatVersion == 2) {
-      assertThat(entries.iterator()).toIterable().hasSize(8);
+      assertThat(entries).hasSize(8);
     } else {
-      assertThat(entries.iterator()).toIterable().hasSize(4);
+      assertThat(entries).hasSize(4);
     }
 
     validateSingleFieldPartition(entries, 0);
@@ -1280,15 +1280,15 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     assertThat(posDeleteTask.file().specId())
         .as("Expected correct partition spec id on task")
         .isEqualTo(0);
-    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()))
+    assertThat((Map<Integer, Integer>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct partition spec id on constant column")
-        .isEqualTo(0);
+        .containsEntry(MetadataColumns.SPEC_ID.fieldId(), 0);
     assertThat(posDeleteTask.file().path())
         .as("Expected correct delete file on task")
         .isEqualTo(FILE_B_DELETES.path());
-    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
+    assertThat((Map<Integer, String>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct delete file on constant column")
-        .isEqualTo(FILE_B_DELETES.path());
+        .containsEntry(MetadataColumns.FILE_PATH.fieldId(), FILE_B_DELETES.path().toString());
   }
 
   @TestTemplate
@@ -1350,16 +1350,15 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     assertThat(posDeleteTask.file().specId())
         .as("Expected correct partition spec id on task")
         .isEqualTo(0);
-    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()))
+    assertThat((Map<Integer, Integer>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct partition spec id on constant column")
-        .isEqualTo(0);
-
+        .containsEntry(MetadataColumns.SPEC_ID.fieldId(), 0);
     assertThat(posDeleteTask.file().path())
         .as("Expected correct delete file on task")
         .isEqualTo(FILE_A_DELETES.path());
-    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
+    assertThat((Map<Integer, String>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct delete file on constant column")
-        .isEqualTo(FILE_A_DELETES.path());
+        .containsEntry(MetadataColumns.FILE_PATH.fieldId(), FILE_A_DELETES.path().toString());
   }
 
   @TestTemplate
@@ -1434,16 +1433,16 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     assertThat(posDeleteTask.file().specId())
         .as("Expected correct partition spec id on task")
         .isEqualTo(1);
-    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()))
+    assertThat((Map<Integer, Integer>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct partition spec id on constant column")
-        .isEqualTo(1);
+        .containsEntry(MetadataColumns.SPEC_ID.fieldId(), 1);
 
     assertThat(posDeleteTask.file().path())
         .as("Expected correct delete file on task")
         .isEqualTo(path1);
-    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
+    assertThat((Map<Integer, String>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct delete file on constant column")
-        .isEqualTo(path1);
+        .containsEntry(MetadataColumns.FILE_PATH.fieldId(), path1);
   }
 
   @TestTemplate
@@ -1538,17 +1537,14 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Types.StructType partitionType = Partitioning.partitionType(table);
 
-    assertThat(
-            constantsMap(scanTasks.get(0), partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
-        .isEqualTo("/path/to/delete1.parquet");
-    assertThat(
-            constantsMap(scanTasks.get(1), partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
-        .isEqualTo("/path/to/delete2.parquet");
-
-    assertThat(constantsMap(scanTasks.get(0), partitionType).get(MetadataColumns.SPEC_ID.fieldId()))
-        .isEqualTo(1);
-    assertThat(constantsMap(scanTasks.get(1), partitionType).get(MetadataColumns.SPEC_ID.fieldId()))
-        .isEqualTo(1);
+    assertThat((Map<Integer, String>) constantsMap(scanTasks.get(0), partitionType))
+        .containsEntry(MetadataColumns.FILE_PATH.fieldId(), "/path/to/delete1.parquet");
+    assertThat((Map<Integer, String>) constantsMap(scanTasks.get(1), partitionType))
+        .containsEntry(MetadataColumns.FILE_PATH.fieldId(), "/path/to/delete2.parquet");
+    assertThat((Map<Integer, Integer>) constantsMap(scanTasks.get(0), partitionType))
+        .containsEntry(MetadataColumns.SPEC_ID.fieldId(), 1);
+    assertThat((Map<Integer, Integer>) constantsMap(scanTasks.get(1), partitionType))
+        .containsEntry(MetadataColumns.SPEC_ID.fieldId(), 1);
 
     StructLikeWrapper wrapper = StructLikeWrapper.forType(Partitioning.partitionType(table));
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -402,12 +402,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> tasksAndEq =
         PartitionsTable.planEntries((StaticTableScan) partitionsTable.newScan());
     for (ManifestEntry<? extends ContentFile<?>> task : tasksAndEq) {
-      assertThat(task.file().columnSizes()).isEmpty();
-      assertThat(task.file().valueCounts()).isEmpty();
-      assertThat(task.file().nullValueCounts()).isEmpty();
-      assertThat(task.file().nanValueCounts()).isEmpty();
-      assertThat(task.file().lowerBounds().isEmpty());
-      assertThat(task.file().upperBounds().isEmpty());
+      assertThat(task.file().columnSizes()).isNull();
+      assertThat(task.file().valueCounts()).isNull();
+      assertThat(task.file().nullValueCounts()).isNull();
+      assertThat(task.file().nanValueCounts()).isNull();
+      assertThat(task.file().lowerBounds()).isNull();
+      assertThat(task.file().upperBounds()).isNull();
     }
   }
 
@@ -1534,7 +1534,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     assertThat(scanTasks).hasSize(2);
     scanTasks.sort(Comparator.comparing(f -> f.file().path().toString()));
     assertThat(scanTasks.get(0).file().path().toString()).isEqualTo("/path/to/delete1.parquet");
-    assertThat(scanTasks.get(0).file().path().toString()).isEqualTo("/path/to/delete2.parquet");
+    assertThat(scanTasks.get(1).file().path().toString()).isEqualTo("/path/to/delete2.parquet");
 
     Types.StructType partitionType = Partitioning.partitionType(table);
 
@@ -1542,7 +1542,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             constantsMap(scanTasks.get(0), partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
         .isEqualTo("/path/to/delete1.parquet");
     assertThat(
-            constantsMap(scanTasks.get(0), partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
+            constantsMap(scanTasks.get(1), partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
         .isEqualTo("/path/to/delete2.parquet");
 
     assertThat(constantsMap(scanTasks.get(0), partitionType).get(MetadataColumns.SPEC_ID.fieldId()))

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -21,9 +21,11 @@ package org.apache.iceberg;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -36,23 +38,16 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeWrapper;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestMetadataTableScans extends MetadataTableScanTestBase {
-
-  public TestMetadataTableScans(int formatVersion) {
-    super(formatVersion);
-  }
 
   private void preparePartitionedTable(boolean transactional) {
     preparePartitionedTableData(transactional);
@@ -100,7 +95,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     preparePartitionedTableData(false);
   }
 
-  @Test
+  @TestTemplate
   public void testManifestsTableWithDroppedPartition() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -119,11 +114,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scan = manifestsTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
+      assertThat(tasks).hasSize(1);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testManifestsTableAlwaysIgnoresResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -132,26 +127,28 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scan = manifestsTable.newScan().filter(Expressions.lessThan("length", 10000L));
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assert.assertTrue("Tasks should not be empty", Iterables.size(tasks) > 0);
+      assertThat(tasks).as("Tasks should not be empty").hasSizeGreaterThan(0);
       for (FileScanTask task : tasks) {
-        Assert.assertEquals("Residuals must be ignored", Expressions.alwaysTrue(), task.residual());
+        assertThat(task.residual())
+            .as("Residuals must be ignored")
+            .isEqualTo(Expressions.alwaysTrue());
       }
     }
   }
 
-  @Test
+  @TestTemplate
   public void testMetadataTableUUID() {
     Table manifestsTable = new ManifestsTable(table);
 
-    Assertions.assertThat(manifestsTable.uuid())
+    assertThat(manifestsTable.uuid())
         .as("UUID should be consistent on multiple calls")
         .isEqualTo(manifestsTable.uuid());
-    Assertions.assertThat(manifestsTable.uuid())
+    assertThat(manifestsTable.uuid())
         .as("Metadata table UUID should be different from the base table UUID")
         .isNotEqualTo(table.uuid());
   }
 
-  @Test
+  @TestTemplate
   public void testDataFilesTableWithDroppedPartition() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -170,11 +167,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scan = dataFilesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
+      assertThat(tasks).hasSize(1);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testDataFilesTableHonorsIgnoreResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -188,7 +185,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     validateTaskScanResiduals(scan2, true);
   }
 
-  @Test
+  @TestTemplate
   public void testManifestEntriesTableHonorsIgnoreResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -205,7 +202,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     validateTaskScanResiduals(scan2, true);
   }
 
-  @Test
+  @TestTemplate
   public void testManifestEntriesTableWithDroppedPartition() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -224,11 +221,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scan = manifestEntriesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
+      assertThat(tasks).hasSize(1);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testAllDataFilesTableHonorsIgnoreResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -242,7 +239,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     validateTaskScanResiduals(scan2, true);
   }
 
-  @Test
+  @TestTemplate
   public void testAllDataFilesTableWithDroppedPartition() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -261,11 +258,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scan = allDataFilesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
+      assertThat(tasks).hasSize(1);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testAllEntriesTableHonorsIgnoreResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -279,7 +276,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     validateTaskScanResiduals(scan2, true);
   }
 
-  @Test
+  @TestTemplate
   public void testAllEntriesTableWithDroppedPartition() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -298,11 +295,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scan = allEntriesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
+      assertThat(tasks).hasSize(1);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableWithDroppedPartition() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -322,11 +319,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scan = allManifestsTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
+      assertThat(tasks).hasSize(1);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableHonorsIgnoreResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -343,7 +340,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     validateTaskScanResiduals(scan2, true);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionsTableScanNoFilter() {
     preparePartitionedTable();
 
@@ -356,14 +353,14 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                     Types.StructType.of(optional(1000, "data_bucket", Types.IntegerType.get()))))
             .asStruct();
     TableScan scanNoFilter = partitionsTable.newScan().select("partition.data_bucket");
-    Assert.assertEquals(expected, scanNoFilter.schema().asStruct());
+    assertThat(scanNoFilter.schema().asStruct()).isEqualTo(expected);
 
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanNoFilter);
     if (formatVersion == 2) {
-      Assert.assertEquals(8, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(8);
     } else {
-      Assert.assertEquals(4, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(4);
     }
 
     validateSingleFieldPartition(entries, 0);
@@ -372,7 +369,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     validateSingleFieldPartition(entries, 3);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionsTableScanWithProjection() {
     preparePartitionedTable();
 
@@ -382,13 +379,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             .asStruct();
 
     TableScan scanWithProjection = partitionsTable.newScan().select("file_count");
-    Assert.assertEquals(expected, scanWithProjection.schema().asStruct());
+    assertThat(scanWithProjection.schema().asStruct()).isEqualTo(expected);
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanWithProjection);
     if (formatVersion == 2) {
-      Assert.assertEquals(8, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(8);
     } else {
-      Assert.assertEquals(4, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(4);
     }
 
     validateSingleFieldPartition(entries, 0);
@@ -397,7 +394,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     validateSingleFieldPartition(entries, 3);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionsTableScanNoStats() {
     table.newFastAppend().appendFile(FILE_WITH_STATS).commit();
 
@@ -405,16 +402,16 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> tasksAndEq =
         PartitionsTable.planEntries((StaticTableScan) partitionsTable.newScan());
     for (ManifestEntry<? extends ContentFile<?>> task : tasksAndEq) {
-      Assert.assertNull(task.file().columnSizes());
-      Assert.assertNull(task.file().valueCounts());
-      Assert.assertNull(task.file().nullValueCounts());
-      Assert.assertNull(task.file().nanValueCounts());
-      Assert.assertNull(task.file().lowerBounds());
-      Assert.assertNull(task.file().upperBounds());
+      assertThat(task.file().columnSizes()).isEmpty();
+      assertThat(task.file().valueCounts()).isEmpty();
+      assertThat(task.file().nullValueCounts()).isEmpty();
+      assertThat(task.file().nanValueCounts()).isEmpty();
+      assertThat(task.file().lowerBounds().isEmpty());
+      assertThat(task.file().upperBounds().isEmpty());
     }
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionsTableScanAndFilter() {
     preparePartitionedTable();
 
@@ -428,15 +425,15 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanAndEq);
     if (formatVersion == 2) {
-      Assert.assertEquals(2, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(2);
     } else {
-      Assert.assertEquals(1, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(1);
     }
 
     validateSingleFieldPartition(entries, 0);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionsTableScanLtFilter() {
     preparePartitionedTable();
 
@@ -450,16 +447,16 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanLtAnd);
     if (formatVersion == 2) {
-      Assert.assertEquals(4, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(4);
     } else {
-      Assert.assertEquals(2, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(2);
     }
 
     validateSingleFieldPartition(entries, 0);
     validateSingleFieldPartition(entries, 1);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionsTableScanOrFilter() {
     preparePartitionedTable();
 
@@ -474,9 +471,9 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanOr);
     if (formatVersion == 2) {
-      Assert.assertEquals(8, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(8);
     } else {
-      Assert.assertEquals(4, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(4);
     }
 
     validateSingleFieldPartition(entries, 0);
@@ -485,7 +482,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     validateSingleFieldPartition(entries, 3);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionsScanNotFilter() {
     preparePartitionedTable();
     Table partitionsTable = new PartitionsTable(table);
@@ -495,16 +492,16 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanNot);
     if (formatVersion == 2) {
-      Assert.assertEquals(4, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(4);
     } else {
-      Assert.assertEquals(2, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(2);
     }
 
     validateSingleFieldPartition(entries, 2);
     validateSingleFieldPartition(entries, 3);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionsTableScanInFilter() {
     preparePartitionedTable();
 
@@ -515,16 +512,17 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanSet);
     if (formatVersion == 2) {
-      Assert.assertEquals(4, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(4);
+      assertThat(entries).hasSize(4);
     } else {
-      Assert.assertEquals(2, Iterators.size(entries.iterator()));
+      assertThat(entries).hasSize(2);
     }
 
     validateSingleFieldPartition(entries, 2);
     validateSingleFieldPartition(entries, 3);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionsTableScanNotNullFilter() {
     preparePartitionedTable();
 
@@ -535,9 +533,9 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanUnary);
     if (formatVersion == 2) {
-      Assert.assertEquals(8, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(8);
     } else {
-      Assert.assertEquals(4, Iterators.size(entries.iterator()));
+      assertThat(entries.iterator()).toIterable().hasSize(4);
     }
 
     validateSingleFieldPartition(entries, 0);
@@ -546,7 +544,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     validateSingleFieldPartition(entries, 3);
   }
 
-  @Test
+  @TestTemplate
   public void testFilesTableScanWithDroppedPartition() throws IOException {
     preparePartitionedTable();
 
@@ -578,7 +576,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Types.NestedField.optional(1000, "data_bucket", Types.IntegerType.get()),
             Types.NestedField.optional(1001, "data_bucket_16", Types.IntegerType.get()),
             Types.NestedField.optional(1002, "data_trunc_2", Types.StringType.get()));
-    Assert.assertEquals("Partition type must match", expectedType, actualType);
+    assertThat(actualType).as("Partition type must match").isEqualTo(expectedType);
     Accessor<StructLike> accessor = schema.accessorForField(1000);
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -588,13 +586,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
               .map(accessor::get)
               .map(i -> (Integer) i)
               .collect(Collectors.toSet());
-      Assert.assertEquals("Partition value must match", Sets.newHashSet(0, 1, 2, 3), results);
+      assertThat(results).as("Partition value must match").containsExactly(0, 1, 2, 3);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteFilesTableSelection() throws IOException {
-    Assume.assumeTrue("Only V2 Tables Support Deletes", formatVersion >= 2);
+    assumeThat(formatVersion).as("Only V2 Tables Support Deletes").isGreaterThanOrEqualTo(2);
 
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -618,10 +616,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                 required(
                     103, "record_count", Types.LongType.get(), "Number of records in the file"))
             .asStruct();
-    Assert.assertEquals(expected, scan.schema().asStruct());
+    assertThat(scan.schema().asStruct()).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testFilesTableReadableMetricsSchema() {
     Table filesTable = new FilesTable(table);
     Types.StructType actual = filesTable.newScan().schema().select("readable_metrics").asStruct();
@@ -705,10 +703,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                         "Metrics for column id")),
                 "Column metrics in readable form"));
 
-    Assert.assertEquals("Dynamic schema for readable_metrics should match", actual, expected);
+    assertThat(actual).as("Dynamic schema for readable_metrics should match").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testEntriesTableReadableMetricsSchema() {
     Table entriesTable = new ManifestEntriesTable(table);
     Types.StructType actual = entriesTable.newScan().schema().select("readable_metrics").asStruct();
@@ -792,10 +790,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                         "Metrics for column id")),
                 "Column metrics in readable form"));
 
-    Assert.assertEquals("Dynamic schema for readable_metrics should match", actual, expected);
+    assertThat(actual).as("Dynamic schema for readable_metrics should match").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionSpecEvolutionAdditive() {
     preparePartitionedTable();
 
@@ -837,10 +835,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         PartitionsTable.planEntries((StaticTableScan) scan);
     if (formatVersion == 2) {
       // Four data files and delete files of old spec, one new data file of new spec
-      Assert.assertEquals(9, Iterables.size(entries));
+      assertThat(entries).hasSize(9);
     } else {
       // Four data files of old spec, one new data file of new spec
-      Assert.assertEquals(5, Iterables.size(entries));
+      assertThat(entries).hasSize(5);
     }
 
     filter =
@@ -853,14 +851,14 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     if (formatVersion == 2) {
       // 1 original data file and delete file written by old spec, plus 1 new data file written by
       // new spec
-      Assert.assertEquals(3, Iterables.size(entries));
+      assertThat(entries).hasSize(3);
     } else {
       // 1 original data file written by old spec, plus 1 new data file written by new spec
-      Assert.assertEquals(2, Iterables.size(entries));
+      assertThat(entries).hasSize(2);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionSpecEvolutionRemoval() {
     preparePartitionedTable();
 
@@ -903,10 +901,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     if (formatVersion == 2) {
       // Four data and delete files of original spec, one data file written by new spec
-      Assert.assertEquals(9, Iterables.size(entries));
+      assertThat(entries).hasSize(9);
     } else {
       // Four data files of original spec, one data file written by new spec
-      Assert.assertEquals(5, Iterables.size(entries));
+      assertThat(entries).hasSize(5);
     }
 
     // Filter for a dropped partition spec field.  Correct behavior is that only old partitions are
@@ -920,7 +918,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     if (formatVersion == 1) {
       // 1 original data file written by old spec
-      Assert.assertEquals(1, Iterables.size(entries));
+      assertThat(entries).hasSize(1);
     } else {
       // 1 original data and 1 delete files written by old spec, plus both of new data file/delete
       // file written by new spec
@@ -935,15 +933,14 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
       // schema.
       // The Partition table final schema is a union of fields of all specs, including dropped
       // fields.
-      Assert.assertEquals(4, Iterables.size(entries));
+      assertThat(entries).hasSize(4);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionColumnNamedPartition() throws Exception {
     TestTables.clearTables();
-    this.tableDir = temp.newFolder();
-    tableDir.delete();
+    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
 
     Schema schema =
         new Schema(
@@ -988,11 +985,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scanAndEq = partitionsTable.newScan().filter(andEquals);
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanAndEq);
-    Assert.assertEquals(1, Iterators.size(entries.iterator()));
+    assertThat(entries).hasSize(1);
     validateSingleFieldPartition(entries, 0);
   }
 
-  @Test
+  @TestTemplate
   public void testAllDataFilesTableScanWithPlanExecutor() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -1011,11 +1008,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                           true); // daemon threads will be terminated abruptly when the JVM exits
                       return thread;
                     }));
-    Assert.assertEquals(1, Iterables.size(scan.planFiles()));
-    Assert.assertTrue("Thread should be created in provided pool", planThreadsIndex.get() > 0);
+    assertThat(scan.planFiles()).hasSize(1);
+    assertThat(planThreadsIndex.get())
+        .as("Thread should be created in provided pool")
+        .isGreaterThan(0);
   }
 
-  @Test
+  @TestTemplate
   public void testAllEntriesTableScanWithPlanExecutor() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -1034,11 +1033,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                           true); // daemon threads will be terminated abruptly when the JVM exits
                       return thread;
                     }));
-    Assert.assertEquals(1, Iterables.size(scan.planFiles()));
-    Assert.assertTrue("Thread should be created in provided pool", planThreadsIndex.get() > 0);
+    assertThat(scan.planFiles()).hasSize(1);
+    assertThat(planThreadsIndex.get())
+        .as("Thread should be created in provided pool")
+        .isGreaterThan(0);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionsTableScanWithPlanExecutor() {
     preparePartitionedTable();
 
@@ -1060,15 +1061,17 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scan);
     if (formatVersion == 2) {
-      Assert.assertEquals(8, Iterators.size(entries.iterator()));
+      assertThat(entries).hasSize(8);
     } else {
-      Assert.assertEquals(4, Iterators.size(entries.iterator()));
+      assertThat(entries).hasSize(4);
     }
 
-    Assert.assertTrue("Thread should be created in provided pool", planThreadsIndex.get() > 0);
+    assertThat(planThreadsIndex.get())
+        .as("Thread should be created in provided pool")
+        .isGreaterThan(0);
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableSnapshotGt() {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
@@ -1077,13 +1080,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.greaterThan("reference_snapshot_id", 2));
 
-    Assert.assertEquals(
-        "Expected snapshots do not match",
-        expectedManifestListPaths(table.snapshots(), 3L, 4L),
-        actualManifestListPaths(manifestsTableScan));
+    assertThat(actualManifestListPaths(manifestsTableScan))
+        .as("Expected snapshots do not match")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 3L, 4L));
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableSnapshotGte() {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
@@ -1092,13 +1094,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.greaterThanOrEqual("reference_snapshot_id", 3));
 
-    Assert.assertEquals(
-        "Expected snapshots do not match",
-        expectedManifestListPaths(table.snapshots(), 3L, 4L),
-        actualManifestListPaths(manifestsTableScan));
+    assertThat(actualManifestListPaths(manifestsTableScan))
+        .as("Expected snapshots do not match")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 3L, 4L));
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableSnapshotLt() {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
@@ -1107,13 +1108,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.lessThan("reference_snapshot_id", 3));
 
-    Assert.assertEquals(
-        "Expected snapshots do not match",
-        expectedManifestListPaths(table.snapshots(), 1L, 2L),
-        actualManifestListPaths(manifestsTableScan));
+    assertThat(actualManifestListPaths(manifestsTableScan))
+        .as("Expected snapshots do not match")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 2L));
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableSnapshotLte() {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
@@ -1122,13 +1122,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.lessThanOrEqual("reference_snapshot_id", 2));
 
-    Assert.assertEquals(
-        "Expected snapshots do not match",
-        expectedManifestListPaths(table.snapshots(), 1L, 2L),
-        actualManifestListPaths(manifestsTableScan));
+    assertThat(actualManifestListPaths(manifestsTableScan))
+        .as("Expected snapshots do not match")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 2L));
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableSnapshotEq() {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
@@ -1137,13 +1136,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.equal("reference_snapshot_id", 2));
 
-    Assert.assertEquals(
-        "Expected snapshots do not match",
-        expectedManifestListPaths(table.snapshots(), 2L),
-        actualManifestListPaths(manifestsTableScan));
+    assertThat(actualManifestListPaths(manifestsTableScan))
+        .as("Expected snapshots do not match")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 2L));
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableSnapshotNotEq() {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
@@ -1152,13 +1150,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.notEqual("reference_snapshot_id", 2));
 
-    Assert.assertEquals(
-        "Expected snapshots do not match",
-        expectedManifestListPaths(table.snapshots(), 1L, 3L, 4L),
-        actualManifestListPaths(manifestsTableScan));
+    assertThat(actualManifestListPaths(manifestsTableScan))
+        .as("Expected snapshots do not match")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 3L, 4L));
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableSnapshotIn() {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
@@ -1167,13 +1164,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.in("reference_snapshot_id", 1, 3));
-    Assert.assertEquals(
-        "Expected snapshots do not match",
-        expectedManifestListPaths(table.snapshots(), 1L, 3L),
-        actualManifestListPaths(manifestsTableScan));
+    assertThat(actualManifestListPaths(manifestsTableScan))
+        .as("Expected snapshots do not match")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 3L));
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableSnapshotNotIn() {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
@@ -1182,13 +1178,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.notIn("reference_snapshot_id", 1, 3));
 
-    Assert.assertEquals(
-        "Expected snapshots do not match",
-        expectedManifestListPaths(table.snapshots(), 2L, 4L),
-        actualManifestListPaths(manifestsTableScan));
+    assertThat(actualManifestListPaths(manifestsTableScan))
+        .as("Expected snapshots do not match")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 2L, 4L));
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableSnapshotAnd() {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
@@ -1202,13 +1197,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                 Expressions.and(
                     Expressions.equal("reference_snapshot_id", 2),
                     Expressions.greaterThan("length", 0)));
-    Assert.assertEquals(
-        "Expected snapshots do not match",
-        expectedManifestListPaths(table.snapshots(), 2L),
-        actualManifestListPaths(manifestsTableScan));
+    assertThat(actualManifestListPaths(manifestsTableScan))
+        .as("Expected snapshots do not match")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 2L));
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableSnapshotOr() {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
@@ -1222,13 +1216,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                 Expressions.or(
                     Expressions.equal("reference_snapshot_id", 2),
                     Expressions.equal("reference_snapshot_id", 4)));
-    Assert.assertEquals(
-        "Expected snapshots do not match",
-        expectedManifestListPaths(table.snapshots(), 2L, 4L),
-        actualManifestListPaths(manifestsTableScan));
+    assertThat(actualManifestListPaths(manifestsTableScan))
+        .as("Expected snapshots do not match")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 2L, 4L));
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableSnapshotNot() {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
@@ -1239,15 +1232,14 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             .newScan()
             .filter(Expressions.not(Expressions.equal("reference_snapshot_id", 2)));
 
-    Assert.assertEquals(
-        "Expected snapshots do not match",
-        expectedManifestListPaths(table.snapshots(), 1L, 3L, 4L),
-        actualManifestListPaths(manifestsTableScan));
+    assertThat(actualManifestListPaths(manifestsTableScan))
+        .as("Expected snapshots do not match")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 3L, 4L));
   }
 
-  @Test
+  @TestTemplate
   public void testPositionDeletesWithFilter() {
-    Assume.assumeTrue("Position deletes supported only for v2 tables", formatVersion == 2);
+    assumeThat(formatVersion).as("Position deletes supported only for v2 tables").isEqualTo(2);
     preparePartitionedTable();
 
     PositionDeletesTable positionDeletesTable = new PositionDeletesTable(table);
@@ -1262,14 +1254,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     List<ScanTask> tasks = Lists.newArrayList(scan.planFiles());
 
-    Assert.assertEquals(
-        "Expected to scan one delete manifest",
-        1,
-        deleteScan.scanMetrics().scannedDeleteManifests().value());
-    Assert.assertEquals(
-        "Expected to skip three delete manifests",
-        3,
-        deleteScan.scanMetrics().skippedDeleteManifests().value());
+    assertThat(deleteScan.scanMetrics().scannedDeleteManifests().value())
+        .as("Expected to scan one delete manifest")
+        .isEqualTo(1);
+    assertThat(deleteScan.scanMetrics().skippedDeleteManifests().value())
+        .as("Expected to skip three delete manifests")
+        .isEqualTo(3);
 
     assertThat(tasks).hasSize(1);
 
@@ -1284,36 +1274,35 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         (StructLike)
             constantsMap(posDeleteTask, partitionType).get(MetadataColumns.PARTITION_COLUMN_ID);
     int taskPartition = taskPartitionStruct.get(0, Integer.class);
-    Assert.assertEquals("Expected correct partition on task's file", 1, filePartition);
-    Assert.assertEquals("Expected correct partition on task's column", 1, taskPartition);
+    assertThat(filePartition).as("Expected correct partition on task's file").isEqualTo(1);
+    assertThat(taskPartition).as("Expected correct partition on task's column").isEqualTo(1);
 
-    Assert.assertEquals(
-        "Expected correct partition spec id on task", 0, posDeleteTask.file().specId());
-    Assert.assertEquals(
-        "Expected correct partition spec id on constant column",
-        0,
-        constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()));
-
-    Assert.assertEquals(
-        "Expected correct delete file on task", FILE_B_DELETES.path(), posDeleteTask.file().path());
-    Assert.assertEquals(
-        "Expected correct delete file on constant column",
-        FILE_B_DELETES.path(),
-        constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()));
+    assertThat(posDeleteTask.file().specId())
+        .as("Expected correct partition spec id on task")
+        .isEqualTo(0);
+    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()))
+        .as("Expected correct partition spec id on constant column")
+        .isEqualTo(0);
+    assertThat(posDeleteTask.file().path())
+        .as("Expected correct delete file on task")
+        .isEqualTo(FILE_B_DELETES.path());
+    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
+        .as("Expected correct delete file on constant column")
+        .isEqualTo(FILE_B_DELETES.path());
   }
 
-  @Test
+  @TestTemplate
   public void testPositionDeletesBaseTableFilterManifestLevel() {
     testPositionDeletesBaseTableFilter(false);
   }
 
-  @Test
+  @TestTemplate
   public void testPositionDeletesBaseTableFilterEntriesLevel() {
     testPositionDeletesBaseTableFilter(true);
   }
 
   private void testPositionDeletesBaseTableFilter(boolean transactional) {
-    Assume.assumeTrue("Position deletes supported only for v2 tables", formatVersion == 2);
+    assumeThat(formatVersion).as("Position deletes supported only for v2 tables").isEqualTo(2);
     preparePartitionedTable(transactional);
 
     PositionDeletesTable positionDeletesTable = new PositionDeletesTable(table);
@@ -1331,15 +1320,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     List<ScanTask> tasks = Lists.newArrayList(scan.planFiles());
 
-    Assert.assertEquals(
-        "Expected to scan one delete manifest",
-        1,
-        deleteScan.scanMetrics().scannedDeleteManifests().value());
+    assertThat(deleteScan.scanMetrics().scannedDeleteManifests().value())
+        .as("Expected to scan one delete manifest")
+        .isEqualTo(1);
     int expectedSkippedManifests = transactional ? 0 : 3;
-    Assert.assertEquals(
-        "Wrong number of manifests skipped",
-        expectedSkippedManifests,
-        deleteScan.scanMetrics().skippedDeleteManifests().value());
+    assertThat(deleteScan.scanMetrics().skippedDeleteManifests().value())
+        .as("Wrong number of manifests skipped")
+        .isEqualTo(expectedSkippedManifests);
 
     assertThat(tasks).hasSize(1);
 
@@ -1357,27 +1344,27 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         (StructLike)
             constantsMap(posDeleteTask, partitionType).get(MetadataColumns.PARTITION_COLUMN_ID);
     int taskPartition = taskPartitionStruct.get(0, Integer.class);
-    Assert.assertEquals("Expected correct partition on task's file", 0, filePartition);
-    Assert.assertEquals("Expected correct partition on task's column", 0, taskPartition);
+    assertThat(filePartition).as("Expected correct partition on task's file").isEqualTo(0);
+    assertThat(taskPartition).as("Expected correct partition on task's column").isEqualTo(0);
 
-    Assert.assertEquals(
-        "Expected correct partition spec id on task", 0, posDeleteTask.file().specId());
-    Assert.assertEquals(
-        "Expected correct partition spec id on constant column",
-        0,
-        constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()));
+    assertThat(posDeleteTask.file().specId())
+        .as("Expected correct partition spec id on task")
+        .isEqualTo(0);
+    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()))
+        .as("Expected correct partition spec id on constant column")
+        .isEqualTo(0);
 
-    Assert.assertEquals(
-        "Expected correct delete file on task", FILE_A_DELETES.path(), posDeleteTask.file().path());
-    Assert.assertEquals(
-        "Expected correct delete file on constant column",
-        FILE_A_DELETES.path(),
-        constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()));
+    assertThat(posDeleteTask.file().path())
+        .as("Expected correct delete file on task")
+        .isEqualTo(FILE_A_DELETES.path());
+    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
+        .as("Expected correct delete file on constant column")
+        .isEqualTo(FILE_A_DELETES.path());
   }
 
-  @Test
+  @TestTemplate
   public void testPositionDeletesWithBaseTableFilterNot() {
-    Assume.assumeTrue("Position deletes supported only for v2 tables", formatVersion == 2);
+    assumeThat(formatVersion).as("Position deletes supported only for v2 tables").isEqualTo(2);
 
     // use identity rather than bucket partition spec,
     // as bucket.project does not support projecting notEq
@@ -1421,10 +1408,9 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     List<ScanTask> tasks = Lists.newArrayList(scan.planFiles());
 
-    Assert.assertEquals(
-        "Expected to scan one delete manifest",
-        1,
-        deleteScan.scanMetrics().scannedDeleteManifests().value());
+    assertThat(deleteScan.scanMetrics().scannedDeleteManifests().value())
+        .as("Expected to scan one delete manifest")
+        .isEqualTo(1);
     assertThat(tasks).hasSize(1);
 
     ScanTask task = tasks.get(0);
@@ -1442,26 +1428,27 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             constantsMap(posDeleteTask, partitionType).get(MetadataColumns.PARTITION_COLUMN_ID);
     int taskPartition =
         taskPartitionStruct.get(1, Integer.class); // new partition field in position 1
-    Assert.assertEquals("Expected correct partition on task's file", 1, filePartition);
-    Assert.assertEquals("Expected correct partition on task's column", 1, taskPartition);
+    assertThat(filePartition).as("Expected correct partition on task's file").isEqualTo(1);
+    assertThat(taskPartition).as("Expected correct partition on task's column").isEqualTo(1);
 
-    Assert.assertEquals(
-        "Expected correct partition spec id on task", 1, posDeleteTask.file().specId());
-    Assert.assertEquals(
-        "Expected correct partition spec id on constant column",
-        1,
-        constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()));
+    assertThat(posDeleteTask.file().specId())
+        .as("Expected correct partition spec id on task")
+        .isEqualTo(1);
+    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()))
+        .as("Expected correct partition spec id on constant column")
+        .isEqualTo(1);
 
-    Assert.assertEquals("Expected correct delete file on task", path1, posDeleteTask.file().path());
-    Assert.assertEquals(
-        "Expected correct delete file on constant column",
-        path1,
-        constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()));
+    assertThat(posDeleteTask.file().path())
+        .as("Expected correct delete file on task")
+        .isEqualTo(path1);
+    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
+        .as("Expected correct delete file on constant column")
+        .isEqualTo(path1);
   }
 
-  @Test
+  @TestTemplate
   public void testPositionDeletesResiduals() {
-    Assume.assumeTrue("Position deletes supported only for v2 tables", formatVersion == 2);
+    assumeThat(formatVersion).as("Position deletes supported only for v2 tables").isEqualTo(2);
     preparePartitionedTable();
 
     PositionDeletesTable positionDeletesTable = new PositionDeletesTable(table);
@@ -1484,18 +1471,16 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     Expression residual = posDeleteTask.residual();
     UnboundPredicate<?> residualPred =
         TestHelpers.assertAndUnwrap(residual, UnboundPredicate.class);
-    Assert.assertEquals(
-        "Expected partition residual to be evaluated", Expression.Operation.GT, residualPred.op());
-    Assert.assertEquals(
-        "Expected partition residual to be evaluated", Literal.of(1), residualPred.literal());
+    assertThat(residualPred.op()).isEqualTo(Expression.Operation.GT);
+    assertThat(residualPred.literal()).isEqualTo(Literal.of(1));
   }
 
-  @Test
+  @TestTemplate
   public void testPositionDeletesUnpartitioned() {
-    Assume.assumeTrue("Position deletes supported only for v2 tables", formatVersion == 2);
+    assumeThat(formatVersion).as("Position deletes supported only for v2 tables").isEqualTo(2);
     table.updateSpec().removeField(Expressions.bucket("data", BUCKETS_NUMBER)).commit();
 
-    Assert.assertEquals("Table should now be unpartitioned", 0, table.spec().fields().size());
+    assertThat(table.spec().fields()).as("Table should now be unpartitioned").hasSize(0);
 
     DataFile dataFile1 =
         DataFiles.builder(table.spec())
@@ -1542,29 +1527,28 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                   return (PositionDeletesScanTask) task;
                 }));
 
-    Assert.assertEquals(
-        "Expected to scan 1 manifest",
-        1,
-        deleteScan.scanMetrics().scannedDeleteManifests().value());
+    assertThat(deleteScan.scanMetrics().scannedDeleteManifests().value())
+        .as("Expected to scan 1 manifest")
+        .isEqualTo(1);
 
-    Assert.assertEquals("Expected 2 tasks", 2, scanTasks.size());
+    assertThat(scanTasks).hasSize(2);
     scanTasks.sort(Comparator.comparing(f -> f.file().path().toString()));
-    Assert.assertEquals("/path/to/delete1.parquet", scanTasks.get(0).file().path().toString());
-    Assert.assertEquals("/path/to/delete2.parquet", scanTasks.get(1).file().path().toString());
+    assertThat(scanTasks.get(0).file().path().toString()).isEqualTo("/path/to/delete1.parquet");
+    assertThat(scanTasks.get(0).file().path().toString()).isEqualTo("/path/to/delete2.parquet");
 
     Types.StructType partitionType = Partitioning.partitionType(table);
 
-    Assert.assertEquals(
-        "/path/to/delete1.parquet",
-        constantsMap(scanTasks.get(0), partitionType).get(MetadataColumns.FILE_PATH.fieldId()));
-    Assert.assertEquals(
-        "/path/to/delete2.parquet",
-        constantsMap(scanTasks.get(1), partitionType).get(MetadataColumns.FILE_PATH.fieldId()));
+    assertThat(
+            constantsMap(scanTasks.get(0), partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
+        .isEqualTo("/path/to/delete1.parquet");
+    assertThat(
+            constantsMap(scanTasks.get(0), partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
+        .isEqualTo("/path/to/delete2.parquet");
 
-    Assert.assertEquals(
-        1, constantsMap(scanTasks.get(0), partitionType).get(MetadataColumns.SPEC_ID.fieldId()));
-    Assert.assertEquals(
-        1, constantsMap(scanTasks.get(1), partitionType).get(MetadataColumns.SPEC_ID.fieldId()));
+    assertThat(constantsMap(scanTasks.get(0), partitionType).get(MetadataColumns.SPEC_ID.fieldId()))
+        .isEqualTo(1);
+    assertThat(constantsMap(scanTasks.get(1), partitionType).get(MetadataColumns.SPEC_ID.fieldId()))
+        .isEqualTo(1);
 
     StructLikeWrapper wrapper = StructLikeWrapper.forType(Partitioning.partitionType(table));
 
@@ -1581,7 +1565,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             constantsMap(scanTasks.get(1), partitionType).get(MetadataColumns.PARTITION_COLUMN_ID);
     StructLikeWrapper scanTask2Partition = wrapper.copyFor(scanTask2PartitionStruct);
 
-    Assert.assertEquals(expected, scanTask1Partition);
-    Assert.assertEquals(expected, scanTask2Partition);
+    assertThat(scanTask1Partition).isEqualTo(expected);
+    assertThat(scanTask2Partition).isEqualTo(expected);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -21,9 +21,11 @@ package org.apache.iceberg;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -31,25 +33,20 @@ import java.util.stream.StreamSupport;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableScanTestBase {
-  public TestMetadataTableScansWithPartitionEvolution(int formatVersion) {
-    super(formatVersion);
-  }
 
-  @Before
+  @BeforeEach
   public void createTable() throws IOException {
     TestTables.clearTables();
-    this.tableDir = temp.newFolder();
+    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     tableDir.delete();
 
     Schema schema =
@@ -73,73 +70,73 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
         .commit();
   }
 
-  @Test
+  @TestTemplate
   public void testManifestsTableWithAddPartitionOnNestedField() throws IOException {
     Table manifestsTable = new ManifestsTable(table);
     TableScan scan = manifestsTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assertions.assertThat(tasks).hasSize(1);
-      Assertions.assertThat(allRows(tasks)).hasSize(2);
+      assertThat(tasks).hasSize(1);
+      assertThat(allRows(tasks)).hasSize(2);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testDataFilesTableWithAddPartitionOnNestedField() throws IOException {
     Table dataFilesTable = new DataFilesTable(table);
     TableScan scan = dataFilesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assertions.assertThat(tasks).hasSize(2);
-      Assertions.assertThat(allRows(tasks)).hasSize(4);
+      assertThat(tasks).hasSize(2);
+      assertThat(allRows(tasks)).hasSize(4);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testManifestEntriesWithAddPartitionOnNestedField() throws IOException {
     Table manifestEntriesTable = new ManifestEntriesTable(table);
     TableScan scan = manifestEntriesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assertions.assertThat(tasks).hasSize(2);
-      Assertions.assertThat(allRows(tasks)).hasSize(4);
+      assertThat(tasks).hasSize(2);
+      assertThat(allRows(tasks)).hasSize(4);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testAllDataFilesTableWithAddPartitionOnNestedField() throws IOException {
     Table allDataFilesTable = new AllDataFilesTable(table);
     TableScan scan = allDataFilesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assertions.assertThat(tasks).hasSize(2);
-      Assertions.assertThat(allRows(tasks)).hasSize(4);
+      assertThat(tasks).hasSize(2);
+      assertThat(allRows(tasks)).hasSize(4);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testAllEntriesTableWithAddPartitionOnNestedField() throws IOException {
     Table allEntriesTable = new AllEntriesTable(table);
     TableScan scan = allEntriesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assertions.assertThat(tasks).hasSize(2);
-      Assertions.assertThat(allRows(tasks)).hasSize(4);
+      assertThat(tasks).hasSize(2);
+      assertThat(allRows(tasks)).hasSize(4);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testAllManifestsTableWithAddPartitionOnNestedField() throws IOException {
     Table allManifestsTable = new AllManifestsTable(table);
     TableScan scan = allManifestsTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assertions.assertThat(tasks).hasSize(2);
-      Assertions.assertThat(allRows(tasks)).hasSize(3);
+      assertThat(tasks).hasSize(2);
+      assertThat(allRows(tasks)).hasSize(3);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionsTableScanWithAddPartitionOnNestedField() {
     Table partitionsTable = new PartitionsTable(table);
     Types.StructType idPartition =
@@ -153,10 +150,10 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
             .asStruct();
 
     TableScan scanNoFilter = partitionsTable.newScan().select("partition");
-    Assert.assertEquals(idPartition, scanNoFilter.schema().asStruct());
+    assertThat(scanNoFilter.schema().asStruct()).isEqualTo(idPartition);
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanNoFilter);
-    Assert.assertEquals(4, Iterators.size(entries.iterator()));
+    assertThat(entries).hasSize(4);
     validatePartition(entries, 0, 0);
     validatePartition(entries, 0, 1);
     validatePartition(entries, 0, 2);
@@ -165,9 +162,9 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
     validatePartition(entries, 1, 3);
   }
 
-  @Test
+  @TestTemplate
   public void testPositionDeletesPartitionSpecRemoval() {
-    Assume.assumeTrue("Position deletes supported only for v2 tables", formatVersion == 2);
+    assumeThat(formatVersion).as("Position deletes supported only for v2 tables").isEqualTo(2);
 
     table.updateSpec().removeField("id").commit();
 
@@ -193,38 +190,36 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
     PositionDeletesScanTask posDeleteTask = (PositionDeletesScanTask) task;
 
     int filePartition = posDeleteTask.file().partition().get(0, Integer.class);
-    Assert.assertEquals("Expected correct partition on task", 1, filePartition);
+    assertThat(filePartition).as("Expected correct partition on task").isEqualTo(1);
 
     // Constant partition struct is common struct that includes even deleted partition column
     int taskConstantPartition =
         ((StructLike)
                 constantsMap(posDeleteTask, partitionType).get(MetadataColumns.PARTITION_COLUMN_ID))
             .get(1, Integer.class);
-    Assert.assertEquals("Expected correct partition on constant column", 1, taskConstantPartition);
+    assertThat(taskConstantPartition)
+        .as("Expected correct partition on constant column")
+        .isEqualTo(1);
 
-    Assert.assertEquals(
-        "Expected correct partition field id on task's spec",
-        table.ops().current().spec().partitionType().fields().get(0).fieldId(),
-        posDeleteTask.spec().fields().get(0).fieldId());
+    assertThat(posDeleteTask.spec().fields().get(0).fieldId())
+        .as("Expected correct partition field id on task's spec")
+        .isEqualTo(table.ops().current().spec().partitionType().fields().get(0).fieldId());
 
-    Assert.assertEquals(
-        "Expected correct partition spec id on task",
-        table.ops().current().spec().specId(),
-        posDeleteTask.file().specId());
-    Assert.assertEquals(
-        "Expected correct partition spec id on constant column",
-        table.ops().current().spec().specId(),
-        constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()));
-
-    Assert.assertEquals(
-        "Expected correct delete file on task", deleteFile.path(), posDeleteTask.file().path());
-    Assert.assertEquals(
-        "Expected correct delete file on constant column",
-        deleteFile.path(),
-        constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()));
+    assertThat(posDeleteTask.file().specId())
+        .as("Expected correct partition spec id on task")
+        .isEqualTo(table.ops().current().spec().specId());
+    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()))
+        .as("Expected correct partition spec id on constant column")
+        .isEqualTo(table.ops().current().spec().specId());
+    assertThat(posDeleteTask.file().path())
+        .as("Expected correct delete file on task")
+        .isEqualTo(deleteFile.path());
+    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
+        .as("Expected correct delete file on constant column")
+        .isEqualTo(deleteFile.path());
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionSpecEvolutionToUnpartitioned() throws IOException {
     // Remove all the partition fields
     table.updateSpec().removeField("id").removeField("nested.id").commit();
@@ -239,15 +234,15 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
     PartitionsTable partitionsTable = new PartitionsTable(table);
     // must contain the partition column even when the current spec is non-partitioned.
-    Assertions.assertThat(partitionsTable.schema().findField("partition")).isNotNull();
+    assertThat(partitionsTable.schema().findField("partition")).isNotNull();
 
     try (CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) partitionsTable.newScan())) {
       // four partitioned data files and one non-partitioned data file.
-      Assertions.assertThat(entries).hasSize(5);
+      assertThat(entries).hasSize(5);
 
       // check for null partition value.
-      Assertions.assertThat(StreamSupport.stream(entries.spliterator(), false))
+      assertThat(StreamSupport.stream(entries.spliterator(), false))
           .anyMatch(
               entry -> {
                 StructLike partition = entry.file().partition();

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -21,15 +21,15 @@ package org.apache.iceberg;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
@@ -208,15 +208,15 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
     assertThat(posDeleteTask.file().specId())
         .as("Expected correct partition spec id on task")
         .isEqualTo(table.ops().current().spec().specId());
-    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()))
+    assertThat((Map<Integer, Integer>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct partition spec id on constant column")
-        .isEqualTo(table.ops().current().spec().specId());
+        .containsEntry(MetadataColumns.SPEC_ID.fieldId(), table.ops().current().spec().specId());
     assertThat(posDeleteTask.file().path())
         .as("Expected correct delete file on task")
         .isEqualTo(deleteFile.path());
-    assertThat(constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()))
+    assertThat((Map<Integer, String>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct delete file on constant column")
-        .isEqualTo(deleteFile.path());
+        .containsEntry(MetadataColumns.FILE_PATH.fieldId(), deleteFile.path().toString());
   }
 
   @TestTemplate
@@ -242,11 +242,11 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
       assertThat(entries).hasSize(5);
 
       // check for null partition value.
-      assertThat(StreamSupport.stream(entries.spliterator(), false))
-          .anyMatch(
+      assertThat(entries)
+          .anySatisfy(
               entry -> {
                 StructLike partition = entry.file().partition();
-                return Objects.equals(null, partition.get(0, Object.class));
+                assertThat(partition.get(0, Object.class)).isNull();
               });
     }
   }


### PR DESCRIPTION
Migrate the following "Read" in iceberg-core to JUnit 5 and AssertJ style for https://github.com/apache/iceberg/issues/9085.

## Current Progress (same as in the issue above)
Read:
- [x] `MetadataTableScanTestBase` (extends `TableTestBase`) 
  - [x] `TestMetadataTableScans` 
  - [x] `TestMetadataTableScansWithPartitionEvolution`
- [x] `TestEntriesMetadataTable`
- [x] `TestBatchScans`
- [x] `TestIncrementalDataTableScan`
- [x] `TestFindFiles`