### PR TITLE
core,api: Refactor code with `hasLiveEntries`

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ManifestFile.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestFile.java
@@ -178,6 +178,15 @@ public interface ManifestFile {
   Long deletedRowsCount();
 
   /**
+   * Returns true if there are any added or existing files
+   *
+   * @return whether this manifest contains entries with ADDED and/or EXISTING
+   */
+  default boolean hasLiveFiles() {
+    return this.hasAddedFiles() || this.hasExistingFiles();
+  }
+
+  /**
    * Returns a list of {@link PartitionFieldSummary partition field summaries}.
    *
    * <p>Each summary corresponds to a field in the manifest file's partition spec, by ordinal. For

--- a/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
@@ -219,7 +219,7 @@ abstract class BaseDistributedDataScan
     Map<Integer, ManifestEvaluator> evalCache = specCache(this::newManifestEvaluator);
 
     return manifests.stream()
-        .filter(manifest -> manifest.hasAddedFiles() || manifest.hasExistingFiles())
+        .filter(ManifestFile::hasLiveFiles)
         .filter(manifest -> evalCache.get(manifest.partitionSpecId()).eval(manifest))
         .collect(Collectors.toList());
   }

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -509,7 +509,7 @@ class DeleteFileIndex {
                   closeableDeleteManifests,
                   manifest ->
                       manifest.content() == ManifestContent.DELETES
-                          && (manifest.hasAddedFiles() || manifest.hasExistingFiles())
+                          && manifest.hasLiveFiles()
                           && evalCache.get(manifest.partitionSpecId()).eval(manifest));
 
       matchingManifests =

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -296,8 +296,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
       return cached;
     }
 
-    boolean hasLiveFiles = manifest.hasAddedFiles() || manifest.hasExistingFiles();
-    if (!hasLiveFiles || !canContainDeletedFiles(manifest)) {
+    if (!manifest.hasLiveFiles() || !canContainDeletedFiles(manifest)) {
       filteredManifests.put(manifest, manifest);
       return manifest;
     }

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -286,9 +286,7 @@ class ManifestGroup {
       // existing files count is missing, the manifest must be scanned.
       matchingManifests =
           CloseableIterable.filter(
-              scanMetrics.skippedDataManifests(),
-              matchingManifests,
-              manifest -> manifest.hasAddedFiles() || manifest.hasExistingFiles());
+              scanMetrics.skippedDataManifests(), matchingManifests, ManifestFile::hasLiveFiles);
     }
 
     if (ignoreExisting) {


### PR DESCRIPTION
While porting some logic to Python, I noticed that this logic was duplicated throughout the codebase.