### PR TITLE
Core:Add test for removing partition filed

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FindFiles.java
+++ b/core/src/main/java/org/apache/iceberg/FindFiles.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
@@ -174,9 +175,13 @@ public class FindFiles {
         Expression partFilter = Expressions.alwaysTrue();
         for (int i = 0; i < spec.fields().size(); i += 1) {
           PartitionField field = spec.fields().get(i);
-          partFilter =
-              Expressions.and(
-                  partFilter, Expressions.equal(field.name(), partitionData.get(i, Object.class)));
+          Object partitionValue = partitionData.get(i, Object.class);
+          if (Objects.isNull(partitionValue)) {
+            partFilter = Expressions.and(partFilter, Expressions.isNull(field.name()));
+          } else {
+            partFilter =
+                Expressions.and(partFilter, Expressions.equal(field.name(), partitionValue));
+          }
         }
         partitionSetFilter = Expressions.or(partitionSetFilter, partFilter);
       }


### PR DESCRIPTION
For a table in v1 format,after deleting a partition, the new data will be stored in the partition with a null partition value. When querying this data using `FindFiles.inPartitions`, the following exception will be thrown.
```
java.lang.NullPointerException: Cannot create expression literal from null
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkNotNull(Preconditions.java:921)
	at org.apache.iceberg.expressions.Literals.from(Literals.java:60)
	at org.apache.iceberg.expressions.UnboundPredicate.<init>(UnboundPredicate.java:40)
	at org.apache.iceberg.expressions.Expressions.equal(Expressions.java:169)
	at org.apache.iceberg.FindFiles$Builder.inPartitions(FindFiles.java:183)
	at org.apache.iceberg.FindFiles$Builder.inPartitions(FindFiles.java:157)
	at org.apache.iceberg.TestFindFiles.testInPartitionsAfterRemovePartitionField(TestFindFiles.java:151)
```