### PR TITLE
fix minor version for striclty libs versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,25 +19,25 @@ delta-core = "2.2.0"
 esotericsoftware-kryo = "4.0.2"
 errorprone-annotations = "2.3.3"
 findbugs-jsr305 = "3.0.2"
-flink115 = { strictly = "[1.15, 1.16[", prefer = "1.15.0"} # see rich version usage explanation above
-flink116 = { strictly = "[1.16, 1.17[", prefer = "1.16.2"}
-flink117 = { strictly = "[1.17, 1.18[", prefer = "1.17.1"}
+flink115 = { strictly = "1.15.0"}
+flink116 = { strictly = "1.16.2"}
+flink117 = { strictly = "1.17.1"}
 google-libraries-bom = "26.18.0"
 guava = "32.1.1-jre"
 hadoop2 = "2.7.3"
 hadoop3-client = "3.3.6"
 httpcomponents-httpclient5 = "5.2.1"
-hive2 = { strictly = "[2, 3[", prefer = "2.3.9"} # see rich version usage explanation above
+hive2 = { strictly = "2.3.9"}
 hive3 = "3.1.3"
 immutables-value = "2.9.2"
 jackson-annotations = "2.15.2"
 jackson-bom = "2.14.2"
 jackson-dataformat-xml = "2.9.9"
-jackson211 = { strictly = "[2.11, 2.12[", prefer = "2.11.4"} # see rich version usage explanation above
-jackson212 = { strictly = "[2.12, 2.13[", prefer = "2.12.3"}
-jackson213 = { strictly = "[2.13, 2.14[", prefer = "2.13.4"}
-jackson214 = { strictly = "[2.14, 2.15[", prefer = "2.14.2"}
-jackson215 = { strictly = "[2.15, 2.16[", prefer = "2.15.2"}
+jackson211 = { strictly = "2.11.4"}
+jackson212 = { strictly = "2.12.3"}
+jackson213 = { strictly = "2.13.4"}
+jackson214 = { strictly = "2.14.2"}
+jackson215 = { strictly = "2.15.2"}
 jakarta-el-api = "3.0.3"
 jaxb-api = "2.3.1"
 jaxb-runtime = "2.3.3"
@@ -68,7 +68,7 @@ spring-web = "5.3.9"
 sqlite-jdbc = "3.42.0.0"
 testcontainers = "1.17.6"
 tez010 = "0.10.2"
-tez08 = { strictly = "[0.8, 0.9[", prefer = "0.8.4"}  # see rich version usage explanation above
+tez08 = { strictly = "0.8.4"}
 
 [libraries]
 activation = { module = "javax.activation:activation", version.ref = "activation" }


### PR DESCRIPTION
https://github.com/apache/iceberg/pull/9484

and there is also a confilict with jackson 2.15.4 and spark 3.5 on gradle 8.4:

`java.lang.IllegalArgumentException: Unsupported class file major version 65`