### PR TITLE
Migrate Scan, Schema and remaining Partition files in Core to JUnit5

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestScanSummary.java
+++ b/core/src/test/java/org/apache/iceberg/TestScanSummary.java
@@ -25,28 +25,24 @@ import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Arrays;
+import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.Pair;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestScanSummary extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestScanSummary extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestScanSummary(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testSnapshotTimeRangeValidation() {
     long t0 = System.currentTimeMillis();
 
@@ -76,12 +72,8 @@ public class TestScanSummary extends TableTestBase {
     // expire the first snapshot
     table.expireSnapshots().expireOlderThan(t1).commit();
 
-    Assert.assertEquals(
-        "Should have one snapshot", 1, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertEquals(
-        "Snapshot should be the second snapshot created",
-        secondSnapshotId,
-        table.currentSnapshot().snapshotId());
+    assertThat(table.snapshots()).hasSize(1);
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(secondSnapshotId);
 
     // this should include the first snapshot, but it was removed from the dataset
     TableScan scan =
@@ -90,63 +82,56 @@ public class TestScanSummary extends TableTestBase {
             .filter(greaterThanOrEqual("dateCreated", t0))
             .filter(lessThan("dateCreated", t2));
 
-    Assertions.assertThatThrownBy(() -> new ScanSummary.Builder(scan).build())
+    assertThatThrownBy(() -> new ScanSummary.Builder(scan).build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot satisfy time filters: time range may include expired snapshots");
   }
 
-  @Test
+  @TestTemplate
   public void testTimestampRanges() {
     long lower = 1542750188523L;
     long upper = 1542750695131L;
 
-    Assert.assertEquals(
-        "Should use inclusive bound",
-        Pair.of(Long.MIN_VALUE, upper),
-        timestampRange(ImmutableList.of(lessThanOrEqual("ts_ms", upper))));
+    assertThat(timestampRange(ImmutableList.of(lessThanOrEqual("ts_ms", upper))))
+        .isEqualTo(Pair.of(Long.MIN_VALUE, upper));
 
-    Assert.assertEquals(
-        "Should use lower value for upper bound",
-        Pair.of(Long.MIN_VALUE, upper),
-        timestampRange(
-            ImmutableList.of(
-                lessThanOrEqual("ts_ms", upper + 918234), lessThanOrEqual("ts_ms", upper))));
+    assertThat(
+            timestampRange(
+                ImmutableList.of(
+                    lessThanOrEqual("ts_ms", upper + 918234), lessThanOrEqual("ts_ms", upper))))
+        .as("Should use lower value for upper bound")
+        .isEqualTo(Pair.of(Long.MIN_VALUE, upper));
 
-    Assert.assertEquals(
-        "Should make upper bound inclusive",
-        Pair.of(Long.MIN_VALUE, upper - 1),
-        timestampRange(ImmutableList.of(lessThan("ts_ms", upper))));
+    assertThat(timestampRange(ImmutableList.of(lessThan("ts_ms", upper))))
+        .as("Should make upper bound inclusive")
+        .isEqualTo(Pair.of(Long.MIN_VALUE, upper - 1));
 
-    Assert.assertEquals(
-        "Should use inclusive bound",
-        Pair.of(lower, Long.MAX_VALUE),
-        timestampRange(ImmutableList.of(greaterThanOrEqual("ts_ms", lower))));
+    assertThat(timestampRange(ImmutableList.of(greaterThanOrEqual("ts_ms", lower))))
+        .isEqualTo(Pair.of(lower, Long.MAX_VALUE));
 
-    Assert.assertEquals(
-        "Should use upper value for lower bound",
-        Pair.of(lower, Long.MAX_VALUE),
-        timestampRange(
-            ImmutableList.of(
-                greaterThanOrEqual("ts_ms", lower - 918234), greaterThanOrEqual("ts_ms", lower))));
+    assertThat(
+            timestampRange(
+                ImmutableList.of(
+                    greaterThanOrEqual("ts_ms", lower - 918234),
+                    greaterThanOrEqual("ts_ms", lower))))
+        .as("Should use upper value for lower bound")
+        .isEqualTo(Pair.of(lower, Long.MAX_VALUE));
 
-    Assert.assertEquals(
-        "Should make lower bound inclusive",
-        Pair.of(lower + 1, Long.MAX_VALUE),
-        timestampRange(ImmutableList.of(greaterThan("ts_ms", lower))));
+    assertThat(timestampRange(ImmutableList.of(greaterThan("ts_ms", lower))))
+        .as("Should make lower bound inclusive")
+        .isEqualTo(Pair.of(lower + 1, Long.MAX_VALUE));
 
-    Assert.assertEquals(
-        "Should set both bounds for equals",
-        Pair.of(lower, lower),
-        timestampRange(ImmutableList.of(equal("ts_ms", lower))));
+    assertThat(timestampRange(ImmutableList.of(equal("ts_ms", lower))))
+        .isEqualTo(Pair.of(lower, lower));
 
-    Assert.assertEquals(
-        "Should set both bounds",
-        Pair.of(lower, upper - 1),
-        timestampRange(
-            ImmutableList.of(greaterThanOrEqual("ts_ms", lower), lessThan("ts_ms", upper))));
+    assertThat(
+            timestampRange(
+                ImmutableList.of(greaterThanOrEqual("ts_ms", lower), lessThan("ts_ms", upper))))
+        .as("Should set both bounds and make upper bound inclusive")
+        .isEqualTo(Pair.of(lower, upper - 1));
 
     // >= lower and < lower is an empty range
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 timestampRange(
                     ImmutableList.of(greaterThanOrEqual("ts_ms", lower), lessThan("ts_ms", lower))))
@@ -154,11 +139,11 @@ public class TestScanSummary extends TableTestBase {
         .hasMessageStartingWith("No timestamps can match filters");
   }
 
-  @Test
+  @TestTemplate
   public void testToMillis() {
     long millis = 1542750947417L;
-    Assert.assertEquals(1542750947000L, toMillis(millis / 1000));
-    Assert.assertEquals(1542750947417L, toMillis(millis));
-    Assert.assertEquals(1542750947417L, toMillis(millis * 1000 + 918));
+    assertThat(toMillis(millis / 1000)).isEqualTo(1542750947000L);
+    assertThat(toMillis(millis)).isEqualTo(1542750947417L);
+    assertThat(toMillis(millis * 1000 + 918)).isEqualTo(1542750947417L);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaAndMappingUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaAndMappingUpdate.java
@@ -19,7 +19,11 @@
 package org.apache.iceberg;
 
 import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -32,24 +36,17 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestSchemaAndMappingUpdate extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSchemaAndMappingUpdate extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestSchemaAndMappingUpdate(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testAddPrimitiveColumn() {
     NameMapping mapping = MappingUtil.create(table.schema());
     String mappingJson = NameMappingParser.toJson(mapping);
@@ -64,15 +61,12 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
     validateUnchanged(mapping, updated);
 
     MappedField newMapping = updated.find("count");
-    Assert.assertNotNull("Mapping for new column should be added", newMapping);
-    Assert.assertEquals(
-        "Mapping should use the assigned field ID",
-        (Integer) table.schema().findField("count").fieldId(),
-        updated.find("count").id());
-    Assert.assertNull("Should not contain a nested mapping", updated.find("count").nestedMapping());
+    assertThat(newMapping).isNotNull();
+    assertThat(updated.find("count").id()).isEqualTo(table.schema().findField("count").fieldId());
+    assertThat(updated.find("count").nestedMapping()).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testAddStructColumn() {
     NameMapping mapping = MappingUtil.create(table.schema());
     String mappingJson = NameMappingParser.toJson(mapping);
@@ -94,31 +88,22 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
     validateUnchanged(mapping, updated);
 
     MappedField newMapping = updated.find("location");
-    Assert.assertNotNull("Mapping for new column should be added", newMapping);
+    assertThat(newMapping).isNotNull();
 
-    Assert.assertEquals(
-        "Mapping should use the assigned field ID",
-        (Integer) table.schema().findField("location").fieldId(),
-        updated.find("location").id());
-    Assert.assertNotNull(
-        "Should contain a nested mapping", updated.find("location").nestedMapping());
+    assertThat(updated.find("location").id())
+        .isEqualTo(table.schema().findField("location").fieldId());
+    assertThat(updated.find("location").nestedMapping()).isNotNull();
 
-    Assert.assertEquals(
-        "Mapping should use the assigned field ID",
-        (Integer) table.schema().findField("location.lat").fieldId(),
-        updated.find("location.lat").id());
-    Assert.assertNull(
-        "Should not contain a nested mapping", updated.find("location.lat").nestedMapping());
+    assertThat(updated.find("location.lat").id())
+        .isEqualTo(table.schema().findField("location.lat").fieldId());
+    assertThat(updated.find("location.lat").nestedMapping()).isNull();
 
-    Assert.assertEquals(
-        "Mapping should use the assigned field ID",
-        (Integer) table.schema().findField("location.long").fieldId(),
-        updated.find("location.long").id());
-    Assert.assertNull(
-        "Should not contain a nested mapping", updated.find("location.long").nestedMapping());
+    assertThat(updated.find("location.long").id())
+        .isEqualTo(table.schema().findField("location.long").fieldId());
+    assertThat(updated.find("location.long").nestedMapping()).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testRenameColumn() {
     NameMapping mapping = MappingUtil.create(table.schema());
     String mappingJson = NameMappingParser.toJson(mapping);
@@ -137,14 +122,12 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
         updated);
 
     MappedField updatedMapping = updated.find(idColumnId);
-    Assert.assertNotNull("Mapping for id column should exist", updatedMapping);
-    Assert.assertEquals(
-        "Should add the new column name to the existing mapping",
-        MappedField.of(idColumnId, ImmutableList.of("id", "object_id")),
-        updatedMapping);
+    assertThat(updatedMapping)
+        .isNotNull()
+        .isEqualTo(MappedField.of(idColumnId, ImmutableList.of("id", "object_id")));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteColumn() {
     NameMapping mapping = MappingUtil.create(table.schema());
     String mappingJson = NameMappingParser.toJson(mapping);
@@ -160,7 +143,7 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
     validateUnchanged(mapping, updated);
   }
 
-  @Test
+  @TestTemplate
   public void testModificationWithMetricsMetrics() {
     NameMapping mapping = MappingUtil.create(table.schema());
     String mappingJson = NameMappingParser.toJson(mapping);
@@ -171,7 +154,7 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
         .set("write.metadata.metrics.column.id", "full")
         .commit();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .updateProperties()
@@ -184,25 +167,19 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
 
     // Re-naming a column with metrics succeeds;
     table.updateSchema().renameColumn("id", "bloop").commit();
-    Assert.assertNotNull(
-        "Make sure the metrics config now has bloop",
-        table.properties().get(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "bloop"));
-    Assert.assertNull(
-        "Make sure the metrics config no longer has id",
-        table.properties().get(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "id"));
+    assertThat(table.properties())
+        .containsEntry(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "bloop", "full")
+        .doesNotContainKey(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "id");
 
     // Deleting a column with metrics succeeds
     table.updateSchema().deleteColumn("bloop").commit();
     // Make sure no more reference to bloop in the metrics config
-    Assert.assertNull(
-        "Make sure the metrics config no longer has id",
-        table.properties().get(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "id"));
-    Assert.assertNull(
-        "Make sure the metrics config no longer has bloop",
-        table.properties().get(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "bloop"));
+    assertThat(table.properties())
+        .doesNotContainKey(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "id")
+        .doesNotContainKey(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "bloop");
   }
 
-  @Test
+  @TestTemplate
   public void testModificationWithParquetBloomConfig() {
     table
         .updateProperties()
@@ -210,20 +187,17 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
         .commit();
 
     table.updateSchema().renameColumn("id", "ID").commit();
-    Assert.assertNotNull(
-        "Parquet bloom config for new column name ID should exists",
-        table.properties().get(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "ID"));
-    Assert.assertNull(
-        "Parquet bloom config for old column name id should not exists",
-        table.properties().get(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id"));
+    assertThat(table.properties())
+        .containsEntry(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "ID", "true")
+        .doesNotContainKey(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id");
 
     table.updateSchema().deleteColumn("ID").commit();
-    Assert.assertNull(
-        "Parquet bloom config for dropped column name ID should not exists",
-        table.properties().get(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "ID"));
+    assertThat(table.properties())
+        .doesNotContainKey(
+            table.properties().get(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "ID"));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteAndAddColumnReassign() {
     NameMapping mapping = MappingUtil.create(table.schema());
     String mappingJson = NameMappingParser.toJson(mapping);
@@ -248,20 +222,18 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
         updated);
 
     MappedField newMapping = updated.find("id");
-    Assert.assertNotNull("Mapping for id column should exist", newMapping);
-    Assert.assertEquals(
-        "Mapping should use the new field ID", (Integer) idColumnId, newMapping.id());
-    Assert.assertNull("Should not contain a nested mapping", newMapping.nestedMapping());
+    assertThat(newMapping).isNotNull();
+    assertThat(newMapping.id()).isEqualTo(idColumnId);
+    assertThat(newMapping.nestedMapping()).isNull();
 
     MappedField updatedMapping = updated.find(startIdColumnId);
-    Assert.assertNotNull("Mapping for original id column should exist", updatedMapping);
-    Assert.assertEquals(
-        "Mapping should use the original field ID", (Integer) startIdColumnId, updatedMapping.id());
-    Assert.assertFalse("Should not use id as a name", updatedMapping.names().contains("id"));
-    Assert.assertNull("Should not contain a nested mapping", updatedMapping.nestedMapping());
+    assertThat(updatedMapping).isNotNull();
+    assertThat(updatedMapping.id()).isEqualTo(startIdColumnId);
+    assertThat(updatedMapping.names()).doesNotContain("id");
+    assertThat(updatedMapping.nestedMapping()).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteAndRenameColumnReassign() {
     NameMapping mapping = MappingUtil.create(table.schema());
     String mappingJson = NameMappingParser.toJson(mapping);
@@ -286,22 +258,19 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
         updated);
 
     MappedField newMapping = updated.find("id");
-    Assert.assertNotNull("Mapping for id column should exist", newMapping);
-    Assert.assertEquals(
-        "Mapping should use the new field ID", (Integer) idColumnId, newMapping.id());
-    Assert.assertEquals(
-        "Should have both names", Sets.newHashSet("id", "data"), newMapping.names());
-    Assert.assertNull("Should not contain a nested mapping", newMapping.nestedMapping());
+    assertThat(newMapping).isNotNull();
+    assertThat(newMapping.id()).isEqualTo(idColumnId);
+    assertThat(newMapping.names()).isEqualTo(Sets.newHashSet("id", "data"));
+    assertThat(newMapping.nestedMapping()).isNull();
 
     MappedField updatedMapping = updated.find(startIdColumnId);
-    Assert.assertNotNull("Mapping for original id column should exist", updatedMapping);
-    Assert.assertEquals(
-        "Mapping should use the original field ID", (Integer) startIdColumnId, updatedMapping.id());
-    Assert.assertFalse("Should not use id as a name", updatedMapping.names().contains("id"));
-    Assert.assertNull("Should not contain a nested mapping", updatedMapping.nestedMapping());
+    assertThat(updatedMapping).isNotNull();
+    assertThat(updatedMapping.id()).isEqualTo(startIdColumnId);
+    assertThat(updatedMapping.names()).doesNotContain("id");
+    assertThat(updatedMapping.nestedMapping()).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testRenameAndAddColumnReassign() {
     NameMapping mapping = MappingUtil.create(table.schema());
     String mappingJson = NameMappingParser.toJson(mapping);
@@ -314,10 +283,8 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
 
     NameMapping afterRename =
         NameMappingParser.fromJson(table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
-    Assert.assertEquals(
-        "Renamed column should have both names",
-        Sets.newHashSet("id", "object_id"),
-        afterRename.find(startIdColumnId).names());
+    assertThat(afterRename.find(startIdColumnId).names())
+        .isEqualTo(Sets.newHashSet("id", "object_id"));
 
     // add a new column with the renamed column's old name
     // also, rename the original column again to ensure its names are handled correctly
@@ -338,21 +305,18 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
         updated);
 
     MappedField newMapping = updated.find("id");
-    Assert.assertNotNull("Mapping for id column should exist", newMapping);
-    Assert.assertEquals(
-        "Mapping should use the new field ID", (Integer) idColumnId, newMapping.id());
-    Assert.assertNull("Should not contain a nested mapping", newMapping.nestedMapping());
+    assertThat(newMapping).isNotNull();
+    assertThat(newMapping.id()).isEqualTo(idColumnId);
+    assertThat(newMapping.nestedMapping()).isNull();
 
     MappedField updatedMapping = updated.find(startIdColumnId);
-    Assert.assertNotNull("Mapping for original id column should exist", updatedMapping);
-    Assert.assertEquals(
-        "Mapping should use the original field ID", (Integer) startIdColumnId, updatedMapping.id());
-    Assert.assertEquals(
-        "Should not use id as a name", Sets.newHashSet("object_id", "oid"), updatedMapping.names());
-    Assert.assertNull("Should not contain a nested mapping", updatedMapping.nestedMapping());
+    assertThat(updatedMapping).isNotNull();
+    assertThat(updatedMapping.id()).isEqualTo(startIdColumnId);
+    assertThat(updatedMapping.names()).isEqualTo(Sets.newHashSet("object_id", "oid"));
+    assertThat(updatedMapping.nestedMapping()).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testRenameAndRenameColumnReassign() {
     NameMapping mapping = MappingUtil.create(table.schema());
     String mappingJson = NameMappingParser.toJson(mapping);
@@ -365,10 +329,8 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
 
     NameMapping afterRename =
         NameMappingParser.fromJson(table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
-    Assert.assertEquals(
-        "Renamed column should have both names",
-        Sets.newHashSet("id", "object_id"),
-        afterRename.find(startIdColumnId).names());
+    assertThat(afterRename.find(startIdColumnId).names())
+        .isEqualTo(Sets.newHashSet("id", "object_id"));
 
     // rename the data column to the renamed column's old name
     // also, rename the original column again to ensure its names are handled correctly
@@ -385,28 +347,23 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
         updated);
 
     MappedField newMapping = updated.find("id");
-    Assert.assertNotNull("Mapping for id column should exist", newMapping);
-    Assert.assertEquals(
-        "Renamed column should have both names", Sets.newHashSet("id", "data"), newMapping.names());
-    Assert.assertEquals(
-        "Mapping should use the new field ID", (Integer) idColumnId, newMapping.id());
-    Assert.assertNull("Should not contain a nested mapping", newMapping.nestedMapping());
+    assertThat(newMapping).isNotNull();
+    assertThat(newMapping.names()).isEqualTo(Sets.newHashSet("id", "data"));
+    assertThat(newMapping.id()).isEqualTo(idColumnId);
+    assertThat(newMapping.nestedMapping()).isNull();
 
     MappedField updatedMapping = updated.find(startIdColumnId);
-    Assert.assertNotNull("Mapping for original id column should exist", updatedMapping);
-    Assert.assertEquals(
-        "Mapping should use the original field ID", (Integer) startIdColumnId, updatedMapping.id());
-    Assert.assertEquals(
-        "Should not use id as a name", Sets.newHashSet("object_id", "oid"), updatedMapping.names());
-    Assert.assertNull("Should not contain a nested mapping", updatedMapping.nestedMapping());
+    assertThat(updatedMapping).isNotNull();
+    assertThat(updatedMapping.id()).isEqualTo(startIdColumnId);
+    assertThat(updatedMapping.names()).isEqualTo(Sets.newHashSet("object_id", "oid"));
+    assertThat(updatedMapping.nestedMapping()).isNull();
   }
 
   /** Asserts that the fields in the original mapping are unchanged in the updated mapping. */
   private void validateUnchanged(NameMapping original, NameMapping updated) {
     MappedFields updatedFields = updated.asMappedFields();
     for (MappedField field : original.asMappedFields().fields()) {
-      Assert.assertEquals(
-          "Existing fields should not change", field, updatedFields.field(field.id()));
+      assertThat(updatedFields.field(field.id())).isEqualTo(field);
     }
   }
 
@@ -414,8 +371,7 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
   private void validateUnchanged(Iterable<MappedField> fields, NameMapping updated) {
     MappedFields updatedFields = updated.asMappedFields();
     for (MappedField field : fields) {
-      Assert.assertEquals(
-          "Existing fields should not change", field, updatedFields.field(field.id()));
+      assertThat(updatedFields.field(field.id())).isEqualTo(field);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaID.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaID.java
@@ -20,32 +20,26 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestSchemaID extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSchemaID extends TestBase {
 
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestSchemaID(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testNoChange() {
     int onlyId = table.schema().schemaId();
     Map<Integer, Schema> onlySchemaMap = schemaMap(table.schema());
@@ -54,46 +48,30 @@ public class TestSchemaID extends TableTestBase {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     TestHelpers.assertSameSchemaMap(onlySchemaMap, table.schemas());
-    Assert.assertEquals(
-        "Current snapshot's schemaId should be the current",
-        table.schema().schemaId(),
-        (int) table.currentSnapshot().schemaId());
+    assertThat(table.currentSnapshot().schemaId()).isEqualTo(table.schema().schemaId());
 
-    Assert.assertEquals(
-        "Schema ids should be correct in snapshots",
-        ImmutableList.of(onlyId),
-        Lists.transform(Lists.newArrayList(table.snapshots()), Snapshot::schemaId));
+    assertThat(table.snapshots()).extracting(Snapshot::schemaId).containsExactly(onlyId);
 
     // remove file from table
     table.newDelete().deleteFile(FILE_A).commit();
 
     TestHelpers.assertSameSchemaMap(onlySchemaMap, table.schemas());
-    Assert.assertEquals(
-        "Current snapshot's schemaId should be the current",
-        table.schema().schemaId(),
-        (int) table.currentSnapshot().schemaId());
+    assertThat(table.currentSnapshot().schemaId()).isEqualTo(table.schema().schemaId());
 
-    Assert.assertEquals(
-        "Schema ids should be correct in snapshots",
-        ImmutableList.of(onlyId, onlyId),
-        Lists.transform(Lists.newArrayList(table.snapshots()), Snapshot::schemaId));
+    assertThat(table.snapshots()).extracting(Snapshot::schemaId).containsExactly(onlyId, onlyId);
 
     // add file to table
     table.newFastAppend().appendFile(FILE_A2).commit();
 
     TestHelpers.assertSameSchemaMap(onlySchemaMap, table.schemas());
-    Assert.assertEquals(
-        "Current snapshot's schemaId should be the current",
-        table.schema().schemaId(),
-        (int) table.currentSnapshot().schemaId());
+    assertThat(table.currentSnapshot().schemaId()).isEqualTo(table.schema().schemaId());
 
-    Assert.assertEquals(
-        "Schema ids should be correct in snapshots",
-        ImmutableList.of(onlyId, onlyId, onlyId),
-        Lists.transform(Lists.newArrayList(table.snapshots()), Snapshot::schemaId));
+    assertThat(table.snapshots())
+        .extracting(Snapshot::schemaId)
+        .containsExactly(onlyId, onlyId, onlyId);
   }
 
-  @Test
+  @TestTemplate
   public void testSchemaIdChangeInSchemaUpdate() {
     Schema originalSchema = table.schema();
 
@@ -101,15 +79,11 @@ public class TestSchemaID extends TableTestBase {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     TestHelpers.assertSameSchemaMap(schemaMap(table.schema()), table.schemas());
-    Assert.assertEquals(
-        "Current snapshot's schemaId should be the current",
-        table.schema().schemaId(),
-        (int) table.currentSnapshot().schemaId());
+    assertThat(table.currentSnapshot().schemaId()).isEqualTo(table.schema().schemaId());
 
-    Assert.assertEquals(
-        "Schema ids should be correct in snapshots",
-        ImmutableList.of(originalSchema.schemaId()),
-        Lists.transform(Lists.newArrayList(table.snapshots()), Snapshot::schemaId));
+    assertThat(table.snapshots())
+        .extracting(Snapshot::schemaId)
+        .containsExactly(originalSchema.schemaId());
 
     // update schema
     table.updateSchema().addColumn("data2", Types.StringType.get()).commit();
@@ -122,50 +96,37 @@ public class TestSchemaID extends TableTestBase {
             optional(3, "data2", Types.StringType.get()));
 
     TestHelpers.assertSameSchemaMap(schemaMap(originalSchema, updatedSchema), table.schemas());
-    Assert.assertEquals(
-        "Current snapshot's schemaId should be old since update schema doesn't create new snapshot",
-        originalSchema.schemaId(),
-        (int) table.currentSnapshot().schemaId());
-    Assert.assertEquals(
-        "Current schema should match", updatedSchema.asStruct(), table.schema().asStruct());
+    assertThat(table.currentSnapshot().schemaId())
+        .as(
+            "Current snapshot's schemaId should be old since update schema doesn't create new snapshot")
+        .isEqualTo(originalSchema.schemaId());
+    assertThat(table.schema().asStruct()).isEqualTo(updatedSchema.asStruct());
 
-    Assert.assertEquals(
-        "Schema ids should be correct in snapshots",
-        ImmutableList.of(originalSchema.schemaId()),
-        Lists.transform(Lists.newArrayList(table.snapshots()), Snapshot::schemaId));
+    assertThat(table.snapshots())
+        .extracting(Snapshot::schemaId)
+        .containsExactly(originalSchema.schemaId());
 
     // remove file from table
     table.newDelete().deleteFile(FILE_A).commit();
 
     TestHelpers.assertSameSchemaMap(schemaMap(originalSchema, updatedSchema), table.schemas());
-    Assert.assertEquals(
-        "Current snapshot's schemaId should be the current",
-        updatedSchema.schemaId(),
-        (int) table.currentSnapshot().schemaId());
-    Assert.assertEquals(
-        "Current schema should match", updatedSchema.asStruct(), table.schema().asStruct());
+    assertThat(table.currentSnapshot().schemaId()).isEqualTo(updatedSchema.schemaId());
+    assertThat(table.schema().asStruct()).isEqualTo(updatedSchema.asStruct());
 
-    Assert.assertEquals(
-        "Schema ids should be correct in snapshots",
-        ImmutableList.of(originalSchema.schemaId(), updatedSchema.schemaId()),
-        Lists.transform(Lists.newArrayList(table.snapshots()), Snapshot::schemaId));
-
+    assertThat(table.snapshots())
+        .extracting(Snapshot::schemaId)
+        .containsExactly(originalSchema.schemaId(), updatedSchema.schemaId());
     // add files to table
     table.newAppend().appendFile(FILE_A2).commit();
 
     TestHelpers.assertSameSchemaMap(schemaMap(originalSchema, updatedSchema), table.schemas());
-    Assert.assertEquals(
-        "Current snapshot's schemaId should be the current",
-        updatedSchema.schemaId(),
-        (int) table.currentSnapshot().schemaId());
-    Assert.assertEquals(
-        "Current schema should match", updatedSchema.asStruct(), table.schema().asStruct());
+    assertThat(table.currentSnapshot().schemaId()).isEqualTo(updatedSchema.schemaId());
+    assertThat(table.schema().asStruct()).isEqualTo(updatedSchema.asStruct());
 
-    Assert.assertEquals(
-        "Schema ids should be correct in snapshots",
-        ImmutableList.of(
-            originalSchema.schemaId(), updatedSchema.schemaId(), updatedSchema.schemaId()),
-        Lists.transform(Lists.newArrayList(table.snapshots()), Snapshot::schemaId));
+    assertThat(table.snapshots())
+        .extracting(Snapshot::schemaId)
+        .containsExactly(
+            originalSchema.schemaId(), updatedSchema.schemaId(), updatedSchema.schemaId());
   }
 
   private Map<Integer, Schema> schemaMap(Schema... schemas) {

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -20,6 +20,8 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Set;
@@ -30,9 +32,7 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSchemaUpdate {
   private static final Schema SCHEMA =
@@ -84,7 +84,7 @@ public class TestSchemaUpdate {
   @Test
   public void testNoChanges() {
     Schema identical = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID).apply();
-    Assert.assertEquals("Should not include any changes", SCHEMA.asStruct(), identical.asStruct());
+    assertThat(identical.asStruct()).isEqualTo(SCHEMA.asStruct());
   }
 
   @Test
@@ -114,10 +114,7 @@ public class TestSchemaUpdate {
 
       Schema del = new SchemaUpdate(SCHEMA, 19).deleteColumn(name).apply();
 
-      Assert.assertEquals(
-          "Should match projection with '" + name + "' removed",
-          TypeUtil.project(SCHEMA, selected).asStruct(),
-          del.asStruct());
+      assertThat(del.asStruct()).isEqualTo(TypeUtil.project(SCHEMA, selected).asStruct());
     }
   }
 
@@ -148,10 +145,7 @@ public class TestSchemaUpdate {
 
       Schema del = new SchemaUpdate(SCHEMA, 19).caseSensitive(false).deleteColumn(name).apply();
 
-      Assert.assertEquals(
-          "Should match projection with '" + name + "' removed",
-          TypeUtil.project(SCHEMA, selected).asStruct(),
-          del.asStruct());
+      assertThat(del.asStruct()).isEqualTo(TypeUtil.project(SCHEMA, selected).asStruct());
     }
   }
 
@@ -206,7 +200,7 @@ public class TestSchemaUpdate {
             .updateColumn("locations.long", Types.DoubleType.get())
             .apply();
 
-    Assert.assertEquals("Should convert types", expected, updated.asStruct());
+    assertThat(updated.asStruct()).isEqualTo(expected);
   }
 
   @Test
@@ -261,7 +255,7 @@ public class TestSchemaUpdate {
             .updateColumn("Locations.Long", Types.DoubleType.get())
             .apply();
 
-    Assert.assertEquals("Should convert types", expected, updated.asStruct());
+    assertThat(updated.asStruct()).isEqualTo(expected);
   }
 
   @Test
@@ -299,13 +293,12 @@ public class TestSchemaUpdate {
         if (fromType.equals(toType) || allowedUpdates.contains(Pair.of(fromType, toType))) {
           Schema expected = new Schema(required(1, "col", toType));
           Schema result = new SchemaUpdate(fromSchema, 1).updateColumn("col", toType).apply();
-          Assert.assertEquals("Should allow update", expected.asStruct(), result.asStruct());
+          assertThat(result.asStruct()).isEqualTo(expected.asStruct());
           continue;
         }
 
         String typeChange = fromType + " -> " + toType.toString();
-        Assertions.assertThatThrownBy(
-                () -> new SchemaUpdate(fromSchema, 1).updateColumn("col", toType))
+        assertThatThrownBy(() -> new SchemaUpdate(fromSchema, 1).updateColumn("col", toType))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Cannot change column type: col: " + typeChange);
       }
@@ -366,7 +359,7 @@ public class TestSchemaUpdate {
             .renameColumn("points.y", "y.y") // has a '.' in the field name
             .apply();
 
-    Assert.assertEquals("Should rename all fields", expected, renamed.asStruct());
+    assertThat(renamed.asStruct()).isEqualTo(expected);
   }
 
   @Test
@@ -424,7 +417,7 @@ public class TestSchemaUpdate {
             .renameColumn("Points.y", "y.y") // has a '.' in the field name
             .apply();
 
-    Assert.assertEquals("Should rename all fields", expected, renamed.asStruct());
+    assertThat(renamed.asStruct()).isEqualTo(expected);
   }
 
   @Test
@@ -483,7 +476,7 @@ public class TestSchemaUpdate {
             .addColumn("points", "t.t", Types.LongType.get()) // name with '.'
             .apply();
 
-    Assert.assertEquals("Should match with added fields", expected.asStruct(), added.asStruct());
+    assertThat(added.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -506,8 +499,7 @@ public class TestSchemaUpdate {
 
     Schema result = new SchemaUpdate(schema, 1).addColumn("location", struct).apply();
 
-    Assert.assertEquals(
-        "Should add struct and reassign column IDs", expected.asStruct(), result.asStruct());
+    assertThat(result.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -546,8 +538,7 @@ public class TestSchemaUpdate {
 
     Schema result = new SchemaUpdate(schema, 1).addColumn("locations", map).apply();
 
-    Assert.assertEquals(
-        "Should add map and reassign column IDs", expected.asStruct(), result.asStruct());
+    assertThat(result.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -574,8 +565,7 @@ public class TestSchemaUpdate {
 
     Schema result = new SchemaUpdate(schema, 1).addColumn("locations", list).apply();
 
-    Assert.assertEquals(
-        "Should add map and reassign column IDs", expected.asStruct(), result.asStruct());
+    assertThat(result.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -586,7 +576,7 @@ public class TestSchemaUpdate {
             required(1, "id", Types.IntegerType.get()),
             required(2, "data", Types.StringType.get()));
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> new SchemaUpdate(schema, 1).addRequiredColumn("data", Types.StringType.get()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Incompatible change: cannot add required column: data");
@@ -597,14 +587,14 @@ public class TestSchemaUpdate {
             .addRequiredColumn("data", Types.StringType.get())
             .apply();
 
-    Assert.assertEquals("Should add required column", expected.asStruct(), result.asStruct());
+    assertThat(result.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
   public void testAddRequiredColumnCaseInsensitive() {
     Schema schema = new Schema(required(1, "id", Types.IntegerType.get()));
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(schema, 1)
                     .caseSensitive(false)
@@ -622,8 +612,7 @@ public class TestSchemaUpdate {
 
     Schema result = new SchemaUpdate(schema, 1).makeColumnOptional("id").apply();
 
-    Assert.assertEquals(
-        "Should update column to be optional", expected.asStruct(), result.asStruct());
+    assertThat(result.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -631,7 +620,7 @@ public class TestSchemaUpdate {
     Schema schema = new Schema(optional(1, "id", Types.IntegerType.get()));
     Schema expected = new Schema(required(1, "id", Types.IntegerType.get()));
 
-    Assertions.assertThatThrownBy(() -> new SchemaUpdate(schema, 1).requireColumn("id"))
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 1).requireColumn("id"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot change column nullability: id: optional -> required");
 
@@ -641,8 +630,7 @@ public class TestSchemaUpdate {
     Schema result =
         new SchemaUpdate(schema, 1).allowIncompatibleChanges().requireColumn("id").apply();
 
-    Assert.assertEquals(
-        "Should update column to be required", expected.asStruct(), result.asStruct());
+    assertThat(result.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -657,8 +645,7 @@ public class TestSchemaUpdate {
             .requireColumn("ID")
             .apply();
 
-    Assert.assertEquals(
-        "Should update column to be required", expected.asStruct(), result.asStruct());
+    assertThat(result.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -729,13 +716,13 @@ public class TestSchemaUpdate {
                 "locations", "description", Types.StringType.get(), "Location description")
             .apply();
 
-    Assert.assertEquals("Should match with added fields", expected.asStruct(), updated.asStruct());
+    assertThat(updated.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
   public void testAmbiguousAdd() {
     // preferences.booleans could be top-level or a field of preferences
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update.addColumn("preferences.booleans", Types.BooleanType.get());
@@ -746,7 +733,7 @@ public class TestSchemaUpdate {
 
   @Test
   public void testAddAlreadyExists() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update.addColumn("preferences", "feature1", Types.BooleanType.get());
@@ -754,7 +741,7 @@ public class TestSchemaUpdate {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot add column, name already exists: preferences.feature1");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update.addColumn("preferences", Types.BooleanType.get());
@@ -774,7 +761,7 @@ public class TestSchemaUpdate {
             .addColumn("id", optional(2, "id", Types.IntegerType.get()).type())
             .apply();
 
-    Assert.assertEquals("Should match with added fields", expected.asStruct(), updated.asStruct());
+    assertThat(updated.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -827,13 +814,12 @@ public class TestSchemaUpdate {
             .addColumn("preferences", "feature1", Types.BooleanType.get())
             .apply();
 
-    Assert.assertEquals(
-        "Should match with added fields", expectedNested.asStruct(), updatedNested.asStruct());
+    assertThat(updatedNested.asStruct()).isEqualTo(expectedNested.asStruct());
   }
 
   @Test
   public void testDeleteMissingColumn() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update.deleteColumn("col");
@@ -844,7 +830,7 @@ public class TestSchemaUpdate {
 
   @Test
   public void testAddDeleteConflict() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update.addColumn("col", Types.IntegerType.get()).deleteColumn("col");
@@ -852,7 +838,7 @@ public class TestSchemaUpdate {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot delete missing column: col");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update
@@ -865,7 +851,7 @@ public class TestSchemaUpdate {
 
   @Test
   public void testRenameMissingColumn() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update.renameColumn("col", "fail");
@@ -876,7 +862,7 @@ public class TestSchemaUpdate {
 
   @Test
   public void testRenameDeleteConflict() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update.renameColumn("id", "col").deleteColumn("id");
@@ -884,7 +870,7 @@ public class TestSchemaUpdate {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot delete a column that has updates: id");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update.renameColumn("id", "col").deleteColumn("col");
@@ -895,7 +881,7 @@ public class TestSchemaUpdate {
 
   @Test
   public void testDeleteRenameConflict() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update.deleteColumn("id").renameColumn("id", "identifier");
@@ -906,7 +892,7 @@ public class TestSchemaUpdate {
 
   @Test
   public void testUpdateMissingColumn() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update.updateColumn("col", Types.DateType.get());
@@ -917,7 +903,7 @@ public class TestSchemaUpdate {
 
   @Test
   public void testUpdateDeleteConflict() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update.updateColumn("id", Types.LongType.get()).deleteColumn("id");
@@ -928,7 +914,7 @@ public class TestSchemaUpdate {
 
   @Test
   public void testDeleteUpdateConflict() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> {
               UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
               update.deleteColumn("id").updateColumn("id", Types.LongType.get());
@@ -939,7 +925,7 @@ public class TestSchemaUpdate {
 
   @Test
   public void testDeleteMapKey() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
                     .deleteColumn("locations.key")
@@ -950,7 +936,7 @@ public class TestSchemaUpdate {
 
   @Test
   public void testAddFieldToMapKey() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
                     .addColumn("locations.key", "address_line_2", Types.StringType.get())
@@ -961,7 +947,7 @@ public class TestSchemaUpdate {
 
   @Test
   public void testAlterMapKey() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
                     .updateColumn("locations.key.zip", Types.LongType.get())
@@ -978,7 +964,7 @@ public class TestSchemaUpdate {
                 1,
                 "m",
                 Types.MapType.ofOptional(2, 3, Types.IntegerType.get(), Types.DoubleType.get())));
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> new SchemaUpdate(schema, 3).updateColumn("m.key", Types.LongType.get()).apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot update map keys: map<int, double>");
@@ -987,7 +973,7 @@ public class TestSchemaUpdate {
   @Test
   public void testUpdateAddedColumnDoc() {
     Schema schema = new Schema(required(1, "i", Types.IntegerType.get()));
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(schema, 3)
                     .addColumn("value", Types.LongType.get())
@@ -1000,7 +986,7 @@ public class TestSchemaUpdate {
   @Test
   public void testUpdateDeletedColumnDoc() {
     Schema schema = new Schema(required(1, "i", Types.IntegerType.get()));
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(schema, 3)
                     .deleteColumn("i")
@@ -1035,7 +1021,7 @@ public class TestSchemaUpdate {
             .moveBefore("d", "a")
             .apply();
 
-    Assert.assertEquals("Schema should match", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1049,7 +1035,7 @@ public class TestSchemaUpdate {
 
     Schema actual = new SchemaUpdate(schema, 2).moveFirst("data").apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1063,7 +1049,7 @@ public class TestSchemaUpdate {
 
     Schema actual = new SchemaUpdate(schema, 2).moveBefore("data", "id").apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1077,7 +1063,7 @@ public class TestSchemaUpdate {
 
     Schema actual = new SchemaUpdate(schema, 2).moveAfter("id", "data").apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1095,7 +1081,7 @@ public class TestSchemaUpdate {
 
     Schema actual = new SchemaUpdate(schema, 3).moveAfter("ts", "id").apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1113,7 +1099,7 @@ public class TestSchemaUpdate {
 
     Schema actual = new SchemaUpdate(schema, 3).moveBefore("ts", "data").apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1139,7 +1125,7 @@ public class TestSchemaUpdate {
 
     Schema actual = new SchemaUpdate(schema, 4).moveFirst("struct.data").apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1165,7 +1151,7 @@ public class TestSchemaUpdate {
 
     Schema actual = new SchemaUpdate(schema, 4).moveBefore("struct.data", "struct.count").apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1191,7 +1177,7 @@ public class TestSchemaUpdate {
 
     Schema actual = new SchemaUpdate(schema, 4).moveAfter("struct.count", "struct.data").apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1219,7 +1205,7 @@ public class TestSchemaUpdate {
 
     Schema actual = new SchemaUpdate(schema, 5).moveAfter("struct.ts", "struct.count").apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1247,7 +1233,7 @@ public class TestSchemaUpdate {
 
     Schema actual = new SchemaUpdate(schema, 5).moveBefore("struct.ts", "struct.data").apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1279,7 +1265,7 @@ public class TestSchemaUpdate {
 
     Schema actual = new SchemaUpdate(schema, 6).moveBefore("list.ts", "list.data").apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1315,7 +1301,7 @@ public class TestSchemaUpdate {
 
     Schema actual = new SchemaUpdate(schema, 7).moveBefore("map.ts", "map.data").apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1335,7 +1321,7 @@ public class TestSchemaUpdate {
             .moveAfter("ts", "id")
             .apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1358,7 +1344,7 @@ public class TestSchemaUpdate {
             .moveAfter("count", "ts")
             .apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1389,7 +1375,7 @@ public class TestSchemaUpdate {
             .moveBefore("struct.ts", "struct.count")
             .apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1423,7 +1409,7 @@ public class TestSchemaUpdate {
             .moveBefore("struct.size", "struct.ts")
             .apply();
 
-    Assert.assertEquals("Should move data first", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1432,11 +1418,11 @@ public class TestSchemaUpdate {
         new Schema(
             required(1, "id", Types.LongType.get()), required(2, "data", Types.StringType.get()));
 
-    Assertions.assertThatThrownBy(() -> new SchemaUpdate(schema, 2).moveBefore("id", "id").apply())
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 2).moveBefore("id", "id").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move id before itself");
 
-    Assertions.assertThatThrownBy(() -> new SchemaUpdate(schema, 2).moveAfter("id", "id").apply())
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 2).moveAfter("id", "id").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move id after itself");
   }
@@ -1447,17 +1433,15 @@ public class TestSchemaUpdate {
         new Schema(
             required(1, "id", Types.LongType.get()), required(2, "data", Types.StringType.get()));
 
-    Assertions.assertThatThrownBy(() -> new SchemaUpdate(schema, 2).moveFirst("items").apply())
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 2).moveFirst("items").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move missing column: items");
 
-    Assertions.assertThatThrownBy(
-            () -> new SchemaUpdate(schema, 2).moveBefore("items", "id").apply())
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 2).moveBefore("items", "id").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move missing column: items");
 
-    Assertions.assertThatThrownBy(
-            () -> new SchemaUpdate(schema, 2).moveAfter("items", "data").apply())
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 2).moveAfter("items", "data").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move missing column: items");
   }
@@ -1468,7 +1452,7 @@ public class TestSchemaUpdate {
         new Schema(
             required(1, "id", Types.LongType.get()), required(2, "data", Types.StringType.get()));
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(schema, 2)
                     .moveFirst("ts")
@@ -1477,7 +1461,7 @@ public class TestSchemaUpdate {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move missing column: ts");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(schema, 2)
                     .moveBefore("ts", "id")
@@ -1486,7 +1470,7 @@ public class TestSchemaUpdate {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move missing column: ts");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(schema, 2)
                     .moveAfter("ts", "data")
@@ -1502,13 +1486,11 @@ public class TestSchemaUpdate {
         new Schema(
             required(1, "id", Types.LongType.get()), required(2, "data", Types.StringType.get()));
 
-    Assertions.assertThatThrownBy(
-            () -> new SchemaUpdate(schema, 2).moveBefore("id", "items").apply())
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 2).moveBefore("id", "items").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move id before missing column: items");
 
-    Assertions.assertThatThrownBy(
-            () -> new SchemaUpdate(schema, 2).moveAfter("data", "items").apply())
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 2).moveAfter("data", "items").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move data after missing column: items");
   }
@@ -1524,8 +1506,7 @@ public class TestSchemaUpdate {
                 "map",
                 Types.MapType.ofRequired(4, 5, Types.StringType.get(), Types.StringType.get())));
 
-    Assertions.assertThatThrownBy(
-            () -> new SchemaUpdate(schema, 5).moveBefore("map.key", "map.value").apply())
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 5).moveBefore("map.key", "map.value").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move fields in non-struct type: map<string, string>");
   }
@@ -1541,8 +1522,7 @@ public class TestSchemaUpdate {
                 "map",
                 Types.MapType.ofRequired(4, 5, Types.StringType.get(), Types.StructType.of())));
 
-    Assertions.assertThatThrownBy(
-            () -> new SchemaUpdate(schema, 5).moveBefore("map.value", "map.key").apply())
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 5).moveBefore("map.value", "map.key").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move fields in non-struct type: map<string, struct<>>");
   }
@@ -1555,8 +1535,7 @@ public class TestSchemaUpdate {
             required(2, "data", Types.StringType.get()),
             optional(3, "list", Types.ListType.ofRequired(4, Types.StringType.get())));
 
-    Assertions.assertThatThrownBy(
-            () -> new SchemaUpdate(schema, 4).moveBefore("list.element", "list").apply())
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 4).moveBefore("list.element", "list").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move fields in non-struct type: list<string>");
   }
@@ -1574,8 +1553,7 @@ public class TestSchemaUpdate {
                     required(4, "x", Types.IntegerType.get()),
                     required(5, "y", Types.IntegerType.get()))));
 
-    Assertions.assertThatThrownBy(
-            () -> new SchemaUpdate(schema, 5).moveBefore("a", "struct.x").apply())
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 5).moveBefore("a", "struct.x").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move field a to a different struct");
   }
@@ -1597,8 +1575,7 @@ public class TestSchemaUpdate {
                     required(5, "x", Types.IntegerType.get()),
                     required(6, "y", Types.IntegerType.get()))));
 
-    Assertions.assertThatThrownBy(
-            () -> new SchemaUpdate(schema, 6).moveBefore("s2.x", "s1.a").apply())
+    assertThatThrownBy(() -> new SchemaUpdate(schema, 6).moveBefore("s2.x", "s1.a").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot move field s2.x to a different struct");
   }
@@ -1608,10 +1585,9 @@ public class TestSchemaUpdate {
     Schema newSchema =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID).setIdentifierFields("id").apply();
 
-    Assert.assertEquals(
-        "add an existing field as identifier field should succeed",
-        Sets.newHashSet(newSchema.findField("id").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("add an existing field as identifier field should succeed")
+        .containsExactly(newSchema.findField("id").fieldId());
   }
 
   @Test
@@ -1623,11 +1599,11 @@ public class TestSchemaUpdate {
             .setIdentifierFields("id", "new_field")
             .apply();
 
-    Assert.assertEquals(
-        "add column then set as identifier should succeed",
-        Sets.newHashSet(
-            newSchema.findField("id").fieldId(), newSchema.findField("new_field").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("add column then set as identifier should succeed")
+        .isEqualTo(
+            Sets.newHashSet(
+                newSchema.findField("id").fieldId(), newSchema.findField("new_field").fieldId()));
 
     newSchema =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -1636,11 +1612,11 @@ public class TestSchemaUpdate {
             .addRequiredColumn("new_field", Types.StringType.get())
             .apply();
 
-    Assert.assertEquals(
-        "set identifier then add column should succeed",
-        Sets.newHashSet(
-            newSchema.findField("id").fieldId(), newSchema.findField("new_field").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("set identifier then add column should succeed")
+        .isEqualTo(
+            Sets.newHashSet(
+                newSchema.findField("id").fieldId(), newSchema.findField("new_field").fieldId()));
   }
 
   @Test
@@ -1660,10 +1636,9 @@ public class TestSchemaUpdate {
             .setIdentifierFields("required_struct.field")
             .apply();
 
-    Assert.assertEquals(
-        "set existing nested field as identifier should succeed",
-        Sets.newHashSet(newSchema.findField("required_struct.field").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("set existing nested field as identifier should succeed")
+        .containsExactly(newSchema.findField("required_struct.field").fieldId());
 
     newSchema =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -1676,10 +1651,9 @@ public class TestSchemaUpdate {
             .setIdentifierFields("new.field")
             .apply();
 
-    Assert.assertEquals(
-        "set newly added nested field as identifier should succeed",
-        Sets.newHashSet(newSchema.findField("new.field").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("set newly added nested field as identifier should succeed")
+        .containsExactly(newSchema.findField("new.field").fieldId());
 
     newSchema =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -1696,10 +1670,9 @@ public class TestSchemaUpdate {
             .setIdentifierFields("new.field.nested")
             .apply();
 
-    Assert.assertEquals(
-        "set newly added multi-layer nested field as identifier should succeed",
-        Sets.newHashSet(newSchema.findField("new.field.nested").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("set newly added multi-layer nested field as identifier should succeed")
+        .containsExactly(newSchema.findField("new.field.nested").fieldId());
   }
 
   @Test
@@ -1711,11 +1684,11 @@ public class TestSchemaUpdate {
             .setIdentifierFields("id", "dot.field")
             .apply();
 
-    Assert.assertEquals(
-        "add a field with dot as identifier should succeed",
-        Sets.newHashSet(
-            newSchema.findField("id").fieldId(), newSchema.findField("dot.field").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("add a field with dot as identifier should succeed")
+        .isEqualTo(
+            Sets.newHashSet(
+                newSchema.findField("id").fieldId(), newSchema.findField("dot.field").fieldId()));
   }
 
   @Test
@@ -1733,22 +1706,19 @@ public class TestSchemaUpdate {
             .setIdentifierFields("new_field", "new_field2")
             .apply();
 
-    Assert.assertEquals(
-        "remove an identifier field should succeed",
-        Sets.newHashSet(
-            newSchema.findField("new_field").fieldId(),
-            newSchema.findField("new_field2").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("remove an identifier field should succeed")
+        .isEqualTo(
+            Sets.newHashSet(
+                newSchema.findField("new_field").fieldId(),
+                newSchema.findField("new_field2").fieldId()));
 
     newSchema =
         new SchemaUpdate(newSchema, SCHEMA_LAST_COLUMN_ID)
             .setIdentifierFields(Sets.newHashSet())
             .apply();
 
-    Assert.assertEquals(
-        "remove all identifier fields should succeed",
-        Sets.newHashSet(),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds()).isEmpty();
   }
 
   @SuppressWarnings("MethodLength")
@@ -1760,29 +1730,25 @@ public class TestSchemaUpdate {
             required(2, "float", Types.FloatType.get()),
             required(3, "double", Types.DoubleType.get()));
 
-    Assertions.assertThatThrownBy(
-            () -> new Schema(testSchema.asStruct().fields(), ImmutableSet.of(999)))
+    assertThatThrownBy(() -> new Schema(testSchema.asStruct().fields(), ImmutableSet.of(999)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot add fieldId 999 as an identifier field: field does not exist");
 
-    Assertions.assertThatThrownBy(
-            () -> new Schema(testSchema.asStruct().fields(), ImmutableSet.of(1)))
+    assertThatThrownBy(() -> new Schema(testSchema.asStruct().fields(), ImmutableSet.of(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot add field id as an identifier field: not a required field");
 
-    Assertions.assertThatThrownBy(
-            () -> new Schema(testSchema.asStruct().fields(), ImmutableSet.of(2)))
+    assertThatThrownBy(() -> new Schema(testSchema.asStruct().fields(), ImmutableSet.of(2)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Cannot add field float as an identifier field: must not be float or double field");
 
-    Assertions.assertThatThrownBy(
-            () -> new Schema(testSchema.asStruct().fields(), ImmutableSet.of(3)))
+    assertThatThrownBy(() -> new Schema(testSchema.asStruct().fields(), ImmutableSet.of(3)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Cannot add field double as an identifier field: must not be float or double field");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
                     .setIdentifierFields("unknown")
@@ -1791,7 +1757,7 @@ public class TestSchemaUpdate {
         .hasMessage(
             "Cannot add field unknown as an identifier field: not found in current schema or added columns");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
                     .setIdentifierFields("locations")
@@ -1800,13 +1766,13 @@ public class TestSchemaUpdate {
         .hasMessage(
             "Cannot add field locations as an identifier field: not a primitive type field");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID).setIdentifierFields("data").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot add field data as an identifier field: not a required field");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
                     .setIdentifierFields("locations.key.zip")
@@ -1816,7 +1782,7 @@ public class TestSchemaUpdate {
             "Cannot add field zip as an identifier field: must not be nested in "
                 + SCHEMA.findField("locations"));
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
                     .setIdentifierFields("points.element.x")
@@ -1865,7 +1831,7 @@ public class TestSchemaUpdate {
 
     int lastColId = SCHEMA_LAST_COLUMN_ID + 15;
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(newSchema, lastColId)
                     .setIdentifierFields("required_list.element.x")
@@ -1875,19 +1841,19 @@ public class TestSchemaUpdate {
             "Cannot add field x as an identifier field: must not be nested in "
                 + newSchema.findField("required_list"));
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> new SchemaUpdate(newSchema, lastColId).setIdentifierFields("col_double").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Cannot add field col_double as an identifier field: must not be float or double field");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> new SchemaUpdate(newSchema, lastColId).setIdentifierFields("col_float").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Cannot add field col_float as an identifier field: must not be float or double field");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(newSchema, lastColId)
                     .setIdentifierFields("new_map.value.val_col")
@@ -1897,7 +1863,7 @@ public class TestSchemaUpdate {
             "Cannot add field val_col as an identifier field: must not be nested in "
                 + newSchema.findField("new_map"));
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(newSchema, lastColId)
                     .setIdentifierFields("new.fields.element.nested")
@@ -1907,7 +1873,7 @@ public class TestSchemaUpdate {
             "Cannot add field nested as an identifier field: must not be nested in "
                 + newSchema.findField("new.fields"));
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(newSchema, lastColId)
                     .setIdentifierFields("preferences.feature1")
@@ -1923,23 +1889,23 @@ public class TestSchemaUpdate {
     Schema schemaWithIdentifierFields =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID).setIdentifierFields("id").apply();
 
-    Assert.assertEquals(
-        "delete column and then reset identifier field should succeed",
-        Sets.newHashSet(),
-        new SchemaUpdate(schemaWithIdentifierFields, SCHEMA_LAST_COLUMN_ID)
-            .deleteColumn("id")
-            .setIdentifierFields(Sets.newHashSet())
-            .apply()
-            .identifierFieldIds());
+    assertThat(
+            new SchemaUpdate(schemaWithIdentifierFields, SCHEMA_LAST_COLUMN_ID)
+                .deleteColumn("id")
+                .setIdentifierFields(Sets.newHashSet())
+                .apply()
+                .identifierFieldIds())
+        .as("delete column and then reset identifier field should succeed")
+        .isEmpty();
 
-    Assert.assertEquals(
-        "delete reset identifier field and then delete column should succeed",
-        Sets.newHashSet(),
-        new SchemaUpdate(schemaWithIdentifierFields, SCHEMA_LAST_COLUMN_ID)
-            .setIdentifierFields(Sets.newHashSet())
-            .deleteColumn("id")
-            .apply()
-            .identifierFieldIds());
+    assertThat(
+            new SchemaUpdate(schemaWithIdentifierFields, SCHEMA_LAST_COLUMN_ID)
+                .setIdentifierFields(Sets.newHashSet())
+                .deleteColumn("id")
+                .apply()
+                .identifierFieldIds())
+        .as("delete reset identifier field and then delete column should succeed")
+        .isEmpty();
   }
 
   @Test
@@ -1947,7 +1913,7 @@ public class TestSchemaUpdate {
     Schema schemaWithIdentifierFields =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID).setIdentifierFields("id").apply();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(schemaWithIdentifierFields, SCHEMA_LAST_COLUMN_ID)
                     .deleteColumn("id")
@@ -1970,7 +1936,7 @@ public class TestSchemaUpdate {
             .setIdentifierFields("out.nested")
             .apply();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new SchemaUpdate(newSchema, SCHEMA_LAST_COLUMN_ID + 2).deleteColumn("out").apply())
         .isInstanceOf(IllegalArgumentException.class)
@@ -1989,10 +1955,9 @@ public class TestSchemaUpdate {
             .renameColumn("id", "id2")
             .apply();
 
-    Assert.assertEquals(
-        "rename should not affect identifier fields",
-        Sets.newHashSet(SCHEMA.findField("id").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("rename should not affect identifier fields")
+        .containsExactly(SCHEMA.findField("id").fieldId());
   }
 
   @Test
@@ -2005,28 +1970,25 @@ public class TestSchemaUpdate {
             .moveAfter("id", "locations")
             .apply();
 
-    Assert.assertEquals(
-        "move after should not affect identifier fields",
-        Sets.newHashSet(SCHEMA.findField("id").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("move after should not affect identifier fields")
+        .containsExactly(SCHEMA.findField("id").fieldId());
 
     newSchema =
         new SchemaUpdate(schemaWithIdentifierFields, SCHEMA_LAST_COLUMN_ID)
             .moveBefore("id", "locations")
             .apply();
 
-    Assert.assertEquals(
-        "move before should not affect identifier fields",
-        Sets.newHashSet(SCHEMA.findField("id").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("move before should not affect identifier fields")
+        .containsExactly(SCHEMA.findField("id").fieldId());
 
     newSchema =
         new SchemaUpdate(schemaWithIdentifierFields, SCHEMA_LAST_COLUMN_ID).moveFirst("id").apply();
 
-    Assert.assertEquals(
-        "move first should not affect identifier fields",
-        Sets.newHashSet(SCHEMA.findField("id").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("move first should not affect identifier fields")
+        .containsExactly(SCHEMA.findField("id").fieldId());
   }
 
   @Test
@@ -2040,10 +2002,9 @@ public class TestSchemaUpdate {
             .moveAfter("iD", "locations")
             .apply();
 
-    Assert.assertEquals(
-        "move after should not affect identifier fields",
-        Sets.newHashSet(SCHEMA.findField("id").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("move after should not affect identifier fields")
+        .containsExactly(SCHEMA.findField("id").fieldId());
 
     newSchema =
         new SchemaUpdate(schemaWithIdentifierFields, SCHEMA_LAST_COLUMN_ID)
@@ -2051,10 +2012,9 @@ public class TestSchemaUpdate {
             .moveBefore("ID", "locations")
             .apply();
 
-    Assert.assertEquals(
-        "move before should not affect identifier fields",
-        Sets.newHashSet(SCHEMA.findField("id").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("move before should not affect identifier fields")
+        .containsExactly(SCHEMA.findField("id").fieldId());
 
     newSchema =
         new SchemaUpdate(schemaWithIdentifierFields, SCHEMA_LAST_COLUMN_ID)
@@ -2062,10 +2022,9 @@ public class TestSchemaUpdate {
             .moveFirst("ID")
             .apply();
 
-    Assert.assertEquals(
-        "move first should not affect identifier fields",
-        Sets.newHashSet(SCHEMA.findField("id").fieldId()),
-        newSchema.identifierFieldIds());
+    assertThat(newSchema.identifierFieldIds())
+        .as("move first should not affect identifier fields")
+        .containsExactly(SCHEMA.findField("id").fieldId());
   }
 
   @Test
@@ -2088,8 +2047,7 @@ public class TestSchemaUpdate {
             .addRequiredColumn("id", Types.IntegerType.get())
             .moveAfter("id", "data")
             .apply();
-    Assert.assertEquals(
-        "Should move deleted column correctly", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -2112,8 +2070,7 @@ public class TestSchemaUpdate {
             .addRequiredColumn("id", Types.IntegerType.get())
             .moveBefore("id", "data_1")
             .apply();
-    Assert.assertEquals(
-        "Should move deleted column correctly", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -2136,8 +2093,7 @@ public class TestSchemaUpdate {
             .addRequiredColumn("id", Types.IntegerType.get())
             .moveFirst("id")
             .apply();
-    Assert.assertEquals(
-        "Should move deleted column correctly", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -2171,8 +2127,7 @@ public class TestSchemaUpdate {
             .moveAfter("struct.data", "struct.count")
             .apply();
 
-    Assert.assertEquals(
-        "Should move deleted nested column correctly", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -2206,8 +2161,7 @@ public class TestSchemaUpdate {
             .moveBefore("struct.data", "struct.data_1")
             .apply();
 
-    Assert.assertEquals(
-        "Should move deleted nested column correctly", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -2241,7 +2195,6 @@ public class TestSchemaUpdate {
             .moveFirst("struct.data")
             .apply();
 
-    Assert.assertEquals(
-        "Should move deleted nested column correctly", expected.asStruct(), actual.asStruct());
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -25,18 +25,18 @@ import static org.apache.iceberg.expressions.Expressions.month;
 import static org.apache.iceberg.expressions.Expressions.ref;
 import static org.apache.iceberg.expressions.Expressions.truncate;
 import static org.apache.iceberg.expressions.Expressions.year;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestUpdatePartitionSpec extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestUpdatePartitionSpec extends TestBase {
   private static final Schema SCHEMA =
       new Schema(
           Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -52,76 +52,72 @@ public class TestUpdatePartitionSpec extends TableTestBase {
           .bucket("id", 16, "shard")
           .build();
 
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestUpdatePartitionSpec(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testAddIdentityByName() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED).addField("category").apply();
 
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA).identity("category").build();
 
-    Assert.assertEquals("Should match expected spec", expected, updated);
+    assertThat(updated).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddIdentityByTerm() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED).addField(ref("category")).apply();
 
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA).identity("category").build();
 
-    Assert.assertEquals("Should match expected spec", expected, updated);
+    assertThat(updated).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddYear() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED).addField(year("ts")).apply();
 
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA).year("ts").build();
 
-    Assert.assertEquals("Should match expected spec", expected, updated);
+    assertThat(updated).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddMonth() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED).addField(month("ts")).apply();
 
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA).month("ts").build();
 
-    Assert.assertEquals("Should match expected spec", expected, updated);
+    assertThat(updated).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddDay() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED).addField(day("ts")).apply();
 
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA).day("ts").build();
 
-    Assert.assertEquals("Should match expected spec", expected, updated);
+    assertThat(updated).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddHour() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED).addField(hour("ts")).apply();
 
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA).hour("ts").build();
 
-    Assert.assertEquals("Should match expected spec", expected, updated);
+    assertThat(updated).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddBucket() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED)
@@ -132,10 +128,10 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(SCHEMA).bucket("id", 16, "id_bucket_16").build();
 
-    Assert.assertEquals("Should match expected spec", expected, updated);
+    assertThat(updated).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddTruncate() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED)
@@ -146,10 +142,10 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(SCHEMA).truncate("data", 4, "data_trunc_4").build();
 
-    Assert.assertEquals("Should match expected spec", expected, updated);
+    assertThat(updated).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddNamedPartition() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED)
@@ -158,10 +154,10 @@ public class TestUpdatePartitionSpec extends TableTestBase {
 
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA).bucket("id", 16, "shard").build();
 
-    Assert.assertEquals("Should match expected spec", expected, updated);
+    assertThat(updated).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddToExisting() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
@@ -176,10 +172,10 @@ public class TestUpdatePartitionSpec extends TableTestBase {
             .truncate("data", 4, "data_trunc_4")
             .build();
 
-    Assert.assertEquals("Should match expected spec", expected, updated);
+    assertThat(updated).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testMultipleAdds() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED)
@@ -197,10 +193,10 @@ public class TestUpdatePartitionSpec extends TableTestBase {
             .truncate("data", 4, "prefix")
             .build();
 
-    Assert.assertEquals("Should match expected spec", expected, updated);
+    assertThat(updated).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddHourToDay() {
     // multiple partitions for the same source with different time granularity is not allowed by the
     // builder, but is
@@ -211,15 +207,13 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     PartitionSpec byHour =
         new BaseUpdatePartitionSpec(formatVersion, byDay).addField(hour("ts")).apply();
 
-    Assert.assertEquals(
-        "Should have a day and an hour time field",
-        ImmutableList.of(
+    assertThat(byHour.fields())
+        .containsExactly(
             new PartitionField(2, 1000, "ts_day", Transforms.day()),
-            new PartitionField(2, 1001, "ts_hour", Transforms.hour())),
-        byHour.fields());
+            new PartitionField(2, 1001, "ts_hour", Transforms.hour()));
   }
 
-  @Test
+  @TestTemplate
   public void testAddMultipleBuckets() {
     PartitionSpec bucket16 =
         new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED)
@@ -235,10 +229,10 @@ public class TestUpdatePartitionSpec extends TableTestBase {
             .bucket("id", 8, "id_bucket_8")
             .build();
 
-    Assert.assertEquals("Should have multiple bucket partition fields", expected, bucket8);
+    assertThat(bucket8).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveIdentityByName() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED).removeField("category").apply();
@@ -261,7 +255,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveBucketByName() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED).removeField("shard").apply();
@@ -284,7 +278,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveIdentityByEquivalent() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
@@ -309,7 +303,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveDayByEquivalent() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED).removeField(day("ts")).apply();
@@ -332,7 +326,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveBucketByEquivalent() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
@@ -354,7 +348,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
   }
 
-  @Test
+  @TestTemplate
   public void testRename() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
@@ -364,10 +358,10 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(SCHEMA).identity("category").day("ts").bucket("id", 16).build();
 
-    Assert.assertEquals("Should match expected spec", expected, updated);
+    assertThat(updated).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testMultipleChanges() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
@@ -396,7 +390,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
   }
 
-  @Test
+  @TestTemplate
   public void testAddDeletedName() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
@@ -418,9 +412,9 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveNewlyAddedFieldByName() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
                     .addField("prefix", truncate("data", 4))
@@ -429,9 +423,9 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .hasMessageStartingWith("Cannot delete newly added field");
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveNewlyAddedFieldByTransform() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
                     .addField("prefix", truncate("data", 4))
@@ -440,9 +434,9 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .hasMessageStartingWith("Cannot delete newly added field");
   }
 
-  @Test
+  @TestTemplate
   public void testAddAlreadyAddedFieldByTransform() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
                     .addField("prefix", truncate("data", 4))
@@ -451,9 +445,9 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .hasMessageStartingWith("Cannot add duplicate partition field");
   }
 
-  @Test
+  @TestTemplate
   public void testAddAlreadyAddedFieldByName() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
                     .addField("prefix", truncate("data", 4))
@@ -462,9 +456,9 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .hasMessageStartingWith("Cannot add duplicate partition field");
   }
 
-  @Test
+  @TestTemplate
   public void testAddRedundantTimePartition() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED)
                     .addField(day("ts"))
@@ -472,7 +466,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot add redundant partition field");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
                     .addField(hour("ts")) // does not conflict with day because day already exists
@@ -481,78 +475,66 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .hasMessageStartingWith("Cannot add redundant partition");
   }
 
-  @Test
+  @TestTemplate
   public void testNoEffectAddDeletedSameFieldWithSameName() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
             .removeField("shard")
             .addField("shard", bucket("id", 16))
             .apply();
-    Assert.assertEquals(PARTITIONED, updated);
+    assertThat(updated).isEqualTo(PARTITIONED);
     updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
             .removeField("shard")
             .addField(bucket("id", 16))
             .apply();
-    Assert.assertEquals(PARTITIONED, updated);
+    assertThat(updated).isEqualTo(PARTITIONED);
   }
 
-  @Test
+  @TestTemplate
   public void testGenerateNewSpecAddDeletedSameFieldWithDifferentName() {
     PartitionSpec updated =
         new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
             .removeField("shard")
             .addField("new_shard", bucket("id", 16))
             .apply();
-    Assert.assertEquals("Should match expected field size", 3, updated.fields().size());
-    Assert.assertEquals(
-        "Should match expected field name", "category", updated.fields().get(0).name());
-    Assert.assertEquals(
-        "Should match expected field name", "ts_day", updated.fields().get(1).name());
-    Assert.assertEquals(
-        "Should match expected field name", "new_shard", updated.fields().get(2).name());
-    Assert.assertEquals(
-        "Should match expected field transform",
-        "identity",
-        updated.fields().get(0).transform().toString());
-    Assert.assertEquals(
-        "Should match expected field transform",
-        "day",
-        updated.fields().get(1).transform().toString());
-    Assert.assertEquals(
-        "Should match expected field transform",
-        "bucket[16]",
-        updated.fields().get(2).transform().toString());
+    assertThat(updated.fields()).hasSize(3);
+    assertThat(updated.fields().get(0).name()).isEqualTo("category");
+    assertThat(updated.fields().get(1).name()).isEqualTo("ts_day");
+    assertThat(updated.fields().get(2).name()).isEqualTo("new_shard");
+    assertThat(updated.fields().get(0).transform()).asString().isEqualTo("identity");
+    assertThat(updated.fields().get(1).transform()).asString().isEqualTo("day");
+    assertThat(updated.fields().get(2).transform()).asString().isEqualTo("bucket[16]");
   }
 
-  @Test
+  @TestTemplate
   public void testAddDuplicateByName() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> new BaseUpdatePartitionSpec(formatVersion, PARTITIONED).addField("category"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot add duplicate partition field");
   }
 
-  @Test
+  @TestTemplate
   public void testAddDuplicateByRef() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> new BaseUpdatePartitionSpec(formatVersion, PARTITIONED).addField(ref("category")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot add duplicate partition field");
   }
 
-  @Test
+  @TestTemplate
   public void testAddDuplicateTransform() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, PARTITIONED).addField(bucket("id", 16)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot add duplicate partition field");
   }
 
-  @Test
+  @TestTemplate
   public void testAddNamedDuplicate() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
                     .addField("b16", bucket("id", 16)))
@@ -560,17 +542,17 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .hasMessageStartingWith("Cannot add duplicate partition field");
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveUnknownFieldByName() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> new BaseUpdatePartitionSpec(formatVersion, PARTITIONED).removeField("moon"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot find partition field to remove");
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveUnknownFieldByEquivalent() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
                     .removeField(hour("ts")) // day(ts) exists
@@ -579,9 +561,9 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .hasMessageStartingWith("Cannot find partition field to remove");
   }
 
-  @Test
+  @TestTemplate
   public void testRenameUnknownField() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
                     .renameField("shake", "seal"))
@@ -589,9 +571,9 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .hasMessage("Cannot find partition field to rename: shake");
   }
 
-  @Test
+  @TestTemplate
   public void testRenameAfterAdd() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
                     .addField("data_trunc", truncate("data", 4))
@@ -600,9 +582,9 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .hasMessage("Cannot rename newly added partition field: data_trunc");
   }
 
-  @Test
+  @TestTemplate
   public void testRenameAndDelete() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
                     .renameField("shard", "id_bucket")
@@ -611,9 +593,9 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .hasMessage("Cannot rename and delete partition field: shard");
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteAndRename() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
                     .removeField(bucket("id", 16))
@@ -622,7 +604,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .hasMessage("Cannot delete and rename partition field: shard");
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveAndAddMultiTimes() {
     PartitionSpec addFirstTime =
         new BaseUpdatePartitionSpec(formatVersion, UNPARTITIONED)
@@ -644,29 +626,15 @@ public class TestUpdatePartitionSpec extends TableTestBase {
             .apply();
 
     if (formatVersion == 1) {
-      Assert.assertEquals("Should match expected spec field size", 3, updated.fields().size());
+      assertThat(updated.fields()).hasSize(3);
 
-      Assert.assertTrue(
-          "Should match expected field name",
-          updated.fields().get(0).name().matches("^ts_date(?:_\\d+)+$"));
-      Assert.assertTrue(
-          "Should match expected field name",
-          updated.fields().get(1).name().matches("^ts_date_(?:\\d+)+$"));
-      Assert.assertEquals(
-          "Should match expected field name", "ts_date", updated.fields().get(2).name());
+      assertThat(updated.fields().get(0).name()).matches("^ts_date(?:_\\d+)+$");
+      assertThat(updated.fields().get(1).name()).matches("^ts_date(?:_\\d+)+$");
+      assertThat(updated.fields().get(2).name()).isEqualTo("ts_date");
 
-      Assert.assertEquals(
-          "Should match expected field transform",
-          "void",
-          updated.fields().get(0).transform().toString());
-      Assert.assertEquals(
-          "Should match expected field transform",
-          "void",
-          updated.fields().get(1).transform().toString());
-      Assert.assertEquals(
-          "Should match expected field transform",
-          "month",
-          updated.fields().get(2).transform().toString());
+      assertThat(updated.fields().get(0).transform()).asString().isEqualTo("void");
+      assertThat(updated.fields().get(1).transform()).asString().isEqualTo("void");
+      assertThat(updated.fields().get(2).transform()).asString().isEqualTo("month");
     }
 
     PartitionSpec v2Expected = PartitionSpec.builderFor(SCHEMA).month("ts", "ts_date").build();
@@ -674,7 +642,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveAndUpdateWithDifferentTransformation() {
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA).month("ts", "ts_transformed").build();
     PartitionSpec updated =
@@ -684,30 +652,16 @@ public class TestUpdatePartitionSpec extends TableTestBase {
             .apply();
 
     if (formatVersion == 1) {
-      Assert.assertEquals("Should match expected spec field size", 2, updated.fields().size());
-      Assert.assertEquals(
-          "Should match expected field name",
-          "ts_transformed_1000",
-          updated.fields().get(0).name());
-      Assert.assertEquals(
-          "Should match expected field name", "ts_transformed", updated.fields().get(1).name());
+      assertThat(updated.fields()).hasSize(2);
+      assertThat(updated.fields().get(0).name()).isEqualTo("ts_transformed_1000");
+      assertThat(updated.fields().get(1).name()).isEqualTo("ts_transformed");
 
-      Assert.assertEquals(
-          "Should match expected field transform",
-          "void",
-          updated.fields().get(0).transform().toString());
-      Assert.assertEquals(
-          "Should match expected field transform",
-          "day",
-          updated.fields().get(1).transform().toString());
+      assertThat(updated.fields().get(0).transform()).asString().isEqualTo("void");
+      assertThat(updated.fields().get(1).transform()).asString().isEqualTo("day");
     } else {
-      Assert.assertEquals("Should match expected spec field size", 1, updated.fields().size());
-      Assert.assertEquals(
-          "Should match expected field name", "ts_transformed", updated.fields().get(0).name());
-      Assert.assertEquals(
-          "Should match expected field transform",
-          "day",
-          updated.fields().get(0).transform().toString());
+      assertThat(updated.fields()).hasSize(1);
+      assertThat(updated.fields().get(0).name()).isEqualTo("ts_transformed");
+      assertThat(updated.fields().get(0).transform()).asString().isEqualTo("day");
     }
   }
 


### PR DESCRIPTION
Migrate the following test classes in iceberg-core to JUnit 5 and AssertJ style for https://github.com/apache/iceberg/issues/9085.

## Current Progress 
Scan

- [x] `TestScanDataFileColumns.java`
- [x] `TestScansAndSchemaEvolution.java`
- [x] `TestScanSummary.java`

Schema
- [x] `TestSchemaAndMappingUpdate.java`
- [x] `TestSchemaID.java`
- [x] `TestSchemaUpdate.java`


Other partitions
- [x] `TestReplacePartitions.java`
- [x] `TestTableUpdatePartitionSpec.java`
- [x] `TestTimestampPartitions.java`
- [x] `TestUpdatePartitionSpec.java`

