### PR TITLE
Migrate Manifest, FormatVersion and LocationProvider files in Core to JUnit5

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestFormatVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestFormatVersions.java
@@ -18,50 +18,54 @@
  */
 package org.apache.iceberg;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class TestFormatVersions extends TableTestBase {
-  public TestFormatVersions() {
-    super(1);
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.TestTemplate;
+
+public class TestFormatVersions extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultFormatVersion() {
-    Assert.assertEquals("Should default to v1", 1, table.ops().current().formatVersion());
+    assertThat(table.ops().current().formatVersion()).isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void testFormatVersionUpgrade() {
     TableOperations ops = table.ops();
     TableMetadata base = ops.current();
     ops.commit(base, base.upgradeToFormatVersion(2));
 
-    Assert.assertEquals("Should report v2", 2, ops.current().formatVersion());
+    assertThat(ops.current().formatVersion()).isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testFormatVersionDowngrade() {
     TableOperations ops = table.ops();
     TableMetadata base = ops.current();
     ops.commit(base, base.upgradeToFormatVersion(2));
 
-    Assert.assertEquals("Should report v2", 2, ops.current().formatVersion());
+    assertThat(ops.current().formatVersion()).isEqualTo(2);
 
-    Assertions.assertThatThrownBy(() -> ops.current().upgradeToFormatVersion(1))
+    assertThatThrownBy(() -> ops.current().upgradeToFormatVersion(1))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot downgrade v2 table to v1");
 
-    Assert.assertEquals("Should report v2", 2, ops.current().formatVersion());
+    assertThat(ops.current().formatVersion()).isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testFormatVersionUpgradeNotSupported() {
     TableOperations ops = table.ops();
     TableMetadata base = ops.current();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 ops.commit(
                     base,
@@ -69,6 +73,6 @@ public class TestFormatVersions extends TableTestBase {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot upgrade table to unsupported format version: v3 (supported: v2)");
 
-    Assert.assertEquals("Should report v1", 1, ops.current().formatVersion());
+    assertThat(ops.current().formatVersion()).isEqualTo(1);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -18,27 +18,22 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestLocationProvider extends TableTestBase {
-  @Parameterized.Parameters
-  public static Object[][] parameters() {
-    return new Object[][] {
-      new Object[] {1}, new Object[] {2},
-    };
-  }
-
-  public TestLocationProvider(int formatVersion) {
-    super(formatVersion);
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestLocationProvider extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
   // publicly visible for testing to be dynamically loaded
@@ -99,29 +94,25 @@ public class TestLocationProvider extends TableTestBase {
     // Default no-arg constructor is present, but does not impelemnt interface LocationProvider
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultLocationProvider() {
     this.table.updateProperties().commit();
 
     this.table.locationProvider().newDataLocation("my_file");
-    Assert.assertEquals(
-        "Default data path should have table location as root",
-        String.format("%s/data/%s", this.table.location(), "my_file"),
-        this.table.locationProvider().newDataLocation("my_file"));
+    assertThat(this.table.locationProvider().newDataLocation("my_file"))
+        .isEqualTo(String.format("%s/data/%s", this.table.location(), "my_file"));
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultLocationProviderWithCustomDataLocation() {
     this.table.updateProperties().set(TableProperties.WRITE_DATA_LOCATION, "new_location").commit();
 
     this.table.locationProvider().newDataLocation("my_file");
-    Assert.assertEquals(
-        "Default location provider should allow custom path location",
-        "new_location/my_file",
-        this.table.locationProvider().newDataLocation("my_file"));
+    assertThat(this.table.locationProvider().newDataLocation("my_file"))
+        .isEqualTo("new_location/my_file");
   }
 
-  @Test
+  @TestTemplate
   public void testNoArgDynamicallyLoadedLocationProvider() {
     String invalidImpl =
         String.format(
@@ -133,13 +124,11 @@ public class TestLocationProvider extends TableTestBase {
         .set(TableProperties.WRITE_LOCATION_PROVIDER_IMPL, invalidImpl)
         .commit();
 
-    Assert.assertEquals(
-        "Custom provider should take base table location",
-        "test_no_arg_provider/my_file",
-        this.table.locationProvider().newDataLocation("my_file"));
+    assertThat(this.table.locationProvider().newDataLocation("my_file"))
+        .isEqualTo("test_no_arg_provider/my_file");
   }
 
-  @Test
+  @TestTemplate
   public void testTwoArgDynamicallyLoadedLocationProvider() {
     this.table
         .updateProperties()
@@ -151,17 +140,15 @@ public class TestLocationProvider extends TableTestBase {
                 TwoArgDynamicallyLoadedLocationProvider.class.getSimpleName()))
         .commit();
 
-    Assert.assertTrue(
-        String.format("Table should load impl defined in its properties"),
-        this.table.locationProvider() instanceof TwoArgDynamicallyLoadedLocationProvider);
+    assertThat(this.table.locationProvider())
+        .as("Table should load impl defined in its properties")
+        .isInstanceOf(TwoArgDynamicallyLoadedLocationProvider.class);
 
-    Assert.assertEquals(
-        "Custom provider should take base table location",
-        String.format("%s/test_custom_provider/%s", this.table.location(), "my_file"),
-        this.table.locationProvider().newDataLocation("my_file"));
+    assertThat(this.table.locationProvider().newDataLocation("my_file"))
+        .isEqualTo(String.format("%s/test_custom_provider/%s", this.table.location(), "my_file"));
   }
 
-  @Test
+  @TestTemplate
   public void testDynamicallyLoadedLocationProviderNotFound() {
     String nonExistentImpl =
         String.format(
@@ -173,7 +160,7 @@ public class TestLocationProvider extends TableTestBase {
         .set(TableProperties.WRITE_LOCATION_PROVIDER_IMPL, nonExistentImpl)
         .commit();
 
-    Assertions.assertThatThrownBy(() -> table.locationProvider())
+    assertThatThrownBy(() -> table.locationProvider())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith(
             String.format(
@@ -185,7 +172,7 @@ public class TestLocationProvider extends TableTestBase {
                 + "taking in the string base table location and its property string map.");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidNoInterfaceDynamicallyLoadedLocationProvider() {
     String invalidImpl =
         String.format(
@@ -197,7 +184,7 @@ public class TestLocationProvider extends TableTestBase {
         .set(TableProperties.WRITE_LOCATION_PROVIDER_IMPL, invalidImpl)
         .commit();
 
-    Assertions.assertThatThrownBy(() -> table.locationProvider())
+    assertThatThrownBy(() -> table.locationProvider())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             String.format(
@@ -205,7 +192,7 @@ public class TestLocationProvider extends TableTestBase {
                 LocationProvider.class));
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidArgTypesDynamicallyLoadedLocationProvider() {
     String invalidImpl =
         String.format(
@@ -217,7 +204,7 @@ public class TestLocationProvider extends TableTestBase {
         .set(TableProperties.WRITE_LOCATION_PROVIDER_IMPL, invalidImpl)
         .commit();
 
-    Assertions.assertThatThrownBy(() -> table.locationProvider())
+    assertThatThrownBy(() -> table.locationProvider())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith(
             String.format(
@@ -225,13 +212,13 @@ public class TestLocationProvider extends TableTestBase {
                 invalidImpl, LocationProvider.class));
   }
 
-  @Test
+  @TestTemplate
   public void testObjectStorageLocationProviderPathResolution() {
     table.updateProperties().set(TableProperties.OBJECT_STORE_ENABLED, "true").commit();
 
-    Assert.assertTrue(
-        "default data location should be used when object storage path not set",
-        table.locationProvider().newDataLocation("file").contains(table.location() + "/data"));
+    assertThat(table.locationProvider().newDataLocation("file"))
+        .as("default data location should be used when object storage path not set")
+        .contains(table.location() + "/data");
 
     String folderPath = "s3://random/folder/location";
     table
@@ -239,32 +226,32 @@ public class TestLocationProvider extends TableTestBase {
         .set(TableProperties.WRITE_FOLDER_STORAGE_LOCATION, folderPath)
         .commit();
 
-    Assert.assertTrue(
-        "folder storage path should be used when set",
-        table.locationProvider().newDataLocation("file").contains(folderPath));
+    assertThat(table.locationProvider().newDataLocation("file"))
+        .as("folder storage path should be used when set")
+        .contains(folderPath);
 
     String objectPath = "s3://random/object/location";
     table.updateProperties().set(TableProperties.OBJECT_STORE_PATH, objectPath).commit();
 
-    Assert.assertTrue(
-        "object storage path should be used when set",
-        table.locationProvider().newDataLocation("file").contains(objectPath));
+    assertThat(table.locationProvider().newDataLocation("file"))
+        .as("object storage path should be used when set")
+        .contains(objectPath);
 
     String dataPath = "s3://random/data/location";
     table.updateProperties().set(TableProperties.WRITE_DATA_LOCATION, dataPath).commit();
 
-    Assert.assertTrue(
-        "write data path should be used when set",
-        table.locationProvider().newDataLocation("file").contains(dataPath));
+    assertThat(table.locationProvider().newDataLocation("file"))
+        .as("write data path should be used when set")
+        .contains(dataPath);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultStorageLocationProviderPathResolution() {
     table.updateProperties().set(TableProperties.OBJECT_STORE_ENABLED, "false").commit();
 
-    Assert.assertTrue(
-        "default data location should be used when object storage path not set",
-        table.locationProvider().newDataLocation("file").contains(table.location() + "/data"));
+    assertThat(table.locationProvider().newDataLocation("file"))
+        .as("default data location should be used when object storage path not set")
+        .contains(table.location() + "/data");
 
     String folderPath = "s3://random/folder/location";
     table
@@ -272,19 +259,19 @@ public class TestLocationProvider extends TableTestBase {
         .set(TableProperties.WRITE_FOLDER_STORAGE_LOCATION, folderPath)
         .commit();
 
-    Assert.assertTrue(
-        "folder storage path should be used when set",
-        table.locationProvider().newDataLocation("file").contains(folderPath));
+    assertThat(table.locationProvider().newDataLocation("file"))
+        .as("folder storage path should be used when set")
+        .contains(folderPath);
 
     String dataPath = "s3://random/data/location";
     table.updateProperties().set(TableProperties.WRITE_DATA_LOCATION, dataPath).commit();
 
-    Assert.assertTrue(
-        "write data path should be used when set",
-        table.locationProvider().newDataLocation("file").contains(dataPath));
+    assertThat(table.locationProvider().newDataLocation("file"))
+        .as("write data path should be used when set")
+        .contains(dataPath);
   }
 
-  @Test
+  @TestTemplate
   public void testObjectStorageWithinTableLocation() {
     table.updateProperties().set(TableProperties.OBJECT_STORE_ENABLED, "true").commit();
 
@@ -292,11 +279,10 @@ public class TestLocationProvider extends TableTestBase {
     String relativeLocation = fileLocation.replaceFirst(table.location(), "");
     List<String> parts = Splitter.on("/").splitToList(relativeLocation);
 
-    Assert.assertEquals("Should contain 4 parts", 4, parts.size());
-    Assert.assertTrue("First part should be empty", parts.get(0).isEmpty());
-    Assert.assertEquals("Second part should be data", "data", parts.get(1));
-    Assert.assertFalse("Third part should be a hash value", parts.get(2).isEmpty());
-    Assert.assertEquals(
-        "Fourth part should be the file name passed in", "test.parquet", parts.get(3));
+    assertThat(parts).hasSize(4);
+    assertThat(parts).first().asString().isEmpty();
+    assertThat(parts).element(1).asString().isEqualTo("data");
+    assertThat(parts).element(2).asString().isNotEmpty();
+    assertThat(parts).element(3).asString().isEqualTo("test.parquet");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestManifestListVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListVersions.java
@@ -196,7 +196,7 @@ public class TestManifestListVersions {
 
   @Test
   public void testManifestsWithoutRowStats() throws IOException {
-    File manifestListFile = File.createTempFile("manifest-list.avro", null, temp.toFile());
+    File manifestListFile = File.createTempFile("manifest-list", ".avro", temp.toFile());
     assertThat(manifestListFile.delete()).isTrue();
 
     Collection<String> columnNamesWithoutRowStats =

--- a/core/src/test/java/org/apache/iceberg/TestManifestListVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListVersions.java
@@ -18,9 +18,13 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import org.apache.avro.AvroRuntimeException;
@@ -39,11 +43,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestManifestListVersions {
   private static final String PATH = "s3://bucket/table/m1.avro";
@@ -98,11 +99,11 @@ public class TestManifestListVersions {
           PARTITION_SUMMARIES,
           KEY_METADATA);
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   @Test
   public void testV1WriteDeleteManifest() {
-    Assertions.assertThatThrownBy(() -> writeManifestList(TEST_DELETE_MANIFEST, 1))
+    assertThatThrownBy(() -> writeManifestList(TEST_DELETE_MANIFEST, 1))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot store delete manifests in a v1 table");
   }
@@ -112,24 +113,21 @@ public class TestManifestListVersions {
     ManifestFile manifest = writeAndReadManifestList(1);
 
     // v2 fields are not written and are defaulted
-    Assert.assertEquals(
-        "Should not contain sequence number, default to 0", 0, manifest.sequenceNumber());
-    Assert.assertEquals(
-        "Should not contain min sequence number, default to 0", 0, manifest.minSequenceNumber());
+    assertThat(manifest.sequenceNumber()).isEqualTo(0);
+    assertThat(manifest.minSequenceNumber()).isEqualTo(0);
 
     // v1 fields are read correctly, even though order changed
-    Assert.assertEquals("Path", PATH, manifest.path());
-    Assert.assertEquals("Length", LENGTH, manifest.length());
-    Assert.assertEquals("Spec id", SPEC_ID, manifest.partitionSpecId());
-    Assert.assertEquals("Content", ManifestContent.DATA, manifest.content());
-    Assert.assertEquals("Snapshot id", SNAPSHOT_ID, (long) manifest.snapshotId());
-    Assert.assertEquals("Added files count", ADDED_FILES, (int) manifest.addedFilesCount());
-    Assert.assertEquals(
-        "Existing files count", EXISTING_FILES, (int) manifest.existingFilesCount());
-    Assert.assertEquals("Deleted files count", DELETED_FILES, (int) manifest.deletedFilesCount());
-    Assert.assertEquals("Added rows count", ADDED_ROWS, (long) manifest.addedRowsCount());
-    Assert.assertEquals("Existing rows count", EXISTING_ROWS, (long) manifest.existingRowsCount());
-    Assert.assertEquals("Deleted rows count", DELETED_ROWS, (long) manifest.deletedRowsCount());
+    assertThat(manifest.path()).isEqualTo(PATH);
+    assertThat(manifest.length()).isEqualTo(LENGTH);
+    assertThat(manifest.partitionSpecId()).isEqualTo(SPEC_ID);
+    assertThat(manifest.content()).isEqualTo(ManifestContent.DATA);
+    assertThat(manifest.snapshotId()).isEqualTo(SNAPSHOT_ID);
+    assertThat(manifest.addedFilesCount()).isEqualTo(ADDED_FILES);
+    assertThat(manifest.existingFilesCount()).isEqualTo(EXISTING_FILES);
+    assertThat(manifest.deletedFilesCount()).isEqualTo(DELETED_FILES);
+    assertThat(manifest.addedRowsCount()).isEqualTo(ADDED_ROWS);
+    assertThat(manifest.existingRowsCount()).isEqualTo(EXISTING_ROWS);
+    assertThat(manifest.deletedRowsCount()).isEqualTo(DELETED_ROWS);
   }
 
   @Test
@@ -137,20 +135,19 @@ public class TestManifestListVersions {
     ManifestFile manifest = writeAndReadManifestList(2);
 
     // all v2 fields should be read correctly
-    Assert.assertEquals("Path", PATH, manifest.path());
-    Assert.assertEquals("Length", LENGTH, manifest.length());
-    Assert.assertEquals("Spec id", SPEC_ID, manifest.partitionSpecId());
-    Assert.assertEquals("Content", ManifestContent.DATA, manifest.content());
-    Assert.assertEquals("Sequence number", SEQ_NUM, manifest.sequenceNumber());
-    Assert.assertEquals("Min sequence number", MIN_SEQ_NUM, manifest.minSequenceNumber());
-    Assert.assertEquals("Snapshot id", SNAPSHOT_ID, (long) manifest.snapshotId());
-    Assert.assertEquals("Added files count", ADDED_FILES, (int) manifest.addedFilesCount());
-    Assert.assertEquals("Added rows count", ADDED_ROWS, (long) manifest.addedRowsCount());
-    Assert.assertEquals(
-        "Existing files count", EXISTING_FILES, (int) manifest.existingFilesCount());
-    Assert.assertEquals("Existing rows count", EXISTING_ROWS, (long) manifest.existingRowsCount());
-    Assert.assertEquals("Deleted files count", DELETED_FILES, (int) manifest.deletedFilesCount());
-    Assert.assertEquals("Deleted rows count", DELETED_ROWS, (long) manifest.deletedRowsCount());
+    assertThat(manifest.path()).isEqualTo(PATH);
+    assertThat(manifest.length()).isEqualTo(LENGTH);
+    assertThat(manifest.partitionSpecId()).isEqualTo(SPEC_ID);
+    assertThat(manifest.content()).isEqualTo(ManifestContent.DATA);
+    assertThat(manifest.sequenceNumber()).isEqualTo(SEQ_NUM);
+    assertThat(manifest.minSequenceNumber()).isEqualTo(MIN_SEQ_NUM);
+    assertThat(manifest.snapshotId()).isEqualTo(SNAPSHOT_ID);
+    assertThat(manifest.addedFilesCount()).isEqualTo(ADDED_FILES);
+    assertThat(manifest.addedRowsCount()).isEqualTo(ADDED_ROWS);
+    assertThat(manifest.existingFilesCount()).isEqualTo(EXISTING_FILES);
+    assertThat(manifest.existingRowsCount()).isEqualTo(EXISTING_ROWS);
+    assertThat(manifest.deletedFilesCount()).isEqualTo(DELETED_FILES);
+    assertThat(manifest.deletedRowsCount()).isEqualTo(DELETED_ROWS);
   }
 
   @Test
@@ -159,20 +156,16 @@ public class TestManifestListVersions {
     GenericData.Record generic = readGeneric(manifestList, V1Metadata.MANIFEST_LIST_SCHEMA);
 
     // v1 metadata should match even though order changed
-    Assert.assertEquals("Path", PATH, generic.get("manifest_path").toString());
-    Assert.assertEquals("Length", LENGTH, generic.get("manifest_length"));
-    Assert.assertEquals("Spec id", SPEC_ID, generic.get("partition_spec_id"));
-    Assert.assertEquals("Snapshot id", SNAPSHOT_ID, (long) generic.get("added_snapshot_id"));
-    Assert.assertEquals("Added files count", ADDED_FILES, (int) generic.get("added_files_count"));
-    Assert.assertEquals(
-        "Existing files count", EXISTING_FILES, (int) generic.get("existing_files_count"));
-    Assert.assertEquals(
-        "Deleted files count", DELETED_FILES, (int) generic.get("deleted_files_count"));
-    Assert.assertEquals("Added rows count", ADDED_ROWS, (long) generic.get("added_rows_count"));
-    Assert.assertEquals(
-        "Existing rows count", EXISTING_ROWS, (long) generic.get("existing_rows_count"));
-    Assert.assertEquals(
-        "Deleted rows count", DELETED_ROWS, (long) generic.get("deleted_rows_count"));
+    assertThat(generic.get("manifest_path")).asString().isEqualTo(PATH);
+    assertThat(generic.get("manifest_length")).isEqualTo(LENGTH);
+    assertThat(generic.get("partition_spec_id")).isEqualTo(SPEC_ID);
+    assertThat(generic.get("added_snapshot_id")).isEqualTo(SNAPSHOT_ID);
+    assertThat(generic.get("added_files_count")).isEqualTo(ADDED_FILES);
+    assertThat(generic.get("existing_files_count")).isEqualTo(EXISTING_FILES);
+    assertThat(generic.get("deleted_files_count")).isEqualTo(DELETED_FILES);
+    assertThat(generic.get("added_rows_count")).isEqualTo(ADDED_ROWS);
+    assertThat(generic.get("existing_rows_count")).isEqualTo(EXISTING_ROWS);
+    assertThat(generic.get("deleted_rows_count")).isEqualTo(DELETED_ROWS);
     assertEmptyAvroField(generic, ManifestFile.MANIFEST_CONTENT.name());
     assertEmptyAvroField(generic, ManifestFile.SEQUENCE_NUMBER.name());
     assertEmptyAvroField(generic, ManifestFile.MIN_SEQUENCE_NUMBER.name());
@@ -186,20 +179,16 @@ public class TestManifestListVersions {
     GenericData.Record generic = readGeneric(manifestList, V1Metadata.MANIFEST_LIST_SCHEMA);
 
     // v1 metadata should match even though order changed
-    Assert.assertEquals("Path", PATH, generic.get("manifest_path").toString());
-    Assert.assertEquals("Length", LENGTH, generic.get("manifest_length"));
-    Assert.assertEquals("Spec id", SPEC_ID, generic.get("partition_spec_id"));
-    Assert.assertEquals("Snapshot id", SNAPSHOT_ID, (long) generic.get("added_snapshot_id"));
-    Assert.assertEquals("Added files count", ADDED_FILES, (int) generic.get("added_files_count"));
-    Assert.assertEquals(
-        "Existing files count", EXISTING_FILES, (int) generic.get("existing_files_count"));
-    Assert.assertEquals(
-        "Deleted files count", DELETED_FILES, (int) generic.get("deleted_files_count"));
-    Assert.assertEquals("Added rows count", ADDED_ROWS, (long) generic.get("added_rows_count"));
-    Assert.assertEquals(
-        "Existing rows count", EXISTING_ROWS, (long) generic.get("existing_rows_count"));
-    Assert.assertEquals(
-        "Deleted rows count", DELETED_ROWS, (long) generic.get("deleted_rows_count"));
+    assertThat(generic.get("manifest_path")).asString().isEqualTo(PATH);
+    assertThat(generic.get("manifest_length")).isEqualTo(LENGTH);
+    assertThat(generic.get("partition_spec_id")).isEqualTo(SPEC_ID);
+    assertThat(generic.get("added_snapshot_id")).isEqualTo(SNAPSHOT_ID);
+    assertThat(generic.get("added_files_count")).isEqualTo(ADDED_FILES);
+    assertThat(generic.get("existing_files_count")).isEqualTo(EXISTING_FILES);
+    assertThat(generic.get("deleted_files_count")).isEqualTo(DELETED_FILES);
+    assertThat(generic.get("added_rows_count")).isEqualTo(ADDED_ROWS);
+    assertThat(generic.get("existing_rows_count")).isEqualTo(EXISTING_ROWS);
+    assertThat(generic.get("deleted_rows_count")).isEqualTo(DELETED_ROWS);
     assertEmptyAvroField(generic, ManifestFile.MANIFEST_CONTENT.name());
     assertEmptyAvroField(generic, ManifestFile.SEQUENCE_NUMBER.name());
     assertEmptyAvroField(generic, ManifestFile.MIN_SEQUENCE_NUMBER.name());
@@ -207,8 +196,8 @@ public class TestManifestListVersions {
 
   @Test
   public void testManifestsWithoutRowStats() throws IOException {
-    File manifestListFile = temp.newFile("manifest-list.avro");
-    Assert.assertTrue(manifestListFile.delete());
+    File manifestListFile = File.createTempFile("manifest-list.avro", null, temp.toFile());
+    assertThat(manifestListFile.delete()).isTrue();
 
     Collection<String> columnNamesWithoutRowStats =
         ImmutableList.of(
@@ -250,18 +239,15 @@ public class TestManifestListVersions {
     List<ManifestFile> files = ManifestLists.read(outputFile.toInputFile());
     ManifestFile manifest = Iterables.getOnlyElement(files);
 
-    Assert.assertTrue("Added files should be present", manifest.hasAddedFiles());
-    Assert.assertEquals("Added files count should match", 2, (int) manifest.addedFilesCount());
-    Assert.assertNull("Added rows count should be null", manifest.addedRowsCount());
-
-    Assert.assertTrue("Existing files should be present", manifest.hasExistingFiles());
-    Assert.assertEquals(
-        "Existing files count should match", 3, (int) manifest.existingFilesCount());
-    Assert.assertNull("Existing rows count should be null", manifest.existingRowsCount());
-
-    Assert.assertTrue("Deleted files should be present", manifest.hasDeletedFiles());
-    Assert.assertEquals("Deleted files count should match", 4, (int) manifest.deletedFilesCount());
-    Assert.assertNull("Deleted rows count should be null", manifest.deletedRowsCount());
+    assertThat(manifest.hasAddedFiles()).isTrue();
+    assertThat(manifest.addedFilesCount()).isEqualTo(2);
+    assertThat(manifest.addedRowsCount()).isNull();
+    assertThat(manifest.hasExistingFiles()).isTrue();
+    assertThat(manifest.existingFilesCount()).isEqualTo(3);
+    assertThat(manifest.existingRowsCount()).isNull();
+    assertThat(manifest.hasDeletedFiles()).isTrue();
+    assertThat(manifest.deletedFilesCount()).isEqualTo(4);
+    assertThat(manifest.deletedRowsCount()).isNull();
   }
 
   @Test
@@ -298,36 +284,19 @@ public class TestManifestListVersions {
 
     List<ManifestFile> files = ManifestLists.read(manifestList);
     ManifestFile returnedManifest = Iterables.getOnlyElement(files);
-    Assert.assertEquals(
-        "Number of partition field summaries should match",
-        2,
-        returnedManifest.partitions().size());
+    assertThat(returnedManifest.partitions()).hasSize(2);
 
     ManifestFile.PartitionFieldSummary first = returnedManifest.partitions().get(0);
-    Assert.assertFalse(
-        "First partition field summary should not contain null", first.containsNull());
-    Assert.assertNull("First partition field summary has unknown NaN", first.containsNaN());
-    Assert.assertEquals(
-        "Lower bound for first partition field summary should match",
-        firstSummaryLowerBound,
-        first.lowerBound());
-    Assert.assertEquals(
-        "Upper bound for first partition field summary should match",
-        firstSummaryUpperBound,
-        first.upperBound());
+    assertThat(first.containsNull()).isFalse();
+    assertThat(first.containsNaN()).isNull();
+    assertThat(first.lowerBound()).isEqualTo(firstSummaryLowerBound);
+    assertThat(first.upperBound()).isEqualTo(firstSummaryUpperBound);
 
     ManifestFile.PartitionFieldSummary second = returnedManifest.partitions().get(1);
-    Assert.assertTrue("Second partition field summary should contain null", second.containsNull());
-    Assert.assertFalse(
-        "Second partition field summary should not contain NaN", second.containsNaN());
-    Assert.assertEquals(
-        "Lower bound for second partition field summary should match",
-        secondSummaryLowerBound,
-        second.lowerBound());
-    Assert.assertEquals(
-        "Upper bound for second partition field summary should match",
-        secondSummaryUpperBound,
-        second.upperBound());
+    assertThat(second.containsNull()).isTrue();
+    assertThat(second.containsNaN()).isFalse();
+    assertThat(second.lowerBound()).isEqualTo(secondSummaryLowerBound);
+    assertThat(second.upperBound()).isEqualTo(secondSummaryUpperBound);
   }
 
   private InputFile writeManifestList(ManifestFile manifest, int formatVersion) throws IOException {
@@ -348,7 +317,7 @@ public class TestManifestListVersions {
     try (CloseableIterable<GenericData.Record> files =
         Avro.read(manifestList).project(schema).reuseContainers(false).build()) {
       List<GenericData.Record> records = Lists.newLinkedList(files);
-      Assert.assertEquals("Should contain one manifest", 1, records.size());
+      assertThat(records).hasSize(1);
       return records.get(0);
     }
   }
@@ -356,12 +325,12 @@ public class TestManifestListVersions {
   private ManifestFile writeAndReadManifestList(int formatVersion) throws IOException {
     List<ManifestFile> manifests =
         ManifestLists.read(writeManifestList(TEST_MANIFEST, formatVersion));
-    Assert.assertEquals("Should contain one manifest", 1, manifests.size());
+    assertThat(manifests).hasSize(1);
     return manifests.get(0);
   }
 
   private void assertEmptyAvroField(GenericRecord record, String field) {
-    Assertions.assertThatThrownBy(() -> record.get(field))
+    assertThatThrownBy(() -> record.get(field))
         .isInstanceOf(AvroRuntimeException.class)
         .hasMessage("Not a valid schema field: " + field);
   }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
@@ -18,8 +18,13 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
@@ -27,21 +32,14 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestManifestReaderStats extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
-  }
-
-  public TestManifestReaderStats(int formatVersion) {
-    super(formatVersion);
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestManifestReaderStats extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
   private static final Map<Integer, Long> VALUE_COUNT = ImmutableMap.of(3, 3L);
@@ -65,7 +63,7 @@ public class TestManifestReaderStats extends TableTestBase {
           .withMetrics(METRICS)
           .build();
 
-  @Test
+  @TestTemplate
   public void testReadIncludesFullStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO)) {
@@ -75,7 +73,7 @@ public class TestManifestReaderStats extends TableTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadEntriesWithFilterIncludesFullStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader =
@@ -86,7 +84,7 @@ public class TestManifestReaderStats extends TableTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadIteratorWithFilterIncludesFullStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader =
@@ -96,7 +94,7 @@ public class TestManifestReaderStats extends TableTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadEntriesWithFilterAndSelectIncludesFullStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader =
@@ -109,7 +107,7 @@ public class TestManifestReaderStats extends TableTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadIteratorWithFilterAndSelectDropsStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader =
@@ -121,7 +119,7 @@ public class TestManifestReaderStats extends TableTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadIteratorWithFilterAndSelectRecordCountDropsStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader =
@@ -133,7 +131,7 @@ public class TestManifestReaderStats extends TableTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadIteratorWithFilterAndSelectStatsIncludesFullStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader =
@@ -148,7 +146,7 @@ public class TestManifestReaderStats extends TableTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadIteratorWithProjectStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader =
@@ -156,18 +154,18 @@ public class TestManifestReaderStats extends TableTestBase {
             .project(new Schema(ImmutableList.of(DataFile.FILE_PATH, DataFile.VALUE_COUNTS)))) {
       DataFile entry = reader.iterator().next();
 
-      Assert.assertEquals(FILE_PATH, entry.path());
-      Assert.assertEquals(VALUE_COUNT, entry.valueCounts());
-      Assert.assertNull(entry.columnSizes());
-      Assert.assertNull(entry.nullValueCounts());
-      Assert.assertNull(entry.nanValueCounts());
-      Assert.assertNull(entry.lowerBounds());
-      Assert.assertNull(entry.upperBounds());
+      assertThat(entry.path()).isEqualTo(FILE_PATH);
+      assertThat(entry.valueCounts()).isEqualTo(VALUE_COUNT);
+      assertThat(entry.columnSizes()).isNull();
+      assertThat(entry.nullValueCounts()).isNull();
+      assertThat(entry.nanValueCounts()).isNull();
+      assertThat(entry.lowerBounds()).isNull();
+      assertThat(entry.upperBounds()).isNull();
       assertNullRecordCount(entry);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadEntriesWithSelectNotProjectStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader =
@@ -177,20 +175,20 @@ public class TestManifestReaderStats extends TableTestBase {
       DataFile dataFile = entry.file();
 
       // selected field is populated
-      Assert.assertEquals(FILE_PATH, dataFile.path());
+      assertThat(dataFile.path()).isEqualTo(FILE_PATH);
 
       // not selected fields are all null and not projected
-      Assert.assertNull(dataFile.columnSizes());
-      Assert.assertNull(dataFile.valueCounts());
-      Assert.assertNull(dataFile.nullValueCounts());
-      Assert.assertNull(dataFile.lowerBounds());
-      Assert.assertNull(dataFile.upperBounds());
-      Assert.assertNull(dataFile.nanValueCounts());
+      assertThat(dataFile.columnSizes()).isNull();
+      assertThat(dataFile.valueCounts()).isNull();
+      assertThat(dataFile.nullValueCounts()).isNull();
+      assertThat(dataFile.nanValueCounts()).isNull();
+      assertThat(dataFile.lowerBounds()).isNull();
+      assertThat(dataFile.upperBounds()).isNull();
       assertNullRecordCount(dataFile);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadEntriesWithSelectCertainStatNotProjectStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader =
@@ -199,82 +197,76 @@ public class TestManifestReaderStats extends TableTestBase {
       DataFile dataFile = reader.iterator().next();
 
       // selected fields are populated
-      Assert.assertEquals(VALUE_COUNT, dataFile.valueCounts());
-      Assert.assertEquals(FILE_PATH, dataFile.path());
+      assertThat(dataFile.path()).isEqualTo(FILE_PATH);
+      assertThat(dataFile.valueCounts()).isEqualTo(VALUE_COUNT);
 
       // not selected fields are all null and not projected
-      Assert.assertNull(dataFile.columnSizes());
-      Assert.assertNull(dataFile.nullValueCounts());
-      Assert.assertNull(dataFile.nanValueCounts());
-      Assert.assertNull(dataFile.lowerBounds());
-      Assert.assertNull(dataFile.upperBounds());
+      assertThat(dataFile.columnSizes()).isNull();
+      assertThat(dataFile.nullValueCounts()).isNull();
+      assertThat(dataFile.nanValueCounts()).isNull();
+      assertThat(dataFile.lowerBounds()).isNull();
+      assertThat(dataFile.upperBounds()).isNull();
       assertNullRecordCount(dataFile);
     }
   }
 
   private void assertFullStats(DataFile dataFile) {
-    Assert.assertEquals(3, dataFile.recordCount());
-    Assert.assertNull(dataFile.columnSizes());
-    Assert.assertEquals(VALUE_COUNT, dataFile.valueCounts());
-    Assert.assertEquals(NULL_VALUE_COUNTS, dataFile.nullValueCounts());
-    Assert.assertEquals(NAN_VALUE_COUNTS, dataFile.nanValueCounts());
-    Assert.assertEquals(LOWER_BOUNDS, dataFile.lowerBounds());
-    Assert.assertEquals(UPPER_BOUNDS, dataFile.upperBounds());
+    assertThat(dataFile.recordCount()).isEqualTo(3);
+    assertThat(dataFile.columnSizes()).isNull();
+    assertThat(dataFile.valueCounts()).isEqualTo(VALUE_COUNT);
+    assertThat(dataFile.nullValueCounts()).isEqualTo(NULL_VALUE_COUNTS);
+    assertThat(dataFile.nanValueCounts()).isEqualTo(NAN_VALUE_COUNTS);
+    assertThat(dataFile.lowerBounds()).isEqualTo(LOWER_BOUNDS);
+    assertThat(dataFile.upperBounds()).isEqualTo(UPPER_BOUNDS);
 
     if (dataFile.valueCounts() != null) {
-      Assertions.assertThatThrownBy(
-              () -> dataFile.valueCounts().clear(), "Should not be modifiable")
+      assertThatThrownBy(() -> dataFile.valueCounts().clear(), "Should not be modifiable")
           .isInstanceOf(UnsupportedOperationException.class);
     }
 
     if (dataFile.nullValueCounts() != null) {
-      Assertions.assertThatThrownBy(
-              () -> dataFile.nullValueCounts().clear(), "Should not be modifiable")
+      assertThatThrownBy(() -> dataFile.nullValueCounts().clear(), "Should not be modifiable")
           .isInstanceOf(UnsupportedOperationException.class);
     }
 
     if (dataFile.nanValueCounts() != null) {
-      Assertions.assertThatThrownBy(
-              () -> dataFile.nanValueCounts().clear(), "Should not be modifiable")
+      assertThatThrownBy(() -> dataFile.nanValueCounts().clear(), "Should not be modifiable")
           .isInstanceOf(UnsupportedOperationException.class);
     }
 
     if (dataFile.upperBounds() != null) {
-      Assertions.assertThatThrownBy(
-              () -> dataFile.upperBounds().clear(), "Should not be modifiable")
+      assertThatThrownBy(() -> dataFile.upperBounds().clear(), "Should not be modifiable")
           .isInstanceOf(UnsupportedOperationException.class);
     }
 
     if (dataFile.lowerBounds() != null) {
-      Assertions.assertThatThrownBy(
-              () -> dataFile.lowerBounds().clear(), "Should not be modifiable")
+      assertThatThrownBy(() -> dataFile.lowerBounds().clear(), "Should not be modifiable")
           .isInstanceOf(UnsupportedOperationException.class);
     }
 
     if (dataFile.columnSizes() != null) {
-      Assertions.assertThatThrownBy(
-              () -> dataFile.columnSizes().clear(), "Should not be modifiable")
+      assertThatThrownBy(() -> dataFile.columnSizes().clear(), "Should not be modifiable")
           .isInstanceOf(UnsupportedOperationException.class);
     }
 
-    Assert.assertEquals(FILE_PATH, dataFile.path()); // always select file path in all test cases
+    assertThat(dataFile.path()).isEqualTo(FILE_PATH); // always select file path in all test cases
   }
 
   private void assertStatsDropped(DataFile dataFile) {
-    Assert.assertEquals(
-        3, dataFile.recordCount()); // record count is not considered as droppable stats
-    Assert.assertNull(dataFile.columnSizes());
-    Assert.assertNull(dataFile.valueCounts());
-    Assert.assertNull(dataFile.nullValueCounts());
-    Assert.assertNull(dataFile.lowerBounds());
-    Assert.assertNull(dataFile.upperBounds());
-    Assert.assertNull(dataFile.nanValueCounts());
+    assertThat(dataFile.recordCount())
+        .isEqualTo(3); // record count is not considered as droppable stats
+    assertThat(dataFile.columnSizes()).isNull();
+    assertThat(dataFile.valueCounts()).isNull();
+    assertThat(dataFile.nullValueCounts()).isNull();
+    assertThat(dataFile.nanValueCounts()).isNull();
+    assertThat(dataFile.lowerBounds()).isNull();
+    assertThat(dataFile.upperBounds()).isNull();
 
-    Assert.assertEquals(FILE_PATH, dataFile.path()); // always select file path in all test cases
+    assertThat(dataFile.path()).isEqualTo(FILE_PATH); // always select file path in all test cases
   }
 
   private void assertNullRecordCount(DataFile dataFile) {
     // record count is a primitive type, accessing null record count will throw NPE
-    Assertions.assertThatThrownBy(dataFile::recordCount).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(dataFile::recordCount).isInstanceOf(NullPointerException.class);
   }
 }


### PR DESCRIPTION
Migrate the following "Read" in iceberg-core to JUnit 5 and AssertJ style for https://github.com/apache/iceberg/issues/9085.

## Current Progress 
- [x] `TestManifestCaching.java`
- [x] `TestManifestCleanup.java`
- [x] `TestManifestEncryption.java`
- [x] `TestManifestListVersions.java`
- [x] `TestManifestReader.java` (already uses JUnit5)
- [x] `TestManifestReaderStats.java`
- [x] `TestManifestWriter.java`
- [x] `TestManifestWriterVersions.java`

Additional classes:
- [x] `TestFormatVersions.java`
- [x] `TestLocationProvider.java`