### PR TITLE
[DRAFT]: Adjust site links to absolute from site_url

### DIFF
--- a/site/docs/community.md
+++ b/site/docs/community.md
@@ -26,7 +26,7 @@ Community discussions happen primarily on the dev mailing list, on apache-iceber
 
 ## Contribute
 
-See [Contributing](contribute.md) for more details on how to contribute to Iceberg.
+See [Contributing](site:contribute/) for more details on how to contribute to Iceberg.
 
 ## Issues
 

--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -24,7 +24,7 @@ these are hard rules and they're meant as a collection of helpful suggestions to
 experience as possible.
 
 If you are thinking of contributing but first would like to discuss the change you wish to make, we welcome you to
-head over to the [Community](community.md) page on the official Iceberg documentation site
+head over to the [Community](site:community/) page on the official Iceberg documentation site
 to find a number of ways to connect with the community, including slack and our mailing lists. Of course, always feel
 free to just open a [new issue](https://github.com/apache/iceberg/issues/new) in the GitHub repo. You can also check the following for a [good first issue](https://github.com/apache/iceberg/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
@@ -443,4 +443,4 @@ Some PRs/changesets might require running benchmarks to determine whether they a
 no "push a single button to get a performance comparison" solution available, therefore one has to run JMH performance tests on their local machine and
 post the results on the PR.
 
-See [Benchmarks](benchmarks.md) for a summary of available benchmarks and how to run them.
+See [Benchmarks](site:benchmarks/) for a summary of available benchmarks and how to run them.

--- a/site/docs/hive-quickstart.md
+++ b/site/docs/hive-quickstart.md
@@ -22,7 +22,7 @@ title: "Hive and Iceberg Quickstart"
 ## Hive and Iceberg Quickstart
 
 This guide will get you up and running with an Iceberg and Hive environment, including sample code to
-highlight some powerful features. You can learn more about Iceberg's Hive runtime by checking out the [Hive](docs/latest/hive.md) section.
+highlight some powerful features. You can learn more about Iceberg's Hive runtime by checking out the [Hive](site:docs/latest/hive/) section.
 
 - [Docker Images](#docker-images)
 - [Creating a Table](#creating-a-table)
@@ -66,7 +66,7 @@ show databases;
 
 ### Creating a Table
 
-To create your first Iceberg table in Hive, run a [`CREATE TABLE`](docs/latest/hive.md#create-table) command. Let's create a table
+To create your first Iceberg table in Hive, run a [`CREATE TABLE`](site:docs/latest/hive/#create-table) command. Let's create a table
 using `nyc.taxis` where `nyc` is the database name and `taxis` is the table name.
 ```sql
 CREATE DATABASE nyc;
@@ -83,11 +83,11 @@ PARTITIONED BY (vendor_id bigint) STORED BY ICEBERG;
 ```
 Iceberg catalogs support the full range of SQL DDL commands, including:
 
-* [`CREATE TABLE`](docs/latest/hive.md#create-table)
-* [`CREATE TABLE AS SELECT`](docs/latest/hive.md#create-table-as-select)
-* [`CREATE TABLE LIKE TABLE`](docs/latest/hive.md#create-table-like-table)
-* [`ALTER TABLE`](docs/latest/hive.md#alter-table)
-* [`DROP TABLE`](docs/latest/hive.md#drop-table)
+* [`CREATE TABLE`](site:docs/latest/hive/#create-table)
+* [`CREATE TABLE AS SELECT`](site:docs/latest/hive/#create-table-as-select)
+* [`CREATE TABLE LIKE TABLE`](site:docs/latest/hive/#create-table-like-table)
+* [`ALTER TABLE`](site:docs/latest/hive/#alter-table)
+* [`DROP TABLE`](site:docs/latest/hive/#drop-table)
 
 ### Writing Data to a Table
 
@@ -108,8 +108,8 @@ SELECT * FROM nyc.taxis;
 
 #### Adding Iceberg to Hive
 
-If you already have a Hive 4.0.0-alpha-1, or later, environment, it comes with the Iceberg 0.13.1 included. No additional downloads or jars are needed. If you have a Hive 2.3.x or Hive 3.1.x environment see [Enabling Iceberg support in Hive](docs/latest/hive.md#enabling-iceberg-support-in-hive).
+If you already have a Hive 4.0.0-alpha-1, or later, environment, it comes with the Iceberg 0.13.1 included. No additional downloads or jars are needed. If you have a Hive 2.3.x or Hive 3.1.x environment see [Enabling Iceberg support in Hive](site:docs/latest/hive/#enabling-iceberg-support-in-hive).
 
 #### Learn More
 
-To learn more about setting up a database other than Derby, see [Apache Hive Quick Start](https://hive.apache.org/developement/quickstart/). You can also [set up a standalone metastore, HS2 and Postgres](https://github.com/apache/hive/blob/master/packaging/src/docker/docker-compose.yml). Now that you're up and running with Iceberg and Hive, check out the [Iceberg-Hive docs](docs/latest/hive.md) to learn more!
+To learn more about setting up a database other than Derby, see [Apache Hive Quick Start](https://hive.apache.org/developement/quickstart/). You can also [set up a standalone metastore, HS2 and Postgres](https://github.com/apache/hive/blob/master/packaging/src/docker/docker-compose.yml). Now that you're up and running with Iceberg and Hive, check out the [Iceberg-Hive docs](site:docs/latest/hive/) to learn more!

--- a/site/docs/how-to-release.md
+++ b/site/docs/how-to-release.md
@@ -384,7 +384,7 @@ A PR needs to be published in the `iceberg-docs` repository with the following c
 
 Each Apache Iceberg release is validated by the community by holding a vote. A community release manager
 will prepare a release candidate and call a vote on the Iceberg
-[dev list](community.md#mailing-lists).
+[dev list](site:community/#mailing-lists).
 To validate the release candidate, community members will test it out in their downstream projects and environments.
 It's recommended to report the Java, Scala, Spark, Flink and Hive versions you have tested against when you vote.
 

--- a/site/docs/multi-engine-support.md
+++ b/site/docs/multi-engine-support.md
@@ -115,4 +115,4 @@ Projects such as [Trino](https://trino.io/docs/current/connector/iceberg.html) a
 In this approach, an Iceberg version upgrade is needed for an engine to consume new Iceberg features.
 To facilitate engine development against unreleased Iceberg features, a daily snapshot is published in the [Apache snapshot repository](https://repository.apache.org/content/repositories/snapshots/org/apache/iceberg/).
 
-If bringing an engine directly to the Iceberg main repository is needed, please raise a discussion thread in the [Iceberg community](community.md).
+If bringing an engine directly to the Iceberg main repository is needed, please raise a discussion thread in the [Iceberg community](site:community/).

--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -680,7 +680,7 @@ Apache Iceberg 0.13.0 was released on February 4th, 2022.
 
 **Other notable changes:**
 
-* The community has finalized the long-term strategy of Spark, Flink and Hive support. See [Multi-Engine Support](multi-engine-support.md) page for more details.
+* The community has finalized the long-term strategy of Spark, Flink and Hive support. See [Multi-Engine Support](site:multi-engine-support/) page for more details.
 
 ### 0.12.1
 
@@ -769,7 +769,7 @@ Apache Iceberg 0.12.0 was released on August 15, 2021. It consists of 395 commit
 
 **Other notable changes:**
 
-* The Iceberg Community [voted to approve](https://mail-archives.apache.org/mod_mbox/iceberg-dev/202107.mbox/%3cCAMwmD1-k1gnShK=wQ0PD88it6cg9mY7Y1hKHjDZ7L-jcDzpyZA@mail.gmail.com%3e) version 2 of the Apache Iceberg Format Specification. The differences between version 1 and 2 of the specification are documented [here](spec.md#version-2).
+* The Iceberg Community [voted to approve](https://mail-archives.apache.org/mod_mbox/iceberg-dev/202107.mbox/%3cCAMwmD1-k1gnShK=wQ0PD88it6cg9mY7Y1hKHjDZ7L-jcDzpyZA@mail.gmail.com%3e) version 2 of the Apache Iceberg Format Specification. The differences between version 1 and 2 of the specification are documented [here](site:spec/#version-2).
 * Bugfixes and stability improvements for NessieCatalog.
 * Improvements and fixes for Iceberg's Python library.
 * Added a vectorized reader for Apache Arrow [[\#2286](https://github.com/apache/iceberg/pull/2286)].

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -21,7 +21,7 @@ title: "Spark and Iceberg Quickstart"
 ## Spark and Iceberg Quickstart
 
 This guide will get you up and running with an Iceberg and Spark environment, including sample code to
-highlight some powerful features. You can learn more about Iceberg's Spark runtime by checking out the [Spark](docs/latest/spark-ddl.md) section.
+highlight some powerful features. You can learn more about Iceberg's Spark runtime by checking out the [Spark](site:docs/latest/spark-ddl/) section.
 
 - [Docker-Compose](#docker-compose)
 - [Creating a table](#creating-a-table)
@@ -147,7 +147,7 @@ You can then run any of the following commands to start a Spark session.
 
 ### Creating a table
 
-To create your first Iceberg table in Spark, run a [`CREATE TABLE`](docs/latest/spark-ddl.md#create-table) command. Let's create a table
+To create your first Iceberg table in Spark, run a [`CREATE TABLE`](site:docs/latest/spark-ddl/#create-table) command. Let's create a table
 using `demo.nyc.taxis` where `demo` is the catalog name, `nyc` is the database name, and `taxis` is the table name.
 
 
@@ -200,10 +200,10 @@ using `demo.nyc.taxis` where `demo` is the catalog name, `nyc` is the database n
 
 Iceberg catalogs support the full range of SQL DDL commands, including:
 
-* [`CREATE TABLE ... PARTITIONED BY`](docs/latest/spark-ddl.md#create-table)
-* [`CREATE TABLE ... AS SELECT`](docs/latest/spark-ddl.md#create-table--as-select)
-* [`ALTER TABLE`](docs/latest/spark-ddl.md#alter-table)
-* [`DROP TABLE`](docs/latest/spark-ddl.md#drop-table)
+* [`CREATE TABLE ... PARTITIONED BY`](site:docs/latest/spark-ddl/#create-table)
+* [`CREATE TABLE ... AS SELECT`](site:docs/latest/spark-ddl/#create-table--as-select)
+* [`ALTER TABLE`](site:docs/latest/spark-ddl/#alter-table)
+* [`DROP TABLE`](site:docs/latest/spark-ddl/#drop-table)
 
 ### Writing Data to a Table
 
@@ -274,7 +274,7 @@ To read a table, simply use the Iceberg table's name.
 Iceberg has several catalog back-ends that can be used to track tables, like JDBC, Hive MetaStore and Glue.
 Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)`. In this guide,
 we use JDBC, but you can follow these instructions to configure other catalog types. To learn more, check out
-the [Catalog](docs/latest/spark-configuration.md#catalogs) page in the Spark section.
+the [Catalog](site:docs/latest/spark-configuration/#catalogs) page in the Spark section.
 
 This configuration creates a path-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog.
 
@@ -333,10 +333,10 @@ If you already have a Spark environment, you can add Iceberg, using the `--packa
 
 !!! note
     If you want to include Iceberg in your Spark installation, add the Iceberg Spark runtime to Spark's `jars` folder.
-    You can download the runtime by visiting to the [Releases](releases.md) page.
+    You can download the runtime by visiting to the [Releases](site:releases/) page.
 
 [spark-runtime-jar]: https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/{{ icebergVersion }}/iceberg-spark-runtime-3.5_2.12-{{ icebergVersion }}.jar
 
 #### Learn More
 
-Now that you're up an running with Iceberg and Spark, check out the [Iceberg-Spark docs](docs/latest/spark-ddl.md) to learn more!
+Now that you're up an running with Iceberg and Spark, check out the [Iceberg-Spark docs](site:docs/latest/spark-ddl/) to learn more!

--- a/site/docs/terms.md
+++ b/site/docs/terms.md
@@ -36,11 +36,11 @@ Each manifest file in the manifest list is stored with information about its con
 
 A **manifest file** is a metadata file that lists a subset of data files that make up a snapshot.
 
-Each data file in a manifest is stored with a [partition tuple](#partition-tuple), column-level stats, and summary information used to prune splits during [scan planning](docs/latest/performance.md#scan-planning).
+Each data file in a manifest is stored with a [partition tuple](#partition-tuple), column-level stats, and summary information used to prune splits during [scan planning](site:docs/latest/performance/#scan-planning).
 
 ### Partition spec
 
-A **partition spec** is a description of how to [partition](docs/latest/partitioning.md) data in a table.
+A **partition spec** is a description of how to [partition](site:docs/latest/partitioning/) data in a table.
 
 A spec consists of a list of source columns and transforms. A transform produces a partition value from a source value. For example, `date(ts)` produces the date associated with a timestamp column named `ts`.
 
@@ -58,4 +58,4 @@ The **snapshot log** is a metadata log of how the table's current snapshot has c
 
 The log is a list of timestamp and ID pairs: when the current snapshot changed and the snapshot ID the current snapshot was changed to.
 
-The snapshot log is stored in [table metadata as `snapshot-log`](spec.md#table-metadata-fields).
+The snapshot log is stored in [table metadata as `snapshot-log`](site:spec/#table-metadata-fields).

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -17,6 +17,7 @@
 
 INHERIT: ./nav.yml
 
+site_url: !ENV [ICEBERG_SITE_URL, 'http://localhost:8000']
 site_name: Apache Iceberg
 
 theme:
@@ -47,6 +48,7 @@ theme:
 
 plugins:
   - search
+  - site-urls
   - macros
   - monorepo
   - privacy

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -21,3 +21,4 @@ mkdocs-material==9.5.9
 mkdocs-material-extensions==1.3.1
 mkdocs-monorepo-plugin @ git+https://github.com/bitsondatadev/mkdocs-monorepo-plugin@url-fix
 mkdocs-redirects==1.2.1
+mkdocs-site-urls==0.2.0


### PR DESCRIPTION
Avoid internal [MkDocs relative linking](https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages) using the [mkdocs-site-urls](https://github.com/OctoPrint/mkdocs-site-urls) plugin.

This can be messy with the mkdoc-monorepo-plugin, which has multiple MkDocs projects stitched together that must link to the top-level and nested pages.

