### PR TITLE
Migrate Transactions, Partitions and Statistics files in Core to JUnit5

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestCommitReporting.java
+++ b/core/src/test/java/org/apache/iceberg/TestCommitReporting.java
@@ -21,21 +21,26 @@ package org.apache.iceberg;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.iceberg.ScanPlanningAndReportingTestBase.TestMetricsReporter;
 import org.apache.iceberg.metrics.CommitMetricsResult;
 import org.apache.iceberg.metrics.CommitReport;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.junit.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestCommitReporting extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestCommitReporting extends TestBase {
 
   private final TestMetricsReporter reporter = new TestMetricsReporter();
 
-  public TestCommitReporting() {
-    super(2);
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(2);
   }
 
-  @Test
+  @TestTemplate
   public void addAndDeleteDataFiles() {
     String tableName = "add-and-delete-data-files";
     Table table =
@@ -80,7 +85,7 @@ public class TestCommitReporting extends TableTestBase {
     assertThat(metrics.totalFilesSizeInBytes().value()).isEqualTo(0L);
   }
 
-  @Test
+  @TestTemplate
   public void addAndDeleteDeleteFiles() {
     String tableName = "add-and-delete-delete-files";
     Table table =
@@ -150,7 +155,7 @@ public class TestCommitReporting extends TableTestBase {
     assertThat(metrics.totalFilesSizeInBytes().value()).isEqualTo(0L);
   }
 
-  @Test
+  @TestTemplate
   public void addAndDeleteManifests() throws IOException {
     String tableName = "add-and-delete-manifests";
     Table table =

--- a/core/src/test/java/org/apache/iceberg/TestPartitionSpecInfo.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitionSpecInfo.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.io.File;
 import java.io.IOException;
@@ -77,8 +78,9 @@ public class TestPartitionSpecInfo {
     assertThat(spec.isUnpartitioned()).isTrue();
     assertThat(table.spec()).isEqualTo(spec);
     assertThat(table.spec().lastAssignedFieldId()).isEqualTo(spec.lastAssignedFieldId());
-    assertThat(table.specs()).containsEntry(spec.specId(), spec);
-    assertThat(table.specs().get(Integer.MAX_VALUE)).isNull();
+    assertThat(table.specs())
+        .containsExactly(entry(spec.specId(), spec))
+        .doesNotContainKey(Integer.MAX_VALUE);
   }
 
   @Test
@@ -88,8 +90,9 @@ public class TestPartitionSpecInfo {
 
     assertThat(table.spec()).isEqualTo(spec);
     assertThat(table.spec().lastAssignedFieldId()).isEqualTo(spec.lastAssignedFieldId());
-    assertThat(table.specs()).containsEntry(spec.specId(), spec);
-    assertThat(table.specs().get(Integer.MAX_VALUE)).isNull();
+    assertThat(table.specs())
+        .containsExactly(entry(spec.specId(), spec))
+        .doesNotContainKey(Integer.MAX_VALUE);
   }
 
   @Test
@@ -111,9 +114,8 @@ public class TestPartitionSpecInfo {
 
     assertThat(table.spec()).isEqualTo(newSpec);
     assertThat(table.specs())
-        .containsEntry(spec.specId(), spec)
-        .containsEntry(newSpec.specId(), newSpec);
-    assertThat(table.specs().get(Integer.MAX_VALUE)).isNull();
+        .containsExactly(entry(spec.specId(), spec), entry(newSpec.specId(), newSpec))
+        .doesNotContainKey(Integer.MAX_VALUE);
     assertThat(table.schema().asStruct()).isEqualTo(expectedSchema.asStruct());
   }
 
@@ -131,8 +133,7 @@ public class TestPartitionSpecInfo {
 
     assertThat(table.spec()).isEqualTo(newSpec);
     assertThat(table.specs())
-        .containsEntry(newSpec.specId(), newSpec)
-        .containsEntry(spec.specId(), spec);
-    assertThat(table.specs().get(Integer.MAX_VALUE)).isNull();
+        .containsExactly(entry(spec.specId(), spec), entry(newSpec.specId(), newSpec))
+        .doesNotContainKey(Integer.MAX_VALUE);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestPartitionSpecParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitionSpecParser.java
@@ -18,12 +18,18 @@
  */
 package org.apache.iceberg;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestPartitionSpecParser extends TableTestBase {
-  public TestPartitionSpecParser() {
-    super(1);
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestPartitionSpecParser extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1);
   }
 
   @Test
@@ -38,7 +44,7 @@ public class TestPartitionSpecParser extends TableTestBase {
             + "    \"field-id\" : 1000\n"
             + "  } ]\n"
             + "}";
-    Assert.assertEquals(expected, PartitionSpecParser.toJson(table.spec(), true));
+    assertThat(PartitionSpecParser.toJson(table.spec(), true)).isEqualTo(expected);
 
     PartitionSpec spec =
         PartitionSpec.builderFor(table.schema()).bucket("id", 8).bucket("data", 16).build();
@@ -60,7 +66,7 @@ public class TestPartitionSpecParser extends TableTestBase {
             + "    \"field-id\" : 1001\n"
             + "  } ]\n"
             + "}";
-    Assert.assertEquals(expected, PartitionSpecParser.toJson(table.spec(), true));
+    assertThat(PartitionSpecParser.toJson(table.spec(), true)).isEqualTo(expected);
   }
 
   @Test
@@ -83,10 +89,10 @@ public class TestPartitionSpecParser extends TableTestBase {
 
     PartitionSpec spec = PartitionSpecParser.fromJson(table.schema(), specString);
 
-    Assert.assertEquals(2, spec.fields().size());
+    assertThat(spec.fields()).hasSize(2);
     // should be the field ids in the JSON
-    Assert.assertEquals(1001, spec.fields().get(0).fieldId());
-    Assert.assertEquals(1000, spec.fields().get(1).fieldId());
+    assertThat(spec.fields().get(0).fieldId()).isEqualTo(1001);
+    assertThat(spec.fields().get(1).fieldId()).isEqualTo(1000);
   }
 
   @Test
@@ -107,17 +113,16 @@ public class TestPartitionSpecParser extends TableTestBase {
 
     PartitionSpec spec = PartitionSpecParser.fromJson(table.schema(), specString);
 
-    Assert.assertEquals(2, spec.fields().size());
+    assertThat(spec.fields()).hasSize(2);
     // should be the default assignment
-    Assert.assertEquals(1000, spec.fields().get(0).fieldId());
-    Assert.assertEquals(1001, spec.fields().get(1).fieldId());
+    assertThat(spec.fields().get(0).fieldId()).isEqualTo(1000);
+    assertThat(spec.fields().get(1).fieldId()).isEqualTo(1001);
   }
 
   @Test
   public void testTransforms() {
     for (PartitionSpec spec : PartitionSpecTestBase.SPECS) {
-      Assert.assertEquals(
-          "To/from JSON should produce equal partition spec", spec, roundTripJSON(spec));
+      assertThat(roundTripJSON(spec)).isEqualTo(spec);
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestPartitioning.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitioning.java
@@ -19,21 +19,22 @@
 package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
-import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestPartitioning {
 
@@ -51,15 +52,15 @@ public class TestPartitioning {
   private static final PartitionSpec BY_DATA_CATEGORY_BUCKET_SPEC =
       PartitionSpec.builderFor(SCHEMA).identity("data").bucket("category", 8).build();
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
   private File tableDir = null;
 
-  @Before
+  @BeforeEach
   public void setupTableDir() throws IOException {
-    this.tableDir = temp.newFolder();
+    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
   }
 
-  @After
+  @AfterEach
   public void cleanupTables() {
     TestTables.clearTables();
   }
@@ -71,19 +72,19 @@ public class TestPartitioning {
 
     table.updateSpec().addField(Expressions.bucket("category", 8)).commit();
 
-    Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
+    assertThat(table.specs()).hasSize(2);
 
     StructType expectedType =
         StructType.of(
             NestedField.optional(1000, "data", Types.StringType.get()),
             NestedField.optional(1001, "category_bucket_8", Types.IntegerType.get()));
     StructType actualType = Partitioning.partitionType(table);
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
 
     table.updateSpec().removeField("data").removeField("category_bucket_8").commit();
 
-    Assert.assertEquals("Should have 3 specs", 3, table.specs().size());
-    Assert.assertTrue("PartitionSpec should be unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.specs()).hasSize(3);
+    assertThat(table.spec().isUnpartitioned()).isTrue();
   }
 
   @Test
@@ -93,14 +94,14 @@ public class TestPartitioning {
 
     table.updateSpec().removeField("data").addField("category").commit();
 
-    Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
+    assertThat(table.specs()).hasSize(2);
 
     StructType expectedType =
         StructType.of(
             NestedField.optional(1000, "data", Types.StringType.get()),
             NestedField.optional(1001, "category", Types.StringType.get()));
     StructType actualType = Partitioning.partitionType(table);
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -118,7 +119,7 @@ public class TestPartitioning {
             NestedField.optional(1000, "p2", Types.StringType.get()),
             NestedField.optional(1001, "category", Types.StringType.get()));
     StructType actualType = Partitioning.partitionType(table);
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -136,7 +137,7 @@ public class TestPartitioning {
             NestedField.optional(1000, "data_1000", Types.StringType.get()),
             NestedField.optional(1001, "data", Types.StringType.get()));
     StructType actualType = Partitioning.partitionType(table);
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -152,7 +153,7 @@ public class TestPartitioning {
     StructType expectedType =
         StructType.of(NestedField.optional(1000, "data", Types.StringType.get()));
     StructType actualType = Partitioning.partitionType(table);
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -166,9 +167,9 @@ public class TestPartitioning {
     TableMetadata current = ops.current();
     ops.commit(current, current.updatePartitionSpec(newSpec));
 
-    Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
+    assertThat(table.specs()).hasSize(2);
 
-    Assertions.assertThatThrownBy(() -> Partitioning.partitionType(table))
+    assertThatThrownBy(() -> Partitioning.partitionType(table))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Conflicting partition fields");
   }
@@ -180,12 +181,12 @@ public class TestPartitioning {
 
     table.updateSpec().addField(Expressions.bucket("category", 8)).commit();
 
-    Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
+    assertThat(table.specs()).hasSize(2);
 
     StructType expectedType =
         StructType.of(NestedField.optional(1000, "data", Types.StringType.get()));
     StructType actualType = Partitioning.groupingKeyType(table.schema(), table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -195,12 +196,12 @@ public class TestPartitioning {
 
     table.updateSpec().addField(Expressions.bucket("category", 8)).commit();
 
-    Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
+    assertThat(table.specs()).hasSize(2);
 
     StructType expectedType =
         StructType.of(NestedField.optional(1000, "data", Types.StringType.get()));
     StructType actualType = Partitioning.groupingKeyType(table.schema(), table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -211,12 +212,12 @@ public class TestPartitioning {
 
     table.updateSpec().removeField(Expressions.bucket("category", 8)).commit();
 
-    Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
+    assertThat(table.specs()).hasSize(2);
 
     StructType expectedType =
         StructType.of(NestedField.optional(1000, "data", Types.StringType.get()));
     StructType actualType = Partitioning.groupingKeyType(table.schema(), table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -227,12 +228,12 @@ public class TestPartitioning {
 
     table.updateSpec().removeField(Expressions.bucket("category", 8)).commit();
 
-    Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
+    assertThat(table.specs()).hasSize(2);
 
     StructType expectedType =
         StructType.of(NestedField.optional(1000, "data", Types.StringType.get()));
     StructType actualType = Partitioning.groupingKeyType(table.schema(), table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -248,7 +249,7 @@ public class TestPartitioning {
     StructType expectedType =
         StructType.of(NestedField.optional(1000, "p2", Types.StringType.get()));
     StructType actualType = Partitioning.groupingKeyType(table.schema(), table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -264,7 +265,7 @@ public class TestPartitioning {
     StructType expectedType =
         StructType.of(NestedField.optional(1000, "p2", Types.StringType.get()));
     StructType actualType = Partitioning.groupingKeyType(table.schema(), table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -274,11 +275,11 @@ public class TestPartitioning {
 
     table.updateSpec().removeField("data").commit();
 
-    Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
+    assertThat(table.specs()).hasSize(2);
 
     StructType expectedType = StructType.of();
     StructType actualType = Partitioning.groupingKeyType(table.schema(), table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -288,11 +289,11 @@ public class TestPartitioning {
 
     table.updateSpec().removeField("data").commit();
 
-    Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
+    assertThat(table.specs()).hasSize(2);
 
     StructType expectedType = StructType.of();
     StructType actualType = Partitioning.groupingKeyType(table.schema(), table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -307,7 +308,7 @@ public class TestPartitioning {
     StructType expectedType =
         StructType.of(NestedField.optional(1000, "category", Types.StringType.get()));
     StructType actualType = Partitioning.groupingKeyType(table.schema(), table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -322,7 +323,7 @@ public class TestPartitioning {
     StructType expectedType =
         StructType.of(NestedField.optional(1000, "category", Types.StringType.get()));
     StructType actualType = Partitioning.groupingKeyType(table.schema(), table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -331,11 +332,11 @@ public class TestPartitioning {
         TestTables.create(
             tableDir, "test", SCHEMA, PartitionSpec.unpartitioned(), V1_FORMAT_VERSION);
 
-    Assert.assertEquals("Should have 1 spec", 1, table.specs().size());
+    assertThat(table.specs()).hasSize(1);
 
     StructType expectedType = StructType.of();
     StructType actualType = Partitioning.groupingKeyType(table.schema(), table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -346,11 +347,11 @@ public class TestPartitioning {
 
     table.updateSpec().addField(Expressions.bucket("category", 8)).commit();
 
-    Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
+    assertThat(table.specs()).hasSize(2);
 
     StructType expectedType = StructType.of();
     StructType actualType = Partitioning.groupingKeyType(table.schema(), table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -363,7 +364,7 @@ public class TestPartitioning {
     StructType expectedType =
         StructType.of(NestedField.optional(1001, "data", Types.StringType.get()));
     StructType actualType = Partitioning.groupingKeyType(projectedSchema, table.specs().values());
-    Assert.assertEquals("Types must match", expectedType, actualType);
+    assertThat(actualType).isEqualTo(expectedType);
   }
 
   @Test
@@ -377,10 +378,9 @@ public class TestPartitioning {
     TableMetadata current = ops.current();
     ops.commit(current, current.updatePartitionSpec(newSpec));
 
-    Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
+    assertThat(table.specs()).hasSize(2);
 
-    Assertions.assertThatThrownBy(
-            () -> Partitioning.groupingKeyType(table.schema(), table.specs().values()))
+    assertThatThrownBy(() -> Partitioning.groupingKeyType(table.schema(), table.specs().values()))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Conflicting partition fields");
   }
@@ -403,6 +403,6 @@ public class TestPartitioning {
             .identity("id")
             .build();
 
-    Assert.assertEquals("The spec should be there", spec, table.spec());
+    assertThat(table.spec()).isEqualTo(spec);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -22,9 +22,15 @@ import static org.apache.iceberg.NullOrder.NULLS_FIRST;
 import static org.apache.iceberg.PartitionSpec.unpartitioned;
 import static org.apache.iceberg.SortDirection.ASC;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -37,32 +43,24 @@ import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestReplaceTransaction extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestReplaceTransaction extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestReplaceTransaction(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testReplaceTransactionWithCustomSortOrder() {
     Snapshot start = table.currentSnapshot();
     Schema schema = table.schema();
 
     table.newAppend().appendFile(FILE_A).commit();
 
-    Assert.assertEquals("Version should be 1", 1L, (long) version());
+    assertThat(version()).isEqualTo(1);
 
     validateSnapshot(start, table.currentSnapshot(), FILE_A);
 
@@ -75,10 +73,9 @@ public class TestReplaceTransaction extends TableTestBase {
 
     table.refresh();
 
-    Assert.assertEquals("Version should be 2", 2L, (long) version());
-    Assert.assertNull("Table should not have a current snapshot", table.currentSnapshot());
-    Assert.assertEquals(
-        "Schema should match previous schema", schema.asStruct(), table.schema().asStruct());
+    assertThat(version()).isEqualTo(2);
+    assertThat(table.currentSnapshot()).isNull();
+    assertThat(table.schema().asStruct()).isEqualTo(schema.asStruct());
 
     PartitionSpec v2Expected = PartitionSpec.builderFor(table.schema()).withSpecId(1).build();
     V2Assert.assertEquals("Table should have an unpartitioned spec", v2Expected, table.spec());
@@ -90,18 +87,17 @@ public class TestReplaceTransaction extends TableTestBase {
             .build();
     V1Assert.assertEquals("Table should have a spec with one void field", v1Expected, table.spec());
 
-    Assert.assertEquals("Table should have 2 orders", 2, table.sortOrders().size());
+    assertThat(table.sortOrders()).hasSize(2);
     SortOrder sortOrder = table.sortOrder();
-    Assert.assertEquals("Order ID must match", 1, sortOrder.orderId());
-    Assert.assertEquals("Order must have 1 field", 1, sortOrder.fields().size());
-    Assert.assertEquals("Direction must match ", ASC, sortOrder.fields().get(0).direction());
-    Assert.assertEquals(
-        "Null order must match ", NULLS_FIRST, sortOrder.fields().get(0).nullOrder());
+    assertThat(sortOrder.orderId()).isEqualTo(1);
+    assertThat(sortOrder.fields()).hasSize(1);
+    assertThat(sortOrder.fields().get(0).direction()).isEqualTo(ASC);
+    assertThat(sortOrder.fields().get(0).nullOrder()).isEqualTo(NULLS_FIRST);
     Transform<?, ?> transform = Transforms.identity();
-    Assert.assertEquals("Transform must match", transform, sortOrder.fields().get(0).transform());
+    assertThat(sortOrder.fields().get(0).transform()).isEqualTo(transform);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceTransaction() {
     Schema newSchema =
         new Schema(
@@ -113,7 +109,7 @@ public class TestReplaceTransaction extends TableTestBase {
 
     table.newAppend().appendFile(FILE_A).commit();
 
-    Assert.assertEquals("Version should be 1", 1L, (long) version());
+    assertThat(version()).isEqualTo(1);
 
     validateSnapshot(start, table.currentSnapshot(), FILE_A);
 
@@ -122,10 +118,9 @@ public class TestReplaceTransaction extends TableTestBase {
 
     table.refresh();
 
-    Assert.assertEquals("Version should be 2", 2L, (long) version());
-    Assert.assertNull("Table should not have a current snapshot", table.currentSnapshot());
-    Assert.assertEquals(
-        "Schema should match previous schema", schema.asStruct(), table.schema().asStruct());
+    assertThat(version()).isEqualTo(2);
+    assertThat(table.currentSnapshot()).isNull();
+    assertThat(table.schema().asStruct()).isEqualTo(schema.asStruct());
 
     PartitionSpec v2Expected = PartitionSpec.builderFor(table.schema()).withSpecId(1).build();
     V2Assert.assertEquals("Table should have an unpartitioned spec", v2Expected, table.spec());
@@ -137,15 +132,16 @@ public class TestReplaceTransaction extends TableTestBase {
             .build();
     V1Assert.assertEquals("Table should have a spec with one void field", v1Expected, table.spec());
 
-    Assert.assertEquals("Table should have 1 order", 1, table.sortOrders().size());
-    Assert.assertEquals("Table order ID should match", 0, table.sortOrder().orderId());
-    Assert.assertTrue("Table should be unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrders()).hasSize(1);
+    assertThat(table.sortOrder().orderId()).isEqualTo(0);
+    assertThat(table.sortOrder().isUnsorted()).isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceWithIncompatibleSchemaUpdate() {
-    Assume.assumeTrue(
-        "Fails early for v1 tables because partition spec cannot drop a field", formatVersion == 2);
+    assumeThat(formatVersion)
+        .as("Fails early for v1 tables because partition spec cannot drop a field")
+        .isEqualTo(2);
 
     Schema newSchema = new Schema(required(4, "obj_id", Types.IntegerType.get()));
 
@@ -153,7 +149,7 @@ public class TestReplaceTransaction extends TableTestBase {
 
     table.newAppend().appendFile(FILE_A).commit();
 
-    Assert.assertEquals("Version should be 1", 1L, (long) version());
+    assertThat(version()).isEqualTo(1);
 
     validateSnapshot(start, table.currentSnapshot(), FILE_A);
 
@@ -162,15 +158,13 @@ public class TestReplaceTransaction extends TableTestBase {
 
     table.refresh();
 
-    Assert.assertEquals("Version should be 2", 2L, (long) version());
-    Assert.assertNull("Table should not have a current snapshot", table.currentSnapshot());
-    Assert.assertEquals(
-        "Schema should use new schema, not compatible with previous",
-        new Schema(required(3, "obj_id", Types.IntegerType.get())).asStruct(),
-        table.schema().asStruct());
+    assertThat(version()).isEqualTo(2);
+    assertThat(table.currentSnapshot()).isNull();
+    assertThat(table.schema().asStruct())
+        .isEqualTo(new Schema(required(3, "obj_id", Types.IntegerType.get())).asStruct());
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceWithNewPartitionSpec() {
     PartitionSpec newSpec = PartitionSpec.unpartitioned();
 
@@ -179,7 +173,7 @@ public class TestReplaceTransaction extends TableTestBase {
 
     table.newAppend().appendFile(FILE_A).commit();
 
-    Assert.assertEquals("Version should be 1", 1L, (long) version());
+    assertThat(version()).isEqualTo(1);
 
     validateSnapshot(start, table.currentSnapshot(), FILE_A);
 
@@ -188,12 +182,9 @@ public class TestReplaceTransaction extends TableTestBase {
 
     table.refresh();
 
-    Assert.assertEquals("Version should be 2", 2L, (long) version());
-    Assert.assertNull("Table should not have a current snapshot", table.currentSnapshot());
-    Assert.assertEquals(
-        "Schema should use new schema, not compatible with previous",
-        schema.asStruct(),
-        table.schema().asStruct());
+    assertThat(version()).isEqualTo(2);
+    assertThat(table.currentSnapshot()).isNull();
+    assertThat(table.schema().asStruct()).isEqualTo(schema.asStruct());
 
     PartitionSpec v2Expected = PartitionSpec.builderFor(table.schema()).withSpecId(1).build();
     V2Assert.assertEquals("Table should have an unpartitioned spec", v2Expected, table.spec());
@@ -206,14 +197,14 @@ public class TestReplaceTransaction extends TableTestBase {
     V1Assert.assertEquals("Table should have a spec with one void field", v1Expected, table.spec());
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceWithNewData() {
     Snapshot start = table.currentSnapshot();
     Schema schema = table.schema();
 
     table.newAppend().appendFile(FILE_A).commit();
 
-    Assert.assertEquals("Version should be 1", 1L, (long) version());
+    assertThat(version()).isEqualTo(1);
 
     validateSnapshot(start, table.currentSnapshot(), FILE_A);
 
@@ -225,19 +216,16 @@ public class TestReplaceTransaction extends TableTestBase {
 
     table.refresh();
 
-    Assert.assertEquals("Version should be 2", 2L, (long) version());
-    Assert.assertNotNull("Table should have a current snapshot", table.currentSnapshot());
-    Assert.assertEquals(
-        "Schema should use new schema, not compatible with previous",
-        schema.asStruct(),
-        table.schema().asStruct());
+    assertThat(version()).isEqualTo(2);
+    assertThat(table.currentSnapshot()).isNotNull();
+    assertThat(table.schema().asStruct()).isEqualTo(schema.asStruct());
 
     validateSnapshot(null, table.currentSnapshot(), FILE_B, FILE_C, FILE_D);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceDetectsUncommittedChangeOnCommit() {
-    Assert.assertEquals("Version should be 0", 0L, (long) version());
+    assertThat(version()).isEqualTo(0);
 
     Transaction replace = TestTables.beginReplace(tableDir, "test", table.schema(), table.spec());
 
@@ -247,16 +235,16 @@ public class TestReplaceTransaction extends TableTestBase {
         .appendFile(FILE_C)
         .appendFile(FILE_D);
 
-    Assertions.assertThatThrownBy(replace::commitTransaction)
+    assertThatThrownBy(replace::commitTransaction)
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot commit transaction: last operation has not committed");
 
-    Assert.assertEquals("Version should be 0", 0L, (long) version());
+    assertThat(version()).isEqualTo(0);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceDetectsUncommittedChangeOnTableCommit() {
-    Assert.assertEquals("Version should be 0", 0L, (long) version());
+    assertThat(version()).isEqualTo(0);
 
     Transaction replace = TestTables.beginReplace(tableDir, "test", table.schema(), table.spec());
 
@@ -267,21 +255,21 @@ public class TestReplaceTransaction extends TableTestBase {
         .appendFile(FILE_C)
         .appendFile(FILE_D);
 
-    Assertions.assertThatThrownBy(replace::commitTransaction)
+    assertThatThrownBy(replace::commitTransaction)
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot commit transaction: last operation has not committed");
 
-    Assert.assertEquals("Version should be 0", 0L, (long) version());
+    assertThat(version()).isEqualTo(0);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceTransactionRetry() {
     Snapshot start = table.currentSnapshot();
     Schema schema = table.schema();
 
     table.newAppend().appendFile(FILE_A).commit();
 
-    Assert.assertEquals("Version should be 1", 1L, (long) version());
+    assertThat(version()).isEqualTo(1);
 
     validateSnapshot(start, table.currentSnapshot(), FILE_A);
 
@@ -296,23 +284,20 @@ public class TestReplaceTransaction extends TableTestBase {
 
     table.refresh();
 
-    Assert.assertEquals("Version should be 2", 2L, (long) version());
-    Assert.assertNotNull("Table should have a current snapshot", table.currentSnapshot());
-    Assert.assertEquals(
-        "Schema should use new schema, not compatible with previous",
-        schema.asStruct(),
-        table.schema().asStruct());
+    assertThat(version()).isEqualTo(2);
+    assertThat(table.currentSnapshot()).isNotNull();
+    assertThat(table.schema().asStruct()).isEqualTo(schema.asStruct());
 
     validateSnapshot(null, table.currentSnapshot(), FILE_B, FILE_C, FILE_D);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceTransactionConflict() {
     Snapshot start = table.currentSnapshot();
 
     table.newAppend().appendFile(FILE_A).commit();
 
-    Assert.assertEquals("Version should be 1", 1L, (long) version());
+    assertThat(version()).isEqualTo(1);
 
     validateSnapshot(start, table.currentSnapshot(), FILE_A);
     Set<File> manifests = Sets.newHashSet(listManifestFiles());
@@ -324,63 +309,52 @@ public class TestReplaceTransaction extends TableTestBase {
     // keep failing to trigger eventual transaction failure
     ((TestTables.TestTableOperations) ((BaseTransaction) replace).ops()).failCommits(100);
 
-    Assertions.assertThatThrownBy(replace::commitTransaction)
+    assertThatThrownBy(replace::commitTransaction)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
 
-    Assert.assertEquals("Version should be 1", 1L, (long) version());
+    assertThat(version()).isEqualTo(1);
 
     table.refresh();
 
     validateSnapshot(start, table.currentSnapshot(), FILE_A);
 
-    Assert.assertEquals(
-        "Should clean up replace manifests", manifests, Sets.newHashSet(listManifestFiles()));
+    assertThat(listManifestFiles()).containsExactlyElementsOf(manifests);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceToCreateAndAppend() throws IOException {
-    File tableDir = temp.newFolder();
-    Assert.assertTrue(tableDir.delete());
+    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableDir.delete()).isTrue();
 
     // this table doesn't exist.
     Transaction replace = TestTables.beginReplace(tableDir, "test_append", SCHEMA, unpartitioned());
 
-    Assert.assertNull(
-        "Starting a create transaction should not commit metadata",
-        TestTables.readMetadata("test_append"));
-    Assert.assertNull("Should have no metadata version", TestTables.metadataVersion("test_append"));
+    assertThat(TestTables.readMetadata("test_append")).isNull();
+    assertThat(TestTables.metadataVersion("test_append")).isNull();
 
-    Assert.assertTrue(
-        "Should return a transaction table",
-        replace.table() instanceof BaseTransaction.TransactionTable);
+    assertThat(replace.table()).isInstanceOf(BaseTransaction.TransactionTable.class);
 
     replace.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Assert.assertNull(
-        "Appending in a transaction should not commit metadata",
-        TestTables.readMetadata("test_append"));
-    Assert.assertNull("Should have no metadata version", TestTables.metadataVersion("test_append"));
+    assertThat(TestTables.readMetadata("test_append")).isNull();
+    assertThat(TestTables.metadataVersion("test_append")).isNull();
 
     replace.commitTransaction();
 
     TableMetadata meta = TestTables.readMetadata("test_append");
-    Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
-    Assert.assertEquals(
-        "Should have metadata version 0", 0, (int) TestTables.metadataVersion("test_append"));
-    Assert.assertEquals("Should have 1 manifest file", 1, listManifestFiles(tableDir).size());
+    assertThat(meta).isNotNull();
+    assertThat(TestTables.metadataVersion("test_append")).isEqualTo(0);
+    assertThat(listManifestFiles(tableDir)).hasSize(1);
 
-    Assert.assertEquals(
-        "Table schema should match with reassigned IDs",
-        assignFreshIds(SCHEMA).asStruct(),
-        meta.schema().asStruct());
-    Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
-    Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
+    assertThat(meta.schema().asStruct()).isEqualTo(assignFreshIds(SCHEMA).asStruct());
+    assertThat(meta.spec()).isEqualTo(unpartitioned());
+    assertThat(meta.snapshots()).hasSize(1);
 
     validateSnapshot(null, meta.currentSnapshot(), FILE_A, FILE_B);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceTransactionWithUnknownState() {
     Schema newSchema =
         new Schema(
@@ -392,7 +366,7 @@ public class TestReplaceTransaction extends TableTestBase {
 
     table.newAppend().appendFile(FILE_A).commit();
 
-    Assert.assertEquals("Version should be 1", 1L, (long) version());
+    assertThat(version()).isEqualTo(1L);
     validateSnapshot(start, table.currentSnapshot(), FILE_A);
 
     TestTables.TestTableOperations ops =
@@ -409,26 +383,23 @@ public class TestReplaceTransaction extends TableTestBase {
 
     replace.newAppend().appendFile(FILE_B).commit();
 
-    Assertions.assertThatThrownBy(replace::commitTransaction)
+    assertThatThrownBy(replace::commitTransaction)
         .isInstanceOf(CommitStateUnknownException.class)
         .hasMessageStartingWith("datacenter on fire");
 
     table.refresh();
 
-    Assert.assertEquals("Version should be 2", 2L, (long) version());
-    Assert.assertNotNull("Table should have a current snapshot", table.currentSnapshot());
-    Assert.assertEquals(
-        "Schema should use new schema, not compatible with previous",
-        schema.asStruct(),
-        table.schema().asStruct());
-    Assert.assertEquals("Should have 4 files in metadata", 4, countAllMetadataFiles(tableDir));
+    assertThat(version()).isEqualTo(2L);
+    assertThat(table.currentSnapshot()).isNotNull();
+    assertThat(table.schema().asStruct()).isEqualTo(schema.asStruct());
+    assertThat(countAllMetadataFiles(tableDir)).isEqualTo(4);
     validateSnapshot(null, table.currentSnapshot(), FILE_B);
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTransactionWithUnknownState() throws IOException {
-    File tableDir = temp.newFolder();
-    Assert.assertTrue(tableDir.delete());
+    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableDir.delete()).isTrue();
 
     // this table doesn't exist.
     TestTables.TestTableOperations ops =
@@ -443,38 +414,28 @@ public class TestReplaceTransaction extends TableTestBase {
             ImmutableMap.of(),
             ops);
 
-    Assert.assertNull(
-        "Starting a create transaction should not commit metadata",
-        TestTables.readMetadata("test_append"));
-    Assert.assertNull("Should have no metadata version", TestTables.metadataVersion("test_append"));
+    assertThat(TestTables.readMetadata("test_append")).isNull();
+    assertThat(TestTables.metadataVersion("test_append")).isNull();
 
-    Assert.assertTrue(
-        "Should return a transaction table",
-        replace.table() instanceof BaseTransaction.TransactionTable);
+    assertThat(replace.table()).isInstanceOf(BaseTransaction.TransactionTable.class);
 
     replace.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Assert.assertNull(
-        "Appending in a transaction should not commit metadata",
-        TestTables.readMetadata("test_append"));
-    Assert.assertNull("Should have no metadata version", TestTables.metadataVersion("test_append"));
+    assertThat(TestTables.readMetadata("test_append")).isNull();
+    assertThat(TestTables.metadataVersion("test_append")).isNull();
 
-    Assertions.assertThatThrownBy(replace::commitTransaction)
+    assertThatThrownBy(replace::commitTransaction)
         .isInstanceOf(CommitStateUnknownException.class)
         .hasMessageStartingWith("datacenter on fire");
 
     TableMetadata meta = TestTables.readMetadata("test_append");
-    Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
-    Assert.assertEquals(
-        "Should have metadata version 0", 0, (int) TestTables.metadataVersion("test_append"));
-    Assert.assertEquals("Should have 1 manifest file", 1, listManifestFiles(tableDir).size());
-    Assert.assertEquals("Should have 2 files in metadata", 2, countAllMetadataFiles(tableDir));
-    Assert.assertEquals(
-        "Table schema should match with reassigned IDs",
-        assignFreshIds(SCHEMA).asStruct(),
-        meta.schema().asStruct());
-    Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
-    Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
+    assertThat(meta).isNotNull();
+    assertThat(TestTables.metadataVersion("test_append")).isEqualTo(0);
+    assertThat(listManifestFiles(tableDir)).hasSize(1);
+    assertThat(countAllMetadataFiles(tableDir)).isEqualTo(2);
+    assertThat(meta.schema().asStruct()).isEqualTo(assignFreshIds(SCHEMA).asStruct());
+    assertThat(meta.spec()).isEqualTo(unpartitioned());
+    assertThat(meta.snapshots()).hasSize(1);
 
     validateSnapshot(null, meta.currentSnapshot(), FILE_A, FILE_B);
   }

--- a/core/src/test/java/org/apache/iceberg/TestSetPartitionStatistics.java
+++ b/core/src/test/java/org/apache/iceberg/TestSetPartitionStatistics.java
@@ -18,36 +18,32 @@
  */
 package org.apache.iceberg;
 
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
-public class TestSetPartitionStatistics extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSetPartitionStatistics extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestSetPartitionStatistics(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testEmptyUpdateStatistics() {
     assertTableMetadataVersion(0);
     TableMetadata base = readMetadata();
 
     table.updatePartitionStatistics().commit();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, table.ops().current());
+    assertThat(table.ops().current()).isSameAs(base);
     assertTableMetadataVersion(1);
   }
 
-  @Test
+  @TestTemplate
   public void testEmptyTransactionalUpdateStatistics() {
     assertTableMetadataVersion(0);
     TableMetadata base = readMetadata();
@@ -56,12 +52,11 @@ public class TestSetPartitionStatistics extends TableTestBase {
     transaction.updatePartitionStatistics().commit();
     transaction.commitTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, table.ops().current());
+    assertThat(table.ops().current()).isSameAs(base);
     assertTableMetadataVersion(0);
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateStatistics() {
     // Create a snapshot
     table.newFastAppend().commit();
@@ -80,17 +75,11 @@ public class TestSetPartitionStatistics extends TableTestBase {
 
     TableMetadata metadata = readMetadata();
     assertTableMetadataVersion(2);
-    Assert.assertEquals(
-        "Table snapshot should be the same after setting partition statistics file",
-        snapshotId,
-        metadata.currentSnapshot().snapshotId());
-    Assert.assertEquals(
-        "Table metadata should have partition statistics files",
-        ImmutableList.of(partitionStatisticsFile),
-        metadata.partitionStatisticsFiles());
+    assertThat(metadata.currentSnapshot().snapshotId()).isEqualTo(snapshotId);
+    assertThat(metadata.partitionStatisticsFiles()).containsExactly(partitionStatisticsFile);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveStatistics() {
     // Create a snapshot
     table.newFastAppend().commit();
@@ -109,23 +98,16 @@ public class TestSetPartitionStatistics extends TableTestBase {
 
     TableMetadata metadata = readMetadata();
     assertTableMetadataVersion(2);
-    Assert.assertEquals(
-        "Table metadata should have partition statistics files",
-        ImmutableList.of(partitionStatisticsFile),
-        metadata.partitionStatisticsFiles());
+    assertThat(metadata.partitionStatisticsFiles()).containsExactly(partitionStatisticsFile);
 
     table.updatePartitionStatistics().removePartitionStatistics(snapshotId).commit();
 
     metadata = readMetadata();
     assertTableMetadataVersion(3);
-    Assert.assertEquals(
-        "Table metadata should have no partition statistics files",
-        ImmutableList.of(),
-        metadata.partitionStatisticsFiles());
+    assertThat(metadata.partitionStatisticsFiles()).isEmpty();
   }
 
   private void assertTableMetadataVersion(int expected) {
-    Assert.assertEquals(
-        String.format("Table should be on version %s", expected), expected, (int) version());
+    assertThat(version()).isEqualTo(expected);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSetStatistics.java
+++ b/core/src/test/java/org/apache/iceberg/TestSetStatistics.java
@@ -18,55 +18,51 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestSetStatistics extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSetStatistics extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestSetStatistics(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testEmptyUpdateStatistics() {
-    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+    assertThat(version()).isEqualTo(0);
     TableMetadata base = readMetadata();
 
     table.updateStatistics().commit();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, table.ops().current());
-    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+    assertThat(table.ops().current()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void testEmptyTransactionalUpdateStatistics() {
-    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+    assertThat(version()).isEqualTo(0);
     TableMetadata base = readMetadata();
 
     Transaction transaction = table.newTransaction();
     transaction.updateStatistics().commit();
     transaction.commitTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, table.ops().current());
-    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+    assertThat(table.ops().current()).isSameAs(base);
+    assertThat(version()).isEqualTo(0);
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateStatistics() {
     // Create a snapshot
     table.newFastAppend().commit();
-    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+    assertThat(version()).isEqualTo(1);
 
     TableMetadata base = readMetadata();
     long snapshotId = base.currentSnapshot().snapshotId();
@@ -87,22 +83,16 @@ public class TestSetStatistics extends TableTestBase {
     table.updateStatistics().setStatistics(snapshotId, statisticsFile).commit();
 
     TableMetadata metadata = readMetadata();
-    Assert.assertEquals("Table should be on version 2", 2, (int) version());
-    Assert.assertEquals(
-        "Table snapshot should be the same after setting statistics file",
-        snapshotId,
-        metadata.currentSnapshot().snapshotId());
-    Assert.assertEquals(
-        "Table metadata should have statistics files",
-        ImmutableList.of(statisticsFile),
-        metadata.statisticsFiles());
+    assertThat(version()).isEqualTo(2);
+    assertThat(metadata.currentSnapshot().snapshotId()).isEqualTo(snapshotId);
+    assertThat(metadata.statisticsFiles()).containsExactly(statisticsFile);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveStatistics() {
     // Create a snapshot
     table.newFastAppend().commit();
-    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+    assertThat(version()).isEqualTo(1);
 
     TableMetadata base = readMetadata();
     long snapshotId = base.currentSnapshot().snapshotId();
@@ -113,19 +103,13 @@ public class TestSetStatistics extends TableTestBase {
     table.updateStatistics().setStatistics(snapshotId, statisticsFile).commit();
 
     TableMetadata metadata = readMetadata();
-    Assert.assertEquals("Table should be on version 2", 2, (int) version());
-    Assert.assertEquals(
-        "Table metadata should have statistics files",
-        ImmutableList.of(statisticsFile),
-        metadata.statisticsFiles());
+    assertThat(version()).isEqualTo(2);
+    assertThat(metadata.statisticsFiles()).containsExactly(statisticsFile);
 
     table.updateStatistics().removeStatistics(snapshotId).commit();
 
     metadata = readMetadata();
-    Assert.assertEquals("Table should be on version 3", 3, (int) version());
-    Assert.assertEquals(
-        "Table metadata should have no statistics files",
-        ImmutableList.of(),
-        metadata.statisticsFiles());
+    assertThat(version()).isEqualTo(3);
+    assertThat(metadata.statisticsFiles()).isEmpty();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -271,8 +271,8 @@ public class TestTransaction extends TestBase {
 
     assertThat(version()).isEqualTo(2);
 
-    assertThat(table.currentSnapshot().allManifests(table.io()))
-        .containsExactlyElementsOf(appendManifests);
+    assertThat(Sets.newHashSet(table.currentSnapshot().allManifests(table.io())))
+        .isEqualTo(appendManifests);
   }
 
   @TestTemplate
@@ -313,8 +313,8 @@ public class TestTransaction extends TestBase {
     expectedManifests.addAll(appendManifests);
     expectedManifests.addAll(conflictAppendManifests);
 
-    assertThat(table.currentSnapshot().allManifests(table.io()))
-        .containsExactlyElementsOf(expectedManifests);
+    assertThat(Sets.newHashSet(table.currentSnapshot().allManifests(table.io())))
+        .isEqualTo(expectedManifests);
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -18,8 +18,13 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -30,65 +35,54 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.Assumptions;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestTransaction extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestTransaction extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestTransaction(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testEmptyTransaction() {
-    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+    assertThat(version()).isEqualTo(0);
 
     TableMetadata base = readMetadata();
 
     Transaction txn = table.newTransaction();
     txn.commitTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(0);
   }
 
-  @Test
+  @TestTemplate
   public void testSingleOperationTransaction() {
-    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+    assertThat(version()).isEqualTo(0);
 
     TableMetadata base = readMetadata();
 
     Transaction txn = table.newTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(0);
 
     txn.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Assert.assertSame(
-        "Base metadata should not change when an append is committed", base, readMetadata());
-    Assert.assertEquals("Table should be on version 0 after append", 0, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(0);
 
     txn.commitTransaction();
 
     validateSnapshot(base.currentSnapshot(), readMetadata().currentSnapshot(), FILE_A, FILE_B);
-    Assert.assertEquals("Table should be on version 1 after commit", 1, (int) version());
+    assertThat(version()).isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void testMultipleOperationTransaction() {
-    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+    assertThat(version()).isEqualTo(0);
 
     table.newAppend().appendFile(FILE_C).commit();
     List<HistoryEntry> initialHistory = table.history();
@@ -97,15 +91,13 @@ public class TestTransaction extends TableTestBase {
 
     Transaction txn = table.newTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after txn create", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     txn.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after txn create", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     Snapshot appendSnapshot = txn.table().currentSnapshot();
 
@@ -113,55 +105,45 @@ public class TestTransaction extends TableTestBase {
 
     Snapshot deleteSnapshot = txn.table().currentSnapshot();
 
-    Assert.assertSame(
-        "Base metadata should not change when an append is committed", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after append", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     txn.commitTransaction();
 
-    Assert.assertEquals("Table should be on version 2 after commit", 2, (int) version());
-    Assert.assertEquals(
-        "Table should have two manifest after commit",
-        2,
-        readMetadata().currentSnapshot().allManifests(table.io()).size());
-    Assert.assertEquals(
-        "Table snapshot should be the delete snapshot",
-        deleteSnapshot,
-        readMetadata().currentSnapshot());
+    assertThat(version()).isEqualTo(2);
+    assertThat(readMetadata().currentSnapshot().allManifests(table.io())).hasSize(2);
+    assertThat(readMetadata().currentSnapshot()).isEqualTo(deleteSnapshot);
     validateManifestEntries(
         readMetadata().currentSnapshot().allManifests(table.io()).get(0),
         ids(deleteSnapshot.snapshotId(), appendSnapshot.snapshotId()),
         files(FILE_A, FILE_B),
         statuses(Status.DELETED, Status.EXISTING));
 
-    Assert.assertEquals(
-        "Table should have a snapshot for each operation", 3, readMetadata().snapshots().size());
+    assertThat(readMetadata().snapshots()).hasSize(3);
     validateManifestEntries(
         readMetadata().snapshots().get(1).allManifests(table.io()).get(0),
         ids(appendSnapshot.snapshotId(), appendSnapshot.snapshotId()),
         files(FILE_A, FILE_B),
         statuses(Status.ADDED, Status.ADDED));
 
-    Assertions.assertThat(table.history()).containsAll(initialHistory);
+    assertThat(table.history()).containsAll(initialHistory);
   }
 
-  @Test
+  @TestTemplate
   public void testMultipleOperationTransactionFromTable() {
-    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+    assertThat(version()).isEqualTo(0);
 
     TableMetadata base = readMetadata();
 
     Transaction txn = table.newTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(0);
 
     txn.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(0);
 
     Snapshot appendSnapshot = txn.table().currentSnapshot();
 
@@ -169,29 +151,21 @@ public class TestTransaction extends TableTestBase {
 
     Snapshot deleteSnapshot = txn.table().currentSnapshot();
 
-    Assert.assertSame(
-        "Base metadata should not change when an append is committed", base, readMetadata());
-    Assert.assertEquals("Table should be on version 0 after append", 0, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(0);
 
     txn.commitTransaction();
 
-    Assert.assertEquals("Table should be on version 1 after commit", 1, (int) version());
-    Assert.assertEquals(
-        "Table should have one manifest after commit",
-        1,
-        readMetadata().currentSnapshot().allManifests(table.io()).size());
-    Assert.assertEquals(
-        "Table snapshot should be the delete snapshot",
-        deleteSnapshot,
-        readMetadata().currentSnapshot());
+    assertThat(version()).isEqualTo(1);
+    assertThat(readMetadata().currentSnapshot().allManifests(table.io())).hasSize(1);
+    assertThat(readMetadata().currentSnapshot()).isEqualTo(deleteSnapshot);
     validateManifestEntries(
         readMetadata().currentSnapshot().allManifests(table.io()).get(0),
         ids(deleteSnapshot.snapshotId(), appendSnapshot.snapshotId()),
         files(FILE_A, FILE_B),
         statuses(Status.DELETED, Status.EXISTING));
 
-    Assert.assertEquals(
-        "Table should have a snapshot for each operation", 2, readMetadata().snapshots().size());
+    assertThat(readMetadata().snapshots()).hasSize(2);
     validateManifestEntries(
         readMetadata().snapshots().get(0).allManifests(table.io()).get(0),
         ids(appendSnapshot.snapshotId(), appendSnapshot.snapshotId()),
@@ -199,165 +173,151 @@ public class TestTransaction extends TableTestBase {
         statuses(Status.ADDED, Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testDetectsUncommittedChange() {
-    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+    assertThat(version()).isEqualTo(0);
 
     TableMetadata base = readMetadata();
 
     Transaction txn = table.newTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(0);
 
     txn.newAppend().appendFile(FILE_A).appendFile(FILE_B); // not committed
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(0);
 
-    Assertions.assertThatThrownBy(txn::newDelete)
+    assertThatThrownBy(txn::newDelete)
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot create new DeleteFiles: last operation has not committed");
   }
 
-  @Test
+  @TestTemplate
   public void testDetectsUncommittedChangeOnCommit() {
-    Assert.assertEquals("Table should be on version 0", 0, (int) version());
+    assertThat(version()).isEqualTo(0);
 
     TableMetadata base = readMetadata();
 
     Transaction txn = table.newTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(0);
 
     txn.newAppend().appendFile(FILE_A).appendFile(FILE_B); // not committed
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(0);
 
-    Assertions.assertThatThrownBy(txn::commitTransaction)
+    assertThatThrownBy(txn::commitTransaction)
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot commit transaction: last operation has not committed");
   }
 
-  @Test
+  @TestTemplate
   public void testTransactionConflict() {
     // set retries to 0 to catch the failure
     table.updateProperties().set(TableProperties.COMMIT_NUM_RETRIES, "0").commit();
 
-    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+    assertThat(version()).isEqualTo(1);
 
     TableMetadata base = readMetadata();
 
     Transaction txn = table.newTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after txn create", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     txn.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after append", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     // cause the transaction commit to fail
     table.ops().failCommits(1);
 
-    Assertions.assertThatThrownBy(txn::commitTransaction)
+    assertThatThrownBy(txn::commitTransaction)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
   }
 
-  @Test
+  @TestTemplate
   public void testTransactionRetry() {
     // use only one retry
     table.updateProperties().set(TableProperties.COMMIT_NUM_RETRIES, "1").commit();
 
-    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+    assertThat(version()).isEqualTo(1);
 
     TableMetadata base = readMetadata();
 
     Transaction txn = table.newTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after txn create", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     txn.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Set<ManifestFile> appendManifests =
         Sets.newHashSet(txn.table().currentSnapshot().allManifests(table.io()));
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after append", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     // cause the transaction commit to fail
     table.ops().failCommits(1);
 
     txn.commitTransaction();
 
-    Assert.assertEquals("Table should be on version 2 after commit", 2, (int) version());
+    assertThat(version()).isEqualTo(2);
 
-    Assert.assertEquals(
-        "Should reuse manifests from initial append commit",
-        appendManifests,
-        Sets.newHashSet(table.currentSnapshot().allManifests(table.io())));
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .containsExactlyElementsOf(appendManifests);
   }
 
-  @Test
+  @TestTemplate
   public void testTransactionRetryMergeAppend() {
     // use only one retry
     table.updateProperties().set(TableProperties.COMMIT_NUM_RETRIES, "1").commit();
 
-    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+    assertThat(version()).isEqualTo(1);
 
     TableMetadata base = readMetadata();
 
     Transaction txn = table.newTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after txn create", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     txn.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Set<ManifestFile> appendManifests =
         Sets.newHashSet(txn.table().currentSnapshot().allManifests(table.io()));
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after append", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     // cause the transaction commit to fail
     table.newAppend().appendFile(FILE_C).appendFile(FILE_D).commit();
 
-    Assert.assertEquals("Table should be on version 2 after real append", 2, (int) version());
+    assertThat(version()).isEqualTo(2);
 
     Set<ManifestFile> conflictAppendManifests =
         Sets.newHashSet(table.currentSnapshot().allManifests(table.io()));
 
     txn.commitTransaction();
 
-    Assert.assertEquals("Table should be on version 3 after commit", 3, (int) version());
+    assertThat(version()).isEqualTo(3);
 
     Set<ManifestFile> expectedManifests = Sets.newHashSet();
     expectedManifests.addAll(appendManifests);
     expectedManifests.addAll(conflictAppendManifests);
 
-    Assert.assertEquals(
-        "Should reuse manifests from initial append commit and conflicting append",
-        expectedManifests,
-        Sets.newHashSet(table.currentSnapshot().allManifests(table.io())));
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .containsExactlyElementsOf(expectedManifests);
   }
 
-  @Test
+  @TestTemplate
   public void testMultipleUpdateTransactionRetryMergeCleanup() {
     // use only one retry and aggressively merge manifests
     table
@@ -366,59 +326,49 @@ public class TestTransaction extends TableTestBase {
         .set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "0")
         .commit();
 
-    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+    assertThat(version()).isEqualTo(1);
 
     TableMetadata base = readMetadata();
 
     Transaction txn = table.newTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after txn create", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     txn.updateProperties().set("test-property", "test-value").commit();
 
     txn.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Assert.assertEquals(
-        "Append should create one manifest",
-        1,
-        txn.table().currentSnapshot().allManifests(table.io()).size());
+    assertThat(txn.table().currentSnapshot().allManifests(table.io())).hasSize(1);
     ManifestFile appendManifest = txn.table().currentSnapshot().allManifests(table.io()).get(0);
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after append", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     // cause the transaction commit to fail
     table.newAppend().appendFile(FILE_C).appendFile(FILE_D).commit();
 
-    Assert.assertEquals("Table should be on version 2 after real append", 2, (int) version());
+    assertThat(version()).isEqualTo(2);
 
     Set<ManifestFile> conflictAppendManifests =
         Sets.newHashSet(table.currentSnapshot().allManifests(table.io()));
 
     txn.commitTransaction();
 
-    Assert.assertEquals("Table should be on version 3 after commit", 3, (int) version());
+    assertThat(version()).isEqualTo(3);
 
     Set<ManifestFile> previousManifests = Sets.newHashSet();
     previousManifests.add(appendManifest);
     previousManifests.addAll(conflictAppendManifests);
 
-    Assert.assertEquals(
-        "Should merge both commit manifests into a single manifest",
-        1,
-        table.currentSnapshot().allManifests(table.io()).size());
-    Assert.assertFalse(
-        "Should merge both commit manifests into a new manifest",
-        previousManifests.contains(table.currentSnapshot().allManifests(table.io()).get(0)));
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .hasSize(1)
+        .doesNotContainAnyElementsOf(previousManifests);
 
-    Assert.assertFalse(
-        "Append manifest should be deleted", new File(appendManifest.path()).exists());
+    assertThat(new File(appendManifest.path())).doesNotExist();
   }
 
-  @Test
+  @TestTemplate
   public void testTransactionRetrySchemaUpdate() {
     // use only one retry
     table.updateProperties().set(TableProperties.COMMIT_NUM_RETRIES, "1").commit();
@@ -434,18 +384,15 @@ public class TestTransaction extends TableTestBase {
     table.updateSchema().addColumn("another-column", Types.IntegerType.get()).commit();
     int conflictingSchemaId = table.schema().schemaId();
 
-    Assert.assertEquals(
-        "Both schema IDs should be the same in order to cause a conflict",
-        conflictingSchemaId,
-        schemaId);
+    assertThat(schemaId).isEqualTo(conflictingSchemaId);
 
     // commit the transaction for adding "new-column"
-    Assertions.assertThatThrownBy(txn::commitTransaction)
+    assertThatThrownBy(txn::commitTransaction)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Table metadata refresh is required");
   }
 
-  @Test
+  @TestTemplate
   public void testTransactionRetryMergeCleanup() {
     // use only one retry and aggressively merge manifests
     table
@@ -454,61 +401,50 @@ public class TestTransaction extends TableTestBase {
         .set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "0")
         .commit();
 
-    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+    assertThat(version()).isEqualTo(1);
 
     TableMetadata base = readMetadata();
 
     Transaction txn = table.newTransaction();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after txn create", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     txn.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Assert.assertEquals(
-        "Append should create one manifest",
-        1,
-        txn.table().currentSnapshot().allManifests(table.io()).size());
+    assertThat(txn.table().currentSnapshot().allManifests(table.io())).hasSize(1);
     ManifestFile appendManifest = txn.table().currentSnapshot().allManifests(table.io()).get(0);
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 1 after append", 1, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(1);
 
     // cause the transaction commit to fail
     table.newAppend().appendFile(FILE_C).appendFile(FILE_D).commit();
 
-    Assert.assertEquals("Table should be on version 2 after real append", 2, (int) version());
+    assertThat(version()).isEqualTo(2);
 
     Set<ManifestFile> conflictAppendManifests =
         Sets.newHashSet(table.currentSnapshot().allManifests(table.io()));
 
     txn.commitTransaction();
 
-    Assert.assertEquals("Table should be on version 3 after commit", 3, (int) version());
+    assertThat(version()).isEqualTo(3);
 
     Set<ManifestFile> previousManifests = Sets.newHashSet();
     previousManifests.add(appendManifest);
     previousManifests.addAll(conflictAppendManifests);
 
-    Assert.assertEquals(
-        "Should merge both commit manifests into a single manifest",
-        1,
-        table.currentSnapshot().allManifests(table.io()).size());
-    Assert.assertFalse(
-        "Should merge both commit manifests into a new manifest",
-        previousManifests.contains(table.currentSnapshot().allManifests(table.io()).get(0)));
-
-    Assert.assertFalse(
-        "Append manifest should be deleted", new File(appendManifest.path()).exists());
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .hasSize(1)
+        .doesNotContainAnyElementsOf(previousManifests);
+    assertThat(new File(appendManifest.path())).doesNotExist();
   }
 
-  @Test
+  @TestTemplate
   public void testTransactionRetryAndAppendManifestsWithoutSnapshotIdInheritance()
       throws Exception {
     // this test assumes append manifests are rewritten, which only happens in V1 tables
-    Assumptions.assumeThat(formatVersion).isEqualTo(1);
+    assumeThat(formatVersion).isEqualTo(1);
 
     // use only one retry and aggressively merge manifests
     table
@@ -517,22 +453,18 @@ public class TestTransaction extends TableTestBase {
         .set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "0")
         .commit();
 
-    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+    assertThat(version()).isEqualTo(1);
 
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Assert.assertEquals("Table should be on version 2 after append", 2, (int) version());
-    Assert.assertEquals(
-        "Append should create one manifest",
-        1,
-        table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(version()).isEqualTo(2);
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
     ManifestFile v1manifest = table.currentSnapshot().allManifests(table.io()).get(0);
 
     TableMetadata base = readMetadata();
 
     // create a manifest append
-    OutputFile manifestLocation =
-        Files.localOutput("/tmp/" + UUID.randomUUID().toString() + ".avro");
+    OutputFile manifestLocation = Files.localOutput("/tmp/" + UUID.randomUUID() + ".avro");
     ManifestWriter<DataFile> writer = ManifestFiles.write(table.spec(), manifestLocation);
     try {
       writer.add(FILE_D);
@@ -544,14 +476,10 @@ public class TestTransaction extends TableTestBase {
 
     txn.newAppend().appendManifest(writer.toManifestFile()).commit();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 2 after txn create", 2, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(2);
 
-    Assert.assertEquals(
-        "Append should have one merged manifest",
-        1,
-        txn.table().currentSnapshot().allManifests(table.io()).size());
+    assertThat(txn.table().currentSnapshot().allManifests(table.io())).hasSize(1);
     ManifestFile mergedManifest = txn.table().currentSnapshot().allManifests(table.io()).get(0);
 
     // find the initial copy of the appended manifest
@@ -562,40 +490,34 @@ public class TestTransaction extends TableTestBase {
                 path ->
                     !v1manifest.path().contains(path) && !mergedManifest.path().contains(path)));
 
-    Assert.assertTrue(
-        "Transaction should hijack the delete of the original copied manifest",
-        ((BaseTransaction) txn).deletedFiles().contains(copiedAppendManifest));
-    Assert.assertTrue(
-        "Copied append manifest should not be deleted yet",
-        new File(copiedAppendManifest).exists());
+    assertThat(((BaseTransaction) txn).deletedFiles())
+        .as("Transaction should hijack the delete of the original copied manifest")
+        .contains(copiedAppendManifest);
+    assertThat(new File(copiedAppendManifest)).exists();
 
     // cause the transaction commit to fail and retry
     table.newAppend().appendFile(FILE_C).commit();
 
-    Assert.assertEquals("Table should be on version 3 after real append", 3, (int) version());
+    assertThat(version()).isEqualTo(3);
 
     txn.commitTransaction();
 
-    Assert.assertEquals("Table should be on version 4 after commit", 4, (int) version());
+    assertThat(version()).isEqualTo(4);
 
-    Assert.assertTrue(
-        "Transaction should hijack the delete of the original copied manifest",
-        ((BaseTransaction) txn).deletedFiles().contains(copiedAppendManifest));
-    Assert.assertFalse(
-        "Append manifest should be deleted", new File(copiedAppendManifest).exists());
-    Assert.assertTrue(
-        "Transaction should hijack the delete of the first merged manifest",
-        ((BaseTransaction) txn).deletedFiles().contains(mergedManifest.path()));
-    Assert.assertFalse(
-        "Append manifest should be deleted", new File(mergedManifest.path()).exists());
+    assertThat(((BaseTransaction) txn).deletedFiles())
+        .as("Transaction should hijack the delete of the original copied manifest")
+        .contains(copiedAppendManifest);
 
-    Assert.assertEquals(
-        "Should merge all commit manifests into a single manifest",
-        1,
-        table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(new File(copiedAppendManifest)).doesNotExist();
+    assertThat(((BaseTransaction) txn).deletedFiles())
+        .as("Transaction should hijack the delete of the first merged manifest")
+        .contains(mergedManifest.path());
+    assertThat(new File(mergedManifest.path())).doesNotExist();
+
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
   }
 
-  @Test
+  @TestTemplate
   public void testTransactionRetryAndAppendManifestsWithSnapshotIdInheritance() throws Exception {
     // use only one retry and aggressively merge manifests
     table
@@ -605,15 +527,12 @@ public class TestTransaction extends TableTestBase {
         .set(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, "true")
         .commit();
 
-    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+    assertThat(version()).isEqualTo(1);
 
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Assert.assertEquals("Table should be on version 2 after append", 2, (int) version());
-    Assert.assertEquals(
-        "Append should create one manifest",
-        1,
-        table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(version()).isEqualTo(2);
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
 
     TableMetadata base = readMetadata();
 
@@ -622,46 +541,37 @@ public class TestTransaction extends TableTestBase {
     ManifestFile appendManifest = writeManifestWithName("input.m0", FILE_D);
     txn.newAppend().appendManifest(appendManifest).commit();
 
-    Assert.assertSame(
-        "Base metadata should not change when commit is created", base, readMetadata());
-    Assert.assertEquals("Table should be on version 2 after txn create", 2, (int) version());
+    assertThat(readMetadata()).isSameAs(base);
+    assertThat(version()).isEqualTo(2);
 
-    Assert.assertEquals(
-        "Append should have one merged manifest",
-        1,
-        txn.table().currentSnapshot().allManifests(table.io()).size());
+    assertThat(txn.table().currentSnapshot().allManifests(table.io())).hasSize(1);
     ManifestFile mergedManifest = txn.table().currentSnapshot().allManifests(table.io()).get(0);
 
     // cause the transaction commit to fail and retry
     table.newAppend().appendFile(FILE_C).commit();
 
-    Assert.assertEquals("Table should be on version 3 after real append", 3, (int) version());
+    assertThat(version()).isEqualTo(3);
 
     txn.commitTransaction();
 
-    Assert.assertEquals("Table should be on version 4 after commit", 4, (int) version());
+    assertThat(version()).isEqualTo(4);
 
-    Assert.assertTrue(
-        "Transaction should hijack the delete of the original append manifest",
-        ((BaseTransaction) txn).deletedFiles().contains(appendManifest.path()));
-    Assert.assertFalse(
-        "Append manifest should be deleted", new File(appendManifest.path()).exists());
+    assertThat(((BaseTransaction) txn).deletedFiles())
+        .as("Transaction should hijack the delete of the original append manifest")
+        .contains(appendManifest.path());
+    assertThat(new File(appendManifest.path())).doesNotExist();
 
-    Assert.assertTrue(
-        "Transaction should hijack the delete of the first merged manifest",
-        ((BaseTransaction) txn).deletedFiles().contains(mergedManifest.path()));
-    Assert.assertFalse(
-        "Merged append manifest should be deleted", new File(mergedManifest.path()).exists());
+    assertThat(((BaseTransaction) txn).deletedFiles())
+        .as("Transaction should hijack the delete of the first merged manifest")
+        .contains(mergedManifest.path());
+    assertThat(new File(appendManifest.path())).doesNotExist();
 
-    Assert.assertEquals(
-        "Should merge all commit manifests into a single manifest",
-        1,
-        table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
   }
 
-  @Test
+  @TestTemplate
   public void testTransactionNoCustomDeleteFunc() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .newTransaction()
@@ -673,7 +583,7 @@ public class TestTransaction extends TableTestBase {
         .hasMessage("Cannot set delete callback more than once");
   }
 
-  @Test
+  @TestTemplate
   public void testTransactionFastAppends() {
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "0").commit();
 
@@ -686,10 +596,10 @@ public class TestTransaction extends TableTestBase {
     txn.commitTransaction();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Expected 2 manifests", 2, manifests.size());
+    assertThat(manifests).hasSize(2);
   }
 
-  @Test
+  @TestTemplate
   public void testTransactionRewriteManifestsAppendedDirectly() throws IOException {
     Table table = load();
 
@@ -706,7 +616,7 @@ public class TestTransaction extends TableTestBase {
     long secondSnapshotId = table.currentSnapshot().snapshotId();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 2 manifests after 2 appends", 2, manifests.size());
+    assertThat(manifests).hasSize(2);
 
     ManifestFile newManifest =
         writeManifest(
@@ -726,11 +636,10 @@ public class TestTransaction extends TableTestBase {
     long finalSnapshotId = table.currentSnapshot().snapshotId();
     long finalSnapshotTimestamp = System.currentTimeMillis();
 
-    Assert.assertTrue(
-        "Append manifest should not be deleted", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).exists();
 
     List<ManifestFile> finalManifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 1 final manifest", 1, finalManifests.size());
+    assertThat(finalManifests).hasSize(1);
 
     validateManifestEntries(
         finalManifests.get(0),
@@ -743,30 +652,29 @@ public class TestTransaction extends TableTestBase {
 
     table.expireSnapshots().expireOlderThan(finalSnapshotTimestamp + 1).retainLast(1).commit();
 
-    Assert.assertFalse(
-        "Append manifest should be deleted on expiry", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).doesNotExist();
   }
 
-  @Test
+  @TestTemplate
   public void testSimpleTransactionNotDeletingMetadataOnUnknownSate() throws IOException {
     Table table = TestTables.tableWithCommitSucceedButStateUnknown(tableDir, "test");
 
     Transaction transaction = table.newTransaction();
     transaction.newAppend().appendFile(FILE_A).commit();
 
-    Assertions.assertThatThrownBy(transaction::commitTransaction)
+    assertThatThrownBy(transaction::commitTransaction)
         .isInstanceOf(CommitStateUnknownException.class)
         .hasMessageStartingWith("datacenter on fire");
 
     // Make sure metadata files still exist
     Snapshot current = table.currentSnapshot();
     List<ManifestFile> manifests = current.allManifests(table.io());
-    Assert.assertEquals("Should have 1 manifest file", 1, manifests.size());
-    Assert.assertTrue("Manifest file should exist", new File(manifests.get(0).path()).exists());
-    Assert.assertEquals("Should have 2 files in metadata", 2, countAllMetadataFiles(tableDir));
+    assertThat(manifests).hasSize(1);
+    assertThat(new File(manifests.get(0).path())).exists();
+    assertThat(countAllMetadataFiles(tableDir)).isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testTransactionRecommit() {
     // update table settings to merge when there are 3 manifests
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "3").commit();
@@ -781,18 +689,14 @@ public class TestTransaction extends TableTestBase {
     AppendFiles append = transaction.newAppend().appendFile(FILE_D);
     Snapshot pending = append.apply();
 
-    Assert.assertEquals(
-        "Should produce 1 pending merged manifest", 1, pending.allManifests(table.io()).size());
+    assertThat(pending.allManifests(table.io())).hasSize(1);
 
     // because a merge happened, the appended manifest is deleted the by append operation
     append.commit();
 
     // concurrently commit FILE_A without a transaction to cause the previous append to retry
     table.newAppend().appendFile(FILE_C).commit();
-    Assert.assertEquals(
-        "Should produce 1 committed merged manifest",
-        1,
-        table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
 
     transaction.commitTransaction();
 
@@ -807,9 +711,7 @@ public class TestTransaction extends TableTestBase {
             FILE_C.path().toString(),
             FILE_D.path().toString());
 
-    Assert.assertEquals("Should contain all committed files", expectedPaths, paths);
-
-    Assert.assertEquals(
-        "Should produce 2 manifests", 2, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(paths).isEqualTo(expectedPaths);
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(2);
   }
 }


### PR DESCRIPTION
Migrate the following test classes in iceberg-core to JUnit 5 and AssertJ style for https://github.com/apache/iceberg/issues/9085.

## Current Progress 
Transactions
- [x] `TestCreateTransaction.java`
- [x] `TestReplaceTransaction.java`
- [x] `TestTransaction.java`

Partitions:
- [x] `TestPartitioning.java`
- [x] `TestPartitionSpecInfo.java`
- [x] `TestPartitionSpecParser.java`

Statistics
- [x] `TestSetPartitionStatistics.java`
- [x] `TestSetStatistics.java`

Other
- [x] `TestCommitReporting.java`