### PR TITLE
Spark: Add a test to check if the bloom filters are added to the parquet files

### DIFF
--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
@@ -119,7 +119,7 @@ public class TestSparkReaderWithBloomFilter {
   @BeforeEach
   public void writeData() throws NoSuchTableException, TableAlreadyExistsException {
     this.tableName = "test";
-    createTable(tableName, schema);
+    createTable(tableName);
     this.rowList = Lists.newArrayList();
 
     for (int i = 0; i < INT_VALUE_COUNT; i += 1) {
@@ -175,7 +175,7 @@ public class TestSparkReaderWithBloomFilter {
     spark = null;
   }
 
-  protected void createTable(String name, StructType schema) throws TableAlreadyExistsException {
+  protected void createTable(String name) throws TableAlreadyExistsException {
     Dataset<Row> emptyDf = spark.createDataFrame(Lists.newArrayList(), schema);
     CreateTableWriter<Row> createTableWriter = emptyDf.writeTo("default." + name);
 
@@ -254,7 +254,7 @@ public class TestSparkReaderWithBloomFilter {
   @TestTemplate
   public void testBloomCreation() throws IOException {
     org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(temp + "/default/test/data");
-    FileSystem fs = FileSystem.get(path.toUri(), spark.sparkContext().hadoopConfiguration());
+    FileSystem fs = FileSystem.get(path.toUri(), spark.sessionState().newHadoopConf());
     Optional<FileStatus> parquetFile = Arrays.stream(fs.listStatus(path)).findAny();
     assertThat(parquetFile).isPresent();
     ParquetMetadata parquetMetadata =

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
@@ -18,101 +18,93 @@
  */
 package org.apache.iceberg.spark.source;
 
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
-import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
-import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
-import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.iceberg.BaseTable;
-import org.apache.iceberg.CatalogUtil;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.DataFiles;
-import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.Files;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.TestHelpers.Row;
-import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.data.GenericAppenderFactory;
-import org.apache.iceberg.data.GenericRecord;
-import org.apache.iceberg.data.Record;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
-import org.apache.iceberg.hive.HiveCatalog;
-import org.apache.iceberg.hive.TestHiveMetastore;
-import org.apache.iceberg.io.FileAppender;
-import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.spark.SparkValueConverter;
-import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.PropertyUtil;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.spark.sql.CreateTableWriter;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestSparkReaderWithBloomFilter {
 
   protected String tableName = null;
   protected Table table = null;
-  protected List<Record> records = null;
+  protected List<Row> rowList = null;
   protected DataFile dataFile = null;
 
-  private static TestHiveMetastore metastore = null;
   protected static SparkSession spark = null;
-  protected static HiveCatalog catalog = null;
-  protected final boolean vectorized;
-  protected final boolean useBloomFilter;
 
-  public TestSparkReaderWithBloomFilter(boolean vectorized, boolean useBloomFilter) {
-    this.vectorized = vectorized;
-    this.useBloomFilter = useBloomFilter;
-  }
+  @Parameter(index = 0)
+  protected boolean vectorized;
+
+  @Parameter(index = 1)
+  protected boolean useBloomFilter;
 
   // Schema passed to create tables
-  public static final Schema SCHEMA =
-      new Schema(
-          Types.NestedField.required(1, "id", Types.IntegerType.get()),
-          Types.NestedField.required(2, "id_long", Types.LongType.get()),
-          Types.NestedField.required(3, "id_double", Types.DoubleType.get()),
-          Types.NestedField.required(4, "id_float", Types.FloatType.get()),
-          Types.NestedField.required(5, "id_string", Types.StringType.get()),
-          Types.NestedField.optional(6, "id_boolean", Types.BooleanType.get()),
-          Types.NestedField.optional(7, "id_date", Types.DateType.get()),
-          Types.NestedField.optional(8, "id_int_decimal", Types.DecimalType.of(8, 2)),
-          Types.NestedField.optional(9, "id_long_decimal", Types.DecimalType.of(14, 2)),
-          Types.NestedField.optional(10, "id_fixed_decimal", Types.DecimalType.of(31, 2)),
-          Types.NestedField.optional(
-              11,
-              "id_nested",
-              Types.StructType.of(
-                  Types.NestedField.optional(12, "nested_id", Types.IntegerType.get()))));
+  public static final StructType schema =
+      new StructType(
+          new StructField[] {
+            new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField("id_long", DataTypes.LongType, false, Metadata.empty()),
+            new StructField("id_double", DataTypes.DoubleType, false, Metadata.empty()),
+            new StructField("id_float", DataTypes.FloatType, false, Metadata.empty()),
+            new StructField("id_string", DataTypes.StringType, false, Metadata.empty()),
+            new StructField("id_boolean", DataTypes.BooleanType, true, Metadata.empty()),
+            new StructField("id_date", DataTypes.DateType, true, Metadata.empty()),
+            new StructField(
+                "id_int_decimal", DataTypes.createDecimalType(8, 2), true, Metadata.empty()),
+            new StructField(
+                "id_long_decimal", DataTypes.createDecimalType(14, 2), true, Metadata.empty()),
+            new StructField(
+                "id_fixed_decimal", DataTypes.createDecimalType(31, 2), true, Metadata.empty()),
+            new StructField(
+                "id_nested",
+                new StructType(
+                    new StructField[] {
+                      new StructField("nested_id", DataTypes.IntegerType, true, Metadata.empty())
+                    }),
+                true,
+                Metadata.empty())
+          });
 
   private static final int INT_MIN_VALUE = 30;
   private static final int INT_MAX_VALUE = 329;
@@ -122,230 +114,107 @@ public class TestSparkReaderWithBloomFilter {
   private static final float FLOAT_BASE = 100000F;
   private static final String BINARY_PREFIX = "BINARY测试_";
 
-  @TempDir private Path temp;
+  @TempDir private static Path temp;
 
-  @Before
-  public void writeTestDataFile() throws IOException {
+  @BeforeEach
+  public void writeData() throws NoSuchTableException, TableAlreadyExistsException {
     this.tableName = "test";
-    createTable(tableName, SCHEMA);
-    this.records = Lists.newArrayList();
-
-    // records all use IDs that are in bucket id_bucket=0
-    GenericRecord record = GenericRecord.create(table.schema());
+    createTable(tableName, schema);
+    this.rowList = Lists.newArrayList();
 
     for (int i = 0; i < INT_VALUE_COUNT; i += 1) {
-      GenericRecord newRecord = record.copy();
-      newRecord.setField("id", INT_MIN_VALUE + i);
-      newRecord.setField("id_long", LONG_BASE + INT_MIN_VALUE + i);
-      newRecord.setField("id_double", DOUBLE_BASE + INT_MIN_VALUE + i);
-      newRecord.setField("id_float", FLOAT_BASE + INT_MIN_VALUE + i);
-      newRecord.setField("id_string", BINARY_PREFIX + (INT_MIN_VALUE + i));
-      newRecord.setField("id_boolean", i % 2 == 0);
-      newRecord.setField("id_date", LocalDate.parse("2021-09-05"));
-      newRecord.setField("id_int_decimal", new BigDecimal(String.valueOf(77.77)));
-      newRecord.setField("id_long_decimal", new BigDecimal(String.valueOf(88.88)));
-      newRecord.setField("id_fixed_decimal", new BigDecimal(String.valueOf(99.99)));
-      GenericRecord nested =
-          GenericRecord.create(
-              table.schema().findField("id_nested").type().asNestedType().asStructType());
-      nested.setField("nested_id", INT_MIN_VALUE + i);
-      newRecord.setField("id_nested", nested);
-      records.add(newRecord);
+      Row row =
+          RowFactory.create(
+              INT_MIN_VALUE + i,
+              LONG_BASE + INT_MIN_VALUE + i,
+              DOUBLE_BASE + INT_MIN_VALUE + i,
+              FLOAT_BASE + INT_MIN_VALUE + i,
+              BINARY_PREFIX + (INT_MIN_VALUE + i),
+              i % 2 == 0,
+              java.sql.Date.valueOf(LocalDate.parse("2021-09-05")),
+              new BigDecimal("77.77"),
+              new BigDecimal("88.88"),
+              new BigDecimal("99.99"),
+              RowFactory.create(INT_MIN_VALUE + i));
+      rowList.add(row);
     }
 
-    this.dataFile = writeDataFile(Files.localOutput(temp.toFile()), Row.of(0), records);
+    Dataset<Row> dataset = spark.createDataFrame(rowList, schema);
 
-    table.newAppend().appendFile(dataFile).commit();
+    dataset.writeTo("default." + tableName).append();
   }
 
-  @After
-  public void cleanup() throws IOException {
+  @AfterEach
+  public void cleanup() {
     dropTable("test");
   }
 
-  @Parameterized.Parameters(name = "vectorized = {0}, useBloomFilter = {1}")
+  @Parameters(name = "vectorized = {0}, useBloomFilter = {1}")
   public static Object[][] parameters() {
     return new Object[][] {{false, false}, {true, false}, {false, true}, {true, true}};
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void startMetastoreAndSpark() {
-    metastore = new TestHiveMetastore();
-    metastore.start();
-    HiveConf hiveConf = metastore.hiveConf();
-
     spark =
         SparkSession.builder()
             .master("local[2]")
-            .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-            .enableHiveSupport()
+            .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.local.type", "hadoop")
+            .config("spark.sql.catalog.local.warehouse", temp.toString())
+            .config("spark.sql.defaultCatalog", "local")
             .getOrCreate();
 
-    catalog =
-        (HiveCatalog)
-            CatalogUtil.loadCatalog(
-                HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
-
-    try {
-      catalog.createNamespace(Namespace.of("default"));
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
-    }
+    spark.sql("CREATE DATABASE IF NOT EXISTS default");
+    spark.sql("USE default");
   }
 
-  @AfterClass
-  public static void stopMetastoreAndSpark() throws Exception {
-    catalog = null;
-    metastore.stop();
-    metastore = null;
+  @AfterAll
+  public static void stopMetastoreAndSpark() {
     spark.stop();
     spark = null;
   }
 
-  protected void createTable(String name, Schema schema) {
-    table = catalog.createTable(TableIdentifier.of("default", name), schema);
-    TableOperations ops = ((BaseTable) table).operations();
-    TableMetadata meta = ops.current();
-    ops.commit(meta, meta.upgradeToFormatVersion(2));
+  protected void createTable(String name, StructType schema) throws TableAlreadyExistsException {
+    Dataset<Row> emptyDf = spark.createDataFrame(Lists.newArrayList(), schema);
+    CreateTableWriter<Row> createTableWriter = emptyDf.writeTo("default." + name);
 
     if (useBloomFilter) {
-      table
-          .updateProperties()
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_double", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_float", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_string", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_boolean", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_date", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_int_decimal", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long_decimal", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_nested.nested_id", "true")
-          .commit();
+      String[] columns = {
+        "id",
+        "id_long",
+        "id_double",
+        "id_float",
+        "id_string",
+        "id_boolean",
+        "id_date",
+        "id_int_decimal",
+        "id_long_decimal",
+        "id_fixed_decimal",
+        "id_nested.nested_id"
+      };
+      for (String column : columns) {
+        createTableWriter.tableProperty(
+            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + column, "true");
+      }
     }
 
-    table
-        .updateProperties()
-        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, "100") // to have multiple row groups
-        .commit();
+    createTableWriter.tableProperty(PARQUET_ROW_GROUP_SIZE_BYTES, "100");
+
     if (vectorized) {
-      table
-          .updateProperties()
-          .set(TableProperties.PARQUET_VECTORIZATION_ENABLED, "true")
-          .set(TableProperties.PARQUET_BATCH_SIZE, "4")
-          .commit();
+      createTableWriter
+          .tableProperty(TableProperties.PARQUET_VECTORIZATION_ENABLED, "true")
+          .tableProperty(TableProperties.PARQUET_BATCH_SIZE, "4");
     }
+
+    createTableWriter.create();
   }
 
   protected void dropTable(String name) {
-    catalog.dropTable(TableIdentifier.of("default", name));
+    spark.sql("DROP TABLE IF EXISTS default." + name);
   }
 
-  private DataFile writeDataFile(OutputFile out, StructLike partition, List<Record> rows)
-      throws IOException {
-    FileFormat format = defaultFormat(table.properties());
-    GenericAppenderFactory factory = new GenericAppenderFactory(table.schema(), table.spec());
-
-    boolean useBloomFilterCol1 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id", Boolean.toString(useBloomFilterCol1));
-    boolean useBloomFilterCol2 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long",
-        Boolean.toString(useBloomFilterCol2));
-    boolean useBloomFilterCol3 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_double", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_double",
-        Boolean.toString(useBloomFilterCol3));
-    boolean useBloomFilterCol4 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_float", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_float",
-        Boolean.toString(useBloomFilterCol4));
-    boolean useBloomFilterCol5 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_string", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_string",
-        Boolean.toString(useBloomFilterCol5));
-    boolean useBloomFilterCol6 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_boolean", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_boolean",
-        Boolean.toString(useBloomFilterCol6));
-    boolean useBloomFilterCol7 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_date", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_date",
-        Boolean.toString(useBloomFilterCol7));
-    boolean useBloomFilterCol8 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(),
-            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_int_decimal",
-            false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_int_decimal",
-        Boolean.toString(useBloomFilterCol8));
-    boolean useBloomFilterCol9 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(),
-            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long_decimal",
-            false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long_decimal",
-        Boolean.toString(useBloomFilterCol9));
-    boolean useBloomFilterCol10 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(),
-            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal",
-            false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal",
-        Boolean.toString(useBloomFilterCol10));
-    boolean useBloomFilterCol11 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(),
-            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_nested.nested_id",
-            false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_nested.nested_id",
-        Boolean.toString(useBloomFilterCol11));
-    int blockSize =
-        PropertyUtil.propertyAsInt(
-            table.properties(), PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
-    factory.set(PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(blockSize));
-
-    FileAppender<Record> writer = factory.newAppender(out, format);
-    try (Closeable toClose = writer) {
-      writer.addAll(rows);
-    }
-
-    return DataFiles.builder(table.spec())
-        .withFormat(format)
-        .withPath(out.location())
-        .withPartition(partition)
-        .withFileSizeInBytes(writer.length())
-        .withSplitOffsets(writer.splitOffsets())
-        .withMetrics(writer.metrics())
-        .build();
-  }
-
-  private FileFormat defaultFormat(Map<String, String> properties) {
-    String formatString = properties.getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT);
-    return FileFormat.fromString(formatString);
-  }
-
-  @Test
+  @TestTemplate
   public void testReadWithFilter() {
     Dataset<org.apache.spark.sql.Row> df =
         spark
@@ -359,11 +228,10 @@ public class TestSparkReaderWithBloomFilter {
                     + " AND id_int_decimal = 77.77 AND id_long_decimal = 88.88 AND id_fixed_decimal = 99.99"
                     + " AND id_nested.nested_id = 30");
 
-    Record record = SparkValueConverter.convert(table.schema(), df.collectAsList().get(0));
+    List<Row> rows = df.collectAsList();
 
-    Assert.assertEquals("Table should contain 1 row", 1, df.collectAsList().size());
-
-    Assert.assertEquals("Table should contain expected rows", record.get(0), 30);
+    assertThat(rows).as("Table should contain 1 row").hasSize(1);
+    assertThat(rows.get(0).get(0)).as("Table should contain expected rows").isEqualTo(30);
 
     df =
         spark
@@ -377,23 +245,26 @@ public class TestSparkReaderWithBloomFilter {
                     + " AND id_int_decimal = 77.77 AND id_long_decimal = 88.88 AND id_fixed_decimal = 99.99"
                     + " AND id_nested.nested_id = 250");
 
-    record = SparkValueConverter.convert(table.schema(), df.collectAsList().get(0));
+    rows = df.collectAsList();
 
-    Assert.assertEquals("Table should contain 1 row", 1, df.collectAsList().size());
-
-    Assert.assertEquals("Table should contain expected rows", record.get(0), 250);
+    assertThat(rows).as("Table should contain 1 row").hasSize(1);
+    assertThat(rows.get(0).get(0)).as("Table should contain expected rows").isEqualTo(250);
   }
 
-  @Test
+  @TestTemplate
   public void testBloomCreation() throws IOException {
-    org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(temp.toString());
-    ParquetMetadata parquetMetadata = ParquetFileReader.readFooter(new Configuration(), path);
+    org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(temp + "/default/test/data");
+    FileSystem fs = FileSystem.get(path.toUri(), spark.sparkContext().hadoopConfiguration());
+    Optional<FileStatus> parquetFile = Arrays.stream(fs.listStatus(path)).findAny();
+    assertThat(parquetFile).isPresent();
+    ParquetMetadata parquetMetadata =
+        ParquetFileReader.readFooter(new Configuration(), parquetFile.get());
     for (int i = 0; i < 11; i++) {
       if (useBloomFilter) {
-        Assert.assertNotEquals(
+        assertNotEquals(
             parquetMetadata.getBlocks().get(0).getColumns().get(0).getBloomFilterOffset(), -1L);
       } else {
-        Assert.assertEquals(
+        assertEquals(
             parquetMetadata.getBlocks().get(0).getColumns().get(0).getBloomFilterOffset(), -1L);
       }
     }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
@@ -119,7 +119,7 @@ public class TestSparkReaderWithBloomFilter {
   @BeforeEach
   public void writeData() throws NoSuchTableException, TableAlreadyExistsException {
     this.tableName = "test";
-    createTable(tableName, schema);
+    createTable(tableName);
     this.rowList = Lists.newArrayList();
 
     for (int i = 0; i < INT_VALUE_COUNT; i += 1) {
@@ -175,7 +175,7 @@ public class TestSparkReaderWithBloomFilter {
     spark = null;
   }
 
-  protected void createTable(String name, StructType schema) throws TableAlreadyExistsException {
+  protected void createTable(String name) throws TableAlreadyExistsException {
     Dataset<Row> emptyDf = spark.createDataFrame(Lists.newArrayList(), schema);
     CreateTableWriter<Row> createTableWriter = emptyDf.writeTo("default." + name);
 
@@ -254,7 +254,7 @@ public class TestSparkReaderWithBloomFilter {
   @TestTemplate
   public void testBloomCreation() throws IOException {
     org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(temp + "/default/test/data");
-    FileSystem fs = FileSystem.get(path.toUri(), spark.sparkContext().hadoopConfiguration());
+    FileSystem fs = FileSystem.get(path.toUri(), spark.sessionState().newHadoopConf());
     Optional<FileStatus> parquetFile = Arrays.stream(fs.listStatus(path)).findAny();
     assertThat(parquetFile).isPresent();
     ParquetMetadata parquetMetadata =

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
@@ -18,101 +18,93 @@
  */
 package org.apache.iceberg.spark.source;
 
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
-import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
-import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
-import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.iceberg.BaseTable;
-import org.apache.iceberg.CatalogUtil;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.DataFiles;
-import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.Files;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.TestHelpers.Row;
-import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.data.GenericAppenderFactory;
-import org.apache.iceberg.data.GenericRecord;
-import org.apache.iceberg.data.Record;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
-import org.apache.iceberg.hive.HiveCatalog;
-import org.apache.iceberg.hive.TestHiveMetastore;
-import org.apache.iceberg.io.FileAppender;
-import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.spark.SparkValueConverter;
-import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.PropertyUtil;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.spark.sql.CreateTableWriter;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestSparkReaderWithBloomFilter {
 
   protected String tableName = null;
   protected Table table = null;
-  protected List<Record> records = null;
+  protected List<Row> rowList = null;
   protected DataFile dataFile = null;
 
-  private static TestHiveMetastore metastore = null;
   protected static SparkSession spark = null;
-  protected static HiveCatalog catalog = null;
-  protected final boolean vectorized;
-  protected final boolean useBloomFilter;
 
-  public TestSparkReaderWithBloomFilter(boolean vectorized, boolean useBloomFilter) {
-    this.vectorized = vectorized;
-    this.useBloomFilter = useBloomFilter;
-  }
+  @Parameter(index = 0)
+  protected boolean vectorized;
+
+  @Parameter(index = 1)
+  protected boolean useBloomFilter;
 
   // Schema passed to create tables
-  public static final Schema SCHEMA =
-      new Schema(
-          Types.NestedField.required(1, "id", Types.IntegerType.get()),
-          Types.NestedField.required(2, "id_long", Types.LongType.get()),
-          Types.NestedField.required(3, "id_double", Types.DoubleType.get()),
-          Types.NestedField.required(4, "id_float", Types.FloatType.get()),
-          Types.NestedField.required(5, "id_string", Types.StringType.get()),
-          Types.NestedField.optional(6, "id_boolean", Types.BooleanType.get()),
-          Types.NestedField.optional(7, "id_date", Types.DateType.get()),
-          Types.NestedField.optional(8, "id_int_decimal", Types.DecimalType.of(8, 2)),
-          Types.NestedField.optional(9, "id_long_decimal", Types.DecimalType.of(14, 2)),
-          Types.NestedField.optional(10, "id_fixed_decimal", Types.DecimalType.of(31, 2)),
-          Types.NestedField.optional(
-              11,
-              "id_nested",
-              Types.StructType.of(
-                  Types.NestedField.optional(12, "nested_id", Types.IntegerType.get()))));
+  public static final StructType schema =
+      new StructType(
+          new StructField[] {
+            new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField("id_long", DataTypes.LongType, false, Metadata.empty()),
+            new StructField("id_double", DataTypes.DoubleType, false, Metadata.empty()),
+            new StructField("id_float", DataTypes.FloatType, false, Metadata.empty()),
+            new StructField("id_string", DataTypes.StringType, false, Metadata.empty()),
+            new StructField("id_boolean", DataTypes.BooleanType, true, Metadata.empty()),
+            new StructField("id_date", DataTypes.DateType, true, Metadata.empty()),
+            new StructField(
+                "id_int_decimal", DataTypes.createDecimalType(8, 2), true, Metadata.empty()),
+            new StructField(
+                "id_long_decimal", DataTypes.createDecimalType(14, 2), true, Metadata.empty()),
+            new StructField(
+                "id_fixed_decimal", DataTypes.createDecimalType(31, 2), true, Metadata.empty()),
+            new StructField(
+                "id_nested",
+                new StructType(
+                    new StructField[] {
+                      new StructField("nested_id", DataTypes.IntegerType, true, Metadata.empty())
+                    }),
+                true,
+                Metadata.empty())
+          });
 
   private static final int INT_MIN_VALUE = 30;
   private static final int INT_MAX_VALUE = 329;
@@ -122,230 +114,107 @@ public class TestSparkReaderWithBloomFilter {
   private static final float FLOAT_BASE = 100000F;
   private static final String BINARY_PREFIX = "BINARY测试_";
 
-  @TempDir private Path temp;
+  @TempDir private static Path temp;
 
-  @Before
-  public void writeTestDataFile() throws IOException {
+  @BeforeEach
+  public void writeData() throws NoSuchTableException, TableAlreadyExistsException {
     this.tableName = "test";
-    createTable(tableName, SCHEMA);
-    this.records = Lists.newArrayList();
-
-    // records all use IDs that are in bucket id_bucket=0
-    GenericRecord record = GenericRecord.create(table.schema());
+    createTable(tableName, schema);
+    this.rowList = Lists.newArrayList();
 
     for (int i = 0; i < INT_VALUE_COUNT; i += 1) {
-      GenericRecord newRecord = record.copy();
-      newRecord.setField("id", INT_MIN_VALUE + i);
-      newRecord.setField("id_long", LONG_BASE + INT_MIN_VALUE + i);
-      newRecord.setField("id_double", DOUBLE_BASE + INT_MIN_VALUE + i);
-      newRecord.setField("id_float", FLOAT_BASE + INT_MIN_VALUE + i);
-      newRecord.setField("id_string", BINARY_PREFIX + (INT_MIN_VALUE + i));
-      newRecord.setField("id_boolean", i % 2 == 0);
-      newRecord.setField("id_date", LocalDate.parse("2021-09-05"));
-      newRecord.setField("id_int_decimal", new BigDecimal(String.valueOf(77.77)));
-      newRecord.setField("id_long_decimal", new BigDecimal(String.valueOf(88.88)));
-      newRecord.setField("id_fixed_decimal", new BigDecimal(String.valueOf(99.99)));
-      GenericRecord nested =
-          GenericRecord.create(
-              table.schema().findField("id_nested").type().asNestedType().asStructType());
-      nested.setField("nested_id", INT_MIN_VALUE + i);
-      newRecord.setField("id_nested", nested);
-      records.add(newRecord);
+      Row row =
+          RowFactory.create(
+              INT_MIN_VALUE + i,
+              LONG_BASE + INT_MIN_VALUE + i,
+              DOUBLE_BASE + INT_MIN_VALUE + i,
+              FLOAT_BASE + INT_MIN_VALUE + i,
+              BINARY_PREFIX + (INT_MIN_VALUE + i),
+              i % 2 == 0,
+              java.sql.Date.valueOf(LocalDate.parse("2021-09-05")),
+              new BigDecimal("77.77"),
+              new BigDecimal("88.88"),
+              new BigDecimal("99.99"),
+              RowFactory.create(INT_MIN_VALUE + i));
+      rowList.add(row);
     }
 
-    this.dataFile = writeDataFile(Files.localOutput(temp.toFile()), Row.of(0), records);
+    Dataset<Row> dataset = spark.createDataFrame(rowList, schema);
 
-    table.newAppend().appendFile(dataFile).commit();
+    dataset.writeTo("default." + tableName).append();
   }
 
-  @After
-  public void cleanup() throws IOException {
+  @AfterEach
+  public void cleanup() {
     dropTable("test");
   }
 
-  @Parameterized.Parameters(name = "vectorized = {0}, useBloomFilter = {1}")
+  @Parameters(name = "vectorized = {0}, useBloomFilter = {1}")
   public static Object[][] parameters() {
     return new Object[][] {{false, false}, {true, false}, {false, true}, {true, true}};
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void startMetastoreAndSpark() {
-    metastore = new TestHiveMetastore();
-    metastore.start();
-    HiveConf hiveConf = metastore.hiveConf();
-
     spark =
         SparkSession.builder()
             .master("local[2]")
-            .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-            .enableHiveSupport()
+            .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.local.type", "hadoop")
+            .config("spark.sql.catalog.local.warehouse", temp.toString())
+            .config("spark.sql.defaultCatalog", "local")
             .getOrCreate();
 
-    catalog =
-        (HiveCatalog)
-            CatalogUtil.loadCatalog(
-                HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
-
-    try {
-      catalog.createNamespace(Namespace.of("default"));
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
-    }
+    spark.sql("CREATE DATABASE IF NOT EXISTS default");
+    spark.sql("USE default");
   }
 
-  @AfterClass
-  public static void stopMetastoreAndSpark() throws Exception {
-    catalog = null;
-    metastore.stop();
-    metastore = null;
+  @AfterAll
+  public static void stopMetastoreAndSpark() {
     spark.stop();
     spark = null;
   }
 
-  protected void createTable(String name, Schema schema) {
-    table = catalog.createTable(TableIdentifier.of("default", name), schema);
-    TableOperations ops = ((BaseTable) table).operations();
-    TableMetadata meta = ops.current();
-    ops.commit(meta, meta.upgradeToFormatVersion(2));
+  protected void createTable(String name, StructType schema) throws TableAlreadyExistsException {
+    Dataset<Row> emptyDf = spark.createDataFrame(Lists.newArrayList(), schema);
+    CreateTableWriter<Row> createTableWriter = emptyDf.writeTo("default." + name);
 
     if (useBloomFilter) {
-      table
-          .updateProperties()
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_double", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_float", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_string", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_boolean", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_date", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_int_decimal", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long_decimal", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_nested.nested_id", "true")
-          .commit();
+      String[] columns = {
+        "id",
+        "id_long",
+        "id_double",
+        "id_float",
+        "id_string",
+        "id_boolean",
+        "id_date",
+        "id_int_decimal",
+        "id_long_decimal",
+        "id_fixed_decimal",
+        "id_nested.nested_id"
+      };
+      for (String column : columns) {
+        createTableWriter.tableProperty(
+            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + column, "true");
+      }
     }
 
-    table
-        .updateProperties()
-        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, "100") // to have multiple row groups
-        .commit();
+    createTableWriter.tableProperty(PARQUET_ROW_GROUP_SIZE_BYTES, "100");
+
     if (vectorized) {
-      table
-          .updateProperties()
-          .set(TableProperties.PARQUET_VECTORIZATION_ENABLED, "true")
-          .set(TableProperties.PARQUET_BATCH_SIZE, "4")
-          .commit();
+      createTableWriter
+          .tableProperty(TableProperties.PARQUET_VECTORIZATION_ENABLED, "true")
+          .tableProperty(TableProperties.PARQUET_BATCH_SIZE, "4");
     }
+
+    createTableWriter.create();
   }
 
   protected void dropTable(String name) {
-    catalog.dropTable(TableIdentifier.of("default", name));
+    spark.sql("DROP TABLE IF EXISTS default." + name);
   }
 
-  private DataFile writeDataFile(OutputFile out, StructLike partition, List<Record> rows)
-      throws IOException {
-    FileFormat format = defaultFormat(table.properties());
-    GenericAppenderFactory factory = new GenericAppenderFactory(table.schema(), table.spec());
-
-    boolean useBloomFilterCol1 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id", Boolean.toString(useBloomFilterCol1));
-    boolean useBloomFilterCol2 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long",
-        Boolean.toString(useBloomFilterCol2));
-    boolean useBloomFilterCol3 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_double", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_double",
-        Boolean.toString(useBloomFilterCol3));
-    boolean useBloomFilterCol4 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_float", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_float",
-        Boolean.toString(useBloomFilterCol4));
-    boolean useBloomFilterCol5 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_string", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_string",
-        Boolean.toString(useBloomFilterCol5));
-    boolean useBloomFilterCol6 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_boolean", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_boolean",
-        Boolean.toString(useBloomFilterCol6));
-    boolean useBloomFilterCol7 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_date", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_date",
-        Boolean.toString(useBloomFilterCol7));
-    boolean useBloomFilterCol8 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(),
-            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_int_decimal",
-            false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_int_decimal",
-        Boolean.toString(useBloomFilterCol8));
-    boolean useBloomFilterCol9 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(),
-            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long_decimal",
-            false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long_decimal",
-        Boolean.toString(useBloomFilterCol9));
-    boolean useBloomFilterCol10 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(),
-            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal",
-            false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal",
-        Boolean.toString(useBloomFilterCol10));
-    boolean useBloomFilterCol11 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(),
-            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_nested.nested_id",
-            false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_nested.nested_id",
-        Boolean.toString(useBloomFilterCol11));
-    int blockSize =
-        PropertyUtil.propertyAsInt(
-            table.properties(), PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
-    factory.set(PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(blockSize));
-
-    FileAppender<Record> writer = factory.newAppender(out, format);
-    try (Closeable toClose = writer) {
-      writer.addAll(rows);
-    }
-
-    return DataFiles.builder(table.spec())
-        .withFormat(format)
-        .withPath(out.location())
-        .withPartition(partition)
-        .withFileSizeInBytes(writer.length())
-        .withSplitOffsets(writer.splitOffsets())
-        .withMetrics(writer.metrics())
-        .build();
-  }
-
-  private FileFormat defaultFormat(Map<String, String> properties) {
-    String formatString = properties.getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT);
-    return FileFormat.fromString(formatString);
-  }
-
-  @Test
+  @TestTemplate
   public void testReadWithFilter() {
     Dataset<org.apache.spark.sql.Row> df =
         spark
@@ -359,11 +228,10 @@ public class TestSparkReaderWithBloomFilter {
                     + " AND id_int_decimal = 77.77 AND id_long_decimal = 88.88 AND id_fixed_decimal = 99.99"
                     + " AND id_nested.nested_id = 30");
 
-    Record record = SparkValueConverter.convert(table.schema(), df.collectAsList().get(0));
+    List<Row> rows = df.collectAsList();
 
-    Assert.assertEquals("Table should contain 1 row", 1, df.collectAsList().size());
-
-    Assert.assertEquals("Table should contain expected rows", record.get(0), 30);
+    assertThat(rows).as("Table should contain 1 row").hasSize(1);
+    assertThat(rows.get(0).get(0)).as("Table should contain expected rows").isEqualTo(30);
 
     df =
         spark
@@ -377,23 +245,26 @@ public class TestSparkReaderWithBloomFilter {
                     + " AND id_int_decimal = 77.77 AND id_long_decimal = 88.88 AND id_fixed_decimal = 99.99"
                     + " AND id_nested.nested_id = 250");
 
-    record = SparkValueConverter.convert(table.schema(), df.collectAsList().get(0));
+    rows = df.collectAsList();
 
-    Assert.assertEquals("Table should contain 1 row", 1, df.collectAsList().size());
-
-    Assert.assertEquals("Table should contain expected rows", record.get(0), 250);
+    assertThat(rows).as("Table should contain 1 row").hasSize(1);
+    assertThat(rows.get(0).get(0)).as("Table should contain expected rows").isEqualTo(250);
   }
 
-  @Test
+  @TestTemplate
   public void testBloomCreation() throws IOException {
-    org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(temp.toString());
-    ParquetMetadata parquetMetadata = ParquetFileReader.readFooter(new Configuration(), path);
+    org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(temp + "/default/test/data");
+    FileSystem fs = FileSystem.get(path.toUri(), spark.sparkContext().hadoopConfiguration());
+    Optional<FileStatus> parquetFile = Arrays.stream(fs.listStatus(path)).findAny();
+    assertThat(parquetFile).isPresent();
+    ParquetMetadata parquetMetadata =
+        ParquetFileReader.readFooter(new Configuration(), parquetFile.get());
     for (int i = 0; i < 11; i++) {
       if (useBloomFilter) {
-        Assert.assertNotEquals(
+        assertNotEquals(
             parquetMetadata.getBlocks().get(0).getColumns().get(0).getBloomFilterOffset(), -1L);
       } else {
-        Assert.assertEquals(
+        assertEquals(
             parquetMetadata.getBlocks().get(0).getColumns().get(0).getBloomFilterOffset(), -1L);
       }
     }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
@@ -119,7 +119,7 @@ public class TestSparkReaderWithBloomFilter {
   @BeforeEach
   public void writeData() throws NoSuchTableException, TableAlreadyExistsException {
     this.tableName = "test";
-    createTable(tableName, schema);
+    createTable(tableName);
     this.rowList = Lists.newArrayList();
 
     for (int i = 0; i < INT_VALUE_COUNT; i += 1) {
@@ -175,7 +175,7 @@ public class TestSparkReaderWithBloomFilter {
     spark = null;
   }
 
-  protected void createTable(String name, StructType schema) throws TableAlreadyExistsException {
+  protected void createTable(String name) throws TableAlreadyExistsException {
     Dataset<Row> emptyDf = spark.createDataFrame(Lists.newArrayList(), schema);
     CreateTableWriter<Row> createTableWriter = emptyDf.writeTo("default." + name);
 
@@ -254,7 +254,7 @@ public class TestSparkReaderWithBloomFilter {
   @TestTemplate
   public void testBloomCreation() throws IOException {
     org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(temp + "/default/test/data");
-    FileSystem fs = FileSystem.get(path.toUri(), spark.sparkContext().hadoopConfiguration());
+    FileSystem fs = FileSystem.get(path.toUri(), spark.sessionState().newHadoopConf());
     Optional<FileStatus> parquetFile = Arrays.stream(fs.listStatus(path)).findAny();
     assertThat(parquetFile).isPresent();
     ParquetMetadata parquetMetadata =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
@@ -25,15 +25,17 @@ import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_COLUMN_ENA
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogUtil;
@@ -66,6 +68,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkValueConverter;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.PropertyUtil;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterAll;
@@ -106,7 +110,12 @@ public class TestSparkReaderWithBloomFilter {
           Types.NestedField.optional(7, "id_date", Types.DateType.get()),
           Types.NestedField.optional(8, "id_int_decimal", Types.DecimalType.of(8, 2)),
           Types.NestedField.optional(9, "id_long_decimal", Types.DecimalType.of(14, 2)),
-          Types.NestedField.optional(10, "id_fixed_decimal", Types.DecimalType.of(31, 2)));
+          Types.NestedField.optional(10, "id_fixed_decimal", Types.DecimalType.of(31, 2)),
+          Types.NestedField.optional(
+              11,
+              "id_nested",
+              Types.StructType.of(
+                  Types.NestedField.optional(12, "nested_id", Types.IntegerType.get()))));
 
   private static final int INT_MIN_VALUE = 30;
   private static final int INT_MAX_VALUE = 329;
@@ -128,36 +137,26 @@ public class TestSparkReaderWithBloomFilter {
     GenericRecord record = GenericRecord.create(table.schema());
 
     for (int i = 0; i < INT_VALUE_COUNT; i += 1) {
-      records.add(
-          record.copy(
-              ImmutableMap.of(
-                  "id",
-                  INT_MIN_VALUE + i,
-                  "id_long",
-                  LONG_BASE + INT_MIN_VALUE + i,
-                  "id_double",
-                  DOUBLE_BASE + INT_MIN_VALUE + i,
-                  "id_float",
-                  FLOAT_BASE + INT_MIN_VALUE + i,
-                  "id_string",
-                  BINARY_PREFIX + (INT_MIN_VALUE + i),
-                  "id_boolean",
-                  i % 2 == 0,
-                  "id_date",
-                  LocalDate.parse("2021-09-05"),
-                  "id_int_decimal",
-                  new BigDecimal(String.valueOf(77.77)),
-                  "id_long_decimal",
-                  new BigDecimal(String.valueOf(88.88)),
-                  "id_fixed_decimal",
-                  new BigDecimal(String.valueOf(99.99)))));
+      GenericRecord newRecord = record.copy();
+      newRecord.setField("id", INT_MIN_VALUE + i);
+      newRecord.setField("id_long", LONG_BASE + INT_MIN_VALUE + i);
+      newRecord.setField("id_double", DOUBLE_BASE + INT_MIN_VALUE + i);
+      newRecord.setField("id_float", FLOAT_BASE + INT_MIN_VALUE + i);
+      newRecord.setField("id_string", BINARY_PREFIX + (INT_MIN_VALUE + i));
+      newRecord.setField("id_boolean", i % 2 == 0);
+      newRecord.setField("id_date", LocalDate.parse("2021-09-05"));
+      newRecord.setField("id_int_decimal", new BigDecimal(String.valueOf(77.77)));
+      newRecord.setField("id_long_decimal", new BigDecimal(String.valueOf(88.88)));
+      newRecord.setField("id_fixed_decimal", new BigDecimal(String.valueOf(99.99)));
+      GenericRecord nested =
+          GenericRecord.create(
+              table.schema().findField("id_nested").type().asNestedType().asStructType());
+      nested.setField("nested_id", INT_MIN_VALUE + i);
+      newRecord.setField("id_nested", nested);
+      records.add(newRecord);
     }
 
-    this.dataFile =
-        writeDataFile(
-            Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
-            Row.of(0),
-            records);
+    this.dataFile = writeDataFile(Files.localOutput(temp.toFile()), Row.of(0), records);
 
     table.newAppend().appendFile(dataFile).commit();
   }
@@ -225,6 +224,7 @@ public class TestSparkReaderWithBloomFilter {
           .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_int_decimal", "true")
           .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long_decimal", "true")
           .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal", "true")
+          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_nested.nested_id", "true")
           .commit();
     }
 
@@ -315,6 +315,14 @@ public class TestSparkReaderWithBloomFilter {
     factory.set(
         PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal",
         Boolean.toString(useBloomFilterCol10));
+    boolean useBloomFilterCol11 =
+        PropertyUtil.propertyAsBoolean(
+            table.properties(),
+            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_nested.nested_id",
+            false);
+    factory.set(
+        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_nested.nested_id",
+        Boolean.toString(useBloomFilterCol11));
     int blockSize =
         PropertyUtil.propertyAsInt(
             table.properties(), PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
@@ -351,7 +359,8 @@ public class TestSparkReaderWithBloomFilter {
             .filter(
                 "id = 30 AND id_long = 1030 AND id_double = 10030.0 AND id_float = 100030.0"
                     + " AND id_string = 'BINARY测试_30' AND id_boolean = true AND id_date = '2021-09-05'"
-                    + " AND id_int_decimal = 77.77 AND id_long_decimal = 88.88 AND id_fixed_decimal = 99.99");
+                    + " AND id_int_decimal = 77.77 AND id_long_decimal = 88.88 AND id_fixed_decimal = 99.99"
+                    + " AND id_nested.nested_id = 30");
 
     Record record = SparkValueConverter.convert(table.schema(), df.collectAsList().get(0));
 
@@ -367,11 +376,27 @@ public class TestSparkReaderWithBloomFilter {
             .filter(
                 "id = 250 AND id_long = 1250 AND id_double = 10250.0 AND id_float = 100250.0"
                     + " AND id_string = 'BINARY测试_250' AND id_boolean = true AND id_date = '2021-09-05'"
-                    + " AND id_int_decimal = 77.77 AND id_long_decimal = 88.88 AND id_fixed_decimal = 99.99");
+                    + " AND id_int_decimal = 77.77 AND id_long_decimal = 88.88 AND id_fixed_decimal = 99.99"
+                    + " AND id_nested.nested_id = 250");
 
     record = SparkValueConverter.convert(table.schema(), df.collectAsList().get(0));
 
     assertThat(df.collectAsList()).as("Table should contain 1 row").hasSize(1);
     assertThat(record.get(0)).as("Table should contain expected rows").isEqualTo(250);
+  }
+
+  @TestTemplate
+  public void testBloomCreation() throws IOException {
+    org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(temp.toString());
+    ParquetMetadata parquetMetadata = ParquetFileReader.readFooter(new Configuration(), path);
+    for (int i = 0; i < 11; i++) {
+      if (useBloomFilter) {
+        assertNotEquals(
+            parquetMetadata.getBlocks().get(0).getColumns().get(0).getBloomFilterOffset(), -1L);
+      } else {
+        assertEquals(
+            parquetMetadata.getBlocks().get(0).getColumns().get(0).getBloomFilterOffset(), -1L);
+      }
+    }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
@@ -18,60 +18,43 @@
  */
 package org.apache.iceberg.spark.source;
 
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
-import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
-import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
-import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.iceberg.BaseTable;
-import org.apache.iceberg.CatalogUtil;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.DataFiles;
-import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.Files;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.TestHelpers.Row;
-import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.data.GenericAppenderFactory;
-import org.apache.iceberg.data.GenericRecord;
-import org.apache.iceberg.data.Record;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
-import org.apache.iceberg.hive.HiveCatalog;
-import org.apache.iceberg.hive.TestHiveMetastore;
-import org.apache.iceberg.io.FileAppender;
-import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.spark.SparkValueConverter;
-import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.PropertyUtil;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.spark.sql.CreateTableWriter;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -85,12 +68,10 @@ public class TestSparkReaderWithBloomFilter {
 
   protected String tableName = null;
   protected Table table = null;
-  protected List<Record> records = null;
+  protected List<Row> rowList = null;
   protected DataFile dataFile = null;
 
-  private static TestHiveMetastore metastore = null;
   protected static SparkSession spark = null;
-  protected static HiveCatalog catalog = null;
 
   @Parameter(index = 0)
   protected boolean vectorized;
@@ -99,23 +80,31 @@ public class TestSparkReaderWithBloomFilter {
   protected boolean useBloomFilter;
 
   // Schema passed to create tables
-  public static final Schema SCHEMA =
-      new Schema(
-          Types.NestedField.required(1, "id", Types.IntegerType.get()),
-          Types.NestedField.required(2, "id_long", Types.LongType.get()),
-          Types.NestedField.required(3, "id_double", Types.DoubleType.get()),
-          Types.NestedField.required(4, "id_float", Types.FloatType.get()),
-          Types.NestedField.required(5, "id_string", Types.StringType.get()),
-          Types.NestedField.optional(6, "id_boolean", Types.BooleanType.get()),
-          Types.NestedField.optional(7, "id_date", Types.DateType.get()),
-          Types.NestedField.optional(8, "id_int_decimal", Types.DecimalType.of(8, 2)),
-          Types.NestedField.optional(9, "id_long_decimal", Types.DecimalType.of(14, 2)),
-          Types.NestedField.optional(10, "id_fixed_decimal", Types.DecimalType.of(31, 2)),
-          Types.NestedField.optional(
-              11,
-              "id_nested",
-              Types.StructType.of(
-                  Types.NestedField.optional(12, "nested_id", Types.IntegerType.get()))));
+  public static final StructType schema =
+      new StructType(
+          new StructField[] {
+            new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField("id_long", DataTypes.LongType, false, Metadata.empty()),
+            new StructField("id_double", DataTypes.DoubleType, false, Metadata.empty()),
+            new StructField("id_float", DataTypes.FloatType, false, Metadata.empty()),
+            new StructField("id_string", DataTypes.StringType, false, Metadata.empty()),
+            new StructField("id_boolean", DataTypes.BooleanType, true, Metadata.empty()),
+            new StructField("id_date", DataTypes.DateType, true, Metadata.empty()),
+            new StructField(
+                "id_int_decimal", DataTypes.createDecimalType(8, 2), true, Metadata.empty()),
+            new StructField(
+                "id_long_decimal", DataTypes.createDecimalType(14, 2), true, Metadata.empty()),
+            new StructField(
+                "id_fixed_decimal", DataTypes.createDecimalType(31, 2), true, Metadata.empty()),
+            new StructField(
+                "id_nested",
+                new StructType(
+                    new StructField[] {
+                      new StructField("nested_id", DataTypes.IntegerType, true, Metadata.empty())
+                    }),
+                true,
+                Metadata.empty())
+          });
 
   private static final int INT_MIN_VALUE = 30;
   private static final int INT_MAX_VALUE = 329;
@@ -125,44 +114,38 @@ public class TestSparkReaderWithBloomFilter {
   private static final float FLOAT_BASE = 100000F;
   private static final String BINARY_PREFIX = "BINARY测试_";
 
-  @TempDir private Path temp;
+  @TempDir private static Path temp;
 
   @BeforeEach
-  public void writeTestDataFile() throws IOException {
+  public void writeData() throws NoSuchTableException, TableAlreadyExistsException {
     this.tableName = "test";
-    createTable(tableName, SCHEMA);
-    this.records = Lists.newArrayList();
-
-    // records all use IDs that are in bucket id_bucket=0
-    GenericRecord record = GenericRecord.create(table.schema());
+    createTable(tableName, schema);
+    this.rowList = Lists.newArrayList();
 
     for (int i = 0; i < INT_VALUE_COUNT; i += 1) {
-      GenericRecord newRecord = record.copy();
-      newRecord.setField("id", INT_MIN_VALUE + i);
-      newRecord.setField("id_long", LONG_BASE + INT_MIN_VALUE + i);
-      newRecord.setField("id_double", DOUBLE_BASE + INT_MIN_VALUE + i);
-      newRecord.setField("id_float", FLOAT_BASE + INT_MIN_VALUE + i);
-      newRecord.setField("id_string", BINARY_PREFIX + (INT_MIN_VALUE + i));
-      newRecord.setField("id_boolean", i % 2 == 0);
-      newRecord.setField("id_date", LocalDate.parse("2021-09-05"));
-      newRecord.setField("id_int_decimal", new BigDecimal(String.valueOf(77.77)));
-      newRecord.setField("id_long_decimal", new BigDecimal(String.valueOf(88.88)));
-      newRecord.setField("id_fixed_decimal", new BigDecimal(String.valueOf(99.99)));
-      GenericRecord nested =
-          GenericRecord.create(
-              table.schema().findField("id_nested").type().asNestedType().asStructType());
-      nested.setField("nested_id", INT_MIN_VALUE + i);
-      newRecord.setField("id_nested", nested);
-      records.add(newRecord);
+      Row row =
+          RowFactory.create(
+              INT_MIN_VALUE + i,
+              LONG_BASE + INT_MIN_VALUE + i,
+              DOUBLE_BASE + INT_MIN_VALUE + i,
+              FLOAT_BASE + INT_MIN_VALUE + i,
+              BINARY_PREFIX + (INT_MIN_VALUE + i),
+              i % 2 == 0,
+              java.sql.Date.valueOf(LocalDate.parse("2021-09-05")),
+              new BigDecimal("77.77"),
+              new BigDecimal("88.88"),
+              new BigDecimal("99.99"),
+              RowFactory.create(INT_MIN_VALUE + i));
+      rowList.add(row);
     }
 
-    this.dataFile = writeDataFile(Files.localOutput(temp.toFile()), Row.of(0), records);
+    Dataset<Row> dataset = spark.createDataFrame(rowList, schema);
 
-    table.newAppend().appendFile(dataFile).commit();
+    dataset.writeTo("default." + tableName).append();
   }
 
   @AfterEach
-  public void cleanup() throws IOException {
+  public void cleanup() {
     dropTable("test");
   }
 
@@ -173,179 +156,62 @@ public class TestSparkReaderWithBloomFilter {
 
   @BeforeAll
   public static void startMetastoreAndSpark() {
-    metastore = new TestHiveMetastore();
-    metastore.start();
-    HiveConf hiveConf = metastore.hiveConf();
-
     spark =
         SparkSession.builder()
             .master("local[2]")
-            .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-            .enableHiveSupport()
+            .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.local.type", "hadoop")
+            .config("spark.sql.catalog.local.warehouse", temp.toString())
+            .config("spark.sql.defaultCatalog", "local")
             .getOrCreate();
 
-    catalog =
-        (HiveCatalog)
-            CatalogUtil.loadCatalog(
-                HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
-
-    try {
-      catalog.createNamespace(Namespace.of("default"));
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
-    }
+    spark.sql("CREATE DATABASE IF NOT EXISTS default");
+    spark.sql("USE default");
   }
 
   @AfterAll
-  public static void stopMetastoreAndSpark() throws Exception {
-    catalog = null;
-    metastore.stop();
-    metastore = null;
+  public static void stopMetastoreAndSpark() {
     spark.stop();
     spark = null;
   }
 
-  protected void createTable(String name, Schema schema) {
-    table = catalog.createTable(TableIdentifier.of("default", name), schema);
-    TableOperations ops = ((BaseTable) table).operations();
-    TableMetadata meta = ops.current();
-    ops.commit(meta, meta.upgradeToFormatVersion(2));
+  protected void createTable(String name, StructType schema) throws TableAlreadyExistsException {
+    Dataset<Row> emptyDf = spark.createDataFrame(Lists.newArrayList(), schema);
+    CreateTableWriter<Row> createTableWriter = emptyDf.writeTo("default." + name);
 
     if (useBloomFilter) {
-      table
-          .updateProperties()
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_double", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_float", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_string", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_boolean", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_date", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_int_decimal", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long_decimal", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal", "true")
-          .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_nested.nested_id", "true")
-          .commit();
+      String[] columns = {
+        "id",
+        "id_long",
+        "id_double",
+        "id_float",
+        "id_string",
+        "id_boolean",
+        "id_date",
+        "id_int_decimal",
+        "id_long_decimal",
+        "id_fixed_decimal",
+        "id_nested.nested_id"
+      };
+      for (String column : columns) {
+        createTableWriter.tableProperty(
+            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + column, "true");
+      }
     }
 
-    table
-        .updateProperties()
-        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, "100") // to have multiple row groups
-        .commit();
+    createTableWriter.tableProperty(PARQUET_ROW_GROUP_SIZE_BYTES, "100");
+
     if (vectorized) {
-      table
-          .updateProperties()
-          .set(TableProperties.PARQUET_VECTORIZATION_ENABLED, "true")
-          .set(TableProperties.PARQUET_BATCH_SIZE, "4")
-          .commit();
+      createTableWriter
+          .tableProperty(TableProperties.PARQUET_VECTORIZATION_ENABLED, "true")
+          .tableProperty(TableProperties.PARQUET_BATCH_SIZE, "4");
     }
+
+    createTableWriter.create();
   }
 
   protected void dropTable(String name) {
-    catalog.dropTable(TableIdentifier.of("default", name));
-  }
-
-  private DataFile writeDataFile(OutputFile out, StructLike partition, List<Record> rows)
-      throws IOException {
-    FileFormat format = defaultFormat(table.properties());
-    GenericAppenderFactory factory = new GenericAppenderFactory(table.schema(), table.spec());
-
-    boolean useBloomFilterCol1 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id", Boolean.toString(useBloomFilterCol1));
-    boolean useBloomFilterCol2 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long",
-        Boolean.toString(useBloomFilterCol2));
-    boolean useBloomFilterCol3 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_double", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_double",
-        Boolean.toString(useBloomFilterCol3));
-    boolean useBloomFilterCol4 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_float", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_float",
-        Boolean.toString(useBloomFilterCol4));
-    boolean useBloomFilterCol5 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_string", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_string",
-        Boolean.toString(useBloomFilterCol5));
-    boolean useBloomFilterCol6 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_boolean", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_boolean",
-        Boolean.toString(useBloomFilterCol6));
-    boolean useBloomFilterCol7 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(), PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_date", false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_date",
-        Boolean.toString(useBloomFilterCol7));
-    boolean useBloomFilterCol8 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(),
-            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_int_decimal",
-            false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_int_decimal",
-        Boolean.toString(useBloomFilterCol8));
-    boolean useBloomFilterCol9 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(),
-            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long_decimal",
-            false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_long_decimal",
-        Boolean.toString(useBloomFilterCol9));
-    boolean useBloomFilterCol10 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(),
-            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal",
-            false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_fixed_decimal",
-        Boolean.toString(useBloomFilterCol10));
-    boolean useBloomFilterCol11 =
-        PropertyUtil.propertyAsBoolean(
-            table.properties(),
-            PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_nested.nested_id",
-            false);
-    factory.set(
-        PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id_nested.nested_id",
-        Boolean.toString(useBloomFilterCol11));
-    int blockSize =
-        PropertyUtil.propertyAsInt(
-            table.properties(), PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
-    factory.set(PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(blockSize));
-
-    FileAppender<Record> writer = factory.newAppender(out, format);
-    try (Closeable toClose = writer) {
-      writer.addAll(rows);
-    }
-
-    return DataFiles.builder(table.spec())
-        .withFormat(format)
-        .withPath(out.location())
-        .withPartition(partition)
-        .withFileSizeInBytes(writer.length())
-        .withSplitOffsets(writer.splitOffsets())
-        .withMetrics(writer.metrics())
-        .build();
-  }
-
-  private FileFormat defaultFormat(Map<String, String> properties) {
-    String formatString = properties.getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT);
-    return FileFormat.fromString(formatString);
+    spark.sql("DROP TABLE IF EXISTS default." + name);
   }
 
   @TestTemplate
@@ -362,10 +228,10 @@ public class TestSparkReaderWithBloomFilter {
                     + " AND id_int_decimal = 77.77 AND id_long_decimal = 88.88 AND id_fixed_decimal = 99.99"
                     + " AND id_nested.nested_id = 30");
 
-    Record record = SparkValueConverter.convert(table.schema(), df.collectAsList().get(0));
+    List<Row> rows = df.collectAsList();
 
-    assertThat(df.collectAsList()).as("Table should contain 1 row").hasSize(1);
-    assertThat(record.get(0)).as("Table should contain expected rows").isEqualTo(30);
+    assertThat(rows).as("Table should contain 1 row").hasSize(1);
+    assertThat(rows.get(0).get(0)).as("Table should contain expected rows").isEqualTo(30);
 
     df =
         spark
@@ -379,16 +245,20 @@ public class TestSparkReaderWithBloomFilter {
                     + " AND id_int_decimal = 77.77 AND id_long_decimal = 88.88 AND id_fixed_decimal = 99.99"
                     + " AND id_nested.nested_id = 250");
 
-    record = SparkValueConverter.convert(table.schema(), df.collectAsList().get(0));
+    rows = df.collectAsList();
 
-    assertThat(df.collectAsList()).as("Table should contain 1 row").hasSize(1);
-    assertThat(record.get(0)).as("Table should contain expected rows").isEqualTo(250);
+    assertThat(rows).as("Table should contain 1 row").hasSize(1);
+    assertThat(rows.get(0).get(0)).as("Table should contain expected rows").isEqualTo(250);
   }
 
   @TestTemplate
   public void testBloomCreation() throws IOException {
-    org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(temp.toString());
-    ParquetMetadata parquetMetadata = ParquetFileReader.readFooter(new Configuration(), path);
+    org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(temp + "/default/test/data");
+    FileSystem fs = FileSystem.get(path.toUri(), spark.sparkContext().hadoopConfiguration());
+    Optional<FileStatus> parquetFile = Arrays.stream(fs.listStatus(path)).findAny();
+    assertThat(parquetFile).isPresent();
+    ParquetMetadata parquetMetadata =
+        ParquetFileReader.readFooter(new Configuration(), parquetFile.get());
     for (int i = 0; i < 11; i++) {
       if (useBloomFilter) {
         assertNotEquals(


### PR DESCRIPTION
related: #9898

This PR refactors `TestSparkReaderWithBloomFilter` tests by replacing avro writer with spark write and makes tests of different versions of spark consistent. It also adds a test new test to check if the bloom filters are correctly added to the parquet files.