### PR TITLE
Docs: Fix inconsistency in branching and tagging scenario 

### DIFF
--- a/docs/docs/branching.md
+++ b/docs/docs/branching.md
@@ -52,7 +52,7 @@ via Spark SQL.
 1. Retain 1 snapshot per week for 1 month. This can be achieved by tagging the weekly snapshot and setting the tag retention to be a month.
 4 weekly snapshots will be kept, and the branch reference itself will be retained for 1 week. 
 ```sql
--- Create a tag for the first end of week snapshot. Retain the snapshot for a week
+-- Create a tag for the first end of week snapshot. Retain the snapshot for a month
 ALTER TABLE prod.db.table CREATE TAG `EOW-01` AS OF VERSION 7 RETAIN 30 DAYS;
 ```
 

--- a/docs/docs/branching.md
+++ b/docs/docs/branching.md
@@ -49,20 +49,21 @@ Tags can be used for retaining important historical snapshots for auditing purpo
 The above diagram demonstrates retaining important historical snapshot with the following retention policy, defined 
 via Spark SQL.
 
-1. Retain 1 snapshot per week for 1 month. This can be achieved by tagging the weekly snapshot and setting the tag retention to be a month.
-4 weekly snapshots will be kept, and the branch reference itself will be retained for 1 week. 
+Assume snapshots are compressed to a single day before this command executes.
+
+1. Create a tag on the snapshot occurring at the end of the first week, that will expire a month after it is created. You do this by setting the tag retention to be 30 days, or an average month. Run this command for each of the following weekend tag.
 ```sql
 -- Create a tag for the first end of week snapshot. Retain the snapshot for a month
 ALTER TABLE prod.db.table CREATE TAG `EOW-01` AS OF VERSION 7 RETAIN 30 DAYS;
 ```
 
-2. Retain 1 snapshot per month for 6 months. This can be achieved by tagging the monthly snapshot and setting the tag retention to be 6 months.
+2. Create a tag on the snapshot occurring at the end of the first month, that will expire three months after it is created. You do this by setting the tag retention to be 180 days, or an average 3 months. Run this command for each of the following month tag.
 ```sql
 -- Create a tag for the first end of month snapshot. Retain the snapshot for 6 months
 ALTER TABLE prod.db.table CREATE TAG `EOM-01` AS OF VERSION 30 RETAIN 180 DAYS;
 ```
 
-3. Retain 1 snapshot per year forever. This can be achieved by tagging the annual snapshot. The default retention for branches and tags is forever.
+3. Create a tag on the snapshot for a year, that will retain forever. You do this by tagging the annual snapshot. The default retention for branches and tags is forever.
 ```sql
 -- Create a tag for the end of the year and retain it forever.
 ALTER TABLE prod.db.table CREATE TAG `EOY-2023` AS OF VERSION 365;

--- a/docs/docs/branching.md
+++ b/docs/docs/branching.md
@@ -51,19 +51,19 @@ via Spark SQL.
 
 Assume snapshots are compressed to a single day before this command executes.
 
-1. Create a tag on the snapshot occurring at the end of the first week, that will expire a month after it is created. You do this by setting the tag retention to be 30 days, or an average month. Run this command for each of the following weekend tag.
+1. Create a tag on the snapshot occurring at the end of the first week, that will expire a month after it is created. You do this by setting the tag retention to be 30 days, or an average month. Run this command for each weekend to keep a weekly Snapshot.
 ```sql
 -- Create a tag for the first end of week snapshot. Retain the snapshot for a month
 ALTER TABLE prod.db.table CREATE TAG `EOW-01` AS OF VERSION 7 RETAIN 30 DAYS;
 ```
 
-2. Create a tag on the snapshot occurring at the end of the first month, that will expire three months after it is created. You do this by setting the tag retention to be 180 days, or an average 3 months. Run this command for each of the following month tag.
+2. Create a tag on the snapshot occurring at the end of the first month, that will expire three months after it is created. You do this by setting the tag retention to be 180 days, or an average 3 months. Run this command for each month to keep a monthly Snapshot.
 ```sql
 -- Create a tag for the first end of month snapshot. Retain the snapshot for 6 months
 ALTER TABLE prod.db.table CREATE TAG `EOM-01` AS OF VERSION 30 RETAIN 180 DAYS;
 ```
 
-3. Create a tag on the snapshot for a year, that will retain forever. You do this by tagging the annual snapshot. The default retention for branches and tags is forever.
+3. Create a tag on the snapshot for a year, that will retain forever. You do this by tagging the annual snapshot. The default retention for branches and tags is forever. Run this command for each year to keep a yearly Snapshot.
 ```sql
 -- Create a tag for the end of the year and retain it forever.
 ALTER TABLE prod.db.table CREATE TAG `EOY-2023` AS OF VERSION 365;

--- a/docs/docs/branching.md
+++ b/docs/docs/branching.md
@@ -50,10 +50,10 @@ The above diagram demonstrates retaining important historical snapshot with the 
 via Spark SQL.
 
 1. Retain 1 snapshot per week for 1 month. This can be achieved by tagging the weekly snapshot and setting the tag retention to be a month.
-snapshots will be kept, and the branch reference itself will be retained for 1 week. 
+4 weekly snapshots will be kept, and the branch reference itself will be retained for 1 week. 
 ```sql
 -- Create a tag for the first end of week snapshot. Retain the snapshot for a week
-ALTER TABLE prod.db.table CREATE TAG `EOW-01` AS OF VERSION 7 RETAIN 7 DAYS;
+ALTER TABLE prod.db.table CREATE TAG `EOW-01` AS OF VERSION 7 RETAIN 30 DAYS;
 ```
 
 2. Retain 1 snapshot per month for 6 months. This can be achieved by tagging the monthly snapshot and setting the tag retention to be 6 months.


### PR DESCRIPTION
There is an inconsistency between the explanation of the snapshot retention strategy and SQL code on EOW-1 scenario. 
The description mentions retaining 1 snapshot per week for 1 month, but the SQL code sets the retention period to only 1 week.

> Retain 1 snapshot per week for 1 month. This can be achieved by tagging the weekly snapshot and setting the tag retention to be a month. snapshots will be kept, and the branch reference itself will be retained for 1 week.
> -- Create a tag for the first end of week snapshot. Retain the snapshot for a week
ALTER TABLE prod.db.table CREATE TAG `EOW-01` AS OF VERSION 7 RETAIN 7 DAYS;

I propose modify the SQK to match the description. 
In addition, clarify that 4 weekly snapshots will be kept and the branch reference itself is also retained for 1 week.

Please review the proposed changes.