### PR TITLE
Fix `TestStrictMetricsEvaluator` assertion message

### DIFF
--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -592,7 +592,7 @@ public class TestStrictMetricsEvaluator {
     boolean shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notIn("id", INT_MIN_VALUE - 25, INT_MIN_VALUE - 24))
             .eval(FILE);
-    assertThat(shouldRead).as("Should not match: all values !=5 and !=6").isTrue();
+    assertThat(shouldRead).as("Should match: all values !=5 and !=6").isTrue();
 
     shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notIn("id", INT_MIN_VALUE - 1, INT_MIN_VALUE))


### PR DESCRIPTION
All values (`5` and `6`) are not between the upper and lower bound of `[30, 79]`.