### PR TITLE
Core: Mark 502 and 504 failures as retryable to the exponential retry strategy

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -60,7 +60,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  *
  * <ul>
  *   <li>SC_TOO_MANY_REQUESTS (429)
+ *   <li>SC_BAD_GATEWAY (502)
  *   <li>SC_SERVICE_UNAVAILABLE (503)
+ *   <li>SC_GATEWAY_TIMEOUT (504)
  * </ul>
  *
  * Most code and behavior is taken from {@link
@@ -77,7 +79,11 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
         maximumRetries > 0, "Cannot set retries to %s, the value must be positive", maximumRetries);
     this.maxRetries = maximumRetries;
     this.retriableCodes =
-        ImmutableSet.of(HttpStatus.SC_TOO_MANY_REQUESTS, HttpStatus.SC_SERVICE_UNAVAILABLE);
+        ImmutableSet.of(
+            HttpStatus.SC_TOO_MANY_REQUESTS,
+            HttpStatus.SC_SERVICE_UNAVAILABLE,
+            HttpStatus.SC_BAD_GATEWAY,
+            HttpStatus.SC_GATEWAY_TIMEOUT);
     this.nonRetriableExceptions =
         ImmutableSet.of(
             InterruptedIOException.class,

--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -196,4 +196,16 @@ public class TestExponentialHttpRequestRetryStrategy {
     assertThat(retryStrategy.getRetryInterval(response, 3, null).toMilliseconds())
         .isBetween(4000L, 5000L);
   }
+
+  @Test
+  public void testRetryBadGateway() {
+    BasicHttpResponse response502 = new BasicHttpResponse(502, "Bad gateway failure");
+    assertThat(retryStrategy.retryRequest(response502, 3, null)).isTrue();
+  }
+
+  @Test
+  public void testRetryGatewayTimeout() {
+    BasicHttpResponse response504 = new BasicHttpResponse(504, "Gateway timeout");
+    assertThat(retryStrategy.retryRequest(response504, 3, null)).isTrue();
+  }
 }


### PR DESCRIPTION
Bad gateway or gateway timeouts should be able to be safely retried. A bad gateway could be caused by a load balancer or proxy between the client and the actual server, when there's some network partition between the LB and server. A retry in this case could route the request to another server.

A gateway timeout could occur when the LB/proxy is waiting for a response from the actual server, but it takes too long. in this case a retry could be performed again to increase the chance of hitting a more available server.