### PR TITLE
Minor: Parse rowGroupSize as a long

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -125,7 +125,7 @@ public class TableProperties {
   public static final String PARQUET_ROW_GROUP_SIZE_BYTES = "write.parquet.row-group-size-bytes";
   public static final String DELETE_PARQUET_ROW_GROUP_SIZE_BYTES =
       "write.delete.parquet.row-group-size-bytes";
-  public static final int PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT = 128 * 1024 * 1024; // 128 MB
+  public static final long PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT = 128 * 1024 * 1024; // 128 MB
 
   public static final String PARQUET_PAGE_SIZE_BYTES = "write.parquet.page-size-bytes";
   public static final String DELETE_PARQUET_PAGE_SIZE_BYTES =

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -275,7 +275,7 @@ public class Parquet {
       // Map Iceberg properties to pass down to the Parquet writer
       Context context = createContextFunc.apply(config);
 
-      int rowGroupSize = context.rowGroupSize();
+      long rowGroupSize = context.rowGroupSize();
       int pageSize = context.pageSize();
       int pageRowLimit = context.pageRowLimit();
       int dictionaryPageSize = context.dictionaryPageSize();
@@ -389,7 +389,7 @@ public class Parquet {
     }
 
     private static class Context {
-      private final int rowGroupSize;
+      private final long rowGroupSize;
       private final int pageSize;
       private final int pageRowLimit;
       private final int dictionaryPageSize;
@@ -402,7 +402,7 @@ public class Parquet {
       private final boolean dictionaryEnabled;
 
       private Context(
-          int rowGroupSize,
+          long rowGroupSize,
           int pageSize,
           int pageRowLimit,
           int dictionaryPageSize,
@@ -427,8 +427,8 @@ public class Parquet {
       }
 
       static Context dataContext(Map<String, String> config) {
-        int rowGroupSize =
-            PropertyUtil.propertyAsInt(
+        long rowGroupSize =
+            PropertyUtil.propertyAsLong(
                 config, PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
         Preconditions.checkArgument(rowGroupSize > 0, "Row group size must be > 0");
 
@@ -502,8 +502,8 @@ public class Parquet {
         // default delete config using data config
         Context dataContext = dataContext(config);
 
-        int rowGroupSize =
-            PropertyUtil.propertyAsInt(
+        long rowGroupSize =
+            PropertyUtil.propertyAsLong(
                 config, DELETE_PARQUET_ROW_GROUP_SIZE_BYTES, dataContext.rowGroupSize());
         Preconditions.checkArgument(rowGroupSize > 0, "Row group size must be > 0");
 
@@ -573,7 +573,7 @@ public class Parquet {
         }
       }
 
-      int rowGroupSize() {
+      long rowGroupSize() {
         return rowGroupSize;
       }
 
@@ -1312,7 +1312,7 @@ public class Parquet {
   public static void concat(
       Iterable<File> inputFiles,
       File outputFile,
-      int rowGroupSize,
+      long rowGroupSize,
       Schema schema,
       Map<String, String> metadata)
       throws IOException {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -71,7 +71,7 @@ public class TestParquet {
     // PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT configs.
     // Even though row group size is 16 bytes, we still have to write 101 records
     // as default PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT is 100.
-    File parquetFile = generateFile(null, 101, 4 * Integer.BYTES, null, null).first();
+    File parquetFile = generateFile(null, 101, 4L * Integer.BYTES, null, null).first();
 
     try (ParquetFileReader reader =
         ParquetFileReader.open(ParquetIO.file(localInput(parquetFile)))) {
@@ -86,7 +86,7 @@ public class TestParquet {
     // We should just need to write 5 integers (20 bytes)
     // to create two row groups with row group size configured at 16 bytes.
     File parquetFile =
-        generateFile(ParquetAvroWriter::buildWriter, 5, 4 * Integer.BYTES, 1, 2).first();
+        generateFile(ParquetAvroWriter::buildWriter, 5, 4L * Integer.BYTES, 1, 2).first();
 
     try (ParquetFileReader reader =
         ParquetFileReader.open(ParquetIO.file(localInput(parquetFile)))) {
@@ -222,7 +222,7 @@ public class TestParquet {
   private Pair<File, Long> generateFile(
       Function<MessageType, ParquetValueWriter<?>> createWriterFunc,
       int desiredRecordCount,
-      Integer rowGroupSizeBytes,
+      Long rowGroupSizeBytes,
       Integer minCheckRecordCount,
       Integer maxCheckRecordCount)
       throws IOException {
@@ -230,7 +230,7 @@ public class TestParquet {
 
     ImmutableMap.Builder<String, String> propsBuilder = ImmutableMap.builder();
     if (rowGroupSizeBytes != null) {
-      propsBuilder.put(PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(rowGroupSizeBytes));
+      propsBuilder.put(PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(rowGroupSizeBytes));
     }
     if (minCheckRecordCount != null) {
       propsBuilder.put(

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -75,7 +75,7 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
       writer.addAll(nonDictionaryData);
     }
 
-    int rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
+    long rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
     File mixedFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", mixedFile.delete());
     Parquet.concat(

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
@@ -309,10 +309,10 @@ public class TestSparkReaderWithBloomFilter {
     factory.set(
         PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal",
         Boolean.toString(useBloomFilterCol10));
-    int blockSize =
-        PropertyUtil.propertyAsInt(
+    long blockSize =
+        PropertyUtil.propertyAsLong(
             table.properties(), PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
-    factory.set(PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(blockSize));
+    factory.set(PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(blockSize));
 
     FileAppender<Record> writer = factory.newAppender(out, format);
     try (Closeable toClose = writer) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -76,7 +76,7 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
       writer.addAll(nonDictionaryData);
     }
 
-    int rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
+    long rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
     File mixedFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", mixedFile.delete());
     Parquet.concat(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
@@ -309,10 +309,10 @@ public class TestSparkReaderWithBloomFilter {
     factory.set(
         PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal",
         Boolean.toString(useBloomFilterCol10));
-    int blockSize =
-        PropertyUtil.propertyAsInt(
+    long blockSize =
+        PropertyUtil.propertyAsLong(
             table.properties(), PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
-    factory.set(PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(blockSize));
+    factory.set(PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(blockSize));
 
     FileAppender<Record> writer = factory.newAppender(out, format);
     try (Closeable toClose = writer) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -76,7 +76,7 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
       writer.addAll(nonDictionaryData);
     }
 
-    int rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
+    long rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
     File mixedFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(mixedFile.delete()).as("Delete should succeed").isTrue();
     Parquet.concat(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
@@ -315,10 +315,10 @@ public class TestSparkReaderWithBloomFilter {
     factory.set(
         PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal",
         Boolean.toString(useBloomFilterCol10));
-    int blockSize =
-        PropertyUtil.propertyAsInt(
+    long blockSize =
+        PropertyUtil.propertyAsLong(
             table.properties(), PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
-    factory.set(PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(blockSize));
+    factory.set(PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(blockSize));
 
     FileAppender<Record> writer = factory.newAppender(out, format);
     try (Closeable toClose = writer) {


### PR DESCRIPTION
`withRowGroupSize(int rowGroupSize)` is deprecated in `ParquetWriter` and currently, the max possible rowGroupSize in Iceberg is 2GB (max Java int) which will be fixed after this PR.