### PR TITLE
Migrate other files in Core to JUnit5

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TestBase.java
@@ -211,6 +211,15 @@ public class TestBase {
                         && Files.getFileExtension(name).equalsIgnoreCase("avro")));
   }
 
+  List<File> listManifestLists(File tableDirToList) {
+    return Lists.newArrayList(
+        new File(tableDirToList, "metadata")
+            .listFiles(
+                (dir, name) ->
+                    name.startsWith("snap")
+                        && Files.getFileExtension(name).equalsIgnoreCase("avro")));
+  }
+
   public static long countAllMetadataFiles(File tableDir) {
     return Arrays.stream(new File(tableDir, "metadata").listFiles())
         .filter(f -> f.isFile())

--- a/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
@@ -19,9 +19,15 @@
 package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.MetricsModes.Counts;
 import org.apache.iceberg.MetricsModes.Full;
@@ -29,56 +35,48 @@ import org.apache.iceberg.MetricsModes.None;
 import org.apache.iceberg.MetricsModes.Truncate;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestMetricsModes {
 
-  private final int formatVersion;
+  @Parameter private int formatVersion;
 
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestMetricsModes(int formatVersion) {
-    this.formatVersion = formatVersion;
-  }
+  @TempDir private Path temp;
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
-
-  @After
+  @AfterEach
   public void after() {
     TestTables.clearTables();
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsModeParsing() {
-    Assert.assertEquals(None.get(), MetricsModes.fromString("none"));
-    Assert.assertEquals(None.get(), MetricsModes.fromString("nOnE"));
-    Assert.assertEquals(Counts.get(), MetricsModes.fromString("counts"));
-    Assert.assertEquals(Counts.get(), MetricsModes.fromString("coUntS"));
-    Assert.assertEquals(Truncate.withLength(1), MetricsModes.fromString("truncate(1)"));
-    Assert.assertEquals(Truncate.withLength(10), MetricsModes.fromString("truNcAte(10)"));
-    Assert.assertEquals(Full.get(), MetricsModes.fromString("full"));
-    Assert.assertEquals(Full.get(), MetricsModes.fromString("FULL"));
+    assertThat(MetricsModes.fromString("none")).isEqualTo(None.get());
+    assertThat(MetricsModes.fromString("nOnE")).isEqualTo(None.get());
+    assertThat(MetricsModes.fromString("counts")).isEqualTo(Counts.get());
+    assertThat(MetricsModes.fromString("coUntS")).isEqualTo(Counts.get());
+    assertThat(MetricsModes.fromString("truncate(1)")).isEqualTo(Truncate.withLength(1));
+    assertThat(MetricsModes.fromString("truNcAte(10)")).isEqualTo(Truncate.withLength(10));
+    assertThat(MetricsModes.fromString("full")).isEqualTo(Full.get());
+    assertThat(MetricsModes.fromString("FULL")).isEqualTo(Full.get());
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidTruncationLength() {
-    Assertions.assertThatThrownBy(() -> MetricsModes.fromString("truncate(0)"))
+    assertThatThrownBy(() -> MetricsModes.fromString("truncate(0)"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Truncate length should be positive");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidColumnModeValue() {
     Map<String, String> properties =
         ImmutableMap.of(
@@ -88,13 +86,12 @@ public class TestMetricsModes {
             "troncate(5)");
 
     MetricsConfig config = MetricsConfig.fromProperties(properties);
-    Assert.assertEquals(
-        "Invalid mode should be defaulted to table default (full)",
-        MetricsModes.Full.get(),
-        config.columnMode("col"));
+    assertThat(config.columnMode("col"))
+        .as("Invalid mode should be defaulted to table default (full)")
+        .isEqualTo(MetricsModes.Full.get());
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidDefaultColumnModeValue() {
     Map<String, String> properties =
         ImmutableMap.of(
@@ -104,16 +101,15 @@ public class TestMetricsModes {
             "troncate(5)");
 
     MetricsConfig config = MetricsConfig.fromProperties(properties);
-    Assert.assertEquals(
-        "Invalid mode should be defaulted to library default (truncate(16))",
-        MetricsModes.Truncate.withLength(16),
-        config.columnMode("col"));
+    assertThat(config.columnMode("col"))
+        .as("Invalid mode should be defaulted to library default (truncate(16))")
+        .isEqualTo(MetricsModes.Truncate.withLength(16));
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsConfigSortedColsDefault() throws Exception {
-    File tableDir = temp.newFolder();
-    tableDir.delete(); // created by table create
+    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableDir.delete()).isTrue();
 
     Schema schema =
         new Schema(
@@ -133,26 +129,24 @@ public class TestMetricsModes {
         .commit();
 
     MetricsConfig config = MetricsConfig.forTable(testTable);
-    Assert.assertEquals(
-        "Non-sorted existing column should not be overridden",
-        Counts.get(),
-        config.columnMode("col1"));
-    Assert.assertEquals(
-        "Sorted column defaults should not override user specified config",
-        None.get(),
-        config.columnMode("col2"));
-    Assert.assertEquals(
-        "Unspecified sorted column should use default",
-        Truncate.withLength(16),
-        config.columnMode("col3"));
-    Assert.assertEquals(
-        "Unspecified normal column should use default", Counts.get(), config.columnMode("col4"));
+    assertThat(config.columnMode("col1"))
+        .as("Non-sorted existing column should not be overridden")
+        .isEqualTo(Counts.get());
+    assertThat(config.columnMode("col2"))
+        .as("Sorted column defaults should not override user specified config")
+        .isEqualTo(None.get());
+    assertThat(config.columnMode("col3"))
+        .as("Unspecified sorted column should use default")
+        .isEqualTo(Truncate.withLength(16));
+    assertThat(config.columnMode("col4"))
+        .as("Unspecified normal column should use default")
+        .isEqualTo(Counts.get());
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsConfigSortedColsDefaultByInvalid() throws Exception {
-    File tableDir = temp.newFolder();
-    tableDir.delete(); // created by table create
+    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableDir.delete()).isTrue();
 
     Schema schema =
         new Schema(
@@ -171,17 +165,15 @@ public class TestMetricsModes {
         .commit();
 
     MetricsConfig config = MetricsConfig.forTable(testTable);
-    Assert.assertEquals(
-        "Non-sorted existing column should not be overridden by sorted column",
-        Full.get(),
-        config.columnMode("col1"));
-    Assert.assertEquals(
-        "Original default applies as user entered invalid mode for sorted column",
-        Counts.get(),
-        config.columnMode("col2"));
+    assertThat(config.columnMode("col1"))
+        .as("Non-sorted existing column should not be overridden by sorted column")
+        .isEqualTo(Full.get());
+    assertThat(config.columnMode("col2"))
+        .as("Original default applies as user entered invalid mode for sorted column")
+        .isEqualTo(Counts.get());
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsConfigInferredDefaultModeLimit() throws IOException {
     Schema schema =
         new Schema(
@@ -189,8 +181,8 @@ public class TestMetricsModes {
             required(2, "col2", Types.IntegerType.get()),
             required(3, "col3", Types.IntegerType.get()));
 
-    File tableDir = temp.newFolder();
-    Assert.assertTrue(tableDir.delete());
+    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableDir.delete()).isTrue();
 
     Table table =
         TestTables.create(
@@ -209,10 +201,8 @@ public class TestMetricsModes {
 
     MetricsConfig config = MetricsConfig.forTable(table);
 
-    Assert.assertEquals(
-        "Should use default mode for col1", Truncate.withLength(16), config.columnMode("col1"));
-    Assert.assertEquals(
-        "Should use default mode for col2", Truncate.withLength(16), config.columnMode("col2"));
-    Assert.assertEquals("Should use None for col3", None.get(), config.columnMode("col3"));
+    assertThat(config.columnMode("col1")).isEqualTo(Truncate.withLength(16));
+    assertThat(config.columnMode("col2")).isEqualTo(Truncate.withLength(16));
+    assertThat(config.columnMode("col3")).isEqualTo(None.get());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -132,7 +132,7 @@ public class TestRewriteManifests extends TestBase {
     table.rewriteManifests().clusterBy(file -> "").commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    assertThat(manifests).as("Manifests must be merged into 1").hasSize(1);
+    assertThat(manifests).hasSize(1);
 
     // get the correct file order
     List<DataFile> files;

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import static org.apache.iceberg.TableProperties.MANIFEST_MERGE_ENABLED;
 import static org.apache.iceberg.TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -40,24 +41,17 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestRewriteManifests extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRewriteManifests extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestRewriteManifests(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testRewriteManifestsAppendedDirectly() throws IOException {
     Table table = load();
 
@@ -70,18 +64,18 @@ public class TestRewriteManifests extends TableTestBase {
     table.newFastAppend().appendManifest(newManifest).commit();
     long appendId = table.currentSnapshot().snapshotId();
 
-    Assert.assertEquals(1, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
 
     table.rewriteManifests().clusterBy(file -> "").commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals(1, manifests.size());
+    assertThat(manifests).hasSize(1);
 
     validateManifestEntries(
         manifests.get(0), ids(appendId), files(FILE_A), statuses(ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteManifestsWithScanExecutor() throws IOException {
     Table table = load();
 
@@ -93,7 +87,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     table.newFastAppend().appendManifest(newManifest).commit();
 
-    Assert.assertEquals(1, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
     AtomicInteger scanThreadsIndex = new AtomicInteger(0);
     table
         .rewriteManifests()
@@ -111,11 +105,13 @@ public class TestRewriteManifests extends TableTestBase {
         .commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals(1, manifests.size());
-    Assert.assertTrue("Thread should be created in provided pool", scanThreadsIndex.get() > 0);
+    assertThat(manifests).hasSize(1);
+    assertThat(scanThreadsIndex.get())
+        .as("Thread should be created in provided pool")
+        .isGreaterThan(0);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteManifestsGeneratedAndAppendedDirectly() throws IOException {
     Table table = load();
 
@@ -131,12 +127,12 @@ public class TestRewriteManifests extends TableTestBase {
     table.newFastAppend().appendFile(FILE_B).commit();
     long fileAppendId = table.currentSnapshot().snapshotId();
 
-    Assert.assertEquals(2, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(2);
 
     table.rewriteManifests().clusterBy(file -> "").commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Manifests must be merged into 1", 1, manifests.size());
+    assertThat(manifests).as("Manifests must be merged into 1").hasSize(1);
 
     // get the correct file order
     List<DataFile> files;
@@ -158,20 +154,20 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.EXISTING, ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceManifestsSeparate() {
     Table table = load();
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
     long appendId = table.currentSnapshot().snapshotId();
 
-    Assert.assertEquals(1, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
 
     // cluster by path will split the manifest into two
 
     table.rewriteManifests().clusterBy(file -> file.path()).commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals(2, manifests.size());
+    assertThat(manifests).hasSize(2);
     manifests.sort(Comparator.comparing(ManifestFile::path));
 
     validateManifestEntries(
@@ -180,7 +176,7 @@ public class TestRewriteManifests extends TableTestBase {
         manifests.get(1), ids(appendId), files(FILE_B), statuses(ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceManifestsConsolidate() throws IOException {
     Table table = load();
 
@@ -189,14 +185,14 @@ public class TestRewriteManifests extends TableTestBase {
     table.newFastAppend().appendFile(FILE_B).commit();
     long appendIdB = table.currentSnapshot().snapshotId();
 
-    Assert.assertEquals(2, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(2);
 
     // cluster by constant will combine manifests into one
 
     table.rewriteManifests().clusterBy(file -> "file").commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals(1, manifests.size());
+    assertThat(manifests).hasSize(1);
 
     // get the file order correct
     List<DataFile> files;
@@ -218,7 +214,7 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.EXISTING, ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceManifestsWithFilter() throws IOException {
     Table table = load();
 
@@ -231,7 +227,7 @@ public class TestRewriteManifests extends TableTestBase {
     table.newFastAppend().appendFile(FILE_C).commit();
     long appendIdC = table.currentSnapshot().snapshotId();
 
-    Assert.assertEquals(3, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(3);
 
     // keep the file A manifest, combine the other two
 
@@ -249,7 +245,7 @@ public class TestRewriteManifests extends TableTestBase {
         .commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals(2, manifests.size());
+    assertThat(manifests).hasSize(2);
 
     // get the file order correct
     List<DataFile> files;
@@ -273,13 +269,13 @@ public class TestRewriteManifests extends TableTestBase {
         manifests.get(1), ids(appendIdA), files(FILE_A), statuses(ManifestEntry.Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceManifestsMaxSize() {
     Table table = load();
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
     long appendId = table.currentSnapshot().snapshotId();
 
-    Assert.assertEquals(1, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
 
     // cluster by constant will combine manifests into one but small target size will create one per
     // entry
@@ -288,7 +284,7 @@ public class TestRewriteManifests extends TableTestBase {
     rewriteManifests.clusterBy(file -> "file").commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals(2, manifests.size());
+    assertThat(manifests).hasSize(2);
     manifests.sort(Comparator.comparing(ManifestFile::path));
 
     validateManifestEntries(
@@ -297,7 +293,7 @@ public class TestRewriteManifests extends TableTestBase {
         manifests.get(1), ids(appendId), files(FILE_B), statuses(ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testConcurrentRewriteManifest() throws IOException {
     Table table = load();
     table.newFastAppend().appendFile(FILE_A).commit();
@@ -323,14 +319,14 @@ public class TestRewriteManifests extends TableTestBase {
             })
         .commit();
 
-    Assert.assertEquals(2, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(2);
 
     // commit the rewrite manifests in progress - this should perform a full rewrite as the manifest
     // with file B is no longer part of the snapshot
     rewrite.commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals(1, manifests.size());
+    assertThat(manifests).hasSize(1);
 
     // get the file order correct
     List<DataFile> files;
@@ -352,7 +348,7 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.EXISTING, ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testAppendDuringRewriteManifest() {
     Table table = load();
     table.newFastAppend().appendFile(FILE_A).commit();
@@ -366,7 +362,7 @@ public class TestRewriteManifests extends TableTestBase {
     table.newFastAppend().appendFile(FILE_B).commit();
     long appendIdB = table.currentSnapshot().snapshotId();
 
-    Assert.assertEquals(2, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(2);
 
     // commit the rewrite manifests in progress
     rewrite.commit();
@@ -376,7 +372,7 @@ public class TestRewriteManifests extends TableTestBase {
     // have a single cluster key, rewritten one should be the first in the list
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals(2, manifests.size());
+    assertThat(manifests).hasSize(2);
 
     validateManifestEntries(
         manifests.get(0), ids(appendIdA), files(FILE_A), statuses(ManifestEntry.Status.EXISTING));
@@ -384,7 +380,7 @@ public class TestRewriteManifests extends TableTestBase {
         manifests.get(1), ids(appendIdB), files(FILE_B), statuses(ManifestEntry.Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteManifestDuringAppend() {
     Table table = load();
     table.newFastAppend().appendFile(FILE_A).commit();
@@ -397,14 +393,14 @@ public class TestRewriteManifests extends TableTestBase {
     // rewrite the manifests - only affects the first
     table.rewriteManifests().clusterBy(file -> "file").commit();
 
-    Assert.assertEquals(1, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
 
     // commit the append in progress
     append.commit();
     long appendIdB = table.currentSnapshot().snapshotId();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals(2, manifests.size());
+    assertThat(manifests).hasSize(2);
 
     // last append should be the first in the list
 
@@ -414,15 +410,15 @@ public class TestRewriteManifests extends TableTestBase {
         manifests.get(1), ids(appendIdA), files(FILE_A), statuses(ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testBasicManifestReplacement() throws IOException {
-    Assert.assertNull("Table should be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
     List<ManifestFile> firstSnapshotManifests = firstSnapshot.allManifests(table.io());
-    Assert.assertEquals(1, firstSnapshotManifests.size());
+    assertThat(firstSnapshotManifests).hasSize(1);
     ManifestFile firstSnapshotManifest = firstSnapshotManifests.get(0);
 
     table.newFastAppend().appendFile(FILE_C).appendFile(FILE_D).commit();
@@ -445,7 +441,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     Snapshot snapshot = table.currentSnapshot();
     List<ManifestFile> manifests = snapshot.allManifests(table.io());
-    Assert.assertEquals(3, manifests.size());
+    assertThat(manifests).hasSize(3);
 
     if (formatVersion == 1) {
       assertThat(manifests.get(0).path()).isNotEqualTo(firstNewManifest.path());
@@ -476,9 +472,9 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.ADDED, ManifestEntry.Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testBasicManifestReplacementWithSnapshotIdInheritance() throws IOException {
-    Assert.assertNull("Table should be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     table.updateProperties().set(SNAPSHOT_ID_INHERITANCE_ENABLED, "true").commit();
 
@@ -486,7 +482,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     Snapshot firstSnapshot = table.currentSnapshot();
     List<ManifestFile> firstSnapshotManifests = firstSnapshot.allManifests(table.io());
-    Assert.assertEquals(1, firstSnapshotManifests.size());
+    assertThat(firstSnapshotManifests).hasSize(1);
     ManifestFile firstSnapshotManifest = firstSnapshotManifests.get(0);
 
     table.newFastAppend().appendFile(FILE_C).appendFile(FILE_D).commit();
@@ -509,7 +505,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     Snapshot snapshot = table.currentSnapshot();
     List<ManifestFile> manifests = snapshot.allManifests(table.io());
-    Assert.assertEquals(3, manifests.size());
+    assertThat(manifests).hasSize(3);
 
     assertThat(manifests.get(0).path()).isEqualTo(firstNewManifest.path());
     assertThat(manifests.get(1).path()).isEqualTo(secondNewManifest.path());
@@ -538,17 +534,14 @@ public class TestRewriteManifests extends TableTestBase {
     table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();
   }
 
-  @Test
+  @TestTemplate
   public void testWithMultiplePartitionSpec() throws IOException {
-    Assert.assertNull("Table should be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     TableMetadata base = readMetadata();
-    Assert.assertEquals(
-        "Should create 1 manifest for initial write",
-        1,
-        base.currentSnapshot().allManifests(table.io()).size());
+    assertThat(base.currentSnapshot().allManifests(table.io())).hasSize(1);
     ManifestFile initialManifest = base.currentSnapshot().allManifests(table.io()).get(0);
 
     int initialPartitionSpecId = initialManifest.partitionSpecId();
@@ -580,8 +573,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     table.newAppend().appendFile(newFileZ).commit();
 
-    Assert.assertEquals(
-        "Should use 3 manifest files", 3, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(3);
 
     RewriteManifests rewriteManifests = table.rewriteManifests();
     // try to cluster in 1 manifest file, but because of 2 partition specs
@@ -589,40 +581,33 @@ public class TestRewriteManifests extends TableTestBase {
     rewriteManifests.clusterBy(dataFile -> "file").commit();
     List<ManifestFile> manifestFiles = table.currentSnapshot().allManifests(table.io());
 
-    Assert.assertEquals(
-        "Rewrite manifest should produce 2 manifest files", 2, manifestFiles.size());
+    assertThat(manifestFiles).as("Rewrite manifest should produce 2 manifest files").hasSize(2);
 
-    Assert.assertEquals(
-        "2 manifest files should have different partitionSpecId",
-        true,
-        manifestFiles.get(0).partitionSpecId() != manifestFiles.get(1).partitionSpecId());
+    assertThat(manifestFiles.get(1).partitionSpecId())
+        .as("2 manifest files should have different partitionSpecId")
+        .isNotEqualTo(manifestFiles.get(0).partitionSpecId());
 
     matchNumberOfManifestFileWithSpecId(manifestFiles, initialPartitionSpecId, 1);
 
     matchNumberOfManifestFileWithSpecId(manifestFiles, table.ops().current().spec().specId(), 1);
 
-    Assert.assertEquals(
-        "first manifest file should have 2 data files",
-        Integer.valueOf(2),
-        manifestFiles.get(0).existingFilesCount());
+    assertThat(manifestFiles.get(0).existingFilesCount())
+        .as("first manifest file should have 2 data files")
+        .isEqualTo(2);
 
-    Assert.assertEquals(
-        "second manifest file should have 2 data files",
-        Integer.valueOf(2),
-        manifestFiles.get(1).existingFilesCount());
+    assertThat(manifestFiles.get(1).existingFilesCount())
+        .as("second manifest file should have 2 data files")
+        .isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testManifestSizeWithMultiplePartitionSpec() throws IOException {
-    Assert.assertNull("Table should be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     TableMetadata base = readMetadata();
-    Assert.assertEquals(
-        "Should create 1 manifest for initial write",
-        1,
-        base.currentSnapshot().allManifests(table.io()).size());
+    assertThat(base.currentSnapshot().allManifests(table.io())).hasSize(1);
     ManifestFile initialManifest = base.currentSnapshot().allManifests(table.io()).get(0);
     int initialPartitionSpecId = initialManifest.partitionSpecId();
 
@@ -653,10 +638,9 @@ public class TestRewriteManifests extends TableTestBase {
 
     table.newAppend().appendFile(newFileZ).commit();
 
-    Assert.assertEquals(
-        "Rewrite manifests should produce 3 manifest files",
-        3,
-        table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Rewrite manifests should produce 3 manifest files")
+        .hasSize(3);
 
     // cluster by constant will combine manifests into one but small target size will create one per
     // entry
@@ -667,42 +651,28 @@ public class TestRewriteManifests extends TableTestBase {
     rewriteManifests.clusterBy(dataFile -> "file").commit();
     List<ManifestFile> manifestFiles = table.currentSnapshot().allManifests(table.io());
 
-    Assert.assertEquals("Should use 4 manifest files", 4, manifestFiles.size());
+    assertThat(manifestFiles).hasSize(4);
 
     matchNumberOfManifestFileWithSpecId(manifestFiles, initialPartitionSpecId, 2);
 
     matchNumberOfManifestFileWithSpecId(manifestFiles, table.ops().current().spec().specId(), 2);
 
-    Assert.assertEquals(
-        "first manifest file should have 1 data files",
-        Integer.valueOf(1),
-        manifestFiles.get(0).existingFilesCount());
+    assertThat(manifestFiles.get(0).existingFilesCount()).isEqualTo(1);
 
-    Assert.assertEquals(
-        "second manifest file should have 1 data files",
-        Integer.valueOf(1),
-        manifestFiles.get(1).existingFilesCount());
-
-    Assert.assertEquals(
-        "third manifest file should have 1 data files",
-        Integer.valueOf(1),
-        manifestFiles.get(2).existingFilesCount());
-
-    Assert.assertEquals(
-        "fourth manifest file should have 1 data files",
-        Integer.valueOf(1),
-        manifestFiles.get(3).existingFilesCount());
+    assertThat(manifestFiles.get(1).existingFilesCount()).isEqualTo(1);
+    assertThat(manifestFiles.get(2).existingFilesCount()).isEqualTo(1);
+    assertThat(manifestFiles.get(3).existingFilesCount()).isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void testManifestReplacementConcurrentAppend() throws IOException {
-    Assert.assertNull("Table should be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
     List<ManifestFile> firstSnapshotManifests = firstSnapshot.allManifests(table.io());
-    Assert.assertEquals(1, firstSnapshotManifests.size());
+    assertThat(firstSnapshotManifests).hasSize(1);
     ManifestFile firstSnapshotManifest = firstSnapshotManifests.get(0);
 
     ManifestFile firstNewManifest =
@@ -722,13 +692,13 @@ public class TestRewriteManifests extends TableTestBase {
     table.newFastAppend().appendFile(FILE_C).appendFile(FILE_D).commit();
     Snapshot secondSnapshot = table.currentSnapshot();
 
-    Assert.assertEquals(2, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(2);
 
     rewriteManifests.commit();
 
     Snapshot snapshot = table.currentSnapshot();
     List<ManifestFile> manifests = snapshot.allManifests(table.io());
-    Assert.assertEquals(3, manifests.size());
+    assertThat(manifests).hasSize(3);
 
     validateSummary(snapshot, 1, 1, 2, 0);
 
@@ -751,9 +721,9 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.ADDED, ManifestEntry.Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testManifestReplacementConcurrentDelete() throws IOException {
-    Assert.assertNull("Table should be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     table.updateProperties().set(MANIFEST_MERGE_ENABLED, "false").commit();
 
@@ -761,7 +731,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     Snapshot firstSnapshot = table.currentSnapshot();
     List<ManifestFile> firstSnapshotManifests = firstSnapshot.allManifests(table.io());
-    Assert.assertEquals(1, firstSnapshotManifests.size());
+    assertThat(firstSnapshotManifests).hasSize(1);
     ManifestFile firstSnapshotManifest = firstSnapshotManifests.get(0);
 
     table.newFastAppend().appendFile(FILE_C).appendFile(FILE_D).commit();
@@ -788,7 +758,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     Snapshot snapshot = table.currentSnapshot();
     List<ManifestFile> manifests = snapshot.allManifests(table.io());
-    Assert.assertEquals(3, manifests.size());
+    assertThat(manifests).hasSize(3);
 
     validateSummary(snapshot, 1, 1, 2, 0);
 
@@ -811,15 +781,15 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.DELETED, ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testManifestReplacementConcurrentConflictingDelete() throws IOException {
-    Assert.assertNull("Table should be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
     List<ManifestFile> firstSnapshotManifests = firstSnapshot.allManifests(table.io());
-    Assert.assertEquals(1, firstSnapshotManifests.size());
+    assertThat(firstSnapshotManifests).hasSize(1);
     ManifestFile firstSnapshotManifest = firstSnapshotManifests.get(0);
 
     ManifestFile firstNewManifest =
@@ -838,20 +808,20 @@ public class TestRewriteManifests extends TableTestBase {
 
     table.newDelete().deleteFile(FILE_A).commit();
 
-    Assertions.assertThatThrownBy(rewriteManifests::commit)
+    assertThatThrownBy(rewriteManifests::commit)
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Manifest is missing");
   }
 
-  @Test
+  @TestTemplate
   public void testManifestReplacementCombinedWithRewrite() throws IOException {
-    Assert.assertNull("Table should be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     table.newFastAppend().appendFile(FILE_A).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
     List<ManifestFile> firstSnapshotManifests = firstSnapshot.allManifests(table.io());
-    Assert.assertEquals(1, firstSnapshotManifests.size());
+    assertThat(firstSnapshotManifests).hasSize(1);
     ManifestFile firstSnapshotManifest = firstSnapshotManifests.get(0);
 
     table.newFastAppend().appendFile(FILE_B).commit();
@@ -862,7 +832,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     table.newFastAppend().appendFile(FILE_D).commit();
 
-    Assert.assertEquals(4, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).hasSize(4);
 
     ManifestFile newManifest =
         writeManifest(
@@ -886,7 +856,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     Snapshot snapshot = table.currentSnapshot();
     List<ManifestFile> manifests = snapshot.allManifests(table.io());
-    Assert.assertEquals(3, manifests.size());
+    assertThat(manifests).hasSize(3);
 
     validateSummary(snapshot, 3, 1, 2, 2);
 
@@ -903,9 +873,9 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testManifestReplacementCombinedWithRewriteConcurrentDelete() throws IOException {
-    Assert.assertNull("Table should be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     table.updateProperties().set(MANIFEST_MERGE_ENABLED, "false").commit();
 
@@ -913,7 +883,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     Snapshot firstSnapshot = table.currentSnapshot();
     List<ManifestFile> firstSnapshotManifests = firstSnapshot.allManifests(table.io());
-    Assert.assertEquals(1, firstSnapshotManifests.size());
+    assertThat(firstSnapshotManifests).hasSize(1);
     ManifestFile firstSnapshotManifest = firstSnapshotManifests.get(0);
 
     table.newFastAppend().appendFile(FILE_B).commit();
@@ -922,7 +892,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     table.newFastAppend().appendFile(FILE_C).commit();
 
-    Assert.assertEquals(3, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).hasSize(3);
 
     ManifestEntry<DataFile> entry =
         manifestEntry(ManifestEntry.Status.EXISTING, firstSnapshot.snapshotId(), FILE_A);
@@ -945,7 +915,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     Snapshot snapshot = table.currentSnapshot();
     List<ManifestFile> manifests = snapshot.allManifests(table.io());
-    Assert.assertEquals(2, manifests.size());
+    assertThat(manifests).hasSize(2);
 
     validateSummary(snapshot, 3, 0, 2, 1);
 
@@ -962,15 +932,15 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidUsage() throws IOException {
-    Assert.assertNull("Table should be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     table.newFastAppend().appendFile(FILE_A).commit();
 
     Snapshot snapshot = table.currentSnapshot();
     List<ManifestFile> manifests = snapshot.allManifests(table.io());
-    Assert.assertEquals(1, manifests.size());
+    assertThat(manifests).hasSize(1);
     ManifestFile manifest = manifests.get(0);
 
     ManifestEntry<DataFile> appendEntry =
@@ -980,7 +950,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     ManifestFile invalidAddedFileManifest = writeManifest("manifest-file-2.avro", appendEntry);
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .rewriteManifests()
@@ -997,7 +967,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     ManifestFile invalidDeletedFileManifest = writeManifest("manifest-file-3.avro", deleteEntry);
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .rewriteManifests()
@@ -1007,28 +977,28 @@ public class TestRewriteManifests extends TableTestBase {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot add manifest with deleted files");
 
-    Assertions.assertThatThrownBy(() -> table.rewriteManifests().deleteManifest(manifest).commit())
+    assertThatThrownBy(() -> table.rewriteManifests().deleteManifest(manifest).commit())
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith(
             "Replaced and created manifests must have the same number of active files");
   }
 
-  @Test
+  @TestTemplate
   public void testManifestReplacementFailure() throws IOException {
-    Assert.assertNull("Table should be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     table.newFastAppend().appendFile(FILE_A).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
     List<ManifestFile> firstSnapshotManifests = firstSnapshot.allManifests(table.io());
-    Assert.assertEquals(1, firstSnapshotManifests.size());
+    assertThat(firstSnapshotManifests).hasSize(1);
     ManifestFile firstSnapshotManifest = firstSnapshotManifests.get(0);
 
     table.newFastAppend().appendFile(FILE_B).commit();
 
     Snapshot secondSnapshot = table.currentSnapshot();
     List<ManifestFile> secondSnapshotManifests = secondSnapshot.allManifests(table.io());
-    Assert.assertEquals(2, secondSnapshotManifests.size());
+    assertThat(secondSnapshotManifests).hasSize(2);
     ManifestFile secondSnapshotManifest = secondSnapshotManifests.get(0);
 
     ManifestFile newManifest =
@@ -1046,16 +1016,16 @@ public class TestRewriteManifests extends TableTestBase {
     rewriteManifests.deleteManifest(secondSnapshotManifest);
     rewriteManifests.addManifest(newManifest);
 
-    Assertions.assertThatThrownBy(rewriteManifests::commit)
+    assertThatThrownBy(rewriteManifests::commit)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
 
-    Assert.assertTrue("New manifest should not be deleted", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).exists();
   }
 
-  @Test
+  @TestTemplate
   public void testManifestReplacementFailureWithSnapshotIdInheritance() throws IOException {
-    Assert.assertNull("Table should be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).isNull();
 
     table.updateProperties().set(SNAPSHOT_ID_INHERITANCE_ENABLED, "true").commit();
 
@@ -1063,14 +1033,14 @@ public class TestRewriteManifests extends TableTestBase {
 
     Snapshot firstSnapshot = table.currentSnapshot();
     List<ManifestFile> firstSnapshotManifests = firstSnapshot.allManifests(table.io());
-    Assert.assertEquals(1, firstSnapshotManifests.size());
+    assertThat(firstSnapshotManifests).hasSize(1);
     ManifestFile firstSnapshotManifest = firstSnapshotManifests.get(0);
 
     table.newFastAppend().appendFile(FILE_B).commit();
 
     Snapshot secondSnapshot = table.currentSnapshot();
     List<ManifestFile> secondSnapshotManifests = secondSnapshot.allManifests(table.io());
-    Assert.assertEquals(2, secondSnapshotManifests.size());
+    assertThat(secondSnapshotManifests).hasSize(2);
     ManifestFile secondSnapshotManifest = secondSnapshotManifests.get(0);
 
     ManifestFile newManifest =
@@ -1088,27 +1058,27 @@ public class TestRewriteManifests extends TableTestBase {
     rewriteManifests.deleteManifest(secondSnapshotManifest);
     rewriteManifests.addManifest(newManifest);
 
-    Assertions.assertThatThrownBy(rewriteManifests::commit)
+    assertThatThrownBy(rewriteManifests::commit)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
 
-    Assert.assertTrue("New manifest should not be deleted", new File(newManifest.path()).exists());
+    assertThat(new File(newManifest.path())).exists();
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteManifestsOnBranchUnsupported() {
 
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Assert.assertEquals(1, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
 
-    Assertions.assertThatThrownBy(() -> table.rewriteManifests().toBranch("someBranch").commit())
+    assertThatThrownBy(() -> table.rewriteManifests().toBranch("someBranch").commit())
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage(
             "Cannot commit to branch someBranch: org.apache.iceberg.BaseRewriteManifests does not support branch commits");
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteDataManifestsPreservesDeletes() {
     assumeThat(formatVersion).isGreaterThan(1);
 
@@ -1170,7 +1140,7 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.ADDED, ManifestEntry.Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceDeleteManifestsOnly() throws IOException {
     assumeThat(formatVersion).isGreaterThan(1);
 
@@ -1256,7 +1226,7 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceDataAndDeleteManifests() throws IOException {
     assumeThat(formatVersion).isGreaterThan(1);
 
@@ -1375,7 +1345,7 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteManifestReplacementConcurrentAppend() throws IOException {
     assumeThat(formatVersion).isGreaterThan(1);
 
@@ -1478,7 +1448,7 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteManifestReplacementConcurrentDeleteFileRemoval() throws IOException {
     assumeThat(formatVersion).isGreaterThan(1);
 
@@ -1586,7 +1556,7 @@ public class TestRewriteManifests extends TableTestBase {
         statuses(ManifestEntry.Status.DELETED, ManifestEntry.Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteManifestReplacementConflictingDeleteFileRemoval() throws IOException {
     assumeThat(formatVersion).isGreaterThan(1);
 
@@ -1632,12 +1602,12 @@ public class TestRewriteManifests extends TableTestBase {
     table.newRewrite().deleteFile(FILE_A_DELETES).commit();
 
     // the rewrite must fail as the original delete manifest was replaced concurrently
-    Assertions.assertThatThrownBy(rewriteManifests::commit)
+    assertThatThrownBy(rewriteManifests::commit)
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Manifest is missing");
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteManifestReplacementFailure() throws IOException {
     assumeThat(formatVersion).isGreaterThan(1);
 
@@ -1693,7 +1663,7 @@ public class TestRewriteManifests extends TableTestBase {
     rewriteManifests.addManifest(newDeleteManifest);
 
     // the rewrite must fail
-    Assertions.assertThatThrownBy(rewriteManifests::commit)
+    assertThatThrownBy(rewriteManifests::commit)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Injected failure");
 
@@ -1717,18 +1687,11 @@ public class TestRewriteManifests extends TableTestBase {
   private void validateSummary(
       Snapshot snapshot, int replaced, int kept, int created, int entryCount) {
     Map<String, String> summary = snapshot.summary();
-    Assert.assertEquals(
-        "Replaced manifest count should match",
-        replaced,
-        Integer.parseInt(summary.get("manifests-replaced")));
-    Assert.assertEquals(
-        "Kept manifest count should match", kept, Integer.parseInt(summary.get("manifests-kept")));
-    Assert.assertEquals(
-        "Created manifest count should match",
-        created,
-        Integer.parseInt(summary.get("manifests-created")));
-    Assert.assertEquals(
-        "Entry count should match", entryCount, Integer.parseInt(summary.get("entries-processed")));
+    assertThat(summary)
+        .containsEntry("manifests-replaced", String.valueOf(replaced))
+        .containsEntry("manifests-kept", String.valueOf(kept))
+        .containsEntry("manifests-created", String.valueOf(created))
+        .containsEntry("entries-processed", String.valueOf(entryCount));
   }
 
   private void matchNumberOfManifestFileWithSpecId(
@@ -1740,12 +1703,12 @@ public class TestRewriteManifests extends TableTestBase {
             .filter(m -> m.partitionSpecId() == toBeMatchedPartitionSpecId)
             .count();
 
-    Assert.assertEquals(
-        "manifest list should have "
-            + numberOfManifestWithPartitionSpecID
-            + " manifests matching this partitionSpecId "
-            + toBeMatchedPartitionSpecId,
-        numberOfManifestWithPartitionSpecID,
-        matchedManifestsCounter);
+    assertThat(matchedManifestsCounter)
+        .as(
+            "manifest list should have "
+                + numberOfManifestWithPartitionSpecID
+                + " manifests matching this partitionSpecId "
+                + toBeMatchedPartitionSpecId)
+        .isEqualTo(numberOfManifestWithPartitionSpecID);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -27,7 +27,10 @@ import static org.apache.iceberg.SnapshotSummary.TOTAL_DATA_FILES_PROP;
 import static org.apache.iceberg.SnapshotSummary.TOTAL_DELETE_FILES_PROP;
 import static org.apache.iceberg.SnapshotSummary.TOTAL_POS_DELETES_PROP;
 import static org.apache.iceberg.util.SnapshotUtil.latestSnapshot;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,44 +41,34 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestRowDelta extends V2TableTestBase {
 
-  private final String branch;
+  @Parameter(index = 1)
+  private String branch;
 
-  @Parameterized.Parameters(name = "branch = {0}")
-  public static Object[] parameters() {
-    return new Object[][] {
-      new Object[] {"main"}, new Object[] {"testBranch"},
-    };
+  @Parameters(name = "formatVersion = {0}, branch = {1}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(new Object[] {2, "main"}, new Object[] {2, "testBranch"});
   }
 
-  public TestRowDelta(String branch) {
-    this.branch = branch;
-  }
-
-  @Test
+  @TestTemplate
   public void testAddDeleteFile() {
     SnapshotUpdate rowDelta =
         table.newRowDelta().addRows(FILE_A).addDeletes(FILE_A_DELETES).addDeletes(FILE_B_DELETES);
 
     commit(table, rowDelta, branch);
     Snapshot snap = latestSnapshot(table, branch);
-    Assert.assertEquals("Commit should produce sequence number 1", 1, snap.sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
-    Assert.assertEquals(
-        "Delta commit should use operation 'overwrite'",
-        DataOperations.OVERWRITE,
-        snap.operation());
+    assertThat(snap.sequenceNumber()).isEqualTo(1);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(1);
+    assertThat(snap.operation())
+        .as("Delta commit should use operation 'overwrite'")
+        .isEqualTo(DataOperations.OVERWRITE);
+    assertThat(snap.dataManifests(table.io())).hasSize(1);
 
-    Assert.assertEquals("Should produce 1 data manifest", 1, snap.dataManifests(table.io()).size());
     validateManifest(
         snap.dataManifests(table.io()).get(0),
         dataSeqs(1L),
@@ -84,8 +77,7 @@ public class TestRowDelta extends V2TableTestBase {
         files(FILE_A),
         statuses(Status.ADDED));
 
-    Assert.assertEquals(
-        "Should produce 1 delete manifest", 1, snap.deleteManifests(table.io()).size());
+    assertThat(snap.deleteManifests(table.io())).hasSize(1);
     validateDeleteManifest(
         snap.deleteManifests(table.io()).get(0),
         dataSeqs(1L, 1L),
@@ -95,7 +87,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED, Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testValidateDataFilesExistDefaults() {
     SnapshotUpdate rowDelta1 = table.newAppend().appendFile(FILE_A).appendFile(FILE_B);
 
@@ -116,7 +108,7 @@ public class TestRowDelta extends V2TableTestBase {
 
     long deleteSnapshotId = latestSnapshot(table, branch).snapshotId();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 commit(
                     table,
@@ -129,15 +121,11 @@ public class TestRowDelta extends V2TableTestBase {
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, missing data files");
 
-    Assert.assertEquals(
-        "Table state should not be modified by failed RowDelta operation",
-        deleteSnapshotId,
-        latestSnapshot(table, branch).snapshotId());
+    assertThat(latestSnapshot(table, branch).snapshotId())
+        .as("Table state should not be modified by failed RowDelta operation")
+        .isEqualTo(deleteSnapshotId);
 
-    Assert.assertEquals(
-        "Table should not have any delete manifests",
-        0,
-        latestSnapshot(table, branch).deleteManifests(table.io()).size());
+    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).hasSize(0);
 
     commit(
         table,
@@ -148,10 +136,7 @@ public class TestRowDelta extends V2TableTestBase {
             .validateFromSnapshot(validateFromSnapshotId),
         branch);
 
-    Assert.assertEquals(
-        "Table should have one new delete manifest",
-        1,
-        latestSnapshot(table, branch).deleteManifests(table.io()).size());
+    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).hasSize(1);
     ManifestFile deletes = latestSnapshot(table, branch).deleteManifests(table.io()).get(0);
     validateDeleteManifest(
         deletes,
@@ -162,7 +147,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testValidateDataFilesExistOverwrite() {
     commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
@@ -174,7 +159,7 @@ public class TestRowDelta extends V2TableTestBase {
 
     long deleteSnapshotId = latestSnapshot(table, branch).snapshotId();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 commit(
                     table,
@@ -187,18 +172,14 @@ public class TestRowDelta extends V2TableTestBase {
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, missing data files");
 
-    Assert.assertEquals(
-        "Table state should not be modified by failed RowDelta operation",
-        deleteSnapshotId,
-        latestSnapshot(table, branch).snapshotId());
+    assertThat(latestSnapshot(table, branch).snapshotId())
+        .as("Table state should not be modified by failed RowDelta operation")
+        .isEqualTo(deleteSnapshotId);
 
-    Assert.assertEquals(
-        "Table should not have any delete manifests",
-        0,
-        latestSnapshot(table, branch).deleteManifests(table.io()).size());
+    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).hasSize(0);
   }
 
-  @Test
+  @TestTemplate
   public void testValidateDataFilesExistReplacePartitions() {
     commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
@@ -210,7 +191,7 @@ public class TestRowDelta extends V2TableTestBase {
 
     long deleteSnapshotId = latestSnapshot(table, branch).snapshotId();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 commit(
                     table,
@@ -223,18 +204,14 @@ public class TestRowDelta extends V2TableTestBase {
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, missing data files");
 
-    Assert.assertEquals(
-        "Table state should not be modified by failed RowDelta operation",
-        deleteSnapshotId,
-        latestSnapshot(table, branch).snapshotId());
+    assertThat(latestSnapshot(table, branch).snapshotId())
+        .as("Table state should not be modified by failed RowDelta operation")
+        .isEqualTo(deleteSnapshotId);
 
-    Assert.assertEquals(
-        "Table should not have any delete manifests",
-        0,
-        latestSnapshot(table, branch).deleteManifests(table.io()).size());
+    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).hasSize(0);
   }
 
-  @Test
+  @TestTemplate
   public void testValidateDataFilesExistFromSnapshot() {
     commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
@@ -259,11 +236,10 @@ public class TestRowDelta extends V2TableTestBase {
         branch);
 
     Snapshot snap = latestSnapshot(table, branch);
-    Assert.assertEquals("Commit should produce sequence number 2", 3, snap.sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 3", 3, table.ops().current().lastSequenceNumber());
+    assertThat(snap.sequenceNumber()).isEqualTo(3);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(3);
 
-    Assert.assertEquals("Should have 2 data manifests", 2, snap.dataManifests(table.io()).size());
+    assertThat(snap.dataManifests(table.io())).hasSize(2);
     // manifest with FILE_A2 added
     validateManifest(
         snap.dataManifests(table.io()).get(0),
@@ -282,8 +258,7 @@ public class TestRowDelta extends V2TableTestBase {
         files(FILE_A, FILE_B),
         statuses(Status.DELETED, Status.EXISTING));
 
-    Assert.assertEquals(
-        "Should have 1 delete manifest", 1, snap.deleteManifests(table.io()).size());
+    assertThat(snap.deleteManifests(table.io())).hasSize(1);
     validateDeleteManifest(
         snap.deleteManifests(table.io()).get(0),
         dataSeqs(3L),
@@ -293,7 +268,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testValidateDataFilesExistRewrite() {
     commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
@@ -308,7 +283,7 @@ public class TestRowDelta extends V2TableTestBase {
 
     long deleteSnapshotId = latestSnapshot(table, branch).snapshotId();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 commit(
                     table,
@@ -321,18 +296,14 @@ public class TestRowDelta extends V2TableTestBase {
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, missing data files");
 
-    Assert.assertEquals(
-        "Table state should not be modified by failed RowDelta operation",
-        deleteSnapshotId,
-        latestSnapshot(table, branch).snapshotId());
+    assertThat(latestSnapshot(table, branch).snapshotId())
+        .as("Table state should not be modified by failed RowDelta operation")
+        .isEqualTo(deleteSnapshotId);
 
-    Assert.assertEquals(
-        "Table should not have any delete manifests",
-        0,
-        latestSnapshot(table, branch).deleteManifests(table.io()).size());
+    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void testValidateDataFilesExistValidateDeletes() {
     commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
@@ -344,7 +315,7 @@ public class TestRowDelta extends V2TableTestBase {
 
     long deleteSnapshotId = latestSnapshot(table, branch).snapshotId();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 commit(
                     table,
@@ -358,18 +329,14 @@ public class TestRowDelta extends V2TableTestBase {
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, missing data files");
 
-    Assert.assertEquals(
-        "Table state should not be modified by failed RowDelta operation",
-        deleteSnapshotId,
-        latestSnapshot(table, branch).snapshotId());
+    assertThat(latestSnapshot(table, branch).snapshotId())
+        .as("Table state should not be modified by failed RowDelta operation")
+        .isEqualTo(deleteSnapshotId);
 
-    Assert.assertEquals(
-        "Table should not have any delete manifests",
-        0,
-        latestSnapshot(table, branch).deleteManifests(table.io()).size());
+    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void testValidateNoConflicts() {
     commit(table, table.newAppend().appendFile(FILE_A), branch);
 
@@ -381,7 +348,7 @@ public class TestRowDelta extends V2TableTestBase {
 
     long appendSnapshotId = latestSnapshot(table, branch).snapshotId();
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 commit(
                     table,
@@ -396,18 +363,14 @@ public class TestRowDelta extends V2TableTestBase {
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Found conflicting files");
 
-    Assert.assertEquals(
-        "Table state should not be modified by failed RowDelta operation",
-        appendSnapshotId,
-        latestSnapshot(table, branch).snapshotId());
+    assertThat(latestSnapshot(table, branch).snapshotId())
+        .as("Table state should not be modified by failed RowDelta operation")
+        .isEqualTo(appendSnapshotId);
 
-    Assert.assertEquals(
-        "Table should not have any delete manifests",
-        0,
-        latestSnapshot(table, branch).deleteManifests(table.io()).size());
+    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void testValidateNoConflictsFromSnapshot() {
     commit(table, table.newAppend().appendFile(FILE_A), branch);
 
@@ -433,11 +396,10 @@ public class TestRowDelta extends V2TableTestBase {
         branch);
 
     Snapshot snap = latestSnapshot(table, branch);
-    Assert.assertEquals("Commit should produce sequence number 2", 3, snap.sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 3", 3, table.ops().current().lastSequenceNumber());
+    assertThat(snap.sequenceNumber()).isEqualTo(3);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(3);
 
-    Assert.assertEquals("Should have 2 data manifests", 2, snap.dataManifests(table.io()).size());
+    assertThat(snap.dataManifests(table.io())).hasSize(2);
     // manifest with FILE_A2 added
     validateManifest(
         snap.dataManifests(table.io()).get(0),
@@ -456,8 +418,7 @@ public class TestRowDelta extends V2TableTestBase {
         files(FILE_A),
         statuses(Status.ADDED));
 
-    Assert.assertEquals(
-        "Should have 1 delete manifest", 1, snap.deleteManifests(table.io()).size());
+    assertThat(snap.deleteManifests(table.io())).hasSize(1);
     validateDeleteManifest(
         snap.deleteManifests(table.io()).get(0),
         dataSeqs(3L),
@@ -467,7 +428,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testOverwriteWithDeleteFile() {
     commit(
         table,
@@ -475,12 +436,8 @@ public class TestRowDelta extends V2TableTestBase {
         branch);
 
     long deltaSnapshotId = latestSnapshot(table, branch).snapshotId();
-    Assert.assertEquals(
-        "Commit should produce sequence number 1",
-        1,
-        latestSnapshot(table, branch).sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
+    assertThat(latestSnapshot(table, branch).sequenceNumber()).isEqualTo(1);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(1);
 
     // overwriting by a filter will also remove delete files that match because all matching data
     // files are removed.
@@ -492,11 +449,10 @@ public class TestRowDelta extends V2TableTestBase {
         branch);
 
     Snapshot snap = latestSnapshot(table, branch);
-    Assert.assertEquals("Commit should produce sequence number 2", 2, snap.sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 2", 2, table.ops().current().lastSequenceNumber());
+    assertThat(snap.sequenceNumber()).isEqualTo(2);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(2);
 
-    Assert.assertEquals("Should produce 1 data manifest", 1, snap.dataManifests(table.io()).size());
+    assertThat(snap.dataManifests(table.io())).hasSize(1);
     validateManifest(
         snap.dataManifests(table.io()).get(0),
         dataSeqs(1L),
@@ -505,8 +461,7 @@ public class TestRowDelta extends V2TableTestBase {
         files(FILE_A),
         statuses(Status.DELETED));
 
-    Assert.assertEquals(
-        "Should produce 1 delete manifest", 1, snap.deleteManifests(table.io()).size());
+    assertThat(snap.deleteManifests(table.io())).hasSize(1);
     validateDeleteManifest(
         snap.deleteManifests(table.io()).get(0),
         dataSeqs(1L, 1L),
@@ -516,7 +471,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.DELETED, Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testReplacePartitionsWithDeleteFile() {
     commit(
         table,
@@ -524,24 +479,18 @@ public class TestRowDelta extends V2TableTestBase {
         branch);
 
     long deltaSnapshotId = latestSnapshot(table, branch).snapshotId();
-    Assert.assertEquals(
-        "Commit should produce sequence number 1",
-        1,
-        latestSnapshot(table, branch).sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
+    assertThat(latestSnapshot(table, branch).sequenceNumber()).isEqualTo(1);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(1);
 
     // overwriting the partition will also remove delete files that match because all matching data
     // files are removed.
     commit(table, table.newReplacePartitions().addFile(FILE_A2), branch);
 
     Snapshot snap = latestSnapshot(table, branch);
-    Assert.assertEquals("Commit should produce sequence number 2", 2, snap.sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 2", 2, table.ops().current().lastSequenceNumber());
+    assertThat(snap.sequenceNumber()).isEqualTo(2);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(2);
 
-    Assert.assertEquals(
-        "Should produce 2 data manifests", 2, snap.dataManifests(table.io()).size());
+    assertThat(snap.dataManifests(table.io())).hasSize(2);
     int deleteManifestPos = snap.dataManifests(table.io()).get(0).deletedFilesCount() > 0 ? 0 : 1;
     validateManifest(
         snap.dataManifests(table.io()).get(deleteManifestPos),
@@ -559,8 +508,7 @@ public class TestRowDelta extends V2TableTestBase {
         files(FILE_A2),
         statuses(Status.ADDED));
 
-    Assert.assertEquals(
-        "Should produce 1 delete manifest", 1, snap.deleteManifests(table.io()).size());
+    assertThat(snap.deleteManifests(table.io())).hasSize(1);
     validateDeleteManifest(
         snap.deleteManifests(table.io()).get(0),
         dataSeqs(1L, 1L),
@@ -570,7 +518,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.DELETED, Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteByExpressionWithDeleteFile() {
     commit(
         table,
@@ -578,23 +526,18 @@ public class TestRowDelta extends V2TableTestBase {
         branch);
 
     long deltaSnapshotId = latestSnapshot(table, branch).snapshotId();
-    Assert.assertEquals(
-        "Commit should produce sequence number 1",
-        1,
-        latestSnapshot(table, branch).sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
+    assertThat(latestSnapshot(table, branch).sequenceNumber()).isEqualTo(1);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(1);
 
     // deleting with a filter will also remove delete files that match because all matching data
     // files are removed.
     commit(table, table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()), branch);
 
     Snapshot snap = latestSnapshot(table, branch);
-    Assert.assertEquals("Commit should produce sequence number 2", 2, snap.sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 2", 2, table.ops().current().lastSequenceNumber());
+    assertThat(snap.sequenceNumber()).isEqualTo(2);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(2);
 
-    Assert.assertEquals("Should produce 1 data manifest", 1, snap.dataManifests(table.io()).size());
+    assertThat(snap.deleteManifests(table.io())).hasSize(1);
     validateManifest(
         snap.dataManifests(table.io()).get(0),
         dataSeqs(1L),
@@ -603,8 +546,7 @@ public class TestRowDelta extends V2TableTestBase {
         files(FILE_A),
         statuses(Status.DELETED));
 
-    Assert.assertEquals(
-        "Should produce 1 delete manifest", 1, snap.deleteManifests(table.io()).size());
+    assertThat(snap.deleteManifests(table.io())).hasSize(1);
     validateDeleteManifest(
         snap.deleteManifests(table.io()).get(0),
         dataSeqs(1L, 1L),
@@ -614,28 +556,22 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.DELETED, Status.DELETED));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteDataFileWithDeleteFile() {
     commit(table, table.newRowDelta().addRows(FILE_A).addDeletes(FILE_A_DELETES), branch);
 
     long deltaSnapshotId = latestSnapshot(table, branch).snapshotId();
-    Assert.assertEquals(
-        "Commit should produce sequence number 1",
-        1,
-        latestSnapshot(table, branch).sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
+    assertThat(latestSnapshot(table, branch).sequenceNumber()).isEqualTo(1);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(1);
 
     // deleting a specific data file will not affect a delete file
     commit(table, table.newDelete().deleteFile(FILE_A), branch);
 
     Snapshot deleteSnap = latestSnapshot(table, branch);
-    Assert.assertEquals("Commit should produce sequence number 2", 2, deleteSnap.sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 2", 2, table.ops().current().lastSequenceNumber());
+    assertThat(deleteSnap.sequenceNumber()).isEqualTo(2);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(2);
 
-    Assert.assertEquals(
-        "Should produce 1 data manifest", 1, deleteSnap.dataManifests(table.io()).size());
+    assertThat(deleteSnap.deleteManifests(table.io())).hasSize(1);
     validateManifest(
         deleteSnap.dataManifests(table.io()).get(0),
         dataSeqs(1L),
@@ -644,8 +580,7 @@ public class TestRowDelta extends V2TableTestBase {
         files(FILE_A),
         statuses(Status.DELETED));
 
-    Assert.assertEquals(
-        "Should produce 1 delete manifest", 1, deleteSnap.deleteManifests(table.io()).size());
+    assertThat(deleteSnap.deleteManifests(table.io())).hasSize(1);
     validateDeleteManifest(
         deleteSnap.deleteManifests(table.io()).get(0),
         dataSeqs(1L),
@@ -662,14 +597,11 @@ public class TestRowDelta extends V2TableTestBase {
     commit(table, table.newDelete().deleteFile("no-such-file"), branch);
 
     Snapshot nextSnap = latestSnapshot(table, branch);
-    Assert.assertEquals("Append should produce sequence number 3", 3, nextSnap.sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 3", 3, table.ops().current().lastSequenceNumber());
+    assertThat(nextSnap.sequenceNumber()).isEqualTo(3);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(3);
 
-    Assert.assertEquals(
-        "Should have 0 data manifests", 0, nextSnap.dataManifests(table.io()).size());
-    Assert.assertEquals(
-        "Should produce 1 delete manifest", 1, nextSnap.deleteManifests(table.io()).size());
+    assertThat(nextSnap.dataManifests(table.io())).isEmpty();
+    assertThat(nextSnap.deleteManifests(table.io())).hasSize(1);
     validateDeleteManifest(
         nextSnap.deleteManifests(table.io()).get(0),
         dataSeqs(1L),
@@ -679,28 +611,22 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.DELETED));
   }
 
-  @Test
+  @TestTemplate
   public void testFastAppendDoesNotRemoveStaleDeleteFiles() {
     commit(table, table.newRowDelta().addRows(FILE_A).addDeletes(FILE_A_DELETES), branch);
 
     long deltaSnapshotId = latestSnapshot(table, branch).snapshotId();
-    Assert.assertEquals(
-        "Commit should produce sequence number 1",
-        1,
-        latestSnapshot(table, branch).sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
+    assertThat(latestSnapshot(table, branch).sequenceNumber()).isEqualTo(1);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(1);
 
     // deleting a specific data file will not affect a delete file
     commit(table, table.newDelete().deleteFile(FILE_A), branch);
 
     Snapshot deleteSnap = latestSnapshot(table, branch);
-    Assert.assertEquals("Commit should produce sequence number 2", 2, deleteSnap.sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 2", 2, table.ops().current().lastSequenceNumber());
+    assertThat(deleteSnap.sequenceNumber()).isEqualTo(2);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(2);
 
-    Assert.assertEquals(
-        "Should produce 1 data manifest", 1, deleteSnap.dataManifests(table.io()).size());
+    assertThat(deleteSnap.deleteManifests(table.io())).hasSize(1);
     validateManifest(
         deleteSnap.dataManifests(table.io()).get(0),
         dataSeqs(1L),
@@ -709,8 +635,7 @@ public class TestRowDelta extends V2TableTestBase {
         files(FILE_A),
         statuses(Status.DELETED));
 
-    Assert.assertEquals(
-        "Should produce 1 delete manifest", 1, deleteSnap.deleteManifests(table.io()).size());
+    assertThat(deleteSnap.deleteManifests(table.io())).hasSize(1);
     validateDeleteManifest(
         deleteSnap.deleteManifests(table.io()).get(0),
         dataSeqs(1L),
@@ -724,12 +649,10 @@ public class TestRowDelta extends V2TableTestBase {
     commit(table, table.newFastAppend().appendFile(FILE_B), branch);
 
     Snapshot nextSnap = latestSnapshot(table, branch);
-    Assert.assertEquals("Append should produce sequence number 3", 3, nextSnap.sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 3", 3, table.ops().current().lastSequenceNumber());
+    assertThat(nextSnap.sequenceNumber()).isEqualTo(3);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(3);
 
-    Assert.assertEquals(
-        "Should have 2 data manifests", 2, nextSnap.dataManifests(table.io()).size());
+    assertThat(nextSnap.dataManifests(table.io())).hasSize(2);
     int deleteManifestPos =
         nextSnap.dataManifests(table.io()).get(0).deletedFilesCount() > 0 ? 0 : 1;
     validateManifest(
@@ -748,8 +671,7 @@ public class TestRowDelta extends V2TableTestBase {
         files(FILE_B),
         statuses(Status.ADDED));
 
-    Assert.assertEquals(
-        "Should produce 1 delete manifest", 1, nextSnap.deleteManifests(table.io()).size());
+    assertThat(nextSnap.deleteManifests(table.io())).hasSize(1);
     validateDeleteManifest(
         nextSnap.deleteManifests(table.io()).get(0),
         dataSeqs(1L),
@@ -759,7 +681,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testValidateDataFilesExistWithConflictDetectionFilter() {
     // change the spec to be partitioned by data
     table
@@ -820,10 +742,7 @@ public class TestRowDelta extends V2TableTestBase {
     // commit the delta for partition A
     commit(table, rowDelta, branch);
 
-    Assert.assertEquals(
-        "Table should have one new delete manifest",
-        1,
-        latestSnapshot(table, branch).deleteManifests(table.io()).size());
+    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).hasSize(1);
     ManifestFile deletes = latestSnapshot(table, branch).deleteManifests(table.io()).get(0);
     validateDeleteManifest(
         deletes,
@@ -834,7 +753,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testValidateDataFilesDoNotExistWithConflictDetectionFilter() {
     // change the spec to be partitioned by data
     table
@@ -881,12 +800,12 @@ public class TestRowDelta extends V2TableTestBase {
     // concurrently delete the file for partition A
     commit(table, table.newDelete().deleteFile(dataFile1), branch);
 
-    Assertions.assertThatThrownBy(() -> commit(table, rowDelta, branch))
+    assertThatThrownBy(() -> commit(table, rowDelta, branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, missing data files");
   }
 
-  @Test
+  @TestTemplate
   public void testAddDeleteFilesMultipleSpecs() {
     // enable partition summaries
     table.updateProperties().set(TableProperties.WRITE_PARTITION_SUMMARY_LIMIT, "10").commit();
@@ -898,7 +817,7 @@ public class TestRowDelta extends V2TableTestBase {
     // remove the only partition field to make the spec unpartitioned
     table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
 
-    Assert.assertTrue("Spec must be unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).isTrue();
 
     // append an unpartitioned data file
     DataFile secondSnapshotDataFile = newDataFile("");
@@ -911,7 +830,7 @@ public class TestRowDelta extends V2TableTestBase {
     DataFile thirdSnapshotDataFile = newDataFile("data=abc");
     commit(table, table.newAppend().appendFile(thirdSnapshotDataFile), branch);
 
-    Assert.assertEquals("Should have 3 specs", 3, table.specs().size());
+    assertThat(table.specs()).hasSize(3);
 
     // commit a row delta with 1 data file and 3 delete files where delete files have different
     // specs
@@ -931,40 +850,32 @@ public class TestRowDelta extends V2TableTestBase {
         branch);
 
     Snapshot snapshot = latestSnapshot(table, branch);
-    Assert.assertEquals("Commit should produce sequence number 4", 4, snapshot.sequenceNumber());
-    Assert.assertEquals(
-        "Last sequence number should be 4", 4, table.ops().current().lastSequenceNumber());
-    Assert.assertEquals(
-        "Delta commit should be 'overwrite'", DataOperations.OVERWRITE, snapshot.operation());
+    assertThat(snapshot.sequenceNumber()).isEqualTo(4);
+    assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(4);
+    assertThat(snapshot.operation()).isEqualTo(DataOperations.OVERWRITE);
 
     Map<String, String> summary = snapshot.summary();
 
-    Assert.assertEquals(
-        "Should change 4 partitions", "4", summary.get(CHANGED_PARTITION_COUNT_PROP));
-    Assert.assertEquals("Should add 1 data file", "1", summary.get(ADDED_FILES_PROP));
-    Assert.assertEquals("Should have 4 data files", "4", summary.get(TOTAL_DATA_FILES_PROP));
-    Assert.assertEquals("Should add 3 delete files", "3", summary.get(ADDED_DELETE_FILES_PROP));
-    Assert.assertEquals("Should have 3 delete files", "3", summary.get(TOTAL_DELETE_FILES_PROP));
-    Assert.assertEquals("Should add 3 position deletes", "3", summary.get(ADDED_POS_DELETES_PROP));
-    Assert.assertEquals("Should have 3 position deletes", "3", summary.get(TOTAL_POS_DELETES_PROP));
-
-    Assert.assertTrue(
-        "Partition metrics must be correct",
-        summary
-            .get(CHANGED_PARTITION_PREFIX + "data_bucket=0")
-            .contains(ADDED_DELETE_FILES_PROP + "=1"));
-    Assert.assertTrue(
-        "Partition metrics must be correct",
-        summary
-            .get(CHANGED_PARTITION_PREFIX + "data=abc")
-            .contains(ADDED_DELETE_FILES_PROP + "=1"));
-    Assert.assertTrue(
-        "Partition metrics must be correct",
-        summary.get(CHANGED_PARTITION_PREFIX + "data=xyz").contains(ADDED_FILES_PROP + "=1"));
+    assertThat(summary)
+        .containsEntry(CHANGED_PARTITION_COUNT_PROP, "4")
+        .containsEntry(ADDED_FILES_PROP, "1")
+        .containsEntry(TOTAL_DATA_FILES_PROP, "4")
+        .containsEntry(ADDED_DELETE_FILES_PROP, "3")
+        .containsEntry(TOTAL_DELETE_FILES_PROP, "3")
+        .containsEntry(ADDED_POS_DELETES_PROP, "3")
+        .containsEntry(TOTAL_POS_DELETES_PROP, "3")
+        .hasEntrySatisfying(
+            CHANGED_PARTITION_PREFIX + "data_bucket=0",
+            v -> assertThat(v).contains(ADDED_DELETE_FILES_PROP + "=1"))
+        .hasEntrySatisfying(
+            CHANGED_PARTITION_PREFIX + "data=abc",
+            v -> assertThat(v).contains(ADDED_DELETE_FILES_PROP + "=1"))
+        .hasEntrySatisfying(
+            CHANGED_PARTITION_PREFIX + "data=xyz",
+            v -> assertThat(v).contains(ADDED_FILES_PROP + "=1"));
 
     // 3 appends + 1 row delta
-    Assert.assertEquals(
-        "Should have 4 data manifest", 4, snapshot.dataManifests(table.io()).size());
+    assertThat(snapshot.dataManifests(table.io())).hasSize(4);
     validateManifest(
         snapshot.dataManifests(table.io()).get(0),
         dataSeqs(4L),
@@ -974,12 +885,10 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED));
 
     // each delete file goes into a separate manifest as the specs are different
-    Assert.assertEquals(
-        "Should produce 3 delete manifest", 3, snapshot.deleteManifests(table.io()).size());
+    assertThat(snapshot.deleteManifests(table.io())).hasSize(3);
 
     ManifestFile firstDeleteManifest = snapshot.deleteManifests(table.io()).get(2);
-    Assert.assertEquals(
-        "Spec must match", firstSnapshotDataFile.specId(), firstDeleteManifest.partitionSpecId());
+    assertThat(firstDeleteManifest.partitionSpecId()).isEqualTo(firstSnapshotDataFile.specId());
     validateDeleteManifest(
         firstDeleteManifest,
         dataSeqs(4L),
@@ -989,8 +898,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED));
 
     ManifestFile secondDeleteManifest = snapshot.deleteManifests(table.io()).get(1);
-    Assert.assertEquals(
-        "Spec must match", secondSnapshotDataFile.specId(), secondDeleteManifest.partitionSpecId());
+    assertThat(secondDeleteManifest.partitionSpecId()).isEqualTo(secondSnapshotDataFile.specId());
     validateDeleteManifest(
         secondDeleteManifest,
         dataSeqs(4L),
@@ -1000,8 +908,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED));
 
     ManifestFile thirdDeleteManifest = snapshot.deleteManifests(table.io()).get(0);
-    Assert.assertEquals(
-        "Spec must match", thirdSnapshotDataFile.specId(), thirdDeleteManifest.partitionSpecId());
+    assertThat(thirdDeleteManifest.partitionSpecId()).isEqualTo(thirdSnapshotDataFile.specId());
     validateDeleteManifest(
         thirdDeleteManifest,
         dataSeqs(4L),
@@ -1011,7 +918,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED));
   }
 
-  @Test
+  @TestTemplate
   public void testManifestMergingMultipleSpecs() {
     // make sure we enable manifest merging
     table
@@ -1027,7 +934,7 @@ public class TestRowDelta extends V2TableTestBase {
     // remove the only partition field to make the spec unpartitioned
     table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
 
-    Assert.assertTrue("Spec must be unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).isTrue();
 
     // append an unpartitioned data file
     DataFile secondSnapshotDataFile = newDataFile("");
@@ -1045,10 +952,8 @@ public class TestRowDelta extends V2TableTestBase {
     Snapshot thirdSnapshot = latestSnapshot(table, branch);
 
     // 2 appends and 1 row delta where delete files belong to different specs
-    Assert.assertEquals(
-        "Should have 2 data manifest", 2, thirdSnapshot.dataManifests(table.io()).size());
-    Assert.assertEquals(
-        "Should have 2 delete manifest", 2, thirdSnapshot.deleteManifests(table.io()).size());
+    assertThat(thirdSnapshot.dataManifests(table.io())).hasSize(2);
+    assertThat(thirdSnapshot.deleteManifests(table.io())).hasSize(2);
 
     // commit two more delete files to the same specs to trigger merging
     DeleteFile thirdDeleteFile = newDeleteFile(firstSnapshotDataFile.specId(), "data_bucket=0");
@@ -1062,14 +967,11 @@ public class TestRowDelta extends V2TableTestBase {
     Snapshot fourthSnapshot = latestSnapshot(table, branch);
 
     // make sure merging respects spec boundaries
-    Assert.assertEquals(
-        "Should have 2 data manifest", 2, fourthSnapshot.dataManifests(table.io()).size());
-    Assert.assertEquals(
-        "Should have 2 delete manifest", 2, fourthSnapshot.deleteManifests(table.io()).size());
+    assertThat(fourthSnapshot.dataManifests(table.io())).hasSize(2);
+    assertThat(fourthSnapshot.deleteManifests(table.io())).hasSize(2);
 
     ManifestFile firstDeleteManifest = fourthSnapshot.deleteManifests(table.io()).get(1);
-    Assert.assertEquals(
-        "Spec must match", firstSnapshotDataFile.specId(), firstDeleteManifest.partitionSpecId());
+    assertThat(firstDeleteManifest.partitionSpecId()).isEqualTo(firstSnapshotDataFile.specId());
     validateDeleteManifest(
         firstDeleteManifest,
         dataSeqs(4L, 3L),
@@ -1079,8 +981,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED, Status.EXISTING));
 
     ManifestFile secondDeleteManifest = fourthSnapshot.deleteManifests(table.io()).get(0);
-    Assert.assertEquals(
-        "Spec must match", secondSnapshotDataFile.specId(), secondDeleteManifest.partitionSpecId());
+    assertThat(secondDeleteManifest.partitionSpecId()).isEqualTo(secondSnapshotDataFile.specId());
     validateDeleteManifest(
         secondDeleteManifest,
         dataSeqs(4L, 3L),
@@ -1090,7 +991,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED, Status.EXISTING));
   }
 
-  @Test
+  @TestTemplate
   public void testAbortMultipleSpecs() {
     // append a partitioned data file
     DataFile firstSnapshotDataFile = newDataFile("data_bucket=0");
@@ -1099,7 +1000,7 @@ public class TestRowDelta extends V2TableTestBase {
     // remove the only partition field to make the spec unpartitioned
     table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
 
-    Assert.assertTrue("Spec must be unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).isTrue();
 
     // append an unpartitioned data file
     DataFile secondSnapshotDataFile = newDataFile("");
@@ -1127,15 +1028,15 @@ public class TestRowDelta extends V2TableTestBase {
     // perform a conflicting concurrent operation
     commit(table, table.newDelete().deleteFile(firstSnapshotDataFile), branch);
 
-    Assertions.assertThatThrownBy(() -> commit(table, rowDelta, branch))
+    assertThatThrownBy(() -> commit(table, rowDelta, branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, missing data files");
 
     // we should clean up 1 manifest list and 2 delete manifests
-    Assert.assertEquals("Should delete 3 files", 3, deletedFiles.size());
+    assertThat(deletedFiles).hasSize(3);
   }
 
-  @Test
+  @TestTemplate
   public void testConcurrentConflictingRowDelta() {
     commit(table, table.newAppend().appendFile(FILE_A), branch);
 
@@ -1164,12 +1065,12 @@ public class TestRowDelta extends V2TableTestBase {
         .validateNoConflictingDataFiles()
         .commit();
 
-    Assertions.assertThatThrownBy(() -> commit(table, rowDelta, branch))
+    assertThatThrownBy(() -> commit(table, rowDelta, branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Found new conflicting delete files");
   }
 
-  @Test
+  @TestTemplate
   public void testConcurrentConflictingRowDeltaWithoutAppendValidation() {
     commit(table, table.newAppend().appendFile(FILE_A), branch);
 
@@ -1195,12 +1096,12 @@ public class TestRowDelta extends V2TableTestBase {
         .validateNoConflictingDataFiles()
         .commit();
 
-    Assertions.assertThatThrownBy(() -> commit(table, rowDelta, branch))
+    assertThatThrownBy(() -> commit(table, rowDelta, branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Found new conflicting delete files");
   }
 
-  @Test
+  @TestTemplate
   public void testConcurrentNonConflictingRowDelta() {
     // change the spec to be partitioned by data
     table
@@ -1278,7 +1179,7 @@ public class TestRowDelta extends V2TableTestBase {
     validateBranchDeleteFiles(table, branch, deleteFile1, deleteFile2);
   }
 
-  @Test
+  @TestTemplate
   public void testConcurrentNonConflictingRowDeltaAndRewriteFilesWithSequenceNumber() {
     // change the spec to be partitioned by data
     table
@@ -1328,7 +1229,7 @@ public class TestRowDelta extends V2TableTestBase {
     validateBranchFiles(table, branch, dataFile2);
   }
 
-  @Test
+  @TestTemplate
   public void testRowDeltaAndRewriteFilesMergeManifestsWithSequenceNumber() {
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "1").commit();
     // change the spec to be partitioned by data
@@ -1376,9 +1277,9 @@ public class TestRowDelta extends V2TableTestBase {
 
     table.refresh();
     List<ManifestFile> dataManifests = latestSnapshot(table, branch).dataManifests(table.io());
-    Assert.assertEquals("should have 1 data manifest", 1, dataManifests.size());
+    assertThat(dataManifests).hasSize(1);
     ManifestFile mergedDataManifest = dataManifests.get(0);
-    Assert.assertEquals("Manifest seq number must match", 3L, mergedDataManifest.sequenceNumber());
+    assertThat(mergedDataManifest.sequenceNumber()).isEqualTo(3);
 
     long currentSnapshotId = latestSnapshot(table, branch).snapshotId();
 
@@ -1391,7 +1292,7 @@ public class TestRowDelta extends V2TableTestBase {
         statuses(Status.ADDED, Status.DELETED));
   }
 
-  @Test
+  @TestTemplate
   public void testConcurrentConflictingRowDeltaAndRewriteFilesWithSequenceNumber() {
     // change the spec to be partitioned by data
     table
@@ -1433,12 +1334,12 @@ public class TestRowDelta extends V2TableTestBase {
 
     commit(table, rowDelta, branch);
 
-    Assertions.assertThatThrownBy(() -> commit(table, rewriteFiles, branch))
+    assertThatThrownBy(() -> commit(table, rewriteFiles, branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, found new position delete for replaced data file");
   }
 
-  @Test
+  @TestTemplate
   public void testRowDeltaCaseSensitivity() {
     commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_A2), branch);
 
@@ -1448,7 +1349,7 @@ public class TestRowDelta extends V2TableTestBase {
 
     Expression conflictDetectionFilter = Expressions.equal(Expressions.bucket("dAtA", 16), 0);
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .newRowDelta()
@@ -1463,7 +1364,7 @@ public class TestRowDelta extends V2TableTestBase {
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot find field 'dAtA'");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .newRowDelta()
@@ -1480,7 +1381,7 @@ public class TestRowDelta extends V2TableTestBase {
         .hasMessageStartingWith("Cannot find field 'dAtA'");
 
     // binding should succeed and trigger the validation
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .newRowDelta()

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -125,7 +125,7 @@ public class TestRowDelta extends V2TableTestBase {
         .as("Table state should not be modified by failed RowDelta operation")
         .isEqualTo(deleteSnapshotId);
 
-    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).hasSize(0);
+    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).isEmpty();
 
     commit(
         table,
@@ -176,7 +176,7 @@ public class TestRowDelta extends V2TableTestBase {
         .as("Table state should not be modified by failed RowDelta operation")
         .isEqualTo(deleteSnapshotId);
 
-    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).hasSize(0);
+    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).isEmpty();
   }
 
   @TestTemplate
@@ -208,7 +208,7 @@ public class TestRowDelta extends V2TableTestBase {
         .as("Table state should not be modified by failed RowDelta operation")
         .isEqualTo(deleteSnapshotId);
 
-    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).hasSize(0);
+    assertThat(latestSnapshot(table, branch).deleteManifests(table.io())).isEmpty();
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestSchemaAndMappingUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaAndMappingUpdate.java
@@ -260,7 +260,7 @@ public class TestSchemaAndMappingUpdate extends TestBase {
     MappedField newMapping = updated.find("id");
     assertThat(newMapping).isNotNull();
     assertThat(newMapping.id()).isEqualTo(idColumnId);
-    assertThat(newMapping.names()).isEqualTo(Sets.newHashSet("id", "data"));
+    assertThat(newMapping.names()).containsExactly("data", "id");
     assertThat(newMapping.nestedMapping()).isNull();
 
     MappedField updatedMapping = updated.find(startIdColumnId);
@@ -283,8 +283,7 @@ public class TestSchemaAndMappingUpdate extends TestBase {
 
     NameMapping afterRename =
         NameMappingParser.fromJson(table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
-    assertThat(afterRename.find(startIdColumnId).names())
-        .isEqualTo(Sets.newHashSet("id", "object_id"));
+    assertThat(afterRename.find(startIdColumnId).names()).containsExactly("id", "object_id");
 
     // add a new column with the renamed column's old name
     // also, rename the original column again to ensure its names are handled correctly
@@ -312,7 +311,7 @@ public class TestSchemaAndMappingUpdate extends TestBase {
     MappedField updatedMapping = updated.find(startIdColumnId);
     assertThat(updatedMapping).isNotNull();
     assertThat(updatedMapping.id()).isEqualTo(startIdColumnId);
-    assertThat(updatedMapping.names()).isEqualTo(Sets.newHashSet("object_id", "oid"));
+    assertThat(updatedMapping.names()).containsExactly("oid", "object_id");
     assertThat(updatedMapping.nestedMapping()).isNull();
   }
 
@@ -329,8 +328,7 @@ public class TestSchemaAndMappingUpdate extends TestBase {
 
     NameMapping afterRename =
         NameMappingParser.fromJson(table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
-    assertThat(afterRename.find(startIdColumnId).names())
-        .isEqualTo(Sets.newHashSet("id", "object_id"));
+    assertThat(afterRename.find(startIdColumnId).names()).containsExactly("id", "object_id");
 
     // rename the data column to the renamed column's old name
     // also, rename the original column again to ensure its names are handled correctly
@@ -348,14 +346,14 @@ public class TestSchemaAndMappingUpdate extends TestBase {
 
     MappedField newMapping = updated.find("id");
     assertThat(newMapping).isNotNull();
-    assertThat(newMapping.names()).isEqualTo(Sets.newHashSet("id", "data"));
+    assertThat(newMapping.names()).containsExactly("data", "id");
     assertThat(newMapping.id()).isEqualTo(idColumnId);
     assertThat(newMapping.nestedMapping()).isNull();
 
     MappedField updatedMapping = updated.find(startIdColumnId);
     assertThat(updatedMapping).isNotNull();
     assertThat(updatedMapping.id()).isEqualTo(startIdColumnId);
-    assertThat(updatedMapping.names()).isEqualTo(Sets.newHashSet("object_id", "oid"));
+    assertThat(updatedMapping.names()).containsExactly("oid", "object_id");
     assertThat(updatedMapping.nestedMapping()).isNull();
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -1601,9 +1601,8 @@ public class TestSchemaUpdate {
 
     assertThat(newSchema.identifierFieldIds())
         .as("add column then set as identifier should succeed")
-        .isEqualTo(
-            Sets.newHashSet(
-                newSchema.findField("id").fieldId(), newSchema.findField("new_field").fieldId()));
+        .containsExactly(
+            newSchema.findField("id").fieldId(), newSchema.findField("new_field").fieldId());
 
     newSchema =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -1614,9 +1613,8 @@ public class TestSchemaUpdate {
 
     assertThat(newSchema.identifierFieldIds())
         .as("set identifier then add column should succeed")
-        .isEqualTo(
-            Sets.newHashSet(
-                newSchema.findField("id").fieldId(), newSchema.findField("new_field").fieldId()));
+        .containsExactly(
+            newSchema.findField("id").fieldId(), newSchema.findField("new_field").fieldId());
   }
 
   @Test
@@ -1686,9 +1684,8 @@ public class TestSchemaUpdate {
 
     assertThat(newSchema.identifierFieldIds())
         .as("add a field with dot as identifier should succeed")
-        .isEqualTo(
-            Sets.newHashSet(
-                newSchema.findField("id").fieldId(), newSchema.findField("dot.field").fieldId()));
+        .containsExactly(
+            newSchema.findField("id").fieldId(), newSchema.findField("dot.field").fieldId());
   }
 
   @Test
@@ -1708,10 +1705,9 @@ public class TestSchemaUpdate {
 
     assertThat(newSchema.identifierFieldIds())
         .as("remove an identifier field should succeed")
-        .isEqualTo(
-            Sets.newHashSet(
-                newSchema.findField("new_field").fieldId(),
-                newSchema.findField("new_field2").fieldId()));
+        .containsExactly(
+            newSchema.findField("new_field").fieldId(),
+            newSchema.findField("new_field2").fieldId());
 
     newSchema =
         new SchemaUpdate(newSchema, SCHEMA_LAST_COLUMN_ID)

--- a/core/src/test/java/org/apache/iceberg/TestSingleValueParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSingleValueParser.java
@@ -20,14 +20,15 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.Locale;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSingleValueParser {
 
@@ -114,22 +115,18 @@ public class TestSingleValueParser {
   public void testInvalidFixed() {
     Type expectedType = Types.FixedType.ofLength(2);
     String defaultJson = "\"111ff\"";
-    Exception exception =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> defaultValueParseAndUnParseRoundTrip(expectedType, defaultJson));
-    Assert.assertTrue(exception.getMessage().startsWith("Cannot parse default fixed[2] value"));
+    assertThatThrownBy(() -> defaultValueParseAndUnParseRoundTrip(expectedType, defaultJson))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot parse default fixed[2] value");
   }
 
   @Test
   public void testInvalidUUID() {
     Type expectedType = Types.UUIDType.get();
     String defaultJson = "\"eb26bdb1-a1d8-4aa6-990e-da940875492c-abcde\"";
-    Exception exception =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> defaultValueParseAndUnParseRoundTrip(expectedType, defaultJson));
-    Assert.assertTrue(exception.getMessage().startsWith("Cannot parse default as a uuid value"));
+    assertThatThrownBy(() -> defaultValueParseAndUnParseRoundTrip(expectedType, defaultJson))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot parse default as a uuid value");
   }
 
   @Test
@@ -137,36 +134,27 @@ public class TestSingleValueParser {
     Type expectedType =
         Types.MapType.ofOptional(1, 2, Types.IntegerType.get(), Types.StringType.get());
     String defaultJson = "{\"keys\": [1, 2, 3], \"values\": [\"foo\", \"bar\"]}";
-    Exception exception =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> defaultValueParseAndUnParseRoundTrip(expectedType, defaultJson));
-    Assert.assertTrue(
-        exception.getMessage().startsWith("Cannot parse default as a map<int, string> value"));
+    assertThatThrownBy(() -> defaultValueParseAndUnParseRoundTrip(expectedType, defaultJson))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot parse default as a map<int, string> value");
   }
 
   @Test
   public void testInvalidDecimal() {
     Type expectedType = Types.DecimalType.of(5, 2);
     String defaultJson = "123.456";
-    Exception exception =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> defaultValueParseAndUnParseRoundTrip(expectedType, defaultJson));
-    Assert.assertTrue(
-        exception.getMessage().startsWith("Cannot parse default as a decimal(5, 2) value"));
+    assertThatThrownBy(() -> defaultValueParseAndUnParseRoundTrip(expectedType, defaultJson))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot parse default as a decimal(5, 2) value");
   }
 
   @Test
   public void testInvalidTimestamptz() {
     Type expectedType = Types.TimestampType.withZone();
     String defaultJson = "\"2007-12-03T10:15:30+01:00\"";
-    Exception exception =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> defaultValueParseAndUnParseRoundTrip(expectedType, defaultJson));
-    Assert.assertTrue(
-        exception.getMessage().startsWith("Cannot parse default as a timestamptz value"));
+    assertThatThrownBy(() -> defaultValueParseAndUnParseRoundTrip(expectedType, defaultJson))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot parse default as a timestamptz value");
   }
 
   // serialize to json and deserialize back should return the same result
@@ -176,6 +164,6 @@ public class TestSingleValueParser {
   }
 
   private static void jsonStringEquals(String s1, String s2) throws IOException {
-    Assert.assertEquals(JsonUtil.mapper().readTree(s1), JsonUtil.mapper().readTree(s2));
+    assertThat(JsonUtil.mapper().readTree(s2)).isEqualTo(JsonUtil.mapper().readTree(s1));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
@@ -19,9 +19,14 @@
 package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -33,17 +38,13 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(Parameterized.class)
-public class TestSplitPlanning extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSplitPlanning extends TestBase {
 
   private static final Configuration CONF = new Configuration();
   private static final HadoopTables TABLES = new HadoopTables(CONF);
@@ -51,22 +52,20 @@ public class TestSplitPlanning extends TableTestBase {
       new Schema(
           optional(1, "id", Types.IntegerType.get()), optional(2, "data", Types.StringType.get()));
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  // @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
+
   private Table table = null;
 
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
-  }
-
-  public TestSplitPlanning(int formatVersion) {
-    super(formatVersion);
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
   @Override
-  @Before
+  @BeforeEach
   public void setupTable() throws IOException {
-    File tableDir = temp.newFolder();
+    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
     String tableLocation = tableDir.toURI().toString();
     table = TABLES.create(SCHEMA, tableLocation);
     table
@@ -77,19 +76,19 @@ public class TestSplitPlanning extends TableTestBase {
         .commit();
   }
 
-  @Test
+  @TestTemplate
   public void testBasicSplitPlanning() {
     List<DataFile> files128Mb = newFiles(4, 128 * 1024 * 1024);
     appendFiles(files128Mb);
     // we expect 4 bins since split size is 128MB and we have 4 files 128MB each
-    Assert.assertEquals(4, Iterables.size(table.newScan().planTasks()));
+    assertThat(table.newScan().planTasks()).hasSize(4);
     List<DataFile> files32Mb = newFiles(16, 32 * 1024 * 1024);
     appendFiles(files32Mb);
     // we expect 8 bins after we add 16 files 32MB each as they will form additional 4 bins
-    Assert.assertEquals(8, Iterables.size(table.newScan().planTasks()));
+    assertThat(table.newScan().planTasks()).hasSize(8);
   }
 
-  @Test
+  @TestTemplate
   public void testSplitPlanningWithSmallFiles() {
     List<DataFile> files60Mb = newFiles(50, 60 * 1024 * 1024);
     List<DataFile> files5Kb = newFiles(370, 5 * 1024);
@@ -101,10 +100,10 @@ public class TestSplitPlanning extends TableTestBase {
     // as "read.split.open-file-cost" is 4MB, each of the original 25 bins will get at most 2 files
     // so 50 of 370 files will be packed into the existing 25 bins and the remaining 320 files
     // will form additional 10 bins, resulting in 35 bins in total
-    Assert.assertEquals(35, Iterables.size(table.newScan().planTasks()));
+    assertThat(table.newScan().planTasks()).hasSize(35);
   }
 
-  @Test
+  @TestTemplate
   public void testSplitPlanningWithNoMinWeight() {
     table.updateProperties().set(TableProperties.SPLIT_OPEN_FILE_COST, "0").commit();
     List<DataFile> files60Mb = newFiles(2, 60 * 1024 * 1024);
@@ -112,30 +111,30 @@ public class TestSplitPlanning extends TableTestBase {
     Iterable<DataFile> files = Iterables.concat(files60Mb, files5Kb);
     appendFiles(files);
     // all small files will be packed into one bin as "read.split.open-file-cost" is set to 0
-    Assert.assertEquals(1, Iterables.size(table.newScan().planTasks()));
+    assertThat(table.newScan().planTasks()).hasSize(1);
   }
 
-  @Test
+  @TestTemplate
   public void testSplitPlanningWithOverridenSize() {
     List<DataFile> files128Mb = newFiles(4, 128 * 1024 * 1024);
     appendFiles(files128Mb);
     // we expect 2 bins since we are overriding split size in scan with 256MB
     TableScan scan =
         table.newScan().option(TableProperties.SPLIT_SIZE, String.valueOf(256L * 1024 * 1024));
-    Assert.assertEquals(2, Iterables.size(scan.planTasks()));
+    assertThat(scan.planTasks()).hasSize(2);
   }
 
-  @Test
+  @TestTemplate
   public void testSplitPlanningWithOverriddenSizeForMetadataJsonFile() {
     List<DataFile> files8Mb = newFiles(32, 8 * 1024 * 1024, FileFormat.METADATA);
     appendFiles(files8Mb);
     // we expect 16 bins since we are overriding split size in scan with 16MB
     TableScan scan =
         table.newScan().option(TableProperties.SPLIT_SIZE, String.valueOf(16L * 1024 * 1024));
-    Assert.assertEquals(16, Iterables.size(scan.planTasks()));
+    assertThat(scan.planTasks()).hasSize(16);
   }
 
-  @Test
+  @TestTemplate
   public void testSplitPlanningWithOverriddenSizeForLargeMetadataJsonFile() {
     List<DataFile> files128Mb = newFiles(4, 128 * 1024 * 1024, FileFormat.METADATA);
     appendFiles(files128Mb);
@@ -143,10 +142,10 @@ public class TestSplitPlanning extends TableTestBase {
     // splittable
     TableScan scan =
         table.newScan().option(TableProperties.SPLIT_SIZE, String.valueOf(8L * 1024 * 1024));
-    Assert.assertEquals(4, Iterables.size(scan.planTasks()));
+    assertThat(scan.planTasks()).hasSize(4);
   }
 
-  @Test
+  @TestTemplate
   public void testSplitPlanningWithOverridenLookback() {
     List<DataFile> files120Mb = newFiles(1, 120 * 1024 * 1024);
     List<DataFile> file128Mb = newFiles(1, 128 * 1024 * 1024);
@@ -155,15 +154,15 @@ public class TestSplitPlanning extends TableTestBase {
     // we expect 2 bins from non-overriden table properties
     TableScan scan = table.newScan().option(TableProperties.SPLIT_LOOKBACK, "1");
     CloseableIterable<CombinedScanTask> tasks = scan.planTasks();
-    Assert.assertEquals(2, Iterables.size(tasks));
+    assertThat(tasks).hasSize(2);
 
     // since lookback was overridden to 1, we expect the first bin to be the largest of the two.
     CombinedScanTask combinedScanTask = tasks.iterator().next();
     FileScanTask task = combinedScanTask.files().iterator().next();
-    Assert.assertEquals(128 * 1024 * 1024, task.length());
+    assertThat(task.length()).isEqualTo(128 * 1024 * 1024);
   }
 
-  @Test
+  @TestTemplate
   public void testSplitPlanningWithOverridenOpenCostSize() {
     List<DataFile> files16Mb = newFiles(16, 16 * 1024 * 1024);
     appendFiles(files16Mb);
@@ -173,18 +172,18 @@ public class TestSplitPlanning extends TableTestBase {
         table
             .newScan()
             .option(TableProperties.SPLIT_OPEN_FILE_COST, String.valueOf(32L * 1024 * 1024));
-    Assert.assertEquals(4, Iterables.size(scan.planTasks()));
+    assertThat(scan.planTasks()).hasSize(4);
   }
 
-  @Test
+  @TestTemplate
   public void testSplitPlanningWithNegativeValues() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table.newScan().option(TableProperties.SPLIT_SIZE, String.valueOf(-10)).planTasks())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Split size must be > 0: -10");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .newScan()
@@ -193,7 +192,7 @@ public class TestSplitPlanning extends TableTestBase {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Split planning lookback must be > 0: -10");
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 table
                     .newScan()
@@ -203,7 +202,7 @@ public class TestSplitPlanning extends TableTestBase {
         .hasMessage("File open cost must be >= 0: -10");
   }
 
-  @Test
+  @TestTemplate
   public void testSplitPlanningWithOffsets() {
     List<DataFile> files16Mb = newFiles(16, 16 * 1024 * 1024, 2);
     appendFiles(files16Mb);
@@ -212,11 +211,10 @@ public class TestSplitPlanning extends TableTestBase {
     // 1 split per row group
     TableScan scan =
         table.newScan().option(TableProperties.SPLIT_SIZE, String.valueOf(10L * 1024 * 1024));
-    Assert.assertEquals(
-        "We should get one task per row group", 32, Iterables.size(scan.planTasks()));
+    assertThat(scan.planTasks()).hasSize(32);
   }
 
-  @Test
+  @TestTemplate
   public void testSplitPlanningWithOffsetsUnableToSplit() {
     List<DataFile> files16Mb = newFiles(16, 16 * 1024 * 1024, 2);
     appendFiles(files16Mb);
@@ -228,11 +226,10 @@ public class TestSplitPlanning extends TableTestBase {
             .newScan()
             .option(TableProperties.SPLIT_OPEN_FILE_COST, String.valueOf(0))
             .option(TableProperties.SPLIT_SIZE, String.valueOf(4L * 1024 * 1024));
-    Assert.assertEquals(
-        "We should still only get 2 tasks per file", 32, Iterables.size(scan.planTasks()));
+    assertThat(scan.planTasks()).hasSize(32);
   }
 
-  @Test
+  @TestTemplate
   public void testBasicSplitPlanningDeleteFiles() {
     table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
     List<DeleteFile> files128Mb = newDeleteFiles(4, 128 * 1024 * 1024);
@@ -240,14 +237,14 @@ public class TestSplitPlanning extends TableTestBase {
 
     PositionDeletesTable posDeletesTable = new PositionDeletesTable(table);
     // we expect 4 bins since split size is 128MB and we have 4 files 128MB each
-    Assert.assertEquals(4, Iterables.size(posDeletesTable.newBatchScan().planTasks()));
+    assertThat(posDeletesTable.newBatchScan().planTasks()).hasSize(4);
     List<DeleteFile> files32Mb = newDeleteFiles(16, 32 * 1024 * 1024);
     appendDeleteFiles(files32Mb);
     // we expect 8 bins after we add 16 files 32MB each as they will form additional 4 bins
-    Assert.assertEquals(8, Iterables.size(posDeletesTable.newBatchScan().planTasks()));
+    assertThat(posDeletesTable.newBatchScan().planTasks()).hasSize(8);
   }
 
-  @Test
+  @TestTemplate
   public void testBasicSplitPlanningDeleteFilesWithSplitOffsets() {
     table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
     List<DeleteFile> files128Mb = newDeleteFiles(4, 128 * 1024 * 1024, 8);
@@ -266,19 +263,19 @@ public class TestSplitPlanning extends TableTestBase {
         long previousOffset = -1;
         for (ScanTask task : group.tasks()) {
           tasksPerGroup++;
-          Assert.assertTrue(task instanceof SplitPositionDeletesScanTask);
+          assertThat(task).isInstanceOf(SplitPositionDeletesScanTask.class);
           SplitPositionDeletesScanTask splitPosDelTask = (SplitPositionDeletesScanTask) task;
           if (previousOffset != -1) {
-            Assert.assertEquals(splitPosDelTask.start(), previousOffset);
+            assertThat(previousOffset).isEqualTo(splitPosDelTask.start());
           }
           previousOffset = splitPosDelTask.start() + splitPosDelTask.length();
         }
 
-        Assert.assertEquals("Should have 1 task as result of task merge", 1, tasksPerGroup);
+        assertThat(tasksPerGroup).isEqualTo(1);
         totalTaskGroups++;
       }
       // we expect 8 bins since split size is 64MB
-      Assert.assertEquals(8, totalTaskGroups);
+      assertThat(totalTaskGroups).isEqualTo(8);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
@@ -52,7 +52,6 @@ public class TestSplitPlanning extends TestBase {
       new Schema(
           optional(1, "id", Types.IntegerType.get()), optional(2, "data", Types.StringType.get()));
 
-  // @Rule public TemporaryFolder temp = new TemporaryFolder();
   @TempDir private Path temp;
 
   private Table table = null;

--- a/core/src/test/java/org/apache/iceberg/TestV1ToV2RowDeltaDelete.java
+++ b/core/src/test/java/org/apache/iceberg/TestV1ToV2RowDeltaDelete.java
@@ -20,19 +20,19 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.expressions.Expressions.bucket;
 import static org.apache.iceberg.expressions.Expressions.equal;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.TestTemplate;
 
-public class TestV1ToV2RowDeltaDelete extends TableTestBase {
+public class TestV1ToV2RowDeltaDelete extends TestBase {
 
-  public TestV1ToV2RowDeltaDelete() {
-    super(1 /* table format version */);
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1);
   }
 
   static final DeleteFile FILE_A_POS_1 =
@@ -55,20 +55,18 @@ public class TestV1ToV2RowDeltaDelete extends TableTestBase {
 
   private void verifyManifestSequenceNumber(
       ManifestFile mf, long sequenceNum, long minSequenceNum) {
-    Assert.assertEquals(
-        "sequence number should be " + sequenceNum, mf.sequenceNumber(), sequenceNum);
-    Assert.assertEquals(
-        "min sequence number should be " + minSequenceNum, mf.minSequenceNumber(), minSequenceNum);
+    assertThat(sequenceNum).isEqualTo(mf.sequenceNumber());
+    assertThat(minSequenceNum).isEqualTo(mf.minSequenceNumber());
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedTableWithPartitionEqDeletes() {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).appendFile(FILE_C).commit();
 
     List<ManifestFile> dataManifests = table.currentSnapshot().dataManifests(table.io());
     List<ManifestFile> deleteManifests = table.currentSnapshot().deleteManifests(table.io());
-    Assert.assertEquals("Should have one data manifest file", 1, dataManifests.size());
-    Assert.assertEquals("Should have zero delete manifest file", 0, deleteManifests.size());
+    assertThat(dataManifests).hasSize(1);
+    assertThat(deleteManifests).isEmpty();
     ManifestFile dataManifest = dataManifests.get(0);
     verifyManifestSequenceNumber(dataManifest, 0, 0);
 
@@ -81,56 +79,52 @@ public class TestV1ToV2RowDeltaDelete extends TableTestBase {
 
     dataManifests = table.currentSnapshot().dataManifests(ops.io());
     deleteManifests = table.currentSnapshot().deleteManifests(ops.io());
-    Assert.assertEquals("Should have one data manifest file", 1, dataManifests.size());
-    Assert.assertEquals("Should have one delete manifest file", 1, deleteManifests.size());
-    Assert.assertEquals(dataManifest, dataManifests.get(0)); // data manifest not changed
+    assertThat(dataManifests).hasSize(1).first().isEqualTo(dataManifest);
+    assertThat(deleteManifests).hasSize(1);
     ManifestFile deleteManifest = deleteManifests.get(0);
     verifyManifestSequenceNumber(deleteManifest, 1, 1);
     List<FileScanTask> tasks = Lists.newArrayList(table.newScan().planFiles().iterator());
-    Assert.assertEquals("Should have three task", 3, tasks.size());
+    assertThat(tasks).hasSize(3);
     Optional<FileScanTask> task =
         tasks.stream().filter(t -> t.file().path().equals(FILE_A.path())).findFirst();
-    Assert.assertTrue(task.isPresent());
-    Assert.assertEquals("Should have one associated delete file", 1, task.get().deletes().size());
-    Assert.assertEquals(
-        "Should have only pos delete file", FILE_A_EQ_1.path(), task.get().deletes().get(0).path());
+    assertThat(task.isPresent()).isTrue();
+    assertThat(task.get().deletes()).hasSize(1);
+    assertThat(task.get().deletes().get(0).path())
+        .as("Should have only pos delete file")
+        .isEqualTo(FILE_A_EQ_1.path());
 
     // first commit after row-delta changes
     table.newDelete().deleteFile(FILE_B).commit();
 
     dataManifests = table.currentSnapshot().dataManifests(ops.io());
     deleteManifests = table.currentSnapshot().deleteManifests(ops.io());
-    Assert.assertEquals("Should have one data manifest file", 1, dataManifests.size());
-    Assert.assertEquals("Should have one delete manifest file", 1, deleteManifests.size());
+    assertThat(dataManifests).hasSize(1).first().isNotEqualTo(dataManifest);
+    assertThat(deleteManifests).hasSize(1).first().isEqualTo(deleteManifest);
     ManifestFile dataManifest2 = dataManifests.get(0);
-    verifyManifestSequenceNumber(dataManifest2, 2, 0);
-    Assert.assertNotEquals(dataManifest, dataManifest2);
-    Assert.assertEquals(deleteManifest, deleteManifests.get(0)); // delete manifest not changed
+    verifyManifestSequenceNumber(dataManifests.get(0), 2, 0);
     tasks = Lists.newArrayList(table.newScan().planFiles().iterator());
-    Assert.assertEquals("Should have two task", 2, tasks.size());
+    assertThat(tasks).hasSize(2);
     task = tasks.stream().filter(t -> t.file().path().equals(FILE_A.path())).findFirst();
-    Assert.assertTrue(task.isPresent());
-    Assert.assertEquals("Should have one associated delete file", 1, task.get().deletes().size());
+    assertThat(task.isPresent()).isTrue();
+    assertThat(task.get().deletes()).hasSize(1);
 
     // second commit after row-delta changes
     table.newDelete().deleteFile(FILE_C).commit();
 
     dataManifests = table.currentSnapshot().dataManifests(ops.io());
     deleteManifests = table.currentSnapshot().deleteManifests(ops.io());
-    Assert.assertEquals("Should have one data manifest file", 1, dataManifests.size());
-    Assert.assertEquals("Should have one delete manifest file", 1, deleteManifests.size());
+    assertThat(dataManifests).hasSize(1).first().isNotEqualTo(dataManifest2);
+    assertThat(deleteManifests).hasSize(1).first().isEqualTo(deleteManifest);
     ManifestFile dataManifest3 = dataManifests.get(0);
     verifyManifestSequenceNumber(dataManifest3, 3, 0);
-    Assert.assertNotEquals(dataManifest2, dataManifest3);
-    Assert.assertEquals(deleteManifest, deleteManifests.get(0)); // delete manifest not changed
     tasks = Lists.newArrayList(table.newScan().planFiles().iterator());
-    Assert.assertEquals("Should have one task", 1, tasks.size());
+    assertThat(tasks).hasSize(1);
     task = tasks.stream().filter(t -> t.file().path().equals(FILE_A.path())).findFirst();
-    Assert.assertTrue(task.isPresent());
-    Assert.assertEquals("Should have one associated delete file", 1, task.get().deletes().size());
+    assertThat(task.isPresent()).isTrue();
+    assertThat(task.get().deletes()).hasSize(1);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedTableWithUnrelatedPartitionDeletes() {
     table.newAppend().appendFile(FILE_B).appendFile(FILE_C).appendFile(FILE_D).commit();
 
@@ -142,26 +136,22 @@ public class TestV1ToV2RowDeltaDelete extends TableTestBase {
     table.newRowDelta().addDeletes(FILE_A_POS_1).addDeletes(FILE_A_EQ_1).commit();
 
     List<FileScanTask> tasks = Lists.newArrayList(table.newScan().planFiles().iterator());
-    Assert.assertEquals("Should have three task", 3, tasks.size());
-    Assert.assertEquals(
-        "Should have the correct data file path", FILE_B.path(), tasks.get(0).file().path());
-    Assert.assertEquals(
-        "Should have zero associated delete file", 0, tasks.get(0).deletes().size());
+    assertThat(tasks).hasSize(3);
+    assertThat(tasks.get(0).file().path()).isEqualTo(FILE_B.path());
+    assertThat(tasks.get(0).deletes()).isEmpty();
 
     table.newDelete().deleteFile(FILE_B).commit();
     tasks = Lists.newArrayList(table.newScan().planFiles().iterator());
-    Assert.assertEquals("Should have two task", 2, tasks.size());
-    Assert.assertEquals(
-        "Should have zero associated delete file", 0, tasks.get(0).deletes().size());
+    assertThat(tasks).hasSize(2);
+    assertThat(tasks.get(0).deletes()).isEmpty();
 
     table.newDelete().deleteFile(FILE_C).commit();
     tasks = Lists.newArrayList(table.newScan().planFiles().iterator());
-    Assert.assertEquals("Should have one task", 1, tasks.size());
-    Assert.assertEquals(
-        "Should have zero associated delete file", 0, tasks.get(0).deletes().size());
+    assertThat(tasks).hasSize(1);
+    assertThat(tasks.get(0).deletes()).isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedTableWithExistingDeleteFile() {
     table.updateProperties().set(TableProperties.MANIFEST_MERGE_ENABLED, "false").commit();
 
@@ -182,30 +172,18 @@ public class TestV1ToV2RowDeltaDelete extends TableTestBase {
         .set(TableProperties.MANIFEST_MERGE_ENABLED, "true")
         .commit();
 
-    Assert.assertEquals(
-        "Should have two delete manifests",
-        2,
-        table.currentSnapshot().deleteManifests(table.io()).size());
+    assertThat(table.currentSnapshot().deleteManifests(table.io())).hasSize(2);
 
     // merge delete manifests
     table.newAppend().appendFile(FILE_B).commit();
 
-    Assert.assertEquals(
-        "Should have one delete manifest",
-        1,
-        table.currentSnapshot().deleteManifests(table.io()).size());
-    Assert.assertEquals(
-        "Should have zero added delete file",
-        0,
-        table.currentSnapshot().deleteManifests(table.io()).get(0).addedFilesCount().intValue());
-    Assert.assertEquals(
-        "Should have zero deleted delete file",
-        0,
-        table.currentSnapshot().deleteManifests(table.io()).get(0).deletedFilesCount().intValue());
-    Assert.assertEquals(
-        "Should have two existing delete files",
-        2,
-        table.currentSnapshot().deleteManifests(table.io()).get(0).existingFilesCount().intValue());
+    assertThat(table.currentSnapshot().deleteManifests(table.io())).hasSize(1);
+    assertThat(table.currentSnapshot().deleteManifests(table.io()).get(0).addedFilesCount())
+        .isEqualTo(0);
+    assertThat(table.currentSnapshot().deleteManifests(table.io()).get(0).deletedFilesCount())
+        .isEqualTo(0);
+    assertThat(table.currentSnapshot().deleteManifests(table.io()).get(0).existingFilesCount())
+        .isEqualTo(2);
 
     List<FileScanTask> tasks =
         Lists.newArrayList(
@@ -214,19 +192,16 @@ public class TestV1ToV2RowDeltaDelete extends TableTestBase {
                 .filter(equal(bucket("data", BUCKETS_NUMBER), 0))
                 .planFiles()
                 .iterator());
-    Assert.assertEquals("Should have one task", 1, tasks.size());
+    assertThat(tasks).hasSize(1);
 
     FileScanTask task = tasks.get(0);
-    Assert.assertEquals(
-        "Should have the correct data file path", FILE_A.path(), task.file().path());
-    Assert.assertEquals("Should have two associated delete files", 2, task.deletes().size());
-    Assert.assertEquals(
-        "Should have expected delete files",
-        Sets.newHashSet(FILE_A_EQ_1.path(), FILE_A_POS_1.path()),
-        Sets.newHashSet(Iterables.transform(task.deletes(), ContentFile::path)));
+    assertThat(task.file().path()).isEqualTo(FILE_A.path());
+    assertThat(task.deletes()).hasSize(2);
+    assertThat(task.deletes().get(0).path()).isEqualTo(FILE_A_EQ_1.path());
+    assertThat(task.deletes().get(1).path()).isEqualTo(FILE_A_POS_1.path());
   }
 
-  @Test
+  @TestTemplate
   public void testSequenceNumbersInUpgradedTables() {
     // add initial data
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();

--- a/core/src/test/java/org/apache/iceberg/V2TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/V2TableTestBase.java
@@ -18,8 +18,12 @@
  */
 package org.apache.iceberg;
 
-public class V2TableTestBase extends TableTestBase {
-  public V2TableTestBase() {
-    super(2);
+import java.util.Arrays;
+import java.util.List;
+
+public class V2TableTestBase extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(2);
   }
 }


### PR DESCRIPTION
Migrate the following test classes in iceberg-core to JUnit 5 and AssertJ style for https://github.com/apache/iceberg/issues/9085.

## Current Progress 
- [x] `TestMetricsModes.java` 
- [x] `TestMicroBatchBuilder.java`
- [x] `TestRemoveSnapshots.java`
- [x] `TestRewriteManifests.java`
- [x] `TestRowDelta.java`
- [x] `TestSequenceNumberForV2Table.java`
- [x] `TestSingleValueParser.java`
- [x] `TestSortOrder.java`
- [x] `TestSortOrderParser.java`
- [x] `TestSplitPlanning.java`
- [x] `TestV1ToV2RowDeltaDelete.java` 
- [x] `V2TableTestBase.java` 

Refactoring (related to https://github.com/apache/iceberg/pull/10014#discussion_r1534263933):
- [x] `TestSchemaAndMappingUpdate.java`
- [x] `TestSchemaUpdate`