### PR TITLE
Core: Fix REST catalog handling when the service has no view support

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -1058,12 +1058,17 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   public View loadView(SessionContext context, TableIdentifier identifier) {
     checkViewIdentifierIsValid(identifier);
 
-    LoadViewResponse response =
-        client.get(
-            paths.view(identifier),
-            LoadViewResponse.class,
-            headers(context),
-            ErrorHandlers.viewErrorHandler());
+    LoadViewResponse response;
+    try {
+      response =
+          client.get(
+              paths.view(identifier),
+              LoadViewResponse.class,
+              headers(context),
+              ErrorHandlers.viewErrorHandler());
+    } catch (UnsupportedOperationException | RESTException e) {
+      throw new NoSuchViewException("Service does not support views");
+    }
 
     AuthSession session = tableSession(response.config(), session(context));
     ViewMetadata metadata = response.metadata();

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -1067,7 +1067,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               headers(context),
               ErrorHandlers.viewErrorHandler());
     } catch (UnsupportedOperationException | RESTException e) {
-      throw new NoSuchViewException("Service does not support views");
+      throw new NoSuchViewException(e, "Unable to load view: %s.%s", name(), identifier);
     }
 
     AuthSession session = tableSession(response.config(), session(context));

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -1067,7 +1067,12 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               headers(context),
               ErrorHandlers.viewErrorHandler());
     } catch (UnsupportedOperationException | RESTException e) {
-      throw new NoSuchViewException(e, "Unable to load view: %s.%s", name(), identifier);
+      // Normally, copying an exception message is a bad practice but engines may show just the
+      // message and suppress the exception cause when the view does not exist. Since 401 and 403
+      // responses can trigger this case, including the message increases the chances that the "Not
+      // authorized" or "Forbidden" message is preserved and shown.
+      throw new NoSuchViewException(
+          e, "Unable to load view %s.%s: %s", name(), identifier, e.getMessage());
     }
 
     AuthSession session = tableSession(response.config(), session(context));


### PR DESCRIPTION
This is a fix for Spark table loading when a REST catalog does not support view extensions.

The problem is that Spark runs `ResolveViews` before `ResolveTables` in the substitution batch of rules. With view support in the REST catalog, table references will result in a `loadView` call to check if the unresolved identifier is a view. If the catalog service does not support views, then a 4XX exception is thrown but not caught and used to indicate the view does not exist.

This translates 4XX calls returned by the load view path to `NoSuchViewException` indicating that the service does not support views.