### PR TITLE
Spark: Add CopyTable spark action

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -70,4 +70,10 @@ public interface ActionsProvider {
     throw new UnsupportedOperationException(
         this.getClass().getName() + " does not implement rewritePositionDeletes");
   }
+
+  /** Instantiates an action to copy table. */
+  default CopyTable copyTable(Table table) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement copyTable");
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/CopyTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/CopyTable.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import org.apache.iceberg.Table;
+
+public interface CopyTable extends Action<CopyTable, CopyTable.Result> {
+
+  /**
+   * Passes the source and target prefixes that will be used to replace the source prefix with the
+   * target one.
+   *
+   * @param sourcePrefix the source prefix to be replaced
+   * @param targetPrefix the target prefix
+   * @return this for method chaining
+   */
+  CopyTable rewriteLocationPrefix(String sourcePrefix, String targetPrefix);
+
+  /**
+   * Pass the version copied last time. It is optional if the target table is provided. The default
+   * value is the target table's current version. User needs to make sure whether the start version
+   * is valid if target table is not provided.
+   *
+   * @param lastCopiedVersion only version file name is needed, not the metadata json file path. For
+   *     example, the version file would be "v2.metadata.json" for a Hadoop table. For metastore
+   *     tables, the version file would be like
+   *     "00001-8893aa9e-f92e-4443-80e7-cfa42238a654.metadata.json".
+   * @return this for method chaining
+   */
+  CopyTable lastCopiedVersion(String lastCopiedVersion);
+
+  /**
+   * The latest version of the table to copy. It is optional, the default value is the source
+   * table's current version.
+   *
+   * @param endVersion only version file name is needed, not the metadata json file path. For
+   *     example, the version file would be "v2.metadata.json" for a Hadoop table. For metastore
+   *     tables, the version file would be like
+   *     "00001-8893aa9e-f92e-4443-80e7-cfa42238a654.metadata.json".
+   * @return this for method chaining
+   */
+  CopyTable endVersion(String endVersion);
+
+  /**
+   * Set the customized staging location. It is optional. By default, staging location is a sub
+   * directory under table's metadata directory.
+   *
+   * @param stagingLocation the staging location
+   * @return this for method chaining
+   */
+  CopyTable stagingLocation(String stagingLocation);
+
+  /**
+   * Set the target table. It is optional if the start version is provided.
+   *
+   * @param targetTable the target table
+   * @return this for method chaining
+   */
+  CopyTable targetTable(Table targetTable);
+
+  /** The action result that contains a summary of the execution. */
+  interface Result {
+    /** Return staging location */
+    String stagingLocation();
+
+    /** Return directory of data files list. */
+    String dataFileListLocation();
+
+    /** Return directory of metadata files list. */
+    String metadataFileListLocation();
+
+    /** Return the latest version */
+    String latestVersion();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -24,7 +24,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 
-interface ManifestEntry<F extends ContentFile<F>> {
+public interface ManifestEntry<F extends ContentFile<F>> {
   enum Status {
     EXISTING(0),
     ADDED(1),

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTest
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,6 +98,13 @@ public class ManifestFiles {
     return CloseableIterable.transform(
         read(manifest, io, null).select(ImmutableList.of("file_path")).liveEntries(),
         entry -> entry.file().path().toString());
+  }
+
+  public static CloseableIterable<Pair<String, Long>> readPathsWithSnapshotId(
+      ManifestFile manifest, FileIO io) {
+    return CloseableIterable.transform(
+        open(manifest, io, null).select(ImmutableList.of("file_path", "snapshot_id")).liveEntries(),
+        entry -> Pair.of(entry.file().path().toString(), entry.snapshotId()));
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -28,10 +28,10 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
-class ManifestLists {
+public class ManifestLists {
   private ManifestLists() {}
 
-  static List<ManifestFile> read(InputFile manifestList) {
+  public static List<ManifestFile> read(InputFile manifestList) {
     try (CloseableIterable<ManifestFile> files =
         Avro.read(manifestList)
             .rename("manifest_file", GenericManifestFile.class.getName())
@@ -50,7 +50,7 @@ class ManifestLists {
     }
   }
 
-  static ManifestListWriter write(
+  public static ManifestListWriter write(
       int formatVersion,
       OutputFile manifestListFile,
       long snapshotId,

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -202,7 +202,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
     return this;
   }
 
-  CloseableIterable<ManifestEntry<F>> entries() {
+  public CloseableIterable<ManifestEntry<F>> entries() {
     return entries(false /* all entries */);
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadataUtil.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataUtil.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.TableMetadata.MetadataLogEntry;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+public class TableMetadataUtil {
+  private TableMetadataUtil() {}
+
+  public static TableMetadata replacePaths(
+      TableMetadata metadata, String sourcePrefix, String targetPrefix) {
+    String newLocation = newPath(metadata.location(), sourcePrefix, targetPrefix);
+    List<Snapshot> newSnapshots = updatePathInSnapshots(metadata, sourcePrefix, targetPrefix);
+    List<MetadataLogEntry> metadataLogEntries =
+        updatePathInMetadataLogs(metadata, sourcePrefix, targetPrefix);
+    long snapshotId =
+        metadata.currentSnapshot() == null ? -1 : metadata.currentSnapshot().snapshotId();
+    Map<String, String> properties =
+        updateProperties(metadata.properties(), sourcePrefix, targetPrefix);
+
+    return new TableMetadata(
+        null,
+        metadata.formatVersion(),
+        metadata.uuid(),
+        newLocation,
+        metadata.lastSequenceNumber(),
+        metadata.lastUpdatedMillis(),
+        metadata.lastColumnId(),
+        metadata.currentSchemaId(),
+        metadata.schemas(),
+        metadata.defaultSpecId(),
+        metadata.specs(),
+        metadata.lastAssignedPartitionId(),
+        metadata.defaultSortOrderId(),
+        metadata.sortOrders(),
+        properties,
+        snapshotId,
+        newSnapshots,
+        () -> newSnapshots,
+        metadata.snapshotLog(),
+        metadataLogEntries,
+        metadata.refs(),
+        metadata.statisticsFiles(),
+        metadata.partitionStatisticsFiles(),
+        metadata.changes());
+  }
+
+  private static Map<String, String> updateProperties(
+      Map<String, String> tableProperties, String sourcePrefix, String targetPrefix) {
+    Map properties = Maps.newHashMap(tableProperties);
+    updatePathInProperty(properties, sourcePrefix, targetPrefix, TableProperties.OBJECT_STORE_PATH);
+    updatePathInProperty(
+        properties, sourcePrefix, targetPrefix, TableProperties.WRITE_FOLDER_STORAGE_LOCATION);
+    updatePathInProperty(
+        properties, sourcePrefix, targetPrefix, TableProperties.WRITE_DATA_LOCATION);
+    updatePathInProperty(
+        properties, sourcePrefix, targetPrefix, TableProperties.WRITE_METADATA_LOCATION);
+
+    return properties;
+  }
+
+  private static void updatePathInProperty(
+      Map<String, String> properties,
+      String sourcePrefix,
+      String targetPrefix,
+      String propertyName) {
+    if (properties.containsKey(propertyName)) {
+      properties.put(
+          propertyName, newPath(properties.get(propertyName), sourcePrefix, targetPrefix));
+    }
+  }
+
+  private static List<MetadataLogEntry> updatePathInMetadataLogs(
+      TableMetadata metadata, String sourcePrefix, String targetPrefix) {
+    List<MetadataLogEntry> metadataLogEntries =
+        Lists.newArrayListWithCapacity(metadata.previousFiles().size());
+    for (MetadataLogEntry metadataLog : metadata.previousFiles()) {
+      MetadataLogEntry newMetadataLog =
+          new MetadataLogEntry(
+              metadataLog.timestampMillis(),
+              newPath(metadataLog.file(), sourcePrefix, targetPrefix));
+      metadataLogEntries.add(newMetadataLog);
+    }
+    return metadataLogEntries;
+  }
+
+  private static List<Snapshot> updatePathInSnapshots(
+      TableMetadata metadata, String sourcePrefix, String targetPrefix) {
+    List<Snapshot> newSnapshots = Lists.newArrayListWithCapacity(metadata.snapshots().size());
+    for (Snapshot snapshot : metadata.snapshots()) {
+      String newManifestListLocation =
+          newPath(snapshot.manifestListLocation(), sourcePrefix, targetPrefix);
+      Snapshot newSnapshot =
+          new BaseSnapshot(
+              snapshot.sequenceNumber(),
+              snapshot.snapshotId(),
+              snapshot.parentId(),
+              snapshot.timestampMillis(),
+              snapshot.operation(),
+              snapshot.summary(),
+              snapshot.schemaId(),
+              newManifestListLocation);
+      newSnapshots.add(newSnapshot);
+    }
+    return newSnapshots;
+  }
+
+  private static String newPath(String path, String sourcePrefix, String targetPrefix) {
+    return path.replaceFirst(sourcePrefix, targetPrefix);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/actions/BaseCopyTableActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseCopyTableActionResult.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+public class BaseCopyTableActionResult implements CopyTable.Result {
+  private final String stagingDirPath;
+  private final String dataFileListPath;
+  private final String metadataFileListPath;
+  private final String latestVersion;
+
+  public BaseCopyTableActionResult(
+      String stagingDirPath,
+      String dataFileListPath,
+      String metadataFileListPath,
+      String latestVersion) {
+    this.stagingDirPath = stagingDirPath;
+    this.dataFileListPath = dataFileListPath;
+    this.metadataFileListPath = metadataFileListPath;
+    this.latestVersion = latestVersion;
+  }
+
+  @Override
+  public String stagingLocation() {
+    return stagingDirPath;
+  }
+
+  @Override
+  public String dataFileListLocation() {
+    return dataFileListPath;
+  }
+
+  @Override
+  public String metadataFileListLocation() {
+    return metadataFileListPath;
+  }
+
+  @Override
+  public String latestVersion() {
+    return latestVersion;
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCopyTableSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCopyTableSparkAction.java
@@ -1,0 +1,870 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestEntry;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestLists;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadata.MetadataLogEntry;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableMetadataUtil;
+import org.apache.iceberg.actions.BaseCopyTableActionResult;
+import org.apache.iceberg.actions.CopyTable;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.avro.DataReader;
+import org.apache.iceberg.data.avro.DataWriter;
+import org.apache.iceberg.data.orc.GenericOrcReader;
+import org.apache.iceberg.data.orc.GenericOrcWriter;
+import org.apache.iceberg.data.parquet.GenericParquetReaders;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.DeleteSchemaUtil;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.spark.api.java.function.MapPartitionsFunction;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoder;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BaseCopyTableSparkAction extends BaseSparkAction<CopyTable> implements CopyTable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseCopyTableSparkAction.class);
+  private static final String DATA_FILE_LIST_DIR = "data-file-list-to-move";
+  private static final String METADATA_FILE_LIST_DIR = "metadata-file-list-to-move";
+
+  private final Table table;
+  private final Set<String> metadataFilesToMove = Collections.synchronizedSet(Sets.newHashSet());
+  private final Set<String> manifestFilePaths = Collections.synchronizedSet(Sets.newHashSet());
+  private final Set<ManifestFile> manifestFilesToRewrite =
+      Collections.synchronizedSet(Sets.newHashSet());
+  private String dataFileListPath = null;
+  private String metadataFileListPath = null;
+  private final boolean enabledPME;
+
+  private String sourcePrefix = "";
+  private String targetPrefix = "";
+  private String startVersion = "";
+  private String endVersion = "";
+  private String stagingDir = "";
+  private Table targetTable = null;
+
+  private Table startStaticTable = null;
+  private Table endStaticTable = null;
+
+  public BaseCopyTableSparkAction(SparkSession spark, Table table) {
+    super(spark);
+    this.table = table;
+    enabledPME = table.properties().containsKey("parquet.encryption.footer.key");
+  }
+
+  @Override
+  public CopyTable rewriteLocationPrefix(String sPrefix, String tPrefix) {
+    Preconditions.checkArgument(
+        sPrefix != null && !sPrefix.isEmpty(), "Source prefix('%s') cannot be empty.", sPrefix);
+    this.sourcePrefix = sPrefix;
+
+    if (tPrefix != null) {
+      this.targetPrefix = tPrefix;
+    }
+    return this;
+  }
+
+  @Override
+  public CopyTable lastCopiedVersion(String sVersion) {
+    Preconditions.checkArgument(
+        sVersion != null && !sVersion.trim().isEmpty(),
+        "Last copied version('%s') cannot be empty.",
+        sVersion);
+    this.startVersion = sVersion;
+    return this;
+  }
+
+  @Override
+  public CopyTable endVersion(String eVersion) {
+    Preconditions.checkArgument(
+        eVersion != null && !eVersion.trim().isEmpty(),
+        "End version('%s') cannot be empty.",
+        eVersion);
+    this.endVersion = eVersion;
+    return this;
+  }
+
+  @Override
+  public CopyTable stagingLocation(String stagingLocation) {
+    Preconditions.checkArgument(
+        stagingLocation != null && !stagingLocation.isEmpty(),
+        "Staging location('%s') cannot be empty.",
+        stagingLocation);
+    this.stagingDir = stagingLocation;
+    return this;
+  }
+
+  @Override
+  public CopyTable targetTable(Table tgtTable) {
+    this.targetTable = tgtTable;
+    return this;
+  }
+
+  @Override
+  protected CopyTable self() {
+    return this;
+  }
+
+  @Override
+  public Result execute() {
+    validateInputs();
+    JobGroupInfo info = newJobGroupInfo("COPY-TABLE", jobDesc());
+    return withJobGroupInfo(info, this::doExecute);
+  }
+
+  private CopyTable.Result doExecute() {
+    rebuildMetaData();
+    return new BaseCopyTableActionResult(
+        stagingDir, dataFileListPath, metadataFileListPath, fileName(endVersion));
+  }
+
+  private void validateInputs() {
+    Preconditions.checkArgument(
+        sourcePrefix != null && !sourcePrefix.isEmpty(),
+        "Source prefix('%s') cannot be empty.",
+        sourcePrefix);
+
+    validateAndSetEndVersion();
+
+    endStaticTable = newStaticTable(endVersion, table.io());
+
+    TableMetadata tableMetadata = ((HasTableOperations) endStaticTable).operations().current();
+    Preconditions.checkArgument(
+        tableMetadata.formatVersion() == 2, "Support Iceberg format version 2 only.");
+
+    validateAndSetStartVersion(tableMetadata);
+
+    if (fileExist(startVersion)) {
+      startStaticTable = newStaticTable(startVersion, table.io());
+    }
+
+    if (stagingDir.isEmpty()) {
+      String stagingDirName = "copy-table-staging-" + UUID.randomUUID();
+      stagingDir = combinePaths(table.location(), stagingDirName);
+    }
+
+    if (!stagingDir.endsWith("/")) {
+      stagingDir = stagingDir + "/";
+    }
+  }
+
+  private void validateAndSetEndVersion() {
+    if (endVersion.isEmpty()) {
+      endVersion = currentMetadataPath(table);
+    } else {
+      TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
+      if (versionInFilePath(tableMetadata.metadataFileLocation(), endVersion)) {
+        endVersion = tableMetadata.metadataFileLocation();
+      }
+      for (MetadataLogEntry metadataLogEntry : tableMetadata.previousFiles()) {
+        if (versionInFilePath(metadataLogEntry.file(), endVersion)) {
+          endVersion = metadataLogEntry.file();
+          break;
+        }
+      }
+
+      Preconditions.checkArgument(
+          fileExist(endVersion),
+          "Cannot find the end version('%s') in the current version " + "files",
+          endVersion);
+    }
+  }
+
+  private void validateAndSetStartVersion(TableMetadata tableMetadata) {
+    if (startVersion.isEmpty()) {
+      if (targetTable == null) {
+        LOG.warn("No input of the start version. Will do a full copy.");
+      } else {
+        String tgtTableCurrentVersion = fileName(currentMetadataPath(targetTable));
+
+        for (MetadataLogEntry metadataLogEntry : tableMetadata.previousFiles()) {
+          if (metadataLogEntry.file().endsWith(tgtTableCurrentVersion)) {
+            startVersion = metadataLogEntry.file();
+            break;
+          }
+        }
+
+        if (fileNotExist(startVersion)) {
+          throw new IllegalArgumentException(
+              "Cannot find the current version of target table in the source table. "
+                  + "Please make sure the target table is a subset of source table.");
+        }
+      }
+    } else {
+      for (MetadataLogEntry metadataLogEntry : tableMetadata.previousFiles()) {
+        if (versionInFilePath(metadataLogEntry.file(), startVersion)) {
+          startVersion = metadataLogEntry.file();
+          break;
+        }
+      }
+
+      Preconditions.checkArgument(
+          fileExist(startVersion), "Start version('%s') is NOT valid.", startVersion);
+
+      if (targetTable != null
+          && !fileName(startVersion).equals(fileName(currentMetadataPath(targetTable)))) {
+        throw new IllegalArgumentException(
+            "The start version isn't the current version of the target table. "
+                + "Please make sure the target table is a subset of source table.");
+      }
+    }
+  }
+
+  private boolean versionInFilePath(String path, String version) {
+    return fileName(path).equals(version);
+  }
+
+  private String jobDesc() {
+    if (startVersion.isEmpty()) {
+      return String.format(
+          "Replacing path prefixes '%s' with '%s' in the metadata files of table %s,"
+              + "up to version '%s'.",
+          sourcePrefix, targetPrefix, table.name(), endVersion);
+    } else {
+      return String.format(
+          "Replacing path prefixes '%s' with '%s' in the metadata files of table %s,"
+              + "from version '%s' to '%s'.",
+          sourcePrefix, targetPrefix, table.name(), startVersion, endVersion);
+    }
+  }
+
+  /**
+   * Here are steps: 1. rebuild version files 2. rebuild manifest list files 3. rebuild manifest
+   * files 4. get all data files need to move
+   */
+  private void rebuildMetaData() {
+    TableMetadata tableMetadata = ((HasTableOperations) endStaticTable).operations().current();
+
+    // rebuild version files
+    Set<Long> allSnapshotIds = rewriteVersionFiles(tableMetadata);
+
+    Set<Long> diffSnapshotIds = getDiffSnapshotIds(allSnapshotIds);
+
+    // get all manifest file paths need to rewrite
+    List<String> manifestFilePathToMove = manifestFilesToMove(diffSnapshotIds);
+    manifestFilePaths.addAll(manifestFilePathToMove);
+
+    // rebuild manifest-list files
+    Set<Snapshot> validSnapshots =
+        Sets.difference(snapshotSet(endVersion), snapshotSet(startVersion));
+    validSnapshots.forEach(snapshot -> rewriteManifestList(snapshot, tableMetadata));
+
+    // rebuild manifest files
+    List<ManifestFile> newManifests = rewriteManifests(tableMetadata);
+    newManifests.forEach(manifestFile -> addToRebuiltFiles(manifestFile.path()));
+    saveMetadataFileList();
+
+    Dataset<Row> dataFiles = getDiffDataFiles(diffSnapshotIds);
+    saveDataFileList(dataFiles);
+  }
+
+  private void saveMetadataFileList() {
+    List<String> fileList = Lists.newArrayList();
+    fileList.addAll(metadataFilesToMove);
+    Dataset<String> metadataFileList = spark().createDataset(fileList, Encoders.STRING());
+    metadataFileListPath = stagingDir + METADATA_FILE_LIST_DIR;
+    metadataFileList
+        .repartition(1)
+        .write()
+        .mode(SaveMode.Overwrite)
+        .format("text")
+        .save(metadataFileListPath);
+  }
+
+  private void saveDataFileList(Dataset<Row> dataFiles) {
+    dataFileListPath = stagingDir + DATA_FILE_LIST_DIR;
+
+    try {
+      dataFiles
+          .repartition(1)
+          .write()
+          .mode(SaveMode.Overwrite)
+          .format("text")
+          .save(dataFileListPath);
+    } catch (Exception e) {
+      throw new UnsupportedOperationException(
+          "Failed to build the data files dataframe, the end version you are "
+              + "trying to copy may contain invalid snapshots, please use the younger version which doesn't have invalid "
+              + "snapshots",
+          e);
+    }
+  }
+
+  private Set<Long> getDiffSnapshotIds(Set<Long> allSnapshotIds) {
+    Set<Long> snapshotIdsInStartVersion = Sets.newHashSet();
+    if (startStaticTable != null) {
+      startStaticTable
+          .snapshots()
+          .forEach(snapshot -> snapshotIdsInStartVersion.add(snapshot.snapshotId()));
+    }
+    return Sets.difference(allSnapshotIds, snapshotIdsInStartVersion);
+  }
+
+  private Set<Long> rewriteVersionFiles(TableMetadata metadata) {
+    Set<Long> allSnapshotIds = Sets.newHashSet();
+
+    String stagingPath = combinePaths(stagingDir, relativize(endVersion, sourcePrefix));
+    metadata.snapshots().forEach(snapshot -> allSnapshotIds.add(snapshot.snapshotId()));
+    rewriteVersionFile(metadata, stagingPath);
+
+    List<MetadataLogEntry> versions = metadata.previousFiles();
+    for (int i = versions.size() - 1; i >= 0; i--) {
+      String versionFilePath = versions.get(i).file();
+      if (versionFilePath.equals(startVersion)) {
+        break;
+      }
+
+      Preconditions.checkArgument(
+          fileExist(versionFilePath),
+          String.format("Version file %s doesn't exist", versionFilePath));
+      String newPath = combinePaths(stagingDir, relativize(versionFilePath, sourcePrefix));
+      TableMetadata tableMetadata =
+          new StaticTableOperations(versionFilePath, table.io()).current();
+
+      tableMetadata.snapshots().forEach(snapshot -> allSnapshotIds.add(snapshot.snapshotId()));
+
+      rewriteVersionFile(tableMetadata, newPath);
+    }
+
+    return allSnapshotIds;
+  }
+
+  private Set<Snapshot> snapshotSet(String metadataPath) {
+    Set<Snapshot> snapshots = Sets.newHashSet();
+    if (!metadataPath.isEmpty()) {
+      StaticTableOperations ops = new StaticTableOperations(metadataPath, table.io());
+      TableMetadata metadata = ops.current();
+      snapshots.addAll(metadata.snapshots());
+    }
+    return snapshots;
+  }
+
+  private void rewriteVersionFile(TableMetadata metadata, String stagingPath) {
+    TableMetadata newTableMetadata =
+        TableMetadataUtil.replacePaths(metadata, sourcePrefix, targetPrefix);
+    TableMetadataParser.overwrite(newTableMetadata, table.io().newOutputFile(stagingPath));
+    addToRebuiltFiles(stagingPath);
+  }
+
+  private void rewriteManifestList(Snapshot snapshot, TableMetadata tableMetadata) {
+    List<ManifestFile> manifestFiles = manifestFilesInSnapshot(snapshot);
+    String path = snapshot.manifestListLocation();
+    String stagingPath = combinePaths(stagingDir, relativize(path, sourcePrefix));
+    OutputFile outputFile = table.io().newOutputFile(stagingPath);
+    try (FileAppender<ManifestFile> writer =
+        ManifestLists.write(
+            tableMetadata.formatVersion(),
+            outputFile,
+            snapshot.snapshotId(),
+            snapshot.parentId(),
+            snapshot.sequenceNumber())) {
+
+      for (ManifestFile file : manifestFiles) {
+        // need to get the ManifestFile object for manifest file rewriting
+        if (manifestFilePaths.contains(file.path())) {
+          manifestFilesToRewrite.add(file);
+        }
+
+        ManifestFile newFile = file.copy();
+        if (newFile.path().startsWith(sourcePrefix)) {
+          ((StructLike) newFile).set(0, newPath(newFile.path(), sourcePrefix, targetPrefix));
+        }
+        writer.add(newFile);
+      }
+
+      addToRebuiltFiles(stagingPath);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to rewrite the manifest list file " + path, e);
+    }
+  }
+
+  private List<ManifestFile> manifestFilesInSnapshot(Snapshot snapshot) {
+    String path = snapshot.manifestListLocation();
+    List<ManifestFile> manifestFiles = Lists.newLinkedList();
+    try {
+      manifestFiles = ManifestLists.read(table.io().newInputFile(path));
+    } catch (RuntimeIOException e) {
+      LOG.warn("Failed to read manifest list {}", path, e);
+    }
+    return manifestFiles;
+  }
+
+  private List<String> manifestFilesToMove(Set<Long> diffSnapshotIds) {
+    try {
+      Dataset<Row> lastVersionFiles = buildManifestFileDF(endStaticTable);
+      if (startStaticTable == null) {
+        return lastVersionFiles.distinct().as(Encoders.STRING()).collectAsList();
+      } else {
+        return lastVersionFiles
+            .distinct()
+            .filter(functions.column("added_snapshot_id").isInCollection(diffSnapshotIds))
+            .as(Encoders.STRING())
+            .collectAsList();
+      }
+    } catch (Exception e) {
+      throw new UnsupportedOperationException(
+          "Failed to build the manifest files dataframe, the end version you are "
+              + "trying to copy may contain invalid snapshots, please use the younger version which doesn't have invalid "
+              + "snapshots",
+          e);
+    }
+  }
+
+  /** Rewrite manifest files in a distributed manner. */
+  private List<ManifestFile> rewriteManifests(TableMetadata tableMetadata) {
+    if (manifestFilesToRewrite.isEmpty()) {
+      return Lists.newArrayList();
+    }
+
+    Encoder<ManifestFile> manifestFileEncoder = Encoders.javaSerialization(ManifestFile.class);
+    Dataset<ManifestFile> manifestDS =
+        spark().createDataset(Lists.newArrayList(manifestFilesToRewrite), manifestFileEncoder);
+
+    FileIO tableIO = SerializableTable.copyOf(table).io();
+    Broadcast<FileIO> io = sparkContext().broadcast(tableIO);
+
+    return manifestDS
+        .repartition(manifestFilesToRewrite.size())
+        .mapPartitions(
+            toManifests(
+                io,
+                stagingDir,
+                tableMetadata.formatVersion(),
+                tableMetadata.specsById(),
+                sourcePrefix,
+                targetPrefix),
+            manifestFileEncoder)
+        .collectAsList();
+  }
+
+  private static MapPartitionsFunction<ManifestFile, ManifestFile> toManifests(
+      Broadcast<FileIO> io,
+      String stagingLocation,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix) {
+
+    return rows -> {
+      List<ManifestFile> manifests = Lists.newArrayList();
+      while (rows.hasNext()) {
+        ManifestFile manifestFile = rows.next();
+        switch (manifestFile.content()) {
+          case DATA:
+            manifests.add(
+                writeDataManifest(
+                    manifestFile,
+                    io,
+                    stagingLocation,
+                    format,
+                    specsById,
+                    sourcePrefix,
+                    targetPrefix));
+            break;
+          case DELETES:
+            manifests.add(
+                writeDeleteManifest(
+                    manifestFile,
+                    io,
+                    stagingLocation,
+                    format,
+                    specsById,
+                    sourcePrefix,
+                    targetPrefix));
+            break;
+          default:
+            throw new UnsupportedOperationException(
+                "Unsupported manifest type: " + manifestFile.content());
+        }
+      }
+
+      return manifests.iterator();
+    };
+  }
+
+  private static ManifestFile writeDataManifest(
+      ManifestFile manifestFile,
+      Broadcast<FileIO> io,
+      String stagingLocation,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix)
+      throws IOException {
+    PartitionSpec spec = specsById.get(manifestFile.partitionSpecId());
+    String stagingPath =
+        combinePaths(stagingLocation, relativize(manifestFile.path(), sourcePrefix));
+    OutputFile outputFile = io.value().newOutputFile(stagingPath);
+    ManifestWriter<DataFile> writer =
+        ManifestFiles.write(format, spec, outputFile, manifestFile.snapshotId());
+
+    try (ManifestReader<DataFile> reader =
+        ManifestFiles.read(manifestFile, io.getValue(), specsById).select(Arrays.asList("*"))) {
+      reader
+          .entries()
+          .forEach(
+              entry ->
+                  appendEntryWithFile(
+                      entry, writer, newDataFile(entry.file(), spec, sourcePrefix, targetPrefix)));
+    } finally {
+      writer.close();
+    }
+    return writer.toManifestFile();
+  }
+
+  private static DataFile newDataFile(
+      DataFile file, PartitionSpec spec, String sourcePrefix, String targetPrefix) {
+    DataFile transformedFile = file;
+    String filePath = file.path().toString();
+    if (filePath.startsWith(sourcePrefix)) {
+      filePath = newPath(filePath, sourcePrefix, targetPrefix);
+      transformedFile = DataFiles.builder(spec).copy(file).withPath(filePath).build();
+    }
+    return transformedFile;
+  }
+
+  private static ManifestFile writeDeleteManifest(
+      ManifestFile manifestFile,
+      Broadcast<FileIO> io,
+      String stagingLocation,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix)
+      throws IOException {
+    PartitionSpec spec = specsById.get(manifestFile.partitionSpecId());
+
+    String manifestStagingPath =
+        combinePaths(stagingLocation, relativize(manifestFile.path(), sourcePrefix));
+    OutputFile manifestOutputFile = io.value().newOutputFile(manifestStagingPath);
+    ManifestWriter<DeleteFile> writer =
+        ManifestFiles.writeDeleteManifest(
+            format, spec, manifestOutputFile, manifestFile.snapshotId());
+
+    try (ManifestReader<DeleteFile> reader =
+        ManifestFiles.readDeleteManifest(manifestFile, io.getValue(), specsById)
+            .select(Arrays.asList("*"))) {
+
+      for (ManifestEntry<DeleteFile> entry : reader.entries()) {
+        DeleteFile file = entry.file();
+
+        switch (file.content()) {
+          case POSITION_DELETES:
+            String filePath = file.path().toString();
+            String deleteFileStagingPath =
+                combinePaths(stagingLocation, relativize(filePath, sourcePrefix));
+            DeleteFile newDeleteFile =
+                rewritePositionDeleteFile(
+                    io, file, deleteFileStagingPath, spec, sourcePrefix, targetPrefix);
+
+            if (filePath.startsWith(sourcePrefix)) {
+              filePath = newPath(filePath, sourcePrefix, targetPrefix);
+              newDeleteFile =
+                  FileMetadata.deleteFileBuilder(spec)
+                      .ofPositionDeletes()
+                      .copy(newDeleteFile)
+                      .withPath(filePath)
+                      .withSplitOffsets(file.splitOffsets())
+                      .build();
+            }
+            appendEntryWithFile(entry, writer, newDeleteFile);
+            break;
+          case EQUALITY_DELETES:
+            appendEntryWithFile(
+                entry, writer, newEqualityDeleteFile(file, spec, sourcePrefix, targetPrefix));
+            break;
+          default:
+            throw new UnsupportedOperationException(
+                "Unsupported delete file type: " + file.content());
+        }
+      }
+    } finally {
+      writer.close();
+    }
+    return writer.toManifestFile();
+  }
+
+  private static DeleteFile newEqualityDeleteFile(
+      DeleteFile file, PartitionSpec spec, String sourcePrefix, String targetPrefix) {
+    DeleteFile transformedFile = file;
+    String filePath = file.path().toString();
+
+    if (filePath.startsWith(sourcePrefix)) {
+      int[] equalityFieldIds =
+          file.equalityFieldIds().stream().mapToInt(Integer::intValue).toArray();
+      filePath = newPath(filePath, sourcePrefix, targetPrefix);
+      transformedFile =
+          FileMetadata.deleteFileBuilder(spec)
+              .ofEqualityDeletes(equalityFieldIds)
+              .copy(file)
+              .withPath(filePath)
+              .withSplitOffsets(file.splitOffsets())
+              .build();
+    }
+    return transformedFile;
+  }
+
+  private static PositionDelete newPositionDeleteRecord(
+      Record record, String sourcePrefix, String targetPrefix) {
+    PositionDelete delete = PositionDelete.create();
+    delete.set(
+        newPath((String) record.get(0), sourcePrefix, targetPrefix),
+        (Long) record.get(1),
+        record.get(2));
+    return delete;
+  }
+
+  private static DeleteFile rewritePositionDeleteFile(
+      Broadcast<FileIO> io,
+      DeleteFile current,
+      String path,
+      PartitionSpec spec,
+      String sourcePrefix,
+      String targetPrefix)
+      throws IOException {
+    OutputFile targetFile = io.value().newOutputFile(path);
+    InputFile sourceFile = io.value().newInputFile(current.path().toString());
+
+    try (CloseableIterable<Record> reader =
+        positionDeletesReader(sourceFile, current.format(), spec)) {
+      Record record = null;
+      Schema rowSchema = null;
+      CloseableIterator<Record> recordIt = reader.iterator();
+
+      if (recordIt.hasNext()) {
+        record = recordIt.next();
+        rowSchema = record.get(2) != null ? spec.schema() : null;
+      }
+
+      PositionDeleteWriter<Record> writer =
+          positionDeletesWriter(targetFile, current.format(), spec, current.partition(), rowSchema);
+
+      try {
+        if (record != null) {
+          writer.write(newPositionDeleteRecord(record, sourcePrefix, targetPrefix));
+        }
+
+        while (recordIt.hasNext()) {
+          record = recordIt.next();
+          writer.write(newPositionDeleteRecord(record, sourcePrefix, targetPrefix));
+        }
+      } finally {
+        writer.close();
+      }
+      return writer.toDeleteFile();
+    }
+  }
+
+  private static CloseableIterable<Record> positionDeletesReader(
+      InputFile inputFile, FileFormat format, PartitionSpec spec) throws IOException {
+    Schema deleteSchema = DeleteSchemaUtil.posDeleteSchema(spec.schema());
+    switch (format) {
+      case AVRO:
+        return Avro.read(inputFile)
+            .project(deleteSchema)
+            .reuseContainers()
+            .createReaderFunc(DataReader::create)
+            .build();
+
+      case PARQUET:
+        return Parquet.read(inputFile)
+            .project(deleteSchema)
+            .reuseContainers()
+            .createReaderFunc(
+                fileSchema -> GenericParquetReaders.buildReader(deleteSchema, fileSchema))
+            .build();
+
+      case ORC:
+        return ORC.read(inputFile)
+            .project(deleteSchema)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(deleteSchema, fileSchema))
+            .build();
+
+      default:
+        throw new UnsupportedOperationException("Unsupported file format: " + format);
+    }
+  }
+
+  private static PositionDeleteWriter<Record> positionDeletesWriter(
+      OutputFile outputFile,
+      FileFormat format,
+      PartitionSpec spec,
+      StructLike partition,
+      Schema rowSchema)
+      throws IOException {
+    switch (format) {
+      case AVRO:
+        return Avro.writeDeletes(outputFile)
+            .createWriterFunc(DataWriter::create)
+            .withPartition(partition)
+            .rowSchema(rowSchema)
+            .withSpec(spec)
+            .buildPositionWriter();
+      case PARQUET:
+        return Parquet.writeDeletes(outputFile)
+            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .withPartition(partition)
+            .rowSchema(rowSchema)
+            .withSpec(spec)
+            .buildPositionWriter();
+      case ORC:
+        return ORC.writeDeletes(outputFile)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .withPartition(partition)
+            .rowSchema(rowSchema)
+            .withSpec(spec)
+            .buildPositionWriter();
+      default:
+        throw new UnsupportedOperationException("Unsupported file format: " + format);
+    }
+  }
+
+  private static <F extends ContentFile<F>> void appendEntryWithFile(
+      ManifestEntry<F> entry, ManifestWriter<F> writer, F file) {
+    switch (entry.status()) {
+      case ADDED:
+        writer.add(file);
+        break;
+      case EXISTING:
+        writer.existing(
+            file, entry.snapshotId(), entry.dataSequenceNumber(), entry.fileSequenceNumber());
+        break;
+      case DELETED:
+        writer.delete(file, entry.dataSequenceNumber(), entry.fileSequenceNumber());
+        break;
+    }
+  }
+
+  private Dataset<Row> getDiffDataFiles(Set<Long> diffSnapshotIds) {
+    Dataset<Row> lastVersionFiles = buildValidDataFileDFWithSnapshotId(endStaticTable);
+    if (startStaticTable == null) {
+      return lastVersionFiles.distinct().select("file_path");
+    } else {
+      return lastVersionFiles
+          .distinct()
+          .filter(functions.column("snapshot_id").isInCollection(diffSnapshotIds))
+          .select("file_path");
+    }
+  }
+
+  private boolean fileNotExist(String path) {
+    return !fileExist(path);
+  }
+
+  private boolean fileExist(String path) {
+    if (path == null || path.trim().isEmpty()) {
+      return false;
+    }
+    return table.io().newInputFile(path).exists();
+  }
+
+  private static String relativize(String path, String prefix) {
+    String toRemove = prefix;
+    if (!toRemove.endsWith("/")) {
+      toRemove += "/";
+    }
+    if (!path.startsWith(toRemove)) {
+      throw new IllegalArgumentException(
+          String.format("Path %s does not start with %s", path, toRemove));
+    }
+    return path.substring(toRemove.length());
+  }
+
+  private static String newPath(String path, String sourcePrefix, String targetPrefix) {
+    return combinePaths(targetPrefix, relativize(path, sourcePrefix));
+  }
+
+  private void addToRebuiltFiles(String path) {
+    metadataFilesToMove.add(path);
+  }
+
+  private String currentMetadataPath(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current().metadataFileLocation();
+  }
+
+  private static String combinePaths(String absolutePath, String relativePath) {
+    String combined = absolutePath;
+    if (!combined.endsWith("/")) {
+      combined += "/";
+    }
+    combined += relativePath;
+    return combined;
+  }
+
+  private static String fileName(String path) {
+    String filename = path;
+    int lastIndex = path.lastIndexOf(File.separator);
+    if (lastIndex != -1) {
+      filename = path.substring(lastIndex + 1);
+    }
+    return filename;
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.apache.iceberg.AllManifestsTable;
@@ -47,7 +46,6 @@ import org.apache.iceberg.ReachableFileUtil;
 import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StaticTableOperations;
-import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -339,14 +337,8 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Dataset<FileInfo> statisticsFileDS(Table table, Set<Long> snapshotIds) {
-    Predicate<StatisticsFile> predicate;
-    if (snapshotIds == null) {
-      predicate = statisticsFile -> true;
-    } else {
-      predicate = statisticsFile -> snapshotIds.contains(statisticsFile.snapshotId());
-    }
-
-    List<String> statisticsFiles = ReachableFileUtil.statisticsFilesLocations(table, predicate);
+    List<String> statisticsFiles =
+        ReachableFileUtil.statisticsFilesLocationsForSnapshots(table, snapshotIds);
     return toFileInfoDS(statisticsFiles, STATISTICS_FILES);
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -31,7 +31,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.apache.iceberg.AllManifestsTable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
@@ -42,9 +44,13 @@ import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReachableFileUtil;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.BulkDeletionFailureException;
@@ -60,10 +66,12 @@ import org.apache.iceberg.relocated.com.google.common.collect.ListMultimap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.spark.JobGroupUtils;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.source.SerializableTableWithSize;
+import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -71,10 +79,12 @@ import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Tuple2;
 
 abstract class BaseSparkAction<ThisT> {
 
@@ -127,6 +137,68 @@ abstract class BaseSparkAction<ThisT> {
     return options;
   }
 
+  /**
+   * Returns all the path locations of all Manifest Lists for a given list of snapshots
+   *
+   * @param snapshots snapshots
+   * @return the paths of the Manifest Lists
+   */
+  private List<String> getManifestListPaths(Iterable<Snapshot> snapshots) {
+    List<String> manifestLists = Lists.newArrayList();
+    for (Snapshot snapshot : snapshots) {
+      String manifestListLocation = snapshot.manifestListLocation();
+      if (manifestListLocation != null) {
+        manifestLists.add(manifestListLocation);
+      }
+    }
+    return manifestLists;
+  }
+
+  /**
+   * Returns all Metadata file paths which may not be in the current metadata. Specifically this
+   * includes "version-hint" files as well as entries in metadata.previousFiles.
+   *
+   * @param ops TableOperations for the table we will be getting paths from
+   * @return a list of paths to metadata files
+   */
+  private List<String> getOtherMetadataFilePaths(TableOperations ops) {
+    List<String> otherMetadataFiles = Lists.newArrayList();
+    otherMetadataFiles.add(ops.metadataFileLocation("version-hint.text"));
+
+    TableMetadata metadata = ops.current();
+    otherMetadataFiles.add(metadata.metadataFileLocation());
+    for (TableMetadata.MetadataLogEntry previousMetadataFile : metadata.previousFiles()) {
+      otherMetadataFiles.add(previousMetadataFile.file());
+    }
+    return otherMetadataFiles;
+  }
+
+  protected Dataset<Row> buildOtherMetadataFileDF(Table table) {
+    return buildOtherMetadataFileDF(
+        table, false /* include all reachable previous metadata locations */);
+  }
+
+  protected Dataset<Row> buildAllReachableOtherMetadataFileDF(Table table) {
+    return buildOtherMetadataFileDF(
+        table, true /* include all reachable previous metadata locations */);
+  }
+
+  private Dataset<Row> buildOtherMetadataFileDF(
+      Table table, boolean includePreviousMetadataLocations) {
+    List<String> otherMetadataFiles = Lists.newArrayList();
+    otherMetadataFiles.addAll(
+        ReachableFileUtil.metadataFileLocations(table, includePreviousMetadataLocations));
+    otherMetadataFiles.add(ReachableFileUtil.versionHintLocation(table));
+    return spark.createDataset(otherMetadataFiles, Encoders.STRING()).toDF(FILE_PATH);
+  }
+
+  protected Dataset<Row> buildValidMetadataFileDF(Table table) {
+    Dataset<Row> manifestDF = buildManifestFileDF(table);
+    Dataset<Row> manifestListDF = buildManifestListDF(table);
+    Dataset<Row> otherMetadataFileDF = buildOtherMetadataFileDF(table);
+    return manifestDF.union(otherMetadataFileDF).union(manifestListDF);
+  }
+
   protected <T> T withJobGroupInfo(JobGroupInfo info, Supplier<T> supplier) {
     SparkContext context = spark().sparkContext();
     JobGroupInfo previousInfo = JobGroupUtils.getJobGroupInfo(context);
@@ -143,7 +215,10 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Table newStaticTable(TableMetadata metadata, FileIO io) {
-    String metadataFileLocation = metadata.metadataFileLocation();
+    return newStaticTable(metadata.metadataFileLocation(), io);
+  }
+
+  protected Table newStaticTable(String metadataFileLocation, FileIO io) {
     StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
     return new BaseTable(ops, metadataFileLocation);
   }
@@ -182,6 +257,68 @@ abstract class BaseSparkAction<ThisT> {
         .as(FileInfo.ENCODER);
   }
 
+  protected Dataset<Row> buildValidDataFileDF(Table table) {
+    JavaSparkContext context = JavaSparkContext.fromSparkContext(spark.sparkContext());
+    Broadcast<Table> tableBroadcast = context.broadcast(SerializableTable.copyOf(table));
+
+    Dataset<ManifestFileBean> allManifests =
+        loadMetadataTable(table, ALL_MANIFESTS)
+            .selectExpr(
+                "content",
+                "path",
+                "length",
+                "partition_spec_id as partitionSpecId",
+                "added_snapshot_id as addedSnapshotId")
+            .dropDuplicates("path")
+            .repartition(
+                spark
+                    .sessionState()
+                    .conf()
+                    .numShufflePartitions()) // avoid adaptive execution combining tasks
+            .as(Encoders.bean(ManifestFileBean.class));
+
+    return allManifests
+        .flatMap(new ReadManifest(tableBroadcast), FileInfo.ENCODER)
+        .toDF("file_path", "file_type")
+        .drop("file_type");
+  }
+
+  protected Dataset<Row> buildValidDataFileDFWithSnapshotId(Table table) {
+    JavaSparkContext context = JavaSparkContext.fromSparkContext(spark.sparkContext());
+    Broadcast<FileIO> ioBroadcast = context.broadcast(SerializableTable.copyOf(table).io());
+
+    Dataset<ManifestFileBean> allManifests =
+        loadMetadataTable(table, ALL_MANIFESTS)
+            .selectExpr(
+                "content",
+                "path",
+                "length",
+                "partition_spec_id as partitionSpecId",
+                "added_snapshot_id as addedSnapshotId")
+            .dropDuplicates("path")
+            .repartition(
+                spark
+                    .sessionState()
+                    .conf()
+                    .numShufflePartitions()) // avoid adaptive execution combining tasks
+            .as(Encoders.bean(ManifestFileBean.class));
+
+    return allManifests
+        .flatMap(
+            new ReadManifestWithSnapshotId(ioBroadcast),
+            Encoders.tuple(Encoders.STRING(), Encoders.LONG()))
+        .toDF("file_path", "snapshot_id");
+  }
+
+  protected Dataset<Row> buildManifestFileDF(Table table) {
+    return loadMetadataTable(table, ALL_MANIFESTS).select(col("path").as(FILE_PATH));
+  }
+
+  protected Dataset<Row> buildManifestListDF(Table table) {
+    List<String> manifestLists = getManifestListPaths(table.snapshots());
+    return spark.createDataset(manifestLists, Encoders.STRING()).toDF("file_path");
+  }
+
   private Dataset<Row> manifestDF(Table table, Set<Long> snapshotIds) {
     Dataset<Row> manifestDF = loadMetadataTable(table, ALL_MANIFESTS);
     if (snapshotIds != null) {
@@ -202,8 +339,14 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Dataset<FileInfo> statisticsFileDS(Table table, Set<Long> snapshotIds) {
-    List<String> statisticsFiles =
-        ReachableFileUtil.statisticsFilesLocationsForSnapshots(table, snapshotIds);
+    Predicate<StatisticsFile> predicate;
+    if (snapshotIds == null) {
+      predicate = statisticsFile -> true;
+    } else {
+      predicate = statisticsFile -> snapshotIds.contains(statisticsFile.snapshotId());
+    }
+
+    List<String> statisticsFiles = ReachableFileUtil.statisticsFilesLocations(table, predicate);
     return toFileInfoDS(statisticsFiles, STATISTICS_FILES);
   }
 
@@ -441,6 +584,24 @@ abstract class BaseSparkAction<ThisT> {
 
     static FileInfo toFileInfo(ContentFile<?> file) {
       return new FileInfo(file.path().toString(), file.content().toString());
+    }
+  }
+
+  private static class ReadManifestWithSnapshotId
+      implements FlatMapFunction<ManifestFileBean, Tuple2<String, Long>> {
+    private final Broadcast<FileIO> io;
+
+    ReadManifestWithSnapshotId(Broadcast<FileIO> io) {
+      this.io = io;
+    }
+
+    @Override
+    public Iterator<Tuple2<String, Long>> call(ManifestFileBean manifest) {
+      Iterator<Pair<String, Long>> iterator =
+          new ClosingIterator<>(
+              ManifestFiles.readPathsWithSnapshotId(manifest, io.getValue()).iterator());
+      Stream<Pair<String, Long>> stream = Streams.stream(iterator);
+      return stream.map(pair -> Tuple2.apply(pair.first(), pair.second())).iterator();
     }
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.actions;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.CopyTable;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.Spark3Util.CatalogAndIdentifier;
 import org.apache.spark.sql.SparkSession;
@@ -95,5 +96,10 @@ public class SparkActions implements ActionsProvider {
   @Override
   public RewritePositionDeleteFilesSparkAction rewritePositionDeletes(Table table) {
     return new RewritePositionDeleteFilesSparkAction(spark, table);
+  }
+
+  @Override
+  public CopyTable copyTable(Table table) {
+    return new BaseCopyTableSparkAction(spark, table);
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCopyTableAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCopyTableAction.java
@@ -1,0 +1,1023 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.CopyTable;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.source.ThreeColumnRecord;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestCopyTableAction extends SparkTestBase {
+  protected ActionsProvider actions() {
+    return SparkActions.get();
+  }
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  protected static final Schema SCHEMA =
+      new Schema(
+          optional(1, "c1", Types.IntegerType.get()),
+          optional(2, "c2", Types.StringType.get()),
+          optional(3, "c3", Types.StringType.get()));
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  private File tableDir = null;
+  protected String tableLocation = null;
+  private Table table = null;
+
+  @Before
+  public void setupTableLocation() throws Exception {
+    this.tableDir = temp.newFolder();
+    this.tableLocation = tableDir.toURI().toString();
+    this.table = createATableWith2Snapshots(tableLocation);
+  }
+
+  private Table createATableWith2Snapshots(String location) {
+    return createTableWithSnapshots(location, 2);
+  }
+
+  private Table createTableWithSnapshots(String location, int snapshotNumber) {
+    return createTableWithSnapshots(location, snapshotNumber, Maps.newHashMap());
+  }
+
+  protected Table createTableWithSnapshots(
+      String location, int snapshotNumber, Map<String, String> properties) {
+    Table newTable = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, location);
+
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+
+    for (int i = 0; i < snapshotNumber; i++) {
+      df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(location);
+    }
+
+    return newTable;
+  }
+
+  @Test
+  public void testCopyTable() throws Exception {
+    String targetTableLocation = newTableLocation();
+
+    // check the data file location before the rebuild
+    List<String> validDataFiles =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation + "#files")
+            .select("file_path")
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertEquals("Should be 2 valid data files", 2, validDataFiles.size());
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(table)
+            .rewriteLocationPrefix(tableLocation, targetTableLocation)
+            .endVersion("v3.metadata.json")
+            .execute();
+
+    Assert.assertEquals("The latest version should be", "v3.metadata.json", result.latestVersion());
+
+    checkMetadataFileNum(3, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(tableLocation, targetTableLocation, stagingDir(result));
+
+    // verify the data file path after the rebuild
+    List<String> validDataFilesAfterRebuilt =
+        spark
+            .read()
+            .format("iceberg")
+            .load(targetTableLocation + "#files")
+            .select("file_path")
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertEquals("Should be 2 valid data files", 2, validDataFilesAfterRebuilt.size());
+    for (String item : validDataFilesAfterRebuilt) {
+      Assert.assertTrue(
+          "Data file should point to the new location", item.startsWith(targetTableLocation));
+    }
+
+    // verify data rows
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(targetTableLocation);
+    List<ThreeColumnRecord> actualRecords =
+        resultDF.sort("c1", "c2", "c3").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.add(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    expectedRecords.add(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+
+    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+  }
+
+  @Test
+  public void testDataFilesDiff() throws Exception {
+    CopyTable.Result result =
+        actions()
+            .copyTable(table)
+            .rewriteLocationPrefix(tableLocation, newTableLocation())
+            .lastCopiedVersion("v2.metadata.json")
+            .execute();
+
+    checkDataFileNum(1, result);
+
+    List<String> rebuiltFiles =
+        spark
+            .read()
+            .format("text")
+            .load(result.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    // v3.metadata.json, one manifest-list file, one manifest file
+    checkMetadataFileNum(3, result);
+
+    String currentSnapshotId = String.valueOf(table.currentSnapshot().snapshotId());
+    Assert.assertTrue(
+        "Should have the current snapshot file",
+        rebuiltFiles.stream().filter(c -> c.contains(currentSnapshotId)).count() == 1);
+
+    String parentSnapshotId = String.valueOf(table.currentSnapshot().parentId());
+    Assert.assertTrue(
+        "Should NOT have the parent snapshot file",
+        rebuiltFiles.stream().filter(c -> c.contains(parentSnapshotId)).count() == 0);
+  }
+
+  @Test
+  public void testTableWith3Snapshots() throws Exception {
+    String location = newTableLocation();
+    Table tableWith3Snaps = createTableWithSnapshots(location, 3);
+    CopyTable.Result result =
+        actions()
+            .copyTable(tableWith3Snaps)
+            .rewriteLocationPrefix(location, newTableLocation())
+            .lastCopiedVersion("v2.metadata.json")
+            .execute();
+
+    checkMetadataFileNum(2, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // start from the first version
+    CopyTable.Result result1 =
+        actions()
+            .copyTable(tableWith3Snaps)
+            .rewriteLocationPrefix(location, newTableLocation())
+            .lastCopiedVersion("v1.metadata.json")
+            .execute();
+
+    checkMetadataFileNum(3, 3, 3, result1);
+    checkDataFileNum(3, result1);
+  }
+
+  @Test
+  public void testFullTableCopy() throws Exception {
+    CopyTable.Result result =
+        actions()
+            .copyTable(table)
+            .rewriteLocationPrefix(tableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(3, 2, 2, result);
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testDeleteDataFile() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(location);
+    List<String> validDataFiles =
+        spark
+            .read()
+            .format("iceberg")
+            .load(location + "#files")
+            .select("file_path")
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    sourceTable.newDelete().deleteFile(validDataFiles.stream().findFirst().get()).commit();
+
+    String targetLocation = newTableLocation();
+    CopyTable.Result result =
+        actions().copyTable(sourceTable).rewriteLocationPrefix(location, targetLocation).execute();
+
+    checkMetadataFileNum(4, 3, 3, result);
+    checkDataFileNum(2, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(location, targetLocation, stagingDir(result));
+
+    // verify data rows
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(targetLocation);
+    Assert.assertEquals(
+        "There are only one row left since we deleted a data file",
+        1,
+        resultDF.as(Encoders.bean(ThreeColumnRecord.class)).count());
+  }
+
+  @Test
+  public void testWithDeleteManifestsAndPositionDeletes() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(location);
+    String targetLocation = newTableLocation();
+
+    List<Pair<CharSequence, Long>> deletes =
+        Lists.newArrayList(
+            Pair.of(
+                sourceTable
+                    .currentSnapshot()
+                    .addedDataFiles(sourceTable.io())
+                    .iterator()
+                    .next()
+                    .path(),
+                0L));
+
+    File file = new File(removePrefix(sourceTable.location()) + "/data/deeply/nested/file.parquet");
+    DeleteFile positionDeletes =
+        FileHelpers.writeDeleteFile(
+                sourceTable, sourceTable.io().newOutputFile(file.toURI().toString()), deletes)
+            .first();
+
+    sourceTable.newRowDelta().addDeletes(positionDeletes).commit();
+
+    CopyTable.Result result =
+        actions().copyTable(sourceTable).rewriteLocationPrefix(location, targetLocation).execute();
+
+    // We have one more snapshot, an additional manifest list, and a new (delete) manifest
+    checkMetadataFileNum(4, 3, 3, result);
+    // We have one additional file for positional deletes
+    checkDataFileNum(3, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(location, targetLocation, stagingDir(result));
+
+    // Positional delete affects a single row, so only one row must remain
+    Assert.assertEquals(
+        "The number of rows should be",
+        1,
+        spark.read().format("iceberg").load(targetLocation).count());
+  }
+
+  @Test
+  public void testWithDeleteManifestsAndEqualityDeletes() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(location, 1);
+    String targetLocation = newTableLocation();
+
+    // Add more varied data
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(
+            new ThreeColumnRecord(2, "AAAAAAAAAA", "AAAA"),
+            new ThreeColumnRecord(3, "BBBBBBBBBB", "BBBB"),
+            new ThreeColumnRecord(4, "CCCCCCCCCC", "CCCC"),
+            new ThreeColumnRecord(5, "DDDDDDDDDD", "DDDD"));
+    spark
+        .createDataFrame(records, ThreeColumnRecord.class)
+        .coalesce(1)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(location);
+
+    Schema deleteRowSchema = sourceTable.schema().select("c2");
+    Record dataDelete = GenericRecord.create(deleteRowSchema);
+    List<Record> dataDeletes =
+        Lists.newArrayList(
+            dataDelete.copy("c2", "AAAAAAAAAA"), dataDelete.copy("c2", "CCCCCCCCCC"));
+    File file = new File(removePrefix(sourceTable.location()) + "/data/deeply/nested/file.parquet");
+    DeleteFile equalityDeletes =
+        FileHelpers.writeDeleteFile(
+            sourceTable,
+            sourceTable.io().newOutputFile(file.toURI().toString()),
+            TestHelpers.Row.of(0),
+            dataDeletes,
+            deleteRowSchema);
+    sourceTable.newRowDelta().addDeletes(equalityDeletes).commit();
+
+    CopyTable.Result result =
+        actions().copyTable(sourceTable).rewriteLocationPrefix(location, targetLocation).execute();
+
+    // We have four metadata files: for the table creation, for the initial snapshot, for the
+    // second append here, and for commit with equality deletes. Thus, we have three manifest lists
+    checkMetadataFileNum(4, 3, 3, result);
+    // A data file for each snapshot (two with data, one with equality deletes)
+    checkDataFileNum(3, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(location, targetLocation, stagingDir(result));
+
+    // Equality deletes affect three rows, so just two rows must remain
+    Assert.assertEquals(
+        "The number of rows should be",
+        2,
+        spark.read().format("iceberg").load(targetLocation).count());
+  }
+
+  @Test
+  public void testFullTableCopyWithDeletedVersionFiles() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(location, 2);
+    // expire the first snapshot
+    Table staticTable = newStaticTable(location + "metadata/v2.metadata.json", table.io());
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(staticTable.currentSnapshot().snapshotId())
+        .execute();
+
+    // create 100 more snapshots
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    for (int i = 0; i < 100; i++) {
+      df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(location);
+    }
+    sourceTable.refresh();
+
+    // v1/v2/v3.metadata.json has been deleted in v104.metadata.json, and there is no way to find
+    // the first snapshot
+    // from the version file history
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(location, newTableLocation())
+            .execute();
+
+    // you can only find 101 snapshots but the manifest file and data file count should be 102.
+    checkMetadataFileNum(101, 101, 101, result);
+    checkDataFileNum(102, result);
+  }
+
+  protected Table newStaticTable(String metadataFileLocation, FileIO io) {
+    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
+    return new BaseTable(ops, metadataFileLocation);
+  }
+
+  @Test
+  public void testRewriteTableWithoutSnapshot() throws Exception {
+    CopyTable.Result result =
+        actions()
+            .copyTable(table)
+            .rewriteLocationPrefix(tableLocation, newTableLocation())
+            .endVersion("v1.metadata.json")
+            .execute();
+
+    // the only rebuilt file is v1.metadata.json since it contains no snapshot
+    checkMetadataFileNum(1, result);
+    checkDataFileNum(0, result);
+  }
+
+  @Test
+  public void testExpireSnapshotBeforeRewrite() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(4, 1, 2, result);
+
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testStartSnapshotWithoutValidSnapshot() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    Assert.assertEquals(
+        "1 out 2 snapshot has been removed", 1, ((List) sourceTable.snapshots()).size());
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion("v2.metadata.json")
+            .execute();
+
+    // 2 metadata.json, 1 manifest list file, 1 manifest files
+    checkMetadataFileNum(4, result);
+    checkDataFileNum(1, result);
+  }
+
+  @Test
+  public void testMoveTheVersionExpireSnapshot() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    // only move version v4, which is the version generated by snapshot expiration
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion("v3.metadata.json")
+            .execute();
+
+    // only v4.metadata.json needs to move
+    checkMetadataFileNum(1, result);
+    // no data file needs to move
+    checkDataFileNum(0, result);
+  }
+
+  @Test
+  public void testMoveVersionWithInvalidSnapshots() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    AssertHelpers.assertThrows(
+        "Copy a version with invalid snapshots aren't allowed",
+        UnsupportedOperationException.class,
+        () ->
+            actions()
+                .copyTable(sourceTable)
+                .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+                .endVersion("v3.metadata.json")
+                .execute());
+  }
+
+  @Test
+  public void testRollBack() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+    Long secondSnapshotId = sourceTable.currentSnapshot().snapshotId();
+
+    // roll back to the first snapshot(v2)
+    sourceTable
+        .manageSnapshots()
+        .setCurrentSnapshot(sourceTable.currentSnapshot().parentId())
+        .commit();
+
+    // add a new snapshot
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(sourceTableLocation);
+
+    sourceTable.refresh();
+
+    // roll back to the second snapshot(v3)
+    sourceTable.manageSnapshots().setCurrentSnapshot(secondSnapshotId).commit();
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    // check the result
+    checkMetadataFileNum(6, 3, 3, result);
+  }
+
+  @Test
+  public void testWriteAuditPublish() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // enable WAP
+    sourceTable
+        .updateProperties()
+        .set(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED, "true")
+        .commit();
+    spark.conf().set("spark.wap.id", "1");
+
+    // add a new snapshot without changing the current snapshot of the table
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(sourceTableLocation);
+
+    sourceTable.refresh();
+
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    // check the result. There are 3 snapshots in total, although the current snapshot is the second
+    // one.
+    checkMetadataFileNum(5, 3, 3, result);
+  }
+
+  @Test
+  public void testSchemaChange() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // change the schema
+    sourceTable.updateSchema().addColumn("c4", Types.StringType.get()).commit();
+
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    // check the result
+    checkMetadataFileNum(4, 2, 2, result);
+  }
+
+  @Test
+  public void testWithTargetTable() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 3);
+    String targetTableLocation = newTableLocation();
+    Table targetTable = createATableWith2Snapshots(targetTableLocation);
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+            .targetTable(targetTable)
+            .execute();
+
+    Assert.assertEquals("The latest version should be", "v4.metadata.json", result.latestVersion());
+
+    // 3 files rebuilt from v3 to v4: v4.metadata.json, one manifest list, one manifest file
+    checkMetadataFileNum(3, result);
+  }
+
+  @Test
+  public void testInvalidStartVersion() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 3);
+    String targetTableLocation = newTableLocation();
+    Table targetTable = createATableWith2Snapshots(targetTableLocation);
+
+    AssertHelpers.assertThrows(
+        "The valid start version should be v3",
+        IllegalArgumentException.class,
+        "The start version isn't the current version of the target table.",
+        () ->
+            actions()
+                .copyTable(sourceTable)
+                .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+                .targetTable(targetTable)
+                .lastCopiedVersion("v2.metadata.json")
+                .execute());
+  }
+
+  @Test
+  public void testSnapshotIdInheritanceEnabled() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, "true");
+
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 2, properties);
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(7, result);
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testMetadataCompression() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.METADATA_COMPRESSION, "gzip");
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 2, properties);
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .endVersion("v2.gz.metadata.json")
+            .execute();
+
+    checkMetadataFileNum(4, result);
+    checkDataFileNum(1, result);
+
+    result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion("v1.gz.metadata.json")
+            .execute();
+
+    checkMetadataFileNum(6, result);
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testInvalidArgs() {
+    CopyTable actions = actions().copyTable(table);
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Source prefix('') cannot be empty",
+        () -> actions.rewriteLocationPrefix("", null));
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Source prefix('null') cannot be empty",
+        () -> actions.rewriteLocationPrefix(null, null));
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Staging location('') cannot be empty",
+        () -> actions.stagingLocation(""));
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Staging location('null') cannot be empty",
+        () -> actions.stagingLocation(null));
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Last copied version('null') cannot be empty",
+        () -> actions.lastCopiedVersion(null));
+
+    AssertHelpers.assertThrows(
+        "Last copied version cannot be empty",
+        IllegalArgumentException.class,
+        () -> actions.lastCopiedVersion(" "));
+
+    AssertHelpers.assertThrows(
+        "End version cannot be empty",
+        IllegalArgumentException.class,
+        () -> actions.endVersion(" "));
+
+    AssertHelpers.assertThrows(
+        "End version cannot be empty",
+        IllegalArgumentException.class,
+        () -> actions.endVersion(null));
+  }
+
+  protected void checkDataFileNum(long count, CopyTable.Result result) {
+    List<String> filesToMove =
+        spark
+            .read()
+            .format("text")
+            .load(result.dataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertEquals("The rebuilt data file number should be", count, filesToMove.size());
+  }
+
+  protected void checkMetadataFileNum(int count, CopyTable.Result result) {
+    List<String> filesToMove =
+        spark
+            .read()
+            .format("text")
+            .load(result.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertEquals("The rebuilt metadata file number should be", count, filesToMove.size());
+  }
+
+  protected void checkMetadataFileNum(
+      int versionFileCount, int manifestListCount, int manifestFileCount, CopyTable.Result result) {
+    List<String> filesToMove =
+        spark
+            .read()
+            .format("text")
+            .load(result.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertEquals(
+        "The rebuilt version file number should be",
+        versionFileCount,
+        filesToMove.stream().filter(f -> f.endsWith(".metadata.json")).count());
+    Assert.assertEquals(
+        "The rebuilt Manifest list file number should be",
+        manifestListCount,
+        filesToMove.stream().filter(f -> f.contains("snap-")).count());
+    Assert.assertEquals(
+        "The rebuilt Manifest file number should be",
+        manifestFileCount,
+        filesToMove.stream().filter(f -> f.endsWith("-m0.avro")).count());
+  }
+
+  private String stagingDir(CopyTable.Result result) {
+    String metadataFileListPath = result.metadataFileListLocation();
+    return metadataFileListPath.substring(0, metadataFileListPath.lastIndexOf(File.separator));
+  }
+
+  protected String newTableLocation() throws IOException {
+    return temp.newFolder().toURI().toString();
+  }
+
+  private void moveTableFiles(String sourceDir, String targetDir, String stagingDir)
+      throws Exception {
+    FileUtils.copyDirectory(
+        new File(removePrefix(sourceDir) + "data/"), new File(removePrefix(targetDir) + "/data/"));
+    // Copy staged metadata files, overwrite previously copied data files with staged ones
+    FileUtils.copyDirectory(new File(removePrefix(stagingDir)), new File(removePrefix(targetDir)));
+  }
+
+  private String removePrefix(String path) {
+    return path.substring(path.lastIndexOf(":") + 1);
+  }
+
+  // Metastore table tests
+  @Test
+  public void testMetadataLocationChange() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createMetastoreTable(sourceTableLocation, Maps.newHashMap(), "tbl", 1);
+    String metadataFilePath = currentMetadata(sourceTable).metadataFileLocation();
+
+    String newMetadataDir = "new-metadata-dir";
+    sourceTable
+        .updateProperties()
+        .set(TableProperties.WRITE_METADATA_LOCATION, sourceTableLocation + newMetadataDir)
+        .commit();
+
+    spark.sql("insert into hive.default.tbl values (1, 'AAAAAAAAAA', 'AAAA')");
+    sourceTable.refresh();
+
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(4, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // pick up a version from the old metadata dir as the end version
+    CopyTable.Result result1 =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .endVersion(fileName(metadataFilePath))
+            .execute();
+
+    checkMetadataFileNum(2, 1, 1, result1);
+
+    // pick up a version from the old metadata dir as the last copied version
+    CopyTable.Result result2 =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion(fileName(metadataFilePath))
+            .execute();
+
+    checkMetadataFileNum(2, 1, 1, result2);
+  }
+
+  @Test
+  public void testMetadataCompressionWithMetastoreTable() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.METADATA_COMPRESSION, "gzip");
+    Table sourceTable =
+        createMetastoreTable(sourceTableLocation, properties, "testMetadataCompression", 2);
+
+    TableMetadata currentMetadata = currentMetadata(sourceTable);
+
+    // set the second version as the endVersion
+    String endVersion = fileName(currentMetadata.previousFiles().get(1).file());
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .endVersion(endVersion)
+            .execute();
+
+    checkMetadataFileNum(4, result);
+    checkDataFileNum(1, result);
+
+    // set the first version as the lastCopiedVersion
+    String firstVersion = fileName(currentMetadata.previousFiles().get(0).file());
+    result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion(firstVersion)
+            .execute();
+
+    checkMetadataFileNum(6, result);
+    checkDataFileNum(2, result);
+  }
+
+  private TableMetadata currentMetadata(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current();
+  }
+
+  @Test
+  public void testDataFileLocationChange() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createMetastoreTable(sourceTableLocation, Maps.newHashMap(), "tbl1", 1);
+    String metadataFilePath = currentMetadata(sourceTable).metadataFileLocation();
+
+    String newMetadataDir = "new-data-dir";
+    sourceTable
+        .updateProperties()
+        .set(TableProperties.OBJECT_STORE_PATH, sourceTableLocation + newMetadataDir)
+        .set(TableProperties.OBJECT_STORE_ENABLED, "true")
+        .commit();
+
+    spark.sql("insert into hive.default.tbl1 values (1, 'AAAAAAAAAA', 'AAAA')");
+    sourceTable.refresh();
+
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(4, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // pick up a version with the data file in the old data directory as the end version
+    String targetTableLocation = newTableLocation();
+    CopyTable.Result result1 =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+            .endVersion(fileName(metadataFilePath))
+            .execute();
+
+    checkMetadataFileNum(2, 1, 1, result1);
+    checkDataFileNum(1, result1);
+    List<String> filesToMove1 =
+        spark
+            .read()
+            .format("text")
+            .load(result1.dataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertTrue(
+        "The data file should be in the old data directory.",
+        filesToMove1.stream().findFirst().get().startsWith(sourceTableLocation + "data"));
+
+    // pick up a version with the data file in the new data directory as the last copied version
+    CopyTable.Result result2 =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+            .lastCopiedVersion(fileName(metadataFilePath))
+            .execute();
+
+    checkMetadataFileNum(2, 1, 1, result2);
+    checkDataFileNum(1, result2);
+    List<String> filesToMove2 =
+        spark
+            .read()
+            .format("text")
+            .load(result2.dataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertTrue(
+        "The data file should be in the new data directory.",
+        filesToMove2.stream().findFirst().get().startsWith(sourceTableLocation + newMetadataDir));
+
+    // check if table properties have been modified
+    List<String> metadataFilesToMove =
+        spark
+            .read()
+            .format("text")
+            .load(result2.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    metadataFilesToMove.stream()
+        .filter(f -> f.endsWith(".metadata.json"))
+        .forEach(
+            metadataFile -> {
+              StaticTableOperations ops = new StaticTableOperations(metadataFile, sourceTable.io());
+              Table targetStaticTable = new BaseTable(ops, metadataFile);
+              if (targetStaticTable.properties().containsKey(TableProperties.OBJECT_STORE_PATH)) {
+                Assert.assertTrue(
+                    "The write.object-storage.path should be modified with the target table location.",
+                    targetStaticTable
+                        .properties()
+                        .get(TableProperties.OBJECT_STORE_PATH)
+                        .startsWith(targetTableLocation));
+              }
+            });
+  }
+
+  private Table createMetastoreTable(
+      String location, Map<String, String> properties, String tableName, int snapshotNumber) {
+    spark.conf().set("spark.sql.catalog.hive", SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog.hive.type", "hive");
+    spark.conf().set("spark.sql.catalog.hive.default-namespace", "default");
+    spark.conf().set("spark.sql.catalog.hive.cache-enabled", "false");
+
+    StringBuilder propertiesStr = new StringBuilder();
+    properties.forEach((k, v) -> propertiesStr.append("'" + k + "'='" + v + "',"));
+    String tblProperties =
+        propertiesStr.substring(0, propertiesStr.length() > 0 ? propertiesStr.length() - 1 : 0);
+
+    if (tblProperties.isEmpty()) {
+      sql(
+          "CREATE TABLE hive.default.%s (c1 bigint, c2 string, c3 string) USING iceberg LOCATION '%s'",
+          tableName, location);
+    } else {
+      sql(
+          "CREATE TABLE hive.default.%s (c1 bigint, c2 string, c3 string) USING iceberg LOCATION '%s' TBLPROPERTIES "
+              + "(%s)",
+          tableName, location, tblProperties);
+    }
+
+    for (int i = 0; i < snapshotNumber; i++) {
+      sql("insert into hive.default.%s values (1, 'AAAAAAAAAA', 'AAAA')", tableName);
+    }
+    return catalog.loadTable(TableIdentifier.of("default", tableName));
+  }
+
+  private static String fileName(String path) {
+    String filename = path;
+    int lastIndex = path.lastIndexOf(File.separator);
+    if (lastIndex != -1) {
+      filename = path.substring(lastIndex + 1);
+    }
+    return filename;
+  }
+}

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCopyTableSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCopyTableSparkAction.java
@@ -1,0 +1,870 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestEntry;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestLists;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadata.MetadataLogEntry;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableMetadataUtil;
+import org.apache.iceberg.actions.BaseCopyTableActionResult;
+import org.apache.iceberg.actions.CopyTable;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.avro.DataReader;
+import org.apache.iceberg.data.avro.DataWriter;
+import org.apache.iceberg.data.orc.GenericOrcReader;
+import org.apache.iceberg.data.orc.GenericOrcWriter;
+import org.apache.iceberg.data.parquet.GenericParquetReaders;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.DeleteSchemaUtil;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.spark.api.java.function.MapPartitionsFunction;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoder;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BaseCopyTableSparkAction extends BaseSparkAction<CopyTable> implements CopyTable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseCopyTableSparkAction.class);
+  private static final String DATA_FILE_LIST_DIR = "data-file-list-to-move";
+  private static final String METADATA_FILE_LIST_DIR = "metadata-file-list-to-move";
+
+  private final Table table;
+  private final Set<String> metadataFilesToMove = Collections.synchronizedSet(Sets.newHashSet());
+  private final Set<String> manifestFilePaths = Collections.synchronizedSet(Sets.newHashSet());
+  private final Set<ManifestFile> manifestFilesToRewrite =
+      Collections.synchronizedSet(Sets.newHashSet());
+  private String dataFileListPath = null;
+  private String metadataFileListPath = null;
+  private final boolean enabledPME;
+
+  private String sourcePrefix = "";
+  private String targetPrefix = "";
+  private String startVersion = "";
+  private String endVersion = "";
+  private String stagingDir = "";
+  private Table targetTable = null;
+
+  private Table startStaticTable = null;
+  private Table endStaticTable = null;
+
+  public BaseCopyTableSparkAction(SparkSession spark, Table table) {
+    super(spark);
+    this.table = table;
+    enabledPME = table.properties().containsKey("parquet.encryption.footer.key");
+  }
+
+  @Override
+  public CopyTable rewriteLocationPrefix(String sPrefix, String tPrefix) {
+    Preconditions.checkArgument(
+        sPrefix != null && !sPrefix.isEmpty(), "Source prefix('%s') cannot be empty.", sPrefix);
+    this.sourcePrefix = sPrefix;
+
+    if (tPrefix != null) {
+      this.targetPrefix = tPrefix;
+    }
+    return this;
+  }
+
+  @Override
+  public CopyTable lastCopiedVersion(String sVersion) {
+    Preconditions.checkArgument(
+        sVersion != null && !sVersion.trim().isEmpty(),
+        "Last copied version('%s') cannot be empty.",
+        sVersion);
+    this.startVersion = sVersion;
+    return this;
+  }
+
+  @Override
+  public CopyTable endVersion(String eVersion) {
+    Preconditions.checkArgument(
+        eVersion != null && !eVersion.trim().isEmpty(),
+        "End version('%s') cannot be empty.",
+        eVersion);
+    this.endVersion = eVersion;
+    return this;
+  }
+
+  @Override
+  public CopyTable stagingLocation(String stagingLocation) {
+    Preconditions.checkArgument(
+        stagingLocation != null && !stagingLocation.isEmpty(),
+        "Staging location('%s') cannot be empty.",
+        stagingLocation);
+    this.stagingDir = stagingLocation;
+    return this;
+  }
+
+  @Override
+  public CopyTable targetTable(Table tgtTable) {
+    this.targetTable = tgtTable;
+    return this;
+  }
+
+  @Override
+  protected CopyTable self() {
+    return this;
+  }
+
+  @Override
+  public Result execute() {
+    validateInputs();
+    JobGroupInfo info = newJobGroupInfo("COPY-TABLE", jobDesc());
+    return withJobGroupInfo(info, this::doExecute);
+  }
+
+  private CopyTable.Result doExecute() {
+    rebuildMetaData();
+    return new BaseCopyTableActionResult(
+        stagingDir, dataFileListPath, metadataFileListPath, fileName(endVersion));
+  }
+
+  private void validateInputs() {
+    Preconditions.checkArgument(
+        sourcePrefix != null && !sourcePrefix.isEmpty(),
+        "Source prefix('%s') cannot be empty.",
+        sourcePrefix);
+
+    validateAndSetEndVersion();
+
+    endStaticTable = newStaticTable(endVersion, table.io());
+
+    TableMetadata tableMetadata = ((HasTableOperations) endStaticTable).operations().current();
+    Preconditions.checkArgument(
+        tableMetadata.formatVersion() == 2, "Support Iceberg format version 2 only.");
+
+    validateAndSetStartVersion(tableMetadata);
+
+    if (fileExist(startVersion)) {
+      startStaticTable = newStaticTable(startVersion, table.io());
+    }
+
+    if (stagingDir.isEmpty()) {
+      String stagingDirName = "copy-table-staging-" + UUID.randomUUID();
+      stagingDir = combinePaths(table.location(), stagingDirName);
+    }
+
+    if (!stagingDir.endsWith("/")) {
+      stagingDir = stagingDir + "/";
+    }
+  }
+
+  private void validateAndSetEndVersion() {
+    if (endVersion.isEmpty()) {
+      endVersion = currentMetadataPath(table);
+    } else {
+      TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
+      if (versionInFilePath(tableMetadata.metadataFileLocation(), endVersion)) {
+        endVersion = tableMetadata.metadataFileLocation();
+      }
+      for (MetadataLogEntry metadataLogEntry : tableMetadata.previousFiles()) {
+        if (versionInFilePath(metadataLogEntry.file(), endVersion)) {
+          endVersion = metadataLogEntry.file();
+          break;
+        }
+      }
+
+      Preconditions.checkArgument(
+          fileExist(endVersion),
+          "Cannot find the end version('%s') in the current version " + "files",
+          endVersion);
+    }
+  }
+
+  private void validateAndSetStartVersion(TableMetadata tableMetadata) {
+    if (startVersion.isEmpty()) {
+      if (targetTable == null) {
+        LOG.warn("No input of the start version. Will do a full copy.");
+      } else {
+        String tgtTableCurrentVersion = fileName(currentMetadataPath(targetTable));
+
+        for (MetadataLogEntry metadataLogEntry : tableMetadata.previousFiles()) {
+          if (metadataLogEntry.file().endsWith(tgtTableCurrentVersion)) {
+            startVersion = metadataLogEntry.file();
+            break;
+          }
+        }
+
+        if (fileNotExist(startVersion)) {
+          throw new IllegalArgumentException(
+              "Cannot find the current version of target table in the source table. "
+                  + "Please make sure the target table is a subset of source table.");
+        }
+      }
+    } else {
+      for (MetadataLogEntry metadataLogEntry : tableMetadata.previousFiles()) {
+        if (versionInFilePath(metadataLogEntry.file(), startVersion)) {
+          startVersion = metadataLogEntry.file();
+          break;
+        }
+      }
+
+      Preconditions.checkArgument(
+          fileExist(startVersion), "Start version('%s') is NOT valid.", startVersion);
+
+      if (targetTable != null
+          && !fileName(startVersion).equals(fileName(currentMetadataPath(targetTable)))) {
+        throw new IllegalArgumentException(
+            "The start version isn't the current version of the target table. "
+                + "Please make sure the target table is a subset of source table.");
+      }
+    }
+  }
+
+  private boolean versionInFilePath(String path, String version) {
+    return fileName(path).equals(version);
+  }
+
+  private String jobDesc() {
+    if (startVersion.isEmpty()) {
+      return String.format(
+          "Replacing path prefixes '%s' with '%s' in the metadata files of table %s,"
+              + "up to version '%s'.",
+          sourcePrefix, targetPrefix, table.name(), endVersion);
+    } else {
+      return String.format(
+          "Replacing path prefixes '%s' with '%s' in the metadata files of table %s,"
+              + "from version '%s' to '%s'.",
+          sourcePrefix, targetPrefix, table.name(), startVersion, endVersion);
+    }
+  }
+
+  /**
+   * Here are steps: 1. rebuild version files 2. rebuild manifest list files 3. rebuild manifest
+   * files 4. get all data files need to move
+   */
+  private void rebuildMetaData() {
+    TableMetadata tableMetadata = ((HasTableOperations) endStaticTable).operations().current();
+
+    // rebuild version files
+    Set<Long> allSnapshotIds = rewriteVersionFiles(tableMetadata);
+
+    Set<Long> diffSnapshotIds = getDiffSnapshotIds(allSnapshotIds);
+
+    // get all manifest file paths need to rewrite
+    List<String> manifestFilePathToMove = manifestFilesToMove(diffSnapshotIds);
+    manifestFilePaths.addAll(manifestFilePathToMove);
+
+    // rebuild manifest-list files
+    Set<Snapshot> validSnapshots =
+        Sets.difference(snapshotSet(endVersion), snapshotSet(startVersion));
+    validSnapshots.forEach(snapshot -> rewriteManifestList(snapshot, tableMetadata));
+
+    // rebuild manifest files
+    List<ManifestFile> newManifests = rewriteManifests(tableMetadata);
+    newManifests.forEach(manifestFile -> addToRebuiltFiles(manifestFile.path()));
+    saveMetadataFileList();
+
+    Dataset<Row> dataFiles = getDiffDataFiles(diffSnapshotIds);
+    saveDataFileList(dataFiles);
+  }
+
+  private void saveMetadataFileList() {
+    List<String> fileList = Lists.newArrayList();
+    fileList.addAll(metadataFilesToMove);
+    Dataset<String> metadataFileList = spark().createDataset(fileList, Encoders.STRING());
+    metadataFileListPath = stagingDir + METADATA_FILE_LIST_DIR;
+    metadataFileList
+        .repartition(1)
+        .write()
+        .mode(SaveMode.Overwrite)
+        .format("text")
+        .save(metadataFileListPath);
+  }
+
+  private void saveDataFileList(Dataset<Row> dataFiles) {
+    dataFileListPath = stagingDir + DATA_FILE_LIST_DIR;
+
+    try {
+      dataFiles
+          .repartition(1)
+          .write()
+          .mode(SaveMode.Overwrite)
+          .format("text")
+          .save(dataFileListPath);
+    } catch (Exception e) {
+      throw new UnsupportedOperationException(
+          "Failed to build the data files dataframe, the end version you are "
+              + "trying to copy may contain invalid snapshots, please use the younger version which doesn't have invalid "
+              + "snapshots",
+          e);
+    }
+  }
+
+  private Set<Long> getDiffSnapshotIds(Set<Long> allSnapshotIds) {
+    Set<Long> snapshotIdsInStartVersion = Sets.newHashSet();
+    if (startStaticTable != null) {
+      startStaticTable
+          .snapshots()
+          .forEach(snapshot -> snapshotIdsInStartVersion.add(snapshot.snapshotId()));
+    }
+    return Sets.difference(allSnapshotIds, snapshotIdsInStartVersion);
+  }
+
+  private Set<Long> rewriteVersionFiles(TableMetadata metadata) {
+    Set<Long> allSnapshotIds = Sets.newHashSet();
+
+    String stagingPath = combinePaths(stagingDir, relativize(endVersion, sourcePrefix));
+    metadata.snapshots().forEach(snapshot -> allSnapshotIds.add(snapshot.snapshotId()));
+    rewriteVersionFile(metadata, stagingPath);
+
+    List<MetadataLogEntry> versions = metadata.previousFiles();
+    for (int i = versions.size() - 1; i >= 0; i--) {
+      String versionFilePath = versions.get(i).file();
+      if (versionFilePath.equals(startVersion)) {
+        break;
+      }
+
+      Preconditions.checkArgument(
+          fileExist(versionFilePath),
+          String.format("Version file %s doesn't exist", versionFilePath));
+      String newPath = combinePaths(stagingDir, relativize(versionFilePath, sourcePrefix));
+      TableMetadata tableMetadata =
+          new StaticTableOperations(versionFilePath, table.io()).current();
+
+      tableMetadata.snapshots().forEach(snapshot -> allSnapshotIds.add(snapshot.snapshotId()));
+
+      rewriteVersionFile(tableMetadata, newPath);
+    }
+
+    return allSnapshotIds;
+  }
+
+  private Set<Snapshot> snapshotSet(String metadataPath) {
+    Set<Snapshot> snapshots = Sets.newHashSet();
+    if (!metadataPath.isEmpty()) {
+      StaticTableOperations ops = new StaticTableOperations(metadataPath, table.io());
+      TableMetadata metadata = ops.current();
+      snapshots.addAll(metadata.snapshots());
+    }
+    return snapshots;
+  }
+
+  private void rewriteVersionFile(TableMetadata metadata, String stagingPath) {
+    TableMetadata newTableMetadata =
+        TableMetadataUtil.replacePaths(metadata, sourcePrefix, targetPrefix);
+    TableMetadataParser.overwrite(newTableMetadata, table.io().newOutputFile(stagingPath));
+    addToRebuiltFiles(stagingPath);
+  }
+
+  private void rewriteManifestList(Snapshot snapshot, TableMetadata tableMetadata) {
+    List<ManifestFile> manifestFiles = manifestFilesInSnapshot(snapshot);
+    String path = snapshot.manifestListLocation();
+    String stagingPath = combinePaths(stagingDir, relativize(path, sourcePrefix));
+    OutputFile outputFile = table.io().newOutputFile(stagingPath);
+    try (FileAppender<ManifestFile> writer =
+        ManifestLists.write(
+            tableMetadata.formatVersion(),
+            outputFile,
+            snapshot.snapshotId(),
+            snapshot.parentId(),
+            snapshot.sequenceNumber())) {
+
+      for (ManifestFile file : manifestFiles) {
+        // need to get the ManifestFile object for manifest file rewriting
+        if (manifestFilePaths.contains(file.path())) {
+          manifestFilesToRewrite.add(file);
+        }
+
+        ManifestFile newFile = file.copy();
+        if (newFile.path().startsWith(sourcePrefix)) {
+          ((StructLike) newFile).set(0, newPath(newFile.path(), sourcePrefix, targetPrefix));
+        }
+        writer.add(newFile);
+      }
+
+      addToRebuiltFiles(stagingPath);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to rewrite the manifest list file " + path, e);
+    }
+  }
+
+  private List<ManifestFile> manifestFilesInSnapshot(Snapshot snapshot) {
+    String path = snapshot.manifestListLocation();
+    List<ManifestFile> manifestFiles = Lists.newLinkedList();
+    try {
+      manifestFiles = ManifestLists.read(table.io().newInputFile(path));
+    } catch (RuntimeIOException e) {
+      LOG.warn("Failed to read manifest list {}", path, e);
+    }
+    return manifestFiles;
+  }
+
+  private List<String> manifestFilesToMove(Set<Long> diffSnapshotIds) {
+    try {
+      Dataset<Row> lastVersionFiles = buildManifestFileDF(endStaticTable);
+      if (startStaticTable == null) {
+        return lastVersionFiles.distinct().as(Encoders.STRING()).collectAsList();
+      } else {
+        return lastVersionFiles
+            .distinct()
+            .filter(functions.column("added_snapshot_id").isInCollection(diffSnapshotIds))
+            .as(Encoders.STRING())
+            .collectAsList();
+      }
+    } catch (Exception e) {
+      throw new UnsupportedOperationException(
+          "Failed to build the manifest files dataframe, the end version you are "
+              + "trying to copy may contain invalid snapshots, please use the younger version which doesn't have invalid "
+              + "snapshots",
+          e);
+    }
+  }
+
+  /** Rewrite manifest files in a distributed manner. */
+  private List<ManifestFile> rewriteManifests(TableMetadata tableMetadata) {
+    if (manifestFilesToRewrite.isEmpty()) {
+      return Lists.newArrayList();
+    }
+
+    Encoder<ManifestFile> manifestFileEncoder = Encoders.javaSerialization(ManifestFile.class);
+    Dataset<ManifestFile> manifestDS =
+        spark().createDataset(Lists.newArrayList(manifestFilesToRewrite), manifestFileEncoder);
+
+    FileIO tableIO = SerializableTable.copyOf(table).io();
+    Broadcast<FileIO> io = sparkContext().broadcast(tableIO);
+
+    return manifestDS
+        .repartition(manifestFilesToRewrite.size())
+        .mapPartitions(
+            toManifests(
+                io,
+                stagingDir,
+                tableMetadata.formatVersion(),
+                tableMetadata.specsById(),
+                sourcePrefix,
+                targetPrefix),
+            manifestFileEncoder)
+        .collectAsList();
+  }
+
+  private static MapPartitionsFunction<ManifestFile, ManifestFile> toManifests(
+      Broadcast<FileIO> io,
+      String stagingLocation,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix) {
+
+    return rows -> {
+      List<ManifestFile> manifests = Lists.newArrayList();
+      while (rows.hasNext()) {
+        ManifestFile manifestFile = rows.next();
+        switch (manifestFile.content()) {
+          case DATA:
+            manifests.add(
+                writeDataManifest(
+                    manifestFile,
+                    io,
+                    stagingLocation,
+                    format,
+                    specsById,
+                    sourcePrefix,
+                    targetPrefix));
+            break;
+          case DELETES:
+            manifests.add(
+                writeDeleteManifest(
+                    manifestFile,
+                    io,
+                    stagingLocation,
+                    format,
+                    specsById,
+                    sourcePrefix,
+                    targetPrefix));
+            break;
+          default:
+            throw new UnsupportedOperationException(
+                "Unsupported manifest type: " + manifestFile.content());
+        }
+      }
+
+      return manifests.iterator();
+    };
+  }
+
+  private static ManifestFile writeDataManifest(
+      ManifestFile manifestFile,
+      Broadcast<FileIO> io,
+      String stagingLocation,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix)
+      throws IOException {
+    PartitionSpec spec = specsById.get(manifestFile.partitionSpecId());
+    String stagingPath =
+        combinePaths(stagingLocation, relativize(manifestFile.path(), sourcePrefix));
+    OutputFile outputFile = io.value().newOutputFile(stagingPath);
+    ManifestWriter<DataFile> writer =
+        ManifestFiles.write(format, spec, outputFile, manifestFile.snapshotId());
+
+    try (ManifestReader<DataFile> reader =
+        ManifestFiles.read(manifestFile, io.getValue(), specsById).select(Arrays.asList("*"))) {
+      reader
+          .entries()
+          .forEach(
+              entry ->
+                  appendEntryWithFile(
+                      entry, writer, newDataFile(entry.file(), spec, sourcePrefix, targetPrefix)));
+    } finally {
+      writer.close();
+    }
+    return writer.toManifestFile();
+  }
+
+  private static DataFile newDataFile(
+      DataFile file, PartitionSpec spec, String sourcePrefix, String targetPrefix) {
+    DataFile transformedFile = file;
+    String filePath = file.path().toString();
+    if (filePath.startsWith(sourcePrefix)) {
+      filePath = newPath(filePath, sourcePrefix, targetPrefix);
+      transformedFile = DataFiles.builder(spec).copy(file).withPath(filePath).build();
+    }
+    return transformedFile;
+  }
+
+  private static ManifestFile writeDeleteManifest(
+      ManifestFile manifestFile,
+      Broadcast<FileIO> io,
+      String stagingLocation,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix)
+      throws IOException {
+    PartitionSpec spec = specsById.get(manifestFile.partitionSpecId());
+
+    String manifestStagingPath =
+        combinePaths(stagingLocation, relativize(manifestFile.path(), sourcePrefix));
+    OutputFile manifestOutputFile = io.value().newOutputFile(manifestStagingPath);
+    ManifestWriter<DeleteFile> writer =
+        ManifestFiles.writeDeleteManifest(
+            format, spec, manifestOutputFile, manifestFile.snapshotId());
+
+    try (ManifestReader<DeleteFile> reader =
+        ManifestFiles.readDeleteManifest(manifestFile, io.getValue(), specsById)
+            .select(Arrays.asList("*"))) {
+
+      for (ManifestEntry<DeleteFile> entry : reader.entries()) {
+        DeleteFile file = entry.file();
+
+        switch (file.content()) {
+          case POSITION_DELETES:
+            String filePath = file.path().toString();
+            String deleteFileStagingPath =
+                combinePaths(stagingLocation, relativize(filePath, sourcePrefix));
+            DeleteFile newDeleteFile =
+                rewritePositionDeleteFile(
+                    io, file, deleteFileStagingPath, spec, sourcePrefix, targetPrefix);
+
+            if (filePath.startsWith(sourcePrefix)) {
+              filePath = newPath(filePath, sourcePrefix, targetPrefix);
+              newDeleteFile =
+                  FileMetadata.deleteFileBuilder(spec)
+                      .ofPositionDeletes()
+                      .copy(newDeleteFile)
+                      .withPath(filePath)
+                      .withSplitOffsets(file.splitOffsets())
+                      .build();
+            }
+            appendEntryWithFile(entry, writer, newDeleteFile);
+            break;
+          case EQUALITY_DELETES:
+            appendEntryWithFile(
+                entry, writer, newEqualityDeleteFile(file, spec, sourcePrefix, targetPrefix));
+            break;
+          default:
+            throw new UnsupportedOperationException(
+                "Unsupported delete file type: " + file.content());
+        }
+      }
+    } finally {
+      writer.close();
+    }
+    return writer.toManifestFile();
+  }
+
+  private static DeleteFile newEqualityDeleteFile(
+      DeleteFile file, PartitionSpec spec, String sourcePrefix, String targetPrefix) {
+    DeleteFile transformedFile = file;
+    String filePath = file.path().toString();
+
+    if (filePath.startsWith(sourcePrefix)) {
+      int[] equalityFieldIds =
+          file.equalityFieldIds().stream().mapToInt(Integer::intValue).toArray();
+      filePath = newPath(filePath, sourcePrefix, targetPrefix);
+      transformedFile =
+          FileMetadata.deleteFileBuilder(spec)
+              .ofEqualityDeletes(equalityFieldIds)
+              .copy(file)
+              .withPath(filePath)
+              .withSplitOffsets(file.splitOffsets())
+              .build();
+    }
+    return transformedFile;
+  }
+
+  private static PositionDelete newPositionDeleteRecord(
+      Record record, String sourcePrefix, String targetPrefix) {
+    PositionDelete delete = PositionDelete.create();
+    delete.set(
+        newPath((String) record.get(0), sourcePrefix, targetPrefix),
+        (Long) record.get(1),
+        record.get(2));
+    return delete;
+  }
+
+  private static DeleteFile rewritePositionDeleteFile(
+      Broadcast<FileIO> io,
+      DeleteFile current,
+      String path,
+      PartitionSpec spec,
+      String sourcePrefix,
+      String targetPrefix)
+      throws IOException {
+    OutputFile targetFile = io.value().newOutputFile(path);
+    InputFile sourceFile = io.value().newInputFile(current.path().toString());
+
+    try (CloseableIterable<Record> reader =
+        positionDeletesReader(sourceFile, current.format(), spec)) {
+      Record record = null;
+      Schema rowSchema = null;
+      CloseableIterator<Record> recordIt = reader.iterator();
+
+      if (recordIt.hasNext()) {
+        record = recordIt.next();
+        rowSchema = record.get(2) != null ? spec.schema() : null;
+      }
+
+      PositionDeleteWriter<Record> writer =
+          positionDeletesWriter(targetFile, current.format(), spec, current.partition(), rowSchema);
+
+      try {
+        if (record != null) {
+          writer.write(newPositionDeleteRecord(record, sourcePrefix, targetPrefix));
+        }
+
+        while (recordIt.hasNext()) {
+          record = recordIt.next();
+          writer.write(newPositionDeleteRecord(record, sourcePrefix, targetPrefix));
+        }
+      } finally {
+        writer.close();
+      }
+      return writer.toDeleteFile();
+    }
+  }
+
+  private static CloseableIterable<Record> positionDeletesReader(
+      InputFile inputFile, FileFormat format, PartitionSpec spec) throws IOException {
+    Schema deleteSchema = DeleteSchemaUtil.posDeleteSchema(spec.schema());
+    switch (format) {
+      case AVRO:
+        return Avro.read(inputFile)
+            .project(deleteSchema)
+            .reuseContainers()
+            .createReaderFunc(DataReader::create)
+            .build();
+
+      case PARQUET:
+        return Parquet.read(inputFile)
+            .project(deleteSchema)
+            .reuseContainers()
+            .createReaderFunc(
+                fileSchema -> GenericParquetReaders.buildReader(deleteSchema, fileSchema))
+            .build();
+
+      case ORC:
+        return ORC.read(inputFile)
+            .project(deleteSchema)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(deleteSchema, fileSchema))
+            .build();
+
+      default:
+        throw new UnsupportedOperationException("Unsupported file format: " + format);
+    }
+  }
+
+  private static PositionDeleteWriter<Record> positionDeletesWriter(
+      OutputFile outputFile,
+      FileFormat format,
+      PartitionSpec spec,
+      StructLike partition,
+      Schema rowSchema)
+      throws IOException {
+    switch (format) {
+      case AVRO:
+        return Avro.writeDeletes(outputFile)
+            .createWriterFunc(DataWriter::create)
+            .withPartition(partition)
+            .rowSchema(rowSchema)
+            .withSpec(spec)
+            .buildPositionWriter();
+      case PARQUET:
+        return Parquet.writeDeletes(outputFile)
+            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .withPartition(partition)
+            .rowSchema(rowSchema)
+            .withSpec(spec)
+            .buildPositionWriter();
+      case ORC:
+        return ORC.writeDeletes(outputFile)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .withPartition(partition)
+            .rowSchema(rowSchema)
+            .withSpec(spec)
+            .buildPositionWriter();
+      default:
+        throw new UnsupportedOperationException("Unsupported file format: " + format);
+    }
+  }
+
+  private static <F extends ContentFile<F>> void appendEntryWithFile(
+      ManifestEntry<F> entry, ManifestWriter<F> writer, F file) {
+    switch (entry.status()) {
+      case ADDED:
+        writer.add(file);
+        break;
+      case EXISTING:
+        writer.existing(
+            file, entry.snapshotId(), entry.dataSequenceNumber(), entry.fileSequenceNumber());
+        break;
+      case DELETED:
+        writer.delete(file, entry.dataSequenceNumber(), entry.fileSequenceNumber());
+        break;
+    }
+  }
+
+  private Dataset<Row> getDiffDataFiles(Set<Long> diffSnapshotIds) {
+    Dataset<Row> lastVersionFiles = buildValidDataFileDFWithSnapshotId(endStaticTable);
+    if (startStaticTable == null) {
+      return lastVersionFiles.distinct().select("file_path");
+    } else {
+      return lastVersionFiles
+          .distinct()
+          .filter(functions.column("snapshot_id").isInCollection(diffSnapshotIds))
+          .select("file_path");
+    }
+  }
+
+  private boolean fileNotExist(String path) {
+    return !fileExist(path);
+  }
+
+  private boolean fileExist(String path) {
+    if (path == null || path.trim().isEmpty()) {
+      return false;
+    }
+    return table.io().newInputFile(path).exists();
+  }
+
+  private static String relativize(String path, String prefix) {
+    String toRemove = prefix;
+    if (!toRemove.endsWith("/")) {
+      toRemove += "/";
+    }
+    if (!path.startsWith(toRemove)) {
+      throw new IllegalArgumentException(
+          String.format("Path %s does not start with %s", path, toRemove));
+    }
+    return path.substring(toRemove.length());
+  }
+
+  private static String newPath(String path, String sourcePrefix, String targetPrefix) {
+    return combinePaths(targetPrefix, relativize(path, sourcePrefix));
+  }
+
+  private void addToRebuiltFiles(String path) {
+    metadataFilesToMove.add(path);
+  }
+
+  private String currentMetadataPath(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current().metadataFileLocation();
+  }
+
+  private static String combinePaths(String absolutePath, String relativePath) {
+    String combined = absolutePath;
+    if (!combined.endsWith("/")) {
+      combined += "/";
+    }
+    combined += relativePath;
+    return combined;
+  }
+
+  private static String fileName(String path) {
+    String filename = path;
+    int lastIndex = path.lastIndexOf(File.separator);
+    if (lastIndex != -1) {
+      filename = path.substring(lastIndex + 1);
+    }
+    return filename;
+  }
+}

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.apache.iceberg.AllManifestsTable;
@@ -47,7 +46,6 @@ import org.apache.iceberg.ReachableFileUtil;
 import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StaticTableOperations;
-import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -230,6 +228,7 @@ abstract class BaseSparkAction<ThisT> {
                 "content",
                 "path",
                 "length",
+                "0 as sequenceNumber",
                 "partition_spec_id as partitionSpecId",
                 "added_snapshot_id as addedSnapshotId")
             .dropDuplicates("path")
@@ -259,6 +258,7 @@ abstract class BaseSparkAction<ThisT> {
                 "content",
                 "path",
                 "length",
+                "0 as sequenceNumber",
                 "partition_spec_id as partitionSpecId",
                 "added_snapshot_id as addedSnapshotId")
             .dropDuplicates("path")
@@ -285,6 +285,7 @@ abstract class BaseSparkAction<ThisT> {
                 "content",
                 "path",
                 "length",
+                "0 as sequenceNumber",
                 "partition_spec_id as partitionSpecId",
                 "added_snapshot_id as addedSnapshotId")
             .dropDuplicates("path")
@@ -331,14 +332,8 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Dataset<FileInfo> statisticsFileDS(Table table, Set<Long> snapshotIds) {
-    Predicate<StatisticsFile> predicate;
-    if (snapshotIds == null) {
-      predicate = statisticsFile -> true;
-    } else {
-      predicate = statisticsFile -> snapshotIds.contains(statisticsFile.snapshotId());
-    }
-
-    List<String> statisticsFiles = ReachableFileUtil.statisticsFilesLocations(table, predicate);
+    List<String> statisticsFiles =
+        ReachableFileUtil.statisticsFilesLocationsForSnapshots(table, snapshotIds);
     return toFileInfoDS(statisticsFiles, STATISTICS_FILES);
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.actions;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.CopyTable;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.Spark3Util.CatalogAndIdentifier;
 import org.apache.spark.sql.SparkSession;
@@ -95,5 +96,10 @@ public class SparkActions implements ActionsProvider {
   @Override
   public RewritePositionDeleteFilesSparkAction rewritePositionDeletes(Table table) {
     return new RewritePositionDeleteFilesSparkAction(spark, table);
+  }
+
+  @Override
+  public CopyTable copyTable(Table table) {
+    return new BaseCopyTableSparkAction(spark, table);
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestCopyTableAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestCopyTableAction.java
@@ -1,0 +1,1023 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.CopyTable;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.source.ThreeColumnRecord;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestCopyTableAction extends SparkTestBase {
+  protected ActionsProvider actions() {
+    return SparkActions.get();
+  }
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  protected static final Schema SCHEMA =
+      new Schema(
+          optional(1, "c1", Types.IntegerType.get()),
+          optional(2, "c2", Types.StringType.get()),
+          optional(3, "c3", Types.StringType.get()));
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  private File tableDir = null;
+  protected String tableLocation = null;
+  private Table table = null;
+
+  @Before
+  public void setupTableLocation() throws Exception {
+    this.tableDir = temp.newFolder();
+    this.tableLocation = tableDir.toURI().toString();
+    this.table = createATableWith2Snapshots(tableLocation);
+  }
+
+  private Table createATableWith2Snapshots(String location) {
+    return createTableWithSnapshots(location, 2);
+  }
+
+  private Table createTableWithSnapshots(String location, int snapshotNumber) {
+    return createTableWithSnapshots(location, snapshotNumber, Maps.newHashMap());
+  }
+
+  protected Table createTableWithSnapshots(
+      String location, int snapshotNumber, Map<String, String> properties) {
+    Table newTable = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, location);
+
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+
+    for (int i = 0; i < snapshotNumber; i++) {
+      df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(location);
+    }
+
+    return newTable;
+  }
+
+  @Test
+  public void testCopyTable() throws Exception {
+    String targetTableLocation = newTableLocation();
+
+    // check the data file location before the rebuild
+    List<String> validDataFiles =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation + "#files")
+            .select("file_path")
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertEquals("Should be 2 valid data files", 2, validDataFiles.size());
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(table)
+            .rewriteLocationPrefix(tableLocation, targetTableLocation)
+            .endVersion("v3.metadata.json")
+            .execute();
+
+    Assert.assertEquals("The latest version should be", "v3.metadata.json", result.latestVersion());
+
+    checkMetadataFileNum(3, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(tableLocation, targetTableLocation, stagingDir(result));
+
+    // verify the data file path after the rebuild
+    List<String> validDataFilesAfterRebuilt =
+        spark
+            .read()
+            .format("iceberg")
+            .load(targetTableLocation + "#files")
+            .select("file_path")
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertEquals("Should be 2 valid data files", 2, validDataFilesAfterRebuilt.size());
+    for (String item : validDataFilesAfterRebuilt) {
+      Assert.assertTrue(
+          "Data file should point to the new location", item.startsWith(targetTableLocation));
+    }
+
+    // verify data rows
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(targetTableLocation);
+    List<ThreeColumnRecord> actualRecords =
+        resultDF.sort("c1", "c2", "c3").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.add(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    expectedRecords.add(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+
+    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+  }
+
+  @Test
+  public void testDataFilesDiff() throws Exception {
+    CopyTable.Result result =
+        actions()
+            .copyTable(table)
+            .rewriteLocationPrefix(tableLocation, newTableLocation())
+            .lastCopiedVersion("v2.metadata.json")
+            .execute();
+
+    checkDataFileNum(1, result);
+
+    List<String> rebuiltFiles =
+        spark
+            .read()
+            .format("text")
+            .load(result.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    // v3.metadata.json, one manifest-list file, one manifest file
+    checkMetadataFileNum(3, result);
+
+    String currentSnapshotId = String.valueOf(table.currentSnapshot().snapshotId());
+    Assert.assertTrue(
+        "Should have the current snapshot file",
+        rebuiltFiles.stream().filter(c -> c.contains(currentSnapshotId)).count() == 1);
+
+    String parentSnapshotId = String.valueOf(table.currentSnapshot().parentId());
+    Assert.assertTrue(
+        "Should NOT have the parent snapshot file",
+        rebuiltFiles.stream().filter(c -> c.contains(parentSnapshotId)).count() == 0);
+  }
+
+  @Test
+  public void testTableWith3Snapshots() throws Exception {
+    String location = newTableLocation();
+    Table tableWith3Snaps = createTableWithSnapshots(location, 3);
+    CopyTable.Result result =
+        actions()
+            .copyTable(tableWith3Snaps)
+            .rewriteLocationPrefix(location, newTableLocation())
+            .lastCopiedVersion("v2.metadata.json")
+            .execute();
+
+    checkMetadataFileNum(2, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // start from the first version
+    CopyTable.Result result1 =
+        actions()
+            .copyTable(tableWith3Snaps)
+            .rewriteLocationPrefix(location, newTableLocation())
+            .lastCopiedVersion("v1.metadata.json")
+            .execute();
+
+    checkMetadataFileNum(3, 3, 3, result1);
+    checkDataFileNum(3, result1);
+  }
+
+  @Test
+  public void testFullTableCopy() throws Exception {
+    CopyTable.Result result =
+        actions()
+            .copyTable(table)
+            .rewriteLocationPrefix(tableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(3, 2, 2, result);
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testDeleteDataFile() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(location);
+    List<String> validDataFiles =
+        spark
+            .read()
+            .format("iceberg")
+            .load(location + "#files")
+            .select("file_path")
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    sourceTable.newDelete().deleteFile(validDataFiles.stream().findFirst().get()).commit();
+
+    String targetLocation = newTableLocation();
+    CopyTable.Result result =
+        actions().copyTable(sourceTable).rewriteLocationPrefix(location, targetLocation).execute();
+
+    checkMetadataFileNum(4, 3, 3, result);
+    checkDataFileNum(2, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(location, targetLocation, stagingDir(result));
+
+    // verify data rows
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(targetLocation);
+    Assert.assertEquals(
+        "There are only one row left since we deleted a data file",
+        1,
+        resultDF.as(Encoders.bean(ThreeColumnRecord.class)).count());
+  }
+
+  @Test
+  public void testWithDeleteManifestsAndPositionDeletes() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(location);
+    String targetLocation = newTableLocation();
+
+    List<Pair<CharSequence, Long>> deletes =
+        Lists.newArrayList(
+            Pair.of(
+                sourceTable
+                    .currentSnapshot()
+                    .addedDataFiles(sourceTable.io())
+                    .iterator()
+                    .next()
+                    .path(),
+                0L));
+
+    File file = new File(removePrefix(sourceTable.location()) + "/data/deeply/nested/file.parquet");
+    DeleteFile positionDeletes =
+        FileHelpers.writeDeleteFile(
+                sourceTable, sourceTable.io().newOutputFile(file.toURI().toString()), deletes)
+            .first();
+
+    sourceTable.newRowDelta().addDeletes(positionDeletes).commit();
+
+    CopyTable.Result result =
+        actions().copyTable(sourceTable).rewriteLocationPrefix(location, targetLocation).execute();
+
+    // We have one more snapshot, an additional manifest list, and a new (delete) manifest
+    checkMetadataFileNum(4, 3, 3, result);
+    // We have one additional file for positional deletes
+    checkDataFileNum(3, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(location, targetLocation, stagingDir(result));
+
+    // Positional delete affects a single row, so only one row must remain
+    Assert.assertEquals(
+        "The number of rows should be",
+        1,
+        spark.read().format("iceberg").load(targetLocation).count());
+  }
+
+  @Test
+  public void testWithDeleteManifestsAndEqualityDeletes() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(location, 1);
+    String targetLocation = newTableLocation();
+
+    // Add more varied data
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(
+            new ThreeColumnRecord(2, "AAAAAAAAAA", "AAAA"),
+            new ThreeColumnRecord(3, "BBBBBBBBBB", "BBBB"),
+            new ThreeColumnRecord(4, "CCCCCCCCCC", "CCCC"),
+            new ThreeColumnRecord(5, "DDDDDDDDDD", "DDDD"));
+    spark
+        .createDataFrame(records, ThreeColumnRecord.class)
+        .coalesce(1)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(location);
+
+    Schema deleteRowSchema = sourceTable.schema().select("c2");
+    Record dataDelete = GenericRecord.create(deleteRowSchema);
+    List<Record> dataDeletes =
+        Lists.newArrayList(
+            dataDelete.copy("c2", "AAAAAAAAAA"), dataDelete.copy("c2", "CCCCCCCCCC"));
+    File file = new File(removePrefix(sourceTable.location()) + "/data/deeply/nested/file.parquet");
+    DeleteFile equalityDeletes =
+        FileHelpers.writeDeleteFile(
+            sourceTable,
+            sourceTable.io().newOutputFile(file.toURI().toString()),
+            TestHelpers.Row.of(0),
+            dataDeletes,
+            deleteRowSchema);
+    sourceTable.newRowDelta().addDeletes(equalityDeletes).commit();
+
+    CopyTable.Result result =
+        actions().copyTable(sourceTable).rewriteLocationPrefix(location, targetLocation).execute();
+
+    // We have four metadata files: for the table creation, for the initial snapshot, for the
+    // second append here, and for commit with equality deletes. Thus, we have three manifest lists
+    checkMetadataFileNum(4, 3, 3, result);
+    // A data file for each snapshot (two with data, one with equality deletes)
+    checkDataFileNum(3, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(location, targetLocation, stagingDir(result));
+
+    // Equality deletes affect three rows, so just two rows must remain
+    Assert.assertEquals(
+        "The number of rows should be",
+        2,
+        spark.read().format("iceberg").load(targetLocation).count());
+  }
+
+  @Test
+  public void testFullTableCopyWithDeletedVersionFiles() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(location, 2);
+    // expire the first snapshot
+    Table staticTable = newStaticTable(location + "metadata/v2.metadata.json", table.io());
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(staticTable.currentSnapshot().snapshotId())
+        .execute();
+
+    // create 100 more snapshots
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    for (int i = 0; i < 100; i++) {
+      df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(location);
+    }
+    sourceTable.refresh();
+
+    // v1/v2/v3.metadata.json has been deleted in v104.metadata.json, and there is no way to find
+    // the first snapshot
+    // from the version file history
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(location, newTableLocation())
+            .execute();
+
+    // you can only find 101 snapshots but the manifest file and data file count should be 102.
+    checkMetadataFileNum(101, 101, 101, result);
+    checkDataFileNum(102, result);
+  }
+
+  protected Table newStaticTable(String metadataFileLocation, FileIO io) {
+    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
+    return new BaseTable(ops, metadataFileLocation);
+  }
+
+  @Test
+  public void testRewriteTableWithoutSnapshot() throws Exception {
+    CopyTable.Result result =
+        actions()
+            .copyTable(table)
+            .rewriteLocationPrefix(tableLocation, newTableLocation())
+            .endVersion("v1.metadata.json")
+            .execute();
+
+    // the only rebuilt file is v1.metadata.json since it contains no snapshot
+    checkMetadataFileNum(1, result);
+    checkDataFileNum(0, result);
+  }
+
+  @Test
+  public void testExpireSnapshotBeforeRewrite() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(4, 1, 2, result);
+
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testStartSnapshotWithoutValidSnapshot() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    Assert.assertEquals(
+        "1 out 2 snapshot has been removed", 1, ((List) sourceTable.snapshots()).size());
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion("v2.metadata.json")
+            .execute();
+
+    // 2 metadata.json, 1 manifest list file, 1 manifest files
+    checkMetadataFileNum(4, result);
+    checkDataFileNum(1, result);
+  }
+
+  @Test
+  public void testMoveTheVersionExpireSnapshot() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    // only move version v4, which is the version generated by snapshot expiration
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion("v3.metadata.json")
+            .execute();
+
+    // only v4.metadata.json needs to move
+    checkMetadataFileNum(1, result);
+    // no data file needs to move
+    checkDataFileNum(0, result);
+  }
+
+  @Test
+  public void testMoveVersionWithInvalidSnapshots() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    AssertHelpers.assertThrows(
+        "Copy a version with invalid snapshots aren't allowed",
+        UnsupportedOperationException.class,
+        () ->
+            actions()
+                .copyTable(sourceTable)
+                .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+                .endVersion("v3.metadata.json")
+                .execute());
+  }
+
+  @Test
+  public void testRollBack() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+    Long secondSnapshotId = sourceTable.currentSnapshot().snapshotId();
+
+    // roll back to the first snapshot(v2)
+    sourceTable
+        .manageSnapshots()
+        .setCurrentSnapshot(sourceTable.currentSnapshot().parentId())
+        .commit();
+
+    // add a new snapshot
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(sourceTableLocation);
+
+    sourceTable.refresh();
+
+    // roll back to the second snapshot(v3)
+    sourceTable.manageSnapshots().setCurrentSnapshot(secondSnapshotId).commit();
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    // check the result
+    checkMetadataFileNum(6, 3, 3, result);
+  }
+
+  @Test
+  public void testWriteAuditPublish() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // enable WAP
+    sourceTable
+        .updateProperties()
+        .set(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED, "true")
+        .commit();
+    spark.conf().set("spark.wap.id", "1");
+
+    // add a new snapshot without changing the current snapshot of the table
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(sourceTableLocation);
+
+    sourceTable.refresh();
+
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    // check the result. There are 3 snapshots in total, although the current snapshot is the second
+    // one.
+    checkMetadataFileNum(5, 3, 3, result);
+  }
+
+  @Test
+  public void testSchemaChange() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // change the schema
+    sourceTable.updateSchema().addColumn("c4", Types.StringType.get()).commit();
+
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    // check the result
+    checkMetadataFileNum(4, 2, 2, result);
+  }
+
+  @Test
+  public void testWithTargetTable() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 3);
+    String targetTableLocation = newTableLocation();
+    Table targetTable = createATableWith2Snapshots(targetTableLocation);
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+            .targetTable(targetTable)
+            .execute();
+
+    Assert.assertEquals("The latest version should be", "v4.metadata.json", result.latestVersion());
+
+    // 3 files rebuilt from v3 to v4: v4.metadata.json, one manifest list, one manifest file
+    checkMetadataFileNum(3, result);
+  }
+
+  @Test
+  public void testInvalidStartVersion() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 3);
+    String targetTableLocation = newTableLocation();
+    Table targetTable = createATableWith2Snapshots(targetTableLocation);
+
+    AssertHelpers.assertThrows(
+        "The valid start version should be v3",
+        IllegalArgumentException.class,
+        "The start version isn't the current version of the target table.",
+        () ->
+            actions()
+                .copyTable(sourceTable)
+                .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+                .targetTable(targetTable)
+                .lastCopiedVersion("v2.metadata.json")
+                .execute());
+  }
+
+  @Test
+  public void testSnapshotIdInheritanceEnabled() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, "true");
+
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 2, properties);
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(7, result);
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testMetadataCompression() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.METADATA_COMPRESSION, "gzip");
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 2, properties);
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .endVersion("v2.gz.metadata.json")
+            .execute();
+
+    checkMetadataFileNum(4, result);
+    checkDataFileNum(1, result);
+
+    result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion("v1.gz.metadata.json")
+            .execute();
+
+    checkMetadataFileNum(6, result);
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testInvalidArgs() {
+    CopyTable actions = actions().copyTable(table);
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Source prefix('') cannot be empty",
+        () -> actions.rewriteLocationPrefix("", null));
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Source prefix('null') cannot be empty",
+        () -> actions.rewriteLocationPrefix(null, null));
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Staging location('') cannot be empty",
+        () -> actions.stagingLocation(""));
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Staging location('null') cannot be empty",
+        () -> actions.stagingLocation(null));
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Last copied version('null') cannot be empty",
+        () -> actions.lastCopiedVersion(null));
+
+    AssertHelpers.assertThrows(
+        "Last copied version cannot be empty",
+        IllegalArgumentException.class,
+        () -> actions.lastCopiedVersion(" "));
+
+    AssertHelpers.assertThrows(
+        "End version cannot be empty",
+        IllegalArgumentException.class,
+        () -> actions.endVersion(" "));
+
+    AssertHelpers.assertThrows(
+        "End version cannot be empty",
+        IllegalArgumentException.class,
+        () -> actions.endVersion(null));
+  }
+
+  protected void checkDataFileNum(long count, CopyTable.Result result) {
+    List<String> filesToMove =
+        spark
+            .read()
+            .format("text")
+            .load(result.dataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertEquals("The rebuilt data file number should be", count, filesToMove.size());
+  }
+
+  protected void checkMetadataFileNum(int count, CopyTable.Result result) {
+    List<String> filesToMove =
+        spark
+            .read()
+            .format("text")
+            .load(result.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertEquals("The rebuilt metadata file number should be", count, filesToMove.size());
+  }
+
+  protected void checkMetadataFileNum(
+      int versionFileCount, int manifestListCount, int manifestFileCount, CopyTable.Result result) {
+    List<String> filesToMove =
+        spark
+            .read()
+            .format("text")
+            .load(result.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertEquals(
+        "The rebuilt version file number should be",
+        versionFileCount,
+        filesToMove.stream().filter(f -> f.endsWith(".metadata.json")).count());
+    Assert.assertEquals(
+        "The rebuilt Manifest list file number should be",
+        manifestListCount,
+        filesToMove.stream().filter(f -> f.contains("snap-")).count());
+    Assert.assertEquals(
+        "The rebuilt Manifest file number should be",
+        manifestFileCount,
+        filesToMove.stream().filter(f -> f.endsWith("-m0.avro")).count());
+  }
+
+  private String stagingDir(CopyTable.Result result) {
+    String metadataFileListPath = result.metadataFileListLocation();
+    return metadataFileListPath.substring(0, metadataFileListPath.lastIndexOf(File.separator));
+  }
+
+  protected String newTableLocation() throws IOException {
+    return temp.newFolder().toURI().toString();
+  }
+
+  private void moveTableFiles(String sourceDir, String targetDir, String stagingDir)
+      throws Exception {
+    FileUtils.copyDirectory(
+        new File(removePrefix(sourceDir) + "data/"), new File(removePrefix(targetDir) + "/data/"));
+    // Copy staged metadata files, overwrite previously copied data files with staged ones
+    FileUtils.copyDirectory(new File(removePrefix(stagingDir)), new File(removePrefix(targetDir)));
+  }
+
+  private String removePrefix(String path) {
+    return path.substring(path.lastIndexOf(":") + 1);
+  }
+
+  // Metastore table tests
+  @Test
+  public void testMetadataLocationChange() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createMetastoreTable(sourceTableLocation, Maps.newHashMap(), "tbl", 1);
+    String metadataFilePath = currentMetadata(sourceTable).metadataFileLocation();
+
+    String newMetadataDir = "new-metadata-dir";
+    sourceTable
+        .updateProperties()
+        .set(TableProperties.WRITE_METADATA_LOCATION, sourceTableLocation + newMetadataDir)
+        .commit();
+
+    spark.sql("insert into hive.default.tbl values (1, 'AAAAAAAAAA', 'AAAA')");
+    sourceTable.refresh();
+
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(4, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // pick up a version from the old metadata dir as the end version
+    CopyTable.Result result1 =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .endVersion(fileName(metadataFilePath))
+            .execute();
+
+    checkMetadataFileNum(2, 1, 1, result1);
+
+    // pick up a version from the old metadata dir as the last copied version
+    CopyTable.Result result2 =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion(fileName(metadataFilePath))
+            .execute();
+
+    checkMetadataFileNum(2, 1, 1, result2);
+  }
+
+  @Test
+  public void testMetadataCompressionWithMetastoreTable() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.METADATA_COMPRESSION, "gzip");
+    Table sourceTable =
+        createMetastoreTable(sourceTableLocation, properties, "testMetadataCompression", 2);
+
+    TableMetadata currentMetadata = currentMetadata(sourceTable);
+
+    // set the second version as the endVersion
+    String endVersion = fileName(currentMetadata.previousFiles().get(1).file());
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .endVersion(endVersion)
+            .execute();
+
+    checkMetadataFileNum(4, result);
+    checkDataFileNum(1, result);
+
+    // set the first version as the lastCopiedVersion
+    String firstVersion = fileName(currentMetadata.previousFiles().get(0).file());
+    result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion(firstVersion)
+            .execute();
+
+    checkMetadataFileNum(6, result);
+    checkDataFileNum(2, result);
+  }
+
+  private TableMetadata currentMetadata(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current();
+  }
+
+  @Test
+  public void testDataFileLocationChange() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createMetastoreTable(sourceTableLocation, Maps.newHashMap(), "tbl1", 1);
+    String metadataFilePath = currentMetadata(sourceTable).metadataFileLocation();
+
+    String newMetadataDir = "new-data-dir";
+    sourceTable
+        .updateProperties()
+        .set(TableProperties.OBJECT_STORE_PATH, sourceTableLocation + newMetadataDir)
+        .set(TableProperties.OBJECT_STORE_ENABLED, "true")
+        .commit();
+
+    spark.sql("insert into hive.default.tbl1 values (1, 'AAAAAAAAAA', 'AAAA')");
+    sourceTable.refresh();
+
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(4, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // pick up a version with the data file in the old data directory as the end version
+    String targetTableLocation = newTableLocation();
+    CopyTable.Result result1 =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+            .endVersion(fileName(metadataFilePath))
+            .execute();
+
+    checkMetadataFileNum(2, 1, 1, result1);
+    checkDataFileNum(1, result1);
+    List<String> filesToMove1 =
+        spark
+            .read()
+            .format("text")
+            .load(result1.dataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertTrue(
+        "The data file should be in the old data directory.",
+        filesToMove1.stream().findFirst().get().startsWith(sourceTableLocation + "data"));
+
+    // pick up a version with the data file in the new data directory as the last copied version
+    CopyTable.Result result2 =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+            .lastCopiedVersion(fileName(metadataFilePath))
+            .execute();
+
+    checkMetadataFileNum(2, 1, 1, result2);
+    checkDataFileNum(1, result2);
+    List<String> filesToMove2 =
+        spark
+            .read()
+            .format("text")
+            .load(result2.dataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    Assert.assertTrue(
+        "The data file should be in the new data directory.",
+        filesToMove2.stream().findFirst().get().startsWith(sourceTableLocation + newMetadataDir));
+
+    // check if table properties have been modified
+    List<String> metadataFilesToMove =
+        spark
+            .read()
+            .format("text")
+            .load(result2.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    metadataFilesToMove.stream()
+        .filter(f -> f.endsWith(".metadata.json"))
+        .forEach(
+            metadataFile -> {
+              StaticTableOperations ops = new StaticTableOperations(metadataFile, sourceTable.io());
+              Table targetStaticTable = new BaseTable(ops, metadataFile);
+              if (targetStaticTable.properties().containsKey(TableProperties.OBJECT_STORE_PATH)) {
+                Assert.assertTrue(
+                    "The write.object-storage.path should be modified with the target table location.",
+                    targetStaticTable
+                        .properties()
+                        .get(TableProperties.OBJECT_STORE_PATH)
+                        .startsWith(targetTableLocation));
+              }
+            });
+  }
+
+  private Table createMetastoreTable(
+      String location, Map<String, String> properties, String tableName, int snapshotNumber) {
+    spark.conf().set("spark.sql.catalog.hive", SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog.hive.type", "hive");
+    spark.conf().set("spark.sql.catalog.hive.default-namespace", "default");
+    spark.conf().set("spark.sql.catalog.hive.cache-enabled", "false");
+
+    StringBuilder propertiesStr = new StringBuilder();
+    properties.forEach((k, v) -> propertiesStr.append("'" + k + "'='" + v + "',"));
+    String tblProperties =
+        propertiesStr.substring(0, propertiesStr.length() > 0 ? propertiesStr.length() - 1 : 0);
+
+    if (tblProperties.isEmpty()) {
+      sql(
+          "CREATE TABLE hive.default.%s (c1 bigint, c2 string, c3 string) USING iceberg LOCATION '%s'",
+          tableName, location);
+    } else {
+      sql(
+          "CREATE TABLE hive.default.%s (c1 bigint, c2 string, c3 string) USING iceberg LOCATION '%s' TBLPROPERTIES "
+              + "(%s)",
+          tableName, location, tblProperties);
+    }
+
+    for (int i = 0; i < snapshotNumber; i++) {
+      sql("insert into hive.default.%s values (1, 'AAAAAAAAAA', 'AAAA')", tableName);
+    }
+    return catalog.loadTable(TableIdentifier.of("default", tableName));
+  }
+
+  private static String fileName(String path) {
+    String filename = path;
+    int lastIndex = path.lastIndexOf(File.separator);
+    if (lastIndex != -1) {
+      filename = path.substring(lastIndex + 1);
+    }
+    return filename;
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCopyTableSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCopyTableSparkAction.java
@@ -1,0 +1,871 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestEntry;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestLists;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadata.MetadataLogEntry;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableMetadataUtil;
+import org.apache.iceberg.actions.BaseCopyTableActionResult;
+import org.apache.iceberg.actions.CopyTable;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.avro.DataReader;
+import org.apache.iceberg.data.avro.DataWriter;
+import org.apache.iceberg.data.orc.GenericOrcReader;
+import org.apache.iceberg.data.orc.GenericOrcWriter;
+import org.apache.iceberg.data.parquet.GenericParquetReaders;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.DeleteSchemaUtil;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.spark.api.java.function.MapPartitionsFunction;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoder;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BaseCopyTableSparkAction extends BaseSparkAction<CopyTable> implements CopyTable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseCopyTableSparkAction.class);
+  private static final String DATA_FILE_LIST_DIR = "data-file-list-to-move";
+  private static final String METADATA_FILE_LIST_DIR = "metadata-file-list-to-move";
+
+  private final Table table;
+  private final Set<String> metadataFilesToMove = Collections.synchronizedSet(Sets.newHashSet());
+  private final Set<String> manifestFilePaths = Collections.synchronizedSet(Sets.newHashSet());
+  private final Set<ManifestFile> manifestFilesToRewrite =
+      Collections.synchronizedSet(Sets.newHashSet());
+  private String dataFileListPath = null;
+  private String metadataFileListPath = null;
+  private final boolean enabledPME;
+
+  private String sourcePrefix = "";
+  private String targetPrefix = "";
+  private String startVersion = "";
+  private String endVersion = "";
+  private String stagingDir = "";
+  private Table targetTable = null;
+
+  private Table startStaticTable = null;
+  private Table endStaticTable = null;
+
+  public BaseCopyTableSparkAction(SparkSession spark, Table table) {
+    super(spark);
+    this.table = table;
+    enabledPME = table.properties().containsKey("parquet.encryption.footer.key");
+  }
+
+  @Override
+  public CopyTable rewriteLocationPrefix(String sPrefix, String tPrefix) {
+    Preconditions.checkArgument(
+        sPrefix != null && !sPrefix.isEmpty(), "Source prefix('%s') cannot be empty.", sPrefix);
+    this.sourcePrefix = sPrefix;
+
+    if (tPrefix != null) {
+      this.targetPrefix = tPrefix;
+    }
+    return this;
+  }
+
+  @Override
+  public CopyTable lastCopiedVersion(String sVersion) {
+    Preconditions.checkArgument(
+        sVersion != null && !sVersion.trim().isEmpty(),
+        "Last copied version('%s') cannot be empty.",
+        sVersion);
+    this.startVersion = sVersion;
+    return this;
+  }
+
+  @Override
+  public CopyTable endVersion(String eVersion) {
+    Preconditions.checkArgument(
+        eVersion != null && !eVersion.trim().isEmpty(),
+        "End version('%s') cannot be empty.",
+        eVersion);
+    this.endVersion = eVersion;
+    return this;
+  }
+
+  @Override
+  public CopyTable stagingLocation(String stagingLocation) {
+    Preconditions.checkArgument(
+        stagingLocation != null && !stagingLocation.isEmpty(),
+        "Staging location('%s') cannot be empty.",
+        stagingLocation);
+    this.stagingDir = stagingLocation;
+    return this;
+  }
+
+  @Override
+  public CopyTable targetTable(Table tgtTable) {
+    this.targetTable = tgtTable;
+    return this;
+  }
+
+  @Override
+  protected CopyTable self() {
+    return this;
+  }
+
+  @Override
+  public Result execute() {
+    validateInputs();
+    JobGroupInfo info = newJobGroupInfo("COPY-TABLE", jobDesc());
+    return withJobGroupInfo(info, this::doExecute);
+  }
+
+  private Result doExecute() {
+    rebuildMetaData();
+    return new BaseCopyTableActionResult(
+        stagingDir, dataFileListPath, metadataFileListPath, fileName(endVersion));
+  }
+
+  private void validateInputs() {
+    Preconditions.checkArgument(
+        sourcePrefix != null && !sourcePrefix.isEmpty(),
+        "Source prefix('%s') cannot be empty.",
+        sourcePrefix);
+
+    validateAndSetEndVersion();
+
+    endStaticTable = newStaticTable(TableMetadataParser.read(table.io(), endVersion), table.io());
+
+    TableMetadata tableMetadata = ((HasTableOperations) endStaticTable).operations().current();
+    Preconditions.checkArgument(
+        tableMetadata.formatVersion() == 2, "Support Iceberg format version 2 only.");
+
+    validateAndSetStartVersion(tableMetadata);
+
+    if (fileExist(startVersion)) {
+      startStaticTable =
+          newStaticTable(TableMetadataParser.read(table.io(), startVersion), table.io());
+    }
+
+    if (stagingDir.isEmpty()) {
+      String stagingDirName = "copy-table-staging-" + UUID.randomUUID();
+      stagingDir = combinePaths(table.location(), stagingDirName);
+    }
+
+    if (!stagingDir.endsWith("/")) {
+      stagingDir = stagingDir + "/";
+    }
+  }
+
+  private void validateAndSetEndVersion() {
+    if (endVersion.isEmpty()) {
+      endVersion = currentMetadataPath(table);
+    } else {
+      TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
+      if (versionInFilePath(tableMetadata.metadataFileLocation(), endVersion)) {
+        endVersion = tableMetadata.metadataFileLocation();
+      }
+      for (MetadataLogEntry metadataLogEntry : tableMetadata.previousFiles()) {
+        if (versionInFilePath(metadataLogEntry.file(), endVersion)) {
+          endVersion = metadataLogEntry.file();
+          break;
+        }
+      }
+
+      Preconditions.checkArgument(
+          fileExist(endVersion),
+          "Cannot find the end version('%s') in the current version " + "files",
+          endVersion);
+    }
+  }
+
+  private void validateAndSetStartVersion(TableMetadata tableMetadata) {
+    if (startVersion.isEmpty()) {
+      if (targetTable == null) {
+        LOG.warn("No input of the start version. Will do a full copy.");
+      } else {
+        String tgtTableCurrentVersion = fileName(currentMetadataPath(targetTable));
+
+        for (MetadataLogEntry metadataLogEntry : tableMetadata.previousFiles()) {
+          if (metadataLogEntry.file().endsWith(tgtTableCurrentVersion)) {
+            startVersion = metadataLogEntry.file();
+            break;
+          }
+        }
+
+        if (fileNotExist(startVersion)) {
+          throw new IllegalArgumentException(
+              "Cannot find the current version of target table in the source table. "
+                  + "Please make sure the target table is a subset of source table.");
+        }
+      }
+    } else {
+      for (MetadataLogEntry metadataLogEntry : tableMetadata.previousFiles()) {
+        if (versionInFilePath(metadataLogEntry.file(), startVersion)) {
+          startVersion = metadataLogEntry.file();
+          break;
+        }
+      }
+
+      Preconditions.checkArgument(
+          fileExist(startVersion), "Start version('%s') is NOT valid.", startVersion);
+
+      if (targetTable != null
+          && !fileName(startVersion).equals(fileName(currentMetadataPath(targetTable)))) {
+        throw new IllegalArgumentException(
+            "The start version isn't the current version of the target table. "
+                + "Please make sure the target table is a subset of source table.");
+      }
+    }
+  }
+
+  private boolean versionInFilePath(String path, String version) {
+    return fileName(path).equals(version);
+  }
+
+  private String jobDesc() {
+    if (startVersion.isEmpty()) {
+      return String.format(
+          "Replacing path prefixes '%s' with '%s' in the metadata files of table %s,"
+              + "up to version '%s'.",
+          sourcePrefix, targetPrefix, table.name(), endVersion);
+    } else {
+      return String.format(
+          "Replacing path prefixes '%s' with '%s' in the metadata files of table %s,"
+              + "from version '%s' to '%s'.",
+          sourcePrefix, targetPrefix, table.name(), startVersion, endVersion);
+    }
+  }
+
+  /**
+   * Here are steps: 1. rebuild version files 2. rebuild manifest list files 3. rebuild manifest
+   * files 4. get all data files need to move
+   */
+  private void rebuildMetaData() {
+    TableMetadata tableMetadata = ((HasTableOperations) endStaticTable).operations().current();
+
+    // rebuild version files
+    Set<Long> allSnapshotIds = rewriteVersionFiles(tableMetadata);
+
+    Set<Long> diffSnapshotIds = getDiffSnapshotIds(allSnapshotIds);
+
+    // get all manifest file paths need to rewrite
+    List<String> manifestFilePathToMove = manifestFilesToMove(diffSnapshotIds);
+    manifestFilePaths.addAll(manifestFilePathToMove);
+
+    // rebuild manifest-list files
+    Set<Snapshot> validSnapshots =
+        Sets.difference(snapshotSet(endVersion), snapshotSet(startVersion));
+    validSnapshots.forEach(snapshot -> rewriteManifestList(snapshot, tableMetadata));
+
+    // rebuild manifest files
+    List<ManifestFile> newManifests = rewriteManifests(tableMetadata);
+    newManifests.forEach(manifestFile -> addToRebuiltFiles(manifestFile.path()));
+    saveMetadataFileList();
+
+    Dataset<Row> dataFiles = getDiffDataFiles(diffSnapshotIds);
+    saveDataFileList(dataFiles);
+  }
+
+  private void saveMetadataFileList() {
+    List<String> fileList = Lists.newArrayList();
+    fileList.addAll(metadataFilesToMove);
+    Dataset<String> metadataFileList = spark().createDataset(fileList, Encoders.STRING());
+    metadataFileListPath = stagingDir + METADATA_FILE_LIST_DIR;
+    metadataFileList
+        .repartition(1)
+        .write()
+        .mode(SaveMode.Overwrite)
+        .format("text")
+        .save(metadataFileListPath);
+  }
+
+  private void saveDataFileList(Dataset<Row> dataFiles) {
+    dataFileListPath = stagingDir + DATA_FILE_LIST_DIR;
+
+    try {
+      dataFiles
+          .repartition(1)
+          .write()
+          .mode(SaveMode.Overwrite)
+          .format("text")
+          .save(dataFileListPath);
+    } catch (Exception e) {
+      throw new UnsupportedOperationException(
+          "Failed to build the data files dataframe, the end version you are "
+              + "trying to copy may contain invalid snapshots, please use the younger version which doesn't have invalid "
+              + "snapshots",
+          e);
+    }
+  }
+
+  private Set<Long> getDiffSnapshotIds(Set<Long> allSnapshotIds) {
+    Set<Long> snapshotIdsInStartVersion = Sets.newHashSet();
+    if (startStaticTable != null) {
+      startStaticTable
+          .snapshots()
+          .forEach(snapshot -> snapshotIdsInStartVersion.add(snapshot.snapshotId()));
+    }
+    return Sets.difference(allSnapshotIds, snapshotIdsInStartVersion);
+  }
+
+  private Set<Long> rewriteVersionFiles(TableMetadata metadata) {
+    Set<Long> allSnapshotIds = Sets.newHashSet();
+
+    String stagingPath = combinePaths(stagingDir, relativize(endVersion, sourcePrefix));
+    metadata.snapshots().forEach(snapshot -> allSnapshotIds.add(snapshot.snapshotId()));
+    rewriteVersionFile(metadata, stagingPath);
+
+    List<MetadataLogEntry> versions = metadata.previousFiles();
+    for (int i = versions.size() - 1; i >= 0; i--) {
+      String versionFilePath = versions.get(i).file();
+      if (versionFilePath.equals(startVersion)) {
+        break;
+      }
+
+      Preconditions.checkArgument(
+          fileExist(versionFilePath),
+          String.format("Version file %s doesn't exist", versionFilePath));
+      String newPath = combinePaths(stagingDir, relativize(versionFilePath, sourcePrefix));
+      TableMetadata tableMetadata =
+          new StaticTableOperations(versionFilePath, table.io()).current();
+
+      tableMetadata.snapshots().forEach(snapshot -> allSnapshotIds.add(snapshot.snapshotId()));
+
+      rewriteVersionFile(tableMetadata, newPath);
+    }
+
+    return allSnapshotIds;
+  }
+
+  private Set<Snapshot> snapshotSet(String metadataPath) {
+    Set<Snapshot> snapshots = Sets.newHashSet();
+    if (!metadataPath.isEmpty()) {
+      StaticTableOperations ops = new StaticTableOperations(metadataPath, table.io());
+      TableMetadata metadata = ops.current();
+      snapshots.addAll(metadata.snapshots());
+    }
+    return snapshots;
+  }
+
+  private void rewriteVersionFile(TableMetadata metadata, String stagingPath) {
+    TableMetadata newTableMetadata =
+        TableMetadataUtil.replacePaths(metadata, sourcePrefix, targetPrefix);
+    TableMetadataParser.overwrite(newTableMetadata, table.io().newOutputFile(stagingPath));
+    addToRebuiltFiles(stagingPath);
+  }
+
+  private void rewriteManifestList(Snapshot snapshot, TableMetadata tableMetadata) {
+    List<ManifestFile> manifestFiles = manifestFilesInSnapshot(snapshot);
+    String path = snapshot.manifestListLocation();
+    String stagingPath = combinePaths(stagingDir, relativize(path, sourcePrefix));
+    OutputFile outputFile = table.io().newOutputFile(stagingPath);
+    try (FileAppender<ManifestFile> writer =
+        ManifestLists.write(
+            tableMetadata.formatVersion(),
+            outputFile,
+            snapshot.snapshotId(),
+            snapshot.parentId(),
+            snapshot.sequenceNumber())) {
+
+      for (ManifestFile file : manifestFiles) {
+        // need to get the ManifestFile object for manifest file rewriting
+        if (manifestFilePaths.contains(file.path())) {
+          manifestFilesToRewrite.add(file);
+        }
+
+        ManifestFile newFile = file.copy();
+        if (newFile.path().startsWith(sourcePrefix)) {
+          ((StructLike) newFile).set(0, newPath(newFile.path(), sourcePrefix, targetPrefix));
+        }
+        writer.add(newFile);
+      }
+
+      addToRebuiltFiles(stagingPath);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to rewrite the manifest list file " + path, e);
+    }
+  }
+
+  private List<ManifestFile> manifestFilesInSnapshot(Snapshot snapshot) {
+    String path = snapshot.manifestListLocation();
+    List<ManifestFile> manifestFiles = Lists.newLinkedList();
+    try {
+      manifestFiles = ManifestLists.read(table.io().newInputFile(path));
+    } catch (RuntimeIOException e) {
+      LOG.warn("Failed to read manifest list {}", path, e);
+    }
+    return manifestFiles;
+  }
+
+  private List<String> manifestFilesToMove(Set<Long> diffSnapshotIds) {
+    try {
+      Dataset<Row> lastVersionFiles = buildManifestFileDF(endStaticTable);
+      if (startStaticTable == null) {
+        return lastVersionFiles.distinct().as(Encoders.STRING()).collectAsList();
+      } else {
+        return lastVersionFiles
+            .distinct()
+            .filter(functions.column("added_snapshot_id").isInCollection(diffSnapshotIds))
+            .as(Encoders.STRING())
+            .collectAsList();
+      }
+    } catch (Exception e) {
+      throw new UnsupportedOperationException(
+          "Failed to build the manifest files dataframe, the end version you are "
+              + "trying to copy may contain invalid snapshots, please use the younger version which doesn't have invalid "
+              + "snapshots",
+          e);
+    }
+  }
+
+  /** Rewrite manifest files in a distributed manner. */
+  private List<ManifestFile> rewriteManifests(TableMetadata tableMetadata) {
+    if (manifestFilesToRewrite.isEmpty()) {
+      return Lists.newArrayList();
+    }
+
+    Encoder<ManifestFile> manifestFileEncoder = Encoders.javaSerialization(ManifestFile.class);
+    Dataset<ManifestFile> manifestDS =
+        spark().createDataset(Lists.newArrayList(manifestFilesToRewrite), manifestFileEncoder);
+
+    FileIO tableIO = SerializableTable.copyOf(table).io();
+    Broadcast<FileIO> io = sparkContext().broadcast(tableIO);
+
+    return manifestDS
+        .repartition(manifestFilesToRewrite.size())
+        .mapPartitions(
+            toManifests(
+                io,
+                stagingDir,
+                tableMetadata.formatVersion(),
+                tableMetadata.specsById(),
+                sourcePrefix,
+                targetPrefix),
+            manifestFileEncoder)
+        .collectAsList();
+  }
+
+  private static MapPartitionsFunction<ManifestFile, ManifestFile> toManifests(
+      Broadcast<FileIO> io,
+      String stagingLocation,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix) {
+
+    return rows -> {
+      List<ManifestFile> manifests = Lists.newArrayList();
+      while (rows.hasNext()) {
+        ManifestFile manifestFile = rows.next();
+        switch (manifestFile.content()) {
+          case DATA:
+            manifests.add(
+                writeDataManifest(
+                    manifestFile,
+                    io,
+                    stagingLocation,
+                    format,
+                    specsById,
+                    sourcePrefix,
+                    targetPrefix));
+            break;
+          case DELETES:
+            manifests.add(
+                writeDeleteManifest(
+                    manifestFile,
+                    io,
+                    stagingLocation,
+                    format,
+                    specsById,
+                    sourcePrefix,
+                    targetPrefix));
+            break;
+          default:
+            throw new UnsupportedOperationException(
+                "Unsupported manifest type: " + manifestFile.content());
+        }
+      }
+
+      return manifests.iterator();
+    };
+  }
+
+  private static ManifestFile writeDataManifest(
+      ManifestFile manifestFile,
+      Broadcast<FileIO> io,
+      String stagingLocation,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix)
+      throws IOException {
+    PartitionSpec spec = specsById.get(manifestFile.partitionSpecId());
+    String stagingPath =
+        combinePaths(stagingLocation, relativize(manifestFile.path(), sourcePrefix));
+    OutputFile outputFile = io.value().newOutputFile(stagingPath);
+    ManifestWriter<DataFile> writer =
+        ManifestFiles.write(format, spec, outputFile, manifestFile.snapshotId());
+
+    try (ManifestReader<DataFile> reader =
+        ManifestFiles.read(manifestFile, io.getValue(), specsById).select(Arrays.asList("*"))) {
+      reader
+          .entries()
+          .forEach(
+              entry ->
+                  appendEntryWithFile(
+                      entry, writer, newDataFile(entry.file(), spec, sourcePrefix, targetPrefix)));
+    } finally {
+      writer.close();
+    }
+    return writer.toManifestFile();
+  }
+
+  private static DataFile newDataFile(
+      DataFile file, PartitionSpec spec, String sourcePrefix, String targetPrefix) {
+    DataFile transformedFile = file;
+    String filePath = file.path().toString();
+    if (filePath.startsWith(sourcePrefix)) {
+      filePath = newPath(filePath, sourcePrefix, targetPrefix);
+      transformedFile = DataFiles.builder(spec).copy(file).withPath(filePath).build();
+    }
+    return transformedFile;
+  }
+
+  private static ManifestFile writeDeleteManifest(
+      ManifestFile manifestFile,
+      Broadcast<FileIO> io,
+      String stagingLocation,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix)
+      throws IOException {
+    PartitionSpec spec = specsById.get(manifestFile.partitionSpecId());
+
+    String manifestStagingPath =
+        combinePaths(stagingLocation, relativize(manifestFile.path(), sourcePrefix));
+    OutputFile manifestOutputFile = io.value().newOutputFile(manifestStagingPath);
+    ManifestWriter<DeleteFile> writer =
+        ManifestFiles.writeDeleteManifest(
+            format, spec, manifestOutputFile, manifestFile.snapshotId());
+
+    try (ManifestReader<DeleteFile> reader =
+        ManifestFiles.readDeleteManifest(manifestFile, io.getValue(), specsById)
+            .select(Arrays.asList("*"))) {
+
+      for (ManifestEntry<DeleteFile> entry : reader.entries()) {
+        DeleteFile file = entry.file();
+
+        switch (file.content()) {
+          case POSITION_DELETES:
+            String filePath = file.path().toString();
+            String deleteFileStagingPath =
+                combinePaths(stagingLocation, relativize(filePath, sourcePrefix));
+            DeleteFile newDeleteFile =
+                rewritePositionDeleteFile(
+                    io, file, deleteFileStagingPath, spec, sourcePrefix, targetPrefix);
+
+            if (filePath.startsWith(sourcePrefix)) {
+              filePath = newPath(filePath, sourcePrefix, targetPrefix);
+              newDeleteFile =
+                  FileMetadata.deleteFileBuilder(spec)
+                      .ofPositionDeletes()
+                      .copy(newDeleteFile)
+                      .withPath(filePath)
+                      .withSplitOffsets(file.splitOffsets())
+                      .build();
+            }
+            appendEntryWithFile(entry, writer, newDeleteFile);
+            break;
+          case EQUALITY_DELETES:
+            appendEntryWithFile(
+                entry, writer, newEqualityDeleteFile(file, spec, sourcePrefix, targetPrefix));
+            break;
+          default:
+            throw new UnsupportedOperationException(
+                "Unsupported delete file type: " + file.content());
+        }
+      }
+    } finally {
+      writer.close();
+    }
+    return writer.toManifestFile();
+  }
+
+  private static DeleteFile newEqualityDeleteFile(
+      DeleteFile file, PartitionSpec spec, String sourcePrefix, String targetPrefix) {
+    DeleteFile transformedFile = file;
+    String filePath = file.path().toString();
+
+    if (filePath.startsWith(sourcePrefix)) {
+      int[] equalityFieldIds =
+          file.equalityFieldIds().stream().mapToInt(Integer::intValue).toArray();
+      filePath = newPath(filePath, sourcePrefix, targetPrefix);
+      transformedFile =
+          FileMetadata.deleteFileBuilder(spec)
+              .ofEqualityDeletes(equalityFieldIds)
+              .copy(file)
+              .withPath(filePath)
+              .withSplitOffsets(file.splitOffsets())
+              .build();
+    }
+    return transformedFile;
+  }
+
+  private static PositionDelete newPositionDeleteRecord(
+      Record record, String sourcePrefix, String targetPrefix) {
+    PositionDelete delete = PositionDelete.create();
+    delete.set(
+        newPath((String) record.get(0), sourcePrefix, targetPrefix),
+        (Long) record.get(1),
+        record.get(2));
+    return delete;
+  }
+
+  private static DeleteFile rewritePositionDeleteFile(
+      Broadcast<FileIO> io,
+      DeleteFile current,
+      String path,
+      PartitionSpec spec,
+      String sourcePrefix,
+      String targetPrefix)
+      throws IOException {
+    OutputFile targetFile = io.value().newOutputFile(path);
+    InputFile sourceFile = io.value().newInputFile(current.path().toString());
+
+    try (CloseableIterable<Record> reader =
+        positionDeletesReader(sourceFile, current.format(), spec)) {
+      Record record = null;
+      Schema rowSchema = null;
+      CloseableIterator<Record> recordIt = reader.iterator();
+
+      if (recordIt.hasNext()) {
+        record = recordIt.next();
+        rowSchema = record.get(2) != null ? spec.schema() : null;
+      }
+
+      PositionDeleteWriter<Record> writer =
+          positionDeletesWriter(targetFile, current.format(), spec, current.partition(), rowSchema);
+
+      try {
+        if (record != null) {
+          writer.write(newPositionDeleteRecord(record, sourcePrefix, targetPrefix));
+        }
+
+        while (recordIt.hasNext()) {
+          record = recordIt.next();
+          writer.write(newPositionDeleteRecord(record, sourcePrefix, targetPrefix));
+        }
+      } finally {
+        writer.close();
+      }
+      return writer.toDeleteFile();
+    }
+  }
+
+  private static CloseableIterable<Record> positionDeletesReader(
+      InputFile inputFile, FileFormat format, PartitionSpec spec) throws IOException {
+    Schema deleteSchema = DeleteSchemaUtil.posDeleteSchema(spec.schema());
+    switch (format) {
+      case AVRO:
+        return Avro.read(inputFile)
+            .project(deleteSchema)
+            .reuseContainers()
+            .createReaderFunc(DataReader::create)
+            .build();
+
+      case PARQUET:
+        return Parquet.read(inputFile)
+            .project(deleteSchema)
+            .reuseContainers()
+            .createReaderFunc(
+                fileSchema -> GenericParquetReaders.buildReader(deleteSchema, fileSchema))
+            .build();
+
+      case ORC:
+        return ORC.read(inputFile)
+            .project(deleteSchema)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(deleteSchema, fileSchema))
+            .build();
+
+      default:
+        throw new UnsupportedOperationException("Unsupported file format: " + format);
+    }
+  }
+
+  private static PositionDeleteWriter<Record> positionDeletesWriter(
+      OutputFile outputFile,
+      FileFormat format,
+      PartitionSpec spec,
+      StructLike partition,
+      Schema rowSchema)
+      throws IOException {
+    switch (format) {
+      case AVRO:
+        return Avro.writeDeletes(outputFile)
+            .createWriterFunc(DataWriter::create)
+            .withPartition(partition)
+            .rowSchema(rowSchema)
+            .withSpec(spec)
+            .buildPositionWriter();
+      case PARQUET:
+        return Parquet.writeDeletes(outputFile)
+            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .withPartition(partition)
+            .rowSchema(rowSchema)
+            .withSpec(spec)
+            .buildPositionWriter();
+      case ORC:
+        return ORC.writeDeletes(outputFile)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .withPartition(partition)
+            .rowSchema(rowSchema)
+            .withSpec(spec)
+            .buildPositionWriter();
+      default:
+        throw new UnsupportedOperationException("Unsupported file format: " + format);
+    }
+  }
+
+  private static <F extends ContentFile<F>> void appendEntryWithFile(
+      ManifestEntry<F> entry, ManifestWriter<F> writer, F file) {
+    switch (entry.status()) {
+      case ADDED:
+        writer.add(file);
+        break;
+      case EXISTING:
+        writer.existing(
+            file, entry.snapshotId(), entry.dataSequenceNumber(), entry.fileSequenceNumber());
+        break;
+      case DELETED:
+        writer.delete(file, entry.dataSequenceNumber(), entry.fileSequenceNumber());
+        break;
+    }
+  }
+
+  private Dataset<Row> getDiffDataFiles(Set<Long> diffSnapshotIds) {
+    Dataset<Row> lastVersionFiles = buildValidDataFileDFWithSnapshotId(endStaticTable);
+    if (startStaticTable == null) {
+      return lastVersionFiles.distinct().select("file_path");
+    } else {
+      return lastVersionFiles
+          .distinct()
+          .filter(functions.column("snapshot_id").isInCollection(diffSnapshotIds))
+          .select("file_path");
+    }
+  }
+
+  private boolean fileNotExist(String path) {
+    return !fileExist(path);
+  }
+
+  private boolean fileExist(String path) {
+    if (path == null || path.trim().isEmpty()) {
+      return false;
+    }
+    return table.io().newInputFile(path).exists();
+  }
+
+  private static String relativize(String path, String prefix) {
+    String toRemove = prefix;
+    if (!toRemove.endsWith("/")) {
+      toRemove += "/";
+    }
+    if (!path.startsWith(toRemove)) {
+      throw new IllegalArgumentException(
+          String.format("Path %s does not start with %s", path, toRemove));
+    }
+    return path.substring(toRemove.length());
+  }
+
+  private static String newPath(String path, String sourcePrefix, String targetPrefix) {
+    return combinePaths(targetPrefix, relativize(path, sourcePrefix));
+  }
+
+  private void addToRebuiltFiles(String path) {
+    metadataFilesToMove.add(path);
+  }
+
+  private String currentMetadataPath(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current().metadataFileLocation();
+  }
+
+  private static String combinePaths(String absolutePath, String relativePath) {
+    String combined = absolutePath;
+    if (!combined.endsWith("/")) {
+      combined += "/";
+    }
+    combined += relativePath;
+    return combined;
+  }
+
+  private static String fileName(String path) {
+    String filename = path;
+    int lastIndex = path.lastIndexOf(File.separator);
+    if (lastIndex != -1) {
+      filename = path.substring(lastIndex + 1);
+    }
+    return filename;
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.apache.iceberg.AllManifestsTable;
@@ -47,7 +46,6 @@ import org.apache.iceberg.ReachableFileUtil;
 import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StaticTableOperations;
-import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -286,6 +284,7 @@ abstract class BaseSparkAction<ThisT> {
                 "content",
                 "path",
                 "length",
+                "0 as sequenceNumber",
                 "partition_spec_id as partitionSpecId",
                 "added_snapshot_id as addedSnapshotId")
             .dropDuplicates("path")
@@ -332,7 +331,8 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Dataset<FileInfo> statisticsFileDS(Table table, Set<Long> snapshotIds) {
-    List<String> statisticsFiles = ReachableFileUtil.statisticsFilesLocationsForSnapshots(table, snapshotIds);
+    List<String> statisticsFiles =
+        ReachableFileUtil.statisticsFilesLocationsForSnapshots(table, snapshotIds);
     return toFileInfoDS(statisticsFiles, STATISTICS_FILES);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -31,7 +31,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.apache.iceberg.AllManifestsTable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
@@ -42,9 +44,13 @@ import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReachableFileUtil;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.BulkDeletionFailureException;
@@ -60,20 +66,24 @@ import org.apache.iceberg.relocated.com.google.common.collect.ListMultimap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.spark.JobGroupUtils;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.source.SerializableTableWithSize;
+import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Tuple2;
 
 abstract class BaseSparkAction<ThisT> {
 
@@ -126,6 +136,68 @@ abstract class BaseSparkAction<ThisT> {
     return options;
   }
 
+  /**
+   * Returns all the path locations of all Manifest Lists for a given list of snapshots
+   *
+   * @param snapshots snapshots
+   * @return the paths of the Manifest Lists
+   */
+  private List<String> getManifestListPaths(Iterable<Snapshot> snapshots) {
+    List<String> manifestLists = Lists.newArrayList();
+    for (Snapshot snapshot : snapshots) {
+      String manifestListLocation = snapshot.manifestListLocation();
+      if (manifestListLocation != null) {
+        manifestLists.add(manifestListLocation);
+      }
+    }
+    return manifestLists;
+  }
+
+  /**
+   * Returns all Metadata file paths which may not be in the current metadata. Specifically this
+   * includes "version-hint" files as well as entries in metadata.previousFiles.
+   *
+   * @param ops TableOperations for the table we will be getting paths from
+   * @return a list of paths to metadata files
+   */
+  private List<String> getOtherMetadataFilePaths(TableOperations ops) {
+    List<String> otherMetadataFiles = Lists.newArrayList();
+    otherMetadataFiles.add(ops.metadataFileLocation("version-hint.text"));
+
+    TableMetadata metadata = ops.current();
+    otherMetadataFiles.add(metadata.metadataFileLocation());
+    for (TableMetadata.MetadataLogEntry previousMetadataFile : metadata.previousFiles()) {
+      otherMetadataFiles.add(previousMetadataFile.file());
+    }
+    return otherMetadataFiles;
+  }
+
+  protected Dataset<Row> buildOtherMetadataFileDF(Table table) {
+    return buildOtherMetadataFileDF(
+        table, false /* include all reachable previous metadata locations */);
+  }
+
+  protected Dataset<Row> buildAllReachableOtherMetadataFileDF(Table table) {
+    return buildOtherMetadataFileDF(
+        table, true /* include all reachable previous metadata locations */);
+  }
+
+  private Dataset<Row> buildOtherMetadataFileDF(
+      Table table, boolean includePreviousMetadataLocations) {
+    List<String> otherMetadataFiles = Lists.newArrayList();
+    otherMetadataFiles.addAll(
+        ReachableFileUtil.metadataFileLocations(table, includePreviousMetadataLocations));
+    otherMetadataFiles.add(ReachableFileUtil.versionHintLocation(table));
+    return spark.createDataset(otherMetadataFiles, Encoders.STRING()).toDF(FILE_PATH);
+  }
+
+  protected Dataset<Row> buildValidMetadataFileDF(Table table) {
+    Dataset<Row> manifestDF = buildManifestFileDF(table);
+    Dataset<Row> manifestListDF = buildManifestListDF(table);
+    Dataset<Row> otherMetadataFileDF = buildOtherMetadataFileDF(table);
+    return manifestDF.union(otherMetadataFileDF).union(manifestListDF);
+  }
+
   protected <T> T withJobGroupInfo(JobGroupInfo info, Supplier<T> supplier) {
     return JobGroupUtils.withJobGroupInfo(sparkContext, info, supplier);
   }
@@ -135,8 +207,12 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Table newStaticTable(TableMetadata metadata, FileIO io) {
-    StaticTableOperations ops = new StaticTableOperations(metadata, io);
-    return new BaseTable(ops, metadata.metadataFileLocation());
+    return newStaticTable(metadata.metadataFileLocation(), io);
+  }
+
+  protected Table newStaticTable(String metadataFileLocation, FileIO io) {
+    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
+    return new BaseTable(ops, metadataFileLocation);
   }
 
   protected Dataset<FileInfo> contentFileDS(Table table) {
@@ -174,6 +250,68 @@ abstract class BaseSparkAction<ThisT> {
         .as(FileInfo.ENCODER);
   }
 
+  protected Dataset<Row> buildValidDataFileDF(Table table) {
+    JavaSparkContext context = JavaSparkContext.fromSparkContext(spark.sparkContext());
+    Broadcast<Table> tableBroadcast = context.broadcast(SerializableTable.copyOf(table));
+
+    Dataset<ManifestFileBean> allManifests =
+        loadMetadataTable(table, ALL_MANIFESTS)
+            .selectExpr(
+                "content",
+                "path",
+                "length",
+                "partition_spec_id as partitionSpecId",
+                "added_snapshot_id as addedSnapshotId")
+            .dropDuplicates("path")
+            .repartition(
+                spark
+                    .sessionState()
+                    .conf()
+                    .numShufflePartitions()) // avoid adaptive execution combining tasks
+            .as(Encoders.bean(ManifestFileBean.class));
+
+    return allManifests
+        .flatMap(new ReadManifest(tableBroadcast), FileInfo.ENCODER)
+        .toDF("file_path", "file_type")
+        .drop("file_type");
+  }
+
+  protected Dataset<Row> buildValidDataFileDFWithSnapshotId(Table table) {
+    JavaSparkContext context = JavaSparkContext.fromSparkContext(spark.sparkContext());
+    Broadcast<FileIO> ioBroadcast = context.broadcast(SerializableTable.copyOf(table).io());
+
+    Dataset<ManifestFileBean> allManifests =
+        loadMetadataTable(table, ALL_MANIFESTS)
+            .selectExpr(
+                "content",
+                "path",
+                "length",
+                "partition_spec_id as partitionSpecId",
+                "added_snapshot_id as addedSnapshotId")
+            .dropDuplicates("path")
+            .repartition(
+                spark
+                    .sessionState()
+                    .conf()
+                    .numShufflePartitions()) // avoid adaptive execution combining tasks
+            .as(Encoders.bean(ManifestFileBean.class));
+
+    return allManifests
+        .flatMap(
+            new ReadManifestWithSnapshotId(ioBroadcast),
+            Encoders.tuple(Encoders.STRING(), Encoders.LONG()))
+        .toDF("file_path", "snapshot_id");
+  }
+
+  protected Dataset<Row> buildManifestFileDF(Table table) {
+    return loadMetadataTable(table, ALL_MANIFESTS).select(col("path").as(FILE_PATH));
+  }
+
+  protected Dataset<Row> buildManifestListDF(Table table) {
+    List<String> manifestLists = getManifestListPaths(table.snapshots());
+    return spark.createDataset(manifestLists, Encoders.STRING()).toDF("file_path");
+  }
+
   private Dataset<Row> manifestDF(Table table, Set<Long> snapshotIds) {
     Dataset<Row> manifestDF = loadMetadataTable(table, ALL_MANIFESTS);
     if (snapshotIds != null) {
@@ -194,8 +332,7 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Dataset<FileInfo> statisticsFileDS(Table table, Set<Long> snapshotIds) {
-    List<String> statisticsFiles =
-        ReachableFileUtil.statisticsFilesLocationsForSnapshots(table, snapshotIds);
+    List<String> statisticsFiles = ReachableFileUtil.statisticsFilesLocationsForSnapshots(table, snapshotIds);
     return toFileInfoDS(statisticsFiles, STATISTICS_FILES);
   }
 
@@ -433,6 +570,24 @@ abstract class BaseSparkAction<ThisT> {
 
     static FileInfo toFileInfo(ContentFile<?> file) {
       return new FileInfo(file.path().toString(), file.content().toString());
+    }
+  }
+
+  private static class ReadManifestWithSnapshotId
+      implements FlatMapFunction<ManifestFileBean, Tuple2<String, Long>> {
+    private final Broadcast<FileIO> io;
+
+    ReadManifestWithSnapshotId(Broadcast<FileIO> io) {
+      this.io = io;
+    }
+
+    @Override
+    public Iterator<Tuple2<String, Long>> call(ManifestFileBean manifest) {
+      Iterator<Pair<String, Long>> iterator =
+          new ClosingIterator<>(
+              ManifestFiles.readPathsWithSnapshotId(manifest, io.getValue()).iterator());
+      Stream<Pair<String, Long>> stream = Streams.stream(iterator);
+      return stream.map(pair -> Tuple2.apply(pair.first(), pair.second())).iterator();
     }
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.actions;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.CopyTable;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.Spark3Util.CatalogAndIdentifier;
 import org.apache.spark.sql.SparkSession;
@@ -95,5 +96,10 @@ public class SparkActions implements ActionsProvider {
   @Override
   public RewritePositionDeleteFilesSparkAction rewritePositionDeletes(Table table) {
     return new RewritePositionDeleteFilesSparkAction(spark, table);
+  }
+
+  @Override
+  public CopyTable copyTable(Table table) {
+    return new BaseCopyTableSparkAction(spark, table);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCopyTableAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCopyTableAction.java
@@ -1,0 +1,1044 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.actions.CopyTable;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.TestBase;
+import org.apache.iceberg.spark.source.ThreeColumnRecord;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestCopyTableAction extends TestBase {
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  protected static final Schema SCHEMA =
+      new Schema(
+          optional(1, "c1", Types.IntegerType.get()),
+          optional(2, "c2", Types.StringType.get()),
+          optional(3, "c3", Types.StringType.get()));
+
+  @TempDir private Path temp;
+
+  protected String tableLocation = null;
+  private Table table = null;
+
+  @BeforeEach
+  public void setupTableLocation() throws Exception {
+    File tableDir = temp.resolve("junit").toFile();
+    this.tableLocation = tableDir.toURI().toString();
+    this.table = createATableWith2Snapshots(tableLocation);
+  }
+
+  private Table createATableWith2Snapshots(String location) {
+    return createTableWithSnapshots(location, 2);
+  }
+
+  private Table createTableWithSnapshots(String location, int snapshotNumber) {
+    return createTableWithSnapshots(location, snapshotNumber, Maps.newHashMap());
+  }
+
+  protected Table createTableWithSnapshots(
+      String location, int snapshotNumber, Map<String, String> properties) {
+    Table newTable = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, location);
+
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+
+    for (int i = 0; i < snapshotNumber; i++) {
+      df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(location);
+    }
+
+    return newTable;
+  }
+
+  @Test
+  public void testCopyTable() throws Exception {
+    String targetTableLocation = newTableLocation();
+
+    // check the data file location before the rebuild
+    List<String> validDataFiles =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation + "#files")
+            .select("file_path")
+            .as(Encoders.STRING())
+            .collectAsList();
+    assertThat(validDataFiles.size()).as("Should be 2 valid data files").isEqualTo(2);
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(table)
+            .rewriteLocationPrefix(tableLocation, targetTableLocation)
+            .endVersion("v3.metadata.json")
+            .execute();
+
+    assertThat(result.latestVersion())
+        .as("The latest version should be")
+        .isEqualTo("v3.metadata.json");
+
+    checkMetadataFileNum(3, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(tableLocation, targetTableLocation, stagingDir(result));
+
+    // verify the data file path after the rebuild
+    List<String> validDataFilesAfterRebuilt =
+        spark
+            .read()
+            .format("iceberg")
+            .load(targetTableLocation + "#files")
+            .select("file_path")
+            .as(Encoders.STRING())
+            .collectAsList();
+    assertThat(validDataFilesAfterRebuilt.size()).as("Should be 2 valid data files").isEqualTo(2);
+
+    for (String item : validDataFilesAfterRebuilt) {
+      assertThat(item.startsWith(targetTableLocation))
+          .as("Data file should point to the new location")
+          .isTrue();
+    }
+
+    // verify data rows
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(targetTableLocation);
+    List<ThreeColumnRecord> actualRecords =
+        resultDF.sort("c1", "c2", "c3").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.add(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    expectedRecords.add(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+
+    assertThat(expectedRecords).as("Rows must match").isEqualTo(actualRecords);
+  }
+
+  @Test
+  public void testDataFilesDiff() throws Exception {
+    CopyTable.Result result =
+        actions()
+            .copyTable(table)
+            .rewriteLocationPrefix(tableLocation, newTableLocation())
+            .lastCopiedVersion("v2.metadata.json")
+            .execute();
+
+    checkDataFileNum(1, result);
+
+    List<String> rebuiltFiles =
+        spark
+            .read()
+            .format("text")
+            .load(result.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    // v3.metadata.json, one manifest-list file, one manifest file
+    checkMetadataFileNum(3, result);
+
+    String currentSnapshotId = String.valueOf(table.currentSnapshot().snapshotId());
+
+    assertThat(rebuiltFiles.stream().filter(c -> c.contains(currentSnapshotId)).count() == 1)
+        .as("Should have the current snapshot file")
+        .isTrue();
+
+    String parentSnapshotId = String.valueOf(table.currentSnapshot().parentId());
+
+    assertThat(rebuiltFiles.stream().filter(c -> c.contains(parentSnapshotId)).count() == 0)
+        .as("Should NOT have the parent snapshot file")
+        .isTrue();
+  }
+
+  @Test
+  public void testTableWith3Snapshots() throws Exception {
+    String location = newTableLocation();
+    Table tableWith3Snaps = createTableWithSnapshots(location, 3);
+    CopyTable.Result result =
+        actions()
+            .copyTable(tableWith3Snaps)
+            .rewriteLocationPrefix(location, newTableLocation())
+            .lastCopiedVersion("v2.metadata.json")
+            .execute();
+
+    checkMetadataFileNum(2, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // start from the first version
+    CopyTable.Result result1 =
+        actions()
+            .copyTable(tableWith3Snaps)
+            .rewriteLocationPrefix(location, newTableLocation())
+            .lastCopiedVersion("v1.metadata.json")
+            .execute();
+
+    checkMetadataFileNum(3, 3, 3, result1);
+    checkDataFileNum(3, result1);
+  }
+
+  @Test
+  public void testFullTableCopy() throws Exception {
+    CopyTable.Result result =
+        actions()
+            .copyTable(table)
+            .rewriteLocationPrefix(tableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(3, 2, 2, result);
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testDeleteDataFile() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(location);
+    List<String> validDataFiles =
+        spark
+            .read()
+            .format("iceberg")
+            .load(location + "#files")
+            .select("file_path")
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    sourceTable.newDelete().deleteFile(validDataFiles.stream().findFirst().get()).commit();
+
+    String targetLocation = newTableLocation();
+    CopyTable.Result result =
+        actions().copyTable(sourceTable).rewriteLocationPrefix(location, targetLocation).execute();
+
+    checkMetadataFileNum(4, 3, 3, result);
+    checkDataFileNum(1, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(location, targetLocation, stagingDir(result));
+
+    // verify data rows
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(targetLocation);
+
+    assertThat(resultDF.as(Encoders.bean(ThreeColumnRecord.class)).count())
+        .as("There are only one row left since we deleted a data file")
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void testWithDeleteManifestsAndPositionDeletes() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(location);
+    String targetLocation = newTableLocation();
+
+    List<Pair<CharSequence, Long>> deletes =
+        Lists.newArrayList(
+            Pair.of(
+                sourceTable
+                    .currentSnapshot()
+                    .addedDataFiles(sourceTable.io())
+                    .iterator()
+                    .next()
+                    .path(),
+                0L));
+
+    File file = new File(removePrefix(sourceTable.location()) + "/data/deeply/nested/file.parquet");
+    DeleteFile positionDeletes =
+        FileHelpers.writeDeleteFile(
+                sourceTable, sourceTable.io().newOutputFile(file.toURI().toString()), deletes)
+            .first();
+
+    sourceTable.newRowDelta().addDeletes(positionDeletes).commit();
+
+    CopyTable.Result result =
+        actions().copyTable(sourceTable).rewriteLocationPrefix(location, targetLocation).execute();
+
+    // We have one more snapshot, an additional manifest list, and a new (delete) manifest
+    checkMetadataFileNum(4, 3, 3, result);
+    // We have one additional file for positional deletes
+    checkDataFileNum(3, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(location, targetLocation, stagingDir(result));
+
+    // Positional delete affects a single row, so only one row must remain
+    assertThat(spark.read().format("iceberg").load(targetLocation).count())
+        .as("The number of rows should be")
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void testWithDeleteManifestsAndEqualityDeletes() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(location, 1);
+    String targetLocation = newTableLocation();
+
+    // Add more varied data
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(
+            new ThreeColumnRecord(2, "AAAAAAAAAA", "AAAA"),
+            new ThreeColumnRecord(3, "BBBBBBBBBB", "BBBB"),
+            new ThreeColumnRecord(4, "CCCCCCCCCC", "CCCC"),
+            new ThreeColumnRecord(5, "DDDDDDDDDD", "DDDD"));
+    spark
+        .createDataFrame(records, ThreeColumnRecord.class)
+        .coalesce(1)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(location);
+
+    Schema deleteRowSchema = sourceTable.schema().select("c2");
+    Record dataDelete = GenericRecord.create(deleteRowSchema);
+    List<Record> dataDeletes =
+        Lists.newArrayList(
+            dataDelete.copy("c2", "AAAAAAAAAA"), dataDelete.copy("c2", "CCCCCCCCCC"));
+    File file = new File(removePrefix(sourceTable.location()) + "/data/deeply/nested/file.parquet");
+    DeleteFile equalityDeletes =
+        FileHelpers.writeDeleteFile(
+            sourceTable,
+            sourceTable.io().newOutputFile(file.toURI().toString()),
+            TestHelpers.Row.of(0),
+            dataDeletes,
+            deleteRowSchema);
+    sourceTable.newRowDelta().addDeletes(equalityDeletes).commit();
+
+    CopyTable.Result result =
+        actions().copyTable(sourceTable).rewriteLocationPrefix(location, targetLocation).execute();
+
+    // We have four metadata files: for the table creation, for the initial snapshot, for the
+    // second append here, and for commit with equality deletes. Thus, we have three manifest lists
+    checkMetadataFileNum(4, 3, 3, result);
+    // A data file for each snapshot (two with data, one with equality deletes)
+    checkDataFileNum(3, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(location, targetLocation, stagingDir(result));
+
+    // Equality deletes affect three rows, so just two rows must remain
+    assertThat(spark.read().format("iceberg").load(targetLocation).count())
+        .as("The number of rows should be")
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void testFullTableCopyWithDeletedVersionFiles() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(location, 2);
+    // expire the first snapshot
+    Table staticTable = newStaticTable(location + "/metadata/v2.metadata.json", table.io());
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(staticTable.currentSnapshot().snapshotId())
+        .execute();
+
+    // create 100 more snapshots
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    for (int i = 0; i < 100; i++) {
+      df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(location);
+    }
+    sourceTable.refresh();
+
+    // v1/v2/v3.metadata.json has been deleted in v104.metadata.json, and there is no way to find
+    // the first snapshot
+    // from the version file history
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(location, newTableLocation())
+            .execute();
+
+    // you can only find 101 snapshots but the manifest file and data file count should be 102.
+    checkMetadataFileNum(101, 101, 101, result);
+    checkDataFileNum(102, result);
+  }
+
+  protected Table newStaticTable(String metadataFileLocation, FileIO io) {
+    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
+    return new BaseTable(ops, metadataFileLocation);
+  }
+
+  @Test
+  public void testRewriteTableWithoutSnapshot() throws Exception {
+    CopyTable.Result result =
+        actions()
+            .copyTable(table)
+            .rewriteLocationPrefix(tableLocation, newTableLocation())
+            .endVersion("v1.metadata.json")
+            .execute();
+
+    // the only rebuilt file is v1.metadata.json since it contains no snapshot
+    checkMetadataFileNum(1, result);
+    checkDataFileNum(0, result);
+  }
+
+  @Test
+  public void testExpireSnapshotBeforeRewrite() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(4, 1, 2, result);
+
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testStartSnapshotWithoutValidSnapshot() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    assertThat(((List) sourceTable.snapshots()).size())
+        .as("1 out 2 snapshot has been removed")
+        .isEqualTo(1);
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion("v2.metadata.json")
+            .execute();
+
+    // 2 metadata.json, 1 manifest list file, 1 manifest files
+    checkMetadataFileNum(4, result);
+    checkDataFileNum(1, result);
+  }
+
+  @Test
+  public void testMoveTheVersionExpireSnapshot() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    // only move version v4, which is the version generated by snapshot expiration
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion("v3.metadata.json")
+            .execute();
+
+    // only v4.metadata.json needs to move
+    checkMetadataFileNum(1, result);
+    // no data file needs to move
+    checkDataFileNum(0, result);
+  }
+
+  @Test
+  public void testMoveVersionWithInvalidSnapshots() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    AssertHelpers.assertThrows(
+        "Copy a version with invalid snapshots aren't allowed",
+        UnsupportedOperationException.class,
+        () ->
+            actions()
+                .copyTable(sourceTable)
+                .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+                .endVersion("v3.metadata.json")
+                .execute());
+  }
+
+  @Test
+  public void testRollBack() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+    Long secondSnapshotId = sourceTable.currentSnapshot().snapshotId();
+
+    // roll back to the first snapshot(v2)
+    sourceTable
+        .manageSnapshots()
+        .setCurrentSnapshot(sourceTable.currentSnapshot().parentId())
+        .commit();
+
+    // add a new snapshot
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(sourceTableLocation);
+
+    sourceTable.refresh();
+
+    // roll back to the second snapshot(v3)
+    sourceTable.manageSnapshots().setCurrentSnapshot(secondSnapshotId).commit();
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    // check the result
+    checkMetadataFileNum(6, 3, 3, result);
+  }
+
+  @Test
+  public void testWriteAuditPublish() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // enable WAP
+    sourceTable
+        .updateProperties()
+        .set(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED, "true")
+        .commit();
+    spark.conf().set("spark.wap.id", "1");
+
+    // add a new snapshot without changing the current snapshot of the table
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(sourceTableLocation);
+
+    sourceTable.refresh();
+
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    // check the result. There are 3 snapshots in total, although the current snapshot is the second
+    // one.
+    checkMetadataFileNum(5, 3, 3, result);
+  }
+
+  @Test
+  public void testSchemaChange() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // change the schema
+    sourceTable.updateSchema().addColumn("c4", Types.StringType.get()).commit();
+
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    // check the result
+    checkMetadataFileNum(4, 2, 2, result);
+  }
+
+  @Test
+  public void testWithTargetTable() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 3);
+    String targetTableLocation = newTableLocation();
+    Table targetTable = createATableWith2Snapshots(targetTableLocation);
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+            .targetTable(targetTable)
+            .execute();
+
+    assertThat(result.latestVersion())
+        .as("The latest version should be")
+        .isEqualTo("v4.metadata.json");
+
+    // 3 files rebuilt from v3 to v4: v4.metadata.json, one manifest list, one manifest file
+    checkMetadataFileNum(3, result);
+  }
+
+  @Test
+  public void testInvalidStartVersion() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 3);
+    String targetTableLocation = newTableLocation();
+    Table targetTable = createATableWith2Snapshots(targetTableLocation);
+
+    AssertHelpers.assertThrows(
+        "The valid start version should be v3",
+        IllegalArgumentException.class,
+        "The start version isn't the current version of the target table.",
+        () ->
+            actions()
+                .copyTable(sourceTable)
+                .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+                .targetTable(targetTable)
+                .lastCopiedVersion("v2.metadata.json")
+                .execute());
+  }
+
+  @Test
+  public void testSnapshotIdInheritanceEnabled() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, "true");
+
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 2, properties);
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(7, result);
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testMetadataCompression() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.METADATA_COMPRESSION, "gzip");
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 2, properties);
+
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .endVersion("v2.gz.metadata.json")
+            .execute();
+
+    checkMetadataFileNum(4, result);
+    checkDataFileNum(1, result);
+
+    result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion("v1.gz.metadata.json")
+            .execute();
+
+    checkMetadataFileNum(6, result);
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testInvalidArgs() {
+    CopyTable actions = actions().copyTable(table);
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Source prefix('') cannot be empty",
+        () -> actions.rewriteLocationPrefix("", null));
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Source prefix('null') cannot be empty",
+        () -> actions.rewriteLocationPrefix(null, null));
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Staging location('') cannot be empty",
+        () -> actions.stagingLocation(""));
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Staging location('null') cannot be empty",
+        () -> actions.stagingLocation(null));
+
+    AssertHelpers.assertThrows(
+        "",
+        IllegalArgumentException.class,
+        "Last copied version('null') cannot be empty",
+        () -> actions.lastCopiedVersion(null));
+
+    AssertHelpers.assertThrows(
+        "Last copied version cannot be empty",
+        IllegalArgumentException.class,
+        () -> actions.lastCopiedVersion(" "));
+
+    AssertHelpers.assertThrows(
+        "End version cannot be empty",
+        IllegalArgumentException.class,
+        () -> actions.endVersion(" "));
+
+    AssertHelpers.assertThrows(
+        "End version cannot be empty",
+        IllegalArgumentException.class,
+        () -> actions.endVersion(null));
+  }
+
+  protected void checkDataFileNum(long count, CopyTable.Result result) {
+    List<String> filesToMove =
+        spark
+            .read()
+            .format("text")
+            .load(result.dataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    assertThat(count).as("The rebuilt data file number should be").isEqualTo(filesToMove.size());
+  }
+
+  protected void checkMetadataFileNum(int count, CopyTable.Result result) {
+    List<String> filesToMove =
+        spark
+            .read()
+            .format("text")
+            .load(result.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    assertThat(count)
+        .as("The rebuilt metadata file number should be")
+        .isEqualTo(filesToMove.size());
+  }
+
+  protected void checkMetadataFileNum(
+      int versionFileCount, int manifestListCount, int manifestFileCount, CopyTable.Result result) {
+    List<String> filesToMove =
+        spark
+            .read()
+            .format("text")
+            .load(result.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    assertThat(versionFileCount)
+        .as("The rebuilt version file number should be")
+        .isEqualTo(filesToMove.stream().filter(f -> f.endsWith(".metadata.json")).count());
+
+    assertThat(manifestListCount)
+        .as("The rebuilt Manifest list file number should be")
+        .isEqualTo(filesToMove.stream().filter(f -> f.contains("snap-")).count());
+
+    assertThat(manifestFileCount)
+        .as("The rebuilt Manifest file number should be")
+        .isEqualTo(filesToMove.stream().filter(f -> f.endsWith("-m0.avro")).count());
+  }
+
+  private String stagingDir(CopyTable.Result result) {
+    String metadataFileListPath = result.metadataFileListLocation();
+    return metadataFileListPath.substring(0, metadataFileListPath.lastIndexOf(File.separator));
+  }
+
+  protected String newTableLocation() throws IOException {
+    return temp.resolve("newjunit-" + UUID.randomUUID()).toFile().toURI().toString();
+  }
+
+  private void moveTableFiles(String sourceDir, String targetDir, String stagingDir)
+      throws Exception {
+
+    FileUtils.copyDirectory(
+        new File(removePrefix(sourceDir) + "/data/"), new File(removePrefix(targetDir) + "/data/"));
+    // Copy staged metadata files, overwrite previously copied data files with staged ones
+    FileUtils.copyDirectory(new File(removePrefix(stagingDir)), new File(removePrefix(targetDir)));
+  }
+
+  private String removePrefix(String path) {
+    return path.substring(path.lastIndexOf(":") + 1);
+  }
+
+  // Metastore table tests
+  @Test
+  public void testMetadataLocationChange() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createMetastoreTable(sourceTableLocation, Maps.newHashMap(), "tbl", 1);
+    String metadataFilePath = currentMetadata(sourceTable).metadataFileLocation();
+
+    String newMetadataDir = "/new-metadata-dir";
+    sourceTable
+        .updateProperties()
+        .set(TableProperties.WRITE_METADATA_LOCATION, sourceTableLocation + newMetadataDir)
+        .commit();
+
+    spark.sql("insert into hive.default.tbl values (1, 'AAAAAAAAAA', 'AAAA')");
+    sourceTable.refresh();
+
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(4, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // pick up a version from the old metadata dir as the end version
+    CopyTable.Result result1 =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .endVersion(fileName(metadataFilePath))
+            .execute();
+
+    checkMetadataFileNum(2, 1, 1, result1);
+
+    // pick up a version from the old metadata dir as the last copied version
+    CopyTable.Result result2 =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion(fileName(metadataFilePath))
+            .execute();
+
+    checkMetadataFileNum(2, 1, 1, result2);
+  }
+
+  @Test
+  public void testMetadataCompressionWithMetastoreTable() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.METADATA_COMPRESSION, "gzip");
+    Table sourceTable =
+        createMetastoreTable(sourceTableLocation, properties, "testMetadataCompression", 2);
+
+    TableMetadata currentMetadata = currentMetadata(sourceTable);
+
+    // set the second version as the endVersion
+    String endVersion = fileName(currentMetadata.previousFiles().get(1).file());
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .endVersion(endVersion)
+            .execute();
+
+    checkMetadataFileNum(4, result);
+    checkDataFileNum(1, result);
+
+    // set the first version as the lastCopiedVersion
+    String firstVersion = fileName(currentMetadata.previousFiles().get(0).file());
+    result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .lastCopiedVersion(firstVersion)
+            .execute();
+
+    checkMetadataFileNum(6, result);
+    checkDataFileNum(2, result);
+  }
+
+  private TableMetadata currentMetadata(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current();
+  }
+
+  @Test
+  public void testDataFileLocationChange() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createMetastoreTable(sourceTableLocation, Maps.newHashMap(), "tbl1", 1);
+    String metadataFilePath = currentMetadata(sourceTable).metadataFileLocation();
+
+    String newMetadataDir = "/new-data-dir";
+    sourceTable
+        .updateProperties()
+        .set(TableProperties.OBJECT_STORE_PATH, sourceTableLocation + newMetadataDir)
+        .set(TableProperties.OBJECT_STORE_ENABLED, "true")
+        .commit();
+
+    spark.sql("insert into hive.default.tbl1 values (1, 'AAAAAAAAAA', 'AAAA')");
+    sourceTable.refresh();
+
+    // copy table
+    CopyTable.Result result =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .execute();
+
+    checkMetadataFileNum(4, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // pick up a version with the data file in the old data directory as the end version
+    String targetTableLocation = newTableLocation();
+    CopyTable.Result result1 =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+            .endVersion(fileName(metadataFilePath))
+            .execute();
+
+    checkMetadataFileNum(2, 1, 1, result1);
+    checkDataFileNum(1, result1);
+    List<String> filesToMove1 =
+        spark
+            .read()
+            .format("text")
+            .load(result1.dataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    assertThat(filesToMove1.stream().findFirst().get().startsWith(sourceTableLocation + "/data"))
+        .as("The data file should be in the old data directory.")
+        .isTrue();
+
+    // pick up a version with the data file in the new data directory as the last copied version
+    CopyTable.Result result2 =
+        actions()
+            .copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+            .lastCopiedVersion(fileName(metadataFilePath))
+            .execute();
+
+    checkMetadataFileNum(2, 1, 1, result2);
+    checkDataFileNum(1, result2);
+    List<String> filesToMove2 =
+        spark
+            .read()
+            .format("text")
+            .load(result2.dataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    assertThat(
+            filesToMove2.stream()
+                .findFirst()
+                .get()
+                .startsWith(sourceTableLocation + newMetadataDir))
+        .as("The data file should be in the new data directory.")
+        .isTrue();
+
+    // check if table properties have been modified
+    List<String> metadataFilesToMove =
+        spark
+            .read()
+            .format("text")
+            .load(result2.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+    metadataFilesToMove.stream()
+        .filter(f -> f.endsWith(".metadata.json"))
+        .forEach(
+            metadataFile -> {
+              StaticTableOperations ops = new StaticTableOperations(metadataFile, sourceTable.io());
+              Table targetStaticTable = new BaseTable(ops, metadataFile);
+              if (targetStaticTable.properties().containsKey(TableProperties.OBJECT_STORE_PATH)) {
+                assertThat(
+                        targetStaticTable
+                            .properties()
+                            .get(TableProperties.OBJECT_STORE_PATH)
+                            .startsWith(targetTableLocation))
+                    .as(
+                        "The write.object-storage.path should be modified with the target table location.")
+                    .isTrue();
+              }
+            });
+  }
+
+  private Table createMetastoreTable(
+      String location, Map<String, String> properties, String tableName, int snapshotNumber) {
+    spark.conf().set("spark.sql.catalog.hive", SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog.hive.type", "hive");
+    spark.conf().set("spark.sql.catalog.hive.default-namespace", "default");
+    spark.conf().set("spark.sql.catalog.hive.cache-enabled", "false");
+
+    StringBuilder propertiesStr = new StringBuilder();
+    properties.forEach((k, v) -> propertiesStr.append("'" + k + "'='" + v + "',"));
+    String tblProperties =
+        propertiesStr.substring(0, propertiesStr.length() > 0 ? propertiesStr.length() - 1 : 0);
+
+    if (tblProperties.isEmpty()) {
+      sql(
+          "CREATE TABLE hive.default.%s (c1 bigint, c2 string, c3 string) USING iceberg LOCATION '%s'",
+          tableName, location);
+    } else {
+      sql(
+          "CREATE TABLE hive.default.%s (c1 bigint, c2 string, c3 string) USING iceberg LOCATION '%s' TBLPROPERTIES "
+              + "(%s)",
+          tableName, location, tblProperties);
+    }
+
+    for (int i = 0; i < snapshotNumber; i++) {
+      sql("insert into hive.default.%s values (1, 'AAAAAAAAAA', 'AAAA')", tableName);
+    }
+    return catalog.loadTable(TableIdentifier.of("default", tableName));
+  }
+
+  private SparkActions actions() {
+    return SparkActions.get();
+  }
+
+  private static String fileName(String path) {
+    String filename = path;
+    int lastIndex = path.lastIndexOf(File.separator);
+    if (lastIndex != -1) {
+      filename = path.substring(lastIndex + 1);
+    }
+    return filename;
+  }
+}


### PR DESCRIPTION
This PR adds a new Spark action to copy an Iceberg table. The action includes processing metadata files, manifest lists, and position delete files to reflect changes in the location prefixes, aiming to support operations like migration to a new storage location or table duplication.

Here's a breakdown of what it does and how it works:

- Initializes and validates input parameters, such as source and target location prefixes, start and end versions.
- Executes the copy action, which involves rebuilding metadata to reflect the new locations, creating a staging area for the copied files, and generating lists of data and metadata files to move.
- Supports rewriting of metadata files, manifest files and lists, and position delete files to update paths inside these files to accommodate the new location prefix.
- Identify which data files need to be moved based on the snapshots included between the specified start and end versions of the table.
- Utilizes Spark to parallelize the processing of rewriting files, enabling efficient handling of large tables.
- Supports Spark 3.3, 3.4 and 3.5

This PR extends @flyrain original PR https://github.com/apache/iceberg/pull/4705 