### PR TITLE
Migrate Files, Append and Overwrite files in Core to JUnit5

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestFastAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestFastAppend.java
@@ -18,8 +18,12 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,31 +32,24 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.assertj.core.api.Assertions;
 import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestFastAppend extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestFastAppend extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestFastAppend(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testEmptyTableAppend() {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
-    Assert.assertEquals(
-        "Table should start with last-sequence-number 0", 0, base.lastSequenceNumber());
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
 
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -68,14 +65,13 @@ public class TestFastAppend extends TableTestBase {
         "Table should end with last-sequence-number 0", 0, base.lastSequenceNumber());
   }
 
-  @Test
+  @TestTemplate
   public void testEmptyTableAppendManifest() throws IOException {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
-    Assert.assertEquals(
-        "Table should start with last-sequence-number 0", 0, base.lastSequenceNumber());
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
 
     ManifestFile manifest = writeManifest(FILE_A, FILE_B);
     table.newFastAppend().appendManifest(manifest).commit();
@@ -86,16 +82,13 @@ public class TestFastAppend extends TableTestBase {
 
     ManifestFile committedManifest = Iterables.getOnlyElement(snap.allManifests(FILE_IO));
     if (formatVersion == 1) {
-      Assertions.assertThat(committedManifest.path()).isNotEqualTo(manifest.path());
+      assertThat(manifest.path()).isNotEqualTo(committedManifest.path());
     } else {
-      Assertions.assertThat(committedManifest.path()).isEqualTo(manifest.path());
+      assertThat(manifest.path()).isEqualTo(committedManifest.path());
     }
 
     // validate that the metadata summary is correct when using appendManifest
-    Assert.assertEquals(
-        "Summary metadata should include 2 added files",
-        "2",
-        snap.summary().get("added-data-files"));
+    assertThat(snap.summary().get("added-data-files")).isEqualTo("2");
 
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap.sequenceNumber());
     V2Assert.assertEquals(
@@ -105,14 +98,13 @@ public class TestFastAppend extends TableTestBase {
         "Table should end with last-sequence-number 0", 0, base.lastSequenceNumber());
   }
 
-  @Test
+  @TestTemplate
   public void testEmptyTableAppendFilesAndManifest() throws IOException {
     Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
-    Assert.assertEquals(
-        "Table should start with last-sequence-number 0", 0, base.lastSequenceNumber());
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
 
     ManifestFile manifest = writeManifest(FILE_A, FILE_B);
     table.newFastAppend().appendFile(FILE_C).appendFile(FILE_D).appendManifest(manifest).commit();
@@ -135,9 +127,9 @@ public class TestFastAppend extends TableTestBase {
         files(FILE_A, FILE_B));
 
     if (formatVersion == 1) {
-      Assertions.assertThat(snap.allManifests(FILE_IO).get(1).path()).isNotEqualTo(manifest.path());
+      assertThat(snap.allManifests(FILE_IO).get(1).path()).isNotEqualTo(manifest.path());
     } else {
-      Assertions.assertThat(snap.allManifests(FILE_IO).get(1).path()).isEqualTo(manifest.path());
+      assertThat(snap.allManifests(FILE_IO).get(1).path()).isEqualTo(manifest.path());
     }
 
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap.sequenceNumber());
@@ -148,35 +140,32 @@ public class TestFastAppend extends TableTestBase {
         "Table should end with last-sequence-number 0", 0, base.lastSequenceNumber());
   }
 
-  @Test
+  @TestTemplate
   public void testNonEmptyTableAppend() {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     TableMetadata base = readMetadata();
-    Assert.assertNotNull("Should have a current snapshot", base.currentSnapshot());
+    assertThat(base.currentSnapshot()).isNotNull();
     List<ManifestFile> v2manifests = base.currentSnapshot().allManifests(FILE_IO);
-    Assert.assertEquals("Should have one existing manifest", 1, v2manifests.size());
+    assertThat(v2manifests).hasSize(1);
 
     // prepare a new append
     Snapshot pending = table.newFastAppend().appendFile(FILE_C).appendFile(FILE_D).apply();
 
-    Assert.assertNotEquals(
-        "Snapshots should have unique IDs",
-        base.currentSnapshot().snapshotId(),
-        pending.snapshotId());
+    assertThat(pending.snapshotId()).isNotEqualTo(base.currentSnapshot().snapshotId());
     validateSnapshot(base.currentSnapshot(), pending, FILE_C, FILE_D);
   }
 
-  @Test
+  @TestTemplate
   public void testNoMerge() {
     table.newAppend().appendFile(FILE_A).commit();
 
     table.newFastAppend().appendFile(FILE_B).commit();
 
     TableMetadata base = readMetadata();
-    Assert.assertNotNull("Should have a current snapshot", base.currentSnapshot());
+    assertThat(base.currentSnapshot()).isNotNull();
     List<ManifestFile> v3manifests = base.currentSnapshot().allManifests(FILE_IO);
-    Assert.assertEquals("Should have 2 existing manifests", 2, v3manifests.size());
+    assertThat(v3manifests).hasSize(2);
 
     // prepare a new append
     Snapshot pending = table.newFastAppend().appendFile(FILE_C).appendFile(FILE_D).apply();
@@ -186,12 +175,12 @@ public class TestFastAppend extends TableTestBase {
       ids.add(snapshot.snapshotId());
     }
     ids.add(pending.snapshotId());
-    Assert.assertEquals("Snapshots should have 3 unique IDs", 3, ids.size());
+    assertThat(ids).hasSize(3);
 
     validateSnapshot(base.currentSnapshot(), pending, FILE_C, FILE_D);
   }
 
-  @Test
+  @TestTemplate
   public void testRefreshBeforeApply() {
     // load a new copy of the table that will not be refreshed by the commit
     Table stale = load();
@@ -199,9 +188,9 @@ public class TestFastAppend extends TableTestBase {
     table.newAppend().appendFile(FILE_A).commit();
 
     TableMetadata base = readMetadata();
-    Assert.assertNotNull("Should have a current snapshot", base.currentSnapshot());
+    assertThat(base.currentSnapshot()).isNotNull();
     List<ManifestFile> v2manifests = base.currentSnapshot().allManifests(FILE_IO);
-    Assert.assertEquals("Should have 1 existing manifest", 1, v2manifests.size());
+    assertThat(v2manifests).hasSize(1);
 
     // commit from the stale table
     AppendFiles append = stale.newFastAppend().appendFile(FILE_D);
@@ -211,7 +200,7 @@ public class TestFastAppend extends TableTestBase {
     validateSnapshot(base.currentSnapshot(), pending, FILE_D);
   }
 
-  @Test
+  @TestTemplate
   public void testRefreshBeforeCommit() {
     // commit from the stale table
     AppendFiles append = table.newFastAppend().appendFile(FILE_D);
@@ -222,9 +211,9 @@ public class TestFastAppend extends TableTestBase {
     table.newAppend().appendFile(FILE_A).commit();
 
     TableMetadata base = readMetadata();
-    Assert.assertNotNull("Should have a current snapshot", base.currentSnapshot());
+    assertThat(base.currentSnapshot()).isNotNull();
     List<ManifestFile> v2manifests = base.currentSnapshot().allManifests(FILE_IO);
-    Assert.assertEquals("Should have 1 existing manifest", 1, v2manifests.size());
+    assertThat(v2manifests).hasSize(1);
 
     append.commit();
 
@@ -236,13 +225,10 @@ public class TestFastAppend extends TableTestBase {
     List<ManifestFile> committedManifests =
         Lists.newArrayList(committed.currentSnapshot().allManifests(FILE_IO));
     committedManifests.removeAll(base.currentSnapshot().allManifests(FILE_IO));
-    Assert.assertEquals(
-        "Should reused manifest created by apply",
-        pending.allManifests(FILE_IO).get(0),
-        committedManifests.get(0));
+    assertThat(committedManifests.get(0)).isEqualTo(pending.allManifests(FILE_IO).get(0));
   }
 
-  @Test
+  @TestTemplate
   public void testFailure() {
     // inject 5 failures
     TestTables.TestTableOperations ops = table.ops();
@@ -251,16 +237,16 @@ public class TestFastAppend extends TableTestBase {
     AppendFiles append = table.newFastAppend().appendFile(FILE_B);
     Snapshot pending = append.apply();
     ManifestFile newManifest = pending.allManifests(FILE_IO).get(0);
-    Assert.assertTrue("Should create new manifest", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).exists();
 
-    Assertions.assertThatThrownBy(append::commit)
+    assertThatThrownBy(append::commit)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
 
-    Assert.assertFalse("Should clean up new manifest", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).doesNotExist();
   }
 
-  @Test
+  @TestTemplate
   public void testAppendManifestCleanup() throws IOException {
     // inject 5 failures
     TestTables.TestTableOperations ops = table.ops();
@@ -270,25 +256,25 @@ public class TestFastAppend extends TableTestBase {
     AppendFiles append = table.newFastAppend().appendManifest(manifest);
     Snapshot pending = append.apply();
     ManifestFile newManifest = pending.allManifests(FILE_IO).get(0);
-    Assert.assertTrue("Should create new manifest", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).exists();
     if (formatVersion == 1) {
-      Assertions.assertThat(newManifest.path()).isNotEqualTo(manifest.path());
+      assertThat(newManifest.path()).isNotEqualTo(manifest.path());
     } else {
-      Assertions.assertThat(newManifest.path()).isEqualTo(manifest.path());
+      assertThat(newManifest.path()).isEqualTo(manifest.path());
     }
 
-    Assertions.assertThatThrownBy(append::commit)
+    assertThatThrownBy(append::commit)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
 
     if (formatVersion == 1) {
-      Assertions.assertThat(new File(newManifest.path())).doesNotExist();
+      assertThat(new File(newManifest.path())).doesNotExist();
     } else {
-      Assertions.assertThat(new File(newManifest.path())).exists();
+      assertThat(new File(newManifest.path())).exists();
     }
   }
 
-  @Test
+  @TestTemplate
   public void testRecoveryWithManifestList() {
     table.updateProperties().set(TableProperties.MANIFEST_LISTS_ENABLED, "true").commit();
 
@@ -299,20 +285,18 @@ public class TestFastAppend extends TableTestBase {
     AppendFiles append = table.newFastAppend().appendFile(FILE_B);
     Snapshot pending = append.apply();
     ManifestFile newManifest = pending.allManifests(FILE_IO).get(0);
-    Assert.assertTrue("Should create new manifest", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).exists();
 
     append.commit();
 
     TableMetadata metadata = readMetadata();
 
     validateSnapshot(null, metadata.currentSnapshot(), FILE_B);
-    Assert.assertTrue("Should commit same new manifest", new File(newManifest.path()).exists());
-    Assert.assertTrue(
-        "Should commit the same new manifest",
-        metadata.currentSnapshot().allManifests(FILE_IO).contains(newManifest));
+    assertThat(new File(newManifest.path())).exists();
+    assertThat(metadata.currentSnapshot().allManifests(FILE_IO)).contains(newManifest);
   }
 
-  @Test
+  @TestTemplate
   public void testRecoveryWithoutManifestList() {
     table.updateProperties().set(TableProperties.MANIFEST_LISTS_ENABLED, "false").commit();
 
@@ -323,27 +307,25 @@ public class TestFastAppend extends TableTestBase {
     AppendFiles append = table.newFastAppend().appendFile(FILE_B);
     Snapshot pending = append.apply();
     ManifestFile newManifest = pending.allManifests(FILE_IO).get(0);
-    Assert.assertTrue("Should create new manifest", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).exists();
 
     append.commit();
 
     TableMetadata metadata = readMetadata();
 
     validateSnapshot(null, metadata.currentSnapshot(), FILE_B);
-    Assert.assertTrue("Should commit same new manifest", new File(newManifest.path()).exists());
-    Assert.assertTrue(
-        "Should commit the same new manifest",
-        metadata.currentSnapshot().allManifests(FILE_IO).contains(newManifest));
+    assertThat(new File(newManifest.path())).exists();
+    assertThat(metadata.currentSnapshot().allManifests(FILE_IO)).contains(newManifest);
   }
 
-  @Test
+  @TestTemplate
   public void testAppendManifestWithSnapshotIdInheritance() throws IOException {
     table.updateProperties().set(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, "true").commit();
 
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
+    assertThat(base.currentSnapshot()).isNull();
 
     ManifestFile manifest = writeManifest(FILE_A, FILE_B);
     table.newFastAppend().appendManifest(manifest).commit();
@@ -351,7 +333,7 @@ public class TestFastAppend extends TableTestBase {
     Snapshot snapshot = table.currentSnapshot();
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(FILE_IO);
     ManifestFile committedManifest = Iterables.getOnlyElement(manifests);
-    Assertions.assertThat(committedManifest.path()).isEqualTo(manifest.path());
+    assertThat(committedManifest.path()).isEqualTo(manifest.path());
 
     validateManifestEntries(
         manifests.get(0),
@@ -360,32 +342,20 @@ public class TestFastAppend extends TableTestBase {
         statuses(Status.ADDED, Status.ADDED));
 
     // validate that the metadata summary is correct when using appendManifest
-    Assert.assertEquals(
-        "Summary metadata should include 2 added files",
-        "2",
-        snapshot.summary().get("added-data-files"));
-    Assert.assertEquals(
-        "Summary metadata should include 2 added records",
-        "2",
-        snapshot.summary().get("added-records"));
-    Assert.assertEquals(
-        "Summary metadata should include 2 files in total",
-        "2",
-        snapshot.summary().get("total-data-files"));
-    Assert.assertEquals(
-        "Summary metadata should include 2 records in total",
-        "2",
-        snapshot.summary().get("total-records"));
+    assertThat(snapshot.summary().get("added-data-files")).isEqualTo("2");
+    assertThat(snapshot.summary().get("added-records")).isEqualTo("2");
+    assertThat(snapshot.summary().get("total-data-files")).isEqualTo("2");
+    assertThat(snapshot.summary().get("total-records")).isEqualTo("2");
   }
 
-  @Test
+  @TestTemplate
   public void testAppendManifestFailureWithSnapshotIdInheritance() throws IOException {
     table.updateProperties().set(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, "true").commit();
 
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
+    assertThat(base.currentSnapshot()).isNull();
 
     table.updateProperties().set(TableProperties.COMMIT_NUM_RETRIES, "1").commit();
 
@@ -396,36 +366,36 @@ public class TestFastAppend extends TableTestBase {
     AppendFiles append = table.newAppend();
     append.appendManifest(manifest);
 
-    Assertions.assertThatThrownBy(append::commit)
+    assertThatThrownBy(append::commit)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
 
-    Assert.assertTrue("Append manifest should not be deleted", new File(manifest.path()).exists());
+    assertThat(new File(manifest.path())).exists();
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidAppendManifest() throws IOException {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
+    assertThat(base.currentSnapshot()).isNull();
 
     ManifestFile manifestWithExistingFiles =
         writeManifest("manifest-file-1.avro", manifestEntry(Status.EXISTING, null, FILE_A));
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> table.newFastAppend().appendManifest(manifestWithExistingFiles).commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot append manifest with existing files");
 
     ManifestFile manifestWithDeletedFiles =
         writeManifest("manifest-file-2.avro", manifestEntry(Status.DELETED, null, FILE_A));
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> table.newFastAppend().appendManifest(manifestWithDeletedFiles).commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot append manifest with deleted files");
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionSummariesOnUnpartitionedTable() {
     Table table =
         TestTables.create(
@@ -447,7 +417,7 @@ public class TestFastAppend extends TableTestBase {
                 .build())
         .commit();
 
-    Assertions.assertThat(
+    assertThat(
             table.currentSnapshot().summary().keySet().stream()
                 .filter(key -> key.startsWith(SnapshotSummary.CHANGED_PARTITION_PREFIX))
                 .collect(Collectors.toSet()))
@@ -455,7 +425,7 @@ public class TestFastAppend extends TableTestBase {
         .isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultPartitionSummaries() {
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -463,23 +433,21 @@ public class TestFastAppend extends TableTestBase {
         table.currentSnapshot().summary().keySet().stream()
             .filter(key -> key.startsWith(SnapshotSummary.CHANGED_PARTITION_PREFIX))
             .collect(Collectors.toSet());
-    Assert.assertEquals(
-        "Should include no partition summaries by default", 0, partitionSummaryKeys.size());
+    assertThat(partitionSummaryKeys).isEmpty();
 
     String summariesIncluded =
         table
             .currentSnapshot()
             .summary()
             .getOrDefault(SnapshotSummary.PARTITION_SUMMARY_PROP, "false");
-    Assert.assertEquals(
-        "Should not set partition-summaries-included to true", "false", summariesIncluded);
+    assertThat(summariesIncluded).isEqualTo("false");
 
     String changedPartitions =
         table.currentSnapshot().summary().get(SnapshotSummary.CHANGED_PARTITION_COUNT_PROP);
-    Assert.assertEquals("Should set changed partition count", "1", changedPartitions);
+    assertThat(changedPartitions).isEqualTo("1");
   }
 
-  @Test
+  @TestTemplate
   public void testIncludedPartitionSummaries() {
     table.updateProperties().set(TableProperties.WRITE_PARTITION_SUMMARY_LIMIT, "1").commit();
 
@@ -489,32 +457,29 @@ public class TestFastAppend extends TableTestBase {
         table.currentSnapshot().summary().keySet().stream()
             .filter(key -> key.startsWith(SnapshotSummary.CHANGED_PARTITION_PREFIX))
             .collect(Collectors.toSet());
-    Assert.assertEquals("Should include a partition summary", 1, partitionSummaryKeys.size());
+    assertThat(partitionSummaryKeys).hasSize(1);
 
     String summariesIncluded =
         table
             .currentSnapshot()
             .summary()
             .getOrDefault(SnapshotSummary.PARTITION_SUMMARY_PROP, "false");
-    Assert.assertEquals(
-        "Should set partition-summaries-included to true", "true", summariesIncluded);
+    assertThat(summariesIncluded).isEqualTo("true");
 
     String changedPartitions =
         table.currentSnapshot().summary().get(SnapshotSummary.CHANGED_PARTITION_COUNT_PROP);
-    Assert.assertEquals("Should set changed partition count", "1", changedPartitions);
+    assertThat(changedPartitions).isEqualTo("1");
 
     String partitionSummary =
         table
             .currentSnapshot()
             .summary()
             .get(SnapshotSummary.CHANGED_PARTITION_PREFIX + "data_bucket=0");
-    Assert.assertEquals(
-        "Summary should include 1 file with 1 record that is 10 bytes",
-        "added-data-files=1,added-records=1,added-files-size=10",
-        partitionSummary);
+    assertThat(partitionSummary)
+        .isEqualTo("added-data-files=1,added-records=1,added-files-size=10");
   }
 
-  @Test
+  @TestTemplate
   public void testIncludedPartitionSummaryLimit() {
     table.updateProperties().set(TableProperties.WRITE_PARTITION_SUMMARY_LIMIT, "1").commit();
 
@@ -524,69 +489,63 @@ public class TestFastAppend extends TableTestBase {
         table.currentSnapshot().summary().keySet().stream()
             .filter(key -> key.startsWith(SnapshotSummary.CHANGED_PARTITION_PREFIX))
             .collect(Collectors.toSet());
-    Assert.assertEquals(
-        "Should include no partition summaries, over limit", 0, partitionSummaryKeys.size());
+    assertThat(partitionSummaryKeys).isEmpty();
 
     String summariesIncluded =
         table
             .currentSnapshot()
             .summary()
             .getOrDefault(SnapshotSummary.PARTITION_SUMMARY_PROP, "false");
-    Assert.assertEquals(
-        "Should not set partition-summaries-included to true", "false", summariesIncluded);
+    assertThat(summariesIncluded).isEqualTo("false");
 
     String changedPartitions =
         table.currentSnapshot().summary().get(SnapshotSummary.CHANGED_PARTITION_COUNT_PROP);
-    Assert.assertEquals("Should set changed partition count", "2", changedPartitions);
+    assertThat(changedPartitions).isEqualTo("2");
   }
 
-  @Test
+  @TestTemplate
   public void testAppendToExistingBranch() {
     table.newFastAppend().appendFile(FILE_A).commit();
     table.manageSnapshots().createBranch("branch", table.currentSnapshot().snapshotId()).commit();
     table.newFastAppend().appendFile(FILE_B).toBranch("branch").commit();
-    int branchSnapshot = 2;
 
-    Assert.assertEquals(table.currentSnapshot().snapshotId(), 1);
-    Assert.assertEquals(table.ops().current().ref("branch").snapshotId(), branchSnapshot);
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(1);
+    assertThat(table.ops().current().ref("branch").snapshotId()).isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testAppendCreatesBranchIfNeeded() {
     table.newFastAppend().appendFile(FILE_A).commit();
     table.newFastAppend().appendFile(FILE_B).toBranch("branch").commit();
-    int branchSnapshot = 2;
 
-    Assert.assertEquals(table.currentSnapshot().snapshotId(), 1);
-    Assert.assertNotNull(table.ops().current().ref("branch"));
-    Assert.assertEquals(table.ops().current().ref("branch").snapshotId(), branchSnapshot);
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(1);
+    assertThat(table.ops().current().ref("branch")).isNotNull();
+    assertThat(table.ops().current().ref("branch").snapshotId()).isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testAppendToBranchEmptyTable() {
     table.newFastAppend().appendFile(FILE_B).toBranch("branch").commit();
-    int branchSnapshot = 1;
 
-    Assert.assertNull(table.currentSnapshot());
-    Assert.assertNotNull(table.ops().current().ref("branch"));
-    Assert.assertEquals(table.ops().current().ref("branch").snapshotId(), branchSnapshot);
+    assertThat(table.currentSnapshot()).isNull();
+    assertThat(table.ops().current().ref("branch")).isNotNull();
+    assertThat(table.ops().current().ref("branch").snapshotId()).isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void testAppendToNullBranchFails() {
-    Assertions.assertThatThrownBy(() -> table.newFastAppend().appendFile(FILE_A).toBranch(null))
+    assertThatThrownBy(() -> table.newFastAppend().appendFile(FILE_A).toBranch(null))
         .as("Invalid branch")
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid branch name: null");
   }
 
-  @Test
+  @TestTemplate
   public void testAppendToTagFails() {
     table.newFastAppend().appendFile(FILE_A).commit();
     table.manageSnapshots().createTag("some-tag", table.currentSnapshot().snapshotId()).commit();
 
-    Assertions.assertThatThrownBy(
-            () -> table.newFastAppend().appendFile(FILE_A).toBranch("some-tag").commit())
+    assertThatThrownBy(() -> table.newFastAppend().appendFile(FILE_A).toBranch("some-tag").commit())
         .as("Invalid branch")
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(

--- a/core/src/test/java/org/apache/iceberg/TestFastAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestFastAppend.java
@@ -341,10 +341,11 @@ public class TestFastAppend extends TestBase {
         statuses(Status.ADDED, Status.ADDED));
 
     // validate that the metadata summary is correct when using appendManifest
-    assertThat(snapshot.summary()).containsEntry("added-data-files", "2");
-    assertThat(snapshot.summary()).containsEntry("added-records", "2");
-    assertThat(snapshot.summary()).containsEntry("total-data-files", "2");
-    assertThat(snapshot.summary()).containsEntry("total-records", "2");
+    assertThat(snapshot.summary())
+        .containsEntry("added-data-files", "2")
+        .containsEntry("added-records", "2")
+        .containsEntry("total-data-files", "2")
+        .containsEntry("total-records", "2");
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -117,7 +117,7 @@ public class TestMergeAppend extends TestBase {
         statuses(Status.ADDED, Status.ADDED));
 
     // validate that the metadata summary is correct when using appendManifest
-    assertThat(committedSnapshot.summary().get("added-data-files")).isEqualTo("2");
+    assertThat(committedSnapshot.summary()).containsEntry("added-data-files", "2");
   }
 
   @TestTemplate
@@ -392,7 +392,7 @@ public class TestMergeAppend extends TestBase {
         statuses(Status.EXISTING, Status.EXISTING, Status.EXISTING));
 
     // validate that the metadata summary is correct when using appendManifest
-    assertThat(snap2.summary().get("added-data-files")).isEqualTo("3");
+    assertThat(snap2.summary()).containsEntry("added-data-files", "3");
   }
 
   @TestTemplate
@@ -578,7 +578,7 @@ public class TestMergeAppend extends TestBase {
         statuses(Status.ADDED));
 
     // validate that the metadata summary is correct when using appendManifest
-    assertThat(committed.summary().get("added-data-files")).isEqualTo("4");
+    assertThat(committed.summary()).containsEntry("added-data-files", "4");
   }
 
   @TestTemplate
@@ -1071,10 +1071,11 @@ public class TestMergeAppend extends TestBase {
         statuses(Status.ADDED, Status.ADDED));
 
     // validate that the metadata summary is correct when using appendManifest
-    assertThat(snapshot.summary().get("added-data-files")).isEqualTo("2");
-    assertThat(snapshot.summary().get("added-records")).isEqualTo("2");
-    assertThat(snapshot.summary().get("total-data-files")).isEqualTo("2");
-    assertThat(snapshot.summary().get("total-records")).isEqualTo("2");
+    assertThat(snapshot.summary())
+        .containsEntry("added-data-files", "2")
+        .containsEntry("added-records", "2")
+        .containsEntry("total-data-files", "2")
+        .containsEntry("total-records", "2");
   }
 
   @TestTemplate
@@ -1320,16 +1321,9 @@ public class TestMergeAppend extends TestBase {
             .collect(Collectors.toSet());
     assertThat(partitionSummaryKeys).isEmpty();
 
-    String summariesIncluded =
-        table
-            .currentSnapshot()
-            .summary()
-            .getOrDefault(SnapshotSummary.PARTITION_SUMMARY_PROP, "false");
-    assertThat(summariesIncluded).isEqualTo("false");
-
-    String changedPartitions =
-        table.currentSnapshot().summary().get(SnapshotSummary.CHANGED_PARTITION_COUNT_PROP);
-    assertThat(changedPartitions).isEqualTo("1");
+    assertThat(table.currentSnapshot().summary())
+        .doesNotContainKey(SnapshotSummary.PARTITION_SUMMARY_PROP)
+        .containsEntry(SnapshotSummary.CHANGED_PARTITION_COUNT_PROP, "1");
   }
 
   @TestTemplate
@@ -1344,24 +1338,12 @@ public class TestMergeAppend extends TestBase {
             .collect(Collectors.toSet());
     assertThat(partitionSummaryKeys).hasSize(1);
 
-    String summariesIncluded =
-        table
-            .currentSnapshot()
-            .summary()
-            .getOrDefault(SnapshotSummary.PARTITION_SUMMARY_PROP, "false");
-    assertThat(summariesIncluded).isEqualTo("true");
-
-    String changedPartitions =
-        table.currentSnapshot().summary().get(SnapshotSummary.CHANGED_PARTITION_COUNT_PROP);
-    assertThat(changedPartitions).isEqualTo("1");
-
-    String partitionSummary =
-        table
-            .currentSnapshot()
-            .summary()
-            .get(SnapshotSummary.CHANGED_PARTITION_PREFIX + "data_bucket=0");
-    assertThat(partitionSummary)
-        .isEqualTo("added-data-files=1,added-records=1,added-files-size=10");
+    assertThat(table.currentSnapshot().summary())
+        .containsEntry(SnapshotSummary.PARTITION_SUMMARY_PROP, "true")
+        .containsEntry(SnapshotSummary.CHANGED_PARTITION_COUNT_PROP, "1")
+        .containsEntry(
+            SnapshotSummary.CHANGED_PARTITION_PREFIX + "data_bucket=0",
+            "added-data-files=1,added-records=1,added-files-size=10");
   }
 
   @TestTemplate
@@ -1376,15 +1358,8 @@ public class TestMergeAppend extends TestBase {
             .collect(Collectors.toSet());
     assertThat(partitionSummaryKeys).isEmpty();
 
-    String summariesIncluded =
-        table
-            .currentSnapshot()
-            .summary()
-            .getOrDefault(SnapshotSummary.PARTITION_SUMMARY_PROP, "false");
-    assertThat(summariesIncluded).isEqualTo("false");
-
-    String changedPartitions =
-        table.currentSnapshot().summary().get(SnapshotSummary.CHANGED_PARTITION_COUNT_PROP);
-    assertThat(changedPartitions).isEqualTo("2");
+    assertThat(table.currentSnapshot().summary())
+        .doesNotContainKey(SnapshotSummary.PARTITION_SUMMARY_PROP)
+        .containsEntry(SnapshotSummary.CHANGED_PARTITION_COUNT_PROP, "2");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -20,9 +20,12 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.relocated.com.google.common.collect.Iterators.concat;
 import static org.apache.iceberg.util.SnapshotUtil.latestSnapshot;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -31,55 +34,43 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestMergeAppend extends TableTestBase {
-  private final String branch;
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestMergeAppend extends TestBase {
+  @Parameter(index = 1)
+  private String branch;
 
-  @Parameterized.Parameters(name = "formatVersion = {0}, branch = {1}")
-  public static Object[] parameters() {
-    return new Object[][] {
-      new Object[] {1, "main"},
-      new Object[] {1, "testBranch"},
-      new Object[] {2, "main"},
-      new Object[] {2, "testBranch"}
-    };
+  @Parameters(name = "formatVersion = {0}, branch = {1}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(
+        new Object[] {1, "main"},
+        new Object[] {1, "testBranch"},
+        new Object[] {2, "main"},
+        new Object[] {2, "testBranch"});
   }
 
-  public TestMergeAppend(int formatVersion, String branch) {
-    super(formatVersion);
-    this.branch = branch;
-  }
-
-  @Test
+  @TestTemplate
   public void testEmptyTableAppend() {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
-    Assert.assertEquals("Last sequence number should be 0", 0, base.lastSequenceNumber());
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
 
     Snapshot committedSnapshot =
         commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
-    Assert.assertNotNull("Should create a snapshot", committedSnapshot);
+    assertThat(committedSnapshot).isNotNull();
     V1Assert.assertEquals(
         "Last sequence number should be 0", 0, table.ops().current().lastSequenceNumber());
     V2Assert.assertEquals(
         "Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
 
-    Assert.assertEquals(
-        "Should create 1 manifest for initial write",
-        1,
-        committedSnapshot.allManifests(table.io()).size());
+    assertThat(committedSnapshot.allManifests(table.io())).hasSize(1);
 
     long snapshotId = committedSnapshot.snapshotId();
 
@@ -92,18 +83,18 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.ADDED, Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testEmptyTableAppendManifest() throws IOException {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
-    Assert.assertEquals("Last sequence number should be 0", 0, base.lastSequenceNumber());
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
 
     ManifestFile manifest = writeManifest(FILE_A, FILE_B);
     Snapshot committedSnapshot = commit(table, table.newAppend().appendManifest(manifest), branch);
 
-    Assert.assertNotNull("Should create a snapshot", committedSnapshot);
+    assertThat(committedSnapshot).isNotNull();
     V1Assert.assertEquals(
         "Last sequence number should be 0", 0, table.ops().current().lastSequenceNumber());
     V2Assert.assertEquals(
@@ -111,9 +102,9 @@ public class TestMergeAppend extends TableTestBase {
     List<ManifestFile> manifests = committedSnapshot.allManifests(table.io());
     ManifestFile committedManifest = Iterables.getOnlyElement(manifests);
     if (formatVersion == 1) {
-      Assertions.assertThat(committedManifest.path()).isNotEqualTo(manifest.path());
+      assertThat(committedManifest.path()).isNotEqualTo(manifest.path());
     } else {
-      Assertions.assertThat(committedManifest.path()).isEqualTo(manifest.path());
+      assertThat(committedManifest.path()).isEqualTo(manifest.path());
     }
 
     long snapshotId = committedSnapshot.snapshotId();
@@ -126,19 +117,16 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.ADDED, Status.ADDED));
 
     // validate that the metadata summary is correct when using appendManifest
-    Assert.assertEquals(
-        "Summary metadata should include 2 added files",
-        "2",
-        committedSnapshot.summary().get("added-data-files"));
+    assertThat(committedSnapshot.summary().get("added-data-files")).isEqualTo("2");
   }
 
-  @Test
+  @TestTemplate
   public void testEmptyTableAppendFilesAndManifest() throws IOException {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
-    Assert.assertEquals("Last sequence number should be 0", 0, base.lastSequenceNumber());
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
 
     ManifestFile manifest = writeManifest(FILE_A, FILE_B);
     Snapshot committedSnapshot =
@@ -147,15 +135,12 @@ public class TestMergeAppend extends TableTestBase {
             table.newAppend().appendFile(FILE_C).appendFile(FILE_D).appendManifest(manifest),
             branch);
 
-    Assert.assertNotNull("Should create a snapshot", committedSnapshot);
+    assertThat(committedSnapshot).isNotNull();
     V1Assert.assertEquals(
         "Last sequence number should be 0", 0, table.ops().current().lastSequenceNumber());
     V2Assert.assertEquals(
         "Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
-    Assert.assertEquals(
-        "Should create 2 manifests for initial write",
-        2,
-        committedSnapshot.allManifests(table.io()).size());
+    assertThat(committedSnapshot.allManifests(table.io())).hasSize(2);
 
     long snapshotId = committedSnapshot.snapshotId();
 
@@ -163,9 +148,9 @@ public class TestMergeAppend extends TableTestBase {
     ManifestFile committedManifest2 = committedSnapshot.allManifests(table.io()).get(1);
 
     if (formatVersion == 1) {
-      Assertions.assertThat(committedManifest2.path()).isNotEqualTo(manifest.path());
+      assertThat(committedManifest2.path()).isNotEqualTo(manifest.path());
     } else {
-      Assertions.assertThat(committedManifest2.path()).isEqualTo(manifest.path());
+      assertThat(committedManifest2.path()).isEqualTo(manifest.path());
     }
 
     validateManifest(
@@ -185,13 +170,13 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.ADDED, Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testAppendWithManifestScanExecutor() {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
-    Assert.assertEquals("Last sequence number should be 0", 0, base.lastSequenceNumber());
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
     AtomicInteger scanThreadsIndex = new AtomicInteger(0);
     Snapshot snapshot =
         commit(
@@ -212,20 +197,22 @@ public class TestMergeAppend extends TableTestBase {
                           return thread;
                         })),
             branch);
-    Assert.assertTrue("Thread should be created in provided pool", scanThreadsIndex.get() > 0);
-    Assert.assertNotNull("Should create a snapshot", snapshot);
+    assertThat(scanThreadsIndex.get())
+        .as("Thread should be created in provided pool")
+        .isGreaterThan(0);
+    assertThat(snapshot).isNotNull();
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithAppendFilesAndManifest() throws IOException {
     // merge all manifests for this test
     table.updateProperties().set("commit.manifest.min-count-to-merge", "1").commit();
 
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
-    Assert.assertEquals("Last sequence number should be 0", 0, base.lastSequenceNumber());
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
 
     ManifestFile manifest = writeManifest(FILE_A, FILE_B);
     Snapshot committedSnapshot =
@@ -234,7 +221,7 @@ public class TestMergeAppend extends TableTestBase {
             table.newAppend().appendFile(FILE_C).appendFile(FILE_D).appendManifest(manifest),
             branch);
 
-    Assert.assertNotNull("Should create a snapshot", committedSnapshot);
+    assertThat(committedSnapshot).isNotNull();
     V1Assert.assertEquals(
         "Last sequence number should be 0", 0, table.ops().current().lastSequenceNumber());
     V2Assert.assertEquals(
@@ -245,7 +232,7 @@ public class TestMergeAppend extends TableTestBase {
     List<ManifestFile> manifests = committedSnapshot.allManifests(table.io());
     ManifestFile committedManifest = Iterables.getOnlyElement(manifests);
 
-    Assertions.assertThat(committedManifest.path()).isNotEqualTo(manifest.path());
+    assertThat(committedManifest.path()).isNotEqualTo(manifest.path());
 
     validateManifest(
         committedManifest,
@@ -256,17 +243,17 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.ADDED, Status.ADDED, Status.ADDED, Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithExistingManifest() {
     // merge all manifests for this test
     table.updateProperties().set("commit.manifest.min-count-to-merge", "1").commit();
-    Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
+    assertThat(readMetadata().lastSequenceNumber()).isEqualTo(0);
 
     Snapshot commitBefore =
         commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
-    Assert.assertNotNull("Should create a snapshot", commitBefore);
+    assertThat(commitBefore).isNotNull();
     V1Assert.assertEquals(
         "Last sequence number should be 0", 0, table.ops().current().lastSequenceNumber());
     V2Assert.assertEquals(
@@ -276,10 +263,7 @@ public class TestMergeAppend extends TableTestBase {
     long baseId = commitBefore.snapshotId();
     validateSnapshot(null, commitBefore, 1, FILE_A, FILE_B);
 
-    Assert.assertEquals(
-        "Should create 1 manifest for initial write",
-        1,
-        commitBefore.allManifests(table.io()).size());
+    assertThat(commitBefore.allManifests(table.io())).hasSize(1);
     ManifestFile initialManifest = commitBefore.allManifests(table.io()).get(0);
     validateManifest(
         initialManifest,
@@ -296,13 +280,9 @@ public class TestMergeAppend extends TableTestBase {
     V2Assert.assertEquals(
         "Last sequence number should be 2", 2, table.ops().current().lastSequenceNumber());
 
-    Assert.assertEquals(
-        "Should contain 1 merged manifest for second write",
-        1,
-        committedAfter.allManifests(table.io()).size());
+    assertThat(committedAfter.allManifests(table.io())).hasSize(1);
     ManifestFile newManifest = committedAfter.allManifests(table.io()).get(0);
-    Assert.assertNotEquals(
-        "Should not contain manifest from initial write", initialManifest, newManifest);
+    assertThat(newManifest).isNotEqualTo(initialManifest);
 
     long snapshotId = committedAfter.snapshotId();
 
@@ -315,9 +295,9 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.ADDED, Status.ADDED, Status.EXISTING, Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testManifestMergeMinCount() throws IOException {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
     table
         .updateProperties()
         .set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "2")
@@ -328,8 +308,8 @@ public class TestMergeAppend extends TableTestBase {
         .commit();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
-    Assert.assertEquals("Last sequence number should be 0", 0, base.lastSequenceNumber());
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
 
     ManifestFile manifest = writeManifestWithName("FILE_A", FILE_A);
     ManifestFile manifest2 = writeManifestWithName("FILE_C", FILE_C);
@@ -351,10 +331,7 @@ public class TestMergeAppend extends TableTestBase {
     V1Assert.assertEquals(
         "Table should end with last-sequence-number 0", 0, base.lastSequenceNumber());
 
-    Assert.assertEquals(
-        "Should contain 2 merged manifest for first write",
-        2,
-        snap1.allManifests(table.io()).size());
+    assertThat(snap1.allManifests(table.io())).hasSize(2);
     validateManifest(
         snap1.allManifests(table.io()).get(0),
         dataSeqs(1L),
@@ -391,10 +368,7 @@ public class TestMergeAppend extends TableTestBase {
     V1Assert.assertEquals(
         "Table should end with last-sequence-number 0", 0, base.lastSequenceNumber());
 
-    Assert.assertEquals(
-        "Should contain 3 merged manifest for second write",
-        3,
-        snap2.allManifests(table.io()).size());
+    assertThat(snap2.allManifests(table.io())).hasSize(3);
     validateManifest(
         snap2.allManifests(table.io()).get(0),
         dataSeqs(2L),
@@ -418,15 +392,12 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.EXISTING, Status.EXISTING, Status.EXISTING));
 
     // validate that the metadata summary is correct when using appendManifest
-    Assert.assertEquals(
-        "Summary metadata should include 3 added files",
-        "3",
-        snap2.summary().get("added-data-files"));
+    assertThat(snap2.summary().get("added-data-files")).isEqualTo("3");
   }
 
-  @Test
+  @TestTemplate
   public void testManifestsMergeIntoOne() throws IOException {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
     Snapshot snap1 = commit(table, table.newAppend().appendFile(FILE_A), branch);
     TableMetadata base = readMetadata();
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap1.sequenceNumber());
@@ -435,7 +406,7 @@ public class TestMergeAppend extends TableTestBase {
         "Table should end with last-sequence-number 0", 0, base.lastSequenceNumber());
     long commitId1 = snap1.snapshotId();
 
-    Assert.assertEquals("Should contain 1 manifest", 1, snap1.allManifests(table.io()).size());
+    assertThat(snap1.allManifests(table.io())).hasSize(1);
     validateManifest(
         snap1.allManifests(table.io()).get(0),
         dataSeqs(1L),
@@ -452,7 +423,7 @@ public class TestMergeAppend extends TableTestBase {
     V1Assert.assertEquals(
         "Table should end with last-sequence-number 0", 0, base.lastSequenceNumber());
 
-    Assert.assertEquals("Should contain 2 manifests", 2, snap2.allManifests(table.io()).size());
+    assertThat(snap2.allManifests(table.io())).hasSize(2);
     validateManifest(
         snap2.allManifests(table.io()).get(0),
         dataSeqs(2L),
@@ -484,7 +455,7 @@ public class TestMergeAppend extends TableTestBase {
     V1Assert.assertEquals(
         "Table should end with last-sequence-number 0", 0, base.lastSequenceNumber());
 
-    Assert.assertEquals("Should contain 3 manifests", 3, snap3.allManifests(table.io()).size());
+    assertThat(snap3.allManifests(table.io())).hasSize(3);
     long commitId3 = snap3.snapshotId();
     validateManifest(
         snap3.allManifests(table.io()).get(0),
@@ -527,8 +498,7 @@ public class TestMergeAppend extends TableTestBase {
         "Table should end with last-sequence-number 0", 0, base.lastSequenceNumber());
 
     long commitId4 = snap4.snapshotId();
-    Assert.assertEquals(
-        "Should only contains 1 merged manifest", 1, snap4.allManifests(table.io()).size());
+    assertThat(snap4.allManifests(table.io())).hasSize(1);
     validateManifest(
         snap4.allManifests(table.io()).get(0),
         dataSeqs(4L, 3L, 2L, 1L),
@@ -538,14 +508,14 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.ADDED, Status.EXISTING, Status.EXISTING, Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testManifestDoNotMergeMinCount() throws IOException {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
     table.updateProperties().set("commit.manifest.min-count-to-merge", "4").commit();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
-    Assert.assertEquals("Last sequence number should be 0", 0, base.lastSequenceNumber());
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
 
     ManifestFile manifest = writeManifest(FILE_A, FILE_B);
     ManifestFile manifest2 = writeManifestWithName("FILE_C", FILE_C);
@@ -560,14 +530,14 @@ public class TestMergeAppend extends TableTestBase {
                 .appendManifest(manifest3),
             branch);
 
-    Assert.assertNotNull("Should create a snapshot", committed);
+    assertThat(committed).isNotNull();
     V1Assert.assertEquals(
         "Last sequence number should be 0", 0, table.ops().current().lastSequenceNumber());
     V2Assert.assertEquals(
         "Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
 
     List<ManifestFile> manifests = committed.allManifests(table.io());
-    Assertions.assertThat(manifests).hasSize(3);
+    assertThat(manifests).hasSize(3);
 
     ManifestFile committedManifest = manifests.get(0);
     ManifestFile committedManifest2 = manifests.get(1);
@@ -576,13 +546,13 @@ public class TestMergeAppend extends TableTestBase {
     long snapshotId = committed.snapshotId();
 
     if (formatVersion == 1) {
-      Assertions.assertThat(committedManifest.path()).isNotEqualTo(manifest.path());
-      Assertions.assertThat(committedManifest2.path()).isNotEqualTo(manifest2.path());
-      Assertions.assertThat(committedManifest3.path()).isNotEqualTo(manifest3.path());
+      assertThat(committedManifest.path()).isNotEqualTo(manifest.path());
+      assertThat(committedManifest2.path()).isNotEqualTo(manifest2.path());
+      assertThat(committedManifest3.path()).isNotEqualTo(manifest3.path());
     } else {
-      Assertions.assertThat(committedManifest.path()).isEqualTo(manifest.path());
-      Assertions.assertThat(committedManifest2.path()).isEqualTo(manifest2.path());
-      Assertions.assertThat(committedManifest3.path()).isEqualTo(manifest3.path());
+      assertThat(committedManifest.path()).isEqualTo(manifest.path());
+      assertThat(committedManifest2.path()).isEqualTo(manifest2.path());
+      assertThat(committedManifest3.path()).isEqualTo(manifest3.path());
     }
 
     validateManifest(
@@ -608,19 +578,16 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.ADDED));
 
     // validate that the metadata summary is correct when using appendManifest
-    Assert.assertEquals(
-        "Summary metadata should include 4 added files",
-        "4",
-        committed.summary().get("added-data-files"));
+    assertThat(committed.summary().get("added-data-files")).isEqualTo("4");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithExistingManifestAfterDelete() {
     // merge all manifests for this test
     table.updateProperties().set("commit.manifest.min-count-to-merge", "1").commit();
 
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
-    Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
+    assertThat(listManifestFiles()).isEmpty();
+    assertThat(readMetadata().lastSequenceNumber()).isEqualTo(0);
 
     Snapshot snap = commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
@@ -628,8 +595,7 @@ public class TestMergeAppend extends TableTestBase {
 
     TableMetadata base = readMetadata();
     long baseId = snap.snapshotId();
-    Assert.assertEquals(
-        "Should create 1 manifest for initial write", 1, snap.allManifests(table.io()).size());
+    assertThat(snap.allManifests(table.io())).hasSize(1);
     ManifestFile initialManifest = snap.allManifests(table.io()).get(0);
     validateManifest(
         initialManifest,
@@ -650,10 +616,7 @@ public class TestMergeAppend extends TableTestBase {
 
     TableMetadata delete = readMetadata();
     long deleteId = latestSnapshot(table, branch).snapshotId();
-    Assert.assertEquals(
-        "Should create 1 filtered manifest for delete",
-        1,
-        latestSnapshot(table, branch).allManifests(table.io()).size());
+    assertThat(latestSnapshot(table, branch).allManifests(table.io())).hasSize(1);
     ManifestFile deleteManifest = deleteSnapshot.allManifests(table.io()).get(0);
 
     validateManifest(
@@ -674,13 +637,9 @@ public class TestMergeAppend extends TableTestBase {
     V1Assert.assertEquals(
         "Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
 
-    Assert.assertEquals(
-        "Should contain 1 merged manifest for second write",
-        1,
-        committedSnapshot.allManifests(table.io()).size());
+    assertThat(committedSnapshot.allManifests(table.io())).hasSize(1);
     ManifestFile newManifest = committedSnapshot.allManifests(table.io()).get(0);
-    Assert.assertNotEquals(
-        "Should not contain manifest from initial write", initialManifest, newManifest);
+    assertThat(newManifest).isNotEqualTo(initialManifest);
 
     long snapshotId = committedSnapshot.snapshotId();
 
@@ -692,13 +651,13 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.ADDED, Status.ADDED, Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testMinMergeCount() {
     // only merge when there are at least 4 manifests
     table.updateProperties().set("commit.manifest.min-count-to-merge", "4").commit();
 
-    Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
+    assertThat(readMetadata().lastSequenceNumber()).isEqualTo(0);
 
     Snapshot snap1 = commit(table, table.newFastAppend().appendFile(FILE_A), branch);
     long idFileA = snap1.snapshotId();
@@ -708,18 +667,14 @@ public class TestMergeAppend extends TableTestBase {
     long idFileB = snap2.snapshotId();
     validateSnapshot(snap1, snap2, 2, FILE_B);
 
-    Assert.assertEquals(
-        "Should have 2 manifests from setup writes", 2, snap2.allManifests(table.io()).size());
+    assertThat(snap2.allManifests(table.io())).hasSize(2);
 
     Snapshot snap3 = commit(table, table.newAppend().appendFile(FILE_C), branch);
     long idFileC = snap3.snapshotId();
     validateSnapshot(snap2, snap3, 3, FILE_C);
 
     TableMetadata base = readMetadata();
-    Assert.assertEquals(
-        "Should have 3 unmerged manifests",
-        3,
-        latestSnapshot(table, branch).allManifests(table.io()).size());
+    assertThat(latestSnapshot(table, branch).allManifests(table.io())).hasSize(3);
     Set<ManifestFile> unmerged =
         Sets.newHashSet(latestSnapshot(table, branch).allManifests(table.io()));
 
@@ -730,12 +685,10 @@ public class TestMergeAppend extends TableTestBase {
     V1Assert.assertEquals(
         "Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
 
-    Assert.assertEquals(
-        "Should contain 1 merged manifest after the 4th write",
-        1,
-        committed.allManifests(table.io()).size());
+    assertThat(committed.allManifests(table.io())).hasSize(1);
+
     ManifestFile newManifest = committed.allManifests(table.io()).get(0);
-    Assert.assertFalse("Should not contain previous manifests", unmerged.contains(newManifest));
+    assertThat(unmerged).doesNotContain(newManifest);
 
     long lastSnapshotId = committed.snapshotId();
 
@@ -748,13 +701,13 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.ADDED, Status.EXISTING, Status.EXISTING, Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeSizeTargetWithExistingManifest() {
     // use a small limit on manifest size to prevent merging
     table.updateProperties().set(TableProperties.MANIFEST_TARGET_SIZE_BYTES, "10").commit();
 
-    Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
+    assertThat(readMetadata().lastSequenceNumber()).isEqualTo(0);
 
     Snapshot snap = commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
@@ -762,8 +715,7 @@ public class TestMergeAppend extends TableTestBase {
 
     TableMetadata base = readMetadata();
     long baseId = snap.snapshotId();
-    Assert.assertEquals(
-        "Should create 1 manifest for initial write", 1, snap.allManifests(table.io()).size());
+    assertThat(snap.allManifests(table.io())).hasSize(1);
     ManifestFile initialManifest = snap.allManifests(table.io()).get(0);
     validateManifest(
         initialManifest,
@@ -782,13 +734,9 @@ public class TestMergeAppend extends TableTestBase {
     V1Assert.assertEquals(
         "Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
 
-    Assert.assertEquals(
-        "Should contain 2 unmerged manifests after second write",
-        2,
-        committed.allManifests(table.io()).size());
+    assertThat(committed.allManifests(table.io())).hasSize(2);
     ManifestFile newManifest = committed.allManifests(table.io()).get(0);
-    Assert.assertNotEquals(
-        "Should not contain manifest from initial write", initialManifest, newManifest);
+    assertThat(newManifest).isNotEqualTo(initialManifest);
 
     long pendingId = committed.snapshotId();
     validateManifest(
@@ -808,7 +756,7 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.ADDED, Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testChangedPartitionSpec() {
     Snapshot snap = commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
@@ -816,8 +764,7 @@ public class TestMergeAppend extends TableTestBase {
     validateSnapshot(null, snap, 1, FILE_A, FILE_B);
 
     TableMetadata base = readMetadata();
-    Assert.assertEquals(
-        "Should create 1 manifest for initial write", 1, snap.allManifests(table.io()).size());
+    assertThat(snap.allManifests(table.io())).hasSize(1);
     ManifestFile initialManifest = snap.allManifests(table.io()).get(0);
     validateManifest(
         initialManifest,
@@ -856,8 +803,7 @@ public class TestMergeAppend extends TableTestBase {
     V1Assert.assertEquals(
         "Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
 
-    Assert.assertEquals(
-        "Should use 2 manifest files", 2, lastSnapshot.allManifests(table.io()).size());
+    assertThat(lastSnapshot.allManifests(table.io())).hasSize(2);
 
     // new manifest comes first
     validateManifest(
@@ -868,13 +814,13 @@ public class TestMergeAppend extends TableTestBase {
         files(newFileY),
         statuses(Status.ADDED));
 
-    Assert.assertEquals(
-        "Second manifest should be the initial manifest with the old spec",
-        initialManifest,
-        lastSnapshot.allManifests(table.io()).get(1));
+    assertThat(lastSnapshot.allManifests(table.io()))
+        .as("Second manifest should be the initial manifest with the old spec")
+        .element(1)
+        .isEqualTo(initialManifest);
   }
 
-  @Test
+  @TestTemplate
   public void testChangedPartitionSpecMergeExisting() {
     Snapshot snap1 = commit(table, table.newAppend().appendFile(FILE_A), branch);
 
@@ -888,7 +834,7 @@ public class TestMergeAppend extends TableTestBase {
     validateSnapshot(snap1, snap2, 2, FILE_B);
 
     TableMetadata base = readMetadata();
-    Assert.assertEquals("Should contain 2 manifests", 2, snap2.allManifests(table.io()).size());
+    assertThat(snap2.allManifests(table.io())).hasSize(2);
     ManifestFile manifest = snap2.allManifests(table.io()).get(0);
 
     // build the new spec using the table's schema, which uses fresh IDs
@@ -919,11 +865,8 @@ public class TestMergeAppend extends TableTestBase {
     V1Assert.assertEquals(
         "Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
 
-    Assert.assertEquals(
-        "Should use 2 manifest files", 2, lastSnapshot.allManifests(table.io()).size());
-    Assert.assertFalse(
-        "First manifest should not be in the new snapshot",
-        lastSnapshot.allManifests(table.io()).contains(manifest));
+    assertThat(lastSnapshot.allManifests(table.io())).hasSize(2);
+    assertThat(lastSnapshot.allManifests(table.io())).doesNotContain(manifest);
 
     validateManifest(
         lastSnapshot.allManifests(table.io()).get(0),
@@ -941,11 +884,11 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.EXISTING, Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testFailure() {
     // merge all manifests for this test
     table.updateProperties().set("commit.manifest.min-count-to-merge", "1").commit();
-    Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
+    assertThat(readMetadata().lastSequenceNumber()).isEqualTo(0);
 
     Snapshot snap = commit(table, table.newAppend().appendFile(FILE_A), branch);
 
@@ -969,16 +912,16 @@ public class TestMergeAppend extends TableTestBase {
     AppendFiles append = table.newAppend().appendFile(FILE_B);
     Snapshot pending = apply(append, branch);
 
-    Assert.assertEquals("Should merge to 1 manifest", 1, pending.allManifests(table.io()).size());
+    assertThat(pending.allManifests(table.io())).hasSize(1);
     ManifestFile newManifest = pending.allManifests(table.io()).get(0);
 
-    Assert.assertTrue("Should create new manifest", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).exists();
     validateManifest(
         newManifest,
         ids(pending.snapshotId(), baseId),
         concat(files(FILE_B), files(initialManifest)));
 
-    Assertions.assertThatThrownBy(() -> commit(table, append, branch))
+    assertThatThrownBy(() -> commit(table, append, branch))
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
 
@@ -986,10 +929,7 @@ public class TestMergeAppend extends TableTestBase {
         "Last sequence number should be 1", 1, readMetadata().lastSequenceNumber());
     V1Assert.assertEquals(
         "Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
-    Assert.assertEquals(
-        "Should only contain 1 manifest file",
-        1,
-        latestSnapshot(table, branch).allManifests(table.io()).size());
+    assertThat(latestSnapshot(table, branch).allManifests(table.io())).hasSize(1);
 
     validateManifest(
         latestSnapshot(table, branch).allManifests(table.io()).get(0),
@@ -999,10 +939,10 @@ public class TestMergeAppend extends TableTestBase {
         files(initialManifest),
         statuses(Status.ADDED));
 
-    Assert.assertFalse("Should clean up new manifest", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).doesNotExist();
   }
 
-  @Test
+  @TestTemplate
   public void testAppendManifestCleanup() throws IOException {
     // inject 5 failures
     TestTables.TestTableOperations ops = table.ops();
@@ -1012,14 +952,14 @@ public class TestMergeAppend extends TableTestBase {
     AppendFiles append = table.newAppend().appendManifest(manifest);
     Snapshot pending = apply(append, branch);
     ManifestFile newManifest = pending.allManifests(table.io()).get(0);
-    Assert.assertTrue("Should create new manifest", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).exists();
     if (formatVersion == 1) {
-      Assertions.assertThat(newManifest.path()).isNotEqualTo(manifest.path());
+      assertThat(newManifest.path()).isNotEqualTo(manifest.path());
     } else {
-      Assertions.assertThat(newManifest.path()).isEqualTo(manifest.path());
+      assertThat(newManifest.path()).isEqualTo(manifest.path());
     }
 
-    Assertions.assertThatThrownBy(() -> commit(table, append, branch))
+    assertThatThrownBy(() -> commit(table, append, branch))
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
     V2Assert.assertEquals(
@@ -1028,18 +968,18 @@ public class TestMergeAppend extends TableTestBase {
         "Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
 
     if (formatVersion == 1) {
-      Assertions.assertThat(new File(newManifest.path())).doesNotExist();
+      assertThat(new File(newManifest.path())).doesNotExist();
     } else {
-      Assertions.assertThat(new File(newManifest.path())).exists();
+      assertThat(new File(newManifest.path())).exists();
     }
   }
 
-  @Test
+  @TestTemplate
   public void testRecovery() {
     // merge all manifests for this test
     table.updateProperties().set("commit.manifest.min-count-to-merge", "1").commit();
 
-    Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
+    assertThat(readMetadata().lastSequenceNumber()).isEqualTo(0);
 
     Snapshot current = commit(table, table.newAppend().appendFile(FILE_A), branch);
 
@@ -1063,10 +1003,10 @@ public class TestMergeAppend extends TableTestBase {
     AppendFiles append = table.newAppend().appendFile(FILE_B);
     Snapshot pending = apply(append, branch);
 
-    Assert.assertEquals("Should merge to 1 manifest", 1, pending.allManifests(table.io()).size());
+    assertThat(pending.allManifests(table.io())).hasSize(1);
     ManifestFile newManifest = pending.allManifests(table.io()).get(0);
 
-    Assert.assertTrue("Should create new manifest", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).exists();
     validateManifest(
         newManifest,
         ids(pending.snapshotId(), baseId),
@@ -1088,14 +1028,10 @@ public class TestMergeAppend extends TableTestBase {
         "Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
 
     TableMetadata metadata = readMetadata();
-    Assert.assertTrue("Should reuse the new manifest", new File(newManifest.path()).exists());
-    Assert.assertEquals(
-        "Should commit the same new manifest during retry",
-        Lists.newArrayList(newManifest),
-        snapshot.allManifests(table.io()));
+    assertThat(new File(newManifest.path())).exists();
+    assertThat(snapshot.allManifests(table.io())).containsExactly(newManifest);
 
-    Assert.assertEquals(
-        "Should only contain 1 merged manifest file", 1, snapshot.allManifests(table.io()).size());
+    assertThat(snapshot.allManifests(table.io())).hasSize(1);
     ManifestFile manifestFile = snapshot.allManifests(table.io()).get(0);
     validateManifest(
         manifestFile,
@@ -1106,15 +1042,15 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.ADDED, Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testAppendManifestWithSnapshotIdInheritance() throws IOException {
     table.updateProperties().set(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, "true").commit();
 
-    Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
+    assertThat(readMetadata().lastSequenceNumber()).isEqualTo(0);
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
+    assertThat(base.currentSnapshot()).isNull();
 
     ManifestFile manifest = writeManifest(FILE_A, FILE_B);
     Snapshot snapshot = commit(table, table.newAppend().appendManifest(manifest), branch);
@@ -1123,9 +1059,9 @@ public class TestMergeAppend extends TableTestBase {
     validateSnapshot(null, snapshot, 1, FILE_A, FILE_B);
 
     List<ManifestFile> manifests = snapshot.allManifests(table.io());
-    Assert.assertEquals("Should have 1 committed manifest", 1, manifests.size());
+    assertThat(manifests).hasSize(1);
     ManifestFile manifestFile = snapshot.allManifests(table.io()).get(0);
-    Assertions.assertThat(manifestFile.path()).isEqualTo(manifest.path());
+    assertThat(manifestFile.path()).isEqualTo(manifest.path());
     validateManifest(
         manifestFile,
         dataSeqs(1L, 1L),
@@ -1135,33 +1071,21 @@ public class TestMergeAppend extends TableTestBase {
         statuses(Status.ADDED, Status.ADDED));
 
     // validate that the metadata summary is correct when using appendManifest
-    Assert.assertEquals(
-        "Summary metadata should include 2 added files",
-        "2",
-        snapshot.summary().get("added-data-files"));
-    Assert.assertEquals(
-        "Summary metadata should include 2 added records",
-        "2",
-        snapshot.summary().get("added-records"));
-    Assert.assertEquals(
-        "Summary metadata should include 2 files in total",
-        "2",
-        snapshot.summary().get("total-data-files"));
-    Assert.assertEquals(
-        "Summary metadata should include 2 records in total",
-        "2",
-        snapshot.summary().get("total-records"));
+    assertThat(snapshot.summary().get("added-data-files")).isEqualTo("2");
+    assertThat(snapshot.summary().get("added-records")).isEqualTo("2");
+    assertThat(snapshot.summary().get("total-data-files")).isEqualTo("2");
+    assertThat(snapshot.summary().get("total-records")).isEqualTo("2");
   }
 
-  @Test
+  @TestTemplate
   public void testMergedAppendManifestCleanupWithSnapshotIdInheritance() throws IOException {
     table.updateProperties().set(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, "true").commit();
 
-    Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
+    assertThat(readMetadata().lastSequenceNumber()).isEqualTo(0);
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
+    assertThat(base.currentSnapshot()).isNull();
 
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "1").commit();
 
@@ -1171,7 +1095,7 @@ public class TestMergeAppend extends TableTestBase {
     long commitId1 = snap1.snapshotId();
     validateSnapshot(null, snap1, 1, FILE_A, FILE_B);
 
-    Assert.assertEquals("Should have only 1 manifest", 1, snap1.allManifests(table.io()).size());
+    assertThat(snap1.allManifests(table.io())).hasSize(1);
     validateManifest(
         snap1.allManifests(table.io()).get(0),
         dataSeqs(1L, 1L),
@@ -1179,8 +1103,7 @@ public class TestMergeAppend extends TableTestBase {
         ids(commitId1, commitId1),
         files(FILE_A, FILE_B),
         statuses(Status.ADDED, Status.ADDED));
-    Assert.assertTrue(
-        "Unmerged append manifest should not be deleted", new File(manifest1.path()).exists());
+    assertThat(new File(manifest1.path())).exists();
 
     ManifestFile manifest2 = writeManifestWithName("manifest-file-2.avro", FILE_C, FILE_D);
     Snapshot snap2 = commit(table, table.newAppend().appendManifest(manifest2), branch);
@@ -1192,8 +1115,7 @@ public class TestMergeAppend extends TableTestBase {
     V1Assert.assertEquals(
         "Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
 
-    Assert.assertEquals(
-        "Manifests should be merged into 1", 1, snap2.allManifests(table.io()).size());
+    assertThat(snap2.allManifests(table.io())).hasSize(1);
     validateManifest(
         latestSnapshot(table, branch).allManifests(table.io()).get(0),
         dataSeqs(2L, 2L, 1L, 1L),
@@ -1202,19 +1124,18 @@ public class TestMergeAppend extends TableTestBase {
         files(FILE_C, FILE_D, FILE_A, FILE_B),
         statuses(Status.ADDED, Status.ADDED, Status.EXISTING, Status.EXISTING));
 
-    Assert.assertFalse(
-        "Merged append manifest should be deleted", new File(manifest2.path()).exists());
+    assertThat(new File(manifest2.path())).doesNotExist();
   }
 
-  @Test
+  @TestTemplate
   public void testAppendManifestFailureWithSnapshotIdInheritance() throws IOException {
     table.updateProperties().set(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, "true").commit();
 
-    Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
+    assertThat(readMetadata().lastSequenceNumber()).isEqualTo(0);
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
+    assertThat(base.currentSnapshot()).isNull();
 
     table.updateProperties().set(TableProperties.COMMIT_NUM_RETRIES, "1").commit();
 
@@ -1225,40 +1146,40 @@ public class TestMergeAppend extends TableTestBase {
     AppendFiles append = table.newAppend();
     append.appendManifest(manifest);
 
-    Assertions.assertThatThrownBy(() -> commit(table, append, branch))
+    assertThatThrownBy(() -> commit(table, append, branch))
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
 
-    Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
-    Assert.assertTrue("Append manifest should not be deleted", new File(manifest.path()).exists());
+    assertThat(readMetadata().lastSequenceNumber()).isEqualTo(0);
+    assertThat(new File(manifest.path())).exists();
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidAppendManifest() throws IOException {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
+    assertThat(base.currentSnapshot()).isNull();
 
     ManifestFile manifestWithExistingFiles =
         writeManifest("manifest-file-1.avro", manifestEntry(Status.EXISTING, null, FILE_A));
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 commit(table, table.newAppend().appendManifest(manifestWithExistingFiles), branch))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot append manifest with existing files");
-    Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
+    assertThat(readMetadata().lastSequenceNumber()).isEqualTo(0);
 
     ManifestFile manifestWithDeletedFiles =
         writeManifest("manifest-file-2.avro", manifestEntry(Status.DELETED, null, FILE_A));
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> commit(table, table.newAppend().appendManifest(manifestWithDeletedFiles), branch))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot append manifest with deleted files");
-    Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
+    assertThat(readMetadata().lastSequenceNumber()).isEqualTo(0);
   }
 
-  @Test
+  @TestTemplate
   public void testUpdatePartitionSpecFieldIdsForV1Table() {
     TableMetadata base = readMetadata();
 
@@ -1273,35 +1194,35 @@ public class TestMergeAppend extends TableTestBase {
 
     // commit the new partition spec to the table manually
     table.ops().commit(base, base.updatePartitionSpec(newSpec));
-    Assert.assertEquals("Last sequence number should be 0", 0, base.lastSequenceNumber());
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
 
     List<PartitionSpec> partitionSpecs = table.ops().current().specs();
     PartitionSpec partitionSpec = partitionSpecs.get(0);
-    Assert.assertEquals(1000, partitionSpec.lastAssignedFieldId());
+    assertThat(partitionSpec.lastAssignedFieldId()).isEqualTo(1000);
 
     Types.StructType structType = partitionSpec.partitionType();
     List<Types.NestedField> fields = structType.fields();
-    Assert.assertEquals(1, fields.size());
-    Assert.assertEquals("data_bucket", fields.get(0).name());
-    Assert.assertEquals(1000, fields.get(0).fieldId());
+    assertThat(fields).hasSize(1);
+    assertThat(fields.get(0).name()).isEqualTo("data_bucket");
+    assertThat(fields.get(0).fieldId()).isEqualTo(1000);
 
     partitionSpec = partitionSpecs.get(1);
-    Assert.assertEquals(1003, partitionSpec.lastAssignedFieldId());
+    assertThat(partitionSpec.lastAssignedFieldId()).isEqualTo(1003);
 
     structType = partitionSpec.partitionType();
     fields = structType.fields();
-    Assert.assertEquals(4, fields.size());
-    Assert.assertEquals("id_bucket", fields.get(0).name());
-    Assert.assertEquals(1000, fields.get(0).fieldId());
-    Assert.assertEquals("data", fields.get(1).name());
-    Assert.assertEquals(1001, fields.get(1).fieldId());
-    Assert.assertEquals("data_bucket", fields.get(2).name());
-    Assert.assertEquals(1002, fields.get(2).fieldId());
-    Assert.assertEquals("data_partition", fields.get(3).name());
-    Assert.assertEquals(1003, fields.get(3).fieldId());
+    assertThat(fields).hasSize(4);
+    assertThat(fields.get(0).name()).isEqualTo("id_bucket");
+    assertThat(fields.get(0).fieldId()).isEqualTo(1000);
+    assertThat(fields.get(1).name()).isEqualTo("data");
+    assertThat(fields.get(1).fieldId()).isEqualTo(1001);
+    assertThat(fields.get(2).name()).isEqualTo("data_bucket");
+    assertThat(fields.get(2).fieldId()).isEqualTo(1002);
+    assertThat(fields.get(3).name()).isEqualTo("data_partition");
+    assertThat(fields.get(3).fieldId()).isEqualTo(1003);
   }
 
-  @Test
+  @TestTemplate
   public void testManifestEntryFieldIdsForChangedPartitionSpecForV1Table() {
     Snapshot snap = commit(table, table.newAppend().appendFile(FILE_A), branch);
 
@@ -1309,8 +1230,7 @@ public class TestMergeAppend extends TableTestBase {
     validateSnapshot(null, snap, 1, FILE_A);
     TableMetadata base = readMetadata();
 
-    Assert.assertEquals(
-        "Should create 1 manifest for initial write", 1, snap.allManifests(table.io()).size());
+    assertThat(snap.allManifests(table.io())).hasSize(1);
     ManifestFile initialManifest = snap.allManifests(table.io()).get(0);
     validateManifest(
         initialManifest,
@@ -1349,8 +1269,7 @@ public class TestMergeAppend extends TableTestBase {
     V1Assert.assertEquals(
         "Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
 
-    Assert.assertEquals(
-        "Should use 2 manifest files", 2, committedSnapshot.allManifests(table.io()).size());
+    assertThat(committedSnapshot.allManifests(table.io())).hasSize(2);
 
     // new manifest comes first
     validateManifest(
@@ -1361,10 +1280,10 @@ public class TestMergeAppend extends TableTestBase {
         files(newFile),
         statuses(Status.ADDED));
 
-    Assert.assertEquals(
-        "Second manifest should be the initial manifest with the old spec",
-        initialManifest,
-        committedSnapshot.allManifests(table.io()).get(1));
+    assertThat(committedSnapshot.allManifests(table.io()))
+        .as("Second manifest should be the initial manifest with the old spec")
+        .element(1)
+        .isEqualTo(initialManifest);
 
     // field ids of manifest entries in two manifests with different specs of the same source field
     // should be different
@@ -1375,11 +1294,11 @@ public class TestMergeAppend extends TableTestBase {
             .next();
     Types.NestedField field =
         ((PartitionData) entry.file().partition()).getPartitionType().fields().get(0);
-    Assert.assertEquals(1000, field.fieldId());
-    Assert.assertEquals("id_bucket", field.name());
+    assertThat(field.fieldId()).isEqualTo(1000);
+    assertThat(field.name()).isEqualTo("id_bucket");
     field = ((PartitionData) entry.file().partition()).getPartitionType().fields().get(1);
-    Assert.assertEquals(1001, field.fieldId());
-    Assert.assertEquals("data_bucket", field.name());
+    assertThat(field.fieldId()).isEqualTo(1001);
+    assertThat(field.name()).isEqualTo("data_bucket");
 
     entry =
         ManifestFiles.read(committedSnapshot.allManifests(table.io()).get(1), FILE_IO)
@@ -1387,11 +1306,11 @@ public class TestMergeAppend extends TableTestBase {
             .iterator()
             .next();
     field = ((PartitionData) entry.file().partition()).getPartitionType().fields().get(0);
-    Assert.assertEquals(1000, field.fieldId());
-    Assert.assertEquals("data_bucket", field.name());
+    assertThat(field.fieldId()).isEqualTo(1000);
+    assertThat(field.name()).isEqualTo("data_bucket");
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultPartitionSummaries() {
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -1399,23 +1318,21 @@ public class TestMergeAppend extends TableTestBase {
         table.currentSnapshot().summary().keySet().stream()
             .filter(key -> key.startsWith(SnapshotSummary.CHANGED_PARTITION_PREFIX))
             .collect(Collectors.toSet());
-    Assert.assertEquals(
-        "Should include no partition summaries by default", 0, partitionSummaryKeys.size());
+    assertThat(partitionSummaryKeys).isEmpty();
 
     String summariesIncluded =
         table
             .currentSnapshot()
             .summary()
             .getOrDefault(SnapshotSummary.PARTITION_SUMMARY_PROP, "false");
-    Assert.assertEquals(
-        "Should not set partition-summaries-included to true", "false", summariesIncluded);
+    assertThat(summariesIncluded).isEqualTo("false");
 
     String changedPartitions =
         table.currentSnapshot().summary().get(SnapshotSummary.CHANGED_PARTITION_COUNT_PROP);
-    Assert.assertEquals("Should set changed partition count", "1", changedPartitions);
+    assertThat(changedPartitions).isEqualTo("1");
   }
 
-  @Test
+  @TestTemplate
   public void testIncludedPartitionSummaries() {
     table.updateProperties().set(TableProperties.WRITE_PARTITION_SUMMARY_LIMIT, "1").commit();
 
@@ -1425,32 +1342,29 @@ public class TestMergeAppend extends TableTestBase {
         table.currentSnapshot().summary().keySet().stream()
             .filter(key -> key.startsWith(SnapshotSummary.CHANGED_PARTITION_PREFIX))
             .collect(Collectors.toSet());
-    Assert.assertEquals("Should include a partition summary", 1, partitionSummaryKeys.size());
+    assertThat(partitionSummaryKeys).hasSize(1);
 
     String summariesIncluded =
         table
             .currentSnapshot()
             .summary()
             .getOrDefault(SnapshotSummary.PARTITION_SUMMARY_PROP, "false");
-    Assert.assertEquals(
-        "Should set partition-summaries-included to true", "true", summariesIncluded);
+    assertThat(summariesIncluded).isEqualTo("true");
 
     String changedPartitions =
         table.currentSnapshot().summary().get(SnapshotSummary.CHANGED_PARTITION_COUNT_PROP);
-    Assert.assertEquals("Should set changed partition count", "1", changedPartitions);
+    assertThat(changedPartitions).isEqualTo("1");
 
     String partitionSummary =
         table
             .currentSnapshot()
             .summary()
             .get(SnapshotSummary.CHANGED_PARTITION_PREFIX + "data_bucket=0");
-    Assert.assertEquals(
-        "Summary should include 1 file with 1 record that is 10 bytes",
-        "added-data-files=1,added-records=1,added-files-size=10",
-        partitionSummary);
+    assertThat(partitionSummary)
+        .isEqualTo("added-data-files=1,added-records=1,added-files-size=10");
   }
 
-  @Test
+  @TestTemplate
   public void testIncludedPartitionSummaryLimit() {
     table.updateProperties().set(TableProperties.WRITE_PARTITION_SUMMARY_LIMIT, "1").commit();
 
@@ -1460,19 +1374,17 @@ public class TestMergeAppend extends TableTestBase {
         table.currentSnapshot().summary().keySet().stream()
             .filter(key -> key.startsWith(SnapshotSummary.CHANGED_PARTITION_PREFIX))
             .collect(Collectors.toSet());
-    Assert.assertEquals(
-        "Should include no partition summaries, over limit", 0, partitionSummaryKeys.size());
+    assertThat(partitionSummaryKeys).isEmpty();
 
     String summariesIncluded =
         table
             .currentSnapshot()
             .summary()
             .getOrDefault(SnapshotSummary.PARTITION_SUMMARY_PROP, "false");
-    Assert.assertEquals(
-        "Should not set partition-summaries-included to true", "false", summariesIncluded);
+    assertThat(summariesIncluded).isEqualTo("false");
 
     String changedPartitions =
         table.currentSnapshot().summary().get(SnapshotSummary.CHANGED_PARTITION_COUNT_PROP);
-    Assert.assertEquals("Should set changed partition count", "2", changedPartitions);
+    assertThat(changedPartitions).isEqualTo("2");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestOverwrite.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwrite.java
@@ -24,24 +24,26 @@ import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.apache.iceberg.util.SnapshotUtil.latestSnapshot;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestOverwrite extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestOverwrite extends TestBase {
   private static final Schema DATE_SCHEMA =
       new Schema(
           required(1, "id", Types.LongType.get()),
@@ -104,21 +106,16 @@ public class TestOverwrite extends TableTestBase {
                   ))
           .build();
 
-  private final String branch;
+  @Parameter(index = 1)
+  private String branch;
 
-  @Parameterized.Parameters(name = "formatVersion = {0}, branch = {1}")
-  public static Object[] parameters() {
-    return new Object[][] {
-      new Object[] {1, "main"},
-      new Object[] {1, "testBranch"},
-      new Object[] {2, "main"},
-      new Object[] {2, "testBranch"}
-    };
-  }
-
-  public TestOverwrite(int formatVersion, String branch) {
-    super(formatVersion);
-    this.branch = branch;
+  @Parameters(name = "formatVersion = {0}, branch = {1}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(
+        new Object[] {1, "main"},
+        new Object[] {1, "testBranch"},
+        new Object[] {2, "main"},
+        new Object[] {2, "testBranch"});
   }
 
   private static ByteBuffer longToBuffer(long value) {
@@ -127,10 +124,10 @@ public class TestOverwrite extends TableTestBase {
 
   private Table table = null;
 
-  @Before
+  @BeforeEach
   public void createTestTable() throws IOException {
-    File tableDir = temp.newFolder();
-    Assert.assertTrue(tableDir.delete());
+    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableDir.delete()).isTrue();
 
     this.table =
         TestTables.create(tableDir, TABLE_NAME, DATE_SCHEMA, PARTITION_BY_DATE, formatVersion);
@@ -138,7 +135,7 @@ public class TestOverwrite extends TableTestBase {
     commit(table, table.newAppend().appendFile(FILE_0_TO_4).appendFile(FILE_5_TO_9), branch);
   }
 
-  @Test
+  @TestTemplate
   public void testOverwriteWithoutAppend() {
     TableMetadata base = TestTables.readMetadata(TABLE_NAME);
     long baseId = latestSnapshot(base, branch).snapshotId();
@@ -147,11 +144,8 @@ public class TestOverwrite extends TableTestBase {
 
     long overwriteId = latestSnapshot(table, branch).snapshotId();
 
-    Assert.assertNotEquals("Should create a new snapshot", baseId, overwriteId);
-    Assert.assertEquals(
-        "Table should have one manifest",
-        1,
-        latestSnapshot(table, branch).allManifests(table.io()).size());
+    assertThat(overwriteId).isNotEqualTo(baseId);
+    assertThat(latestSnapshot(table, branch).allManifests(table.io())).hasSize(1);
 
     validateManifestEntries(
         latestSnapshot(table, branch).allManifests(table.io()).get(0),
@@ -160,7 +154,7 @@ public class TestOverwrite extends TableTestBase {
         statuses(Status.DELETED, Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testOverwriteFailsDelete() {
     TableMetadata base = TestTables.readMetadata(TABLE_NAME);
     long baseId =
@@ -171,15 +165,14 @@ public class TestOverwrite extends TableTestBase {
             .newOverwrite()
             .overwriteByRowFilter(and(equal("date", "2018-06-09"), lessThan("id", 9)));
 
-    Assertions.assertThatThrownBy(() -> commit(table, overwrite, branch))
+    assertThatThrownBy(() -> commit(table, overwrite, branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot delete file where some, but not all, rows match filter");
 
-    Assert.assertEquals(
-        "Should not create a new snapshot", baseId, latestSnapshot(base, branch).snapshotId());
+    assertThat(latestSnapshot(base, branch).snapshotId()).isEqualTo(baseId);
   }
 
-  @Test
+  @TestTemplate
   public void testOverwriteWithAppendOutsideOfDelete() {
     TableMetadata base = TestTables.readMetadata(TABLE_NAME);
     Snapshot latestSnapshot = latestSnapshot(base, branch);
@@ -195,11 +188,8 @@ public class TestOverwrite extends TableTestBase {
 
     long overwriteId = latestSnapshot(table, branch).snapshotId();
 
-    Assert.assertNotEquals("Should create a new snapshot", baseId, overwriteId);
-    Assert.assertEquals(
-        "Table should have 2 manifests",
-        2,
-        latestSnapshot(table, branch).allManifests(table.io()).size());
+    assertThat(overwriteId).isNotEqualTo(baseId);
+    assertThat(latestSnapshot(table, branch).allManifests(table.io())).hasSize(2);
 
     // manifest is not merged because it is less than the minimum
     validateManifestEntries(
@@ -215,7 +205,7 @@ public class TestOverwrite extends TableTestBase {
         statuses(Status.DELETED, Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testOverwriteWithMergedAppendOutsideOfDelete() {
     // ensure the overwrite results in a merge
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "1").commit();
@@ -234,11 +224,8 @@ public class TestOverwrite extends TableTestBase {
 
     long overwriteId = latestSnapshot(table, branch).snapshotId();
 
-    Assert.assertNotEquals("Should create a new snapshot", baseId, overwriteId);
-    Assert.assertEquals(
-        "Table should have one merged manifest",
-        1,
-        latestSnapshot(table, branch).allManifests(table.io()).size());
+    assertThat(overwriteId).isNotEqualTo(baseId);
+    assertThat(latestSnapshot(table, branch).allManifests(table.io())).hasSize(1);
 
     validateManifestEntries(
         latestSnapshot(table, branch).allManifests(table.io()).get(0),
@@ -247,7 +234,7 @@ public class TestOverwrite extends TableTestBase {
         statuses(Status.ADDED, Status.DELETED, Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testValidatedOverwriteWithAppendOutsideOfDelete() {
     // ensure the overwrite results in a merge
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "1").commit();
@@ -263,15 +250,14 @@ public class TestOverwrite extends TableTestBase {
             .addFile(FILE_10_TO_14) // in 2018-06-09, NOT in 2018-06-08
             .validateAddedFilesMatchOverwriteFilter();
 
-    Assertions.assertThatThrownBy(() -> commit(table, overwrite, branch))
+    assertThatThrownBy(() -> commit(table, overwrite, branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot append file with rows that do not match filter");
 
-    Assert.assertEquals(
-        "Should not create a new snapshot", baseId, latestSnapshot(table, branch).snapshotId());
+    assertThat(latestSnapshot(table, branch).snapshotId()).isEqualTo(baseId);
   }
 
-  @Test
+  @TestTemplate
   public void testValidatedOverwriteWithAppendOutsideOfDeleteMetrics() {
     TableMetadata base = TestTables.readMetadata(TABLE_NAME);
     long baseId =
@@ -284,15 +270,14 @@ public class TestOverwrite extends TableTestBase {
             .addFile(FILE_10_TO_14) // in 2018-06-09 matches, but IDs are outside range
             .validateAddedFilesMatchOverwriteFilter();
 
-    Assertions.assertThatThrownBy(() -> commit(table, overwrite, branch))
+    assertThatThrownBy(() -> commit(table, overwrite, branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot append file with rows that do not match filter");
 
-    Assert.assertEquals(
-        "Should not create a new snapshot", baseId, latestSnapshot(base, branch).snapshotId());
+    assertThat(latestSnapshot(base, branch).snapshotId()).isEqualTo(baseId);
   }
 
-  @Test
+  @TestTemplate
   public void testValidatedOverwriteWithAppendSuccess() {
     TableMetadata base = TestTables.readMetadata(TABLE_NAME);
     long baseId =
@@ -305,11 +290,10 @@ public class TestOverwrite extends TableTestBase {
             .addFile(FILE_10_TO_14) // in 2018-06-09 matches and IDs are inside range
             .validateAddedFilesMatchOverwriteFilter();
 
-    Assertions.assertThatThrownBy(() -> commit(table, overwrite, branch))
+    assertThatThrownBy(() -> commit(table, overwrite, branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot append file with rows that do not match filter");
 
-    Assert.assertEquals(
-        "Should not create a new snapshot", baseId, latestSnapshot(base, branch).snapshotId());
+    assertThat(latestSnapshot(base, branch).snapshotId()).isEqualTo(baseId);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -236,9 +236,7 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testRewriteDataAndDeleteFiles() {
-    assumeThat(formatVersion)
-        .as("Rewriting delete files is only supported in iceberg format v2 or later")
-        .isGreaterThan(1);
+    assumeThat(formatVersion).isGreaterThan(1);
     assertThat(listManifestFiles()).isEmpty();
 
     commit(
@@ -311,9 +309,7 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testRewriteDataAndAssignOldSequenceNumber() {
-    assumeThat(formatVersion)
-        .as("Sequence number is only supported in iceberg format v2 or later")
-        .isGreaterThan(1);
+    assumeThat(formatVersion).isGreaterThan(1);
     assertThat(listManifestFiles()).isEmpty();
 
     commit(
@@ -417,9 +413,7 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testFailureWhenRewriteBothDataAndDeleteFiles() {
-    assumeThat(formatVersion)
-        .as("Rewriting delete files is only supported in iceberg format v2 or later.")
-        .isGreaterThan(1);
+    assumeThat(formatVersion).isGreaterThan(1);
 
     commit(
         table,
@@ -514,9 +508,7 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testRecoverWhenRewriteBothDataAndDeleteFiles() {
-    assumeThat(formatVersion)
-        .as("Rewriting delete files is only supported in iceberg format v2 or later.")
-        .isGreaterThan(1);
+    assumeThat(formatVersion).isGreaterThan(1);
 
     commit(
         table,
@@ -581,9 +573,7 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testReplaceEqualityDeletesWithPositionDeletes() {
-    assumeThat(formatVersion)
-        .as("Rewriting delete files is only supported in iceberg format v2 or later.")
-        .isGreaterThan(1);
+    assumeThat(formatVersion).isGreaterThan(1);
 
     commit(table, table.newRowDelta().addRows(FILE_A2).addDeletes(FILE_A2_DELETES), branch);
 
@@ -639,9 +629,7 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testRemoveAllDeletes() {
-    assumeThat(formatVersion)
-        .as("Rewriting delete files is only supported in iceberg format v2 or later.")
-        .isGreaterThan(1);
+    assumeThat(formatVersion).isGreaterThan(1);
 
     commit(table, table.newRowDelta().addRows(FILE_A).addDeletes(FILE_A_DELETES), branch);
 
@@ -746,9 +734,7 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testNewDeleteFile() {
-    assumeThat(formatVersion)
-        .as("Delete files are only supported in iceberg format v2 or later.")
-        .isGreaterThan(1);
+    assumeThat(formatVersion).isGreaterThan(1);
 
     commit(table, table.newAppend().appendFile(FILE_A), branch);
 

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -22,50 +22,45 @@ import static org.apache.iceberg.ManifestEntry.Status.ADDED;
 import static org.apache.iceberg.ManifestEntry.Status.DELETED;
 import static org.apache.iceberg.ManifestEntry.Status.EXISTING;
 import static org.apache.iceberg.util.SnapshotUtil.latestSnapshot;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.internal.util.collections.Sets;
 
-@RunWith(Parameterized.class)
-public class TestRewriteFiles extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRewriteFiles extends TestBase {
 
-  private final String branch;
+  @Parameter(index = 1)
+  private String branch;
 
-  @Parameterized.Parameters(name = "formatVersion = {0}, branch = {1}")
-  public static Object[] parameters() {
-    return new Object[][] {
-      new Object[] {1, "main"},
-      new Object[] {1, "testBranch"},
-      new Object[] {2, "main"},
-      new Object[] {2, "testBranch"}
-    };
+  @Parameters(name = "formatVersion = {0}, branch = {1}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(
+        new Object[] {1, "main"},
+        new Object[] {1, "testBranch"},
+        new Object[] {2, "main"},
+        new Object[] {2, "testBranch"});
   }
 
-  public TestRewriteFiles(int formatVersion, String branch) {
-    super(formatVersion);
-    this.branch = branch;
-  }
-
-  @Test
+  @TestTemplate
   public void testEmptyTable() {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
-    Assert.assertNull("Should not have a current snapshot", base.ref(branch));
+    assertThat(base.ref(branch)).isNull();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 commit(
                     table,
@@ -74,7 +69,7 @@ public class TestRewriteFiles extends TableTestBase {
         .isInstanceOf(ValidationException.class)
         .hasMessage("Missing required files to delete: /path/to/data-a.parquet");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 commit(
                     table,
@@ -90,11 +85,11 @@ public class TestRewriteFiles extends TableTestBase {
         .hasMessage("Missing required files to delete: /path/to/data-a-deletes.parquet");
   }
 
-  @Test
+  @TestTemplate
   public void testAddOnly() {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 apply(
                     table.newRewrite().rewriteFiles(Sets.newSet(FILE_A), Collections.emptySet()),
@@ -102,7 +97,7 @@ public class TestRewriteFiles extends TableTestBase {
         .isInstanceOf(ValidationException.class)
         .hasMessage("Missing required files to delete: /path/to/data-a.parquet");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 apply(
                     table
@@ -117,7 +112,7 @@ public class TestRewriteFiles extends TableTestBase {
         .hasMessage(
             "Delete files to add must be empty because there's no delete file to be rewritten");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 apply(
                     table
@@ -133,11 +128,11 @@ public class TestRewriteFiles extends TableTestBase {
             "Delete files to add must be empty because there's no delete file to be rewritten");
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteOnly() {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 apply(
                     table.newRewrite().rewriteFiles(Collections.emptySet(), Sets.newSet(FILE_A)),
@@ -145,7 +140,7 @@ public class TestRewriteFiles extends TableTestBase {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Files to delete cannot be empty");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 apply(
                     table
@@ -159,7 +154,7 @@ public class TestRewriteFiles extends TableTestBase {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Files to delete cannot be empty");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 apply(
                     table
@@ -174,28 +169,23 @@ public class TestRewriteFiles extends TableTestBase {
         .hasMessage("Files to delete cannot be empty");
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithDuplicateEntriesInManifest() {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     commit(
         table, table.newAppend().appendFile(FILE_A).appendFile(FILE_A).appendFile(FILE_B), branch);
 
     TableMetadata base = readMetadata();
     long baseSnapshotId = latestSnapshot(base, branch).snapshotId();
-    Assert.assertEquals(
-        "Should create 1 manifest for initial write",
-        1,
-        latestSnapshot(base, branch).allManifests(table.io()).size());
+    assertThat(latestSnapshot(base, branch).allManifests(table.io())).hasSize(1);
     ManifestFile initialManifest = latestSnapshot(base, branch).allManifests(table.io()).get(0);
 
     Snapshot pending =
         apply(table.newRewrite().rewriteFiles(Sets.newSet(FILE_A), Sets.newSet(FILE_C)), branch);
 
-    Assert.assertEquals("Should contain 2 manifest", 2, pending.allManifests(table.io()).size());
-    Assert.assertFalse(
-        "Should not contain manifest from initial write",
-        pending.allManifests(table.io()).contains(initialManifest));
+    assertThat(pending.allManifests(table.io())).hasSize(2);
+    assertThat(pending.allManifests(table.io())).doesNotContain(initialManifest);
 
     long pendingId = pending.snapshotId();
 
@@ -209,30 +199,25 @@ public class TestRewriteFiles extends TableTestBase {
         statuses(DELETED, DELETED, EXISTING));
 
     // We should only get the 3 manifests that this test is expected to add.
-    Assert.assertEquals("Only 3 manifests should exist", 3, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(3);
   }
 
-  @Test
+  @TestTemplate
   public void testAddAndDelete() {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
     TableMetadata base = readMetadata();
     long baseSnapshotId = latestSnapshot(base, branch).snapshotId();
-    Assert.assertEquals(
-        "Should create 1 manifest for initial write",
-        1,
-        latestSnapshot(table, branch).allManifests(table.io()).size());
+    assertThat(latestSnapshot(table, branch).allManifests(table.io())).hasSize(1);
     ManifestFile initialManifest = latestSnapshot(table, branch).allManifests(table.io()).get(0);
 
     Snapshot pending =
         apply(table.newRewrite().rewriteFiles(Sets.newSet(FILE_A), Sets.newSet(FILE_C)), branch);
 
-    Assert.assertEquals("Should contain 2 manifest", 2, pending.allManifests(table.io()).size());
-    Assert.assertFalse(
-        "Should not contain manifest from initial write",
-        pending.allManifests(table.io()).contains(initialManifest));
+    assertThat(pending.allManifests(table.io())).hasSize(2);
+    assertThat(pending.allManifests(table.io())).doesNotContain(initialManifest);
 
     long pendingId = pending.snapshotId();
 
@@ -246,14 +231,15 @@ public class TestRewriteFiles extends TableTestBase {
         statuses(DELETED, EXISTING));
 
     // We should only get the 3 manifests that this test is expected to add.
-    Assert.assertEquals("Only 3 manifests should exist", 3, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(3);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteDataAndDeleteFiles() {
-    Assume.assumeTrue(
-        "Rewriting delete files is only supported in iceberg format v2. ", formatVersion > 1);
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assumeThat(formatVersion)
+        .as("Rewriting delete files is only supported in iceberg format v2 or later")
+        .isGreaterThan(1);
+    assertThat(listManifestFiles()).isEmpty();
 
     commit(
         table,
@@ -269,8 +255,7 @@ public class TestRewriteFiles extends TableTestBase {
     TableMetadata base = readMetadata();
     Snapshot baseSnap = latestSnapshot(base, branch);
     long baseSnapshotId = baseSnap.snapshotId();
-    Assert.assertEquals(
-        "Should create 2 manifests for initial write", 2, baseSnap.allManifests(table.io()).size());
+    assertThat(baseSnap.allManifests(table.io())).hasSize(2);
     List<ManifestFile> initialManifests = baseSnap.allManifests(table.io());
 
     validateManifestEntries(
@@ -299,10 +284,8 @@ public class TestRewriteFiles extends TableTestBase {
                     ImmutableSet.of()),
             branch);
 
-    Assert.assertEquals("Should contain 3 manifest", 3, pending.allManifests(table.io()).size());
-    Assert.assertFalse(
-        "Should not contain manifest from initial write",
-        pending.allManifests(table.io()).stream().anyMatch(initialManifests::contains));
+    assertThat(pending.allManifests(table.io())).hasSize(3);
+    assertThat(pending.allManifests(table.io())).doesNotContainAnyElementsOf(initialManifests);
 
     long pendingId = pending.snapshotId();
     validateManifestEntries(
@@ -323,14 +306,15 @@ public class TestRewriteFiles extends TableTestBase {
         statuses(DELETED, EXISTING));
 
     // We should only get the 5 manifests that this test is expected to add.
-    Assert.assertEquals("Only 5 manifests should exist", 5, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(5);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteDataAndAssignOldSequenceNumber() {
-    Assume.assumeTrue(
-        "Sequence number is only supported in iceberg format v2. ", formatVersion > 1);
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assumeThat(formatVersion)
+        .as("Sequence number is only supported in iceberg format v2 or later")
+        .isGreaterThan(1);
+    assertThat(listManifestFiles()).isEmpty();
 
     commit(
         table,
@@ -346,8 +330,7 @@ public class TestRewriteFiles extends TableTestBase {
     TableMetadata base = readMetadata();
     Snapshot baseSnap = latestSnapshot(base, branch);
     long baseSnapshotId = baseSnap.snapshotId();
-    Assert.assertEquals(
-        "Should create 2 manifests for initial write", 2, baseSnap.allManifests(table.io()).size());
+    assertThat(baseSnap.allManifests(table.io())).hasSize(2);
     List<ManifestFile> initialManifests = baseSnap.allManifests(table.io());
 
     validateManifestEntries(
@@ -373,24 +356,18 @@ public class TestRewriteFiles extends TableTestBase {
                 .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_D), oldSequenceNumber),
             branch);
 
-    Assert.assertEquals("Should contain 3 manifest", 3, pending.allManifests(table.io()).size());
-    Assert.assertFalse(
-        "Should not contain data manifest from initial write",
-        pending.dataManifests(table.io()).stream().anyMatch(initialManifests::contains));
+    assertThat(pending.allManifests(table.io())).hasSize(3);
+    assertThat(pending.dataManifests(table.io())).doesNotContainAnyElementsOf(initialManifests);
 
     long pendingId = pending.snapshotId();
     ManifestFile newManifest = pending.allManifests(table.io()).get(0);
     validateManifestEntries(newManifest, ids(pendingId), files(FILE_D), statuses(ADDED));
-    for (ManifestEntry<DataFile> entry : ManifestFiles.read(newManifest, FILE_IO).entries()) {
-      Assert.assertEquals(
-          "Should have old sequence number for manifest entries",
-          oldSequenceNumber,
-          (long) entry.dataSequenceNumber());
-    }
-    Assert.assertEquals(
-        "Should use new sequence number for the manifest file",
-        oldSequenceNumber + 1,
-        newManifest.sequenceNumber());
+    assertThat(ManifestFiles.read(newManifest, FILE_IO).entries())
+        .allSatisfy(
+            entry -> {
+              assertThat(entry.dataSequenceNumber()).isEqualTo(oldSequenceNumber);
+            });
+    assertThat(newManifest.sequenceNumber()).isEqualTo(oldSequenceNumber + 1);
 
     validateManifestEntries(
         pending.allManifests(table.io()).get(1),
@@ -407,10 +384,10 @@ public class TestRewriteFiles extends TableTestBase {
         statuses(ADDED, ADDED));
 
     // We should only get the 4 manifests that this test is expected to add.
-    Assert.assertEquals("Only 4 manifests should exist", 4, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(4);
   }
 
-  @Test
+  @TestTemplate
   public void testFailure() {
     commit(table, table.newAppend().appendFile(FILE_A), branch);
 
@@ -420,28 +397,29 @@ public class TestRewriteFiles extends TableTestBase {
         table.newRewrite().rewriteFiles(Sets.newSet(FILE_A), Sets.newSet(FILE_B));
     Snapshot pending = apply(rewrite, branch);
 
-    Assert.assertEquals("Should produce 2 manifests", 2, pending.allManifests(table.io()).size());
+    assertThat(pending.allManifests(table.io())).hasSize(2);
     ManifestFile manifest1 = pending.allManifests(table.io()).get(0);
     ManifestFile manifest2 = pending.allManifests(table.io()).get(1);
 
     validateManifestEntries(manifest1, ids(pending.snapshotId()), files(FILE_B), statuses(ADDED));
     validateManifestEntries(manifest2, ids(pending.snapshotId()), files(FILE_A), statuses(DELETED));
 
-    Assertions.assertThatThrownBy(() -> commit(table, rewrite, branch))
+    assertThatThrownBy(() -> commit(table, rewrite, branch))
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
 
-    Assert.assertFalse("Should clean up new manifest", new File(manifest1.path()).exists());
-    Assert.assertFalse("Should clean up new manifest", new File(manifest2.path()).exists());
+    assertThat(new File(manifest1.path())).doesNotExist();
+    assertThat(new File(manifest2.path())).doesNotExist();
 
     // As commit failed all the manifests added with rewrite should be cleaned up
-    Assert.assertEquals("Only 1 manifest should exist", 1, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(1);
   }
 
-  @Test
+  @TestTemplate
   public void testFailureWhenRewriteBothDataAndDeleteFiles() {
-    Assume.assumeTrue(
-        "Rewriting delete files is only supported in iceberg format v2. ", formatVersion > 1);
+    assumeThat(formatVersion)
+        .as("Rewriting delete files is only supported in iceberg format v2 or later.")
+        .isGreaterThan(1);
 
     commit(
         table,
@@ -468,7 +446,7 @@ public class TestRewriteFiles extends TableTestBase {
                 ImmutableSet.of());
     Snapshot pending = apply(rewrite, branch);
 
-    Assert.assertEquals("Should produce 3 manifests", 3, pending.allManifests(table.io()).size());
+    assertThat(pending.allManifests(table.io())).hasSize(3);
     ManifestFile manifest1 = pending.allManifests(table.io()).get(0);
     ManifestFile manifest2 = pending.allManifests(table.io()).get(1);
     ManifestFile manifest3 = pending.allManifests(table.io()).get(2);
@@ -493,19 +471,19 @@ public class TestRewriteFiles extends TableTestBase {
         files(FILE_A_DELETES, FILE_B_DELETES),
         statuses(DELETED, DELETED));
 
-    Assertions.assertThatThrownBy(rewrite::commit)
+    assertThatThrownBy(rewrite::commit)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
 
-    Assert.assertFalse("Should clean up new manifest", new File(manifest1.path()).exists());
-    Assert.assertFalse("Should clean up new manifest", new File(manifest2.path()).exists());
-    Assert.assertFalse("Should clean up new manifest", new File(manifest3.path()).exists());
+    assertThat(new File(manifest1.path())).doesNotExist();
+    assertThat(new File(manifest2.path())).doesNotExist();
+    assertThat(new File(manifest3.path())).doesNotExist();
 
     // As commit failed all the manifests added with rewrite should be cleaned up
-    Assert.assertEquals("Only 2 manifest should exist", 2, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(2);
   }
 
-  @Test
+  @TestTemplate
   public void testRecovery() {
     commit(table, table.newAppend().appendFile(FILE_A), branch);
 
@@ -515,7 +493,7 @@ public class TestRewriteFiles extends TableTestBase {
         table.newRewrite().rewriteFiles(Sets.newSet(FILE_A), Sets.newSet(FILE_B));
     Snapshot pending = apply(rewrite, branch);
 
-    Assert.assertEquals("Should produce 2 manifests", 2, pending.allManifests(table.io()).size());
+    assertThat(pending.allManifests(table.io())).hasSize(2);
     ManifestFile manifest1 = pending.allManifests(table.io()).get(0);
     ManifestFile manifest2 = pending.allManifests(table.io()).get(1);
 
@@ -524,23 +502,21 @@ public class TestRewriteFiles extends TableTestBase {
 
     commit(table, rewrite, branch);
 
-    Assert.assertTrue("Should reuse the manifest for appends", new File(manifest1.path()).exists());
-    Assert.assertTrue(
-        "Should reuse the manifest with deletes", new File(manifest2.path()).exists());
+    assertThat(new File(manifest1.path())).exists();
+    assertThat(new File(manifest2.path())).exists();
 
     TableMetadata metadata = readMetadata();
-    Assert.assertTrue(
-        "Should commit the manifest for append",
-        latestSnapshot(metadata, branch).allManifests(table.io()).contains(manifest2));
+    assertThat(latestSnapshot(metadata, branch).allManifests(table.io())).contains(manifest2);
 
     // 2 manifests added by rewrite and 1 original manifest should be found.
-    Assert.assertEquals("Only 3 manifests should exist", 3, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(3);
   }
 
-  @Test
+  @TestTemplate
   public void testRecoverWhenRewriteBothDataAndDeleteFiles() {
-    Assume.assumeTrue(
-        "Rewriting delete files is only supported in iceberg format v2. ", formatVersion > 1);
+    assumeThat(formatVersion)
+        .as("Rewriting delete files is only supported in iceberg format v2 or later.")
+        .isGreaterThan(1);
 
     commit(
         table,
@@ -567,7 +543,7 @@ public class TestRewriteFiles extends TableTestBase {
                 ImmutableSet.of());
     Snapshot pending = apply(rewrite, branch);
 
-    Assert.assertEquals("Should produce 3 manifests", 3, pending.allManifests(table.io()).size());
+    assertThat(pending.allManifests(table.io())).hasSize(3);
     ManifestFile manifest1 = pending.allManifests(table.io()).get(0);
     ManifestFile manifest2 = pending.allManifests(table.io()).get(1);
     ManifestFile manifest3 = pending.allManifests(table.io()).get(2);
@@ -590,25 +566,24 @@ public class TestRewriteFiles extends TableTestBase {
 
     commit(table, rewrite, branch);
 
-    Assert.assertTrue("Should reuse new manifest", new File(manifest1.path()).exists());
-    Assert.assertTrue("Should reuse new manifest", new File(manifest2.path()).exists());
-    Assert.assertTrue("Should reuse new manifest", new File(manifest3.path()).exists());
+    assertThat(new File(manifest1.path())).exists();
+    assertThat(new File(manifest2.path())).exists();
+    assertThat(new File(manifest3.path())).exists();
 
     TableMetadata metadata = readMetadata();
     List<ManifestFile> committedManifests = Lists.newArrayList(manifest1, manifest2, manifest3);
-    Assert.assertEquals(
-        "Should committed the manifests",
-        latestSnapshot(metadata, branch).allManifests(table.io()),
-        committedManifests);
+    assertThat(latestSnapshot(metadata, branch).allManifests(table.io()))
+        .isEqualTo(committedManifests);
 
     // As commit success all the manifests added with rewrite should be available.
-    Assert.assertEquals("Only 5 manifest should exist", 5, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(5);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceEqualityDeletesWithPositionDeletes() {
-    Assume.assumeTrue(
-        "Rewriting delete files is only supported in iceberg format v2. ", formatVersion > 1);
+    assumeThat(formatVersion)
+        .as("Rewriting delete files is only supported in iceberg format v2 or later.")
+        .isGreaterThan(1);
 
     commit(table, table.newRowDelta().addRows(FILE_A2).addDeletes(FILE_A2_DELETES), branch);
 
@@ -624,7 +599,7 @@ public class TestRewriteFiles extends TableTestBase {
                 ImmutableSet.of(), ImmutableSet.of(FILE_B_DELETES));
     Snapshot pending = apply(rewrite, branch);
 
-    Assert.assertEquals("Should produce 3 manifests", 3, pending.allManifests(table.io()).size());
+    assertThat(pending.allManifests(table.io())).hasSize(3);
     ManifestFile manifest1 = pending.allManifests(table.io()).get(0);
     ManifestFile manifest2 = pending.allManifests(table.io()).get(1);
     ManifestFile manifest3 = pending.allManifests(table.io()).get(2);
@@ -649,25 +624,24 @@ public class TestRewriteFiles extends TableTestBase {
 
     commit(table, rewrite, branch);
 
-    Assert.assertTrue("Should reuse new manifest", new File(manifest1.path()).exists());
-    Assert.assertTrue("Should reuse new manifest", new File(manifest2.path()).exists());
-    Assert.assertTrue("Should reuse new manifest", new File(manifest3.path()).exists());
+    assertThat(new File(manifest1.path())).exists();
+    assertThat(new File(manifest2.path())).exists();
+    assertThat(new File(manifest3.path())).exists();
 
     metadata = readMetadata();
     List<ManifestFile> committedManifests = Lists.newArrayList(manifest1, manifest2, manifest3);
-    Assert.assertEquals(
-        "Should committed the manifests",
-        latestSnapshot(metadata, branch).allManifests(table.io()),
-        committedManifests);
+    assertThat(latestSnapshot(metadata, branch).allManifests(table.io()))
+        .isEqualTo(committedManifests);
 
     // As commit success all the manifests added with rewrite should be available.
-    Assert.assertEquals("4 manifests should exist", 4, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(4);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveAllDeletes() {
-    Assume.assumeTrue(
-        "Rewriting delete files is only supported in iceberg format v2. ", formatVersion > 1);
+    assumeThat(formatVersion)
+        .as("Rewriting delete files is only supported in iceberg format v2 or later.")
+        .isGreaterThan(1);
 
     commit(table, table.newRowDelta().addRows(FILE_A).addDeletes(FILE_A_DELETES), branch);
 
@@ -681,7 +655,7 @@ public class TestRewriteFiles extends TableTestBase {
                 ImmutableSet.of(), ImmutableSet.of());
     Snapshot pending = apply(rewrite, branch);
 
-    Assert.assertEquals("Should produce 2 manifests", 2, pending.allManifests(table.io()).size());
+    assertThat(pending.allManifests(table.io())).hasSize(2);
     ManifestFile manifest1 = pending.allManifests(table.io()).get(0);
     ManifestFile manifest2 = pending.allManifests(table.io()).get(1);
 
@@ -697,32 +671,28 @@ public class TestRewriteFiles extends TableTestBase {
 
     commit(table, rewrite, branch);
 
-    Assert.assertTrue("Should reuse the new manifest", new File(manifest1.path()).exists());
-    Assert.assertTrue("Should reuse the new manifest", new File(manifest2.path()).exists());
+    assertThat(new File(manifest1.path())).exists();
+    assertThat(new File(manifest2.path())).exists();
 
     TableMetadata metadata = readMetadata();
     List<ManifestFile> committedManifests = Lists.newArrayList(manifest1, manifest2);
-    Assert.assertTrue(
-        "Should committed the manifests",
-        latestSnapshot(metadata, branch).allManifests(table.io()).containsAll(committedManifests));
+    assertThat(latestSnapshot(metadata, branch).allManifests(table.io()))
+        .containsAll(committedManifests);
 
     // As commit success all the manifests added with rewrite should be available.
-    Assert.assertEquals("4 manifests should exist", 4, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(4);
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteNonExistentFile() {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
     TableMetadata base = readMetadata();
-    Assert.assertEquals(
-        "Should create 1 manifest for initial write",
-        1,
-        latestSnapshot(base, branch).allManifests(table.io()).size());
+    assertThat(latestSnapshot(base, branch).allManifests(table.io())).hasSize(1);
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 commit(
                     table,
@@ -731,26 +701,23 @@ public class TestRewriteFiles extends TableTestBase {
         .isInstanceOf(ValidationException.class)
         .hasMessage("Missing required files to delete: /path/to/data-c.parquet");
 
-    Assert.assertEquals("Only 1 manifests should exist", 1, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(1);
   }
 
-  @Test
+  @TestTemplate
   public void testAlreadyDeletedFile() {
-    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+    assertThat(listManifestFiles()).isEmpty();
 
     commit(table, table.newAppend().appendFile(FILE_A), branch);
 
     TableMetadata base = readMetadata();
-    Assert.assertEquals(
-        "Should create 1 manifest for initial write",
-        1,
-        latestSnapshot(base, branch).allManifests(table.io()).size());
+    assertThat(latestSnapshot(base, branch).allManifests(table.io())).hasSize(1);
 
     RewriteFiles rewrite = table.newRewrite();
     Snapshot pending =
         apply(rewrite.rewriteFiles(Sets.newSet(FILE_A), Sets.newSet(FILE_B)), branch);
 
-    Assert.assertEquals("Should contain 2 manifest", 2, pending.allManifests(table.io()).size());
+    assertThat(pending.allManifests(table.io())).hasSize(2);
 
     long pendingId = pending.snapshotId();
 
@@ -765,7 +732,7 @@ public class TestRewriteFiles extends TableTestBase {
 
     commit(table, rewrite, branch);
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 commit(
                     table,
@@ -774,12 +741,14 @@ public class TestRewriteFiles extends TableTestBase {
         .isInstanceOf(ValidationException.class)
         .hasMessage("Missing required files to delete: /path/to/data-a.parquet");
 
-    Assert.assertEquals("Only 3 manifests should exist", 3, listManifestFiles().size());
+    assertThat(listManifestFiles()).hasSize(3);
   }
 
-  @Test
+  @TestTemplate
   public void testNewDeleteFile() {
-    Assume.assumeTrue("Delete files are only supported in v2", formatVersion > 1);
+    assumeThat(formatVersion)
+        .as("Delete files are only supported in iceberg format v2 or later.")
+        .isGreaterThan(1);
 
     commit(table, table.newAppend().appendFile(FILE_A), branch);
 
@@ -789,7 +758,7 @@ public class TestRewriteFiles extends TableTestBase {
 
     long snapshotAfterDeletes = latestSnapshot(table, branch).snapshotId();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 apply(
                     table

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -236,7 +236,9 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testRewriteDataAndDeleteFiles() {
-    assumeThat(formatVersion).isGreaterThan(1);
+    assumeThat(formatVersion)
+        .as("Rewriting delete files is only supported in iceberg format v2 or later")
+        .isGreaterThan(1);
     assertThat(listManifestFiles()).isEmpty();
 
     commit(
@@ -309,7 +311,9 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testRewriteDataAndAssignOldSequenceNumber() {
-    assumeThat(formatVersion).isGreaterThan(1);
+    assumeThat(formatVersion)
+        .as("Sequence number is only supported in iceberg format v2 or later")
+        .isGreaterThan(1);
     assertThat(listManifestFiles()).isEmpty();
 
     commit(
@@ -359,10 +363,7 @@ public class TestRewriteFiles extends TestBase {
     ManifestFile newManifest = pending.allManifests(table.io()).get(0);
     validateManifestEntries(newManifest, ids(pendingId), files(FILE_D), statuses(ADDED));
     assertThat(ManifestFiles.read(newManifest, FILE_IO).entries())
-        .allSatisfy(
-            entry -> {
-              assertThat(entry.dataSequenceNumber()).isEqualTo(oldSequenceNumber);
-            });
+        .allSatisfy(entry -> assertThat(entry.dataSequenceNumber()).isEqualTo(oldSequenceNumber));
     assertThat(newManifest.sequenceNumber()).isEqualTo(oldSequenceNumber + 1);
 
     validateManifestEntries(
@@ -413,7 +414,9 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testFailureWhenRewriteBothDataAndDeleteFiles() {
-    assumeThat(formatVersion).isGreaterThan(1);
+    assumeThat(formatVersion)
+        .as("Rewriting delete files is only supported in iceberg format v2 or later")
+        .isGreaterThan(1);
 
     commit(
         table,
@@ -508,7 +511,9 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testRecoverWhenRewriteBothDataAndDeleteFiles() {
-    assumeThat(formatVersion).isGreaterThan(1);
+    assumeThat(formatVersion)
+        .as("Rewriting delete files is only supported in iceberg format v2 or later")
+        .isGreaterThan(1);
 
     commit(
         table,
@@ -573,7 +578,9 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testReplaceEqualityDeletesWithPositionDeletes() {
-    assumeThat(formatVersion).isGreaterThan(1);
+    assumeThat(formatVersion)
+        .as("Rewriting delete files is only supported in iceberg format v2 or later")
+        .isGreaterThan(1);
 
     commit(table, table.newRowDelta().addRows(FILE_A2).addDeletes(FILE_A2_DELETES), branch);
 
@@ -629,7 +636,9 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testRemoveAllDeletes() {
-    assumeThat(formatVersion).isGreaterThan(1);
+    assumeThat(formatVersion)
+        .as("Rewriting delete files is only supported in iceberg format v2 or later")
+        .isGreaterThan(1);
 
     commit(table, table.newRowDelta().addRows(FILE_A).addDeletes(FILE_A_DELETES), branch);
 
@@ -734,7 +743,9 @@ public class TestRewriteFiles extends TestBase {
 
   @TestTemplate
   public void testNewDeleteFile() {
-    assumeThat(formatVersion).isGreaterThan(1);
+    assumeThat(formatVersion)
+        .as("Rewriting delete files is only supported in iceberg format v2 or later")
+        .isGreaterThan(1);
 
     commit(table, table.newAppend().appendFile(FILE_A), branch);
 


### PR DESCRIPTION
Migrate the following test classes in iceberg-core to JUnit 5 and AssertJ style for https://github.com/apache/iceberg/issues/9085.

## Current Progress 
- [x] `TestFastAppend.java`
- [x] `TestMergeAppend.java`
- [x] `TestOverwrite.java`
- [x] `TestOverwriteWithValidation.java`

Files:
- [x] `TestDeleteFiles.java`
- [x] `TestRewriteFiles.java`