### PR TITLE
API: Fix default FileIO#newInputFile ManifestFile, DataFile and DeleteFile implementation to pass lengths

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/FileIO.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileIO.java
@@ -49,25 +49,25 @@ public interface FileIO extends Serializable, Closeable {
   default InputFile newInputFile(DataFile file) {
     Preconditions.checkArgument(
         file.keyMetadata() == null,
-        "Cannot decrypt data file: {} (use EncryptingFileIO)",
+        "Cannot decrypt data file: %s (use EncryptingFileIO)",
         file.path());
-    return newInputFile(file.path().toString());
+    return newInputFile(file.path().toString(), file.fileSizeInBytes());
   }
 
   default InputFile newInputFile(DeleteFile file) {
     Preconditions.checkArgument(
         file.keyMetadata() == null,
-        "Cannot decrypt delete file: {} (use EncryptingFileIO)",
+        "Cannot decrypt delete file: %s (use EncryptingFileIO)",
         file.path());
-    return newInputFile(file.path().toString());
+    return newInputFile(file.path().toString(), file.fileSizeInBytes());
   }
 
   default InputFile newInputFile(ManifestFile manifest) {
     Preconditions.checkArgument(
         manifest.keyMetadata() == null,
-        "Cannot decrypt manifest: {} (use EncryptingFileIO)",
+        "Cannot decrypt manifest: %s (use EncryptingFileIO)",
         manifest.path());
-    return newInputFile(manifest.path());
+    return newInputFile(manifest.path(), manifest.length());
   }
 
   /** Get a {@link OutputFile} instance to write bytes to the file at the given path. */


### PR DESCRIPTION
As part of adding encryption support, in https://github.com/apache/iceberg/pull/9592 we added some new FileIO APIs, namely 

```
newInputFile(ManifestFile)
newInputFile(DataFile)
newInputFile(DeleteFile)
```
The overriden implementaiton in EncryptedFileIO is correct but the default implementation in `FileIO` for these new APIs should pass in a length since it's always known from the Iceberg metadata. 

Without this, FileIO implementations which end up calling these default implementations (specifically referring to these new APIs)will make extra requests to the object store/file system to determine the length which we can avoid. 