### PR TITLE
add notes in hive docs

### DIFF
--- a/docs/docs/hive.md
+++ b/docs/docs/hive.md
@@ -556,6 +556,9 @@ your tables. You can enable auto-conversion through Hadoop configuration (not en
 This type conversion table describes how Hive types are converted to the Iceberg types. The conversion applies on both
 creating Iceberg table and writing to Iceberg table via Hive.
 
+    Note, that the Hive Types mentioned above are not Hive Data Types used in Hive SQL.For example, there isn't a long type in Hive Data Types instead of a bigint type. The hive SQL parser provides a mechanism for converting one type to another.
+
+
 | Hive             | Iceberg                 | Notes |
 |------------------|-------------------------|-------|
 | boolean          | boolean                 |       |

--- a/docs/docs/hive.md
+++ b/docs/docs/hive.md
@@ -556,7 +556,8 @@ your tables. You can enable auto-conversion through Hadoop configuration (not en
 This type conversion table describes how Hive types are converted to the Iceberg types. The conversion applies on both
 creating Iceberg table and writing to Iceberg table via Hive.
 
-    Note, that the Hive Types mentioned above are not Hive Data Types used in Hive SQL.For example, there isn't a long type in Hive Data Types instead of a bigint type. The hive SQL parser provides a mechanism for converting one type to another.
+!!! info
+    Note, that the Hive Types mentioned above are not Hive Data Types used in Hive SQL. For example, there isn't a long type in Hive Data Types instead of a bigint type. The hive SQL parser provides a mechanism for converting one type to another.
 
 
 | Hive             | Iceberg                 | Notes |


### PR DESCRIPTION
For issue:
https://github.com/apache/iceberg/issues/9863

There is Ambiguity in the chapter "Hive type to Iceberg type."

For general hive users, they think the Hive type is the Hive Data type.

However, the Hive type in the docs is hidden underneath the Hive SQL parser and is not the data type used in Hive SQL.

Only sophisticated developers can recognize that immediately.

I think adding some notes here is helpful.