### PR TITLE
Data, Spark, Flink: Migrate TestAppenderFactory and subclasses to JUnit5

### DIFF
--- a/data/src/test/java/org/apache/iceberg/TestGenericAppenderFactory.java
+++ b/data/src/test/java/org/apache/iceberg/TestGenericAppenderFactory.java
@@ -30,12 +30,7 @@ import org.apache.iceberg.util.StructLikeSet;
 
 public class TestGenericAppenderFactory extends TestAppenderFactory<Record> {
 
-  private final GenericRecord gRecord;
-
-  public TestGenericAppenderFactory(String fileFormat, boolean partitioned) {
-    super(fileFormat, partitioned);
-    this.gRecord = GenericRecord.create(SCHEMA);
-  }
+  private final GenericRecord gRecord = GenericRecord.create(SCHEMA);
 
   @Override
   protected FileAppenderFactory<Record> createAppenderFactory(

--- a/data/src/test/java/org/apache/iceberg/io/TestBaseTaskWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestBaseTaskWriter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.io;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -27,46 +29,47 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
-import org.apache.iceberg.TableTestBase;
+import org.apache.iceberg.TestBase;
 import org.apache.iceberg.data.GenericAppenderFactory;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.IcebergGenerics;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.StructLikeSet;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestBaseTaskWriter extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestBaseTaskWriter extends TestBase {
   private static final int FORMAT_V2 = 2;
 
-  private final FileFormat format;
   private final GenericRecord gRecord = GenericRecord.create(SCHEMA);
 
   private OutputFileFactory fileFactory = null;
   private FileAppenderFactory<Record> appenderFactory = null;
 
-  @Parameterized.Parameters(name = "FileFormat = {0}")
-  public static Object[][] parameters() {
-    return new Object[][] {{"avro"}, {"orc"}, {"parquet"}};
-  }
+  @Parameter(index = 1)
+  protected FileFormat format;
 
-  public TestBaseTaskWriter(String fileFormat) {
-    super(FORMAT_V2);
-    this.format = FileFormat.fromString(fileFormat);
+  @Parameters(name = "formatVersion = {0}, FileFormat = {1}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(
+        new Object[] {FORMAT_V2, FileFormat.AVRO},
+        new Object[] {FORMAT_V2, FileFormat.ORC},
+        new Object[] {FORMAT_V2, FileFormat.PARQUET});
   }
 
   @Override
-  @Before
+  @BeforeEach
   public void setupTable() throws IOException {
-    this.tableDir = temp.newFolder();
-    Assert.assertTrue(tableDir.delete()); // created by table create
+    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableDir.delete()).isTrue(); // created by table create
 
     this.metadataDir = new File(tableDir, "metadata");
 
@@ -90,23 +93,23 @@ public class TestBaseTaskWriter extends TableTestBase {
     return gRecord.copy("id", id, "data", data);
   }
 
-  @Test
+  @TestTemplate
   public void testWriteZeroRecord() throws IOException {
     try (TestTaskWriter writer = createTaskWriter(128 * 1024 * 1024)) {
       writer.close();
 
       WriteResult result = writer.complete();
-      Assert.assertEquals(0, result.dataFiles().length);
-      Assert.assertEquals(0, result.deleteFiles().length);
+      assertThat(result.dataFiles()).hasSize(0);
+      assertThat(result.deleteFiles()).hasSize(0);
 
       writer.close();
       result = writer.complete();
-      Assert.assertEquals(0, result.dataFiles().length);
-      Assert.assertEquals(0, result.deleteFiles().length);
+      assertThat(result.dataFiles()).hasSize(0);
+      assertThat(result.deleteFiles()).hasSize(0);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testAbort() throws IOException {
     List<Record> records = Lists.newArrayList();
     for (int i = 0; i < 2000; i++) {
@@ -128,18 +131,18 @@ public class TestBaseTaskWriter extends TableTestBase {
           Files.list(Paths.get(tableDir.getPath(), "data"))
               .filter(p -> !p.toString().endsWith(".crc"))
               .collect(Collectors.toList());
-      Assert.assertEquals("Should have 4 files but the files are: " + files, 4, files.size());
+      assertThat(files).as("Should have 4 files but the files are: " + files).hasSize(4);
 
       // Abort to clean all delete files and data files.
       taskWriter.abort();
     }
 
     for (Path path : files) {
-      Assert.assertFalse(Files.exists(path));
+      assertThat(path).doesNotExist();
     }
   }
 
-  @Test
+  @TestTemplate
   public void testRollIfExceedTargetFileSize() throws IOException {
     List<Record> records = Lists.newArrayListWithCapacity(8000);
     for (int i = 0; i < 2000; i++) {
@@ -156,8 +159,8 @@ public class TestBaseTaskWriter extends TableTestBase {
       }
 
       result = taskWriter.complete();
-      Assert.assertEquals(8, result.dataFiles().length);
-      Assert.assertEquals(0, result.deleteFiles().length);
+      assertThat(result.dataFiles()).hasSize(8);
+      assertThat(result.deleteFiles()).hasSize(0);
     }
 
     RowDelta rowDelta = table.newRowDelta();
@@ -178,8 +181,8 @@ public class TestBaseTaskWriter extends TableTestBase {
       }
 
       result = taskWriter.complete();
-      Assert.assertEquals(8, result.dataFiles().length);
-      Assert.assertEquals(8, result.deleteFiles().length);
+      assertThat(result.dataFiles()).hasSize(8);
+      assertThat(result.deleteFiles()).hasSize(8);
     }
 
     rowDelta = table.newRowDelta();
@@ -187,8 +190,9 @@ public class TestBaseTaskWriter extends TableTestBase {
     Arrays.stream(result.deleteFiles()).forEach(rowDelta::addDeletes);
     rowDelta.commit();
 
-    Assert.assertEquals(
-        "Should have expected records", expectedRowSet(expected), actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .as("Should have expected records")
+        .isEqualTo(expectedRowSet(expected));
   }
 
   private StructLikeSet expectedRowSet(Iterable<Record> records) {

--- a/data/src/test/java/org/apache/iceberg/io/TestTaskEqualityDeltaWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestTaskEqualityDeltaWriter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.io;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -28,12 +30,15 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
-import org.apache.iceberg.TableTestBase;
+import org.apache.iceberg.TestBase;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.data.GenericAppenderFactory;
 import org.apache.iceberg.data.GenericRecord;
@@ -48,18 +53,14 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.StructLikeSet;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestTaskEqualityDeltaWriter extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestTaskEqualityDeltaWriter extends TestBase {
   private static final int FORMAT_V2 = 2;
   private static final long TARGET_FILE_SIZE = 128 * 1024 * 1024L;
-
-  private final FileFormat format;
   private final GenericRecord gRecord = GenericRecord.create(SCHEMA);
   private final GenericRecord posRecord = GenericRecord.create(DeleteSchemaUtil.pathPosSchema());
 
@@ -67,21 +68,22 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
   private int idFieldId;
   private int dataFieldId;
 
-  @Parameterized.Parameters(name = "FileFormat = {0}")
-  public static Object[][] parameters() {
-    return new Object[][] {{"avro"}, {"orc"}, {"parquet"}};
-  }
+  @Parameter(index = 1)
+  protected FileFormat format;
 
-  public TestTaskEqualityDeltaWriter(String fileFormat) {
-    super(FORMAT_V2);
-    this.format = FileFormat.fromString(fileFormat);
+  @Parameters(name = "formatVersion = {0}, FileFormat = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(
+        new Object[] {FORMAT_V2, FileFormat.AVRO},
+        new Object[] {FORMAT_V2, FileFormat.ORC},
+        new Object[] {FORMAT_V2, FileFormat.PARQUET});
   }
 
   @Override
-  @Before
+  @BeforeEach
   public void setupTable() throws IOException {
-    this.tableDir = temp.newFolder();
-    Assert.assertTrue(tableDir.delete()); // created by table create
+    this.tableDir = java.nio.file.Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableDir.delete()).isTrue(); // created by table create
 
     this.metadataDir = new File(tableDir, "metadata");
 
@@ -98,7 +100,7 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
     return gRecord.copy("id", id, "data", data);
   }
 
-  @Test
+  @TestTemplate
   public void testPureInsert() throws IOException {
     List<Integer> eqDeleteFieldIds = Lists.newArrayList(idFieldId, dataFieldId);
     Schema eqDeleteRowSchema = table.schema();
@@ -113,11 +115,12 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
     }
 
     WriteResult result = deltaWriter.complete();
-    Assert.assertEquals("Should only have a data file.", 1, result.dataFiles().length);
-    Assert.assertEquals("Should have no delete file", 0, result.deleteFiles().length);
+    assertThat(result.dataFiles()).as("Should only have a data file.").hasSize(1);
+    assertThat(result.deleteFiles()).as("Should have no delete file").hasSize(0);
     commitTransaction(result);
-    Assert.assertEquals(
-        "Should have expected records", expectedRowSet(expected), actualRowSet("*"));
+    assertThat(expectedRowSet(expected))
+        .as("Should have expected records")
+        .isEqualTo(actualRowSet("*"));
 
     deltaWriter = createTaskWriter(eqDeleteFieldIds, eqDeleteRowSchema);
     for (int i = 20; i < 30; i++) {
@@ -127,14 +130,15 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
       deltaWriter.write(record);
     }
     result = deltaWriter.complete();
-    Assert.assertEquals("Should only have a data file.", 1, result.dataFiles().length);
-    Assert.assertEquals("Should have no delete file", 0, result.deleteFiles().length);
+    assertThat(result.dataFiles()).as("Should only have a data file.").hasSize(1);
+    assertThat(result.deleteFiles()).as("Should have no delete file").hasSize(0);
     commitTransaction(result);
-    Assert.assertEquals(
-        "Should have expected records", expectedRowSet(expected), actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .as("Should have expected records")
+        .isEqualTo(expectedRowSet(expected));
   }
 
-  @Test
+  @TestTemplate
   public void testInsertDuplicatedKey() throws IOException {
     List<Integer> equalityFieldIds = Lists.newArrayList(idFieldId);
     Schema eqDeleteRowSchema = table.schema();
@@ -152,48 +156,49 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
     WriteResult result = deltaWriter.complete();
     commitTransaction(result);
 
-    Assert.assertEquals("Should have a data file.", 1, result.dataFiles().length);
-    Assert.assertEquals("Should have a pos-delete file", 1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).as("Should have a data file.").hasSize(1);
+    assertThat(result.deleteFiles()).as("Should have a pos-delete file").hasSize(1);
     DeleteFile posDeleteFile = result.deleteFiles()[0];
-    Assert.assertEquals(
-        "Should be a pos-delete file", FileContent.POSITION_DELETES, posDeleteFile.content());
-    Assert.assertEquals(1, result.referencedDataFiles().length);
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(
-            ImmutableList.of(
-                createRecord(4, "eee"),
-                createRecord(3, "fff"),
-                createRecord(2, "ggg"),
-                createRecord(1, "hhh"))),
-        actualRowSet("*"));
+    assertThat(posDeleteFile.content())
+        .as("Should be a pos-delete file")
+        .isEqualTo(FileContent.POSITION_DELETES);
+    assertThat(result.referencedDataFiles()).hasSize(1);
+    assertThat(actualRowSet("*"))
+        .as("Should have expected records")
+        .isEqualTo(
+            expectedRowSet(
+                ImmutableList.of(
+                    createRecord(4, "eee"),
+                    createRecord(3, "fff"),
+                    createRecord(2, "ggg"),
+                    createRecord(1, "hhh"))));
 
     // Check records in the data file.
     DataFile dataFile = result.dataFiles()[0];
-    Assert.assertEquals(
-        ImmutableList.of(
-            createRecord(1, "aaa"),
-            createRecord(2, "bbb"),
-            createRecord(3, "ccc"),
-            createRecord(4, "ddd"),
-            createRecord(4, "eee"),
-            createRecord(3, "fff"),
-            createRecord(2, "ggg"),
-            createRecord(1, "hhh")),
-        readRecordsAsList(table.schema(), dataFile.path()));
+    assertThat(readRecordsAsList(table.schema(), dataFile.path()))
+        .isEqualTo(
+            ImmutableList.of(
+                createRecord(1, "aaa"),
+                createRecord(2, "bbb"),
+                createRecord(3, "ccc"),
+                createRecord(4, "ddd"),
+                createRecord(4, "eee"),
+                createRecord(3, "fff"),
+                createRecord(2, "ggg"),
+                createRecord(1, "hhh")));
 
     // Check records in the pos-delete file.
     Schema posDeleteSchema = DeleteSchemaUtil.pathPosSchema();
-    Assert.assertEquals(
-        ImmutableList.of(
-            posRecord.copy("file_path", dataFile.path(), "pos", 0L),
-            posRecord.copy("file_path", dataFile.path(), "pos", 1L),
-            posRecord.copy("file_path", dataFile.path(), "pos", 2L),
-            posRecord.copy("file_path", dataFile.path(), "pos", 3L)),
-        readRecordsAsList(posDeleteSchema, posDeleteFile.path()));
+    assertThat(readRecordsAsList(posDeleteSchema, posDeleteFile.path()))
+        .isEqualTo(
+            ImmutableList.of(
+                posRecord.copy("file_path", dataFile.path(), "pos", 0L),
+                posRecord.copy("file_path", dataFile.path(), "pos", 1L),
+                posRecord.copy("file_path", dataFile.path(), "pos", 2L),
+                posRecord.copy("file_path", dataFile.path(), "pos", 3L)));
   }
 
-  @Test
+  @TestTemplate
   public void testUpsertSameRow() throws IOException {
     List<Integer> eqDeleteFieldIds = Lists.newArrayList(idFieldId, dataFieldId);
     Schema eqDeleteRowSchema = table.schema();
@@ -208,36 +213,35 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
     deltaWriter.write(record);
 
     WriteResult result = deltaWriter.complete();
-    Assert.assertEquals("Should have a data file.", 1, result.dataFiles().length);
-    Assert.assertEquals("Should have a pos-delete file.", 1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).as("Should have a data file.").hasSize(1);
+    assertThat(result.deleteFiles()).as("Should have a pos-delete file").hasSize(1);
     commitTransaction(result);
-    Assert.assertEquals(
-        "Should have an expected record",
-        expectedRowSet(ImmutableList.of(record)),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .as("Should have an expected record")
+        .isEqualTo(expectedRowSet(ImmutableList.of(record)));
 
     // Check records in the data file.
     DataFile dataFile = result.dataFiles()[0];
-    Assert.assertEquals(
-        ImmutableList.of(record, record), readRecordsAsList(table.schema(), dataFile.path()));
+    assertThat(readRecordsAsList(table.schema(), dataFile.path()))
+        .isEqualTo(ImmutableList.of(record, record));
 
     // Check records in the pos-delete file.
     DeleteFile posDeleteFile = result.deleteFiles()[0];
-    Assert.assertEquals(
-        ImmutableList.of(posRecord.copy("file_path", dataFile.path(), "pos", 0L)),
-        readRecordsAsList(DeleteSchemaUtil.pathPosSchema(), posDeleteFile.path()));
+    assertThat(readRecordsAsList(DeleteSchemaUtil.pathPosSchema(), posDeleteFile.path()))
+        .isEqualTo(ImmutableList.of(posRecord.copy("file_path", dataFile.path(), "pos", 0L)));
 
     deltaWriter = createTaskWriter(eqDeleteFieldIds, eqDeleteRowSchema);
     deltaWriter.delete(record);
     result = deltaWriter.complete();
-    Assert.assertEquals("Should have 0 data file.", 0, result.dataFiles().length);
-    Assert.assertEquals("Should have 1 eq-delete file", 1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).as("Should have 0 data file.").hasSize(0);
+    assertThat(result.deleteFiles()).as("Should have 1 eq-delete file").hasSize(1);
     commitTransaction(result);
-    Assert.assertEquals(
-        "Should have no record", expectedRowSet(ImmutableList.of()), actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .as("Should have no record")
+        .isEqualTo(expectedRowSet(ImmutableList.of()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpsertData() throws IOException {
     List<Integer> eqDeleteFieldIds = Lists.newArrayList(dataFieldId);
     Schema eqDeleteRowSchema = table.schema().select("data");
@@ -251,22 +255,22 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
 
     // Commit the 1th transaction.
     WriteResult result = deltaWriter.complete();
-    Assert.assertEquals("Should have a data file", 1, result.dataFiles().length);
-    Assert.assertEquals(
-        "Should have a pos-delete file for deduplication purpose", 1, result.deleteFiles().length);
-    Assert.assertEquals(
-        "Should be pos-delete file",
-        FileContent.POSITION_DELETES,
-        result.deleteFiles()[0].content());
-    Assert.assertEquals(1, result.referencedDataFiles().length);
+    assertThat(result.dataFiles()).as("Should have a data file").hasSize(1);
+    assertThat(result.deleteFiles())
+        .as("Should have a pos-delete file for deduplication purpose")
+        .hasSize(1);
+    assertThat(result.deleteFiles()[0].content())
+        .as("Should be pos-delete file")
+        .isEqualTo(FileContent.POSITION_DELETES);
+    assertThat(result.referencedDataFiles()).hasSize(1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(
-            ImmutableList.of(
-                createRecord(2, "bbb"), createRecord(3, "aaa"), createRecord(4, "ccc"))),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .as("Should have expected records")
+        .isEqualTo(
+            expectedRowSet(
+                ImmutableList.of(
+                    createRecord(2, "bbb"), createRecord(3, "aaa"), createRecord(4, "ccc"))));
 
     // Start the 2nd transaction.
     deltaWriter = createTaskWriter(eqDeleteFieldIds, eqDeleteRowSchema);
@@ -290,38 +294,38 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
 
     // Commit the 2nd transaction.
     result = deltaWriter.complete();
-    Assert.assertEquals(1, result.dataFiles().length);
-    Assert.assertEquals(2, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(1);
+    assertThat(result.deleteFiles()).hasSize(2);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(ImmutableList.of(createRecord(6, "aaa"), createRecord(7, "ccc"))),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .as("Should have expected records")
+        .isEqualTo(
+            expectedRowSet(ImmutableList.of(createRecord(6, "aaa"), createRecord(7, "ccc"))));
 
     // Check records in the data file.
     DataFile dataFile = result.dataFiles()[0];
-    Assert.assertEquals(
-        ImmutableList.of(createRecord(5, "aaa"), createRecord(6, "aaa"), createRecord(7, "ccc")),
-        readRecordsAsList(table.schema(), dataFile.path()));
+    assertThat(readRecordsAsList(table.schema(), dataFile.path()))
+        .isEqualTo(
+            ImmutableList.of(
+                createRecord(5, "aaa"), createRecord(6, "aaa"), createRecord(7, "ccc")));
 
     // Check records in the eq-delete file.
     DeleteFile eqDeleteFile = result.deleteFiles()[0];
-    Assert.assertEquals(FileContent.EQUALITY_DELETES, eqDeleteFile.content());
-    Assert.assertEquals(
-        ImmutableList.of(keyFunc.apply("aaa"), keyFunc.apply("ccc"), keyFunc.apply("bbb")),
-        readRecordsAsList(eqDeleteRowSchema, eqDeleteFile.path()));
+    assertThat(eqDeleteFile.content()).isEqualTo(FileContent.EQUALITY_DELETES);
+    assertThat(readRecordsAsList(eqDeleteRowSchema, eqDeleteFile.path()))
+        .isEqualTo(
+            ImmutableList.of(keyFunc.apply("aaa"), keyFunc.apply("ccc"), keyFunc.apply("bbb")));
 
     // Check records in the pos-delete file.
     DeleteFile posDeleteFile = result.deleteFiles()[1];
     Schema posDeleteSchema = DeleteSchemaUtil.pathPosSchema();
-    Assert.assertEquals(FileContent.POSITION_DELETES, posDeleteFile.content());
-    Assert.assertEquals(
-        ImmutableList.of(posRecord.copy("file_path", dataFile.path(), "pos", 0L)),
-        readRecordsAsList(posDeleteSchema, posDeleteFile.path()));
+    assertThat(posDeleteFile.content()).isEqualTo(FileContent.POSITION_DELETES);
+    assertThat(readRecordsAsList(posDeleteSchema, posDeleteFile.path()))
+        .isEqualTo(ImmutableList.of(posRecord.copy("file_path", dataFile.path(), "pos", 0L)));
   }
 
-  @Test
+  @TestTemplate
   public void testUpsertDataWithFullRowSchema() throws IOException {
     List<Integer> eqDeleteFieldIds = Lists.newArrayList(dataFieldId);
     Schema eqDeleteRowSchema = table.schema();
@@ -335,22 +339,22 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
 
     // Commit the 1th transaction.
     WriteResult result = deltaWriter.complete();
-    Assert.assertEquals("Should have a data file", 1, result.dataFiles().length);
-    Assert.assertEquals(
-        "Should have a pos-delete file for deduplication purpose", 1, result.deleteFiles().length);
-    Assert.assertEquals(
-        "Should be pos-delete file",
-        FileContent.POSITION_DELETES,
-        result.deleteFiles()[0].content());
-    Assert.assertEquals(1, result.referencedDataFiles().length);
+    assertThat(result.dataFiles()).as("Should have a data file").hasSize(1);
+    assertThat(result.deleteFiles())
+        .as("Should have a pos-delete file for deduplication purpose")
+        .hasSize(1);
+    assertThat(result.deleteFiles()[0].content())
+        .as("Should be pos-delete file")
+        .isEqualTo(FileContent.POSITION_DELETES);
+    assertThat(result.referencedDataFiles()).hasSize(1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(
-            ImmutableList.of(
-                createRecord(2, "bbb"), createRecord(3, "aaa"), createRecord(4, "ccc"))),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .as("Should have expected records")
+        .isEqualTo(
+            expectedRowSet(
+                ImmutableList.of(
+                    createRecord(2, "bbb"), createRecord(3, "aaa"), createRecord(4, "ccc"))));
 
     // Start the 2nd transaction.
     deltaWriter = createTaskWriter(eqDeleteFieldIds, eqDeleteRowSchema);
@@ -372,36 +376,37 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
 
     // Commit the 2nd transaction.
     result = deltaWriter.complete();
-    Assert.assertEquals(1, result.dataFiles().length);
-    Assert.assertEquals(2, result.deleteFiles().length);
-    Assert.assertEquals(1, result.referencedDataFiles().length);
+    assertThat(result.dataFiles()).hasSize(1);
+    assertThat(result.deleteFiles()).hasSize(2);
+    assertThat(result.referencedDataFiles()).hasSize(1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(ImmutableList.of(createRecord(6, "aaa"), createRecord(7, "ccc"))),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .as("Should have expected records")
+        .isEqualTo(
+            expectedRowSet(ImmutableList.of(createRecord(6, "aaa"), createRecord(7, "ccc"))));
 
     // Check records in the data file.
     DataFile dataFile = result.dataFiles()[0];
-    Assert.assertEquals(
-        ImmutableList.of(createRecord(5, "aaa"), createRecord(6, "aaa"), createRecord(7, "ccc")),
-        readRecordsAsList(table.schema(), dataFile.path()));
+    assertThat(readRecordsAsList(table.schema(), dataFile.path()))
+        .isEqualTo(
+            ImmutableList.of(
+                createRecord(5, "aaa"), createRecord(6, "aaa"), createRecord(7, "ccc")));
 
     // Check records in the eq-delete file.
     DeleteFile eqDeleteFile = result.deleteFiles()[0];
-    Assert.assertEquals(FileContent.EQUALITY_DELETES, eqDeleteFile.content());
-    Assert.assertEquals(
-        ImmutableList.of(createRecord(3, "aaa"), createRecord(4, "ccc"), createRecord(2, "bbb")),
-        readRecordsAsList(eqDeleteRowSchema, eqDeleteFile.path()));
+    assertThat(eqDeleteFile.content()).isEqualTo(FileContent.EQUALITY_DELETES);
+    assertThat(readRecordsAsList(eqDeleteRowSchema, eqDeleteFile.path()))
+        .isEqualTo(
+            ImmutableList.of(
+                createRecord(3, "aaa"), createRecord(4, "ccc"), createRecord(2, "bbb")));
 
     // Check records in the pos-delete file.
     DeleteFile posDeleteFile = result.deleteFiles()[1];
     Schema posDeleteSchema = DeleteSchemaUtil.pathPosSchema();
-    Assert.assertEquals(FileContent.POSITION_DELETES, posDeleteFile.content());
-    Assert.assertEquals(
-        ImmutableList.of(posRecord.copy("file_path", dataFile.path(), "pos", 0L)),
-        readRecordsAsList(posDeleteSchema, posDeleteFile.path()));
+    assertThat(posDeleteFile.content()).isEqualTo(FileContent.POSITION_DELETES);
+    assertThat(readRecordsAsList(posDeleteSchema, posDeleteFile.path()))
+        .isEqualTo(ImmutableList.of(posRecord.copy("file_path", dataFile.path(), "pos", 0L)));
   }
 
   private void commitTransaction(WriteResult result) {

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkAppenderFactory.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkAppenderFactory.java
@@ -32,12 +32,7 @@ import org.apache.iceberg.util.StructLikeSet;
 
 public class TestFlinkAppenderFactory extends TestAppenderFactory<RowData> {
 
-  private final RowType rowType;
-
-  public TestFlinkAppenderFactory(String fileFormat, boolean partitioned) {
-    super(fileFormat, partitioned);
-    this.rowType = FlinkSchemaUtil.convert(SCHEMA);
-  }
+  private final RowType rowType = FlinkSchemaUtil.convert(SCHEMA);
 
   @Override
   protected FileAppenderFactory<RowData> createAppenderFactory(

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkAppenderFactory.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkAppenderFactory.java
@@ -32,12 +32,7 @@ import org.apache.iceberg.util.StructLikeSet;
 
 public class TestFlinkAppenderFactory extends TestAppenderFactory<RowData> {
 
-  private final RowType rowType;
-
-  public TestFlinkAppenderFactory(String fileFormat, boolean partitioned) {
-    super(fileFormat, partitioned);
-    this.rowType = FlinkSchemaUtil.convert(SCHEMA);
-  }
+  private final RowType rowType = FlinkSchemaUtil.convert(SCHEMA);
 
   @Override
   protected FileAppenderFactory<RowData> createAppenderFactory(

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkAppenderFactory.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkAppenderFactory.java
@@ -32,12 +32,7 @@ import org.apache.iceberg.util.StructLikeSet;
 
 public class TestFlinkAppenderFactory extends TestAppenderFactory<RowData> {
 
-  private final RowType rowType;
-
-  public TestFlinkAppenderFactory(String fileFormat, boolean partitioned) {
-    super(fileFormat, partitioned);
-    this.rowType = FlinkSchemaUtil.convert(SCHEMA);
-  }
+  private final RowType rowType = FlinkSchemaUtil.convert(SCHEMA);
 
   @Override
   protected FileAppenderFactory<RowData> createAppenderFactory(

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAppenderFactory.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAppenderFactory.java
@@ -32,12 +32,7 @@ import org.apache.spark.unsafe.types.UTF8String;
 
 public class TestSparkAppenderFactory extends TestAppenderFactory<InternalRow> {
 
-  private final StructType sparkType;
-
-  public TestSparkAppenderFactory(String fileFormat, boolean partitioned) {
-    super(fileFormat, partitioned);
-    this.sparkType = SparkSchemaUtil.convert(SCHEMA);
-  }
+  private final StructType sparkType = SparkSchemaUtil.convert(SCHEMA);
 
   @Override
   protected FileAppenderFactory<InternalRow> createAppenderFactory(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAppenderFactory.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAppenderFactory.java
@@ -32,12 +32,7 @@ import org.apache.spark.unsafe.types.UTF8String;
 
 public class TestSparkAppenderFactory extends TestAppenderFactory<InternalRow> {
 
-  private final StructType sparkType;
-
-  public TestSparkAppenderFactory(String fileFormat, boolean partitioned) {
-    super(fileFormat, partitioned);
-    this.sparkType = SparkSchemaUtil.convert(SCHEMA);
-  }
+  private final StructType sparkType = SparkSchemaUtil.convert(SCHEMA);
 
   @Override
   protected FileAppenderFactory<InternalRow> createAppenderFactory(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAppenderFactory.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAppenderFactory.java
@@ -32,12 +32,7 @@ import org.apache.spark.unsafe.types.UTF8String;
 
 public class TestSparkAppenderFactory extends TestAppenderFactory<InternalRow> {
 
-  private final StructType sparkType;
-
-  public TestSparkAppenderFactory(String fileFormat, boolean partitioned) {
-    super(fileFormat, partitioned);
-    this.sparkType = SparkSchemaUtil.convert(SCHEMA);
-  }
+  private final StructType sparkType = SparkSchemaUtil.convert(SCHEMA);
 
   @Override
   protected FileAppenderFactory<InternalRow> createAppenderFactory(


### PR DESCRIPTION
Issue #9085 

In this patch I planned to replace [TestBase](https://github.com/apache/iceberg/blob/main/core/src/test/java/org/apache/iceberg/TestBase.java) with [TableTestBase](https://github.com/apache/iceberg/blob/main/core/src/test/java/org/apache/iceberg/TableTestBase.java) for following base classes. 

1. TestBaseTaskWriter
2. TestAppenderFactory
3. TestTaskEqualityDeltaWriter