### PR TITLE
Core: Add test for renaming table to a non-existing namespace

### DIFF
--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -784,6 +784,26 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
+  public void renameTableNamespaceMissing() {
+    TableIdentifier from = TableIdentifier.of("ns", "table");
+    TableIdentifier to = TableIdentifier.of("non_existing", "renamedTable");
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(from.namespace());
+    }
+
+    Assertions.assertThat(catalog().tableExists(from)).as("Table should not exist").isFalse();
+
+    catalog().buildTable(from, SCHEMA).create();
+
+    Assertions.assertThat(catalog().tableExists(from)).as("Table should exist").isTrue();
+
+    Assertions.assertThatThrownBy(() -> catalog().renameTable(from, to))
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessageContaining("Namespace does not exist: non_existing");
+  }
+
+  @Test
   public void testRenameTableDestinationTableAlreadyExists() {
     C catalog = catalog();
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -228,6 +228,10 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
 
     TableIdentifier to = removeCatalogName(originalTo);
     Preconditions.checkArgument(isValidIdentifier(to), "Invalid identifier: %s", to);
+    if (!namespaceExists(to.namespace())) {
+      throw new NoSuchNamespaceException(
+          "Cannot rename %s to %s. Namespace does not exist: %s", from, to, to.namespace());
+    }
 
     String toDatabase = to.namespace().level(0);
     String fromDatabase = from.namespace().level(0);


### PR DESCRIPTION
For view catalogs we already test the same behavior in https://github.com/apache/iceberg/blob/main/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java#L589-L611 but we haven't done so for table catalogs.
