### PR TITLE
Migrate Metadata files in Core to JUnit5

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TableMetadataParserCodecTest.java
+++ b/core/src/test/java/org/apache/iceberg/TableMetadataParserCodecTest.java
@@ -18,36 +18,37 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.apache.iceberg.TableMetadataParser.Codec;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TableMetadataParserCodecTest {
 
   @Test
   public void testCompressionCodec() {
-    Assert.assertEquals(Codec.GZIP, Codec.fromName("gzip"));
-    Assert.assertEquals(Codec.GZIP, Codec.fromName("gZiP"));
-    Assert.assertEquals(Codec.GZIP, Codec.fromFileName("v3.gz.metadata.json"));
-    Assert.assertEquals(Codec.GZIP, Codec.fromFileName("v3-f326-4b66-a541-7b1c.gz.metadata.json"));
-    Assert.assertEquals(Codec.GZIP, Codec.fromFileName("v3-f326-4b66-a541-7b1c.metadata.json.gz"));
-    Assert.assertEquals(Codec.NONE, Codec.fromName("none"));
-    Assert.assertEquals(Codec.NONE, Codec.fromName("nOnE"));
-    Assert.assertEquals(Codec.NONE, Codec.fromFileName("v3.metadata.json"));
-    Assert.assertEquals(Codec.NONE, Codec.fromFileName("v3-f326-4b66-a541-7b1c.metadata.json"));
+    assertThat(Codec.fromName("gzip")).isEqualTo(Codec.GZIP);
+    assertThat(Codec.fromName("gZiP")).isEqualTo(Codec.GZIP);
+    assertThat(Codec.fromFileName("v3.gz.metadata.json")).isEqualTo(Codec.GZIP);
+    assertThat(Codec.fromFileName("v3-f326-4b66-a541-7b1c.gz.metadata.json")).isEqualTo(Codec.GZIP);
+    assertThat(Codec.fromFileName("v3-f326-4b66-a541-7b1c.metadata.json.gz")).isEqualTo(Codec.GZIP);
+    assertThat(Codec.fromName("none")).isEqualTo(Codec.NONE);
+    assertThat(Codec.fromName("nOnE")).isEqualTo(Codec.NONE);
+    assertThat(Codec.fromFileName("v3.metadata.json")).isEqualTo(Codec.NONE);
+    assertThat(Codec.fromFileName("v3-f326-4b66-a541-7b1c.metadata.json")).isEqualTo(Codec.NONE);
   }
 
   @Test
   public void testInvalidCodecName() {
-    Assertions.assertThatThrownBy(() -> Codec.fromName("invalid"))
+    assertThatThrownBy(() -> Codec.fromName("invalid"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid codec name: invalid");
   }
 
   @Test
   public void testInvalidFileName() {
-    Assertions.assertThatThrownBy(() -> Codec.fromFileName("path/to/file.parquet"))
+    assertThatThrownBy(() -> Codec.fromFileName("path/to/file.parquet"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("path/to/file.parquet is not a valid metadata file");
   }

--- a/core/src/test/java/org/apache/iceberg/TableMetadataParserTest.java
+++ b/core/src/test/java/org/apache/iceberg/TableMetadataParserTest.java
@@ -50,7 +50,7 @@ public class TableMetadataParserTest {
   private static final Schema SCHEMA = new Schema(optional(1, "b", BooleanType.get()));
 
   @Parameters(name = "codecName = {0}")
-  protected static List<Object> parameters() {
+  private static List<Object> parameters() {
     return Arrays.asList("none", "gzip");
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -19,14 +19,16 @@
 package org.apache.iceberg;
 
 import static org.apache.iceberg.Files.localInput;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.IntStream;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -38,15 +40,12 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.view.ImmutableViewVersion;
 import org.apache.iceberg.view.ViewVersion;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestMetadataUpdateParser {
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private static final Schema ID_DATA_SCHEMA =
       new Schema(
@@ -59,7 +58,7 @@ public class TestMetadataUpdateParser {
         ImmutableList.of("{\"action\":null,\"format-version\":2}", "{\"format-version\":2}");
 
     for (String json : invalidJson) {
-      Assertions.assertThatThrownBy(() -> MetadataUpdateParser.fromJson(json))
+      assertThatThrownBy(() -> MetadataUpdateParser.fromJson(json))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessage("Cannot parse metadata update. Missing field: action");
     }
@@ -81,10 +80,9 @@ public class TestMetadataUpdateParser {
     String expected =
         "{\"action\":\"assign-uuid\",\"uuid\":\"9510c070-5e6d-4b40-bf40-a8915bb76e5d\"}";
     MetadataUpdate actual = new MetadataUpdate.AssignUUID(uuid);
-    Assert.assertEquals(
-        "Assign UUID should convert to the correct JSON value",
-        expected,
-        MetadataUpdateParser.toJson(actual));
+    assertThat(MetadataUpdateParser.toJson(actual))
+        .as("Assign UUID should convert to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   /** UpgradeFormatVersion * */
@@ -104,10 +102,9 @@ public class TestMetadataUpdateParser {
     String expected = "{\"action\":\"upgrade-format-version\",\"format-version\":2}";
     MetadataUpdate.UpgradeFormatVersion actual =
         new MetadataUpdate.UpgradeFormatVersion(formatVersion);
-    Assert.assertEquals(
-        "Upgrade format version should convert to the correct JSON value",
-        expected,
-        MetadataUpdateParser.toJson(actual));
+    assertThat(MetadataUpdateParser.toJson(actual))
+        .as("Upgrade format version should convert to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   /** AddSchema * */
@@ -145,7 +142,9 @@ public class TestMetadataUpdateParser {
             SchemaParser.toJson(schema), lastColumnId);
     MetadataUpdate update = new MetadataUpdate.AddSchema(schema, lastColumnId);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals("Add schema should convert to the correct JSON value", expected, actual);
+    assertThat(actual)
+        .as("Add schema should convert to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   /** SetCurrentSchema * */
@@ -165,8 +164,9 @@ public class TestMetadataUpdateParser {
     String expected = String.format("{\"action\":\"%s\",\"schema-id\":%d}", action, schemaId);
     MetadataUpdate update = new MetadataUpdate.SetCurrentSchema(schemaId);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Set current schema should convert to the correct JSON value", expected, actual);
+    assertThat(actual)
+        .as("Set current schema should convert to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   /** AddPartitionSpec * */
@@ -277,8 +277,9 @@ public class TestMetadataUpdateParser {
             .build();
     MetadataUpdate update = new MetadataUpdate.AddPartitionSpec(expectedSpec);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Add partition spec should convert to the correct JSON value", expected, actual);
+    assertThat(actual)
+        .as("Add partition spec should convert to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   /** SetDefaultPartitionSpec * */
@@ -289,8 +290,9 @@ public class TestMetadataUpdateParser {
     String expected = String.format("{\"action\":\"%s\",\"spec-id\":%d}", action, specId);
     MetadataUpdate update = new MetadataUpdate.SetDefaultPartitionSpec(specId);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Set default partition spec should serialize to the correct JSON value", expected, actual);
+    assertThat(actual)
+        .as("Set default partition spec should serialize to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -319,10 +321,9 @@ public class TestMetadataUpdateParser {
         String.format(
             "{\"action\":\"%s\",\"sort-order\":%s}", action, SortOrderParser.toJson(sortOrder));
     MetadataUpdate update = new MetadataUpdate.AddSortOrder(sortOrder);
-    Assert.assertEquals(
-        "Add sort order should serialize to the correct JSON value",
-        expected,
-        MetadataUpdateParser.toJson(update));
+    assertThat(MetadataUpdateParser.toJson(update))
+        .as("Add sort order should serialize to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -352,8 +353,9 @@ public class TestMetadataUpdateParser {
         String.format("{\"action\":\"%s\",\"sort-order-id\":%d}", action, sortOrderId);
     MetadataUpdate update = new MetadataUpdate.SetDefaultSortOrder(sortOrderId);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Set default sort order should serialize to the correct JSON value", expected, actual);
+    assertThat(actual)
+        .as("Set default sort order should serialize to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -389,8 +391,9 @@ public class TestMetadataUpdateParser {
     String expected = String.format("{\"action\":\"%s\",\"snapshot\":%s}", action, snapshotJson);
     MetadataUpdate update = new MetadataUpdate.AddSnapshot(snapshot);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Add snapshot should serialize to the correct JSON value", expected, actual);
+    assertThat(actual)
+        .as("Add snapshot should serialize to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -435,8 +438,9 @@ public class TestMetadataUpdateParser {
     String expected = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2]}", action);
     MetadataUpdate update = new MetadataUpdate.RemoveSnapshot(snapshotId);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Remove snapshots should serialize to the correct JSON value", expected, actual);
+    assertThat(actual)
+        .as("Remove snapshots should serialize to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   /** RemoveSnapshotRef * */
@@ -454,10 +458,9 @@ public class TestMetadataUpdateParser {
     String snapshotRef = "snapshot-ref";
     String expected = "{\"action\":\"remove-snapshot-ref\",\"ref-name\":\"snapshot-ref\"}";
     MetadataUpdate actual = new MetadataUpdate.RemoveSnapshotRef(snapshotRef);
-    Assert.assertEquals(
-        "RemoveSnapshotRef should convert to the correct JSON value",
-        expected,
-        MetadataUpdateParser.toJson(actual));
+    assertThat(MetadataUpdateParser.toJson(actual))
+        .as("RemoveSnapshotRef should convert to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   /** SetSnapshotRef * */
@@ -599,10 +602,10 @@ public class TestMetadataUpdateParser {
         new MetadataUpdate.SetSnapshotRef(
             refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Set snapshot ref should serialize to the correct JSON value for tag with default fields",
-        expected,
-        actual);
+    assertThat(actual)
+        .as(
+            "Set snapshot ref should serialize to the correct JSON value for tag with default fields")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -620,10 +623,9 @@ public class TestMetadataUpdateParser {
         new MetadataUpdate.SetSnapshotRef(
             refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Set snapshot ref should serialize to the correct JSON value for tag with all fields",
-        expected,
-        actual);
+    assertThat(actual)
+        .as("Set snapshot ref should serialize to the correct JSON value for tag with all fields")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -640,10 +642,10 @@ public class TestMetadataUpdateParser {
         new MetadataUpdate.SetSnapshotRef(
             refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Set snapshot ref should serialize to the correct JSON value for branch with default fields",
-        expected,
-        actual);
+    assertThat(actual)
+        .as(
+            "Set snapshot ref should serialize to the correct JSON value for branch with default fields")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -661,10 +663,10 @@ public class TestMetadataUpdateParser {
         new MetadataUpdate.SetSnapshotRef(
             refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Set snapshot ref should serialize to the correct JSON value for branch with all fields",
-        expected,
-        actual);
+    assertThat(actual)
+        .as(
+            "Set snapshot ref should serialize to the correct JSON value for branch with all fields")
+        .isEqualTo(expected);
   }
 
   /** SetProperties */
@@ -703,7 +705,7 @@ public class TestMetadataUpdateParser {
     props.put("prop2", null);
     String propsMap = "{\"prop1\":\"val1\",\"prop2\":null}";
     String json = String.format("{\"action\":\"%s\",\"updated\":%s}", action, propsMap);
-    Assertions.assertThatThrownBy(() -> MetadataUpdateParser.fromJson(json))
+    assertThatThrownBy(() -> MetadataUpdateParser.fromJson(json))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse to a string value: prop2: null");
   }
@@ -719,8 +721,9 @@ public class TestMetadataUpdateParser {
     String expected = String.format("{\"action\":\"%s\",\"updates\":%s}", action, propsMap);
     MetadataUpdate update = new MetadataUpdate.SetProperties(props);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Set properties should serialize to the correct JSON value", expected, actual);
+    assertThat(actual)
+        .as("Set properties should serialize to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   /** RemoveProperties */
@@ -755,8 +758,9 @@ public class TestMetadataUpdateParser {
     String expected = String.format("{\"action\":\"%s\",\"removals\":%s}", action, toRemoveAsJSON);
     MetadataUpdate update = new MetadataUpdate.RemoveProperties(toRemove);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Remove properties should serialize to the correct JSON value", expected, actual);
+    assertThat(actual)
+        .as("Remove properties should serialize to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   /** SetLocation */
@@ -776,8 +780,9 @@ public class TestMetadataUpdateParser {
     String expected = String.format("{\"action\":\"%s\",\"location\":\"%s\"}", action, location);
     MetadataUpdate update = new MetadataUpdate.SetLocation(location);
     String actual = MetadataUpdateParser.toJson(update);
-    Assert.assertEquals(
-        "Remove properties should serialize to the correct JSON value", expected, actual);
+    assertThat(actual)
+        .as("Remove properties should serialize to the correct JSON value")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -807,10 +812,9 @@ public class TestMetadataUpdateParser {
                         ImmutableMap.of("prop-key", "prop-value")))));
     assertEquals(
         MetadataUpdateParser.SET_STATISTICS, expected, MetadataUpdateParser.fromJson(json));
-    Assert.assertEquals(
-        "Set statistics should convert to the correct JSON value",
-        json,
-        MetadataUpdateParser.toJson(expected));
+    assertThat(MetadataUpdateParser.toJson(expected))
+        .as("Set statistics should convert to the correct JSON value")
+        .isEqualTo(json);
   }
 
   @Test
@@ -819,10 +823,9 @@ public class TestMetadataUpdateParser {
     MetadataUpdate expected = new MetadataUpdate.RemoveStatistics(1940541653261589030L);
     assertEquals(
         MetadataUpdateParser.REMOVE_STATISTICS, expected, MetadataUpdateParser.fromJson(json));
-    Assert.assertEquals(
-        "Remove statistics should convert to the correct JSON value",
-        json,
-        MetadataUpdateParser.toJson(expected));
+    assertThat(MetadataUpdateParser.toJson(expected))
+        .as("Remove statistics should convert to the correct JSON value")
+        .isEqualTo(json);
   }
 
   /** AddViewVersion */
@@ -864,7 +867,7 @@ public class TestMetadataUpdateParser {
             action);
 
     MetadataUpdate update = new MetadataUpdate.AddViewVersion(viewVersion);
-    Assertions.assertThat(MetadataUpdateParser.toJson(update)).isEqualTo(expected);
+    assertThat(MetadataUpdateParser.toJson(update)).isEqualTo(expected);
   }
 
   /** SetCurrentViewVersion */
@@ -881,7 +884,7 @@ public class TestMetadataUpdateParser {
     String action = MetadataUpdateParser.SET_CURRENT_VIEW_VERSION;
     String expected = String.format("{\"action\":\"%s\",\"view-version-id\":23}", action);
     MetadataUpdate update = new MetadataUpdate.SetCurrentViewVersion(23);
-    Assertions.assertThat(MetadataUpdateParser.toJson(update)).isEqualTo(expected);
+    assertThat(MetadataUpdateParser.toJson(update)).isEqualTo(expected);
   }
 
   @Test
@@ -904,10 +907,9 @@ public class TestMetadataUpdateParser {
         MetadataUpdateParser.SET_PARTITION_STATISTICS,
         expected,
         MetadataUpdateParser.fromJson(json));
-    Assert.assertEquals(
-        "Set partition statistics should convert to the correct JSON value",
-        json,
-        MetadataUpdateParser.toJson(expected));
+    assertThat(MetadataUpdateParser.toJson(expected))
+        .as("Set partition statistics should convert to the correct JSON value")
+        .isEqualTo(json);
   }
 
   @Test
@@ -919,10 +921,9 @@ public class TestMetadataUpdateParser {
         MetadataUpdateParser.REMOVE_PARTITION_STATISTICS,
         expected,
         MetadataUpdateParser.fromJson(json));
-    Assert.assertEquals(
-        "Remove partition statistics should convert to the correct JSON value",
-        json,
-        MetadataUpdateParser.toJson(expected));
+    assertThat(MetadataUpdateParser.toJson(expected))
+        .as("Remove partition statistics should convert to the correct JSON value")
+        .isEqualTo(json);
   }
 
   public void assertEquals(
@@ -1030,49 +1031,45 @@ public class TestMetadataUpdateParser {
             (MetadataUpdate.SetCurrentViewVersion) actualUpdate);
         break;
       default:
-        Assert.fail("Unrecognized metadata update action: " + action);
+        fail("Unrecognized metadata update action: " + action);
     }
   }
 
   private static void assertEqualsAssignUUID(
       MetadataUpdate.AssignUUID expected, MetadataUpdate.AssignUUID actual) {
-    Assert.assertEquals("UUIDs should be equal", expected.uuid(), actual.uuid());
+    assertThat(actual.uuid()).isEqualTo(expected.uuid());
   }
 
   private static void assertEqualsUpgradeFormatVersion(
       MetadataUpdate.UpgradeFormatVersion expected, MetadataUpdate.UpgradeFormatVersion actual) {
-    Assert.assertEquals(
-        "Format version should be equal", expected.formatVersion(), actual.formatVersion());
+    assertThat(actual.formatVersion()).isEqualTo(expected.formatVersion());
   }
 
   private static void assertEqualsAddSchema(
       MetadataUpdate.AddSchema expected, MetadataUpdate.AddSchema actual) {
-    Assert.assertTrue("Schemas should be the same", expected.schema().sameSchema(actual.schema()));
-    Assert.assertEquals(
-        "Last column id should be equal", expected.lastColumnId(), actual.lastColumnId());
+    assertThat(actual.schema().sameSchema(expected.schema())).isTrue();
+    assertThat(actual.lastColumnId()).isEqualTo(expected.lastColumnId());
   }
 
   private static void assertEqualsSetCurrentSchema(
       MetadataUpdate.SetCurrentSchema expected, MetadataUpdate.SetCurrentSchema actual) {
-    Assert.assertEquals("Schema id should be equal", expected.schemaId(), actual.schemaId());
+    assertThat(actual.schemaId()).isEqualTo(expected.schemaId());
   }
 
   private static void assertEqualsSetDefaultPartitionSpec(
       MetadataUpdate.SetDefaultPartitionSpec expected,
       MetadataUpdate.SetDefaultPartitionSpec actual) {
-    Assertions.assertThat(actual.specId()).isEqualTo(expected.specId());
+    assertThat(actual.specId()).isEqualTo(expected.specId());
   }
 
   private static void assertEqualsAddPartitionSpec(
       MetadataUpdate.AddPartitionSpec expected, MetadataUpdate.AddPartitionSpec actual) {
-    Assert.assertEquals(
-        "Unbound partition specs should have the same spec id",
-        expected.spec().specId(),
-        actual.spec().specId());
-    Assert.assertEquals(
-        "Unbound partition specs should have the same number of fields",
-        expected.spec().fields().size(),
-        actual.spec().fields().size());
+    assertThat(actual.spec().specId())
+        .as("Unbound partition specs should have the same spec id")
+        .isEqualTo(expected.spec().specId());
+    assertThat(actual.spec().fields())
+        .as("Unbound partition specs should have the same number of fields")
+        .hasSameSizeAs(expected.spec().fields());
 
     IntStream.range(0, expected.spec().fields().size())
         .forEachOrdered(
@@ -1081,27 +1078,23 @@ public class TestMetadataUpdateParser {
                   expected.spec().fields().get(i);
               UnboundPartitionSpec.UnboundPartitionField actualField =
                   actual.spec().fields().get(i);
-              Assert.assertTrue(
-                  "Fields of the unbound partition spec should be the same",
-                  Objects.equals(expectedField.partitionId(), actualField.partitionId())
-                      && expectedField.name().equals(actualField.name())
-                      && Objects.equals(
-                          expectedField.transformAsString(), actualField.transformAsString())
-                      && expectedField.sourceId() == actualField.sourceId());
+              assertThat(actualField.partitionId()).isEqualTo(expectedField.partitionId());
+              assertThat(actualField.name()).isEqualTo(expectedField.name());
+              assertThat(actualField.transformAsString())
+                  .isEqualTo(expectedField.transformAsString());
+              assertThat(actualField.sourceId()).isEqualTo(expectedField.sourceId());
             });
   }
 
   private static void assertEqualsAddSortOrder(
       MetadataUpdate.AddSortOrder expected, MetadataUpdate.AddSortOrder actual) {
-    Assert.assertEquals(
-        "Order id of the sort order should be the same",
-        expected.sortOrder().orderId(),
-        actual.sortOrder().orderId());
+    assertThat(actual.sortOrder().orderId())
+        .as("Order id of the sort order should be the same")
+        .isEqualTo(expected.sortOrder().orderId());
 
-    Assert.assertEquals(
-        "Sort orders should have the same number of fields",
-        expected.sortOrder().fields().size(),
-        actual.sortOrder().fields().size());
+    assertThat(actual.sortOrder().fields())
+        .as("Sort orders should have the same number of fields")
+        .hasSameSizeAs(expected.sortOrder().fields());
 
     IntStream.range(0, expected.sortOrder().fields().size())
         .forEachOrdered(
@@ -1109,45 +1102,31 @@ public class TestMetadataUpdateParser {
               UnboundSortOrder.UnboundSortField expectedField =
                   expected.sortOrder().fields().get(i);
               UnboundSortOrder.UnboundSortField actualField = actual.sortOrder().fields().get(i);
-              Assert.assertTrue(
-                  "Fields of the sort order should be the same",
-                  expectedField.sourceId() == actualField.sourceId()
-                      && expectedField.nullOrder().equals(actualField.nullOrder())
-                      && expectedField.direction().equals(actualField.direction())
-                      && Objects.equals(
-                          expectedField.transformAsString(), actualField.transformAsString()));
+              assertThat(actualField.sourceId()).isEqualTo(expectedField.sourceId());
+              assertThat(actualField.nullOrder()).isEqualTo(expectedField.nullOrder());
+              assertThat(actualField.direction()).isEqualTo(expectedField.direction());
+              assertThat(actualField.transformAsString())
+                  .isEqualTo(expectedField.transformAsString());
             });
   }
 
   private static void assertEqualsSetDefaultSortOrder(
       MetadataUpdate.SetDefaultSortOrder expected, MetadataUpdate.SetDefaultSortOrder actual) {
-    Assert.assertEquals(
-        "Sort order id should be the same", expected.sortOrderId(), actual.sortOrderId());
+    assertThat(actual.sortOrderId()).isEqualTo(expected.sortOrderId());
   }
 
   private static void assertEqualsSetStatistics(
       MetadataUpdate.SetStatistics expected, MetadataUpdate.SetStatistics actual) {
-    Assert.assertEquals("Snapshot IDs should be equal", expected.snapshotId(), actual.snapshotId());
-    Assert.assertEquals(
-        "Statistics files snapshot IDs should be equal",
-        expected.statisticsFile().snapshotId(),
-        actual.statisticsFile().snapshotId());
-    Assert.assertEquals(
-        "Statistics files paths should be equal",
-        expected.statisticsFile().path(),
-        actual.statisticsFile().path());
-    Assert.assertEquals(
-        "Statistics files size should be equal",
-        expected.statisticsFile().fileSizeInBytes(),
-        actual.statisticsFile().fileSizeInBytes());
-    Assert.assertEquals(
-        "Statistics files footer size should be equal",
-        expected.statisticsFile().fileFooterSizeInBytes(),
-        actual.statisticsFile().fileFooterSizeInBytes());
-    Assert.assertEquals(
-        "Statistics blob list size should be equal",
-        expected.statisticsFile().blobMetadata().size(),
-        actual.statisticsFile().blobMetadata().size());
+    assertThat(actual.snapshotId()).isEqualTo(expected.snapshotId());
+    assertThat(actual.statisticsFile().snapshotId())
+        .isEqualTo(expected.statisticsFile().snapshotId());
+    assertThat(actual.statisticsFile().path()).isEqualTo(expected.statisticsFile().path());
+    assertThat(actual.statisticsFile().fileSizeInBytes())
+        .isEqualTo(expected.statisticsFile().fileSizeInBytes());
+    assertThat(actual.statisticsFile().fileFooterSizeInBytes())
+        .isEqualTo(expected.statisticsFile().fileFooterSizeInBytes());
+    assertThat(actual.statisticsFile().blobMetadata())
+        .hasSameSizeAs(expected.statisticsFile().blobMetadata());
 
     Streams.zip(
             expected.statisticsFile().blobMetadata().stream(),
@@ -1158,123 +1137,92 @@ public class TestMetadataUpdateParser {
               BlobMetadata expectedBlob = pair.first();
               BlobMetadata actualBlob = pair.second();
 
-              Assert.assertEquals(
-                  "Expected blob type should be equal", expectedBlob.type(), actualBlob.type());
-              Assert.assertEquals(
-                  "Expected blob fields should be equal",
-                  expectedBlob.fields(),
-                  actualBlob.fields());
-              Assert.assertEquals(
-                  "Expected blob source snapshot ID should be equal",
-                  expectedBlob.sourceSnapshotId(),
-                  actualBlob.sourceSnapshotId());
-              Assert.assertEquals(
-                  "Expected blob source snapshot sequence number should be equal",
-                  expectedBlob.sourceSnapshotSequenceNumber(),
-                  actualBlob.sourceSnapshotSequenceNumber());
-              Assert.assertEquals(
-                  "Expected blob properties should be equal",
-                  expectedBlob.properties(),
-                  actualBlob.properties());
+              assertThat(actualBlob.type()).isEqualTo(expectedBlob.type());
+              assertThat(actualBlob.fields()).isEqualTo(expectedBlob.fields());
+              assertThat(actualBlob.sourceSnapshotId()).isEqualTo(expectedBlob.sourceSnapshotId());
+              assertThat(actualBlob.sourceSnapshotSequenceNumber())
+                  .isEqualTo(expectedBlob.sourceSnapshotSequenceNumber());
+              assertThat(actualBlob.properties()).isEqualTo(expectedBlob.properties());
             });
   }
 
   private static void assertEqualsRemoveStatistics(
       MetadataUpdate.RemoveStatistics expected, MetadataUpdate.RemoveStatistics actual) {
-    Assert.assertEquals(
-        "Snapshots to remove should be the same", expected.snapshotId(), actual.snapshotId());
+    assertThat(actual.snapshotId())
+        .as("Snapshots to remove should be the same")
+        .isEqualTo(expected.snapshotId());
   }
 
   private static void assertEqualsSetPartitionStatistics(
       MetadataUpdate.SetPartitionStatistics expected,
       MetadataUpdate.SetPartitionStatistics actual) {
-    Assert.assertEquals("Snapshot IDs should be equal", expected.snapshotId(), actual.snapshotId());
-    Assert.assertEquals(
-        "Partition Statistics files snapshot IDs should be equal",
-        expected.partitionStatisticsFile().snapshotId(),
-        actual.partitionStatisticsFile().snapshotId());
-    Assert.assertEquals(
-        "Partition statistics files paths should be equal",
-        expected.partitionStatisticsFile().path(),
-        actual.partitionStatisticsFile().path());
-    Assert.assertEquals(
-        "Partition statistics file size should be equal",
-        expected.partitionStatisticsFile().fileSizeInBytes(),
-        actual.partitionStatisticsFile().fileSizeInBytes());
+    assertThat(actual.snapshotId()).isEqualTo(expected.snapshotId());
+    assertThat(actual.partitionStatisticsFile().snapshotId())
+        .isEqualTo(expected.partitionStatisticsFile().snapshotId());
+    assertThat(actual.partitionStatisticsFile().path())
+        .isEqualTo(expected.partitionStatisticsFile().path());
+    assertThat(actual.partitionStatisticsFile().fileSizeInBytes())
+        .isEqualTo(expected.partitionStatisticsFile().fileSizeInBytes());
   }
 
   private static void assertEqualsRemovePartitionStatistics(
       MetadataUpdate.RemovePartitionStatistics expected,
       MetadataUpdate.RemovePartitionStatistics actual) {
-    Assert.assertEquals(
-        "Snapshots to remove should be the same", expected.snapshotId(), actual.snapshotId());
+    assertThat(actual.snapshotId()).isEqualTo(expected.snapshotId());
   }
 
   private static void assertEqualsAddSnapshot(
       MetadataUpdate.AddSnapshot expected, MetadataUpdate.AddSnapshot actual) {
-    Assert.assertEquals(
-        "Snapshot ID should be equal",
-        expected.snapshot().snapshotId(),
-        actual.snapshot().snapshotId());
-    Assert.assertEquals(
-        "Manifest list location should be equal",
-        expected.snapshot().manifestListLocation(),
-        actual.snapshot().manifestListLocation());
-    Assertions.assertThat(actual.snapshot().summary())
+    assertThat(actual.snapshot().snapshotId()).isEqualTo(expected.snapshot().snapshotId());
+    assertThat(actual.snapshot().manifestListLocation())
+        .isEqualTo(expected.snapshot().manifestListLocation());
+    assertThat(actual.snapshot().summary())
         .as("Snapshot summary should be equivalent")
         .containsExactlyEntriesOf(expected.snapshot().summary());
-    Assert.assertEquals(
-        "Snapshot Parent ID should be equal",
-        expected.snapshot().parentId(),
-        actual.snapshot().parentId());
-    Assert.assertEquals(
-        "Snapshot timestamp should be equal",
-        expected.snapshot().timestampMillis(),
-        actual.snapshot().timestampMillis());
-    Assert.assertEquals(
-        "Snapshot schema id should be equal",
-        expected.snapshot().schemaId(),
-        actual.snapshot().schemaId());
+    assertThat(actual.snapshot().parentId()).isEqualTo(expected.snapshot().parentId());
+    assertThat(actual.snapshot().timestampMillis())
+        .isEqualTo(expected.snapshot().timestampMillis());
+    assertThat(actual.snapshot().schemaId()).isEqualTo(expected.snapshot().schemaId());
   }
 
   private static void assertEqualsRemoveSnapshots(
       MetadataUpdate.RemoveSnapshot expected, MetadataUpdate.RemoveSnapshot actual) {
-    Assert.assertEquals(
-        "Snapshots to remove should be the same", expected.snapshotId(), actual.snapshotId());
+    assertThat(actual.snapshotId())
+        .as("Snapshots to remove should be the same")
+        .isEqualTo(expected.snapshotId());
   }
 
   private static void assertEqualsSetSnapshotRef(
       MetadataUpdate.SetSnapshotRef expected, MetadataUpdate.SetSnapshotRef actual) {
     // Non-null fields
-    Assert.assertNotNull("Snapshot ref name should not be null", actual.name());
-    Assert.assertEquals("Snapshot ref name should be equal", expected.name(), actual.name());
-    Assert.assertEquals("Snapshot ID should be equal", expected.snapshotId(), actual.snapshotId());
-    Assert.assertNotNull("Snapshot reference type should not be null", actual.type());
-    Assert.assertEquals("Snapshot reference type should be equal", expected.type(), actual.type());
+    assertThat(actual.name()).isNotNull();
+    assertThat(actual.name()).isEqualTo(expected.name());
+    assertThat(actual.snapshotId()).isEqualTo(expected.snapshotId());
+    assertThat(actual.type()).isNotNull();
+    assertThat(actual.type()).isEqualTo(expected.type());
 
     // Nullable fields
-    Assert.assertEquals(
-        "Min snapshots to keep should be equal when present and null when missing or explicitly null",
-        expected.minSnapshotsToKeep(),
-        actual.minSnapshotsToKeep());
-    Assert.assertEquals(
-        "Max snapshot age ms should be equal when present and null when missing or explicitly null",
-        expected.maxSnapshotAgeMs(),
-        actual.maxSnapshotAgeMs());
-    Assert.assertEquals(
-        "Max ref age ms should be equal when present and null when missing or explicitly null",
-        expected.maxRefAgeMs(),
-        actual.maxRefAgeMs());
+    assertThat(actual.minSnapshotsToKeep())
+        .as(
+            "Min snapshots to keep should be equal when present and null when missing or explicitly null")
+        .isEqualTo(expected.minSnapshotsToKeep());
+    assertThat(actual.maxSnapshotAgeMs())
+        .as(
+            "Max snapshot age ms should be equal when present and null when missing or explicitly null")
+        .isEqualTo(expected.maxSnapshotAgeMs());
+    assertThat(actual.maxRefAgeMs())
+        .as("Max ref age ms should be equal when present and null when missing or explicitly null")
+        .isEqualTo(expected.maxRefAgeMs());
   }
 
   private static void assertEqualsRemoveSnapshotRef(
       MetadataUpdate.RemoveSnapshotRef expected, MetadataUpdate.RemoveSnapshotRef actual) {
-    Assertions.assertThat(actual.name()).isEqualTo(expected.name());
+    assertThat(actual.name()).isEqualTo(expected.name());
   }
 
   private static void assertEqualsSetProperties(
       MetadataUpdate.SetProperties expected, MetadataUpdate.SetProperties actual) {
-    Assertions.assertThat(actual.updated())
+    assertThat(actual.updated())
         .as("Properties to set / update should not be null")
         .isNotNull()
         .as("Properties to set / update should be the same")
@@ -1283,7 +1231,7 @@ public class TestMetadataUpdateParser {
 
   private static void assertEqualsRemoveProperties(
       MetadataUpdate.RemoveProperties expected, MetadataUpdate.RemoveProperties actual) {
-    Assertions.assertThat(actual.removed())
+    assertThat(actual.removed())
         .as("Properties to remove should not be null")
         .isNotNull()
         .as("Properties to remove should be equal")
@@ -1292,22 +1240,22 @@ public class TestMetadataUpdateParser {
 
   private static void assertEqualsSetLocation(
       MetadataUpdate.SetLocation expected, MetadataUpdate.SetLocation actual) {
-    Assert.assertEquals("Location should be the same", expected.location(), actual.location());
+    assertThat(actual.location()).isEqualTo(expected.location());
   }
 
   private static void assertEqualsAddViewVersion(
       MetadataUpdate.AddViewVersion expected, MetadataUpdate.AddViewVersion actual) {
-    Assertions.assertThat(actual.viewVersion()).isEqualTo(expected.viewVersion());
+    assertThat(actual.viewVersion()).isEqualTo(expected.viewVersion());
   }
 
   private static void assertEqualsSetCurrentViewVersion(
       MetadataUpdate.SetCurrentViewVersion expected, MetadataUpdate.SetCurrentViewVersion actual) {
-    Assertions.assertThat(actual.versionId()).isEqualTo(expected.versionId());
+    assertThat(actual.versionId()).isEqualTo(expected.versionId());
   }
 
   private String createManifestListWithManifestFiles(long snapshotId, Long parentSnapshotId)
       throws IOException {
-    File manifestList = temp.newFile("manifests" + UUID.randomUUID());
+    File manifestList = File.createTempFile("manifests", null, temp.toFile());
     manifestList.deleteOnExit();
 
     List<ManifestFile> manifests =

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -1047,7 +1047,7 @@ public class TestMetadataUpdateParser {
 
   private static void assertEqualsAddSchema(
       MetadataUpdate.AddSchema expected, MetadataUpdate.AddSchema actual) {
-    assertThat(actual.schema().sameSchema(expected.schema())).isTrue();
+    assertThat(actual.schema().asStruct()).isEqualTo(expected.schema().asStruct());
     assertThat(actual.lastColumnId()).isEqualTo(expected.lastColumnId());
   }
 
@@ -1195,11 +1195,9 @@ public class TestMetadataUpdateParser {
   private static void assertEqualsSetSnapshotRef(
       MetadataUpdate.SetSnapshotRef expected, MetadataUpdate.SetSnapshotRef actual) {
     // Non-null fields
-    assertThat(actual.name()).isNotNull();
-    assertThat(actual.name()).isEqualTo(expected.name());
+    assertThat(actual.name()).isNotNull().isEqualTo(expected.name());
     assertThat(actual.snapshotId()).isEqualTo(expected.snapshotId());
-    assertThat(actual.type()).isNotNull();
-    assertThat(actual.type()).isEqualTo(expected.type());
+    assertThat(actual.type()).isNotNull().isEqualTo(expected.type());
 
     // Nullable fields
     assertThat(actual.minSnapshotsToKeep())

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -31,6 +31,7 @@ import static org.apache.iceberg.TableMetadataParser.SNAPSHOTS;
 import static org.apache.iceberg.TestHelpers.assertSameSchemaList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.File;
@@ -283,7 +284,7 @@ public class TestTableMetadata {
         .as("Current schema ID should be default to TableMetadata.INITIAL_SCHEMA_ID")
         .isEqualTo(TableMetadata.INITIAL_SCHEMA_ID);
     assertThat(metadata.schemas()).hasSize(1);
-    assertThat(schema.asStruct()).isEqualTo(metadata.schemas().get(0).asStruct());
+    assertThat(metadata.schemas().get(0).asStruct()).isEqualTo(schema.asStruct());
     assertThat(metadata.spec().toString()).isEqualTo(expected.spec().toString());
     assertThat(metadata.defaultSpecId()).isEqualTo(TableMetadata.INITIAL_SPEC_ID);
     assertThat(metadata.specs()).hasSize(1);
@@ -1511,16 +1512,15 @@ public class TestTableMetadata {
         .isEqualTo(2);
     assertThat(meta.properties())
         .as("should not contain format-version but should contain new properties")
-        .containsEntry("key2", "val2");
+        .containsExactly(entry("key2", "val2"));
   }
 
   @Test
   public void testParseStatisticsFiles() throws Exception {
     String data = readTableMetadataInputFile("TableMetadataStatisticsFiles.json");
     TableMetadata parsed = TableMetadataParser.fromJson(data);
-    assertThat(parsed.statisticsFiles()).as("parsed statistics files").hasSize(1);
+    assertThat(parsed.statisticsFiles()).hasSize(1);
     assertThat(parsed.statisticsFiles())
-        .as("parsed statistics file")
         .hasSize(1)
         .first()
         .isEqualTo(
@@ -1539,7 +1539,6 @@ public class TestTableMetadata {
     String data = readTableMetadataInputFile("TableMetadataPartitionStatisticsFiles.json");
     TableMetadata parsed = TableMetadataParser.fromJson(data);
     assertThat(parsed.partitionStatisticsFiles())
-        .as("parsed partition statistics files")
         .hasSize(1)
         .first()
         .isEqualTo(

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -30,6 +30,7 @@ import static org.apache.iceberg.TableMetadataParser.SCHEMA;
 import static org.apache.iceberg.TableMetadataParser.SNAPSHOTS;
 import static org.apache.iceberg.TestHelpers.assertSameSchemaList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.File;
@@ -59,8 +60,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -183,72 +182,34 @@ public class TestTableMetadata {
     String asJson = TableMetadataParser.toJson(expected);
     TableMetadata metadata = TableMetadataParser.fromJson(asJson);
 
-    Assert.assertEquals(
-        "Format version should match", expected.formatVersion(), metadata.formatVersion());
-    Assert.assertEquals("Table UUID should match", expected.uuid(), metadata.uuid());
-    Assert.assertEquals("Table location should match", expected.location(), metadata.location());
-    Assert.assertEquals(
-        "Last sequence number should match",
-        expected.lastSequenceNumber(),
-        metadata.lastSequenceNumber());
-    Assert.assertEquals(
-        "Last column ID should match", expected.lastColumnId(), metadata.lastColumnId());
-    Assert.assertEquals(
-        "Current schema id should match", expected.currentSchemaId(), metadata.currentSchemaId());
+    assertThat(metadata.formatVersion()).isEqualTo(expected.formatVersion());
+    assertThat(metadata.uuid()).isEqualTo(expected.uuid());
+    assertThat(metadata.location()).isEqualTo(expected.location());
+    assertThat(metadata.lastSequenceNumber()).isEqualTo(expected.lastSequenceNumber());
+    assertThat(metadata.lastColumnId()).isEqualTo(expected.lastColumnId());
+    assertThat(metadata.currentSchemaId()).isEqualTo(expected.currentSchemaId());
     assertSameSchemaList(expected.schemas(), metadata.schemas());
-    Assert.assertEquals(
-        "Partition spec should match", expected.spec().toString(), metadata.spec().toString());
-    Assert.assertEquals(
-        "Default spec ID should match", expected.defaultSpecId(), metadata.defaultSpecId());
-    Assert.assertEquals("PartitionSpec map should match", expected.specs(), metadata.specs());
-    Assert.assertEquals(
-        "lastAssignedFieldId across all PartitionSpecs should match",
-        expected.spec().lastAssignedFieldId(),
-        metadata.lastAssignedPartitionId());
-    Assert.assertEquals(
-        "Default sort ID should match",
-        expected.defaultSortOrderId(),
-        metadata.defaultSortOrderId());
-    Assert.assertEquals("Sort order should match", expected.sortOrder(), metadata.sortOrder());
-    Assert.assertEquals(
-        "Sort order map should match", expected.sortOrders(), metadata.sortOrders());
-    Assert.assertEquals("Properties should match", expected.properties(), metadata.properties());
-    Assert.assertEquals(
-        "Snapshot logs should match", expected.snapshotLog(), metadata.snapshotLog());
-    Assert.assertEquals(
-        "Current snapshot ID should match",
-        currentSnapshotId,
-        metadata.currentSnapshot().snapshotId());
-    Assert.assertEquals(
-        "Parent snapshot ID should match",
-        (Long) previousSnapshotId,
-        metadata.currentSnapshot().parentId());
-    Assert.assertEquals(
-        "Current snapshot files should match",
-        currentSnapshot.allManifests(ops.io()),
-        metadata.currentSnapshot().allManifests(ops.io()));
-    Assert.assertEquals(
-        "Schema ID for current snapshot should match",
-        (Integer) 7,
-        metadata.currentSnapshot().schemaId());
-    Assert.assertEquals(
-        "Previous snapshot ID should match",
-        previousSnapshotId,
-        metadata.snapshot(previousSnapshotId).snapshotId());
-    Assert.assertEquals(
-        "Previous snapshot files should match",
-        previousSnapshot.allManifests(ops.io()),
-        metadata.snapshot(previousSnapshotId).allManifests(ops.io()));
-    Assert.assertNull(
-        "Previous snapshot's schema ID should be null",
-        metadata.snapshot(previousSnapshotId).schemaId());
-    Assert.assertEquals(
-        "Statistics files should match", statisticsFiles, metadata.statisticsFiles());
-    Assert.assertEquals(
-        "Partition statistics files should match",
-        partitionStatisticsFiles,
-        metadata.partitionStatisticsFiles());
-    Assert.assertEquals("Refs map should match", refs, metadata.refs());
+    assertThat(metadata.spec().toString()).isEqualTo(expected.spec().toString());
+    assertThat(metadata.defaultSpecId()).isEqualTo(expected.defaultSpecId());
+    assertThat(metadata.specs()).isEqualTo(expected.specs());
+    assertThat(metadata.lastAssignedPartitionId()).isEqualTo(expected.spec().lastAssignedFieldId());
+    assertThat(metadata.defaultSortOrderId()).isEqualTo(expected.defaultSortOrderId());
+    assertThat(metadata.sortOrder()).isEqualTo(expected.sortOrder());
+    assertThat(metadata.sortOrders()).isEqualTo(expected.sortOrders());
+    assertThat(metadata.properties()).isEqualTo(expected.properties());
+    assertThat(metadata.snapshotLog()).isEqualTo(expected.snapshotLog());
+    assertThat(metadata.currentSnapshot().snapshotId()).isEqualTo(currentSnapshotId);
+    assertThat(metadata.currentSnapshot().parentId()).isEqualTo(previousSnapshotId);
+    assertThat(metadata.currentSnapshot().allManifests(ops.io()))
+        .isEqualTo(currentSnapshot.allManifests(ops.io()));
+    assertThat(metadata.currentSnapshot().schemaId()).isEqualTo(7);
+    assertThat(metadata.snapshot(previousSnapshotId).snapshotId()).isEqualTo(previousSnapshotId);
+    assertThat(metadata.snapshot(previousSnapshotId).allManifests(ops.io()))
+        .isEqualTo(previousSnapshot.allManifests(ops.io()));
+    assertThat(metadata.snapshot(previousSnapshotId).schemaId()).isNull();
+    assertThat(metadata.statisticsFiles()).isEqualTo(statisticsFiles);
+    assertThat(metadata.partitionStatisticsFiles()).isEqualTo(partitionStatisticsFiles);
+    assertThat(metadata.refs()).isEqualTo(refs);
   }
 
   @Test
@@ -310,74 +271,40 @@ public class TestTableMetadata {
     String asJson = toJsonWithoutSpecAndSchemaList(expected);
     TableMetadata metadata = TableMetadataParser.fromJson(asJson);
 
-    Assert.assertEquals(
-        "Format version should match", expected.formatVersion(), metadata.formatVersion());
-    Assert.assertNull("Table UUID should not be assigned", metadata.uuid());
-    Assert.assertEquals("Table location should match", expected.location(), metadata.location());
-    Assert.assertEquals(
-        "Last sequence number should default to 0",
-        expected.lastSequenceNumber(),
-        metadata.lastSequenceNumber());
-    Assert.assertEquals(
-        "Last column ID should match", expected.lastColumnId(), metadata.lastColumnId());
-    Assert.assertEquals(
-        "Current schema ID should be default to TableMetadata.INITIAL_SCHEMA_ID",
-        TableMetadata.INITIAL_SCHEMA_ID,
-        metadata.currentSchemaId());
-    Assert.assertEquals("Schemas size should match", 1, metadata.schemas().size());
-    Assert.assertEquals(
-        "Schemas should contain the schema",
-        metadata.schemas().get(0).asStruct(),
-        schema.asStruct());
-    Assert.assertEquals(
-        "Partition spec should be the default",
-        expected.spec().toString(),
-        metadata.spec().toString());
-    Assert.assertEquals(
-        "Default spec ID should default to TableMetadata.INITIAL_SPEC_ID",
-        TableMetadata.INITIAL_SPEC_ID,
-        metadata.defaultSpecId());
-    Assert.assertEquals("PartitionSpec should contain the spec", 1, metadata.specs().size());
-    Assert.assertTrue(
-        "PartitionSpec should contain the spec", metadata.specs().get(0).compatibleWith(spec));
-    Assert.assertEquals(
-        "PartitionSpec should have ID TableMetadata.INITIAL_SPEC_ID",
-        TableMetadata.INITIAL_SPEC_ID,
-        metadata.specs().get(0).specId());
-    Assert.assertEquals(
-        "lastAssignedFieldId across all PartitionSpecs should match",
-        expected.spec().lastAssignedFieldId(),
-        metadata.lastAssignedPartitionId());
-    Assert.assertEquals("Properties should match", expected.properties(), metadata.properties());
-    Assert.assertEquals(
-        "Snapshot logs should match", expected.snapshotLog(), metadata.snapshotLog());
-    Assert.assertEquals(
-        "Current snapshot ID should match",
-        currentSnapshotId,
-        metadata.currentSnapshot().snapshotId());
-    Assert.assertEquals(
-        "Parent snapshot ID should match",
-        (Long) previousSnapshotId,
-        metadata.currentSnapshot().parentId());
-    Assert.assertEquals(
-        "Current snapshot files should match",
-        currentSnapshot.allManifests(ops.io()),
-        metadata.currentSnapshot().allManifests(ops.io()));
-    Assert.assertNull(
-        "Current snapshot's schema ID should be null", metadata.currentSnapshot().schemaId());
-    Assert.assertEquals(
-        "Previous snapshot ID should match",
-        previousSnapshotId,
-        metadata.snapshot(previousSnapshotId).snapshotId());
-    Assert.assertEquals(
-        "Previous snapshot files should match",
-        previousSnapshot.allManifests(ops.io()),
-        metadata.snapshot(previousSnapshotId).allManifests(ops.io()));
-    Assert.assertEquals(
-        "Snapshot logs should match", expected.previousFiles(), metadata.previousFiles());
-    Assert.assertNull(
-        "Previous snapshot's schema ID should be null",
-        metadata.snapshot(previousSnapshotId).schemaId());
+    assertThat(metadata.formatVersion()).isEqualTo(expected.formatVersion());
+    assertThat(metadata.uuid()).as("Table UUID should not be assigned").isNull();
+    assertThat(metadata.location()).isEqualTo(expected.location());
+    assertThat(metadata.lastSequenceNumber())
+        .as("Last sequence number should default to 0")
+        .isEqualTo(expected.lastSequenceNumber());
+
+    assertThat(metadata.lastColumnId()).isEqualTo(expected.lastColumnId());
+    assertThat(metadata.currentSchemaId())
+        .as("Current schema ID should be default to TableMetadata.INITIAL_SCHEMA_ID")
+        .isEqualTo(TableMetadata.INITIAL_SCHEMA_ID);
+    assertThat(metadata.schemas()).hasSize(1);
+    assertThat(schema.asStruct()).isEqualTo(metadata.schemas().get(0).asStruct());
+    assertThat(metadata.spec().toString()).isEqualTo(expected.spec().toString());
+    assertThat(metadata.defaultSpecId()).isEqualTo(TableMetadata.INITIAL_SPEC_ID);
+    assertThat(metadata.specs()).hasSize(1);
+    assertThat(metadata.specs())
+        .first()
+        .satisfies(partitionSpec -> partitionSpec.compatibleWith(spec));
+    assertThat(metadata.specs().get(0).specId()).isEqualTo(TableMetadata.INITIAL_SPEC_ID);
+    assertThat(metadata.lastAssignedPartitionId()).isEqualTo(expected.spec().lastAssignedFieldId());
+    assertThat(metadata.properties()).isEqualTo(expected.properties());
+    assertThat(metadata.snapshotLog()).isEqualTo(expected.snapshotLog());
+    assertThat(metadata.currentSnapshot().snapshotId()).isEqualTo(currentSnapshotId);
+    assertThat(metadata.currentSnapshot().parentId()).isEqualTo(previousSnapshotId);
+    assertThat(metadata.currentSnapshot().allManifests(ops.io()))
+        .as("Current snapshot files should match")
+        .isEqualTo(currentSnapshot.allManifests(ops.io()));
+    assertThat(metadata.currentSnapshot().schemaId()).isNull();
+    assertThat(metadata.snapshot(previousSnapshotId).snapshotId()).isEqualTo(previousSnapshotId);
+    assertThat(metadata.snapshot(previousSnapshotId).allManifests(ops.io()))
+        .isEqualTo(previousSnapshot.allManifests(ops.io()));
+    assertThat(metadata.previousFiles()).isEqualTo(expected.previousFiles());
+    assertThat(metadata.snapshot(previousSnapshotId).schemaId()).isNull();
   }
 
   @Test
@@ -421,7 +348,7 @@ public class TestTableMetadata {
     Map<String, SnapshotRef> refs =
         ImmutableMap.of("main", SnapshotRef.branchBuilder(previousSnapshotId).build());
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new TableMetadata(
                     null,
@@ -466,7 +393,7 @@ public class TestTableMetadata {
     Map<String, SnapshotRef> refs =
         ImmutableMap.of("main", SnapshotRef.branchBuilder(snapshotId).build());
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new TableMetadata(
                     null,
@@ -506,7 +433,7 @@ public class TestTableMetadata {
     Map<String, SnapshotRef> refs =
         ImmutableMap.of("main", SnapshotRef.branchBuilder(snapshotId).build());
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new TableMetadata(
                     null,
@@ -641,8 +568,7 @@ public class TestTableMetadata {
     String asJson = TableMetadataParser.toJson(base);
     TableMetadata metadataFromJson = TableMetadataParser.fromJson(asJson);
 
-    Assert.assertEquals(
-        "Metadata logs should match", previousMetadataLog, metadataFromJson.previousFiles());
+    assertThat(metadataFromJson.previousFiles()).isEqualTo(previousMetadataLog);
   }
 
   @Test
@@ -726,9 +652,8 @@ public class TestTableMetadata {
     Set<MetadataLogEntry> removedPreviousMetadata = Sets.newHashSet(base.previousFiles());
     removedPreviousMetadata.removeAll(metadata.previousFiles());
 
-    Assert.assertEquals(
-        "Metadata logs should match", previousMetadataLog, metadata.previousFiles());
-    Assert.assertEquals("Removed Metadata logs should be empty", 0, removedPreviousMetadata.size());
+    assertThat(metadata.previousFiles()).isEqualTo(previousMetadataLog);
+    assertThat(removedPreviousMetadata).isEmpty();
   }
 
   @Test
@@ -827,12 +752,9 @@ public class TestTableMetadata {
     removedPreviousMetadata.addAll(base.previousFiles());
     removedPreviousMetadata.removeAll(metadata.previousFiles());
 
-    Assert.assertEquals(
-        "Metadata logs should match", previousMetadataLog.subList(1, 6), metadata.previousFiles());
-    Assert.assertEquals(
-        "Removed Metadata logs should contain 1",
-        previousMetadataLog.subList(0, 1),
-        ImmutableList.copyOf(removedPreviousMetadata));
+    assertThat(metadata.previousFiles()).isEqualTo(previousMetadataLog.subList(1, 6));
+    assertThat(ImmutableList.copyOf(removedPreviousMetadata))
+        .isEqualTo(previousMetadataLog.subList(0, 1));
   }
 
   @Test
@@ -931,17 +853,14 @@ public class TestTableMetadata {
     removedPreviousMetadata.addAll(base.previousFiles());
     removedPreviousMetadata.removeAll(metadata.previousFiles());
 
-    Assert.assertEquals(
-        "Metadata logs should match", previousMetadataLog.subList(4, 6), metadata.previousFiles());
-    Assert.assertEquals(
-        "Removed Metadata logs should contain 4",
-        previousMetadataLog.subList(0, 4),
-        ImmutableList.copyOf(removedPreviousMetadata));
+    assertThat(metadata.previousFiles()).isEqualTo(previousMetadataLog.subList(4, 6));
+    assertThat(ImmutableList.copyOf(removedPreviousMetadata))
+        .isEqualTo(previousMetadataLog.subList(0, 4));
   }
 
   @Test
   public void testV2UUIDValidation() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new TableMetadata(
                     null,
@@ -975,7 +894,7 @@ public class TestTableMetadata {
   @Test
   public void testVersionValidation() {
     int unsupportedVersion = TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION + 1;
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new TableMetadata(
                     null,
@@ -1010,14 +929,14 @@ public class TestTableMetadata {
   public void testParserVersionValidation() throws Exception {
     String supportedVersion1 = readTableMetadataInputFile("TableMetadataV1Valid.json");
     TableMetadata parsed1 = TableMetadataParser.fromJson(supportedVersion1);
-    Assert.assertNotNull("Should successfully read supported metadata version", parsed1);
+    assertThat(parsed1).as("Should successfully read supported metadata version").isNotNull();
 
     String supportedVersion2 = readTableMetadataInputFile("TableMetadataV2Valid.json");
     TableMetadata parsed2 = TableMetadataParser.fromJson(supportedVersion2);
-    Assert.assertNotNull("Should successfully read supported metadata version", parsed2);
+    assertThat(parsed2).as("Should successfully read supported metadata version").isNotNull();
 
     String unsupportedVersion = readTableMetadataInputFile("TableMetadataUnsupportedVersion.json");
-    Assertions.assertThatThrownBy(() -> TableMetadataParser.fromJson(unsupportedVersion))
+    assertThatThrownBy(() -> TableMetadataParser.fromJson(unsupportedVersion))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot read unsupported version");
   }
@@ -1026,7 +945,7 @@ public class TestTableMetadata {
   public void testParserV2PartitionSpecsValidation() throws Exception {
     String unsupportedVersion =
         readTableMetadataInputFile("TableMetadataV2MissingPartitionSpecs.json");
-    Assertions.assertThatThrownBy(() -> TableMetadataParser.fromJson(unsupportedVersion))
+    assertThatThrownBy(() -> TableMetadataParser.fromJson(unsupportedVersion))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("partition-specs must exist in format v2");
   }
@@ -1035,7 +954,7 @@ public class TestTableMetadata {
   public void testParserV2LastAssignedFieldIdValidation() throws Exception {
     String unsupportedVersion =
         readTableMetadataInputFile("TableMetadataV2MissingLastPartitionId.json");
-    Assertions.assertThatThrownBy(() -> TableMetadataParser.fromJson(unsupportedVersion))
+    assertThatThrownBy(() -> TableMetadataParser.fromJson(unsupportedVersion))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("last-partition-id must exist in format v2");
   }
@@ -1043,7 +962,7 @@ public class TestTableMetadata {
   @Test
   public void testParserV2SortOrderValidation() throws Exception {
     String unsupportedVersion = readTableMetadataInputFile("TableMetadataV2MissingSortOrder.json");
-    Assertions.assertThatThrownBy(() -> TableMetadataParser.fromJson(unsupportedVersion))
+    assertThatThrownBy(() -> TableMetadataParser.fromJson(unsupportedVersion))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("sort-orders must exist in format v2");
   }
@@ -1051,7 +970,7 @@ public class TestTableMetadata {
   @Test
   public void testParserV2CurrentSchemaIdValidation() throws Exception {
     String unsupported = readTableMetadataInputFile("TableMetadataV2CurrentSchemaNotFound.json");
-    Assertions.assertThatThrownBy(() -> TableMetadataParser.fromJson(unsupported))
+    assertThatThrownBy(() -> TableMetadataParser.fromJson(unsupported))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot find schema with current-schema-id=2 from schemas");
   }
@@ -1059,7 +978,7 @@ public class TestTableMetadata {
   @Test
   public void testParserV2SchemasValidation() throws Exception {
     String unsupported = readTableMetadataInputFile("TableMetadataV2MissingSchemas.json");
-    Assertions.assertThatThrownBy(() -> TableMetadataParser.fromJson(unsupported))
+    assertThatThrownBy(() -> TableMetadataParser.fromJson(unsupported))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("schemas must exist in format v2");
   }
@@ -1095,7 +1014,7 @@ public class TestTableMetadata {
             .add(3, 1001, "z_partition", Transforms.bucket(8))
             .build();
 
-    Assert.assertEquals(expected, metadata.spec());
+    assertThat(metadata.spec()).isEqualTo(expected);
   }
 
   @Test
@@ -1117,7 +1036,7 @@ public class TestTableMetadata {
             ImmutableMap.of(),
             1);
 
-    Assertions.assertThatThrownBy(() -> metadata.updatePartitionSpec(spec))
+    assertThatThrownBy(() -> metadata.updatePartitionSpec(spec))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Spec does not use sequential IDs that are required in v1");
   }
@@ -1134,7 +1053,7 @@ public class TestTableMetadata {
     TableMetadata metadata =
         TableMetadata.newTableMetadata(
             schema, spec, SortOrder.unsorted(), location, ImmutableMap.of(), 1);
-    Assert.assertEquals(spec, metadata.spec());
+    assertThat(metadata.spec()).isEqualTo(spec);
 
     Schema updatedSchema =
         new Schema(
@@ -1153,10 +1072,10 @@ public class TestTableMetadata {
             .add(2, 1001, "y", Transforms.alwaysNull())
             .add(3, 1002, "z_bucket", Transforms.bucket(8))
             .build();
-    Assert.assertEquals(
-        "Should reassign the partition field IDs and reuse any existing IDs for equivalent fields",
-        expected,
-        updated.spec());
+    assertThat(updated.spec())
+        .as(
+            "Should reassign the partition field IDs and reuse any existing IDs for equivalent fields")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -1171,7 +1090,7 @@ public class TestTableMetadata {
     TableMetadata metadata =
         TableMetadata.newTableMetadata(
             schema, spec, SortOrder.unsorted(), location, ImmutableMap.of(), 2);
-    Assert.assertEquals(spec, metadata.spec());
+    assertThat(metadata.spec()).isEqualTo(spec);
 
     Schema updatedSchema =
         new Schema(
@@ -1188,10 +1107,10 @@ public class TestTableMetadata {
             .add(3, 1002, "z_bucket", Transforms.bucket(8))
             .add(1, 1000, "x", Transforms.identity())
             .build();
-    Assert.assertEquals(
-        "Should reassign the partition field IDs and reuse any existing IDs for equivalent fields",
-        expected,
-        updated.spec());
+    assertThat(updated.spec())
+        .as(
+            "Should reassign the partition field IDs and reuse any existing IDs for equivalent fields")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -1201,11 +1120,10 @@ public class TestTableMetadata {
     TableMetadata meta =
         TableMetadata.newTableMetadata(
             schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
-    Assert.assertTrue("Should default to unsorted order", meta.sortOrder().isUnsorted());
-    Assert.assertSame(
-        "Should detect identical unsorted order",
-        meta,
-        meta.replaceSortOrder(SortOrder.unsorted()));
+    assertThat(meta.sortOrder().isUnsorted()).isTrue();
+    assertThat(meta.replaceSortOrder(SortOrder.unsorted()))
+        .as("Should detect identical unsorted order")
+        .isSameAs(meta);
   }
 
   @Test
@@ -1217,49 +1135,34 @@ public class TestTableMetadata {
     TableMetadata sortedByX =
         TableMetadata.newTableMetadata(
             schema, PartitionSpec.unpartitioned(), order, null, ImmutableMap.of());
-    Assert.assertEquals("Should have 1 sort order", 1, sortedByX.sortOrders().size());
-    Assert.assertEquals("Should use orderId 1", 1, sortedByX.sortOrder().orderId());
-    Assert.assertEquals("Should be sorted by one field", 1, sortedByX.sortOrder().fields().size());
-    Assert.assertEquals(
-        "Should use the table's field ids", 1, sortedByX.sortOrder().fields().get(0).sourceId());
-    Assert.assertEquals(
-        "Should be ascending",
-        SortDirection.ASC,
-        sortedByX.sortOrder().fields().get(0).direction());
-    Assert.assertEquals(
-        "Should be nulls first",
-        NullOrder.NULLS_FIRST,
-        sortedByX.sortOrder().fields().get(0).nullOrder());
+    assertThat(sortedByX.sortOrders()).hasSize(1);
+    assertThat(sortedByX.sortOrder().orderId()).isEqualTo(1);
+    assertThat(sortedByX.sortOrder().fields()).hasSize(1);
+    assertThat(sortedByX.sortOrder().fields().get(0).sourceId()).isEqualTo(1);
+    assertThat(sortedByX.sortOrder().fields().get(0).direction()).isEqualTo(SortDirection.ASC);
+    assertThat(sortedByX.sortOrder().fields().get(0).nullOrder()).isEqualTo(NullOrder.NULLS_FIRST);
 
     // build an equivalent order with the correct schema
     SortOrder newOrder = SortOrder.builderFor(sortedByX.schema()).asc("x").build();
 
     TableMetadata alsoSortedByX = sortedByX.replaceSortOrder(newOrder);
-    Assert.assertSame("Should detect current sortOrder and not update", alsoSortedByX, sortedByX);
+    assertThat(sortedByX)
+        .as("Should detect current sortOrder and not update")
+        .isSameAs(alsoSortedByX);
 
     TableMetadata unsorted = alsoSortedByX.replaceSortOrder(SortOrder.unsorted());
-    Assert.assertEquals("Should have 2 sort orders", 2, unsorted.sortOrders().size());
-    Assert.assertEquals("Should use orderId 0", 0, unsorted.sortOrder().orderId());
-    Assert.assertTrue("Should be unsorted", unsorted.sortOrder().isUnsorted());
+    assertThat(unsorted.sortOrders()).hasSize(2);
+    assertThat(unsorted.sortOrder().orderId()).isEqualTo(0);
+    assertThat(unsorted.sortOrder().isUnsorted()).isTrue();
 
     TableMetadata sortedByXDesc =
         unsorted.replaceSortOrder(SortOrder.builderFor(unsorted.schema()).desc("x").build());
-    Assert.assertEquals("Should have 3 sort orders", 3, sortedByXDesc.sortOrders().size());
-    Assert.assertEquals("Should use orderId 2", 2, sortedByXDesc.sortOrder().orderId());
-    Assert.assertEquals(
-        "Should be sorted by one field", 1, sortedByXDesc.sortOrder().fields().size());
-    Assert.assertEquals(
-        "Should use the table's field ids",
-        1,
-        sortedByXDesc.sortOrder().fields().get(0).sourceId());
-    Assert.assertEquals(
-        "Should be ascending",
-        SortDirection.DESC,
-        sortedByXDesc.sortOrder().fields().get(0).direction());
-    Assert.assertEquals(
-        "Should be nulls first",
-        NullOrder.NULLS_FIRST,
-        sortedByX.sortOrder().fields().get(0).nullOrder());
+    assertThat(sortedByXDesc.sortOrders()).hasSize(3);
+    assertThat(sortedByXDesc.sortOrder().orderId()).isEqualTo(2);
+    assertThat(sortedByXDesc.sortOrder().fields()).hasSize(1);
+    assertThat(sortedByXDesc.sortOrder().fields().get(0).sourceId()).isEqualTo(1);
+    assertThat(sortedByXDesc.sortOrder().fields().get(0).direction()).isEqualTo(SortDirection.DESC);
+    assertThat(sortedByX.sortOrder().fields().get(0).nullOrder()).isEqualTo(NullOrder.NULLS_FIRST);
   }
 
   @Test
@@ -1269,8 +1172,7 @@ public class TestTableMetadata {
     TableMetadata meta =
         TableMetadata.newTableMetadata(
             schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
-    Assert.assertEquals(
-        "Should default to no statistics files", ImmutableList.of(), meta.statisticsFiles());
+    assertThat(meta.statisticsFiles()).as("Should default to no statistics files").isEmpty();
   }
 
   @Test
@@ -1289,12 +1191,12 @@ public class TestTableMetadata {
                     43, "/some/path/to/stats/file", 128, 27, ImmutableList.of()))
             .build();
 
-    Assertions.assertThat(withStatistics.statisticsFiles())
+    assertThat(withStatistics.statisticsFiles())
         .as("There should be one statistics file registered")
         .hasSize(1);
     StatisticsFile statisticsFile = Iterables.getOnlyElement(withStatistics.statisticsFiles());
-    Assert.assertEquals("Statistics file snapshot", 43L, statisticsFile.snapshotId());
-    Assert.assertEquals("Statistics file path", "/some/path/to/stats/file", statisticsFile.path());
+    assertThat(statisticsFile.snapshotId()).isEqualTo(43L);
+    assertThat(statisticsFile.path()).isEqualTo("/some/path/to/stats/file");
 
     TableMetadata withStatisticsReplaced =
         TableMetadata.buildFrom(withStatistics)
@@ -1304,12 +1206,12 @@ public class TestTableMetadata {
                     43, "/some/path/to/stats/file2", 128, 27, ImmutableList.of()))
             .build();
 
-    Assertions.assertThat(withStatisticsReplaced.statisticsFiles())
+    assertThat(withStatisticsReplaced.statisticsFiles())
         .as("There should be one statistics file registered")
         .hasSize(1);
     statisticsFile = Iterables.getOnlyElement(withStatisticsReplaced.statisticsFiles());
-    Assert.assertEquals("Statistics file snapshot", 43L, statisticsFile.snapshotId());
-    Assert.assertEquals("Statistics file path", "/some/path/to/stats/file2", statisticsFile.path());
+    assertThat(statisticsFile.snapshotId()).isEqualTo(43L);
+    assertThat(statisticsFile.path()).isEqualTo("/some/path/to/stats/file2");
   }
 
   @Test
@@ -1330,19 +1232,18 @@ public class TestTableMetadata {
                     44, "/some/path/to/stats/file2", 128, 27, ImmutableList.of()))
             .build();
 
-    Assert.assertSame(
-        "Should detect no statistics to remove",
-        meta,
-        TableMetadata.buildFrom(meta).removeStatistics(42L).build());
+    assertThat(TableMetadata.buildFrom(meta).removeStatistics(42L).build())
+        .as("Should detect no statistics to remove")
+        .isSameAs(meta);
 
     TableMetadata withOneRemoved = TableMetadata.buildFrom(meta).removeStatistics(43).build();
 
-    Assertions.assertThat(withOneRemoved.statisticsFiles())
+    assertThat(withOneRemoved.statisticsFiles())
         .as("There should be one statistics file retained")
         .hasSize(1);
     StatisticsFile statisticsFile = Iterables.getOnlyElement(withOneRemoved.statisticsFiles());
-    Assert.assertEquals("Statistics file snapshot", 44L, statisticsFile.snapshotId());
-    Assert.assertEquals("Statistics file path", "/some/path/to/stats/file2", statisticsFile.path());
+    assertThat(statisticsFile.snapshotId()).isEqualTo(44L);
+    assertThat(statisticsFile.path()).isEqualTo("/some/path/to/stats/file2");
   }
 
   @Test
@@ -1352,10 +1253,9 @@ public class TestTableMetadata {
     TableMetadata meta =
         TableMetadata.newTableMetadata(
             schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
-    Assert.assertEquals(
-        "Should default to no partition statistics files",
-        ImmutableList.of(),
-        meta.partitionStatisticsFiles());
+    assertThat(meta.partitionStatisticsFiles())
+        .as("Should default to no partition statistics files")
+        .isEmpty();
   }
 
   @Test
@@ -1376,18 +1276,15 @@ public class TestTableMetadata {
                     .build())
             .build();
 
-    Assertions.assertThat(withPartitionStatistics.partitionStatisticsFiles())
+    assertThat(withPartitionStatistics.partitionStatisticsFiles())
         .as("There should be one partition statistics file registered")
         .hasSize(1);
     PartitionStatisticsFile partitionStatisticsFile =
         Iterables.getOnlyElement(withPartitionStatistics.partitionStatisticsFiles());
-    Assert.assertEquals("Statistics file snapshot", 43L, partitionStatisticsFile.snapshotId());
-    Assert.assertEquals(
-        "Statistics file path",
-        "/some/path/to/partition/stats/file.parquet",
-        partitionStatisticsFile.path());
-    Assert.assertEquals(
-        "Statistics file size in bytes", 42L, partitionStatisticsFile.fileSizeInBytes());
+    assertThat(partitionStatisticsFile.snapshotId()).isEqualTo(43L);
+    assertThat(partitionStatisticsFile.path())
+        .isEqualTo("/some/path/to/partition/stats/file.parquet");
+    assertThat(partitionStatisticsFile.fileSizeInBytes()).isEqualTo(42L);
 
     TableMetadata withStatisticsReplaced =
         TableMetadata.buildFrom(withPartitionStatistics)
@@ -1399,18 +1296,15 @@ public class TestTableMetadata {
                     .build())
             .build();
 
-    Assertions.assertThat(withStatisticsReplaced.partitionStatisticsFiles())
+    assertThat(withStatisticsReplaced.partitionStatisticsFiles())
         .as("There should be one statistics file registered")
         .hasSize(1);
     partitionStatisticsFile =
         Iterables.getOnlyElement(withStatisticsReplaced.partitionStatisticsFiles());
-    Assert.assertEquals("Statistics file snapshot", 43L, partitionStatisticsFile.snapshotId());
-    Assert.assertEquals(
-        "Statistics file path",
-        "/some/path/to/partition/stats/file2.parquet",
-        partitionStatisticsFile.path());
-    Assert.assertEquals(
-        "Statistics file size in bytes", 48L, partitionStatisticsFile.fileSizeInBytes());
+    assertThat(partitionStatisticsFile.snapshotId()).isEqualTo(43L);
+    assertThat(partitionStatisticsFile.path())
+        .isEqualTo("/some/path/to/partition/stats/file2.parquet");
+    assertThat(partitionStatisticsFile.fileSizeInBytes()).isEqualTo(48L);
   }
 
   @Test
@@ -1435,44 +1329,40 @@ public class TestTableMetadata {
                     .build())
             .build();
 
-    Assert.assertSame(
-        "Should detect no partition statistics to remove",
-        meta,
-        TableMetadata.buildFrom(meta).removePartitionStatistics(42L).build());
+    assertThat(TableMetadata.buildFrom(meta).removePartitionStatistics(42L).build())
+        .as("Should detect no partition statistics to remove")
+        .isSameAs(meta);
 
     TableMetadata withOneRemoved =
         TableMetadata.buildFrom(meta).removePartitionStatistics(43).build();
 
-    Assertions.assertThat(withOneRemoved.partitionStatisticsFiles())
+    assertThat(withOneRemoved.partitionStatisticsFiles())
         .as("There should be one partition statistics file retained")
         .hasSize(1);
     PartitionStatisticsFile partitionStatisticsFile =
         Iterables.getOnlyElement(withOneRemoved.partitionStatisticsFiles());
-    Assert.assertEquals("Statistics file snapshot", 44L, partitionStatisticsFile.snapshotId());
-    Assert.assertEquals(
-        "Statistics file path",
-        "/some/path/to/partition/stats/file2.parquet",
-        partitionStatisticsFile.path());
-    Assert.assertEquals(
-        "Statistics file size in bytes", 49L, partitionStatisticsFile.fileSizeInBytes());
+    assertThat(partitionStatisticsFile.snapshotId()).isEqualTo(44L);
+    assertThat(partitionStatisticsFile.path())
+        .isEqualTo("/some/path/to/partition/stats/file2.parquet");
+    assertThat(partitionStatisticsFile.fileSizeInBytes()).isEqualTo(49L);
   }
 
   @Test
   public void testParseSchemaIdentifierFields() throws Exception {
     String data = readTableMetadataInputFile("TableMetadataV2Valid.json");
     TableMetadata parsed = TableMetadataParser.fromJson(data);
-    Assert.assertEquals(Sets.newHashSet(), parsed.schemasById().get(0).identifierFieldIds());
-    Assert.assertEquals(Sets.newHashSet(1, 2), parsed.schemasById().get(1).identifierFieldIds());
+    assertThat(parsed.schemasById().get(0).identifierFieldIds()).isEmpty();
+    assertThat(parsed.schemasById().get(1).identifierFieldIds()).containsExactly(1, 2);
   }
 
   @Test
   public void testParseMinimal() throws Exception {
     String data = readTableMetadataInputFile("TableMetadataV2ValidMinimal.json");
     TableMetadata parsed = TableMetadataParser.fromJson(data);
-    Assertions.assertThat(parsed.snapshots()).isEmpty();
-    Assertions.assertThat(parsed.snapshotLog()).isEmpty();
-    Assertions.assertThat(parsed.properties()).isEmpty();
-    Assertions.assertThat(parsed.previousFiles()).isEmpty();
+    assertThat(parsed.snapshots()).isEmpty();
+    assertThat(parsed.snapshotLog()).isEmpty();
+    assertThat(parsed.properties()).isEmpty();
+    assertThat(parsed.previousFiles()).isEmpty();
   }
 
   @Test
@@ -1488,8 +1378,8 @@ public class TestTableMetadata {
             Lists.newArrayList(Types.NestedField.required(1, "x", Types.StringType.get())),
             Sets.newHashSet(1));
     TableMetadata newMeta = meta.updateSchema(newSchema, 1);
-    Assert.assertEquals(2, newMeta.schemas().size());
-    Assert.assertEquals(Sets.newHashSet(1), newMeta.schema().identifierFieldIds());
+    assertThat(newMeta.schemas()).hasSize(2);
+    assertThat(newMeta.schema().identifierFieldIds()).containsExactly(1);
   }
 
   @Test
@@ -1499,16 +1389,10 @@ public class TestTableMetadata {
     TableMetadata freshTable =
         TableMetadata.newTableMetadata(
             schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
-    Assert.assertEquals(
-        "Should use TableMetadata.INITIAL_SCHEMA_ID for current schema id",
-        TableMetadata.INITIAL_SCHEMA_ID,
-        freshTable.currentSchemaId());
+    assertThat(freshTable.currentSchemaId()).isEqualTo(TableMetadata.INITIAL_SCHEMA_ID);
     assertSameSchemaList(ImmutableList.of(schema), freshTable.schemas());
-    Assert.assertEquals(
-        "Should have expected schema upon return",
-        schema.asStruct(),
-        freshTable.schema().asStruct());
-    Assert.assertEquals("Should return expected last column id", 1, freshTable.lastColumnId());
+    assertThat(freshTable.schema().asStruct()).isEqualTo(schema.asStruct());
+    assertThat(freshTable.lastColumnId()).isEqualTo(1);
 
     // update schema
     Schema schema2 =
@@ -1516,14 +1400,11 @@ public class TestTableMetadata {
             Types.NestedField.required(1, "y", Types.LongType.get(), "comment"),
             Types.NestedField.required(2, "x", Types.StringType.get()));
     TableMetadata twoSchemasTable = freshTable.updateSchema(schema2, 2);
-    Assert.assertEquals("Should have current schema id as 1", 1, twoSchemasTable.currentSchemaId());
+    assertThat(twoSchemasTable.currentSchemaId()).isEqualTo(1);
     assertSameSchemaList(
         ImmutableList.of(schema, new Schema(1, schema2.columns())), twoSchemasTable.schemas());
-    Assert.assertEquals(
-        "Should have expected schema upon return",
-        schema2.asStruct(),
-        twoSchemasTable.schema().asStruct());
-    Assert.assertEquals("Should return expected last column id", 2, twoSchemasTable.lastColumnId());
+    assertThat(twoSchemasTable.schema().asStruct()).isEqualTo(schema2.asStruct());
+    assertThat(twoSchemasTable.lastColumnId()).isEqualTo(2);
 
     // update schema with the same schema and last column ID as current shouldn't cause change
     Schema sameSchema2 =
@@ -1531,35 +1412,25 @@ public class TestTableMetadata {
             Types.NestedField.required(1, "y", Types.LongType.get(), "comment"),
             Types.NestedField.required(2, "x", Types.StringType.get()));
     TableMetadata sameSchemaTable = twoSchemasTable.updateSchema(sameSchema2, 2);
-    Assert.assertSame("Should return same table metadata", twoSchemasTable, sameSchemaTable);
+    assertThat(sameSchemaTable).isSameAs(twoSchemasTable);
 
     // update schema with the same schema and different last column ID as current should create
     // a new table
     TableMetadata differentColumnIdTable = sameSchemaTable.updateSchema(sameSchema2, 3);
-    Assert.assertEquals(
-        "Should have current schema id as 1", 1, differentColumnIdTable.currentSchemaId());
+    assertThat(differentColumnIdTable.currentSchemaId()).isEqualTo(1);
     assertSameSchemaList(
         ImmutableList.of(schema, new Schema(1, schema2.columns())),
         differentColumnIdTable.schemas());
-    Assert.assertEquals(
-        "Should have expected schema upon return",
-        schema2.asStruct(),
-        differentColumnIdTable.schema().asStruct());
-    Assert.assertEquals(
-        "Should return expected last column id", 3, differentColumnIdTable.lastColumnId());
+    assertThat(differentColumnIdTable.schema().asStruct()).isEqualTo(schema2.asStruct());
+    assertThat(differentColumnIdTable.lastColumnId()).isEqualTo(3);
 
     // update schema with old schema does not change schemas
     TableMetadata revertSchemaTable = differentColumnIdTable.updateSchema(schema, 3);
-    Assert.assertEquals(
-        "Should have current schema id as 0", 0, revertSchemaTable.currentSchemaId());
+    assertThat(revertSchemaTable.currentSchemaId()).isEqualTo(0);
     assertSameSchemaList(
         ImmutableList.of(schema, new Schema(1, schema2.columns())), revertSchemaTable.schemas());
-    Assert.assertEquals(
-        "Should have expected schema upon return",
-        schema.asStruct(),
-        revertSchemaTable.schema().asStruct());
-    Assert.assertEquals(
-        "Should return expected last column id", 3, revertSchemaTable.lastColumnId());
+    assertThat(revertSchemaTable.schema().asStruct()).isEqualTo(schema.asStruct());
+    assertThat(revertSchemaTable.lastColumnId()).isEqualTo(3);
 
     // create new schema will use the largest schema id + 1
     Schema schema3 =
@@ -1568,18 +1439,13 @@ public class TestTableMetadata {
             Types.NestedField.required(4, "x", Types.StringType.get()),
             Types.NestedField.required(6, "z", Types.IntegerType.get()));
     TableMetadata threeSchemaTable = revertSchemaTable.updateSchema(schema3, 6);
-    Assert.assertEquals(
-        "Should have current schema id as 2", 2, threeSchemaTable.currentSchemaId());
+    assertThat(threeSchemaTable.currentSchemaId()).isEqualTo(2);
     assertSameSchemaList(
         ImmutableList.of(
             schema, new Schema(1, schema2.columns()), new Schema(2, schema3.columns())),
         threeSchemaTable.schemas());
-    Assert.assertEquals(
-        "Should have expected schema upon return",
-        schema3.asStruct(),
-        threeSchemaTable.schema().asStruct());
-    Assert.assertEquals(
-        "Should return expected last column id", 6, threeSchemaTable.lastColumnId());
+    assertThat(threeSchemaTable.schema().asStruct()).isEqualTo(schema3.asStruct());
+    assertThat(threeSchemaTable.lastColumnId()).isEqualTo(6);
   }
 
   @Test
@@ -1640,56 +1506,55 @@ public class TestTableMetadata {
         meta.replaceProperties(
             ImmutableMap.of(TableProperties.FORMAT_VERSION, "2", "key2", "val2"));
 
-    Assert.assertEquals(
-        "format version should be configured based on the format-version key",
-        2,
-        meta.formatVersion());
-    Assert.assertEquals(
-        "should not contain format-version but should contain new properties",
-        ImmutableMap.of("key2", "val2"),
-        meta.properties());
+    assertThat(meta.formatVersion())
+        .as("format version should be configured based on the format-version key")
+        .isEqualTo(2);
+    assertThat(meta.properties())
+        .as("should not contain format-version but should contain new properties")
+        .containsEntry("key2", "val2");
   }
 
   @Test
   public void testParseStatisticsFiles() throws Exception {
     String data = readTableMetadataInputFile("TableMetadataStatisticsFiles.json");
     TableMetadata parsed = TableMetadataParser.fromJson(data);
-    Assertions.assertThat(parsed.statisticsFiles()).as("parsed statistics files").hasSize(1);
-    Assert.assertEquals(
-        "parsed statistics file",
-        new GenericStatisticsFile(
-            3055729675574597004L,
-            "s3://a/b/stats.puffin",
-            413,
-            42,
-            ImmutableList.of(
-                new GenericBlobMetadata(
-                    "ndv", 3055729675574597004L, 1, ImmutableList.of(1), ImmutableMap.of()))),
-        Iterables.getOnlyElement(parsed.statisticsFiles()));
+    assertThat(parsed.statisticsFiles()).as("parsed statistics files").hasSize(1);
+    assertThat(parsed.statisticsFiles())
+        .as("parsed statistics file")
+        .hasSize(1)
+        .first()
+        .isEqualTo(
+            new GenericStatisticsFile(
+                3055729675574597004L,
+                "s3://a/b/stats.puffin",
+                413,
+                42,
+                ImmutableList.of(
+                    new GenericBlobMetadata(
+                        "ndv", 3055729675574597004L, 1, ImmutableList.of(1), ImmutableMap.of()))));
   }
 
   @Test
   public void testParsePartitionStatisticsFiles() throws Exception {
     String data = readTableMetadataInputFile("TableMetadataPartitionStatisticsFiles.json");
     TableMetadata parsed = TableMetadataParser.fromJson(data);
-    Assertions.assertThat(parsed.partitionStatisticsFiles())
+    assertThat(parsed.partitionStatisticsFiles())
         .as("parsed partition statistics files")
-        .hasSize(1);
-    Assert.assertEquals(
-        "parsed partition statistics file",
-        ImmutableGenericPartitionStatisticsFile.builder()
-            .snapshotId(3055729675574597004L)
-            .path("s3://a/b/partition-stats.parquet")
-            .fileSizeInBytes(43L)
-            .build(),
-        Iterables.getOnlyElement(parsed.partitionStatisticsFiles()));
+        .hasSize(1)
+        .first()
+        .isEqualTo(
+            ImmutableGenericPartitionStatisticsFile.builder()
+                .snapshotId(3055729675574597004L)
+                .path("s3://a/b/partition-stats.parquet")
+                .fileSizeInBytes(43L)
+                .build());
   }
 
   @Test
   public void testNoReservedPropertyForTableMetadataCreation() {
     Schema schema = new Schema(Types.NestedField.required(10, "x", Types.StringType.get()));
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 TableMetadata.newTableMetadata(
                     schema,
@@ -1702,7 +1567,7 @@ public class TestTableMetadata {
         .hasMessage(
             "Table properties should not contain reserved properties, but got {format-version=1}");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 TableMetadata.newTableMetadata(
                     schema,
@@ -1722,10 +1587,9 @@ public class TestTableMetadata {
     TableMetadata meta =
         TableMetadata.newTableMetadata(
             TEST_SCHEMA, SPEC_5, SORT_ORDER_3, locationWithSlash, Collections.emptyMap());
-    Assert.assertEquals(
-        "Metadata should never return a location ending in a slash",
-        locationWithoutSlash,
-        meta.location());
+    assertThat(meta.location())
+        .as("Metadata should never return a location ending in a slash")
+        .isEqualTo(locationWithoutSlash);
   }
 
   private String createManifestListWithManifestFile(
@@ -1746,9 +1610,9 @@ public class TestTableMetadata {
   public void buildReplacementKeepsSnapshotLog() throws Exception {
     TableMetadata metadata =
         TableMetadataParser.fromJson(readTableMetadataInputFile("TableMetadataV2Valid.json"));
-    Assertions.assertThat(metadata.currentSnapshot()).isNotNull();
-    Assertions.assertThat(metadata.snapshots()).hasSize(2);
-    Assertions.assertThat(metadata.snapshotLog()).hasSize(2);
+    assertThat(metadata.currentSnapshot()).isNotNull();
+    assertThat(metadata.snapshots()).hasSize(2);
+    assertThat(metadata.snapshotLog()).hasSize(2);
 
     TableMetadata replacement =
         metadata.buildReplacement(
@@ -1758,11 +1622,9 @@ public class TestTableMetadata {
             metadata.location(),
             metadata.properties());
 
-    Assertions.assertThat(replacement.currentSnapshot()).isNull();
-    Assertions.assertThat(replacement.snapshots())
-        .hasSize(2)
-        .containsExactlyElementsOf(metadata.snapshots());
-    Assertions.assertThat(replacement.snapshotLog())
+    assertThat(replacement.currentSnapshot()).isNull();
+    assertThat(replacement.snapshots()).hasSize(2).containsExactlyElementsOf(metadata.snapshots());
+    assertThat(replacement.snapshotLog())
         .hasSize(2)
         .containsExactlyElementsOf(metadata.snapshotLog());
   }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadataSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadataSerialization.java
@@ -19,29 +19,26 @@
 package org.apache.iceberg;
 
 import static org.apache.iceberg.TestHelpers.assertSameSchemaList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestTableMetadataSerialization extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestTableMetadataSerialization extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestTableMetadataSerialization(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testSerialization() throws Exception {
     // add a commit to the metadata so there is at least one snapshot, and history
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
@@ -59,31 +56,21 @@ public class TestTableMetadataSerialization extends TableTestBase {
       result = (TableMetadata) reader.readObject();
     }
 
-    Assert.assertEquals(
-        "Metadata file location should match",
-        meta.metadataFileLocation(),
-        result.metadataFileLocation());
-    Assert.assertEquals("UUID should match", meta.uuid(), result.uuid());
-    Assert.assertEquals("Location should match", meta.location(), result.location());
-    Assert.assertEquals(
-        "Last updated should match", meta.lastUpdatedMillis(), result.lastUpdatedMillis());
-    Assert.assertEquals("Last column id", meta.lastColumnId(), result.lastColumnId());
-    Assert.assertEquals(
-        "Schema should match", meta.schema().asStruct(), result.schema().asStruct());
+    assertThat(result.metadataFileLocation()).isEqualTo(meta.metadataFileLocation());
+    assertThat(result.uuid()).isEqualTo(meta.uuid());
+    assertThat(result.location()).isEqualTo(meta.location());
+    assertThat(result.lastUpdatedMillis()).isEqualTo(meta.lastUpdatedMillis());
+    assertThat(result.lastColumnId()).isEqualTo(meta.lastColumnId());
+    assertThat(result.schema().asStruct()).isEqualTo(meta.schema().asStruct());
     assertSameSchemaList(meta.schemas(), result.schemas());
-    Assert.assertEquals(
-        "Current schema id should match", meta.currentSchemaId(), result.currentSchemaId());
-    Assert.assertEquals("Spec should match", meta.defaultSpecId(), result.defaultSpecId());
-    Assert.assertEquals("Spec list should match", meta.specs(), result.specs());
-    Assert.assertEquals("Properties should match", meta.properties(), result.properties());
-    Assert.assertEquals(
-        "Current snapshot ID should match",
-        meta.currentSnapshot().snapshotId(),
-        result.currentSnapshot().snapshotId());
-    Assert.assertEquals(
-        "Snapshots should match",
-        Lists.transform(meta.snapshots(), Snapshot::snapshotId),
-        Lists.transform(result.snapshots(), Snapshot::snapshotId));
-    Assert.assertEquals("History should match", meta.snapshotLog(), result.snapshotLog());
+    assertThat(result.currentSchemaId()).isEqualTo(meta.currentSchemaId());
+    assertThat(result.defaultSpecId()).isEqualTo(meta.defaultSpecId());
+    assertThat(result.specs()).isEqualTo(meta.specs());
+    assertThat(result.properties()).isEqualTo(meta.properties());
+    assertThat(result.currentSnapshot().snapshotId())
+        .isEqualTo(meta.currentSnapshot().snapshotId());
+    assertThat(Lists.transform(result.snapshots(), Snapshot::snapshotId))
+        .isEqualTo(Lists.transform(meta.snapshots(), Snapshot::snapshotId));
+    assertThat(result.snapshotLog()).isEqualTo(meta.snapshotLog());
   }
 }


### PR DESCRIPTION
Migrate the following "Read" in iceberg-core to JUnit 5 for https://github.com/apache/iceberg/issues/9085.

## Current Progress
- [x] TableMetadataParserCodecTest
- [x] TableMetadataParserTest
- [x] TestMetadataUpdateParser
- [x] TestMetadataTableFilters
- [x] TestTableMetadata
- [x] TestTableMetadataSerialization
