### PR TITLE
AWS: Glue table operations hang when aws authentication parameters are illegal

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.LocationUtil;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,6 +84,9 @@ import software.amazon.awssdk.services.dynamodb.model.TableStatus;
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItemsRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+import static org.apache.iceberg.CatalogProperties.METADATA_REFRESH_MAX_RETRIES;
+import static org.apache.iceberg.CatalogProperties.METADATA_REFRESH_MAX_RETRIES_DEFAULT;
 
 /** DynamoDB implementation of Iceberg catalog */
 public class DynamoDbCatalog extends BaseMetastoreCatalog
@@ -156,7 +160,10 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog
   @Override
   protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
     validateTableIdentifier(tableIdentifier);
-    return new DynamoDbTableOperations(dynamo, awsProperties, catalogName, fileIO, tableIdentifier);
+    int metadataRefreshMaxRetries = PropertyUtil.propertyAsInt(
+            catalogProperties, METADATA_REFRESH_MAX_RETRIES, METADATA_REFRESH_MAX_RETRIES_DEFAULT);
+    return new DynamoDbTableOperations(
+            dynamo, awsProperties, catalogName, fileIO, tableIdentifier, metadataRefreshMaxRetries);
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -59,7 +59,9 @@ class DynamoDbTableOperations extends BaseMetastoreTableOperations {
       AwsProperties awsProperties,
       String catalogName,
       FileIO fileIO,
-      TableIdentifier tableIdentifier) {
+      TableIdentifier tableIdentifier,
+      int metadataRefreshMaxRetries) {
+    setMetadataRefreshMaxRetries(metadataRefreshMaxRetries);
     this.dynamo = dynamo;
     this.awsProperties = awsProperties;
     this.fullTableName = String.format("%s.%s", catalogName, tableIdentifier);

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -83,6 +83,9 @@ import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.glue.model.TableInput;
 import software.amazon.awssdk.services.glue.model.UpdateDatabaseRequest;
 
+import static org.apache.iceberg.CatalogProperties.METADATA_REFRESH_MAX_RETRIES;
+import static org.apache.iceberg.CatalogProperties.METADATA_REFRESH_MAX_RETRIES_DEFAULT;
+
 public class GlueCatalog extends BaseMetastoreCatalog
     implements SupportsNamespaces, Configurable<Configuration> {
 
@@ -232,6 +235,9 @@ public class GlueCatalog extends BaseMetastoreCatalog
             .put(S3FileIOProperties.PRELOAD_CLIENT_ENABLED, String.valueOf(true));
       }
 
+      int metadataRefreshMaxRetries = PropertyUtil.propertyAsInt(
+              catalogProperties, METADATA_REFRESH_MAX_RETRIES, METADATA_REFRESH_MAX_RETRIES_DEFAULT);
+
       // FileIO initialization depends on tableSpecificCatalogProperties, so a new FileIO is
       // initialized each time
       GlueTableOperations glueTableOperations =
@@ -242,7 +248,8 @@ public class GlueCatalog extends BaseMetastoreCatalog
               awsProperties,
               tableSpecificCatalogPropertiesBuilder.buildOrThrow(),
               hadoopConf,
-              tableIdentifier);
+              tableIdentifier,
+              metadataRefreshMaxRetries);
       fileIOCloser.put(glueTableOperations, glueTableOperations.io());
       return glueTableOperations;
     }
@@ -255,7 +262,8 @@ public class GlueCatalog extends BaseMetastoreCatalog
             awsProperties,
             catalogProperties,
             hadoopConf,
-            tableIdentifier);
+            tableIdentifier,
+            METADATA_REFRESH_MAX_RETRIES_DEFAULT);
     fileIOCloser.put(glueTableOperations, glueTableOperations.io());
     return glueTableOperations;
   }

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import static org.apache.iceberg.CatalogProperties.METADATA_REFRESH_MAX_RETRIES_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_NUM_STATUS_CHECKS;
 import static org.apache.iceberg.TableProperties.COMMIT_NUM_STATUS_CHECKS_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_STATUS_CHECKS_MAX_WAIT_MS;
@@ -56,13 +57,13 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   public static final String ICEBERG_TABLE_TYPE_VALUE = "iceberg";
   public static final String METADATA_LOCATION_PROP = "metadata_location";
   public static final String PREVIOUS_METADATA_LOCATION_PROP = "previous_metadata_location";
-
   private static final String METADATA_FOLDER_NAME = "metadata";
 
   private TableMetadata currentMetadata = null;
   private String currentMetadataLocation = null;
   private boolean shouldRefresh = true;
   private int version = -1;
+  protected int metadataRefreshMaxRetries = METADATA_REFRESH_MAX_RETRIES_DEFAULT;
 
   protected BaseMetastoreTableOperations() {}
 
