### PR TITLE
Fix `rewrite_position_delete_files` result file set

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackPositionDeletesRewriter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackPositionDeletesRewriter.java
@@ -64,6 +64,8 @@ class SparkBinPackPositionDeletesRewriter extends SizeBasedPositionDeletesRewrit
     // Disable Adaptive Query Execution as this may change the output partitioning of our write
     this.spark = spark.cloneSession();
     this.spark.conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), false);
+    // Because we're turning off AQE we need to turn off shuffle partitions b/c deletes rewriter makes a join later
+    this.spark.conf().set(SQLConf.SHUFFLE_PARTITIONS().key(), "1");
   }
 
   @Override


### PR DESCRIPTION
The SparkBinPackPositionDeletesRewriter module disables Adaptive Query Execution (AQE) to correct issues with partitioning.

However, if the parent Spark session is configured with a `spark.sql.shuffle.partitions` value not equal to 1, this can lead to the creation of multiple delete files, rather than a single file.

To address this issue, enforce setting sql.shuffle.partitions to 1.

Fixes https://github.com/apache/iceberg/issues/9833