### PR TITLE
Add issue template and docs for iceberg proposals

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_proposal.yml
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: Iceberg Improvement Proposal
+description: Propose a Spec change or major feature
+labels: ["proposal"]
+body:
+  - type: markdown
+    attributes:
+      value: "Please see documentation site for information on [contributing proposals](https://iceberg.apache.org/contribute/#iceberg-improvement-proposals)"
+  - type: textarea
+    attributes:
+      label: Proposed Change
+      description: Please describe the proposal and elaborate on the use case and motivation
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Proposal document
+      description: |
+        Link to the proposal document.  Google Docs is preferred format to allow for public 
+        comment and sharing
+  - type: checkboxes
+    attributes:
+      label: Specifications
+      description: Which specifications are affected by this proposal?
+      options:
+        - label: Table
+        - label: View
+        - label: REST
+        - label: Puffin
+        - label: Encryption
+        - label: Other

--- a/.github/ISSUE_TEMPLATE/iceberg_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_proposal.yml
@@ -35,7 +35,7 @@ body:
     attributes:
       label: Proposal document
       description: |
-        Link to the proposal document.  Google Docs is preferred format to allow for public 
+        Link to the proposal document. Google Docs is preferred format to allow for public 
         comment and sharing
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/iceberg_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_proposal.yml
@@ -24,7 +24,7 @@ labels: ["proposal"]
 body:
   - type: markdown
     attributes:
-      value: "Please see documentation site for information on [contributing proposals](https://iceberg.apache.org/contribute/#iceberg-improvement-proposals)"
+      value: "Please see documentation site for information on [contributing proposals](https://iceberg.apache.org/contribute/#apache-iceberg-improvement-proposals)"
   - type: textarea
     attributes:
       label: Proposed Change

--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -56,7 +56,7 @@ scope need to be considered carefully and incorporate feedback from many communi
 
 ### What should a proposal include?
 
-1. A GitHub issue created using the `Iceberg Improvement Proposal` template
+1. A GitHub issue created using the `Apache Iceberg Improvement Proposal` template
 2. A document including the following:
     * Motivation for the change 
     * Implementation proposal 

--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -51,7 +51,7 @@ The Iceberg community prefers to receive contributions as [Github pull requests]
 ### What is an improvement proposal?
 
 An improvement proposal is a major change to Apache Iceberg that may require changes to an existing specification, creation
-of a new specification, or significant changes to any of the existing Iceberg implementations.  Changes that are large in
+of a new specification, or significant additions/changes to any of the existing Iceberg implementations.  Changes that are large in
 scope need to be considered carefully and incorporate feedback from many community stakeholders.
 
 ### What should a proposal include?

--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -62,7 +62,7 @@ scope need to be considered carefully and incorporate feedback from many communi
     * Implementation proposal 
     * Breaking changes/incompatibilities 
     * Alternatives considered
-3. A discussion thread initiated in the dev list with the Subject: '[DISCUSS] \<proposal title\>'
+3. A discussion thread initiated in the dev list with the Subject: '[DISCUSS] <proposal title\>'
 
 ### Who can submit a proposal?
 
@@ -72,7 +72,15 @@ Anyone can submit a proposal, but be considerate and submit only if you plan on 
 
 Current proposals are tracked in GitHub issues with the label [Proposal][iceberg-proposals]
 
+### How are proposals adopted?
+
+Once general consensus has been reached, a vote should be raised on the dev list.  The vote follows the ASF 
+[code modification][apache-vote] model with three positive PMC votes required and no lazy consensus modifier.
+The voting process should be held in good faith to reinforce and affirm the agreed upon proposal, not to 
+settle disagreements or to force a decision.
+
 [iceberg-proposals]: https://github.com/apache/iceberg/issues?q=is%3Aissue+is%3Aopen+label%3Aproposal+
+[apache-vote]: https://www.apache.org/foundation/voting.html#apache-voting-process
 
 ## Building the Project Locally
 

--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -46,7 +46,7 @@ The Iceberg community prefers to receive contributions as [Github pull requests]
 * If a PR is posted for visibility and isn't necessarily ready for review or merging, be sure to convert the PR to a draft
 
 
-## Iceberg Improvement Proposals
+## Apache Iceberg Improvement Proposals
 
 ### What is an improvement proposal?
 

--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -46,6 +46,34 @@ The Iceberg community prefers to receive contributions as [Github pull requests]
 * If a PR is posted for visibility and isn't necessarily ready for review or merging, be sure to convert the PR to a draft
 
 
+## Iceberg Improvement Proposals
+
+### What is an improvement proposal?
+
+An improvement proposal is a major change to Apache Iceberg that may require changes to an existing specification, creation
+of a new specification, or significant changes to any of the existing Iceberg implementations.  Changes that are large in
+scope need to be considered carefully and incorporate feedback from many community stakeholders.
+
+### What should a proposal include?
+
+1. A GitHub issue created using the `Iceberg Improvement Proposal` template
+2. A document including the following:
+    * Motivation for the change 
+    * Implementation proposal 
+    * Breaking changes/incompatibilities 
+    * Alternatives considered
+3. A discussion thread initiated in the dev list with the Subject: '[DISCUSS] \<proposal title\>'
+
+### Who can submit a proposal?
+
+Anyone can submit a proposal, but be considerate and submit only if you plan on contributing to the implementation.
+
+### Where can I find current proposals?
+
+Current proposals are tracked in GitHub issues with the label [Proposal][iceberg-proposals]
+
+[iceberg-proposals]: https://github.com/apache/iceberg/issues?q=is%3Aissue+is%3Aopen+label%3Aproposal+
+
 ## Building the Project Locally
 
 Iceberg is built using Gradle with Java 8 or Java 11.


### PR DESCRIPTION
This PR adds an issue template for Iceberg improvement proposals and adds docs to the site to cover the proposal process.