@@ -173,7 +174,7 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   }
 
   protected void refreshFromMetadataLocation(String newLocation) {
-    refreshFromMetadataLocation(newLocation, null, 20);
+    refreshFromMetadataLocation(newLocation, null, metadataRefreshMaxRetries);
   }
 
   protected void refreshFromMetadataLocation(String newLocation, int numRetries) {
@@ -241,6 +242,10 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   @Override
   public LocationProvider locationProvider() {
     return LocationProviders.locationsFor(current().location(), current().properties());
+  }
+
+  protected void setMetadataRefreshMaxRetries(int metadataRefreshMaxRetries) {
+    this.metadataRefreshMaxRetries = metadataRefreshMaxRetries;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -159,4 +159,8 @@ public class CatalogProperties {
 
   public static final String ENCRYPTION_KMS_TYPE = "encryption.kms-type";
   public static final String ENCRYPTION_KMS_IMPL = "encryption.kms-impl";
+
+  public static final String METADATA_REFRESH_MAX_RETRIES = "metadata-refresh-max-retries";
+  public static final int METADATA_REFRESH_MAX_RETRIES_DEFAULT = 20;
+
 }

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -68,6 +68,9 @@ import org.apache.iceberg.view.ViewOperations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.iceberg.CatalogProperties.METADATA_REFRESH_MAX_RETRIES;
+import static org.apache.iceberg.CatalogProperties.METADATA_REFRESH_MAX_RETRIES_DEFAULT;
+
 public class JdbcCatalog extends BaseMetastoreViewCatalog
     implements Configurable<Object>, SupportsNamespaces {
 
@@ -244,8 +247,10 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
 
   @Override
   protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
+    int metadataRefreshMaxRetries = PropertyUtil.propertyAsInt(
+            catalogProperties, METADATA_REFRESH_MAX_RETRIES, METADATA_REFRESH_MAX_RETRIES_DEFAULT);
     return new JdbcTableOperations(
-        connections, io, catalogName, tableIdentifier, catalogProperties, schemaVersion);
+        connections, io, catalogName, tableIdentifier, catalogProperties, schemaVersion, metadataRefreshMaxRetries);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcTableOperations.java
@@ -57,7 +57,9 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
       String catalogName,
       TableIdentifier tableIdentifier,
       Map<String, String> catalogProperties,
-      JdbcUtil.SchemaVersion schemaVersion) {
+      JdbcUtil.SchemaVersion schemaVersion,
+      int metadataRefreshMaxRetries) {
+    setMetadataRefreshMaxRetries(metadataRefreshMaxRetries);
     this.catalogName = catalogName;
     this.tableIdentifier = tableIdentifier;
     this.fileIO = fileIO;

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
@@ -59,8 +59,12 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.apache.iceberg.util.LocationUtil;
+import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.iceberg.CatalogProperties.METADATA_REFRESH_MAX_RETRIES;
+import static org.apache.iceberg.CatalogProperties.METADATA_REFRESH_MAX_RETRIES_DEFAULT;
 
 public class EcsCatalog extends BaseMetastoreCatalog
     implements SupportsNamespaces, Configurable<Object> {
@@ -127,11 +131,14 @@ public class EcsCatalog extends BaseMetastoreCatalog
 
   @Override
   protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
+    int metadataRefreshMaxRetries = PropertyUtil.propertyAsInt(
+            catalogProperties, METADATA_REFRESH_MAX_RETRIES, METADATA_REFRESH_MAX_RETRIES_DEFAULT);
     return new EcsTableOperations(
         String.format("%s.%s", catalogName, tableIdentifier),
         tableURI(tableIdentifier),
         fileIO,
-        this);
+        this,
+        metadataRefreshMaxRetries);
   }
 
   @Override

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsTableOperations.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsTableOperations.java
@@ -45,7 +45,8 @@ public class EcsTableOperations extends BaseMetastoreTableOperations {
   private String eTag;
 
   public EcsTableOperations(
-      String tableName, EcsURI tableObject, FileIO fileIO, EcsCatalog catalog) {
+      String tableName, EcsURI tableObject, FileIO fileIO, EcsCatalog catalog, int metadataRefreshMaxRetries) {
+    setMetadataRefreshMaxRetries(metadataRefreshMaxRetries);
     this.tableName = tableName;
     this.tableObject = tableObject;
     this.fileIO = fileIO;

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
@@ -40,8 +40,12 @@ import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.jdbc.JdbcClientPool;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.iceberg.CatalogProperties.METADATA_REFRESH_MAX_RETRIES;
+import static org.apache.iceberg.CatalogProperties.METADATA_REFRESH_MAX_RETRIES_DEFAULT;
 
 public class SnowflakeCatalog extends BaseMetastoreCatalog
     implements SupportsNamespaces, Configurable<Object> {
@@ -253,7 +257,11 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
     // support tables across different cloud/storage providers with disjoint FileIO implementations.
     FileIO fileIO = fileIOFactory.newFileIO(fileIOImpl, catalogProperties, conf);
     closeableGroup.addCloseable(fileIO);
-    return new SnowflakeTableOperations(snowflakeClient, fileIO, catalogName, tableIdentifier);
+    int metadataRefreshMaxRetries = PropertyUtil.propertyAsInt(
+            catalogProperties, METADATA_REFRESH_MAX_RETRIES, METADATA_REFRESH_MAX_RETRIES_DEFAULT);
+
+    return new SnowflakeTableOperations(
+            snowflakeClient, fileIO, catalogName, tableIdentifier, metadataRefreshMaxRetries);
   }
 
   @Override

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeTableOperations.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeTableOperations.java
@@ -42,7 +42,9 @@ class SnowflakeTableOperations extends BaseMetastoreTableOperations {
       SnowflakeClient snowflakeClient,
       FileIO fileIO,
       String catalogName,
-      TableIdentifier tableIdentifier) {
+      TableIdentifier tableIdentifier,
+      int metadataRefreshMaxRetries) {
+    setMetadataRefreshMaxRetries(metadataRefreshMaxRetries);
     this.snowflakeClient = snowflakeClient;
     this.fileIO = fileIO;
     this.tableIdentifier = tableIdentifier;


### PR DESCRIPTION
For all Iceberg table operations (select, insert, alter, etc..) Glue tries to load the Iceberg table by reading in its metadata files.
When loading an iceberg table and aws properties are illegal in catalog, GlueTableOperations repeatedly try to look for the metadata file. Retries up to 20 times with `exponential backoff` result in a long > 2 minutes hang.

This PR introduces a new config, `iceberg.glue.metadata-refresh-max-retries`, in GlueTableOperations which default value remains unchanged.  By adjusting the configuration in the catalog properties, errors message can be returned to the user ASAP when using starrocks.