### PR TITLE
Spark 3.2: Support arbitrary scans in SparkBatchQueryScan

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -499,11 +499,6 @@ public class TableMetadata implements Serializable {
       List<Snapshot> loadedSnapshots = Lists.newArrayList(snapshotsSupplier.get());
       loadedSnapshots.removeIf(s -> s.sequenceNumber() > lastSequenceNumber);
 
-      // Format version 1 does not have accurate sequence numbering, so remove based on timestamp
-      if (this.formatVersion == 1) {
-        loadedSnapshots.removeIf(s -> s.timestampMillis() > currentSnapshot().timestampMillis());
-      }
-
       this.snapshots = ImmutableList.copyOf(loadedSnapshots);
       this.snapshotsById = indexAndValidateSnapshots(snapshots, lastSequenceNumber);
       validateCurrentSnapshot();

--- a/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Queues;
@@ -49,13 +50,16 @@ import org.slf4j.LoggerFactory;
 abstract class BaseCommitService<T> implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(BaseCommitService.class);
 
+  public static final long TIMEOUT_IN_MS_DEFAULT = TimeUnit.MINUTES.toMillis(120);
+
   private final Table table;
   private final ExecutorService committerService;
   private final ConcurrentLinkedQueue<T> completedRewrites;
   private final ConcurrentLinkedQueue<String> inProgressCommits;
-  private final List<T> committedRewrites;
+  private final ConcurrentLinkedQueue<T> committedRewrites;
   private final int rewritesPerCommit;
   private final AtomicBoolean running = new AtomicBoolean(false);
+  private final long timeoutInMS;
 
   /**
    * Constructs a {@link BaseCommitService}
@@ -64,17 +68,30 @@ abstract class BaseCommitService<T> implements Closeable {
    * @param rewritesPerCommit number of file groups to include in a commit
    */
   BaseCommitService(Table table, int rewritesPerCommit) {
+    this(table, rewritesPerCommit, TIMEOUT_IN_MS_DEFAULT);
+  }
+
+  /**
+   * Constructs a {@link BaseCommitService}
+   *
+   * @param table table to perform commit on
+   * @param rewritesPerCommit number of file groups to include in a commit
+   * @param timeoutInMS The timeout to wait for commits to complete after all rewrite jobs have been
+   *     completed
+   */
+  BaseCommitService(Table table, int rewritesPerCommit, long timeoutInMS) {
     this.table = table;
     LOG.info(
         "Creating commit service for table {} with {} groups per commit", table, rewritesPerCommit);
     this.rewritesPerCommit = rewritesPerCommit;
+    this.timeoutInMS = timeoutInMS;
 
     committerService =
         Executors.newSingleThreadExecutor(
             new ThreadFactoryBuilder().setNameFormat("Committer-Service").build());
 
     completedRewrites = Queues.newConcurrentLinkedQueue();
-    committedRewrites = Lists.newArrayList();
+    committedRewrites = Queues.newConcurrentLinkedQueue();
     inProgressCommits = Queues.newConcurrentLinkedQueue();
   }
 
@@ -138,7 +155,7 @@ abstract class BaseCommitService<T> implements Closeable {
     Preconditions.checkState(
         committerService.isShutdown(),
         "Cannot get results from a service which has not been closed");
-    return committedRewrites;
+    return Lists.newArrayList(committedRewrites.iterator());
   }
 
   @Override
@@ -154,11 +171,13 @@ abstract class BaseCommitService<T> implements Closeable {
       // the commit pool to finish doing its commits to Iceberg State. In the case of partial
       // progress this should have been occurring simultaneously with rewrites, if not there should
       // be only a single commit operation.
-      if (!committerService.awaitTermination(120, TimeUnit.MINUTES)) {
+      if (!committerService.awaitTermination(timeoutInMS, TimeUnit.MILLISECONDS)) {
         LOG.warn(
-            "Commit operation did not complete within 120 minutes of the all files "
+            "Commit operation did not complete within {} minutes ({} ms) of the all files "
                 + "being rewritten. This may mean that some changes were not successfully committed to the "
-                + "table.");
+                + "table.",
+            TimeUnit.MILLISECONDS.toMinutes(timeoutInMS),
+            timeoutInMS);
         timeout = true;
       }
     } catch (InterruptedException e) {
@@ -169,7 +188,11 @@ abstract class BaseCommitService<T> implements Closeable {
 
     if (!completedRewrites.isEmpty() && timeout) {
       LOG.error("Attempting to cleanup uncommitted file groups");
-      completedRewrites.forEach(this::abortFileGroup);
+      synchronized (completedRewrites) {
+        while (!completedRewrites.isEmpty()) {
+          abortFileGroup(completedRewrites.poll());
+        }
+      }
     }
 
     Preconditions.checkArgument(
@@ -211,11 +234,17 @@ abstract class BaseCommitService<T> implements Closeable {
     }
   }
 
-  private boolean canCreateCommitGroup() {
+  @VisibleForTesting
+  boolean canCreateCommitGroup() {
     // Either we have a full commit group, or we have completed writing and need to commit
     // what is left over
     boolean fullCommitGroup = completedRewrites.size() >= rewritesPerCommit;
     boolean writingComplete = !running.get() && completedRewrites.size() > 0;
     return fullCommitGroup || writingComplete;
+  }
+
+  @VisibleForTesting
+  boolean completedRewritesAllCommitted() {
+    return completedRewrites.isEmpty() && inProgressCommits.isEmpty();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotLoading.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotLoading.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.SerializableSupplier;
+import org.assertj.core.api.Assumptions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -131,6 +132,10 @@ public class TestSnapshotLoading extends TableTestBase {
 
   @Test
   public void testFutureSnapshotsAreRemoved() {
+    Assumptions.assumeThat(formatVersion)
+        .as("Future snapshots are only removed for V2 tables")
+        .isGreaterThan(1);
+
     table.newFastAppend().appendFile(FILE_C).commit();
 
     TableMetadata futureTableMetadata =

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -1344,6 +1344,16 @@ public class TestTableMetadata {
   }
 
   @Test
+  public void testParseMinimal() throws Exception {
+    String data = readTableMetadataInputFile("TableMetadataV2ValidMinimal.json");
+    TableMetadata parsed = TableMetadataParser.fromJson(data);
+    Assertions.assertThat(parsed.snapshots()).isEmpty();
+    Assertions.assertThat(parsed.snapshotLog()).isEmpty();
+    Assertions.assertThat(parsed.properties()).isEmpty();
+    Assertions.assertThat(parsed.previousFiles()).isEmpty();
+  }
+
+  @Test
   public void testUpdateSchemaIdentifierFields() {
     Schema schema = new Schema(Types.NestedField.required(10, "x", Types.StringType.get()));
 

--- a/core/src/test/java/org/apache/iceberg/actions/TestCommitService.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestCommitService.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableTestBase;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.Tasks;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.Test;
+
+public class TestCommitService extends TableTestBase {
+
+  public TestCommitService() {
+    super(1);
+  }
+
+  @Test
+  public void testCommittedResultsCorrectly() {
+    CustomCommitService commitService = new CustomCommitService(table, 5, 10000);
+    commitService.start();
+
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+    int numberOfFileGroups = 100;
+    Tasks.range(numberOfFileGroups).executeWith(executorService).run(commitService::offer);
+    commitService.close();
+
+    Set<Integer> expected = Sets.newHashSet(IntStream.range(0, 100).iterator());
+    Set<Integer> actual = Sets.newHashSet(commitService.results());
+    Assertions.assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void testAbortFileGroupsAfterTimeout() {
+    CustomCommitService commitService = new CustomCommitService(table, 5, 200);
+    commitService.start();
+
+    // Add file groups [0-3] for commit.
+    // There are less than the rewritesPerCommit, and thus will not trigger a commit action. Those
+    // file groups will be added to the completedRewrites queue.
+    // Now the queue has 4 file groups that need to commit.
+    for (int i = 0; i < 4; i++) {
+      commitService.offer(i);
+    }
+
+    // Add file groups [4-7] for commit
+    // These are gated to not be able to commit, so all those 4 file groups will be added to the
+    // queue as well.
+    // Now the queue has 8 file groups that need to commit.
+    CustomCommitService spyCommitService = spy(commitService);
+    doReturn(false).when(spyCommitService).canCreateCommitGroup();
+    for (int i = 4; i < 8; i++) {
+      spyCommitService.offer(i);
+    }
+
+    // close commitService.
+    // This allows committerService thread to start to commit the remaining file groups [0-7] in the
+    // completedRewrites queue. And also the main thread waits for the committerService thread to
+    // finish within a timeout.
+
+    // The committerService thread commits file groups [0-4]. These will wait a fixed duration to
+    // simulate timeout on the main thread, which then tries to abort file groups [5-7].
+    // This tests the race conditions, as the committerService is also trying to commit groups
+    // [5-7].
+    Assertions.assertThatThrownBy(commitService::close)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Timeout occurred when waiting for commits");
+
+    // Wait for the commitService to finish. Committed all file groups or aborted remaining file
+    // groups.
+    Awaitility.await()
+        .atMost(5, TimeUnit.SECONDS)
+        .pollInSameThread()
+        .untilAsserted(() -> assertThat(commitService.completedRewritesAllCommitted()).isTrue());
+    if (commitService.aborted.isEmpty()) {
+      // All file groups are committed
+      Assertions.assertThat(commitService.results())
+          .isEqualTo(ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7));
+    } else {
+      // File groups [5-7] are aborted
+      Assertions.assertThat(commitService.results())
+          .doesNotContainAnyElementsOf(commitService.aborted);
+      Assertions.assertThat(commitService.results()).isEqualTo(ImmutableList.of(0, 1, 2, 3, 4));
+      Assertions.assertThat(commitService.aborted).isEqualTo(ImmutableSet.of(5, 6, 7));
+    }
+  }
+
+  private static class CustomCommitService extends BaseCommitService<Integer> {
+    private final Set<Integer> aborted = Sets.newConcurrentHashSet();
+
+    CustomCommitService(Table table, int rewritesPerCommit, int timeoutInSeconds) {
+      super(table, rewritesPerCommit, timeoutInSeconds);
+    }
+
+    @Override
+    protected void commitOrClean(Set<Integer> batch) {
+      try {
+        // Slightly longer than timeout
+        Thread.sleep(210);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    protected void abortFileGroup(Integer group) {
+      aborted.add(group);
+    }
+  }
+}

--- a/core/src/test/resources/TableMetadataV2ValidMinimal.json
+++ b/core/src/test/resources/TableMetadataV2ValidMinimal.json
@@ -1,0 +1,71 @@
+{
+  "format-version": 2,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "current-schema-id": 0,
+  "schemas": [
+    {
+      "type": "struct",
+      "schema-id": 0,
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long"
+        },
+        {
+          "id": 2,
+          "name": "y",
+          "required": true,
+          "type": "long",
+          "doc": "comment"
+        },
+        {
+          "id": 3,
+          "name": "z",
+          "required": true,
+          "type": "long"
+        }
+      ]
+    }
+  ],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "last-partition-id": 1000,
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ]
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -124,14 +124,7 @@ public class FlinkCatalog extends AbstractCatalog {
   }
 
   @Override
-  public void open() throws CatalogException {
-    // Create the default database if it does not exist.
-    try {
-      createDatabase(getDefaultDatabase(), ImmutableMap.of(), true);
-    } catch (DatabaseAlreadyExistException e) {
-      // Ignore the exception if it's already exist.
-    }
-  }
+  public void open() throws CatalogException {}
 
   @Override
   public void close() throws CatalogException {

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -24,12 +24,11 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.types.Row;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -75,19 +74,6 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
   }
 
   @Test
-  public void testDefaultDatabase() {
-    sql("USE CATALOG %s", catalogName);
-    sql("SHOW TABLES");
-
-    Assert.assertEquals(
-        "Should use the current catalog", getTableEnv().getCurrentCatalog(), catalogName);
-    Assert.assertEquals(
-        "Should use the configured default namespace",
-        getTableEnv().getCurrentDatabase(),
-        "default");
-  }
-
-  @Test
   public void testDropEmptyDatabase() {
     Assert.assertFalse(
         "Namespace should not already exist",
@@ -126,11 +112,11 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
         "Table should exist",
         validationCatalog.tableExists(TableIdentifier.of(icebergNamespace, "tl")));
 
-    AssertHelpers.assertThrowsCause(
-        "Should fail if trying to delete a non-empty database",
-        DatabaseNotEmptyException.class,
-        String.format("Database %s in catalog %s is not empty.", DATABASE, catalogName),
-        () -> sql("DROP DATABASE %s", flinkDatabase));
+    Assertions.assertThatThrownBy(() -> sql("DROP DATABASE %s", flinkDatabase))
+        .cause()
+        .isInstanceOf(DatabaseNotEmptyException.class)
+        .hasMessage(
+            String.format("Database %s in catalog %s is not empty.", DATABASE, catalogName));
 
     sql("DROP TABLE %s.tl", flinkDatabase);
   }
@@ -174,22 +160,17 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
     List<Row> databases = sql("SHOW DATABASES");
 
     if (isHadoopCatalog) {
-      Assert.assertEquals("Should have 2 database", 2, databases.size());
-      Assert.assertEquals(
-          "Should have db and default database",
-          Sets.newHashSet("default", "db"),
-          Sets.newHashSet(databases.get(0).getField(0), databases.get(1).getField(0)));
+      Assert.assertEquals("Should have 1 database", 1, databases.size());
+      Assert.assertEquals("Should have db database", "db", databases.get(0).getField(0));
 
       if (!baseNamespace.isEmpty()) {
         // test namespace not belongs to this catalog
         validationNamespaceCatalog.createNamespace(
             Namespace.of(baseNamespace.level(0), "UNKNOWN_NAMESPACE"));
         databases = sql("SHOW DATABASES");
-        Assert.assertEquals("Should have 2 database", 2, databases.size());
+        Assert.assertEquals("Should have 1 database", 1, databases.size());
         Assert.assertEquals(
-            "Should have db and default database",
-            Sets.newHashSet("default", "db"),
-            Sets.newHashSet(databases.get(0).getField(0), databases.get(1).getField(0)));
+            "Should have db and default database", "db", databases.get(0).getField(0));
       }
     } else {
       // If there are multiple classes extends FlinkTestBase, TestHiveMetastore may loose the
@@ -301,10 +282,12 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
         "Namespace should not already exist",
         validationNamespaceCatalog.namespaceExists(icebergNamespace));
 
-    AssertHelpers.assertThrowsCause(
-        "Should fail if trying to create database with location in hadoop catalog.",
-        UnsupportedOperationException.class,
-        String.format("Cannot create namespace %s: metadata is not supported", icebergNamespace),
-        () -> sql("CREATE DATABASE %s WITH ('prop'='value')", flinkDatabase));
+    Assertions.assertThatThrownBy(
+            () -> sql("CREATE DATABASE %s WITH ('prop'='value')", flinkDatabase))
+        .cause()
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(
+            String.format(
+                "Cannot create namespace %s: metadata is not supported", icebergNamespace));
   }
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -124,14 +124,7 @@ public class FlinkCatalog extends AbstractCatalog {
   }
 
   @Override
-  public void open() throws CatalogException {
-    // Create the default database if it does not exist.
-    try {
-      createDatabase(getDefaultDatabase(), ImmutableMap.of(), true);
-    } catch (DatabaseAlreadyExistException e) {
-      // Ignore the exception if it's already exist.
-    }
-  }
+  public void open() throws CatalogException {}
 
   @Override
   public void close() throws CatalogException {

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -24,12 +24,11 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.types.Row;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -75,19 +74,6 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
   }
 
   @Test
-  public void testDefaultDatabase() {
-    sql("USE CATALOG %s", catalogName);
-    sql("SHOW TABLES");
-
-    Assert.assertEquals(
-        "Should use the current catalog", getTableEnv().getCurrentCatalog(), catalogName);
-    Assert.assertEquals(
-        "Should use the configured default namespace",
-        getTableEnv().getCurrentDatabase(),
-        "default");
-  }
-
-  @Test
   public void testDropEmptyDatabase() {
     Assert.assertFalse(
         "Namespace should not already exist",
@@ -126,11 +112,11 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
         "Table should exist",
         validationCatalog.tableExists(TableIdentifier.of(icebergNamespace, "tl")));
 
-    AssertHelpers.assertThrowsCause(
-        "Should fail if trying to delete a non-empty database",
-        DatabaseNotEmptyException.class,
-        String.format("Database %s in catalog %s is not empty.", DATABASE, catalogName),
-        () -> sql("DROP DATABASE %s", flinkDatabase));
+    Assertions.assertThatThrownBy(() -> sql("DROP DATABASE %s", flinkDatabase))
+        .cause()
+        .isInstanceOf(DatabaseNotEmptyException.class)
+        .hasMessage(
+            String.format("Database %s in catalog %s is not empty.", DATABASE, catalogName));
 
     sql("DROP TABLE %s.tl", flinkDatabase);
   }
@@ -174,22 +160,17 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
     List<Row> databases = sql("SHOW DATABASES");
 
     if (isHadoopCatalog) {
-      Assert.assertEquals("Should have 2 database", 2, databases.size());
-      Assert.assertEquals(
-          "Should have db and default database",
-          Sets.newHashSet("default", "db"),
-          Sets.newHashSet(databases.get(0).getField(0), databases.get(1).getField(0)));
+      Assert.assertEquals("Should have 1 database", 1, databases.size());
+      Assert.assertEquals("Should have db database", "db", databases.get(0).getField(0));
 
       if (!baseNamespace.isEmpty()) {
         // test namespace not belongs to this catalog
         validationNamespaceCatalog.createNamespace(
             Namespace.of(baseNamespace.level(0), "UNKNOWN_NAMESPACE"));
         databases = sql("SHOW DATABASES");
-        Assert.assertEquals("Should have 2 database", 2, databases.size());
+        Assert.assertEquals("Should have 1 database", 1, databases.size());
         Assert.assertEquals(
-            "Should have db and default database",
-            Sets.newHashSet("default", "db"),
-            Sets.newHashSet(databases.get(0).getField(0), databases.get(1).getField(0)));
+            "Should have db and default database", "db", databases.get(0).getField(0));
       }
     } else {
       // If there are multiple classes extends FlinkTestBase, TestHiveMetastore may loose the
@@ -301,10 +282,12 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
         "Namespace should not already exist",
         validationNamespaceCatalog.namespaceExists(icebergNamespace));
 
-    AssertHelpers.assertThrowsCause(
-        "Should fail if trying to create database with location in hadoop catalog.",
-        UnsupportedOperationException.class,
-        String.format("Cannot create namespace %s: metadata is not supported", icebergNamespace),
-        () -> sql("CREATE DATABASE %s WITH ('prop'='value')", flinkDatabase));
+    Assertions.assertThatThrownBy(
+            () -> sql("CREATE DATABASE %s WITH ('prop'='value')", flinkDatabase))
+        .cause()
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(
+            String.format(
+                "Cannot create namespace %s: metadata is not supported", icebergNamespace));
   }
 }

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -124,14 +124,7 @@ public class FlinkCatalog extends AbstractCatalog {
   }
 
   @Override
-  public void open() throws CatalogException {
-    // Create the default database if it does not exist.
-    try {
-      createDatabase(getDefaultDatabase(), ImmutableMap.of(), true);
-    } catch (DatabaseAlreadyExistException e) {
-      // Ignore the exception if it's already exist.
-    }
-  }
+  public void open() throws CatalogException {}
 
   @Override
   public void close() throws CatalogException {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -250,6 +250,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
 
         commitStatus = CommitStatus.SUCCESS;
       } catch (LockException le) {
+        commitStatus = CommitStatus.UNKNOWN;
         throw new CommitStateUnknownException(
             "Failed to heartbeat for hive lock while "
                 + "committing changes. This can lead to a concurrent commit attempt be able to overwrite this commit. "

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -20,11 +20,15 @@ package org.apache.iceberg.spark.source;
 
 import java.util.List;
 import java.util.Objects;
-
-import org.apache.iceberg.*;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.ScanTask;
+import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.source.SparkScan.ReaderFactory;
-import org.apache.iceberg.util.TableScanUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -108,9 +112,9 @@ class SparkBatch implements Batch {
   // - all tasks are of FileScanTask type and read only Parquet files
   private boolean useParquetBatchReads() {
     return readConf.parquetVectorizationEnabled()
-            && expectedSchema.columns().size() > 0
-            && expectedSchema.columns().stream().allMatch(c -> c.type().isPrimitiveType())
-            && taskGroups.stream().allMatch(this::supportsParquetBatchReads);
+        && expectedSchema.columns().size() > 0
+        && expectedSchema.columns().stream().allMatch(c -> c.type().isPrimitiveType())
+        && taskGroups.stream().allMatch(this::supportsParquetBatchReads);
   }
 
   private boolean supportsParquetBatchReads(ScanTask task) {
@@ -132,7 +136,7 @@ class SparkBatch implements Batch {
   // - all tasks are of type FileScanTask and read only ORC files with no delete files
   private boolean useOrcBatchReads() {
     return readConf.orcVectorizationEnabled()
-            && taskGroups.stream().allMatch(this::supportsOrcBatchReads);
+        && taskGroups.stream().allMatch(this::supportsOrcBatchReads);
   }
 
   private boolean supportsOrcBatchReads(ScanTask task) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -20,11 +20,8 @@ package org.apache.iceberg.spark.source;
 
 import java.util.List;
 import java.util.Objects;
-import org.apache.iceberg.CombinedScanTask;
-import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.Table;
+
+import org.apache.iceberg.*;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.source.SparkScan.ReaderFactory;
 import org.apache.iceberg.util.TableScanUtil;
@@ -41,7 +38,7 @@ class SparkBatch implements Batch {
   private final JavaSparkContext sparkContext;
   private final Table table;
   private final SparkReadConf readConf;
-  private final List<CombinedScanTask> taskGroups;
+  private final List<? extends ScanTaskGroup<?>> taskGroups;
   private final Schema expectedSchema;
   private final boolean caseSensitive;
   private final boolean localityEnabled;
@@ -51,7 +48,7 @@ class SparkBatch implements Batch {
       JavaSparkContext sparkContext,
       Table table,
       SparkReadConf readConf,
-      List<CombinedScanTask> taskGroups,
+      List<? extends ScanTaskGroup<?>> taskGroups,
       Schema expectedSchema,
       int scanHashCode) {
     this.sparkContext = sparkContext;
@@ -95,43 +92,61 @@ class SparkBatch implements Batch {
   }
 
   private int batchSize() {
-    if (parquetOnly() && parquetBatchReadsEnabled()) {
+    if (useParquetBatchReads()) {
       return readConf.parquetBatchSize();
-    } else if (orcOnly() && orcBatchReadsEnabled()) {
+    } else if (useOrcBatchReads()) {
       return readConf.orcBatchSize();
     } else {
       return 0;
     }
   }
 
-  private boolean parquetOnly() {
-    return taskGroups.stream()
-        .allMatch(task -> !task.isDataTask() && onlyFileFormat(task, FileFormat.PARQUET));
-  }
-
-  private boolean parquetBatchReadsEnabled() {
+  // conditions for using Parquet batch reads:
+  // - Parquet vectorization is enabled
+  // - at least one column is projected
+  // - only primitives are projected
+  // - all tasks are of FileScanTask type and read only Parquet files
+  private boolean useParquetBatchReads() {
     return readConf.parquetVectorizationEnabled()
-        && // vectorization enabled
-        expectedSchema.columns().size() > 0
-        && // at least one column is projected
-        expectedSchema.columns().stream()
-            .allMatch(c -> c.type().isPrimitiveType()); // only primitives
+            && expectedSchema.columns().size() > 0
+            && expectedSchema.columns().stream().allMatch(c -> c.type().isPrimitiveType())
+            && taskGroups.stream().allMatch(this::supportsParquetBatchReads);
   }
 
-  private boolean orcOnly() {
-    return taskGroups.stream()
-        .allMatch(task -> !task.isDataTask() && onlyFileFormat(task, FileFormat.ORC));
+  private boolean supportsParquetBatchReads(ScanTask task) {
+    if (task instanceof ScanTaskGroup) {
+      ScanTaskGroup<?> taskGroup = (ScanTaskGroup<?>) task;
+      return taskGroup.tasks().stream().allMatch(this::supportsParquetBatchReads);
+
+    } else if (task.isFileScanTask() && !task.isDataTask()) {
+      FileScanTask fileScanTask = task.asFileScanTask();
+      return fileScanTask.file().format() == FileFormat.PARQUET;
+
+    } else {
+      return false;
+    }
   }
 
-  private boolean orcBatchReadsEnabled() {
+  // conditions for using ORC batch reads:
+  // - ORC vectorization is enabled
+  // - all tasks are of type FileScanTask and read only ORC files with no delete files
+  private boolean useOrcBatchReads() {
     return readConf.orcVectorizationEnabled()
-        && // vectorization enabled
-        taskGroups.stream().noneMatch(TableScanUtil::hasDeletes); // no delete files
+            && taskGroups.stream().allMatch(this::supportsOrcBatchReads);
   }
 
-  private boolean onlyFileFormat(CombinedScanTask task, FileFormat fileFormat) {
-    return task.files().stream()
-        .allMatch(fileScanTask -> fileScanTask.file().format().equals(fileFormat));
+  private boolean supportsOrcBatchReads(ScanTask task) {
+    if (task instanceof ScanTaskGroup) {
+      ScanTaskGroup<?> taskGroup = (ScanTaskGroup<?>) task;
+      return taskGroup.tasks().stream().allMatch(this::supportsOrcBatchReads);
+
+    } else if (task.isFileScanTask() && !task.isDataTask()) {
+      FileScanTask fileScanTask = task.asFileScanTask();
+      return fileScanTask.file().format() == FileFormat.ORC && fileScanTask.deletes().isEmpty();
+
+    } else {
+      return false;
+    }
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -26,14 +26,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.iceberg.CombinedScanTask;
-import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.Snapshot;
-import org.apache.iceberg.Table;
-import org.apache.iceberg.TableScan;
+
+import org.apache.iceberg.*;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Evaluator;
@@ -63,7 +57,7 @@ class SparkBatchQueryScan extends SparkScan implements SupportsRuntimeFiltering 
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkBatchQueryScan.class);
 
-  private final TableScan scan;
+  private final Scan<?, ? extends ScanTask, ? extends ScanTaskGroup<?>> scan;
   private final Long snapshotId;
   private final Long startSnapshotId;
   private final Long endSnapshotId;
@@ -71,13 +65,13 @@ class SparkBatchQueryScan extends SparkScan implements SupportsRuntimeFiltering 
   private final List<Expression> runtimeFilterExpressions;
 
   private Set<Integer> specIds = null; // lazy cache of scanned spec IDs
-  private List<FileScanTask> files = null; // lazy cache of files
-  private List<CombinedScanTask> tasks = null; // lazy cache of tasks
+  private List<PartitionScanTask> tasks = null; // lazy cache of uncombined tasks
+  private List<ScanTaskGroup<PartitionScanTask>> taskGroups = null; // lazy cache of task groups
 
   SparkBatchQueryScan(
       SparkSession spark,
       Table table,
-      TableScan scan,
+      Scan<?, ? extends ScanTask, ? extends ScanTaskGroup<?>> scan,
       SparkReadConf readConf,
       Schema expectedSchema,
       List<Expression> filters) {
@@ -93,8 +87,8 @@ class SparkBatchQueryScan extends SparkScan implements SupportsRuntimeFiltering 
 
     if (scan == null) {
       this.specIds = Collections.emptySet();
-      this.files = Collections.emptyList();
       this.tasks = Collections.emptyList();
+      this.taskGroups = Collections.emptyList();
     }
   }
 
@@ -105,8 +99,8 @@ class SparkBatchQueryScan extends SparkScan implements SupportsRuntimeFiltering 
   private Set<Integer> specIds() {
     if (specIds == null) {
       Set<Integer> specIdSet = Sets.newHashSet();
-      for (FileScanTask file : files()) {
-        specIdSet.add(file.spec().specId());
+      for (PartitionScanTask task : tasks()) {
+        specIdSet.add(task.spec().specId());
       }
       this.specIds = specIdSet;
     }
@@ -114,31 +108,40 @@ class SparkBatchQueryScan extends SparkScan implements SupportsRuntimeFiltering 
     return specIds;
   }
 
-  private List<FileScanTask> files() {
-    if (files == null) {
-      try (CloseableIterable<FileScanTask> filesIterable = scan.planFiles()) {
-        this.files = Lists.newArrayList(filesIterable);
+  private List<PartitionScanTask> tasks() {
+    if (tasks == null) {
+      try (CloseableIterable<? extends ScanTask> taskIterable = scan.planFiles()) {
+        List<PartitionScanTask> partitionScanTasks = Lists.newArrayList();
+        for (ScanTask task : taskIterable) {
+          ValidationException.check(
+                  task instanceof PartitionScanTask,
+                  "Unsupported task type, expected a subtype of PartitionScanTask: %",
+                  task.getClass().getName());
+
+          partitionScanTasks.add((PartitionScanTask) task);
+        }
+        this.tasks = partitionScanTasks;
       } catch (IOException e) {
-        throw new UncheckedIOException("Failed to close table scan: " + scan, e);
+        throw new UncheckedIOException("Failed to close scan: " + scan, e);
       }
     }
 
-    return files;
+    return tasks;
   }
 
   @Override
-  protected List<CombinedScanTask> tasks() {
-    if (tasks == null) {
-      CloseableIterable<FileScanTask> splitFiles =
-          TableScanUtil.splitFiles(
-              CloseableIterable.withNoopClose(files()), scan.targetSplitSize());
-      CloseableIterable<CombinedScanTask> scanTasks =
-          TableScanUtil.planTasks(
-              splitFiles, scan.targetSplitSize(), scan.splitLookback(), scan.splitOpenFileCost());
-      tasks = Lists.newArrayList(scanTasks);
+  protected List<ScanTaskGroup<PartitionScanTask>> taskGroups() {
+    if (taskGroups == null) {
+      CloseableIterable<ScanTaskGroup<PartitionScanTask>> plannedTaskGroups =
+              TableScanUtil.planTaskGroups(
+                      CloseableIterable.withNoopClose(tasks()),
+                      scan.targetSplitSize(),
+                      scan.splitLookback(),
+                      scan.splitOpenFileCost());
+      taskGroups = Lists.newArrayList(plannedTaskGroups);
     }
 
-    return tasks;
+    return taskGroups;
   }
 
   @Override
@@ -180,30 +183,30 @@ class SparkBatchQueryScan extends SparkScan implements SupportsRuntimeFiltering 
       }
 
       LOG.info(
-          "Trying to filter {} files using runtime filter {}",
-          files().size(),
-          ExpressionUtil.toSanitizedString(runtimeFilterExpr));
+              "Trying to filter {} tasks using runtime filter {}",
+              tasks().size(),
+              ExpressionUtil.toSanitizedString(runtimeFilterExpr));
 
-      List<FileScanTask> filteredFiles =
-          files().stream()
-              .filter(
-                  file -> {
-                    Evaluator evaluator = evaluatorsBySpecId.get(file.spec().specId());
-                    return evaluator.eval(file.file().partition());
+      List<PartitionScanTask> filteredTasks =
+              tasks().stream()
+                      .filter(
+                              task -> {
+                                Evaluator evaluator = evaluatorsBySpecId.get(task.spec().specId());
+                                return evaluator.eval(task.partition());
                   })
               .collect(Collectors.toList());
 
       LOG.info(
-          "{}/{} files matched runtime filter {}",
-          filteredFiles.size(),
-          files().size(),
+          "{}/{} tasks matched runtime filter {}",
+          filteredTasks.size(),
+          tasks().size(),
           ExpressionUtil.toSanitizedString(runtimeFilterExpr));
 
       // don't invalidate tasks if the runtime filter had no effect to avoid planning splits again
-      if (filteredFiles.size() < files().size()) {
+      if (filteredTasks.size() < tasks().size()) {
         this.specIds = null;
-        this.files = filteredFiles;
-        this.tasks = null;
+        this.tasks = filteredTasks;
+        this.taskGroups = null;
       }
 
       // save the evaluated filter for equals/hashCode

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -151,7 +151,7 @@ class SparkCopyOnWriteScan extends SparkScan implements SupportsRuntimeFiltering
   }
 
   @Override
-  protected synchronized List<CombinedScanTask> tasks() {
+  protected synchronized List<CombinedScanTask> taskGroups() {
     if (tasks == null) {
       CloseableIterable<FileScanTask> splitFiles =
           TableScanUtil.splitFiles(

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkFilesScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkFilesScan.java
@@ -50,7 +50,7 @@ class SparkFilesScan extends SparkScan {
   }
 
   @Override
-  protected List<CombinedScanTask> tasks() {
+  protected List<CombinedScanTask> taskGroups() {
     if (tasks == null) {
       FileScanTaskSetManager taskSetManager = FileScanTaskSetManager.get();
       List<FileScanTask> files = taskSetManager.fetchTasks(table(), taskSetID);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.spark.source;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -104,11 +104,11 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     return filterExpressions;
   }
 
-  protected abstract List<CombinedScanTask> tasks();
+  protected abstract List<? extends ScanTaskGroup<?>> taskGroups();
 
   @Override
   public Batch toBatch() {
-    return new SparkBatch(sparkContext, table, readConf, tasks(), expectedSchema, hashCode());
+    return new SparkBatch(sparkContext, table, readConf, taskGroups(), expectedSchema, hashCode());
   }
 
   @Override
@@ -149,7 +149,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
       return new Stats(SparkSchemaUtil.estimateSize(readSchema(), totalRecords), totalRecords);
     }
 
-    long rowsCount = tasks().stream().mapToLong(ScanTaskGroup::estimatedRowsCount).sum();
+    long rowsCount = taskGroups().stream().mapToLong(ScanTaskGroup::estimatedRowsCount).sum();
     long sizeInBytes = SparkSchemaUtil.estimateSize(readSchema(), rowsCount);
     return new Stats(sizeInBytes, rowsCount);
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -21,8 +21,15 @@ package org.apache.iceberg.spark.source;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.apache.iceberg.*;
+import org.apache.iceberg.BatchScan;
+import org.apache.iceberg.IncrementalAppendScan;
+import org.apache.iceberg.IncrementalChangelogScan;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TableScan;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
@@ -216,11 +223,11 @@ public class SparkScanBuilder
     if (startSnapshotId != null) {
       return buildIncrementalAppendScan(startSnapshotId, endSnapshotId);
     } else {
-      return buildBatchScan(snapshotId, asOfTimestamp, branch, tag);
+      return buildBatchScan(snapshotId, asOfTimestamp);
     }
   }
 
-  private Scan buildBatchScan(Long snapshotId, Long asOfTimestamp, String branch, String tag) {
+  private Scan buildBatchScan(Long snapshotId, Long asOfTimestamp) {
     Schema expectedSchema = schemaWithMetadataColumns();
 
     BatchScan scan =
@@ -247,12 +254,12 @@ public class SparkScanBuilder
     Schema expectedSchema = schemaWithMetadataColumns();
 
     IncrementalAppendScan scan =
-            table
-                    .newIncrementalAppendScan()
-                    .fromSnapshotExclusive(startSnapshotId)
-                    .caseSensitive(caseSensitive)
-                    .filter(filterExpression())
-                    .project(expectedSchema);
+        table
+            .newIncrementalAppendScan()
+            .fromSnapshotExclusive(startSnapshotId)
+            .caseSensitive(caseSensitive)
+            .filter(filterExpression())
+            .project(expectedSchema);
 
     if (endSnapshotId != null) {
       scan = scan.toSnapshot(endSnapshotId);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -21,13 +21,8 @@ package org.apache.iceberg.spark.source;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.iceberg.IncrementalChangelogScan;
-import org.apache.iceberg.MetadataColumns;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.Snapshot;
-import org.apache.iceberg.Table;
-import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.TableScan;
+
+import org.apache.iceberg.*;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
@@ -218,12 +213,19 @@ public class SparkScanBuilder
             + "changelog scans.",
         SparkReadOptions.START_TIMESTAMP,
         SparkReadOptions.END_TIMESTAMP);
+    if (startSnapshotId != null) {
+      return buildIncrementalAppendScan(startSnapshotId, endSnapshotId);
+    } else {
+      return buildBatchScan(snapshotId, asOfTimestamp, branch, tag);
+    }
+  }
 
+  private Scan buildBatchScan(Long snapshotId, Long asOfTimestamp, String branch, String tag) {
     Schema expectedSchema = schemaWithMetadataColumns();
 
-    TableScan scan =
+    BatchScan scan =
         table
-            .newScan()
+            .newBatchScan()
             .caseSensitive(caseSensitive)
             .filter(filterExpression())
             .project(expectedSchema);
@@ -236,12 +238,24 @@ public class SparkScanBuilder
       scan = scan.asOfTime(asOfTimestamp);
     }
 
-    if (startSnapshotId != null) {
-      if (endSnapshotId != null) {
-        scan = scan.appendsBetween(startSnapshotId, endSnapshotId);
-      } else {
-        scan = scan.appendsAfter(startSnapshotId);
-      }
+    scan = configureSplitPlanning(scan);
+
+    return new SparkBatchQueryScan(spark, table, scan, readConf, expectedSchema, filterExpressions);
+  }
+
+  private Scan buildIncrementalAppendScan(long startSnapshotId, Long endSnapshotId) {
+    Schema expectedSchema = schemaWithMetadataColumns();
+
+    IncrementalAppendScan scan =
+            table
+                    .newIncrementalAppendScan()
+                    .fromSnapshotExclusive(startSnapshotId)
+                    .caseSensitive(caseSensitive)
+                    .filter(filterExpression())
+                    .project(expectedSchema);
+
+    if (endSnapshotId != null) {
+      scan = scan.toSnapshot(endSnapshotId);
     }
 
     scan = configureSplitPlanning(scan);
@@ -355,9 +369,9 @@ public class SparkScanBuilder
 
     Schema expectedSchema = schemaWithMetadataColumns();
 
-    TableScan scan =
+    BatchScan scan =
         table
-            .newScan()
+            .newBatchScan()
             .useSnapshot(snapshotId)
             .caseSensitive(caseSensitive)
             .filter(filterExpression())

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -25,6 +25,7 @@ import static org.apache.iceberg.TableProperties.DELETE_MODE_DEFAULT;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -46,6 +47,7 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.GenericRecord;
@@ -1133,6 +1135,42 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                     String.format(
                         "Cannot write to both branch and WAP branch, but got branch [%s] and WAP branch [wap]",
                         branch)));
+  }
+
+  @Test
+  public void testDeleteToCustomWapBranchWithoutWhereClause() throws NoSuchTableException {
+    assumeThat(branch)
+        .as("Run only if custom WAP branch is not main")
+        .isNotNull()
+        .isNotEqualTo(SnapshotRef.MAIN_BRANCH);
+
+    createAndInitPartitionedTable();
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'true')",
+        tableName, TableProperties.WRITE_AUDIT_PUBLISH_ENABLED);
+    append(tableName, new Employee(0, "hr"), new Employee(1, "hr"), new Employee(2, "hr"));
+    createBranchIfNeeded();
+
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, branch),
+        () -> {
+          sql("DELETE FROM %s t WHERE id=1", tableName);
+          Assertions.assertThat(spark.table(tableName).count()).isEqualTo(2L);
+          Assertions.assertThat(spark.table(tableName + ".branch_" + branch).count()).isEqualTo(2L);
+          Assertions.assertThat(spark.table(tableName + ".branch_main").count())
+              .as("Should not modify main branch")
+              .isEqualTo(3L);
+        });
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, branch),
+        () -> {
+          sql("DELETE FROM %s t", tableName);
+          Assertions.assertThat(spark.table(tableName).count()).isEqualTo(0L);
+          Assertions.assertThat(spark.table(tableName + ".branch_" + branch).count()).isEqualTo(0L);
+          Assertions.assertThat(spark.table(tableName + ".branch_main").count())
+              .as("Should not modify main branch")
+              .isEqualTo(3L);
+        });
   }
 
   // TODO: multiple stripes for ORC

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
@@ -1,0 +1,408 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
+import static org.apache.spark.sql.functions.expr;
+import static org.apache.spark.sql.functions.lit;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.PositionDeletesScanTask;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.ScanTask;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.RewritePositionDeleteFiles.FileGroupRewriteResult;
+import org.apache.iceberg.actions.RewritePositionDeleteFiles.Result;
+import org.apache.iceberg.actions.SizeBasedFileRewriter;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.encryption.EncryptedFiles;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppenderFactory;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
+import org.apache.iceberg.util.Pair;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.StructType;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runners.Parameterized;
+
+public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
+
+  private static final Map<String, String> CATALOG_PROPS =
+      ImmutableMap.of(
+          "type", "hive",
+          "default-namespace", "default",
+          "cache-enabled", "false");
+
+  private static final int NUM_DATA_FILES = 5;
+  private static final int ROWS_PER_DATA_FILE = 100;
+  private static final int DELETE_FILES_PER_PARTITION = 2;
+  private static final int DELETE_FILE_SIZE = 10;
+
+  @Parameterized.Parameters(
+      name = "formatVersion = {0}, catalogName = {1}, implementation = {2}, config = {3}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        CATALOG_PROPS
+      }
+    };
+  }
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  public TestRewritePositionDeleteFiles(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void cleanup() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testDatePartition() throws Exception {
+    createTable("date");
+    Date baseDate = Date.valueOf("2023-01-01");
+    insertData(i -> Date.valueOf(baseDate.toLocalDate().plusDays(i)));
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testBooleanPartition() throws Exception {
+    createTable("boolean");
+    insertData(i -> i % 2 == 0, 2);
+    testDanglingDelete(2);
+  }
+
+  @Test
+  public void testTimestampPartition() throws Exception {
+    createTable("timestamp");
+    Timestamp baseTimestamp = Timestamp.valueOf("2023-01-01 15:30:00");
+    insertData(i -> Timestamp.valueOf(baseTimestamp.toLocalDateTime().plusDays(i)));
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testBytePartition() throws Exception {
+    createTable("byte");
+    insertData(i -> i);
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testDecimalPartition() throws Exception {
+    createTable("decimal(18, 10)");
+    BigDecimal baseDecimal = new BigDecimal("1.0");
+    insertData(i -> baseDecimal.add(new BigDecimal(i)));
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testBinaryPartition() throws Exception {
+    createTable("binary");
+    insertData(i -> java.nio.ByteBuffer.allocate(4).putInt(i).array());
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testCharPartition() throws Exception {
+    createTable("char(10)");
+    insertData(Object::toString);
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testVarcharPartition() throws Exception {
+    createTable("varchar(10)");
+    insertData(Object::toString);
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testIntPartition() throws Exception {
+    createTable("int");
+    insertData(i -> i);
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testDaysPartitionTransform() throws Exception {
+    createTable("timestamp", "days(partition_col)");
+    Timestamp baseTimestamp = Timestamp.valueOf("2023-01-01 15:30:00");
+    insertData(i -> Timestamp.valueOf(baseTimestamp.toLocalDateTime().plusDays(i)));
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testNullTransform() throws Exception {
+    createTable("int");
+    insertData(i -> i == 0 ? null : 1, 2);
+    testDanglingDelete(2);
+  }
+
+  private <T> void testDanglingDelete() throws Exception {
+    testDanglingDelete(NUM_DATA_FILES);
+  }
+
+  private <T> void testDanglingDelete(int numDataFiles) throws Exception {
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+
+    List<DataFile> dataFiles = dataFiles(table);
+    Assert.assertEquals(numDataFiles, dataFiles.size());
+
+    SparkActions.get(spark)
+        .rewriteDataFiles(table)
+        .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
+        .execute();
+
+    // write dangling delete files for 'old data files'
+    writePosDeletesForFiles(table, dataFiles);
+    List<DeleteFile> deleteFiles = deleteFiles(table);
+    Assert.assertEquals(numDataFiles * DELETE_FILES_PER_PARTITION, deleteFiles.size());
+
+    List<Object[]> expectedRecords = records(tableName);
+
+    Result result =
+        SparkActions.get(spark)
+            .rewritePositionDeletes(table)
+            .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
+            .execute();
+
+    List<DeleteFile> newDeleteFiles = deleteFiles(table);
+    Assert.assertEquals("Should have removed all dangling delete files", 0, newDeleteFiles.size());
+    checkResult(result, deleteFiles, Lists.newArrayList(), numDataFiles);
+
+    List<Object[]> actualRecords = records(tableName);
+    assertEquals("Rows must match", expectedRecords, actualRecords);
+  }
+
+  private void createTable(String partitionType) {
+    createTable(partitionType, "partition_col");
+  }
+
+  private void createTable(String partitionType, String partitionCol) {
+    sql(
+        "CREATE TABLE %s (id long, partition_col %s, c1 string, c2 string) "
+            + "USING iceberg "
+            + "PARTITIONED BY (%s) "
+            + "TBLPROPERTIES('format-version'='2')",
+        tableName, partitionType, partitionCol);
+  }
+
+  private <T> void insertData(Function<Integer, ?> partitionValueFunction) throws Exception {
+    insertData(partitionValueFunction, NUM_DATA_FILES);
+  }
+
+  private <T> void insertData(Function<Integer, ?> partitionValue, int numDataFiles)
+      throws Exception {
+    for (int i = 0; i < numDataFiles; i++) {
+      Dataset<Row> df =
+          spark
+              .range(0, ROWS_PER_DATA_FILE)
+              .withColumn("partition_col", lit(partitionValue.apply(i)))
+              .withColumn("c1", expr("CAST(id AS STRING)"))
+              .withColumn("c2", expr("CAST(id AS STRING)"));
+      appendAsFile(df);
+    }
+  }
+
+  private void appendAsFile(Dataset<Row> df) throws Exception {
+    // ensure the schema is precise
+    StructType sparkSchema = spark.table(tableName).schema();
+    spark.createDataFrame(df.rdd(), sparkSchema).coalesce(1).writeTo(tableName).append();
+  }
+
+  private void writePosDeletesForFiles(Table table, List<DataFile> files) throws IOException {
+
+    Map<StructLike, List<DataFile>> filesByPartition =
+        files.stream().collect(Collectors.groupingBy(ContentFile::partition));
+    List<DeleteFile> deleteFiles =
+        Lists.newArrayListWithCapacity(DELETE_FILES_PER_PARTITION * filesByPartition.size());
+
+    for (Map.Entry<StructLike, List<DataFile>> filesByPartitionEntry :
+        filesByPartition.entrySet()) {
+
+      StructLike partition = filesByPartitionEntry.getKey();
+      List<DataFile> partitionFiles = filesByPartitionEntry.getValue();
+
+      int deletesForPartition = partitionFiles.size() * DELETE_FILE_SIZE;
+      Assert.assertEquals(
+          "Number of delete files per partition should be "
+              + "evenly divisible by requested deletes per data file times number of data files in this partition",
+          0,
+          deletesForPartition % DELETE_FILE_SIZE);
+      int deleteFileSize = deletesForPartition / DELETE_FILES_PER_PARTITION;
+
+      int counter = 0;
+      List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
+      for (DataFile partitionFile : partitionFiles) {
+        for (int deletePos = 0; deletePos < DELETE_FILE_SIZE; deletePos++) {
+          deletes.add(Pair.of(partitionFile.path(), (long) deletePos));
+          counter++;
+          if (counter == deleteFileSize) {
+            // Dump to file and reset variables
+            OutputFile output = Files.localOutput(temp.newFile());
+            deleteFiles.add(writeDeleteFile(table, output, partition, deletes));
+            counter = 0;
+            deletes.clear();
+          }
+        }
+      }
+    }
+
+    RowDelta rowDelta = table.newRowDelta();
+    deleteFiles.forEach(rowDelta::addDeletes);
+    rowDelta.commit();
+  }
+
+  private DeleteFile writeDeleteFile(
+      Table table, OutputFile out, StructLike partition, List<Pair<CharSequence, Long>> deletes)
+      throws IOException {
+    FileFormat format = defaultFormat(table.properties());
+    FileAppenderFactory<Record> factory = new GenericAppenderFactory(table.schema(), table.spec());
+
+    PositionDeleteWriter<Record> writer =
+        factory.newPosDeleteWriter(encrypt(out), format, partition);
+    PositionDelete<Record> posDelete = PositionDelete.create();
+    try (Closeable toClose = writer) {
+      for (Pair<CharSequence, Long> delete : deletes) {
+        writer.write(posDelete.set(delete.first(), delete.second(), null));
+      }
+    }
+
+    return writer.toDeleteFile();
+  }
+
+  private static EncryptedOutputFile encrypt(OutputFile out) {
+    return EncryptedFiles.encryptedOutput(out, EncryptionKeyMetadata.EMPTY);
+  }
+
+  private static FileFormat defaultFormat(Map<String, String> properties) {
+    String formatString = properties.getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT);
+    return FileFormat.fromString(formatString);
+  }
+
+  private List<Object[]> records(String table) {
+    return rowsToJava(
+        spark.read().format("iceberg").load(table).sort("partition_col", "id").collectAsList());
+  }
+
+  private long size(List<DeleteFile> deleteFiles) {
+    return deleteFiles.stream().mapToLong(DeleteFile::fileSizeInBytes).sum();
+  }
+
+  private List<DataFile> dataFiles(Table table) {
+    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+    return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
+  }
+
+  private List<DeleteFile> deleteFiles(Table table) {
+    Table deletesTable =
+        MetadataTableUtils.createMetadataTableInstance(table, MetadataTableType.POSITION_DELETES);
+    CloseableIterable<ScanTask> tasks = deletesTable.newBatchScan().planFiles();
+    return Lists.newArrayList(
+        CloseableIterable.transform(tasks, t -> ((PositionDeletesScanTask) t).file()));
+  }
+
+  private void checkResult(
+      Result result,
+      List<DeleteFile> rewrittenDeletes,
+      List<DeleteFile> newDeletes,
+      int expectedGroups) {
+    Assert.assertEquals(
+        "Expected rewritten delete file count does not match",
+        rewrittenDeletes.size(),
+        result.rewrittenDeleteFilesCount());
+    Assert.assertEquals(
+        "Expected new delete file count does not match",
+        newDeletes.size(),
+        result.addedDeleteFilesCount());
+    Assert.assertEquals(
+        "Expected rewritten delete byte count does not match",
+        size(rewrittenDeletes),
+        result.rewrittenBytesCount());
+    Assert.assertEquals(
+        "Expected new delete byte count does not match",
+        size(newDeletes),
+        result.addedBytesCount());
+
+    Assert.assertEquals(
+        "Expected rewrite group count does not match",
+        expectedGroups,
+        result.rewriteResults().size());
+    Assert.assertEquals(
+        "Expected rewritten delete file count in all groups to match",
+        rewrittenDeletes.size(),
+        result.rewriteResults().stream()
+            .mapToInt(FileGroupRewriteResult::rewrittenDeleteFilesCount)
+            .sum());
+    Assert.assertEquals(
+        "Expected added delete file count in all groups to match",
+        newDeletes.size(),
+        result.rewriteResults().stream()
+            .mapToInt(FileGroupRewriteResult::addedDeleteFilesCount)
+            .sum());
+    Assert.assertEquals(
+        "Expected rewritten delete bytes in all groups to match",
+        size(rewrittenDeletes),
+        result.rewriteResults().stream()
+            .mapToLong(FileGroupRewriteResult::rewrittenBytesCount)
+            .sum());
+    Assert.assertEquals(
+        "Expected added delete bytes in all groups to match",
+        size(newDeletes),
+        result.rewriteResults().stream().mapToLong(FileGroupRewriteResult::addedBytesCount).sum());
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.TableMigrationUtil;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.hadoop.Util;
@@ -713,6 +714,43 @@ public class SparkTableUtil {
     CaseInsensitiveStringMap options = new CaseInsensitiveStringMap(extraOptions);
     return Dataset.ofRows(
         spark, DataSourceV2Relation.create(metadataTable, Some.empty(), Some.empty(), options));
+  }
+
+  /**
+   * Determine the write branch.
+   *
+   * <p>Validate wap config and determine the write branch.
+   *
+   * @param spark a Spark Session
+   * @param branch write branch if there is no WAP branch configured
+   * @return branch for write operation
+   */
+  public static String determineWriteBranch(SparkSession spark, String branch) {
+    String wapId = spark.conf().get(SparkSQLProperties.WAP_ID, null);
+    String wapBranch = spark.conf().get(SparkSQLProperties.WAP_BRANCH, null);
+    ValidationException.check(
+        wapId == null || wapBranch == null,
+        "Cannot set both WAP ID and branch, but got ID [%s] and branch [%s]",
+        wapId,
+        wapBranch);
+
+    if (wapBranch != null) {
+      ValidationException.check(
+          branch == null,
+          "Cannot write to both branch and WAP branch, but got branch [%s] and WAP branch [%s]",
+          branch,
+          wapBranch);
+
+      return wapBranch;
+    }
+    return branch;
+  }
+
+  public static boolean wapEnabled(Table table) {
+    return PropertyUtil.propertyAsBoolean(
+        table.properties(),
+        TableProperties.WRITE_AUDIT_PUBLISH_ENABLED,
+        Boolean.getBoolean(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT));
   }
 
   /** Class representing a table partition. */

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ByteBuffers;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 
@@ -119,5 +120,40 @@ public class SparkValueConverter {
       }
     }
     return record;
+  }
+
+  public static Object convertToSpark(Type type, Object object) {
+    if (object == null) {
+      return null;
+    }
+
+    switch (type.typeId()) {
+      case STRUCT:
+      case LIST:
+      case MAP:
+        return new UnsupportedOperationException("Complex types currently not supported");
+      case DATE:
+        return DateTimeUtils.daysToLocalDate((int) object);
+      case TIMESTAMP:
+        Types.TimestampType ts = (Types.TimestampType) type.asPrimitiveType();
+        if (ts.shouldAdjustToUTC()) {
+          return DateTimeUtils.microsToInstant((long) object);
+        } else {
+          return DateTimeUtils.microsToLocalDateTime((long) object);
+        }
+      case BINARY:
+        return ByteBuffers.toByteArray((ByteBuffer) object);
+      case INTEGER:
+      case BOOLEAN:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case DECIMAL:
+      case STRING:
+      case FIXED:
+        return object;
+      default:
+        throw new UnsupportedOperationException("Not a supported type: " + type);
+    }
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackPositionDeletesRewriter.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackPositionDeletesRewriter.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.MetadataTableType.POSITION_DELETES;
 import static org.apache.spark.sql.functions.col;
+import static org.apache.spark.sql.functions.lit;
 
 import java.util.List;
 import java.util.Optional;
@@ -40,7 +41,9 @@ import org.apache.iceberg.spark.ScanTaskSetManager;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkTableCache;
 import org.apache.iceberg.spark.SparkTableUtil;
+import org.apache.iceberg.spark.SparkValueConverter;
 import org.apache.iceberg.spark.SparkWriteOptions;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
@@ -125,10 +128,11 @@ class SparkBinPackPositionDeletesRewriter extends SizeBasedPositionDeletesRewrit
         IntStream.range(0, fields.size())
             .mapToObj(
                 i -> {
-                  Class<?> type = fields.get(i).type().typeId().javaClass();
-                  Object value = partition.get(i, type);
+                  Type type = fields.get(i).type();
+                  Object value = partition.get(i, type.typeId().javaClass());
+                  Object convertedValue = SparkValueConverter.convertToSpark(type, value);
                   Column col = col("partition." + fields.get(i).name());
-                  return col.equalTo(value);
+                  return col.eqNullSafe(lit(convertedValue));
                 })
             .reduce(Column::and);
     if (condition.isPresent()) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -56,6 +56,7 @@ import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkFilters;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
@@ -370,6 +371,10 @@ public class SparkTable
             .newDelete()
             .set("spark.app.id", sparkSession().sparkContext().applicationId())
             .deleteFromRowFilter(deleteExpr);
+
+    if (SparkTableUtil.wapEnabled(table())) {
+      branch = SparkTableUtil.determineWriteBranch(sparkSession(), branch);
+    }
 
     if (branch != null) {
       deleteFiles.toBranch(branch);

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -27,6 +27,7 @@ import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.SPLIT_OPEN_FILE_COST;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,6 +50,7 @@ import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -1260,6 +1262,42 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                     String.format(
                         "Cannot write to both branch and WAP branch, but got branch [%s] and WAP branch [wap]",
                         branch)));
+  }
+
+  @Test
+  public void testDeleteToCustomWapBranchWithoutWhereClause() throws NoSuchTableException {
+    assumeThat(branch)
+        .as("Run only if custom WAP branch is not main")
+        .isNotNull()
+        .isNotEqualTo(SnapshotRef.MAIN_BRANCH);
+
+    createAndInitPartitionedTable();
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'true')",
+        tableName, TableProperties.WRITE_AUDIT_PUBLISH_ENABLED);
+    append(tableName, new Employee(0, "hr"), new Employee(1, "hr"), new Employee(2, "hr"));
+    createBranchIfNeeded();
+
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, branch),
+        () -> {
+          sql("DELETE FROM %s t WHERE id=1", tableName);
+          Assertions.assertThat(spark.table(tableName).count()).isEqualTo(2L);
+          Assertions.assertThat(spark.table(tableName + ".branch_" + branch).count()).isEqualTo(2L);
+          Assertions.assertThat(spark.table(tableName + ".branch_main").count())
+              .as("Should not modify main branch")
+              .isEqualTo(3L);
+        });
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, branch),
+        () -> {
+          sql("DELETE FROM %s t", tableName);
+          Assertions.assertThat(spark.table(tableName).count()).isEqualTo(0L);
+          Assertions.assertThat(spark.table(tableName + ".branch_" + branch).count()).isEqualTo(0L);
+          Assertions.assertThat(spark.table(tableName + ".branch_main").count())
+              .as("Should not modify main branch")
+              .isEqualTo(3L);
+        });
   }
 
   // TODO: multiple stripes for ORC

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
@@ -1,0 +1,417 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
+import static org.apache.spark.sql.functions.expr;
+import static org.apache.spark.sql.functions.lit;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.PositionDeletesScanTask;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.ScanTask;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.RewritePositionDeleteFiles.FileGroupRewriteResult;
+import org.apache.iceberg.actions.RewritePositionDeleteFiles.Result;
+import org.apache.iceberg.actions.SizeBasedFileRewriter;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.encryption.EncryptedFiles;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppenderFactory;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
+import org.apache.iceberg.util.Pair;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.StructType;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runners.Parameterized;
+
+public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
+
+  private static final Map<String, String> CATALOG_PROPS =
+      ImmutableMap.of(
+          "type", "hive",
+          "default-namespace", "default",
+          "cache-enabled", "false");
+
+  private static final int NUM_DATA_FILES = 5;
+  private static final int ROWS_PER_DATA_FILE = 100;
+  private static final int DELETE_FILES_PER_PARTITION = 2;
+  private static final int DELETE_FILE_SIZE = 10;
+
+  @Parameterized.Parameters(
+      name = "formatVersion = {0}, catalogName = {1}, implementation = {2}, config = {3}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        CATALOG_PROPS
+      }
+    };
+  }
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  public TestRewritePositionDeleteFiles(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void cleanup() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testDatePartition() throws Exception {
+    createTable("date");
+    Date baseDate = Date.valueOf("2023-01-01");
+    insertData(i -> Date.valueOf(baseDate.toLocalDate().plusDays(i)));
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testBooleanPartition() throws Exception {
+    createTable("boolean");
+    insertData(i -> i % 2 == 0, 2);
+    testDanglingDelete(2);
+  }
+
+  @Test
+  public void testTimestampPartition() throws Exception {
+    createTable("timestamp");
+    Timestamp baseTimestamp = Timestamp.valueOf("2023-01-01 15:30:00");
+    insertData(i -> Timestamp.valueOf(baseTimestamp.toLocalDateTime().plusDays(i)));
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testTimestampNtz() throws Exception {
+    createTable("timestamp_ntz");
+    LocalDateTime baseTimestamp = Timestamp.valueOf("2023-01-01 15:30:00").toLocalDateTime();
+    insertData(baseTimestamp::plusDays);
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testBytePartition() throws Exception {
+    createTable("byte");
+    insertData(i -> i);
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testDecimalPartition() throws Exception {
+    createTable("decimal(18, 10)");
+    BigDecimal baseDecimal = new BigDecimal("1.0");
+    insertData(i -> baseDecimal.add(new BigDecimal(i)));
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testBinaryPartition() throws Exception {
+    createTable("binary");
+    insertData(i -> java.nio.ByteBuffer.allocate(4).putInt(i).array());
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testCharPartition() throws Exception {
+    createTable("char(10)");
+    insertData(Object::toString);
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testVarcharPartition() throws Exception {
+    createTable("varchar(10)");
+    insertData(Object::toString);
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testIntPartition() throws Exception {
+    createTable("int");
+    insertData(i -> i);
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testDaysPartitionTransform() throws Exception {
+    createTable("timestamp", "days(partition_col)");
+    Timestamp baseTimestamp = Timestamp.valueOf("2023-01-01 15:30:00");
+    insertData(i -> Timestamp.valueOf(baseTimestamp.toLocalDateTime().plusDays(i)));
+    testDanglingDelete();
+  }
+
+  @Test
+  public void testNullTransform() throws Exception {
+    createTable("int");
+    insertData(i -> i == 0 ? null : 1, 2);
+    testDanglingDelete(2);
+  }
+
+  private <T> void testDanglingDelete() throws Exception {
+    testDanglingDelete(NUM_DATA_FILES);
+  }
+
+  private <T> void testDanglingDelete(int numDataFiles) throws Exception {
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+
+    List<DataFile> dataFiles = dataFiles(table);
+    Assert.assertEquals(numDataFiles, dataFiles.size());
+
+    SparkActions.get(spark)
+        .rewriteDataFiles(table)
+        .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
+        .execute();
+
+    // write dangling delete files for 'old data files'
+    writePosDeletesForFiles(table, dataFiles);
+    List<DeleteFile> deleteFiles = deleteFiles(table);
+    Assert.assertEquals(numDataFiles * DELETE_FILES_PER_PARTITION, deleteFiles.size());
+
+    List<Object[]> expectedRecords = records(tableName);
+
+    Result result =
+        SparkActions.get(spark)
+            .rewritePositionDeletes(table)
+            .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
+            .execute();
+
+    List<DeleteFile> newDeleteFiles = deleteFiles(table);
+    Assert.assertEquals("Should have removed all dangling delete files", 0, newDeleteFiles.size());
+    checkResult(result, deleteFiles, Lists.newArrayList(), numDataFiles);
+
+    List<Object[]> actualRecords = records(tableName);
+    assertEquals("Rows must match", expectedRecords, actualRecords);
+  }
+
+  private void createTable(String partitionType) {
+    createTable(partitionType, "partition_col");
+  }
+
+  private void createTable(String partitionType, String partitionCol) {
+    sql(
+        "CREATE TABLE %s (id long, partition_col %s, c1 string, c2 string) "
+            + "USING iceberg "
+            + "PARTITIONED BY (%s) "
+            + "TBLPROPERTIES('format-version'='2')",
+        tableName, partitionType, partitionCol);
+  }
+
+  private <T> void insertData(Function<Integer, ?> partitionValueFunction) throws Exception {
+    insertData(partitionValueFunction, NUM_DATA_FILES);
+  }
+
+  private <T> void insertData(Function<Integer, ?> partitionValue, int numDataFiles)
+      throws Exception {
+    for (int i = 0; i < numDataFiles; i++) {
+      Dataset<Row> df =
+          spark
+              .range(0, ROWS_PER_DATA_FILE)
+              .withColumn("partition_col", lit(partitionValue.apply(i)))
+              .withColumn("c1", expr("CAST(id AS STRING)"))
+              .withColumn("c2", expr("CAST(id AS STRING)"));
+      appendAsFile(df);
+    }
+  }
+
+  private void appendAsFile(Dataset<Row> df) throws Exception {
+    // ensure the schema is precise
+    StructType sparkSchema = spark.table(tableName).schema();
+    spark.createDataFrame(df.rdd(), sparkSchema).coalesce(1).writeTo(tableName).append();
+  }
+
+  private void writePosDeletesForFiles(Table table, List<DataFile> files) throws IOException {
+
+    Map<StructLike, List<DataFile>> filesByPartition =
+        files.stream().collect(Collectors.groupingBy(ContentFile::partition));
+    List<DeleteFile> deleteFiles =
+        Lists.newArrayListWithCapacity(DELETE_FILES_PER_PARTITION * filesByPartition.size());
+
+    for (Map.Entry<StructLike, List<DataFile>> filesByPartitionEntry :
+        filesByPartition.entrySet()) {
+
+      StructLike partition = filesByPartitionEntry.getKey();
+      List<DataFile> partitionFiles = filesByPartitionEntry.getValue();
+
+      int deletesForPartition = partitionFiles.size() * DELETE_FILE_SIZE;
+      Assert.assertEquals(
+          "Number of delete files per partition should be "
+              + "evenly divisible by requested deletes per data file times number of data files in this partition",
+          0,
+          deletesForPartition % DELETE_FILE_SIZE);
+      int deleteFileSize = deletesForPartition / DELETE_FILES_PER_PARTITION;
+
+      int counter = 0;
+      List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
+      for (DataFile partitionFile : partitionFiles) {
+        for (int deletePos = 0; deletePos < DELETE_FILE_SIZE; deletePos++) {
+          deletes.add(Pair.of(partitionFile.path(), (long) deletePos));
+          counter++;
+          if (counter == deleteFileSize) {
+            // Dump to file and reset variables
+            OutputFile output = Files.localOutput(temp.newFile());
+            deleteFiles.add(writeDeleteFile(table, output, partition, deletes));
+            counter = 0;
+            deletes.clear();
+          }
+        }
+      }
+    }
+
+    RowDelta rowDelta = table.newRowDelta();
+    deleteFiles.forEach(rowDelta::addDeletes);
+    rowDelta.commit();
+  }
+
+  private DeleteFile writeDeleteFile(
+      Table table, OutputFile out, StructLike partition, List<Pair<CharSequence, Long>> deletes)
+      throws IOException {
+    FileFormat format = defaultFormat(table.properties());
+    FileAppenderFactory<Record> factory = new GenericAppenderFactory(table.schema(), table.spec());
+
+    PositionDeleteWriter<Record> writer =
+        factory.newPosDeleteWriter(encrypt(out), format, partition);
+    PositionDelete<Record> posDelete = PositionDelete.create();
+    try (Closeable toClose = writer) {
+      for (Pair<CharSequence, Long> delete : deletes) {
+        writer.write(posDelete.set(delete.first(), delete.second(), null));
+      }
+    }
+
+    return writer.toDeleteFile();
+  }
+
+  private static EncryptedOutputFile encrypt(OutputFile out) {
+    return EncryptedFiles.encryptedOutput(out, EncryptionKeyMetadata.EMPTY);
+  }
+
+  private static FileFormat defaultFormat(Map<String, String> properties) {
+    String formatString = properties.getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT);
+    return FileFormat.fromString(formatString);
+  }
+
+  private List<Object[]> records(String table) {
+    return rowsToJava(
+        spark.read().format("iceberg").load(table).sort("partition_col", "id").collectAsList());
+  }
+
+  private long size(List<DeleteFile> deleteFiles) {
+    return deleteFiles.stream().mapToLong(DeleteFile::fileSizeInBytes).sum();
+  }
+
+  private List<DataFile> dataFiles(Table table) {
+    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+    return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
+  }
+
+  private List<DeleteFile> deleteFiles(Table table) {
+    Table deletesTable =
+        MetadataTableUtils.createMetadataTableInstance(table, MetadataTableType.POSITION_DELETES);
+    CloseableIterable<ScanTask> tasks = deletesTable.newBatchScan().planFiles();
+    return Lists.newArrayList(
+        CloseableIterable.transform(tasks, t -> ((PositionDeletesScanTask) t).file()));
+  }
+
+  private void checkResult(
+      Result result,
+      List<DeleteFile> rewrittenDeletes,
+      List<DeleteFile> newDeletes,
+      int expectedGroups) {
+    Assert.assertEquals(
+        "Expected rewritten delete file count does not match",
+        rewrittenDeletes.size(),
+        result.rewrittenDeleteFilesCount());
+    Assert.assertEquals(
+        "Expected new delete file count does not match",
+        newDeletes.size(),
+        result.addedDeleteFilesCount());
+    Assert.assertEquals(
+        "Expected rewritten delete byte count does not match",
+        size(rewrittenDeletes),
+        result.rewrittenBytesCount());
+    Assert.assertEquals(
+        "Expected new delete byte count does not match",
+        size(newDeletes),
+        result.addedBytesCount());
+
+    Assert.assertEquals(
+        "Expected rewrite group count does not match",
+        expectedGroups,
+        result.rewriteResults().size());
+    Assert.assertEquals(
+        "Expected rewritten delete file count in all groups to match",
+        rewrittenDeletes.size(),
+        result.rewriteResults().stream()
+            .mapToInt(FileGroupRewriteResult::rewrittenDeleteFilesCount)
+            .sum());
+    Assert.assertEquals(
+        "Expected added delete file count in all groups to match",
+        newDeletes.size(),
+        result.rewriteResults().stream()
+            .mapToInt(FileGroupRewriteResult::addedDeleteFilesCount)
+            .sum());
+    Assert.assertEquals(
+        "Expected rewritten delete bytes in all groups to match",
+        size(rewrittenDeletes),
+        result.rewriteResults().stream()
+            .mapToLong(FileGroupRewriteResult::rewrittenBytesCount)
+            .sum());
+    Assert.assertEquals(
+        "Expected added delete bytes in all groups to match",
+        size(newDeletes),
+        result.rewriteResults().stream().mapToLong(FileGroupRewriteResult::addedBytesCount).sum());
+  }
+}

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.TableMigrationUtil;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.hadoop.Util;
@@ -664,6 +665,43 @@ public class SparkTableUtil {
     CaseInsensitiveStringMap options = new CaseInsensitiveStringMap(extraOptions);
     return Dataset.ofRows(
         spark, DataSourceV2Relation.create(metadataTable, Some.empty(), Some.empty(), options));
+  }
+
+  /**
+   * Determine the write branch.
+   *
+   * <p>Validate wap config and determine the write branch.
+   *
+   * @param spark a Spark Session
+   * @param branch write branch if there is no WAP branch configured
+   * @return branch for write operation
+   */
+  public static String determineWriteBranch(SparkSession spark, String branch) {
+    String wapId = spark.conf().get(SparkSQLProperties.WAP_ID, null);
+    String wapBranch = spark.conf().get(SparkSQLProperties.WAP_BRANCH, null);
+    ValidationException.check(
+        wapId == null || wapBranch == null,
+        "Cannot set both WAP ID and branch, but got ID [%s] and branch [%s]",
+        wapId,
+        wapBranch);
+
+    if (wapBranch != null) {
+      ValidationException.check(
+          branch == null,
+          "Cannot write to both branch and WAP branch, but got branch [%s] and WAP branch [%s]",
+          branch,
+          wapBranch);
+
+      return wapBranch;
+    }
+    return branch;
+  }
+
+  public static boolean wapEnabled(Table table) {
+    return PropertyUtil.propertyAsBoolean(
+        table.properties(),
+        TableProperties.WRITE_AUDIT_PUBLISH_ENABLED,
+        Boolean.getBoolean(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT));
   }
 
   /** Class representing a table partition. */

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackPositionDeletesRewriter.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackPositionDeletesRewriter.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.MetadataTableType.POSITION_DELETES;
 import static org.apache.spark.sql.functions.col;
+import static org.apache.spark.sql.functions.lit;
 
 import java.util.List;
 import java.util.Optional;
@@ -40,7 +41,9 @@ import org.apache.iceberg.spark.ScanTaskSetManager;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkTableCache;
 import org.apache.iceberg.spark.SparkTableUtil;
+import org.apache.iceberg.spark.SparkValueConverter;
 import org.apache.iceberg.spark.SparkWriteOptions;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
@@ -125,10 +128,11 @@ class SparkBinPackPositionDeletesRewriter extends SizeBasedPositionDeletesRewrit
         IntStream.range(0, fields.size())
             .mapToObj(
                 i -> {
-                  Class<?> type = fields.get(i).type().typeId().javaClass();
-                  Object value = partition.get(i, type);
+                  Type type = fields.get(i).type();
+                  Object value = partition.get(i, type.typeId().javaClass());
+                  Object convertedValue = SparkValueConverter.convertToSpark(type, value);
                   Column col = col("partition." + fields.get(i).name());
-                  return col.equalTo(value);
+                  return col.eqNullSafe(lit(convertedValue));
                 })
             .reduce(Column::and);
     if (condition.isPresent()) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -56,6 +56,7 @@ import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkFilters;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
@@ -370,6 +371,10 @@ public class SparkTable
             .newDelete()
             .set("spark.app.id", sparkSession().sparkContext().applicationId())
             .deleteFromRowFilter(deleteExpr);
+
+    if (SparkTableUtil.wapEnabled(table())) {
+      branch = SparkTableUtil.determineWriteBranch(sparkSession(), branch);
+    }
 
     if (branch != null) {
       deleteFiles.toBranch(branch);


### PR DESCRIPTION
Backport https://github.com/apache/iceberg/pull/6309 to Spark 3.2.