### PR TITLE
Hive: Use base table metadata to create HiveLock

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -242,7 +242,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
 
       try {
         persistTable(
-            tbl, updateHiveTable, hiveLockEnabled(metadata, conf) ? null : baseMetadataLocation);
+            tbl, updateHiveTable, hiveLockEnabled(base, conf) ? null : baseMetadataLocation);
         lock.ensureActive();
 
         commitStatus = BaseMetastoreOperations.CommitStatus.SUCCESS;
@@ -510,7 +510,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
    * @return if the hive engine related values should be enabled or not
    */
   private static boolean hiveLockEnabled(TableMetadata metadata, Configuration conf) {
-    if (metadata.properties().get(TableProperties.HIVE_LOCK_ENABLED) != null) {
+    if (metadata != null && metadata.properties().get(TableProperties.HIVE_LOCK_ENABLED) != null) {
       // We know that the property is set, so default value will not be used,
       return metadata.propertyAsBoolean(TableProperties.HIVE_LOCK_ENABLED, false);
     }
@@ -521,7 +521,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
 
   @VisibleForTesting
   HiveLock lockObject(TableMetadata metadata) {
-    if (metadata == null || hiveLockEnabled(metadata, conf)) {
+    if (hiveLockEnabled(metadata, conf)) {
       return new MetastoreLock(conf, metaClients, catalogName, database, tableName);
     } else {
       return new NoLock();

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -179,7 +179,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
         BaseMetastoreOperations.CommitStatus.FAILURE;
     boolean updateHiveTable = false;
 
-    HiveLock lock = lockObject(metadata);
+    HiveLock lock = lockObject(base);
     try {
       lock.lock();
 
@@ -521,7 +521,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
 
   @VisibleForTesting
   HiveLock lockObject(TableMetadata metadata) {
-    if (hiveLockEnabled(metadata, conf)) {
+    if (metadata == null || hiveLockEnabled(metadata, conf)) {
       return new MetastoreLock(conf, metaClients, catalogName, database, tableName);
     } else {
       return new NoLock();

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -66,7 +66,7 @@ public class TestHiveCommits extends HiveTableBaseTest {
 
     AtomicReference<HiveLock> lockRef = new AtomicReference<>();
 
-    when(spyOps.lockObject(any()))
+    when(spyOps.lockObject(metadataV2))
         .thenAnswer(
             i -> {
               HiveLock lock = (HiveLock) i.callRealMethod();
@@ -275,11 +275,11 @@ public class TestHiveCommits extends HiveTableBaseTest {
     AtomicReference<HiveLock> lock = new AtomicReference<>();
     doAnswer(
             l -> {
-              lock.set(ops.lockObject(l.getArgument(0)));
+              lock.set(ops.lockObject(metadataV2));
               return lock.get();
             })
         .when(spyOps)
-        .lockObject(any());
+        .lockObject(metadataV2);
 
     concurrentCommitAndThrowException(ops, spyOps, table, lock);
 
@@ -432,7 +432,7 @@ public class TestHiveCommits extends HiveTableBaseTest {
               return lockRef.get();
             })
         .when(spyOps)
-        .lockObject(any());
+        .lockObject(base);
 
     TableMetadata newMetadata =
         TableMetadata.buildFrom(base)
@@ -442,6 +442,7 @@ public class TestHiveCommits extends HiveTableBaseTest {
             .build();
     spyOps.commit(base, newMetadata);
 
+    assertThat(lockRef).as("Lock not captured by the stub").doesNotHaveNullValue();
     assertThat(lockRef.get())
         .as("New lock mechanism shouldn't take effect before the commit completes")
         .hasSameClassAs(initialLock);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.hive;
 
+import static org.apache.iceberg.TableProperties.HIVE_LOCK_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
@@ -39,6 +40,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.apache.thrift.TException;
 import org.junit.jupiter.api.Test;
@@ -64,7 +66,7 @@ public class TestHiveCommits extends HiveTableBaseTest {
 
     AtomicReference<HiveLock> lockRef = new AtomicReference<>();
 
-    when(spyOps.lockObject(metadataV1))
+    when(spyOps.lockObject(any()))
         .thenAnswer(
             i -> {
               HiveLock lock = (HiveLock) i.callRealMethod();
@@ -273,11 +275,11 @@ public class TestHiveCommits extends HiveTableBaseTest {
     AtomicReference<HiveLock> lock = new AtomicReference<>();
     doAnswer(
             l -> {
-              lock.set(ops.lockObject(metadataV1));
+              lock.set(ops.lockObject(l.getArgument(0)));
               return lock.get();
             })
         .when(spyOps)
-        .lockObject(metadataV1);
+        .lockObject(any());
 
     concurrentCommitAndThrowException(ops, spyOps, table, lock);
 
@@ -413,6 +415,36 @@ public class TestHiveCommits extends HiveTableBaseTest {
     assertThatThrownBy(() -> spyOps.commit(ops.current(), metadataV1))
         .isInstanceOf(CommitStateUnknownException.class)
         .hasMessageStartingWith("null\nCannot determine whether the commit was successful or not");
+  }
+
+  @Test
+  public void testChangeLockWithAlterTable() throws Exception {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+    TableMetadata base = ops.current();
+    final HiveLock initialLock = ops.lockObject(base);
+
+    AtomicReference<HiveLock> lockRef = new AtomicReference<>();
+    HiveTableOperations spyOps = spy(ops);
+    doAnswer(
+            i -> {
+              lockRef.set(ops.lockObject(i.getArgument(0)));
+              return lockRef.get();
+            })
+        .when(spyOps)
+        .lockObject(any());
+
+    TableMetadata newMetadata =
+        TableMetadata.buildFrom(base)
+            .setProperties(
+                ImmutableMap.of(
+                    HIVE_LOCK_ENABLED, initialLock instanceof NoLock ? "true" : "false"))
+            .build();
+    spyOps.commit(base, newMetadata);
+
+    assertThat(lockRef.get())
+        .as("New lock mechanism shouldn't take effect before the commit completes")
+        .hasSameClassAs(initialLock);
   }
 
   private void commitAndThrowException(


### PR DESCRIPTION
Use base (instead of new) table metadata to create the lock object, so that concurrent commits use the same lock mechanism.

Fixes #10006 