### PR TITLE
[core] fix #9997 - Handle s3a file upload interrupt which results in table metadata pointing to files that doesn't exist

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
@@ -185,20 +185,17 @@ public class HadoopStreams {
 
     @Override
     public void close() throws IOException {
-      try {
-        stream.close();
-        // {@link org.apache.hadoop.fs.s3a.S3ABlockOutputStream#close()} calls {@link
-        // org.apache.hadoop.fs.s3a.S3ABlockOutputStream#putObject()}
-        // which doesn't throw an exception when interrupted.
-        // Need to check the interrupted flag to detect failed object upload
-        // and propagate the error up.
-        if (Thread.interrupted()
-            && "org.apache.hadoop.fs.s3a.S3ABlockOutputStream"
-                .equals(stream.getWrappedStream().getClass().getName())) {
-          throw new IOException("Failed to close stream as object failed to upload.");
-        }
-      } finally {
-        this.closed = true;
+      stream.close();
+      this.closed = true;
+      // {@link org.apache.hadoop.fs.s3a.S3ABlockOutputStream#close()} calls {@link
+      // org.apache.hadoop.fs.s3a.S3ABlockOutputStream#putObject()}
+      // which doesn't throw an exception when interrupted.
+      // Need to check the interrupted flag to detect failed object upload
+      // and propagate the error up.
+      if (Thread.interrupted()
+          && "org.apache.hadoop.fs.s3a.S3ABlockOutputStream"
+              .equals(stream.getWrappedStream().getClass().getName())) {
+        throw new IOException("Failed to close stream as object failed to upload.");
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
@@ -195,7 +195,8 @@ public class HadoopStreams {
       if (Thread.interrupted()
           && "org.apache.hadoop.fs.s3a.S3ABlockOutputStream"
               .equals(stream.getWrappedStream().getClass().getName())) {
-        throw new IOException("Failed to close stream as object failed to upload.");
+        throw new IOException(
+            "S3ABlockOutputStream failed to upload object after stream was closed");
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
@@ -194,7 +194,7 @@ public class HadoopStreams {
         if (Thread.interrupted()
             && "S3ABlockOutputStream"
                 .equals(stream.getWrappedStream().getClass().getSimpleName())) {
-          throw new IOException("s3a putObject interrupted");
+          throw new IOException("object upload failed as it was interrupted during close");
         }
       } finally {
         this.closed = true;

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
@@ -189,8 +189,8 @@ public class HadoopStreams {
         stream.close();
         // {@link org.apache.hadoop.fs.s3a.S3ABlockOutputStream#close()} calls {@link
         // org.apache.hadoop.fs.s3a.S3ABlockOutputStream#putObject()}
-        // which doesn't throw an exception when interrupted. Need to check the interrupted flag to
-        // detect failed object upload
+        // which doesn't throw an exception when interrupted.
+        // Need to check the interrupted flag to detect failed object upload
         // and propagate the error up.
         if (Thread.interrupted()
             && "org.apache.hadoop.fs.s3a.S3ABlockOutputStream"

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
@@ -195,7 +195,7 @@ public class HadoopStreams {
         if (Thread.interrupted()
             && "org.apache.hadoop.fs.s3a.S3ABlockOutputStream"
                 .equals(stream.getWrappedStream().getClass().getName())) {
-          throw new IOException("object upload failed as it was interrupted during close");
+          throw new IOException("Failed to close stream as object failed to upload.");
         }
       } finally {
         this.closed = true;

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
@@ -189,11 +189,12 @@ public class HadoopStreams {
         stream.close();
         // {@link org.apache.hadoop.fs.s3a.S3ABlockOutputStream#close()} calls {@link
         // org.apache.hadoop.fs.s3a.S3ABlockOutputStream#putObject()}
-        // which doesn't throw an exception when interrupted. Need to handle interrupts here to make
-        // sure file is uploaded on close.
+        // which doesn't throw an exception when interrupted. Need to check the interrupted flag to
+        // detect failed object upload
+        // and propagate the error up.
         if (Thread.interrupted()
-            && "S3ABlockOutputStream"
-                .equals(stream.getWrappedStream().getClass().getSimpleName())) {
+            && "org.apache.hadoop.fs.s3a.S3ABlockOutputStream"
+                .equals(stream.getWrappedStream().getClass().getName())) {
           throw new IOException("object upload failed as it was interrupted during close");
         }
       } finally {

--- a/core/src/test/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/core/src/test/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -26,7 +26,7 @@ public class S3ABlockOutputStream extends OutputStream {
 
   @Override
   public void write(int b) throws IOException {
-    throw new IOException("mocked clas, do not use");
+    throw new IOException("mocked class, do not use");
   }
 
   @Override

--- a/core/src/test/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
+++ b/core/src/test/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hadoop.fs.s3a;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/** mock class for testing hadoop s3a writer */
+public class S3ABlockOutputStream extends OutputStream {
+
+  @Override
+  public void write(int b) throws IOException {
+    throw new IOException("mocked clas, do not use");
+  }
+
+  @Override
+  public void close() throws IOException {
+    super.close();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopStreamsTest.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopStreamsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hadoop;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.s3a.S3ABlockOutputStream;
+import org.apache.iceberg.io.PositionOutputStream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class HadoopStreamsTest {
+
+  @Test
+  void closeShouldThrowIOExceptionOnInterrupted() throws IOException {
+
+    FSDataOutputStream fsDataOutputStream =
+        new FSDataOutputStream(new S3ABlockOutputStream(), null);
+    PositionOutputStream wrap = HadoopStreams.wrap(fsDataOutputStream);
+
+    // mock interrupt in S3ABlockOutputStream#putObject
+    Thread.currentThread().interrupt();
+
+    Assertions.assertThrowsExactly(IOException.class, wrap::close);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopStreamsTest.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopStreamsTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg.hadoop;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.io.IOException;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.s3a.S3ABlockOutputStream;

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopStreams.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopStreams.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.s3a.S3ABlockOutputStream;
 import org.apache.iceberg.io.PositionOutputStream;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TestHadoopStreams {
@@ -36,7 +37,7 @@ class TestHadoopStreams {
     // mock interrupt in S3ABlockOutputStream#putObject
     Thread.currentThread().interrupt();
 
-    org.assertj.core.api.Assertions.assertThatThrownBy(wrap::close)
+    Assertions.assertThatThrownBy(wrap::close)
         .isInstanceOf(IOException.class)
         .hasMessage("Failed to close stream as object failed to upload.");
   }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopStreams.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopStreams.java
@@ -34,7 +34,6 @@ class TestHadoopStreams {
     S3ABlockOutputStream s3ABlockOutputStream = new S3ABlockOutputStream();
     FSDataOutputStream fsDataOutputStream = new FSDataOutputStream(s3ABlockOutputStream, null);
     PositionOutputStream wrap = HadoopStreams.wrap(fsDataOutputStream);
-
     // interrupt mock upload on close after a delay
     Executors.newSingleThreadExecutor()
         .execute(

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopStreams.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopStreams.java
@@ -22,10 +22,9 @@ import java.io.IOException;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.s3a.S3ABlockOutputStream;
 import org.apache.iceberg.io.PositionOutputStream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class HadoopStreamsTest {
+class TestHadoopStreams {
 
   @Test
   void closeShouldThrowIOExceptionOnInterrupted() throws IOException {
@@ -37,6 +36,8 @@ class HadoopStreamsTest {
     // mock interrupt in S3ABlockOutputStream#putObject
     Thread.currentThread().interrupt();
 
-    Assertions.assertThrowsExactly(IOException.class, wrap::close);
+    org.assertj.core.api.Assertions.assertThatThrownBy(wrap::close)
+        .isInstanceOf(IOException.class)
+        .hasMessage("Failed to close stream as object failed to upload.");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopStreams.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopStreams.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 class TestHadoopStreams {
 
   @Test
-  void closeShouldThrowIOExceptionOnInterrupted() throws IOException {
+  void closeShouldThrowIOExceptionWhenInterrupted() throws IOException {
 
     FSDataOutputStream fsDataOutputStream =
         new FSDataOutputStream(new S3ABlockOutputStream(), null);
@@ -39,6 +39,6 @@ class TestHadoopStreams {
 
     Assertions.assertThatThrownBy(wrap::close)
         .isInstanceOf(IOException.class)
-        .hasMessage("Failed to close stream as object failed to upload.");
+        .hasMessage("S3ABlockOutputStream failed to upload object after stream was closed");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopStreams.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopStreams.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.s3a.S3ABlockOutputStream;
 import org.apache.iceberg.io.PositionOutputStream;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 class TestHadoopStreams {
@@ -32,7 +31,6 @@ class TestHadoopStreams {
   @Test
   void closeShouldThrowIOExceptionWhenInterrupted() throws Exception {
 
-    long startTime = System.currentTimeMillis();
     S3ABlockOutputStream s3ABlockOutputStream = new S3ABlockOutputStream();
     FSDataOutputStream fsDataOutputStream = new FSDataOutputStream(s3ABlockOutputStream, null);
     PositionOutputStream wrap = HadoopStreams.wrap(fsDataOutputStream);
@@ -52,9 +50,5 @@ class TestHadoopStreams {
     Assertions.assertThatThrownBy(wrap::close)
         .isInstanceOf(IOException.class)
         .hasMessage("S3ABlockOutputStream failed to upload object after stream was closed");
-
-    long endTime = System.currentTimeMillis();
-    long closeDuration = endTime - startTime;
-    Assert.assertTrue(closeDuration < 30 * 1000 && closeDuration > 1000);
   }
 }


### PR DESCRIPTION
This is fix for https://github.com/apache/iceberg/issues/9997

### Root cause

s3a putObject was interrupted due to flink pipeline failure _while_ the object was being uploaded. As this interrupt is not handled and thrown as an exception, the metadata writer assumes write was successful which results in table pointing to a metadata json file that doesn't exist.

#### Hadoop S3A code
This is the s3a code block which is called from stream close to putObject which is the root cause.

https://github.com/apache/hadoop/blob/0f51d2a4ec17bad754beb17048409811a151be53/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ABlockOutputStream.java#L636

``` 
try {
      putObjectResult.get();
      return size;
    } catch (InterruptedException ie) {
      LOG.warn("Interrupted object upload", ie);
      Thread.currentThread().interrupt();
      return 0;
    } catch (ExecutionException ee) {
      throw extractException("regular upload", key, ee);
    }
```


#### Iceberg commit successful on upload interrupt

`
2024-03-06T23:06:36.160+00:00 INFO org.apache.iceberg.hive.HiveTableOperations  Committed to table iceberg.default.some_table with the new metadata location s3a://bucket/prefix/default.db/some_table/metadata/52949-1e28478a-bf5e-4ec0-8d2c-......metadata.json `

But request interrupted 
`2024-03-06T23:06:36.024+00:00 WARN  org.apache.hadoop.fs.s3a.S3ABlockOutputStream  Interrupted object upload`