### PR TITLE
Core: Add explicit JSON parser for ConfigResponse

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -55,6 +55,8 @@ import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequestParser;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequestParser;
+import org.apache.iceberg.rest.responses.ConfigResponse;
+import org.apache.iceberg.rest.responses.ConfigResponseParser;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.apache.iceberg.rest.responses.ImmutableLoadViewResponse;
@@ -111,7 +113,9 @@ public class RESTSerializers {
         .addSerializer(LoadViewResponse.class, new LoadViewResponseSerializer<>())
         .addSerializer(ImmutableLoadViewResponse.class, new LoadViewResponseSerializer<>())
         .addDeserializer(LoadViewResponse.class, new LoadViewResponseDeserializer<>())
-        .addDeserializer(ImmutableLoadViewResponse.class, new LoadViewResponseDeserializer<>());
+        .addDeserializer(ImmutableLoadViewResponse.class, new LoadViewResponseDeserializer<>())
+        .addSerializer(ConfigResponse.class, new ConfigResponseSerializer<>())
+        .addDeserializer(ConfigResponse.class, new ConfigResponseDeserializer<>());
 
     mapper.registerModule(module);
   }
@@ -400,6 +404,22 @@ public class RESTSerializers {
     public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
       JsonNode jsonNode = p.getCodec().readTree(p);
       return (T) LoadViewResponseParser.fromJson(jsonNode);
+    }
+  }
+
+  static class ConfigResponseSerializer<T extends ConfigResponse> extends JsonSerializer<T> {
+    @Override
+    public void serialize(T request, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      ConfigResponseParser.toJson(request, gen);
+    }
+  }
+
+  static class ConfigResponseDeserializer<T extends ConfigResponse> extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) ConfigResponseParser.fromJson(jsonNode);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ConfigResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ConfigResponseParser.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class ConfigResponseParser {
+
+  private static final String DEFAULTS = "defaults";
+  private static final String OVERRIDES = "overrides";
+
+  private ConfigResponseParser() {}
+
+  public static String toJson(ConfigResponse response) {
+    return toJson(response, false);
+  }
+
+  public static String toJson(ConfigResponse response, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(response, gen), pretty);
+  }
+
+  public static void toJson(ConfigResponse response, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != response, "Invalid config response: null");
+
+    gen.writeStartObject();
+
+    JsonUtil.writeStringMap(DEFAULTS, response.defaults(), gen);
+    JsonUtil.writeStringMap(OVERRIDES, response.overrides(), gen);
+
+    gen.writeEndObject();
+  }
+
+  public static ConfigResponse fromJson(String json) {
+    return JsonUtil.parse(json, ConfigResponseParser::fromJson);
+  }
+
+  public static ConfigResponse fromJson(JsonNode json) {
+    Preconditions.checkArgument(null != json, "Cannot parse config response from null object");
+
+    ConfigResponse.Builder builder = ConfigResponse.builder();
+
+    if (json.hasNonNull(DEFAULTS)) {
+      builder.withDefaults(JsonUtil.getStringMapNullableValues(DEFAULTS, json));
+    }
+
+    if (json.hasNonNull(OVERRIDES)) {
+      builder.withOverrides(JsonUtil.getStringMapNullableValues(OVERRIDES, json));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 
 public class JsonUtil {
@@ -204,6 +205,25 @@ public class JsonUtil {
       builder.put(field, getString(field, pNode));
     }
     return builder.build();
+  }
+
+  public static Map<String, String> getStringMapNullableValues(String property, JsonNode node) {
+    Preconditions.checkArgument(node.has(property), "Cannot parse missing map: %s", property);
+    JsonNode pNode = node.get(property);
+    Preconditions.checkArgument(
+        pNode != null && !pNode.isNull() && pNode.isObject(),
+        "Cannot parse string map from non-object value: %s: %s",
+        property,
+        pNode);
+
+    Map<String, String> map = Maps.newHashMap();
+    Iterator<String> fields = pNode.fieldNames();
+    while (fields.hasNext()) {
+      String field = fields.next();
+      map.put(field, getStringOrNull(field, pNode));
+    }
+
+    return map;
   }
 
   public static String[] getStringArray(JsonNode node) {

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestConfigResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestConfigResponse.java
@@ -145,15 +145,16 @@ public class TestConfigResponse extends RequestResponseTestBase<ConfigResponse> 
     String jsonDefaultsHasWrongType =
         "{\"defaults\":[\"warehouse\",\"s3://bucket/warehouse\"],\"overrides\":{\"clients\":\"5\"}}";
     Assertions.assertThatThrownBy(() -> deserialize(jsonDefaultsHasWrongType))
-        .isInstanceOf(JsonProcessingException.class)
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Cannot deserialize value of type `java.util.LinkedHashMap<java.lang.String,java.lang.String>`");
+            "Cannot parse string map from non-object value: defaults: [\"warehouse\",\"s3://bucket/warehouse\"]");
 
     String jsonOverridesHasWrongType =
         "{\"defaults\":{\"warehouse\":\"s3://bucket/warehouse\"},\"overrides\":\"clients\"}";
     Assertions.assertThatThrownBy(() -> deserialize(jsonOverridesHasWrongType))
-        .isInstanceOf(JsonProcessingException.class)
-        .hasMessageContaining("Cannot construct instance of `java.util.LinkedHashMap`");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot parse string map from non-object value: overrides: \"clients\"");
 
     Assertions.assertThatThrownBy(() -> deserialize(null))
         .isInstanceOf(IllegalArgumentException.class)

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestConfigResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestConfigResponseParser.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+public class TestConfigResponseParser {
+
+  @Test
+  public void nullAndEmptyCheck() {
+    assertThatThrownBy(() -> ConfigResponseParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid config response: null");
+
+    assertThatThrownBy(() -> ConfigResponseParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse config response from null object");
+
+    ConfigResponse actual = ConfigResponseParser.fromJson("{}");
+    ConfigResponse expected = ConfigResponse.builder().build();
+    // ConfigResponse doesn't implement hashCode/equals
+    assertThat(actual.defaults()).isEqualTo(expected.defaults()).isEmpty();
+    assertThat(actual.overrides()).isEqualTo(expected.overrides()).isEmpty();
+  }
+
+  @Test
+  public void unknownFields() {
+    ConfigResponse actual = ConfigResponseParser.fromJson("{\"x\": \"val\", \"y\": \"val2\"}");
+    ConfigResponse expected = ConfigResponse.builder().build();
+    // ConfigResponse doesn't implement hashCode/equals
+    assertThat(actual.defaults()).isEqualTo(expected.defaults()).isEmpty();
+    assertThat(actual.overrides()).isEqualTo(expected.overrides()).isEmpty();
+  }
+
+  @Test
+  public void defaultsOnly() {
+    Map<String, String> defaults = Maps.newHashMap();
+    defaults.put("a", "1");
+    defaults.put("b", null);
+    defaults.put("c", "2");
+    defaults.put("d", null);
+
+    ConfigResponse response = ConfigResponse.builder().withDefaults(defaults).build();
+    String expectedJson =
+        "{\n"
+            + "  \"defaults\" : {\n"
+            + "    \"a\" : \"1\",\n"
+            + "    \"b\" : null,\n"
+            + "    \"c\" : \"2\",\n"
+            + "    \"d\" : null\n"
+            + "  },\n"
+            + "  \"overrides\" : { }\n"
+            + "}";
+
+    String json = ConfigResponseParser.toJson(response, true);
+    assertThat(json).isEqualTo(expectedJson);
+    assertThat(ConfigResponseParser.toJson(ConfigResponseParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void overridesOnly() {
+    Map<String, String> overrides = Maps.newHashMap();
+    overrides.put("a", "1");
+    overrides.put("b", null);
+    overrides.put("c", "2");
+    overrides.put("d", null);
+
+    ConfigResponse response = ConfigResponse.builder().withOverrides(overrides).build();
+    String expectedJson =
+        "{\n"
+            + "  \"defaults\" : { },\n"
+            + "  \"overrides\" : {\n"
+            + "    \"a\" : \"1\",\n"
+            + "    \"b\" : null,\n"
+            + "    \"c\" : \"2\",\n"
+            + "    \"d\" : null\n"
+            + "  }\n"
+            + "}";
+
+    String json = ConfigResponseParser.toJson(response, true);
+    assertThat(json).isEqualTo(expectedJson);
+    assertThat(ConfigResponseParser.toJson(ConfigResponseParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void roundTripSerde() {
+    Map<String, String> defaults = Maps.newHashMap();
+    defaults.put("key1", "1");
+    defaults.put("key2", null);
+
+    Map<String, String> overrides = Maps.newHashMap();
+    overrides.put("key3", "23");
+    overrides.put("key4", null);
+
+    ConfigResponse response =
+        ConfigResponse.builder().withDefaults(defaults).withOverrides(overrides).build();
+    String expectedJson =
+        "{\n"
+            + "  \"defaults\" : {\n"
+            + "    \"key1\" : \"1\",\n"
+            + "    \"key2\" : null\n"
+            + "  },\n"
+            + "  \"overrides\" : {\n"
+            + "    \"key3\" : \"23\",\n"
+            + "    \"key4\" : null\n"
+            + "  }\n"
+            + "}";
+
+    String json = ConfigResponseParser.toJson(response, true);
+    assertThat(json).isEqualTo(expectedJson);
+    assertThat(ConfigResponseParser.toJson(ConfigResponseParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
+}


### PR DESCRIPTION
This introduces an explicit JSON parser for `ConfigResponse` as a preparation step for the `capabilities` that are being introduced by https://github.com/apache/iceberg/pull/9940.

Currently, `ConfigResponse` is relying on reflection to properly do JSON <--> `ConfigResponse`.
Having an explicit JSON parser has the advantage that the underlying `capabilities` can be parsed in a way that gives us more flexiblity and allows to be fully forward/backward compatible when new capabilities are being added. 