### PR TITLE
Migrate Snapshot files in Core to JUnit5

### DIFF
--- a/core/src/test/java/org/apache/iceberg/LocalTableOperations.java
+++ b/core/src/test/java/org/apache/iceberg/LocalTableOperations.java
@@ -19,20 +19,22 @@
 package org.apache.iceberg;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Map;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.junit.rules.TemporaryFolder;
 
 class LocalTableOperations implements TableOperations {
-  private final TemporaryFolder temp;
+
+  private final Path temp;
+
   private final FileIO io;
 
   private final Map<String, String> createdMetadataFilePaths = Maps.newHashMap();
 
-  LocalTableOperations(TemporaryFolder temp) {
+  LocalTableOperations(Path temp) {
     this.temp = temp;
     this.io = new TestTables.LocalFileIO();
   }
@@ -63,7 +65,9 @@ class LocalTableOperations implements TableOperations {
         fileName,
         name -> {
           try {
-            return temp.newFile(name).getAbsolutePath();
+            return java.nio.file.Files.createTempDirectory(temp, "junit")
+                .toFile()
+                .getAbsolutePath();
           } catch (IOException e) {
             throw new RuntimeIOException(e);
           }

--- a/core/src/test/java/org/apache/iceberg/LocalTableOperations.java
+++ b/core/src/test/java/org/apache/iceberg/LocalTableOperations.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
@@ -27,7 +28,6 @@ import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 class LocalTableOperations implements TableOperations {
-
   private final Path temp;
 
   private final FileIO io;
@@ -65,9 +65,7 @@ class LocalTableOperations implements TableOperations {
         fileName,
         name -> {
           try {
-            return java.nio.file.Files.createTempDirectory(temp, "junit")
-                .toFile()
-                .getAbsolutePath();
+            return File.createTempFile("junit", null, temp.toFile()).getAbsolutePath();
           } catch (IOException e) {
             throw new RuntimeIOException(e);
           }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -19,23 +19,24 @@
 package org.apache.iceberg;
 
 import static org.apache.iceberg.Files.localInput;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
-import java.util.UUID;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestSnapshotJson {
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private static Path temp;
 
-  public TableOperations ops = new LocalTableOperations(temp);
+  public TableOperations ops =
+      new LocalTableOperations(java.nio.file.Files.createTempDirectory(temp, "junit"));
+
+  public TestSnapshotJson() throws IOException {}
 
   @Test
   public void testJsonConversion() throws IOException {
@@ -49,12 +50,23 @@ public class TestSnapshotJson {
     String json = SnapshotParser.toJson(expected);
     Snapshot snapshot = SnapshotParser.fromJson(json);
 
-    Assert.assertEquals("Snapshot ID should match", expected.snapshotId(), snapshot.snapshotId());
-    Assert.assertEquals(
-        "Files should match", expected.allManifests(ops.io()), snapshot.allManifests(ops.io()));
-    Assert.assertNull("Operation should be null", snapshot.operation());
-    Assert.assertNull("Summary should be null", snapshot.summary());
-    Assert.assertEquals("Schema ID should match", Integer.valueOf(1), snapshot.schemaId());
+    assertThat(snapshot.snapshotId()).isEqualTo(expected.snapshotId());
+    assertThat(snapshot.allManifests(ops.io())).hasSize(2);
+
+    for (int i = 0; i < snapshot.allManifests(ops.io()).size(); i++) {
+      ManifestFile actualManifestFile = snapshot.allManifests(ops.io()).get(i);
+      ManifestFile expectedManifestFile = expected.allManifests(ops.io()).get(i);
+
+      assertThat(actualManifestFile.content()).isEqualTo(expectedManifestFile.content());
+      assertThat(actualManifestFile.path()).isEqualTo(expectedManifestFile.path());
+      assertThat(actualManifestFile.length()).isEqualTo(expectedManifestFile.length());
+      assertThat(actualManifestFile.partitionSpecId())
+          .isEqualTo(expectedManifestFile.partitionSpecId());
+    }
+
+    assertThat(snapshot.operation()).isNull();
+    assertThat(snapshot.summary()).isNull();
+    assertThat(snapshot.schemaId()).isEqualTo(1);
   }
 
   @Test
@@ -69,12 +81,23 @@ public class TestSnapshotJson {
     String json = SnapshotParser.toJson(expected);
     Snapshot snapshot = SnapshotParser.fromJson(json);
 
-    Assert.assertEquals("Snapshot ID should match", expected.snapshotId(), snapshot.snapshotId());
-    Assert.assertEquals(
-        "Files should match", expected.allManifests(ops.io()), snapshot.allManifests(ops.io()));
-    Assert.assertNull("Operation should be null", snapshot.operation());
-    Assert.assertNull("Summary should be null", snapshot.summary());
-    Assert.assertNull("Schema ID should be null", snapshot.schemaId());
+    assertThat(snapshot.snapshotId()).isEqualTo(expected.snapshotId());
+    assertThat(snapshot.allManifests(ops.io())).hasSize(2);
+
+    for (int i = 0; i < snapshot.allManifests(ops.io()).size(); i++) {
+      ManifestFile actualManifestFile = snapshot.allManifests(ops.io()).get(i);
+      ManifestFile expectedManifestFile = expected.allManifests(ops.io()).get(i);
+
+      assertThat(actualManifestFile.content()).isEqualTo(expectedManifestFile.content());
+      assertThat(actualManifestFile.path()).isEqualTo(expectedManifestFile.path());
+      assertThat(actualManifestFile.length()).isEqualTo(expectedManifestFile.length());
+      assertThat(actualManifestFile.partitionSpecId())
+          .isEqualTo(expectedManifestFile.partitionSpecId());
+    }
+
+    assertThat(snapshot.operation()).isNull();
+    assertThat(snapshot.summary()).isNull();
+    assertThat(snapshot.schemaId()).isNull();
   }
 
   @Test
@@ -98,20 +121,30 @@ public class TestSnapshotJson {
     String json = SnapshotParser.toJson(expected);
     Snapshot snapshot = SnapshotParser.fromJson(json);
 
-    Assert.assertEquals("Sequence number should default to 0 for v1", 0, snapshot.sequenceNumber());
-    Assert.assertEquals("Snapshot ID should match", expected.snapshotId(), snapshot.snapshotId());
-    Assert.assertEquals(
-        "Timestamp should match", expected.timestampMillis(), snapshot.timestampMillis());
-    Assert.assertEquals("Parent ID should match", expected.parentId(), snapshot.parentId());
-    Assert.assertEquals(
-        "Manifest list should match",
-        expected.manifestListLocation(),
-        snapshot.manifestListLocation());
-    Assert.assertEquals(
-        "Files should match", expected.allManifests(ops.io()), snapshot.allManifests(ops.io()));
-    Assert.assertEquals("Operation should match", expected.operation(), snapshot.operation());
-    Assert.assertEquals("Summary should match", expected.summary(), snapshot.summary());
-    Assert.assertEquals("Schema ID should match", expected.schemaId(), snapshot.schemaId());
+    assertThat(snapshot.sequenceNumber())
+        .as("Sequence number should default to 0 for v1")
+        .isEqualTo(0);
+    assertThat(snapshot.snapshotId()).isEqualTo(expected.snapshotId());
+    assertThat(snapshot.timestampMillis()).isEqualTo(expected.timestampMillis());
+    assertThat(snapshot.parentId()).isEqualTo(expected.parentId());
+    assertThat(snapshot.manifestListLocation()).isEqualTo(expected.manifestListLocation());
+
+    assertThat(snapshot.allManifests(ops.io())).hasSize(2);
+
+    for (int i = 0; i < snapshot.allManifests(ops.io()).size(); i++) {
+      ManifestFile actualManifestFile = snapshot.allManifests(ops.io()).get(i);
+      ManifestFile expectedManifestFile = expected.allManifests(ops.io()).get(i);
+
+      assertThat(actualManifestFile.content()).isEqualTo(expectedManifestFile.content());
+      assertThat(actualManifestFile.path()).isEqualTo(expectedManifestFile.path());
+      assertThat(actualManifestFile.length()).isEqualTo(expectedManifestFile.length());
+      assertThat(actualManifestFile.partitionSpecId())
+          .isEqualTo(expectedManifestFile.partitionSpecId());
+    }
+
+    assertThat(snapshot.operation()).isEqualTo(expected.operation());
+    assertThat(snapshot.summary()).isEqualTo(expected.summary());
+    assertThat(snapshot.schemaId()).isEqualTo(expected.schemaId());
   }
 
   @Test
@@ -149,29 +182,34 @@ public class TestSnapshotJson {
             timestampMillis);
 
     String json = SnapshotParser.toJson(expected, true);
-    Assertions.assertThat(json).isEqualTo(expectedJson);
+    assertThat(json).isEqualTo(expectedJson);
     Snapshot snapshot = SnapshotParser.fromJson(json);
-    Assertions.assertThat(snapshot).isEqualTo(expected);
+    assertThat(snapshot).isEqualTo(expected);
 
-    Assert.assertEquals("Sequence number should default to 0 for v1", 0, snapshot.sequenceNumber());
-    Assert.assertEquals("Snapshot ID should match", expected.snapshotId(), snapshot.snapshotId());
-    Assert.assertEquals(
-        "Timestamp should match", expected.timestampMillis(), snapshot.timestampMillis());
-    Assert.assertEquals("Parent ID should match", expected.parentId(), snapshot.parentId());
-    Assert.assertEquals(
-        "Manifest list should match",
-        expected.manifestListLocation(),
-        snapshot.manifestListLocation());
-    Assert.assertEquals(
-        "Files should match", expected.allManifests(ops.io()), snapshot.allManifests(ops.io()));
-    Assert.assertEquals("Operation should match", expected.operation(), snapshot.operation());
-    Assert.assertEquals("Summary should match", expected.summary(), snapshot.summary());
-    Assert.assertEquals("Schema ID should match", expected.schemaId(), snapshot.schemaId());
+    assertThat(snapshot.sequenceNumber()).isEqualTo(0);
+    assertThat(snapshot.snapshotId()).isEqualTo(expected.snapshotId());
+    assertThat(snapshot.timestampMillis()).isEqualTo(expected.timestampMillis());
+    assertThat(snapshot.parentId()).isEqualTo(expected.parentId());
+    assertThat(snapshot.manifestListLocation()).isEqualTo(expected.manifestListLocation());
+
+    assertThat(snapshot.allManifests(ops.io())).hasSize(2);
+
+    for (int i = 0; i < snapshot.allManifests(ops.io()).size(); i++) {
+      ManifestFile actualManifestFile = snapshot.allManifests(ops.io()).get(i);
+      ManifestFile expectedManifestFile = expected.allManifests(ops.io()).get(i);
+
+      assertThat(actualManifestFile.content()).isEqualTo(expectedManifestFile.content());
+      assertThat(actualManifestFile.path()).isEqualTo(expectedManifestFile.path());
+    }
+
+    assertThat(snapshot.operation()).isEqualTo(expected.operation());
+    assertThat(snapshot.summary()).isEqualTo(expected.summary());
+    assertThat(snapshot.schemaId()).isEqualTo(expected.schemaId());
   }
 
   private String createManifestListWithManifestFiles(long snapshotId, Long parentSnapshotId)
       throws IOException {
-    File manifestList = temp.newFile("manifests" + UUID.randomUUID());
+    File manifestList = java.nio.file.Files.createTempDirectory(temp, "junit").toFile();
     manifestList.deleteOnExit();
 
     List<ManifestFile> manifests =

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -31,12 +31,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class TestSnapshotJson {
-  @TempDir private static Path temp;
+  @TempDir private Path temp;
 
-  public TableOperations ops =
-      new LocalTableOperations(java.nio.file.Files.createTempDirectory(temp, "junit"));
-
-  public TestSnapshotJson() throws IOException {}
+  public TableOperations ops = new LocalTableOperations(temp);
 
   @Test
   public void testJsonConversion() throws IOException {
@@ -51,19 +48,7 @@ public class TestSnapshotJson {
     Snapshot snapshot = SnapshotParser.fromJson(json);
 
     assertThat(snapshot.snapshotId()).isEqualTo(expected.snapshotId());
-    assertThat(snapshot.allManifests(ops.io())).hasSize(2);
-
-    for (int i = 0; i < snapshot.allManifests(ops.io()).size(); i++) {
-      ManifestFile actualManifestFile = snapshot.allManifests(ops.io()).get(i);
-      ManifestFile expectedManifestFile = expected.allManifests(ops.io()).get(i);
-
-      assertThat(actualManifestFile.content()).isEqualTo(expectedManifestFile.content());
-      assertThat(actualManifestFile.path()).isEqualTo(expectedManifestFile.path());
-      assertThat(actualManifestFile.length()).isEqualTo(expectedManifestFile.length());
-      assertThat(actualManifestFile.partitionSpecId())
-          .isEqualTo(expectedManifestFile.partitionSpecId());
-    }
-
+    assertThat(snapshot.allManifests(ops.io())).isEqualTo(expected.allManifests(ops.io()));
     assertThat(snapshot.operation()).isNull();
     assertThat(snapshot.summary()).isNull();
     assertThat(snapshot.schemaId()).isEqualTo(1);
@@ -82,19 +67,7 @@ public class TestSnapshotJson {
     Snapshot snapshot = SnapshotParser.fromJson(json);
 
     assertThat(snapshot.snapshotId()).isEqualTo(expected.snapshotId());
-    assertThat(snapshot.allManifests(ops.io())).hasSize(2);
-
-    for (int i = 0; i < snapshot.allManifests(ops.io()).size(); i++) {
-      ManifestFile actualManifestFile = snapshot.allManifests(ops.io()).get(i);
-      ManifestFile expectedManifestFile = expected.allManifests(ops.io()).get(i);
-
-      assertThat(actualManifestFile.content()).isEqualTo(expectedManifestFile.content());
-      assertThat(actualManifestFile.path()).isEqualTo(expectedManifestFile.path());
-      assertThat(actualManifestFile.length()).isEqualTo(expectedManifestFile.length());
-      assertThat(actualManifestFile.partitionSpecId())
-          .isEqualTo(expectedManifestFile.partitionSpecId());
-    }
-
+    assertThat(snapshot.allManifests(ops.io())).isEqualTo(expected.allManifests(ops.io()));
     assertThat(snapshot.operation()).isNull();
     assertThat(snapshot.summary()).isNull();
     assertThat(snapshot.schemaId()).isNull();
@@ -128,20 +101,7 @@ public class TestSnapshotJson {
     assertThat(snapshot.timestampMillis()).isEqualTo(expected.timestampMillis());
     assertThat(snapshot.parentId()).isEqualTo(expected.parentId());
     assertThat(snapshot.manifestListLocation()).isEqualTo(expected.manifestListLocation());
-
-    assertThat(snapshot.allManifests(ops.io())).hasSize(2);
-
-    for (int i = 0; i < snapshot.allManifests(ops.io()).size(); i++) {
-      ManifestFile actualManifestFile = snapshot.allManifests(ops.io()).get(i);
-      ManifestFile expectedManifestFile = expected.allManifests(ops.io()).get(i);
-
-      assertThat(actualManifestFile.content()).isEqualTo(expectedManifestFile.content());
-      assertThat(actualManifestFile.path()).isEqualTo(expectedManifestFile.path());
-      assertThat(actualManifestFile.length()).isEqualTo(expectedManifestFile.length());
-      assertThat(actualManifestFile.partitionSpecId())
-          .isEqualTo(expectedManifestFile.partitionSpecId());
-    }
-
+    assertThat(snapshot.allManifests(ops.io())).isEqualTo(expected.allManifests(ops.io()));
     assertThat(snapshot.operation()).isEqualTo(expected.operation());
     assertThat(snapshot.summary()).isEqualTo(expected.summary());
     assertThat(snapshot.schemaId()).isEqualTo(expected.schemaId());
@@ -186,22 +146,14 @@ public class TestSnapshotJson {
     Snapshot snapshot = SnapshotParser.fromJson(json);
     assertThat(snapshot).isEqualTo(expected);
 
-    assertThat(snapshot.sequenceNumber()).isEqualTo(0);
+    assertThat(snapshot.sequenceNumber())
+        .as("Sequence number should default to 0 for v1")
+        .isEqualTo(0);
     assertThat(snapshot.snapshotId()).isEqualTo(expected.snapshotId());
     assertThat(snapshot.timestampMillis()).isEqualTo(expected.timestampMillis());
     assertThat(snapshot.parentId()).isEqualTo(expected.parentId());
     assertThat(snapshot.manifestListLocation()).isEqualTo(expected.manifestListLocation());
-
-    assertThat(snapshot.allManifests(ops.io())).hasSize(2);
-
-    for (int i = 0; i < snapshot.allManifests(ops.io()).size(); i++) {
-      ManifestFile actualManifestFile = snapshot.allManifests(ops.io()).get(i);
-      ManifestFile expectedManifestFile = expected.allManifests(ops.io()).get(i);
-
-      assertThat(actualManifestFile.content()).isEqualTo(expectedManifestFile.content());
-      assertThat(actualManifestFile.path()).isEqualTo(expectedManifestFile.path());
-    }
-
+    assertThat(snapshot.allManifests(ops.io())).isEqualTo(expected.allManifests(ops.io()));
     assertThat(snapshot.operation()).isEqualTo(expected.operation());
     assertThat(snapshot.summary()).isEqualTo(expected.summary());
     assertThat(snapshot.schemaId()).isEqualTo(expected.schemaId());
@@ -209,7 +161,7 @@ public class TestSnapshotJson {
 
   private String createManifestListWithManifestFiles(long snapshotId, Long parentSnapshotId)
       throws IOException {
-    File manifestList = java.nio.file.Files.createTempDirectory(temp, "junit").toFile();
+    File manifestList = File.createTempFile("junit", null, temp.toFile());
     manifestList.deleteOnExit();
 
     List<ManifestFile> manifests =

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -161,7 +161,7 @@ public class TestSnapshotJson {
 
   private String createManifestListWithManifestFiles(long snapshotId, Long parentSnapshotId)
       throws IOException {
-    File manifestList = File.createTempFile("junit", null, temp.toFile());
+    File manifestList = File.createTempFile("manifests", null, temp.toFile());
     manifestList.deleteOnExit();
 
     List<ManifestFile> manifests =

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
@@ -222,8 +222,7 @@ public class TestSnapshotManager extends TestBase {
     // Test a basic case of creating a branch
     table.manageSnapshots().createBranch("branch1", snapshotId).commit();
     SnapshotRef expectedBranch = table.ops().refresh().ref("branch1");
-    assertThat(expectedBranch).isNotNull();
-    assertThat(expectedBranch).isEqualTo(SnapshotRef.branchBuilder(snapshotId).build());
+    assertThat(expectedBranch).isNotNull().isEqualTo(SnapshotRef.branchBuilder(snapshotId).build());
   }
 
   @TestTemplate
@@ -233,8 +232,7 @@ public class TestSnapshotManager extends TestBase {
     // Test a basic case of creating a branch
     table.manageSnapshots().createBranch("branch1").commit();
     SnapshotRef actualBranch = table.ops().refresh().ref("branch1");
-    assertThat(actualBranch).isNotNull();
-    assertThat(actualBranch).isEqualTo(SnapshotRef.branchBuilder(snapshotId).build());
+    assertThat(actualBranch).isNotNull().isEqualTo(SnapshotRef.branchBuilder(snapshotId).build());
   }
 
   @TestTemplate
@@ -304,8 +302,7 @@ public class TestSnapshotManager extends TestBase {
     table.manageSnapshots().createTag("tag1", snapshotId).commit();
     SnapshotRef expectedTag = table.ops().refresh().ref("tag1");
 
-    assertThat(expectedTag).isNotNull();
-    assertThat(expectedTag).isEqualTo(SnapshotRef.tagBuilder(snapshotId).build());
+    assertThat(expectedTag).isNotNull().isEqualTo(SnapshotRef.tagBuilder(snapshotId).build());
   }
 
   @TestTemplate
@@ -714,7 +711,7 @@ public class TestSnapshotManager extends TestBase {
 
     assertThat(readMetadata())
         .as("Base metadata should not change when manageSnapshots is created")
-        .isEqualTo(base);
+        .isSameAs(base);
     assertThat(version())
         .as("Table should be on version 2 after creating manageSnapshots")
         .isEqualTo(2);
@@ -723,12 +720,12 @@ public class TestSnapshotManager extends TestBase {
 
     assertThat(readMetadata())
         .as("Base metadata should not change when invoking rollbackTo")
-        .isEqualTo(base);
+        .isSameAs(base);
     assertThat(version()).as("Table should be on version 2 after invoking rollbackTo").isEqualTo(2);
 
     txn.commitTransaction();
 
-    assertThat(readMetadata().currentSnapshot()).isEqualTo(snapshotAfterFirstAppend);
+    assertThat(readMetadata().currentSnapshot()).isSameAs(snapshotAfterFirstAppend);
     validateSnapshot(null, snapshotAfterFirstAppend, FILE_A);
     assertThat(version()).as("Table should be on version 3 after invoking rollbackTo").isEqualTo(3);
   }
@@ -750,14 +747,14 @@ public class TestSnapshotManager extends TestBase {
     txn.updateProperties().set("some_prop", "some_prop_value").commit();
     assertThat(readMetadata())
         .as("Base metadata should not change when transaction is not committed")
-        .isEqualTo(base);
+        .isSameAs(base);
     assertThat(version())
         .as("Table should remain on version 2 when transaction is not committed")
         .isEqualTo(2);
 
     txn.commitTransaction();
 
-    assertThat(readMetadata().currentSnapshot()).isEqualTo(snapshotAfterFirstAppend);
+    assertThat(readMetadata().currentSnapshot()).isSameAs(snapshotAfterFirstAppend);
     assertThat(version()).as("Table should be on version 3 after invoking rollbackTo").isEqualTo(3);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
@@ -701,7 +701,7 @@ public class TestSnapshotManager extends TestBase {
 
     assertThat(readMetadata())
         .as("Base metadata should not change when transaction is created")
-        .isEqualTo(base);
+        .isSameAs(base);
     assertThat(version())
         .as("Table should be on version 2 after creating transaction")
         .isEqualTo(2);
@@ -725,7 +725,7 @@ public class TestSnapshotManager extends TestBase {
 
     txn.commitTransaction();
 
-    assertThat(readMetadata().currentSnapshot()).isSameAs(snapshotAfterFirstAppend);
+    assertThat(readMetadata().currentSnapshot()).isEqualTo(snapshotAfterFirstAppend);
     validateSnapshot(null, snapshotAfterFirstAppend, FILE_A);
     assertThat(version()).as("Table should be on version 3 after invoking rollbackTo").isEqualTo(3);
   }
@@ -754,7 +754,7 @@ public class TestSnapshotManager extends TestBase {
 
     txn.commitTransaction();
 
-    assertThat(readMetadata().currentSnapshot()).isSameAs(snapshotAfterFirstAppend);
+    assertThat(readMetadata().currentSnapshot()).isEqualTo(snapshotAfterFirstAppend);
     assertThat(version()).as("Table should be on version 3 after invoking rollbackTo").isEqualTo(3);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
@@ -18,16 +18,18 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.List;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestSnapshotManager extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSnapshotManager extends TestBase {
 
   // replacement for FILE_A
   static final DataFile REPLACEMENT_FILE_A =
@@ -47,16 +49,12 @@ public class TestSnapshotManager extends TableTestBase {
           .withRecordCount(1)
           .build();
 
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestSnapshotManager(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testCherryPickDynamicOverwrite() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -64,8 +62,9 @@ public class TestSnapshotManager extends TableTestBase {
     table.newReplacePartitions().addFile(REPLACEMENT_FILE_A).stageOnly().commit();
 
     Snapshot staged = Iterables.getLast(table.snapshots());
-    Assert.assertEquals(
-        "Should find the staged overwrite snapshot", DataOperations.OVERWRITE, staged.operation());
+    assertThat(staged.operation())
+        .as("Should find the staged overwrite snapshot")
+        .isEqualTo(DataOperations.OVERWRITE);
 
     // add another append so that the original commit can't be fast-forwarded
     table.newAppend().appendFile(FILE_B).commit();
@@ -73,21 +72,23 @@ public class TestSnapshotManager extends TableTestBase {
     // pick the snapshot into the current state
     table.manageSnapshots().cherrypick(staged.snapshotId()).commit();
 
-    Assert.assertNotEquals(
-        "Should not fast-forward", staged.snapshotId(), table.currentSnapshot().snapshotId());
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Should not fast-forward")
+        .isNotEqualTo(staged.snapshotId());
     validateTableFiles(table, FILE_B, REPLACEMENT_FILE_A);
   }
 
-  @Test
+  @TestTemplate
   public void testCherryPickDynamicOverwriteWithoutParent() {
-    Assert.assertNull("Table should not have a current snapshot", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     // stage an overwrite that replaces FILE_A
     table.newReplacePartitions().addFile(REPLACEMENT_FILE_A).stageOnly().commit();
 
     Snapshot staged = Iterables.getLast(table.snapshots());
-    Assert.assertEquals(
-        "Should find the staged overwrite snapshot", DataOperations.OVERWRITE, staged.operation());
+    assertThat(staged.operation())
+        .as("Should find the staged overwrite snapshot")
+        .isEqualTo(DataOperations.OVERWRITE);
 
     // add another append so that the original commit can't be fast-forwarded
     table.newAppend().appendFile(FILE_B).commit();
@@ -95,12 +96,13 @@ public class TestSnapshotManager extends TableTestBase {
     // pick the snapshot into the current state
     table.manageSnapshots().cherrypick(staged.snapshotId()).commit();
 
-    Assert.assertNotEquals(
-        "Should not fast-forward", staged.snapshotId(), table.currentSnapshot().snapshotId());
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Should not fast-forward")
+        .isNotEqualTo(staged.snapshotId());
     validateTableFiles(table, FILE_B, REPLACEMENT_FILE_A);
   }
 
-  @Test
+  @TestTemplate
   public void testCherryPickDynamicOverwriteConflict() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -108,27 +110,26 @@ public class TestSnapshotManager extends TableTestBase {
     table.newReplacePartitions().addFile(REPLACEMENT_FILE_A).stageOnly().commit();
 
     Snapshot staged = Iterables.getLast(table.snapshots());
-    Assert.assertEquals(
-        "Should find the staged overwrite snapshot", DataOperations.OVERWRITE, staged.operation());
+    assertThat(staged.operation())
+        .as("Should find the staged overwrite snapshot")
+        .isEqualTo(DataOperations.OVERWRITE);
 
     // add another append so that the original commit can't be fast-forwarded
     table.newAppend().appendFile(CONFLICT_FILE_A).commit();
     long lastSnapshotId = table.currentSnapshot().snapshotId();
 
     // pick the snapshot into the current state
-    Assertions.assertThatThrownBy(
-            () -> table.manageSnapshots().cherrypick(staged.snapshotId()).commit())
+    assertThatThrownBy(() -> table.manageSnapshots().cherrypick(staged.snapshotId()).commit())
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot cherry-pick replace partitions with changed partition");
 
-    Assert.assertEquals(
-        "Failed cherry-pick should not change the table state",
-        lastSnapshotId,
-        table.currentSnapshot().snapshotId());
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Failed cherry-pick should not change the table state")
+        .isEqualTo(lastSnapshotId);
     validateTableFiles(table, FILE_A, CONFLICT_FILE_A);
   }
 
-  @Test
+  @TestTemplate
   public void testCherryPickDynamicOverwriteDeleteConflict() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -136,8 +137,9 @@ public class TestSnapshotManager extends TableTestBase {
     table.newReplacePartitions().addFile(REPLACEMENT_FILE_A).stageOnly().commit();
 
     Snapshot staged = Iterables.getLast(table.snapshots());
-    Assert.assertEquals(
-        "Should find the staged overwrite snapshot", DataOperations.OVERWRITE, staged.operation());
+    assertThat(staged.operation())
+        .as("Should find the staged overwrite snapshot")
+        .isEqualTo(DataOperations.OVERWRITE);
 
     // add FILE_B s
     table.newAppend().appendFile(FILE_B).commit();
@@ -147,19 +149,17 @@ public class TestSnapshotManager extends TableTestBase {
     long lastSnapshotId = table.currentSnapshot().snapshotId();
 
     // pick the snapshot into the current state
-    Assertions.assertThatThrownBy(
-            () -> table.manageSnapshots().cherrypick(staged.snapshotId()).commit())
+    assertThatThrownBy(() -> table.manageSnapshots().cherrypick(staged.snapshotId()).commit())
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Missing required files to delete");
 
-    Assert.assertEquals(
-        "Failed cherry-pick should not change the table state",
-        lastSnapshotId,
-        table.currentSnapshot().snapshotId());
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Failed cherry-pick should not change the table state")
+        .isEqualTo(lastSnapshotId);
     validateTableFiles(table, FILE_B);
   }
 
-  @Test
+  @TestTemplate
   public void testCherryPickFromBranch() {
     table.newAppend().appendFile(FILE_A).commit();
     long branchSnapshotId = table.currentSnapshot().snapshotId();
@@ -177,20 +177,18 @@ public class TestSnapshotManager extends TableTestBase {
     long lastSnapshotId = table.currentSnapshot().snapshotId();
 
     // pick the snapshot into the current state
-    Assertions.assertThatThrownBy(
-            () -> table.manageSnapshots().cherrypick(replaceSnapshotId).commit())
+    assertThatThrownBy(() -> table.manageSnapshots().cherrypick(replaceSnapshotId).commit())
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith(
             "Cannot cherry-pick overwrite not based on an ancestor of the current state");
 
-    Assert.assertEquals(
-        "Failed cherry-pick should not change the table state",
-        lastSnapshotId,
-        table.currentSnapshot().snapshotId());
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Failed cherry-pick should not change the table state")
+        .isEqualTo(lastSnapshotId);
     validateTableFiles(table, FILE_A);
   }
 
-  @Test
+  @TestTemplate
   public void testCherryPickOverwrite() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -198,99 +196,96 @@ public class TestSnapshotManager extends TableTestBase {
     table.newOverwrite().deleteFile(FILE_A).addFile(REPLACEMENT_FILE_A).stageOnly().commit();
 
     Snapshot staged = Iterables.getLast(table.snapshots());
-    Assert.assertEquals(
-        "Should find the staged overwrite snapshot", DataOperations.OVERWRITE, staged.operation());
+    assertThat(staged.operation())
+        .as("Should find the staged overwrite snapshot")
+        .isEqualTo(DataOperations.OVERWRITE);
 
     // add another append so that the original commit can't be fast-forwarded
     table.newAppend().appendFile(FILE_B).commit();
     long lastSnapshotId = table.currentSnapshot().snapshotId();
 
     // pick the snapshot into the current state
-    Assertions.assertThatThrownBy(
-            () -> table.manageSnapshots().cherrypick(staged.snapshotId()).commit())
+    assertThatThrownBy(() -> table.manageSnapshots().cherrypick(staged.snapshotId()).commit())
         .isInstanceOf(ValidationException.class)
         .hasMessageEndingWith("not append, dynamic overwrite, or fast-forward");
 
-    Assert.assertEquals(
-        "Failed cherry-pick should not change the table state",
-        lastSnapshotId,
-        table.currentSnapshot().snapshotId());
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Failed cherry-pick should not change the table state")
+        .isEqualTo(lastSnapshotId);
     validateTableFiles(table, FILE_A, FILE_B);
   }
 
-  @Test
+  @TestTemplate
   public void testCreateBranch() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
     // Test a basic case of creating a branch
     table.manageSnapshots().createBranch("branch1", snapshotId).commit();
     SnapshotRef expectedBranch = table.ops().refresh().ref("branch1");
-    Assert.assertTrue(
-        expectedBranch != null
-            && expectedBranch.equals(SnapshotRef.branchBuilder(snapshotId).build()));
+    assertThat(expectedBranch).isNotNull();
+    assertThat(expectedBranch).isEqualTo(SnapshotRef.branchBuilder(snapshotId).build());
   }
 
-  @Test
+  @TestTemplate
   public void testCreateBranchWithoutSnapshotId() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
     // Test a basic case of creating a branch
     table.manageSnapshots().createBranch("branch1").commit();
     SnapshotRef actualBranch = table.ops().refresh().ref("branch1");
-    Assertions.assertThat(actualBranch).isNotNull();
-    Assertions.assertThat(actualBranch).isEqualTo(SnapshotRef.branchBuilder(snapshotId).build());
+    assertThat(actualBranch).isNotNull();
+    assertThat(actualBranch).isEqualTo(SnapshotRef.branchBuilder(snapshotId).build());
   }
 
-  @Test
+  @TestTemplate
   public void testCreateBranchOnEmptyTable() {
     table.manageSnapshots().createBranch("branch1").commit();
 
     SnapshotRef mainSnapshotRef = table.ops().refresh().ref(SnapshotRef.MAIN_BRANCH);
-    Assertions.assertThat(mainSnapshotRef).isNull();
+    assertThat(mainSnapshotRef).isNull();
 
     SnapshotRef branch1SnapshotRef = table.ops().refresh().ref("branch1");
-    Assertions.assertThat(branch1SnapshotRef).isNotNull();
-    Assertions.assertThat(branch1SnapshotRef.minSnapshotsToKeep()).isNull();
-    Assertions.assertThat(branch1SnapshotRef.maxSnapshotAgeMs()).isNull();
-    Assertions.assertThat(branch1SnapshotRef.maxRefAgeMs()).isNull();
+    assertThat(branch1SnapshotRef).isNotNull();
+    assertThat(branch1SnapshotRef.minSnapshotsToKeep()).isNull();
+    assertThat(branch1SnapshotRef.maxSnapshotAgeMs()).isNull();
+    assertThat(branch1SnapshotRef.maxRefAgeMs()).isNull();
 
     Snapshot snapshot = table.snapshot(branch1SnapshotRef.snapshotId());
-    Assertions.assertThat(snapshot.parentId()).isNull();
-    Assertions.assertThat(snapshot.addedDataFiles(table.io())).isEmpty();
-    Assertions.assertThat(snapshot.removedDataFiles(table.io())).isEmpty();
-    Assertions.assertThat(snapshot.addedDeleteFiles(table.io())).isEmpty();
-    Assertions.assertThat(snapshot.removedDeleteFiles(table.io())).isEmpty();
+    assertThat(snapshot.parentId()).isNull();
+    assertThat(snapshot.addedDataFiles(table.io())).isEmpty();
+    assertThat(snapshot.removedDataFiles(table.io())).isEmpty();
+    assertThat(snapshot.addedDeleteFiles(table.io())).isEmpty();
+    assertThat(snapshot.removedDeleteFiles(table.io())).isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void testCreateBranchOnEmptyTableFailsWhenRefAlreadyExists() {
     table.manageSnapshots().createBranch("branch1").commit();
 
     // Trying to create a branch with an existing name should fail
-    Assertions.assertThatThrownBy(() -> table.manageSnapshots().createBranch("branch1").commit())
+    assertThatThrownBy(() -> table.manageSnapshots().createBranch("branch1").commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Ref branch1 already exists");
 
     // Trying to create another branch within the same chain
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> table.manageSnapshots().createBranch("branch2").createBranch("branch2").commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Ref branch2 already exists");
   }
 
-  @Test
+  @TestTemplate
   public void testCreateBranchFailsWhenRefAlreadyExists() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().createBranch("branch1", snapshotId).commit();
     // Trying to create a branch with an existing name should fail
-    Assertions.assertThatThrownBy(
-            () -> table.manageSnapshots().createBranch("branch1", snapshotId).commit())
+    assertThatThrownBy(() -> table.manageSnapshots().createBranch("branch1", snapshotId).commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Ref branch1 already exists");
 
     // Trying to create another branch within the same chain
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .manageSnapshots()
@@ -301,7 +296,7 @@ public class TestSnapshotManager extends TableTestBase {
         .hasMessage("Ref branch2 already exists");
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTag() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -309,24 +304,23 @@ public class TestSnapshotManager extends TableTestBase {
     table.manageSnapshots().createTag("tag1", snapshotId).commit();
     SnapshotRef expectedTag = table.ops().refresh().ref("tag1");
 
-    Assert.assertTrue(
-        expectedTag != null && expectedTag.equals(SnapshotRef.tagBuilder(snapshotId).build()));
+    assertThat(expectedTag).isNotNull();
+    assertThat(expectedTag).isEqualTo(SnapshotRef.tagBuilder(snapshotId).build());
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTagFailsWhenRefAlreadyExists() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().createTag("tag1", snapshotId).commit();
 
     // Trying to create a tag with an existing name should fail
-    Assertions.assertThatThrownBy(
-            () -> table.manageSnapshots().createTag("tag1", snapshotId).commit())
+    assertThatThrownBy(() -> table.manageSnapshots().createTag("tag1", snapshotId).commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Ref tag1 already exists");
 
     // Trying to create another tag within the same chain
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .manageSnapshots()
@@ -337,7 +331,7 @@ public class TestSnapshotManager extends TableTestBase {
         .hasMessage("Ref tag2 already exists");
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveBranch() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -347,31 +341,29 @@ public class TestSnapshotManager extends TableTestBase {
 
     TableMetadata updated = table.ops().refresh();
     SnapshotRef expectedBranch = updated.ref("branch1");
-    Assert.assertNull(expectedBranch);
+    assertThat(expectedBranch).isNull();
 
     // Test chained creating and removal of branch and tag
     table.manageSnapshots().createBranch("branch2", snapshotId).removeBranch("branch2").commit();
     updated = table.ops().refresh();
-    Assert.assertNull(updated.ref("branch2"));
+    assertThat(updated.ref("branch2")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testRemovingNonExistingBranchFails() {
-    Assertions.assertThatThrownBy(
-            () -> table.manageSnapshots().removeBranch("non-existing").commit())
+    assertThatThrownBy(() -> table.manageSnapshots().removeBranch("non-existing").commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Branch does not exist: non-existing");
   }
 
-  @Test
+  @TestTemplate
   public void testRemovingMainBranchFails() {
-    Assertions.assertThatThrownBy(
-            () -> table.manageSnapshots().removeBranch(SnapshotRef.MAIN_BRANCH).commit())
+    assertThatThrownBy(() -> table.manageSnapshots().removeBranch(SnapshotRef.MAIN_BRANCH).commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot remove main branch");
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveTag() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -380,22 +372,22 @@ public class TestSnapshotManager extends TableTestBase {
     table.manageSnapshots().removeTag("tag1").commit();
     TableMetadata updated = table.ops().refresh();
     SnapshotRef expectedTag = updated.ref("tag1");
-    Assert.assertNull(expectedTag);
+    assertThat(expectedTag).isNull();
 
     // Test chained creating and removal of a tag
     table.manageSnapshots().createTag("tag2", snapshotId).removeTag("tag2").commit();
-    Assert.assertEquals(updated, table.ops().refresh());
-    Assert.assertNull(updated.ref("tag2"));
+    assertThat(table.ops().refresh()).isEqualTo(updated);
+    assertThat(updated.ref("tag2")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testRemovingNonExistingTagFails() {
-    Assertions.assertThatThrownBy(() -> table.manageSnapshots().removeTag("non-existing").commit())
+    assertThatThrownBy(() -> table.manageSnapshots().removeTag("non-existing").commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Tag does not exist: non-existing");
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceBranch() {
     table.newAppend().appendFile(FILE_A).set("wap.id", "123").stageOnly().commit();
     Snapshot firstSnapshot = Iterables.getOnlyElement(table.snapshots());
@@ -404,63 +396,61 @@ public class TestSnapshotManager extends TableTestBase {
     Snapshot secondSnapshot = Iterables.get(table.snapshots(), 1);
     table.manageSnapshots().createBranch("branch2", secondSnapshot.snapshotId()).commit();
     table.manageSnapshots().replaceBranch("branch1", "branch2").commit();
-    Assert.assertEquals(
-        table.ops().refresh().ref("branch1").snapshotId(), secondSnapshot.snapshotId());
+    assertThat(secondSnapshot.snapshotId())
+        .isEqualTo(table.ops().refresh().ref("branch1").snapshotId());
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceBranchNonExistingToBranchFails() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().createBranch("branch1", snapshotId).commit();
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> table.manageSnapshots().replaceBranch("branch1", "non-existing").commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Ref does not exist: non-existing");
   }
 
-  @Test
+  @TestTemplate
   public void testFastForwardBranchNonExistingFromBranchCreatesTheBranch() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().createBranch("branch1", snapshotId).commit();
     table.manageSnapshots().fastForwardBranch("new-branch", "branch1").commit();
 
-    Assertions.assertThat(table.ops().current().ref("new-branch").isBranch()).isTrue();
-    Assertions.assertThat(table.ops().current().ref("new-branch").snapshotId())
-        .isEqualTo(snapshotId);
+    assertThat(table.ops().current().ref("new-branch").isBranch()).isTrue();
+    assertThat(table.ops().current().ref("new-branch").snapshotId()).isEqualTo(snapshotId);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceBranchNonExistingFromBranchCreatesTheBranch() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().createBranch("branch1", snapshotId).commit();
     table.manageSnapshots().replaceBranch("new-branch", "branch1").commit();
 
-    Assertions.assertThat(table.ops().current().ref("new-branch").isBranch()).isTrue();
-    Assertions.assertThat(table.ops().current().ref("new-branch").snapshotId())
-        .isEqualTo(snapshotId);
+    assertThat(table.ops().current().ref("new-branch").isBranch()).isTrue();
+    assertThat(table.ops().current().ref("new-branch").snapshotId()).isEqualTo(snapshotId);
   }
 
-  @Test
+  @TestTemplate
   public void testFastForwardBranchNonExistingToFails() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().createBranch("branch1", snapshotId).commit();
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> table.manageSnapshots().fastForwardBranch("branch1", "non-existing").commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Ref does not exist: non-existing");
   }
 
-  @Test
+  @TestTemplate
   public void testFastForward() {
     table.newAppend().appendFile(FILE_A).commit();
 
     table.newAppend().appendFile(FILE_B).set("wap.id", "123456789").stageOnly().commit();
 
-    Assert.assertEquals(table.currentSnapshot().snapshotId(), 1);
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(1);
 
     table.manageSnapshots().createBranch("new-branch-at-staged-snapshot", 2).commit();
     table
@@ -468,10 +458,10 @@ public class TestSnapshotManager extends TableTestBase {
         .fastForwardBranch(SnapshotRef.MAIN_BRANCH, "new-branch-at-staged-snapshot")
         .commit();
 
-    Assert.assertEquals(table.currentSnapshot().snapshotId(), 2);
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testFastForwardWhenFromIsNotAncestorFails() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -485,7 +475,7 @@ public class TestSnapshotManager extends TableTestBase {
     final String newBranch = "new-branch-at-staged-snapshot";
     table.manageSnapshots().createBranch(newBranch, snapshot).commit();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .manageSnapshots()
@@ -496,7 +486,7 @@ public class TestSnapshotManager extends TableTestBase {
             "Cannot fast-forward: main is not an ancestor of new-branch-at-staged-snapshot");
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceTag() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -505,10 +495,10 @@ public class TestSnapshotManager extends TableTestBase {
     table.newAppend().appendFile(FILE_B).commit();
     long currentSnapshot = table.ops().refresh().currentSnapshot().snapshotId();
     table.manageSnapshots().replaceTag("tag1", currentSnapshot).commit();
-    Assert.assertEquals(table.ops().refresh().ref("tag1").snapshotId(), currentSnapshot);
+    assertThat(currentSnapshot).isEqualTo(table.ops().refresh().ref("tag1").snapshotId());
   }
 
-  @Test
+  @TestTemplate
   public void testUpdatingBranchRetention() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -520,8 +510,8 @@ public class TestSnapshotManager extends TableTestBase {
         .setMaxSnapshotAgeMs("branch1", 20000)
         .commit();
     TableMetadata updated = table.ops().refresh();
-    Assert.assertEquals(20000, (long) updated.ref("branch1").maxSnapshotAgeMs());
-    Assert.assertEquals(10, (long) updated.ref("branch1").minSnapshotsToKeep());
+    assertThat(updated.ref("branch1").maxSnapshotAgeMs()).isEqualTo(20000);
+    assertThat(updated.ref("branch1").minSnapshotsToKeep()).isEqualTo(10);
     // Test creating and updating in a chain
     table
         .manageSnapshots()
@@ -530,16 +520,16 @@ public class TestSnapshotManager extends TableTestBase {
         .setMaxSnapshotAgeMs("branch2", 20000)
         .commit();
     updated = table.ops().refresh();
-    Assert.assertEquals(20000, (long) updated.ref("branch2").maxSnapshotAgeMs());
-    Assert.assertEquals(10, (long) updated.ref("branch2").minSnapshotsToKeep());
+    assertThat(updated.ref("branch2").maxSnapshotAgeMs()).isEqualTo(20000);
+    assertThat(updated.ref("branch2").minSnapshotsToKeep()).isEqualTo(10);
   }
 
-  @Test
+  @TestTemplate
   public void testSettingBranchRetentionOnTagFails() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .manageSnapshots()
@@ -549,7 +539,7 @@ public class TestSnapshotManager extends TableTestBase {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Tags do not support setting minSnapshotsToKeep");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .manageSnapshots()
@@ -560,7 +550,7 @@ public class TestSnapshotManager extends TableTestBase {
         .hasMessage("Tags do not support setting maxSnapshotAgeMs");
   }
 
-  @Test
+  @TestTemplate
   public void testUpdatingBranchMaxRefAge() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -570,11 +560,10 @@ public class TestSnapshotManager extends TableTestBase {
     table.manageSnapshots().createBranch("branch1", snapshotId).commit();
     table.manageSnapshots().setMaxRefAgeMs("branch1", 10000).commit();
     TableMetadata updated = table.ops().refresh();
-    Assert.assertEquals(maxRefAgeMs, (long) updated.ref("branch1").maxRefAgeMs());
-    Assert.assertEquals(maxRefAgeMs, (long) updated.ref("branch1").maxRefAgeMs());
+    assertThat(updated.ref("branch1").maxRefAgeMs()).isEqualTo(maxRefAgeMs);
   }
 
-  @Test
+  @TestTemplate
   public void testUpdatingTagMaxRefAge() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -585,7 +574,7 @@ public class TestSnapshotManager extends TableTestBase {
     table.manageSnapshots().setMaxRefAgeMs("tag1", maxRefAgeMs).commit();
 
     TableMetadata updated = table.ops().refresh();
-    Assert.assertEquals(maxRefAgeMs, (long) updated.ref("tag1").maxRefAgeMs());
+    assertThat(updated.ref("tag1").maxRefAgeMs()).isEqualTo(maxRefAgeMs);
 
     // Test creating and updating in a chain
     table
@@ -594,10 +583,10 @@ public class TestSnapshotManager extends TableTestBase {
         .setMaxRefAgeMs("tag2", maxRefAgeMs)
         .commit();
     updated = table.ops().refresh();
-    Assert.assertEquals(maxRefAgeMs, (long) updated.ref("tag2").maxRefAgeMs());
+    assertThat(updated.ref("tag2").maxRefAgeMs()).isEqualTo(maxRefAgeMs);
   }
 
-  @Test
+  @TestTemplate
   public void testRenameBranch() {
     table.newAppend().appendFile(FILE_A).commit();
     table.newAppend().appendFile(FILE_A).commit();
@@ -607,8 +596,8 @@ public class TestSnapshotManager extends TableTestBase {
     table.manageSnapshots().createBranch("branch1", snapshotId).commit();
     table.manageSnapshots().renameBranch("branch1", "branch2").commit();
     TableMetadata updated = table.ops().refresh();
-    Assert.assertNull(updated.ref("branch1"));
-    Assert.assertEquals(updated.ref("branch2"), SnapshotRef.branchBuilder(snapshotId).build());
+    assertThat(updated.ref("branch1")).isNull();
+    assertThat(SnapshotRef.branchBuilder(snapshotId).build()).isEqualTo(updated.ref("branch2"));
 
     table
         .manageSnapshots()
@@ -617,13 +606,13 @@ public class TestSnapshotManager extends TableTestBase {
         .commit();
 
     updated = table.ops().refresh();
-    Assert.assertNull(updated.ref("branch3"));
-    Assert.assertEquals(updated.ref("branch4"), SnapshotRef.branchBuilder(snapshotId).build());
+    assertThat(updated.ref("branch3")).isNull();
+    assertThat(SnapshotRef.branchBuilder(snapshotId).build()).isEqualTo(updated.ref("branch4"));
   }
 
-  @Test
+  @TestTemplate
   public void testFailRenamingMainBranch() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .manageSnapshots()
@@ -633,16 +622,16 @@ public class TestSnapshotManager extends TableTestBase {
         .hasMessage("Cannot rename main branch");
   }
 
-  @Test
+  @TestTemplate
   public void testRenamingNonExistingBranchFails() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table.manageSnapshots().renameBranch("some-missing-branch", "some-branch").commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Branch does not exist: some-missing-branch");
   }
 
-  @Test
+  @TestTemplate
   public void testCreateReferencesAndRollback() {
     table.newAppend().appendFile(FILE_A).commit();
     table.newAppend().appendFile(FILE_A).commit();
@@ -656,15 +645,15 @@ public class TestSnapshotManager extends TableTestBase {
         .commit();
 
     TableMetadata current = table.ops().current();
-    Assert.assertEquals(current.currentSnapshot().snapshotId(), 1);
+    assertThat(current.currentSnapshot().snapshotId()).isEqualTo(1);
     SnapshotRef actualTag = current.ref("tag1");
     SnapshotRef actualBranch = current.ref("branch1");
-    Assert.assertEquals(1, current.currentSnapshot().snapshotId());
-    Assert.assertEquals(SnapshotRef.branchBuilder(snapshotPriorToRollback).build(), actualBranch);
-    Assert.assertEquals(SnapshotRef.tagBuilder(snapshotPriorToRollback).build(), actualTag);
+    assertThat(current.currentSnapshot().snapshotId()).isEqualTo(1);
+    assertThat(actualBranch).isEqualTo(SnapshotRef.branchBuilder(snapshotPriorToRollback).build());
+    assertThat(actualTag).isEqualTo(SnapshotRef.tagBuilder(snapshotPriorToRollback).build());
   }
 
-  @Test
+  @TestTemplate
   public void testCreateReferencesAndCherrypick() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -681,15 +670,15 @@ public class TestSnapshotManager extends TableTestBase {
         .commit();
 
     TableMetadata current = table.ops().current();
-    Assert.assertEquals(current.currentSnapshot().snapshotId(), 2);
+    assertThat(current.currentSnapshot().snapshotId()).isEqualTo(2);
     SnapshotRef actualTag = current.ref("tag1");
     SnapshotRef actualBranch = current.ref("branch1");
-    Assert.assertEquals(2, current.currentSnapshot().snapshotId());
-    Assert.assertEquals(SnapshotRef.branchBuilder(1).build(), actualBranch);
-    Assert.assertEquals(SnapshotRef.tagBuilder(1).build(), actualTag);
+    assertThat(current.currentSnapshot().snapshotId()).isEqualTo(2);
+    assertThat(actualBranch).isEqualTo(SnapshotRef.branchBuilder(1).build());
+    assertThat(actualTag).isEqualTo(SnapshotRef.tagBuilder(1).build());
   }
 
-  @Test
+  @TestTemplate
   public void testAttemptToRollbackToCurrentSnapshot() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -700,7 +689,7 @@ public class TestSnapshotManager extends TableTestBase {
     table.manageSnapshots().rollbackTo(currentSnapshotId).commit();
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotManagerThroughTransaction() {
     table.newAppend().appendFile(FILE_A).commit();
     Snapshot snapshotAfterFirstAppend = readMetadata().currentSnapshot();
@@ -708,40 +697,43 @@ public class TestSnapshotManager extends TableTestBase {
 
     table.newAppend().appendFile(FILE_B).commit();
     validateSnapshot(snapshotAfterFirstAppend, readMetadata().currentSnapshot(), FILE_B);
-    Assert.assertEquals("Table should be on version 2 after appending twice", 2, (int) version());
+    assertThat(version()).as("Table should be on version 2 after appending twice").isEqualTo(2);
 
     TableMetadata base = readMetadata();
     Transaction txn = table.newTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when transaction is created", base, readMetadata());
-    Assert.assertEquals(
-        "Table should be on version 2 after creating transaction", 2, (int) version());
+    assertThat(readMetadata())
+        .as("Base metadata should not change when transaction is created")
+        .isEqualTo(base);
+    assertThat(version())
+        .as("Table should be on version 2 after creating transaction")
+        .isEqualTo(2);
 
     ManageSnapshots manageSnapshots = txn.manageSnapshots();
-    Assert.assertNotNull(manageSnapshots);
+    assertThat(manageSnapshots).isNotNull();
 
-    Assert.assertSame(
-        "Base metadata should not change when manageSnapshots is created", base, readMetadata());
-    Assert.assertEquals(
-        "Table should be on version 2 after creating manageSnapshots", 2, (int) version());
+    assertThat(readMetadata())
+        .as("Base metadata should not change when manageSnapshots is created")
+        .isEqualTo(base);
+    assertThat(version())
+        .as("Table should be on version 2 after creating manageSnapshots")
+        .isEqualTo(2);
 
     manageSnapshots.rollbackTo(snapshotAfterFirstAppend.snapshotId()).commit();
 
-    Assert.assertSame(
-        "Base metadata should not change when invoking rollbackTo", base, readMetadata());
-    Assert.assertEquals(
-        "Table should be on version 2 after invoking rollbackTo", 2, (int) version());
+    assertThat(readMetadata())
+        .as("Base metadata should not change when invoking rollbackTo")
+        .isEqualTo(base);
+    assertThat(version()).as("Table should be on version 2 after invoking rollbackTo").isEqualTo(2);
 
     txn.commitTransaction();
 
-    Assert.assertEquals(snapshotAfterFirstAppend, readMetadata().currentSnapshot());
+    assertThat(readMetadata().currentSnapshot()).isEqualTo(snapshotAfterFirstAppend);
     validateSnapshot(null, snapshotAfterFirstAppend, FILE_A);
-    Assert.assertEquals(
-        "Table should be on version 3 after invoking rollbackTo", 3, (int) version());
+    assertThat(version()).as("Table should be on version 3 after invoking rollbackTo").isEqualTo(3);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotManagerThroughTransactionMultiOperation() {
     table.newAppend().appendFile(FILE_A).commit();
     Snapshot snapshotAfterFirstAppend = readMetadata().currentSnapshot();
@@ -749,32 +741,30 @@ public class TestSnapshotManager extends TableTestBase {
 
     table.newAppend().appendFile(FILE_B).commit();
     validateSnapshot(snapshotAfterFirstAppend, readMetadata().currentSnapshot(), FILE_B);
-    Assert.assertEquals("Table should be on version 2 after appending twice", 2, (int) version());
+    assertThat(version()).as("Table should be on version 2 after appending twice").isEqualTo(2);
 
     TableMetadata base = readMetadata();
     Transaction txn = table.newTransaction();
 
     txn.manageSnapshots().rollbackTo(snapshotAfterFirstAppend.snapshotId()).commit();
     txn.updateProperties().set("some_prop", "some_prop_value").commit();
-    Assert.assertSame(
-        "Base metadata should not change when transaction is not committed", base, readMetadata());
-    Assert.assertEquals(
-        "Table should remain on version 2 when transaction is not committed", 2, (int) version());
+    assertThat(readMetadata())
+        .as("Base metadata should not change when transaction is not committed")
+        .isEqualTo(base);
+    assertThat(version())
+        .as("Table should remain on version 2 when transaction is not committed")
+        .isEqualTo(2);
 
     txn.commitTransaction();
 
-    Assert.assertEquals(snapshotAfterFirstAppend, readMetadata().currentSnapshot());
-    Assert.assertEquals(
-        "Table should be on version 3 after invoking rollbackTo", 3, (int) version());
+    assertThat(readMetadata().currentSnapshot()).isEqualTo(snapshotAfterFirstAppend);
+    assertThat(version()).as("Table should be on version 3 after invoking rollbackTo").isEqualTo(3);
   }
 
-  @Test
-  public void testSnapshotManagerInvalidParameters() throws Exception {
-    Assert.assertThrows(
-        "Incorrect input transaction: null",
-        IllegalArgumentException.class,
-        () -> {
-          new SnapshotManager(null);
-        });
+  @TestTemplate
+  public void testSnapshotManagerInvalidParameters() {
+    assertThatThrownBy(() -> new SnapshotManager(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid input transaction: null");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotRefParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotRefParser.java
@@ -18,9 +18,10 @@
  */
 package org.apache.iceberg;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
 
 public class TestSnapshotRefParser {
 
@@ -28,24 +29,27 @@ public class TestSnapshotRefParser {
   public void testTagToJsonDefault() {
     String json = "{\"snapshot-id\":1,\"type\":\"tag\"}";
     SnapshotRef ref = SnapshotRef.tagBuilder(1L).build();
-    Assert.assertEquals(
-        "Should be able to serialize default tag", json, SnapshotRefParser.toJson(ref));
+    assertThat(SnapshotRefParser.toJson(ref))
+        .as("Should be able to serialize default tag")
+        .isEqualTo(json);
   }
 
   @Test
   public void testTagToJsonAllFields() {
     String json = "{\"snapshot-id\":1,\"type\":\"tag\",\"max-ref-age-ms\":1}";
     SnapshotRef ref = SnapshotRef.tagBuilder(1L).maxRefAgeMs(1L).build();
-    Assert.assertEquals(
-        "Should be able to serialize tag with all fields", json, SnapshotRefParser.toJson(ref));
+    assertThat(SnapshotRefParser.toJson(ref))
+        .as("Should be able to serialize tag with all fields")
+        .isEqualTo(json);
   }
 
   @Test
   public void testBranchToJsonDefault() {
     String json = "{\"snapshot-id\":1,\"type\":\"branch\"}";
     SnapshotRef ref = SnapshotRef.branchBuilder(1L).build();
-    Assert.assertEquals(
-        "Should be able to serialize default branch", json, SnapshotRefParser.toJson(ref));
+    assertThat(SnapshotRefParser.toJson(ref))
+        .as("Should be able to serialize default branch")
+        .isEqualTo(json);
   }
 
   @Test
@@ -59,32 +63,36 @@ public class TestSnapshotRefParser {
             .maxSnapshotAgeMs(3L)
             .maxRefAgeMs(4L)
             .build();
-    Assert.assertEquals(
-        "Should be able to serialize branch with all fields", json, SnapshotRefParser.toJson(ref));
+    assertThat(SnapshotRefParser.toJson(ref))
+        .as("Should be able to serialize branch with all fields")
+        .isEqualTo(json);
   }
 
   @Test
   public void testTagFromJsonDefault() {
     String json = "{\"snapshot-id\":1,\"type\":\"tag\"}";
     SnapshotRef ref = SnapshotRef.tagBuilder(1L).build();
-    Assert.assertEquals(
-        "Should be able to deserialize default tag", ref, SnapshotRefParser.fromJson(json));
+    assertThat(SnapshotRefParser.fromJson(json))
+        .as("Should be able to deserialize default tag")
+        .isEqualTo(ref);
   }
 
   @Test
   public void testTagFromJsonAllFields() {
     String json = "{\"snapshot-id\":1,\"type\":\"tag\",\"max-ref-age-ms\":1}";
     SnapshotRef ref = SnapshotRef.tagBuilder(1L).maxRefAgeMs(1L).build();
-    Assert.assertEquals(
-        "Should be able to deserialize tag with all fields", ref, SnapshotRefParser.fromJson(json));
+    assertThat(SnapshotRefParser.fromJson(json))
+        .as("Should be able to deserialize tag with all fields")
+        .isEqualTo(ref);
   }
 
   @Test
   public void testBranchFromJsonDefault() {
     String json = "{\"snapshot-id\":1,\"type\":\"branch\"}";
     SnapshotRef ref = SnapshotRef.branchBuilder(1L).build();
-    Assert.assertEquals(
-        "Should be able to deserialize default branch", ref, SnapshotRefParser.fromJson(json));
+    assertThat(SnapshotRefParser.fromJson(json))
+        .as("Should be able to deserialize default branch")
+        .isEqualTo(ref);
   }
 
   @Test
@@ -98,21 +106,20 @@ public class TestSnapshotRefParser {
             .maxSnapshotAgeMs(3L)
             .maxRefAgeMs(4L)
             .build();
-    Assert.assertEquals(
-        "Should be able to deserialize branch with all fields",
-        ref,
-        SnapshotRefParser.fromJson(json));
+    assertThat(SnapshotRefParser.fromJson(json))
+        .as("Should be able to deserialize branch with all fields")
+        .isEqualTo(ref);
   }
 
   @Test
   public void testFailParsingWhenNullOrEmptyJson() {
     String nullJson = null;
-    Assertions.assertThatThrownBy(() -> SnapshotRefParser.fromJson(nullJson))
+    assertThatThrownBy(() -> SnapshotRefParser.fromJson(nullJson))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot parse snapshot ref from invalid JSON");
 
     String emptyJson = "";
-    Assertions.assertThatThrownBy(() -> SnapshotRefParser.fromJson(emptyJson))
+    assertThatThrownBy(() -> SnapshotRefParser.fromJson(emptyJson))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot parse snapshot ref from invalid JSON");
   }
@@ -120,12 +127,12 @@ public class TestSnapshotRefParser {
   @Test
   public void testFailParsingWhenMissingRequiredFields() {
     String refMissingType = "{\"snapshot-id\":1}";
-    Assertions.assertThatThrownBy(() -> SnapshotRefParser.fromJson(refMissingType))
+    assertThatThrownBy(() -> SnapshotRefParser.fromJson(refMissingType))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot parse missing string");
 
     String refMissingSnapshotId = "{\"type\":\"branch\"}";
-    Assertions.assertThatThrownBy(() -> SnapshotRefParser.fromJson(refMissingSnapshotId))
+    assertThatThrownBy(() -> SnapshotRefParser.fromJson(refMissingSnapshotId))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot parse missing long");
   }
@@ -134,31 +141,31 @@ public class TestSnapshotRefParser {
   public void testFailWhenFieldsHaveInvalidValues() {
     String invalidSnapshotId =
         "{\"snapshot-id\":\"invalid-snapshot-id\",\"type\":\"not-a-valid-tag-type\"}";
-    Assertions.assertThatThrownBy(() -> SnapshotRefParser.fromJson(invalidSnapshotId))
+    assertThatThrownBy(() -> SnapshotRefParser.fromJson(invalidSnapshotId))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse to a long value: snapshot-id: \"invalid-snapshot-id\"");
 
     String invalidTagType = "{\"snapshot-id\":1,\"type\":\"not-a-valid-tag-type\"}";
-    Assertions.assertThatThrownBy(() -> SnapshotRefParser.fromJson(invalidTagType))
+    assertThatThrownBy(() -> SnapshotRefParser.fromJson(invalidTagType))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid snapshot ref type: not-a-valid-tag-type");
 
     String invalidRefAge =
         "{\"snapshot-id\":1,\"type\":\"tag\",\"max-ref-age-ms\":\"not-a-valid-value\"}";
-    Assertions.assertThatThrownBy(() -> SnapshotRefParser.fromJson(invalidRefAge))
+    assertThatThrownBy(() -> SnapshotRefParser.fromJson(invalidRefAge))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse to a long value: max-ref-age-ms: \"not-a-valid-value\"");
 
     String invalidSnapshotsToKeep =
         "{\"snapshot-id\":1,\"type\":\"branch\", "
             + "\"min-snapshots-to-keep\":\"invalid-number\"}";
-    Assertions.assertThatThrownBy(() -> SnapshotRefParser.fromJson(invalidSnapshotsToKeep))
+    assertThatThrownBy(() -> SnapshotRefParser.fromJson(invalidSnapshotsToKeep))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse to an integer value: min-snapshots-to-keep: \"invalid-number\"");
 
     String invalidMaxSnapshotAge =
         "{\"snapshot-id\":1,\"type\":\"branch\", " + "\"max-snapshot-age-ms\":\"invalid-age\"}";
-    Assertions.assertThatThrownBy(() -> SnapshotRefParser.fromJson(invalidMaxSnapshotAge))
+    assertThatThrownBy(() -> SnapshotRefParser.fromJson(invalidMaxSnapshotAge))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse to a long value: max-snapshot-age-ms: \"invalid-age\"");
   }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotSelection.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotSelection.java
@@ -18,29 +18,27 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestSnapshotSelection extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSnapshotSelection extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestSnapshotSelection(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testSnapshotSelectionById() {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(0);
 
     table.newFastAppend().appendFile(FILE_A).commit();
     Snapshot firstSnapshot = table.currentSnapshot();
@@ -48,12 +46,12 @@ public class TestSnapshotSelection extends TableTestBase {
     table.newFastAppend().appendFile(FILE_B).commit();
     Snapshot secondSnapshot = table.currentSnapshot();
 
-    Assert.assertEquals("Table should have two snapshots", 2, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).hasSize(2);
     validateSnapshot(null, table.snapshot(firstSnapshot.snapshotId()), FILE_A);
     validateSnapshot(firstSnapshot, table.snapshot(secondSnapshot.snapshotId()), FILE_B);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotStatsForAddedFiles() {
     DataFile fileWithStats =
         DataFiles.builder(SPEC)
@@ -76,12 +74,12 @@ public class TestSnapshotSelection extends TableTestBase {
 
     Snapshot snapshot = table.currentSnapshot();
     Iterable<DataFile> addedFiles = snapshot.addedDataFiles(table.io());
-    Assert.assertEquals(1, Iterables.size(addedFiles));
+    assertThat(addedFiles).hasSize(1);
     DataFile dataFile = Iterables.getOnlyElement(addedFiles);
-    Assert.assertNotNull("Value counts should be not null", dataFile.valueCounts());
-    Assert.assertNotNull("Null value counts should be not null", dataFile.nullValueCounts());
-    Assert.assertNotNull("Lower bounds should be not null", dataFile.lowerBounds());
-    Assert.assertNotNull("Upper bounds should be not null", dataFile.upperBounds());
+    assertThat(dataFile.valueCounts()).isNotNull();
+    assertThat(dataFile.nullValueCounts()).isNotNull();
+    assertThat(dataFile.lowerBounds()).isNotNull();
+    assertThat(dataFile.upperBounds()).isNotNull();
   }
 
   private ByteBuffer longToBuffer(long value) {

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
@@ -18,40 +18,41 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestSnapshotSummary extends TableTestBase {
-  public TestSnapshotSummary(int formatVersion) {
-    super(formatVersion);
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSnapshotSummary extends TestBase {
+
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
-  }
-
-  @Test
+  @TestTemplate
   public void testFileSizeSummary() {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(0);
 
     // fast append
     table.newFastAppend().appendFile(FILE_A).commit();
     Map<String, String> summary = table.currentSnapshot().summary();
-    Assert.assertEquals("10", summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
-    Assert.assertNull(summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
-    Assert.assertEquals("10", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+    assertThat(summary)
+        .containsEntry(SnapshotSummary.ADDED_FILE_SIZE_PROP, "10")
+        .containsEntry(SnapshotSummary.TOTAL_FILE_SIZE_PROP, "10")
+        .doesNotContainKey(SnapshotSummary.REMOVED_FILE_SIZE_PROP);
 
     // merge append
     table.newAppend().appendFile(FILE_B).commit();
     summary = table.currentSnapshot().summary();
-    Assert.assertEquals("10", summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
-    Assert.assertNull(summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
-    Assert.assertEquals("20", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+    assertThat(summary)
+        .containsEntry(SnapshotSummary.ADDED_FILE_SIZE_PROP, "10")
+        .containsEntry(SnapshotSummary.TOTAL_FILE_SIZE_PROP, "20")
+        .doesNotContainKey(SnapshotSummary.REMOVED_FILE_SIZE_PROP);
 
     table
         .newOverwrite()
@@ -62,18 +63,20 @@ public class TestSnapshotSummary extends TableTestBase {
         .addFile(FILE_D)
         .commit();
     summary = table.currentSnapshot().summary();
-    Assert.assertEquals("30", summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
-    Assert.assertEquals("20", summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
-    Assert.assertEquals("30", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+    assertThat(summary)
+        .containsEntry(SnapshotSummary.ADDED_FILE_SIZE_PROP, "30")
+        .containsEntry(SnapshotSummary.REMOVED_FILE_SIZE_PROP, "20")
+        .containsEntry(SnapshotSummary.TOTAL_FILE_SIZE_PROP, "30");
 
     table.newDelete().deleteFile(FILE_C).deleteFile(FILE_D).commit();
     summary = table.currentSnapshot().summary();
-    Assert.assertNull(summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
-    Assert.assertEquals("20", summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
-    Assert.assertEquals("10", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+    assertThat(summary)
+        .containsEntry(SnapshotSummary.REMOVED_FILE_SIZE_PROP, "20")
+        .containsEntry(SnapshotSummary.TOTAL_FILE_SIZE_PROP, "10")
+        .doesNotContainKey(SnapshotSummary.ADDED_FILE_SIZE_PROP);
   }
 
-  @Test
+  @TestTemplate
   public void testFileSizeSummaryWithDeletes() {
     if (formatVersion == 1) {
       return;
@@ -83,7 +86,8 @@ public class TestSnapshotSummary extends TableTestBase {
 
     table.refresh();
     Map<String, String> summary = table.currentSnapshot().summary();
-    Assert.assertEquals("1", summary.get(SnapshotSummary.ADD_EQ_DELETE_FILES_PROP));
-    Assert.assertEquals("1", summary.get(SnapshotSummary.ADD_POS_DELETE_FILES_PROP));
+    assertThat(summary)
+        .containsEntry(SnapshotSummary.ADD_EQ_DELETE_FILES_PROP, "1")
+        .containsEntry(SnapshotSummary.ADD_POS_DELETE_FILES_PROP, "1");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -61,7 +61,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class TestTableMetadata {
@@ -86,7 +86,7 @@ public class TestTableMetadata {
           .desc(Expressions.bucket("z", 4), NullOrder.NULLS_LAST)
           .build();
 
-  @TempDir private Path temp;
+  @TempDir protected static Path temp;
 
   public TableOperations ops = new LocalTableOperations(temp);
 

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -61,9 +61,8 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestTableMetadata {
   private static final String TEST_LOCATION = "s3://bucket/test/location";
@@ -87,7 +86,7 @@ public class TestTableMetadata {
           .desc(Expressions.bucket("z", 4), NullOrder.NULLS_LAST)
           .build();
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   public TableOperations ops = new LocalTableOperations(temp);
 
@@ -1731,7 +1730,7 @@ public class TestTableMetadata {
 
   private String createManifestListWithManifestFile(
       long snapshotId, Long parentSnapshotId, String manifestFile) throws IOException {
-    File manifestList = temp.newFile("manifests" + UUID.randomUUID());
+    File manifestList = java.nio.file.Files.createTempDirectory(temp, "junit").toFile();
     manifestList.deleteOnExit();
 
     try (ManifestListWriter writer =

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -1730,7 +1730,7 @@ public class TestTableMetadata {
 
   private String createManifestListWithManifestFile(
       long snapshotId, Long parentSnapshotId, String manifestFile) throws IOException {
-    File manifestList = File.createTempFile("junit", null, temp.toFile());
+    File manifestList = File.createTempFile("manifests", null, temp.toFile());
     manifestList.deleteOnExit();
 
     try (ManifestListWriter writer =

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -86,7 +86,7 @@ public class TestTableMetadata {
           .desc(Expressions.bucket("z", 4), NullOrder.NULLS_LAST)
           .build();
 
-  @TempDir protected static Path temp;
+  @TempDir private Path temp;
 
   public TableOperations ops = new LocalTableOperations(temp);
 
@@ -1730,7 +1730,7 @@ public class TestTableMetadata {
 
   private String createManifestListWithManifestFile(
       long snapshotId, Long parentSnapshotId, String manifestFile) throws IOException {
-    File manifestList = java.nio.file.Files.createTempDirectory(temp, "junit").toFile();
+    File manifestList = File.createTempFile("junit", null, temp.toFile());
     manifestList.deleteOnExit();
 
     try (ManifestListWriter writer =


### PR DESCRIPTION
Migrate the following "Read" in iceberg-core to JUnit 5 for https://github.com/apache/iceberg/issues/9085.

## Current Progress
Snapshots:
- [x] TestSnapshot
- [x] TestSnapshotJson
    - [x] LocalTableOperations
    - [x] TestTableMetadata (partially changed, the change is related to LocalTableOperations)
- [x] TestSnapshotLoading
- [x] TestSnapshotSelection
- [x] TestSnapshotSummary

The following classes are for Iceberg procedures:
- [x] TestSnapshotManager
- [x] TestSnapshotRefParser 
