### PR TITLE
Support convert orc timestamptz

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/ConfigProperties.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/ConfigProperties.java
@@ -25,4 +25,6 @@ public class ConfigProperties {
   public static final String ENGINE_HIVE_ENABLED = "iceberg.engine.hive.enabled";
   public static final String LOCK_HIVE_ENABLED = "iceberg.engine.hive.lock-enabled";
   public static final String KEEP_HIVE_STATS = "iceberg.hive.keep.stats";
+
+  public static final String ORC_CONVERT_TIMESTAMPTZ = "iceberg.orc.convert.timestamptz";
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -258,6 +258,7 @@ public final class ORCSchemaUtil {
    *
    * @param schema an Iceberg schema
    * @param originalOrcSchema an existing ORC file schema
+   * @param config Hadoop configuration
    * @return the resulting ORC schema
    */
   public static TypeDescription buildOrcProjection(

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -273,10 +273,10 @@ public final class ORCSchemaUtil {
    * @return the resulting ORC schema
    */
   public static TypeDescription buildOrcProjection(
-          Schema schema, TypeDescription originalOrcSchema, Boolean convertTimestampTZ) {
+      Schema schema, TypeDescription originalOrcSchema, Boolean convertTimestampTZ) {
     final Map<Integer, OrcField> icebergToOrc = icebergToOrcMapping("root", originalOrcSchema);
     return buildOrcProjection(
-            Integer.MIN_VALUE, schema.asStruct(), true, icebergToOrc, convertTimestampTZ);
+        Integer.MIN_VALUE, schema.asStruct(), true, icebergToOrc, convertTimestampTZ);
   }
 
   private static TypeDescription buildOrcProjection(

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.hadoop.ConfigProperties;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMultimap;
@@ -258,13 +257,26 @@ public final class ORCSchemaUtil {
    *
    * @param schema an Iceberg schema
    * @param originalOrcSchema an existing ORC file schema
-   * @param config Hadoop configuration
    * @return the resulting ORC schema
    */
   public static TypeDescription buildOrcProjection(
-      Schema schema, TypeDescription originalOrcSchema, Boolean convertTimestampTZ) {
+      Schema schema, TypeDescription originalOrcSchema) {
+    return buildOrcProjection(schema, originalOrcSchema, false);
+  }
+
+  /**
+   * Overload function `buildOrcProjection`
+   *
+   * @param schema an Iceberg schema
+   * @param originalOrcSchema an existing ORC file schema
+   * @param convertTimestampTZ should convert timestamptz as timestamp
+   * @return the resulting ORC schema
+   */
+  public static TypeDescription buildOrcProjection(
+          Schema schema, TypeDescription originalOrcSchema, Boolean convertTimestampTZ) {
     final Map<Integer, OrcField> icebergToOrc = icebergToOrcMapping("root", originalOrcSchema);
-    return buildOrcProjection(Integer.MIN_VALUE, schema.asStruct(), true, icebergToOrc, convertTimestampTZ);
+    return buildOrcProjection(
+            Integer.MIN_VALUE, schema.asStruct(), true, icebergToOrc, convertTimestampTZ);
   }
 
   private static TypeDescription buildOrcProjection(
@@ -292,7 +304,7 @@ public final class ORCSchemaUtil {
                   nestedField.type(),
                   isRequired && nestedField.isRequired(),
                   mapping,
-                      convertTimestampTZ);
+                  convertTimestampTZ);
           orcType.addField(name, childType);
         }
         break;

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -273,7 +273,7 @@ public final class ORCSchemaUtil {
    * @return the resulting ORC schema
    */
   public static TypeDescription buildOrcProjection(
-      Schema schema, TypeDescription originalOrcSchema, Boolean convertTimestampTZ) {
+      Schema schema, TypeDescription originalOrcSchema, boolean convertTimestampTZ) {
     final Map<Integer, OrcField> icebergToOrc = icebergToOrcMapping("root", originalOrcSchema);
     return buildOrcProjection(
         Integer.MIN_VALUE, schema.asStruct(), true, icebergToOrc, convertTimestampTZ);
@@ -284,7 +284,7 @@ public final class ORCSchemaUtil {
       Type type,
       boolean isRequired,
       Map<Integer, OrcField> mapping,
-      Boolean convertTimestampTZ) {
+      boolean convertTimestampTZ) {
     final TypeDescription orcType;
 
     switch (type.typeId()) {

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.hadoop.ConfigProperties;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
@@ -82,8 +83,7 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
   public CloseableIterator<T> iterator() {
     Reader orcFileReader = ORC.newFileReader(file, config);
     addCloseable(orcFileReader);
-    boolean convertTimestampTZ =
-            config.getBoolean(ConfigProperties.ORC_CONVERT_TIMESTAMPTZ, false);
+    boolean convertTimestampTZ = config.getBoolean(ConfigProperties.ORC_CONVERT_TIMESTAMPTZ, false);
 
     TypeDescription fileSchema = orcFileReader.getSchema();
     final TypeDescription readOrcSchema;

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -82,17 +82,19 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
   public CloseableIterator<T> iterator() {
     Reader orcFileReader = ORC.newFileReader(file, config);
     addCloseable(orcFileReader);
+    boolean convertTimestampTZ =
+            config.getBoolean(ConfigProperties.ORC_CONVERT_TIMESTAMPTZ, false);
 
     TypeDescription fileSchema = orcFileReader.getSchema();
     final TypeDescription readOrcSchema;
     if (ORCSchemaUtil.hasIds(fileSchema)) {
-      readOrcSchema = ORCSchemaUtil.buildOrcProjection(schema, fileSchema);
+      readOrcSchema = ORCSchemaUtil.buildOrcProjection(schema, fileSchema, convertTimestampTZ);
     } else {
       if (nameMapping == null) {
         nameMapping = MappingUtil.create(schema);
       }
       TypeDescription typeWithIds = ORCSchemaUtil.applyNameMapping(fileSchema, nameMapping);
-      readOrcSchema = ORCSchemaUtil.buildOrcProjection(schema, typeWithIds);
+      readOrcSchema = ORCSchemaUtil.buildOrcProjection(schema, typeWithIds, convertTimestampTZ);
     }
 
     SearchArgument sarg = null;

--- a/orc/src/test/java/org/apache/iceberg/orc/TestBuildOrcProjection.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestBuildOrcProjection.java
@@ -23,9 +23,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.hadoop.ConfigProperties;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
 import org.junit.jupiter.api.Test;
@@ -50,7 +48,6 @@ public class TestBuildOrcProjection {
 
   @Test
   public void testProjectionPrimitive() {
-    Configuration config = new Configuration();
     Schema originalSchema =
         new Schema(
             optional(1, "a", Types.IntegerType.get()), optional(2, "b", Types.StringType.get()));
@@ -77,7 +74,6 @@ public class TestBuildOrcProjection {
 
   @Test
   public void testProjectionNestedNoOp() {
-    Configuration config = new Configuration();
     Types.StructType nestedStructType =
         Types.StructType.of(
             optional(2, "b", Types.StringType.get()), optional(3, "c", Types.DateType.get()));
@@ -99,7 +95,6 @@ public class TestBuildOrcProjection {
 
   @Test
   public void testProjectionNested() {
-    Configuration config = new Configuration();
     Types.StructType nestedStructType =
         Types.StructType.of(
             optional(2, "b", Types.StringType.get()), optional(3, "c", Types.DateType.get()));
@@ -127,7 +122,6 @@ public class TestBuildOrcProjection {
 
   @Test
   public void testEvolutionAddContainerField() {
-    Configuration config = new Configuration();
     Schema baseSchema = new Schema(required(1, "a", Types.IntegerType.get()));
     TypeDescription baseOrcSchema = ORCSchemaUtil.convert(baseSchema);
 
@@ -150,7 +144,6 @@ public class TestBuildOrcProjection {
 
   @Test
   public void testRequiredNestedFieldMissingInFile() {
-    Configuration config = new Configuration();
     Schema baseSchema =
         new Schema(
             required(1, "a", Types.IntegerType.get()),
@@ -174,9 +167,6 @@ public class TestBuildOrcProjection {
 
   @Test
   public void testTimestampType() {
-    Configuration config = new Configuration();
-    config.setBoolean(ConfigProperties.ORC_CONVERT_TIMESTAMPTZ, true);
-
     Schema originalSchema = new Schema(optional(1, "a", Types.TimestampType.withoutZone()));
     // Orc schema would be `timestamp` if table is converted from a hive table
     TypeDescription orcSchema = ORCSchemaUtil.convert(originalSchema);

--- a/orc/src/test/java/org/apache/iceberg/orc/TestBuildOrcProjection.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestBuildOrcProjection.java
@@ -86,8 +86,7 @@ public class TestBuildOrcProjection {
     // Original mapping (stored in ORC)
     TypeDescription orcSchema = ORCSchemaUtil.convert(originalSchema);
 
-    TypeDescription newOrcSchema =
-        ORCSchemaUtil.buildOrcProjection(originalSchema, orcSchema);
+    TypeDescription newOrcSchema = ORCSchemaUtil.buildOrcProjection(originalSchema, orcSchema);
     assertThat(newOrcSchema.getChildren()).hasSize(1);
     assertThat(newOrcSchema.findSubtype("a").getCategory())
         .isEqualTo(TypeDescription.Category.STRUCT);
@@ -137,8 +136,7 @@ public class TestBuildOrcProjection {
             required(1, "a", Types.IntegerType.get()),
             optional(2, "b", Types.StructType.of(required(3, "c", Types.LongType.get()))));
 
-    TypeDescription newOrcSchema =
-        ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema);
+    TypeDescription newOrcSchema = ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema);
     assertThat(newOrcSchema.getChildren()).hasSize(2);
     assertThat(newOrcSchema.findSubtype("a").getCategory()).isEqualTo(TypeDescription.Category.INT);
     assertThat(newOrcSchema.findSubtype("b_r2").getId()).isEqualTo(2);
@@ -187,8 +185,7 @@ public class TestBuildOrcProjection {
     Schema evolveSchema = new Schema(optional(1, "a", Types.TimestampType.withZone()));
 
     // iceberg schema is timestamptz
-    TypeDescription newOrcSchema =
-        ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema, true);
+    TypeDescription newOrcSchema = ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema, true);
     assertThat(newOrcSchema.getChildren()).hasSize(1);
     assertThat(newOrcSchema.findSubtype("a").getId()).isEqualTo(1);
     assertThat(newOrcSchema.findSubtype("a").getCategory())

--- a/orc/src/test/java/org/apache/iceberg/orc/TestBuildOrcProjection.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestBuildOrcProjection.java
@@ -65,8 +65,7 @@ public class TestBuildOrcProjection {
             optional(3, "c", Types.DateType.get()) // will produce ORC column c_r3 (new)
             );
 
-    TypeDescription newOrcSchema =
-        ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema, false);
+    TypeDescription newOrcSchema = ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema);
     assertThat(newOrcSchema.getChildren()).hasSize(2);
     assertThat(newOrcSchema.findSubtype("b").getId()).isEqualTo(1);
     assertThat(newOrcSchema.findSubtype("b").getCategory())
@@ -88,7 +87,7 @@ public class TestBuildOrcProjection {
     TypeDescription orcSchema = ORCSchemaUtil.convert(originalSchema);
 
     TypeDescription newOrcSchema =
-        ORCSchemaUtil.buildOrcProjection(originalSchema, orcSchema, false);
+        ORCSchemaUtil.buildOrcProjection(originalSchema, orcSchema);
     assertThat(newOrcSchema.getChildren()).hasSize(1);
     assertThat(newOrcSchema.findSubtype("a").getCategory())
         .isEqualTo(TypeDescription.Category.STRUCT);
@@ -116,8 +115,7 @@ public class TestBuildOrcProjection {
             optional(3, "cc", Types.DateType.get()), optional(2, "bb", Types.StringType.get()));
     Schema evolveSchema = new Schema(optional(1, "aa", newNestedStructType));
 
-    TypeDescription newOrcSchema =
-        ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema, false);
+    TypeDescription newOrcSchema = ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema);
     assertThat(newOrcSchema.getChildren()).hasSize(1);
     assertThat(newOrcSchema.findSubtype("a").getCategory())
         .isEqualTo(TypeDescription.Category.STRUCT);
@@ -140,10 +138,9 @@ public class TestBuildOrcProjection {
             optional(2, "b", Types.StructType.of(required(3, "c", Types.LongType.get()))));
 
     TypeDescription newOrcSchema =
-        ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema, false);
+        ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema);
     assertThat(newOrcSchema.getChildren()).hasSize(2);
-    assertThat(newOrcSchema.findSubtype("a").getCategory())
-        .isEqualTo(TypeDescription.Category.INT);
+    assertThat(newOrcSchema.findSubtype("a").getCategory()).isEqualTo(TypeDescription.Category.INT);
     assertThat(newOrcSchema.findSubtype("b_r2").getId()).isEqualTo(2);
     assertThat(newOrcSchema.findSubtype("b_r2").getCategory())
         .isEqualTo(TypeDescription.Category.STRUCT);
@@ -172,8 +169,7 @@ public class TestBuildOrcProjection {
                     required(3, "c", Types.LongType.get()),
                     required(4, "d", Types.LongType.get()))));
 
-    assertThatThrownBy(
-            () -> ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema, false))
+    assertThatThrownBy(() -> ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Field 4 of type long is required and was not found.");
   }
@@ -192,10 +188,10 @@ public class TestBuildOrcProjection {
 
     // iceberg schema is timestamptz
     TypeDescription newOrcSchema =
-        ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema, config);
-    Assertions.assertThat(newOrcSchema.getChildren()).hasSize(1);
-    Assertions.assertThat(newOrcSchema.findSubtype("a").getId()).isEqualTo(1);
-    Assertions.assertThat(newOrcSchema.findSubtype("a").getCategory())
+        ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema, true);
+    assertThat(newOrcSchema.getChildren()).hasSize(1);
+    assertThat(newOrcSchema.findSubtype("a").getId()).isEqualTo(1);
+    assertThat(newOrcSchema.findSubtype("a").getCategory())
         .isEqualTo(TypeDescription.Category.TIMESTAMP_INSTANT);
   }
 }

--- a/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
@@ -48,6 +48,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.TimeZone;
 import java.util.UUID;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
@@ -297,6 +298,7 @@ public class TestExpressionToSearchArgument {
 
   @Test
   public void testEvolvedSchema() {
+    Configuration config = new Configuration();
     Schema fileSchema =
         new Schema(
             required(1, "int", Types.IntegerType.get()),
@@ -308,7 +310,7 @@ public class TestExpressionToSearchArgument {
             optional(3, "float_added", Types.FloatType.get()));
 
     TypeDescription readSchema =
-        ORCSchemaUtil.buildOrcProjection(evolvedSchema, ORCSchemaUtil.convert(fileSchema));
+        ORCSchemaUtil.buildOrcProjection(evolvedSchema, ORCSchemaUtil.convert(fileSchema), config);
 
     Expression expr = equal("int_renamed", 1);
     Expression boundFilter = Binder.bind(evolvedSchema.asStruct(), expr, true);
@@ -332,6 +334,7 @@ public class TestExpressionToSearchArgument {
 
   @Test
   public void testOriginalSchemaNameMapping() {
+    Configuration config = new Configuration();
     Schema originalSchema =
         new Schema(
             required(1, "int", Types.IntegerType.get()), optional(2, "long", Types.LongType.get()));
@@ -342,7 +345,9 @@ public class TestExpressionToSearchArgument {
 
     TypeDescription readSchema =
         ORCSchemaUtil.buildOrcProjection(
-            originalSchema, ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping));
+            originalSchema,
+            ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping),
+            config);
 
     Expression expr = and(equal("int", 1), equal("long", 1));
     Expression boundFilter = Binder.bind(originalSchema.asStruct(), expr, true);
@@ -358,6 +363,7 @@ public class TestExpressionToSearchArgument {
 
   @Test
   public void testModifiedSimpleSchemaNameMapping() {
+    Configuration config = new Configuration();
     Schema originalSchema =
         new Schema(
             required(1, "int", Types.IntegerType.get()),
@@ -372,7 +378,9 @@ public class TestExpressionToSearchArgument {
 
     TypeDescription readSchema =
         ORCSchemaUtil.buildOrcProjection(
-            mappingSchema, ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping));
+            mappingSchema,
+            ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping),
+            config);
 
     Expression expr = equal("int", 1);
     Expression boundFilter = Binder.bind(mappingSchema.asStruct(), expr, true);
@@ -396,6 +404,7 @@ public class TestExpressionToSearchArgument {
 
   @Test
   public void testModifiedComplexSchemaNameMapping() {
+    Configuration config = new Configuration();
     Schema originalSchema =
         new Schema(
             optional(1, "struct", Types.StructType.of(required(2, "long", Types.LongType.get()))),
@@ -444,7 +453,9 @@ public class TestExpressionToSearchArgument {
 
     TypeDescription readSchema =
         ORCSchemaUtil.buildOrcProjection(
-            mappingSchema, ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping));
+            mappingSchema,
+            ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping),
+            config);
 
     Expression expr =
         and(

--- a/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
@@ -310,7 +310,7 @@ public class TestExpressionToSearchArgument {
             optional(3, "float_added", Types.FloatType.get()));
 
     TypeDescription readSchema =
-        ORCSchemaUtil.buildOrcProjection(evolvedSchema, ORCSchemaUtil.convert(fileSchema), config);
+        ORCSchemaUtil.buildOrcProjection(evolvedSchema, ORCSchemaUtil.convert(fileSchema), false);
 
     Expression expr = equal("int_renamed", 1);
     Expression boundFilter = Binder.bind(evolvedSchema.asStruct(), expr, true);
@@ -347,7 +347,7 @@ public class TestExpressionToSearchArgument {
         ORCSchemaUtil.buildOrcProjection(
             originalSchema,
             ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping),
-            config);
+            false);
 
     Expression expr = and(equal("int", 1), equal("long", 1));
     Expression boundFilter = Binder.bind(originalSchema.asStruct(), expr, true);
@@ -380,7 +380,7 @@ public class TestExpressionToSearchArgument {
         ORCSchemaUtil.buildOrcProjection(
             mappingSchema,
             ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping),
-            config);
+            false);
 
     Expression expr = equal("int", 1);
     Expression boundFilter = Binder.bind(mappingSchema.asStruct(), expr, true);
@@ -455,7 +455,7 @@ public class TestExpressionToSearchArgument {
         ORCSchemaUtil.buildOrcProjection(
             mappingSchema,
             ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping),
-            config);
+            false);
 
     Expression expr =
         and(

--- a/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
@@ -378,9 +378,7 @@ public class TestExpressionToSearchArgument {
 
     TypeDescription readSchema =
         ORCSchemaUtil.buildOrcProjection(
-            mappingSchema,
-            ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping),
-            false);
+            mappingSchema, ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping), false);
 
     Expression expr = equal("int", 1);
     Expression boundFilter = Binder.bind(mappingSchema.asStruct(), expr, true);
@@ -453,9 +451,7 @@ public class TestExpressionToSearchArgument {
 
     TypeDescription readSchema =
         ORCSchemaUtil.buildOrcProjection(
-            mappingSchema,
-            ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping),
-            false);
+            mappingSchema, ORCSchemaUtil.applyNameMapping(orcSchemaWithoutIds, nameMapping), false);
 
     Expression expr =
         and(

--- a/orc/src/test/java/org/apache/iceberg/orc/TestORCSchemaUtil.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestORCSchemaUtil.java
@@ -212,8 +212,7 @@ public class TestORCSchemaUtil {
             optional(2, "b", Types.DoubleType.get()),
             optional(3, "c", Types.DecimalType.of(15, 2)));
 
-    TypeDescription newOrcSchema =
-        ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema, false);
+    TypeDescription newOrcSchema = ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema, false);
     assertThat(newOrcSchema.getChildren()).hasSize(3);
     assertThat(newOrcSchema.findSubtype("a").getId()).isEqualTo(1);
     assertThat(newOrcSchema.findSubtype("a").getCategory())
@@ -236,8 +235,7 @@ public class TestORCSchemaUtil {
     TypeDescription orcSchema = ORCSchemaUtil.convert(originalSchema);
     Schema evolveSchema = new Schema(optional(1, "a", Types.IntegerType.get()));
 
-    assertThatThrownBy(
-            () -> ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema, false))
+    assertThatThrownBy(() -> ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema, false))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Can not promote LONG type to INTEGER");
   }
@@ -522,7 +520,7 @@ public class TestORCSchemaUtil {
 
     TypeDescription projectedOrcSchema =
         ORCSchemaUtil.buildOrcProjection(
-            mappingSchema, typeDescriptionWithIdsFromNameMapping, config);
+            mappingSchema, typeDescriptionWithIdsFromNameMapping);
 
     assertThat(equalsWithIds(expected, projectedOrcSchema))
         .as("Schema should be the prunned by projection")

--- a/orc/src/test/java/org/apache/iceberg/orc/TestORCSchemaUtil.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestORCSchemaUtil.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
@@ -195,7 +194,6 @@ public class TestORCSchemaUtil {
 
   @Test
   public void testTypePromotions() {
-    Configuration config = new Configuration();
     Schema originalSchema =
         new Schema(
             optional(1, "a", Types.IntegerType.get()),
@@ -229,7 +227,6 @@ public class TestORCSchemaUtil {
 
   @Test
   public void testInvalidTypePromotions() {
-    Configuration config = new Configuration();
     Schema originalSchema = new Schema(optional(1, "a", Types.LongType.get()));
 
     TypeDescription orcSchema = ORCSchemaUtil.convert(originalSchema);
@@ -412,7 +409,6 @@ public class TestORCSchemaUtil {
 
   @Test
   public void testAssignIdsByNameMappingAndProject() {
-    Configuration config = new Configuration();
     Types.StructType structType =
         Types.StructType.of(
             required(1, "id", Types.LongType.get()),

--- a/orc/src/test/java/org/apache/iceberg/orc/TestORCSchemaUtil.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestORCSchemaUtil.java
@@ -519,8 +519,7 @@ public class TestORCSchemaUtil {
         .isTrue();
 
     TypeDescription projectedOrcSchema =
-        ORCSchemaUtil.buildOrcProjection(
-            mappingSchema, typeDescriptionWithIdsFromNameMapping);
+        ORCSchemaUtil.buildOrcProjection(mappingSchema, typeDescriptionWithIdsFromNameMapping);
 
     assertThat(equalsWithIds(expected, projectedOrcSchema))
         .as("Schema should be the prunned by projection")


### PR DESCRIPTION
### What changes were proposed in this pull request?

A user was attempting to convert an ORC backed external table in hive to a Iceberg table using the migrate command but was immediately met with a "Can not promote TIMESTAMP to TIMESTAMP" error. This occurs because our Spark -> Iceberg conversion code always converts to a Timestamp.withZone.

it relate issue : https://github.com/apache/iceberg/issues/9784

```
spark.sql("CREATE EXTERNAL TABLE mytable (foo timestamp) STORED AS orc LOCATION '/Users/russellspitzer/Temp/foo'") 
spark.sql("INSERT INTO mytable VALUES (now())")
 spark.sql("CALL spark_catalog.system.migrate('mytable')") 
 spark.sql("SELECT * FROM mytable")
```

```
java.lang.IllegalArgumentException: Can not promote TIMESTAMP type to TIMESTAMP
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:441)
	at org.apache.iceberg.orc.ORCSchemaUtil.buildOrcProjection(ORCSchemaUtil.java:301)
	at org.apache.iceberg.orc.ORCSchemaUtil.buildOrcProjection(ORCSchemaUtil.java:275)
	at org.apache.iceberg.orc.ORCSchemaUtil.buildOrcProjection(ORCSchemaUtil.java:258)
```
add a config , `iceberg.orc.convert.timestamptz` , when set is as true , it will auto convert orc `TIMESTAMP` as orc `TIMESTAMP_INSTANT` , so we can fix this issue.

### Why are the changes needed?
fix issue.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
add a UT