### PR TITLE
Core: add support to add custom schemes via properties in ResolvingFileIO

### DIFF
--- a/core/src/test/java/org/apache/iceberg/io/TestCustomResolvingFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestCustomResolvingFileIO.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+public class TestCustomResolvingFileIO implements DelegateFileIO {
+  @Override
+  public InputFile newInputFile(String path) {
+    return null;
+  }
+
+  @Override
+  public OutputFile newOutputFile(String path) {
+    return null;
+  }
+
+  @Override
+  public void deleteFile(String path) {}
+
+  @Override
+  public void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException {}
+
+  @Override
+  public Iterable<FileInfo> listPrefix(String prefix) {
+    return null;
+  }
+
+  @Override
+  public void deletePrefix(String prefix) {}
+}

--- a/core/src/test/java/org/apache/iceberg/io/TestResolvingIO.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestResolvingIO.java
@@ -182,4 +182,16 @@ public class TestResolvingIO {
     // being null is ok here as long as the code doesn't throw an exception
     assertThat(resolvingFileIO.newInputFile("/file")).isNull();
   }
+
+  @Test
+  public void customFileIOScheme() {
+    ResolvingFileIO resolvingFileIO = new ResolvingFileIO();
+    resolvingFileIO.setConf(new Configuration());
+    resolvingFileIO.initialize(
+        ImmutableMap.of(
+            "resolving-io.schemes.custom", "org.apache.iceberg.io.TestCustomResolvingFileIO"));
+
+    // testing custom scheme
+    assertThat(resolvingFileIO.ioClass("custom://foo")).isEqualTo(TestCustomResolvingFileIO.class);
+  }
 }


### PR DESCRIPTION
This PR adds a way to load custom schemes (in addition of the default ones) in `ResolvingFileIO` using properties prefixed with `resolving-io.schemes.`.
The idea (as described in the corresponding issue) is to let users add new file IO implementation (like wasabi for instance), or tweak/override existing implementations.


This closes #9883 