### PR TITLE
Fix hive mapreduce insert error in kerberos environment

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergGenTokenHook.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergGenTokenHook.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.mr.hive;
+
+import java.io.Serializable;
+import java.util.stream.Stream;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.QueryPlan;
+import org.apache.hadoop.hive.ql.exec.Task;
+import org.apache.hadoop.hive.ql.exec.mr.MapRedTask;
+import org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext;
+import org.apache.hadoop.hive.ql.hooks.HookContext;
+import org.apache.hadoop.hive.ql.hooks.WriteEntity;
+import org.apache.hadoop.hive.ql.metadata.Hive;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+
+public class HiveIcebergGenTokenHook implements ExecuteWithHookContext {
+  private static final String ICEBERG_HIVE_METASTORE_TOKEN = "iceberg.hive.metastore.token";
+  private static final String ICEBERG_SERDE = "org.apache.iceberg.mr.hive.HiveIcebergSerDe";
+
+  @Override
+  public void run(HookContext hookContext) {
+    HiveConf conf = hookContext.getConf();
+    if (!conf.get(ICEBERG_HIVE_METASTORE_TOKEN, "").isEmpty()
+        || hookContext.isHiveServerQuery()
+        || hookContext.getOperationName() == null) {
+      return;
+    }
+
+    QueryPlan qp = hookContext.getQueryPlan();
+    Stream<WriteEntity> writeEntirys =
+        qp.getOutputs().stream()
+            .filter(
+                output -> {
+                  return output.getTable() != null
+                      && output
+                          .getTable()
+                          .getSd()
+                          .getSerdeInfo()
+                          .getSerializationLib()
+                          .equals(ICEBERG_SERDE);
+                });
+    Stream<Task<? extends Serializable>> tasks =
+        qp.getRootTasks().stream()
+            .filter(
+                task -> {
+                  return MapRedTask.class.isInstance(task);
+                });
+
+    if (writeEntirys.count() == 0 || tasks.count() == 0) {
+      return;
+    }
+
+    Hive db;
+    String token;
+    try {
+      db = Hive.get(hookContext.getConf());
+      token = db.getDelegationToken(hookContext.getUserName(), hookContext.getUgi().getUserName());
+    } catch (HiveException e) {
+      // ignore
+      db = null;
+      return;
+    }
+    if (token != null && !token.isEmpty()) {
+      hookContext.getConf().set(ICEBERG_HIVE_METASTORE_TOKEN, token);
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?


When we are in kerberos environment, use hive mr to insert data into iceberg table, we will get Exception :

```
Caused by: MetaException(message:Could not connect to meta store using any of the URIs provided. Most recent failure: org.apache.thrift.transport.TTransportException: GSS initiate failed at org.apache.thrift.transport.TSaslTransport.sendAndThrowMessage(TSaslTransport.java:232) 
at org.apache.thrift.transport.TSaslTransport.open(TSaslTransport.java:316) at org.apache.thrift.transport.TSaslClientTransport.open(TSaslClientTransport.java:37) 
at org.apache.hadoop.hive.thrift.client.TUGIAssumingTransport$1.run(TUGIAssumingTransport.java:52)

```
hive can not connect HMS in yarn container beacause it has no kerberos ticket. So we need to send delegation token to the yarn container.

To resolve this issue, i define a hive hook and get delegation before mapreduce runging. Then store the delegation token to config . When `OutputCommitter#setupJob` , it would get the token from the config then add it to UGI . So hive can connect to HMS in the yarn container.



### Why are the changes needed?
fix issue.

### Does this PR introduce any user-facing change?
add hive hook:

```
    <property>
        <name>hive.exec.pre.hooks</name>
        <value>org.apache.iceberg.mr.hive.HiveIcebergGenTokenHook</value>
    </property>
```

### How was this patch tested?
Manual testing
