### PR TITLE
Migrate WAP, Metrics and FilterFiles in Core to JUnit5

### DIFF
--- a/core/src/test/java/org/apache/iceberg/FilterFilesTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/FilterFilesTestBase.java
@@ -19,7 +19,7 @@
 package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,7 +28,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
@@ -119,10 +118,10 @@ public abstract class FilterFilesTestBase<
     table.refresh();
 
     ScanT emptyScan = newScan(table).filter(Expressions.equal("id", 5));
-    assertEquals(0, Iterables.size(emptyScan.planFiles()));
+    assertThat(emptyScan.planFiles()).isEmpty();
 
     ScanT nonEmptyScan = newScan(table).filter(Expressions.equal("id", 1));
-    assertEquals(1, Iterables.size(nonEmptyScan.planFiles()));
+    assertThat(nonEmptyScan.planFiles()).hasSize(1);
   }
 
   private void testCaseInsensitiveFilterFiles(Table table) {
@@ -153,9 +152,9 @@ public abstract class FilterFilesTestBase<
     table.refresh();
 
     ScanT emptyScan = newScan(table).caseSensitive(false).filter(Expressions.equal("ID", 5));
-    assertEquals(0, Iterables.size(emptyScan.planFiles()));
+    assertThat(emptyScan.planFiles()).hasSize(0);
 
     ScanT nonEmptyScan = newScan(table).caseSensitive(false).filter(Expressions.equal("ID", 1));
-    assertEquals(1, Iterables.size(nonEmptyScan.planFiles()));
+    assertThat(nonEmptyScan.planFiles()).hasSize(1);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -21,6 +21,8 @@ package org.apache.iceberg;
 import static org.apache.iceberg.types.Conversions.fromByteBuffer;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,9 +30,12 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.InputFile;
@@ -56,21 +61,19 @@ import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.types.Types.TimeType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.util.DateTimeUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Tests for Metrics. */
 public abstract class TestMetrics {
 
-  protected TestMetrics(int formatVersion) {
-    this.formatVersion = formatVersion;
+  @Parameters(name = "formatVersion = {0}")
+  public static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir public Path temp;
 
   private static final StructType LEAF_STRUCT_TYPE =
       StructType.of(
@@ -113,10 +116,10 @@ public abstract class TestMetrics {
   private static final Record NAN_ONLY_RECORD =
       createRecordWithFloatAndDouble(Float.NaN, Double.NaN);
 
-  private final int formatVersion;
+  @Parameter private int formatVersion;
   private final byte[] fixed = "abcd".getBytes(StandardCharsets.UTF_8);
 
-  @After
+  @AfterEach
   public void after() {
     TestTables.clearTables();
   }
@@ -146,7 +149,7 @@ public abstract class TestMetrics {
 
   protected abstract OutputFile createOutputFile() throws IOException;
 
-  @Test
+  @TestTemplate
   public void testMetricsForRepeatedValues() throws IOException {
     Record record = GenericRecord.create(SIMPLE_SCHEMA);
     record.setField("booleanCol", true);
@@ -164,7 +167,7 @@ public abstract class TestMetrics {
     record.setField("timestampColBelowEpoch", DateTimeUtil.timestampFromMicros(0L));
 
     Metrics metrics = getMetrics(SIMPLE_SCHEMA, record, record);
-    Assert.assertEquals(2L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(2L);
     assertCounts(1, 2L, 0L, metrics);
     assertCounts(2, 2L, 0L, metrics);
     assertCounts(3, 2L, 2L, metrics);
@@ -180,7 +183,7 @@ public abstract class TestMetrics {
     assertCounts(13, 2L, 0L, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsForTopLevelFields() throws IOException {
     Record firstRecord = GenericRecord.create(SIMPLE_SCHEMA);
     firstRecord.setField("booleanCol", true);
@@ -212,7 +215,7 @@ public abstract class TestMetrics {
     secondRecord.setField("timestampColBelowEpoch", DateTimeUtil.timestampFromMicros(-7_000L));
 
     Metrics metrics = getMetrics(SIMPLE_SCHEMA, firstRecord, secondRecord);
-    Assert.assertEquals(2L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(2L);
     assertCounts(1, 2L, 0L, metrics);
     assertBounds(1, BooleanType.get(), false, true, metrics);
     assertCounts(2, 2L, 0L, metrics);
@@ -255,7 +258,7 @@ public abstract class TestMetrics {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsForDecimals() throws IOException {
     Schema schema =
         new Schema(
@@ -269,7 +272,7 @@ public abstract class TestMetrics {
     record.setField("decimalAsFixed", new BigDecimal("5.80"));
 
     Metrics metrics = getMetrics(schema, record);
-    Assert.assertEquals(1L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(1);
     assertCounts(1, 1L, 0L, metrics);
     assertBounds(1, DecimalType.of(4, 2), new BigDecimal("2.55"), new BigDecimal("2.55"), metrics);
     assertCounts(2, 1L, 0L, metrics);
@@ -278,10 +281,10 @@ public abstract class TestMetrics {
     assertBounds(3, DecimalType.of(22, 2), new BigDecimal("5.80"), new BigDecimal("5.80"), metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsForNestedStructFields() throws IOException {
     Metrics metrics = getMetrics(NESTED_SCHEMA, buildNestedTestRecord());
-    Assert.assertEquals(1L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(1L);
     assertCounts(1, 1L, 0L, metrics);
     assertBounds(1, IntegerType.get(), Integer.MAX_VALUE, Integer.MAX_VALUE, metrics);
     assertCounts(3, 1L, 0L, metrics);
@@ -299,7 +302,7 @@ public abstract class TestMetrics {
     assertBounds(7, DoubleType.get(), null, null, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsModeForNestedStructFields() throws IOException {
     Map<String, String> properties =
         ImmutableMap.of(
@@ -310,9 +313,9 @@ public abstract class TestMetrics {
     MetricsConfig config = MetricsConfig.fromProperties(properties);
 
     Metrics metrics = getMetrics(NESTED_SCHEMA, config, buildNestedTestRecord());
-    Assert.assertEquals(1L, (long) metrics.recordCount());
-    Assert.assertEquals(1, metrics.lowerBounds().size());
-    Assert.assertEquals(1, metrics.upperBounds().size());
+    assertThat(metrics.recordCount()).isEqualTo(1L);
+    assertThat(metrics.lowerBounds()).hasSize(1);
+    assertThat(metrics.upperBounds()).hasSize(1);
     assertBounds(3, LongType.get(), 100L, 100L, metrics);
   }
 
@@ -331,7 +334,7 @@ public abstract class TestMetrics {
     return record;
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsForListAndMapElements() throws IOException {
     StructType structType =
         StructType.of(
@@ -352,7 +355,7 @@ public abstract class TestMetrics {
     record.set(1, map);
 
     Metrics metrics = getMetrics(schema, record);
-    Assert.assertEquals(1L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(1L);
     if (fileFormat() != FileFormat.ORC) {
       assertCounts(1, 1L, 0L, metrics);
       assertCounts(2, 1L, 0L, metrics);
@@ -371,7 +374,7 @@ public abstract class TestMetrics {
     assertBounds(7, structType, null, null, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsForNullColumns() throws IOException {
     Schema schema = new Schema(optional(1, "intCol", IntegerType.get()));
     Record firstRecord = GenericRecord.create(schema);
@@ -380,15 +383,15 @@ public abstract class TestMetrics {
     secondRecord.setField("intCol", null);
 
     Metrics metrics = getMetrics(schema, firstRecord, secondRecord);
-    Assert.assertEquals(2L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(2L);
     assertCounts(1, 2L, 2L, metrics);
     assertBounds(1, IntegerType.get(), null, null, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsForNaNColumns() throws IOException {
     Metrics metrics = getMetrics(FLOAT_DOUBLE_ONLY_SCHEMA, NAN_ONLY_RECORD, NAN_ONLY_RECORD);
-    Assert.assertEquals(2L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(2L);
     assertCounts(1, 2L, 0L, 2L, metrics);
     assertCounts(2, 2L, 0L, 2L, metrics);
 
@@ -396,7 +399,7 @@ public abstract class TestMetrics {
     assertBounds(2, DoubleType.get(), null, null, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testColumnBoundsWithNaNValueAtFront() throws IOException {
     Metrics metrics =
         getMetrics(
@@ -404,7 +407,7 @@ public abstract class TestMetrics {
             NAN_ONLY_RECORD,
             FLOAT_DOUBLE_RECORD_1,
             FLOAT_DOUBLE_RECORD_2);
-    Assert.assertEquals(3L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(3L);
     assertCounts(1, 3L, 0L, 1L, metrics);
     assertCounts(2, 3L, 0L, 1L, metrics);
 
@@ -412,7 +415,7 @@ public abstract class TestMetrics {
     assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testColumnBoundsWithNaNValueInMiddle() throws IOException {
     Metrics metrics =
         getMetrics(
@@ -420,7 +423,7 @@ public abstract class TestMetrics {
             FLOAT_DOUBLE_RECORD_1,
             NAN_ONLY_RECORD,
             FLOAT_DOUBLE_RECORD_2);
-    Assert.assertEquals(3L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(3L);
     assertCounts(1, 3L, 0L, 1L, metrics);
     assertCounts(2, 3L, 0L, 1L, metrics);
 
@@ -428,7 +431,7 @@ public abstract class TestMetrics {
     assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testColumnBoundsWithNaNValueAtEnd() throws IOException {
     Metrics metrics =
         getMetrics(
@@ -436,7 +439,7 @@ public abstract class TestMetrics {
             FLOAT_DOUBLE_RECORD_1,
             FLOAT_DOUBLE_RECORD_2,
             NAN_ONLY_RECORD);
-    Assert.assertEquals(3L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(3L);
     assertCounts(1, 3L, 0L, 1L, metrics);
     assertCounts(2, 3L, 0L, 1L, metrics);
 
@@ -444,10 +447,11 @@ public abstract class TestMetrics {
     assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsForTopLevelWithMultipleRowGroup() throws Exception {
-    Assume.assumeTrue(
-        "Skip test for formats that do not support small row groups", supportsSmallRowGroups());
+    assumeThat(supportsSmallRowGroups())
+        .as("Skip test for formats that do not support small row groups")
+        .isTrue();
 
     int recordCount = 201;
     List<Record> records = Lists.newArrayListWithExpectedSize(recordCount);
@@ -479,11 +483,11 @@ public abstract class TestMetrics {
             SIMPLE_SCHEMA, outputFile, records.toArray(new Record[0]));
     InputFile recordsFile = outputFile.toInputFile();
 
-    Assert.assertNotNull(recordsFile);
+    assertThat(recordsFile).isNotNull();
     // rowgroup size should be > 1
-    Assert.assertEquals(3, splitCount(recordsFile));
+    assertThat(splitCount(recordsFile)).isEqualTo(3);
 
-    Assert.assertEquals(201L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(201L);
     assertCounts(1, 201L, 0L, metrics);
     assertBounds(1, Types.BooleanType.get(), false, true, metrics);
     assertBounds(2, Types.IntegerType.get(), 1, 201, metrics);
@@ -498,10 +502,11 @@ public abstract class TestMetrics {
         6, Types.DecimalType.of(10, 2), new BigDecimal("2.00"), new BigDecimal("201.00"), metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsForNestedStructFieldsWithMultipleRowGroup() throws IOException {
-    Assume.assumeTrue(
-        "Skip test for formats that do not support small row groups", supportsSmallRowGroups());
+    assumeThat(supportsSmallRowGroups())
+        .as("Skip test for formats that do not support small row groups")
+        .isTrue();
 
     int recordCount = 201;
     List<Record> records = Lists.newArrayListWithExpectedSize(recordCount);
@@ -527,11 +532,11 @@ public abstract class TestMetrics {
             NESTED_SCHEMA, outputFile, records.toArray(new Record[0]));
     InputFile recordsFile = outputFile.toInputFile();
 
-    Assert.assertNotNull(recordsFile);
+    assertThat(recordsFile).isNotNull();
     // rowgroup size should be > 1
-    Assert.assertEquals(3, splitCount(recordsFile));
+    assertThat(splitCount(recordsFile)).isEqualTo(3);
 
-    Assert.assertEquals(201L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(201L);
     assertCounts(1, 201L, 0L, metrics);
     assertBounds(1, IntegerType.get(), 1, 201, metrics);
     assertCounts(3, 201L, 0L, metrics);
@@ -549,15 +554,15 @@ public abstract class TestMetrics {
     assertBounds(7, DoubleType.get(), null, null, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testNoneMetricsMode() throws IOException {
     Metrics metrics =
         getMetrics(
             NESTED_SCHEMA,
             MetricsConfig.fromProperties(ImmutableMap.of("write.metadata.metrics.default", "none")),
             buildNestedTestRecord());
-    Assert.assertEquals(1L, (long) metrics.recordCount());
-    Assert.assertTrue(metrics.columnSizes().values().stream().allMatch(Objects::nonNull));
+    assertThat(metrics.recordCount()).isEqualTo(1L);
+    assertThat(metrics.columnSizes()).doesNotContainValue(null);
     assertCounts(1, null, null, metrics);
     assertBounds(1, Types.IntegerType.get(), null, null, metrics);
     assertCounts(3, null, null, metrics);
@@ -570,7 +575,7 @@ public abstract class TestMetrics {
     assertBounds(7, Types.DoubleType.get(), null, null, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testCountsMetricsMode() throws IOException {
     Metrics metrics =
         getMetrics(
@@ -578,8 +583,8 @@ public abstract class TestMetrics {
             MetricsConfig.fromProperties(
                 ImmutableMap.of("write.metadata.metrics.default", "counts")),
             buildNestedTestRecord());
-    Assert.assertEquals(1L, (long) metrics.recordCount());
-    Assert.assertTrue(metrics.columnSizes().values().stream().allMatch(Objects::nonNull));
+    assertThat(metrics.recordCount()).isEqualTo(1L);
+    assertThat(metrics.columnSizes()).doesNotContainValue(null);
     assertCounts(1, 1L, 0L, metrics);
     assertBounds(1, Types.IntegerType.get(), null, null, metrics);
     assertCounts(3, 1L, 0L, metrics);
@@ -592,15 +597,15 @@ public abstract class TestMetrics {
     assertBounds(7, Types.DoubleType.get(), null, null, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testFullMetricsMode() throws IOException {
     Metrics metrics =
         getMetrics(
             NESTED_SCHEMA,
             MetricsConfig.fromProperties(ImmutableMap.of("write.metadata.metrics.default", "full")),
             buildNestedTestRecord());
-    Assert.assertEquals(1L, (long) metrics.recordCount());
-    Assert.assertTrue(metrics.columnSizes().values().stream().allMatch(Objects::nonNull));
+    assertThat(metrics.recordCount()).isEqualTo(1L);
+    assertThat(metrics.columnSizes()).doesNotContainValue(null);
     assertCounts(1, 1L, 0L, metrics);
     assertBounds(1, Types.IntegerType.get(), Integer.MAX_VALUE, Integer.MAX_VALUE, metrics);
     assertCounts(3, 1L, 0L, metrics);
@@ -618,7 +623,7 @@ public abstract class TestMetrics {
     assertBounds(7, Types.DoubleType.get(), null, null, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testTruncateStringMetricsMode() throws IOException {
     String colName = "str_to_truncate";
     Schema singleStringColSchema = new Schema(required(1, colName, Types.StringType.get()));
@@ -636,13 +641,13 @@ public abstract class TestMetrics {
 
     CharBuffer expectedMinBound = CharBuffer.wrap("Lorem ipsu");
     CharBuffer expectedMaxBound = CharBuffer.wrap("Lorem ipsv");
-    Assert.assertEquals(1L, (long) metrics.recordCount());
-    Assert.assertTrue(metrics.columnSizes().values().stream().allMatch(Objects::nonNull));
+    assertThat(metrics.recordCount()).isEqualTo(1L);
+    assertThat(metrics.columnSizes()).doesNotContainValue(null);
     assertCounts(1, 1L, 0L, metrics);
     assertBounds(1, Types.StringType.get(), expectedMinBound, expectedMaxBound, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testTruncateBinaryMetricsMode() throws IOException {
     String colName = "bin_to_truncate";
     Schema singleBinaryColSchema = new Schema(required(1, colName, Types.BinaryType.get()));
@@ -660,16 +665,16 @@ public abstract class TestMetrics {
 
     ByteBuffer expectedMinBounds = ByteBuffer.wrap(new byte[] {0x1, 0x2, 0x3, 0x4, 0x5});
     ByteBuffer expectedMaxBounds = ByteBuffer.wrap(new byte[] {0x1, 0x2, 0x3, 0x4, 0x6});
-    Assert.assertEquals(1L, (long) metrics.recordCount());
-    Assert.assertTrue(metrics.columnSizes().values().stream().allMatch(Objects::nonNull));
+    assertThat(metrics.recordCount()).isEqualTo(1L);
+    assertThat(metrics.columnSizes()).doesNotContainValue(null);
     assertCounts(1, 1L, 0L, metrics);
     assertBounds(1, Types.BinaryType.get(), expectedMinBounds, expectedMaxBounds, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testSortedColumnMetrics() throws IOException {
-    File tableDir = temp.newFolder();
-    tableDir.delete(); // created by table create
+    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableDir.delete()).isTrue(); // created by table create
 
     SortOrder sortOrder =
         SortOrder.builderFor(SIMPLE_SCHEMA)
@@ -719,7 +724,7 @@ public abstract class TestMetrics {
     Metrics metrics =
         getMetrics(SIMPLE_SCHEMA, MetricsConfig.forTable(table), firstRecord, secondRecord);
 
-    Assert.assertEquals(2L, (long) metrics.recordCount());
+    assertThat(metrics.recordCount()).isEqualTo(2L);
     assertBounds(1, BooleanType.get(), false, true, metrics);
     assertBounds(2, IntegerType.get(), Integer.MIN_VALUE, Integer.MAX_VALUE, metrics);
     assertBounds(3, LongType.get(), Long.MIN_VALUE, Long.MAX_VALUE, metrics);
@@ -729,10 +734,10 @@ public abstract class TestMetrics {
     assertBounds(8, DateType.get(), 1500, 3000, metrics);
   }
 
-  @Test
+  @TestTemplate
   public void testMetricsForSortedNestedStructFields() throws IOException {
-    File tableDir = temp.newFolder();
-    tableDir.delete(); // created by table create
+    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableDir.delete()).isTrue(); // created by table create
 
     SortOrder sortOrder =
         SortOrder.builderFor(NESTED_SCHEMA)
@@ -766,24 +771,38 @@ public abstract class TestMetrics {
 
   protected void assertCounts(
       int fieldId, Long valueCount, Long nullValueCount, Long nanValueCount, Metrics metrics) {
-    Map<Integer, Long> valueCounts = metrics.valueCounts();
-    Map<Integer, Long> nullValueCounts = metrics.nullValueCounts();
-    Map<Integer, Long> nanValueCounts = metrics.nanValueCounts();
-    Assert.assertEquals(valueCount, valueCounts.get(fieldId));
-    Assert.assertEquals(nullValueCount, nullValueCounts.get(fieldId));
-    Assert.assertEquals(nanValueCount, nanValueCounts.get(fieldId));
+    assertThat(metrics.valueCounts())
+        .satisfiesAnyOf(
+            valueCounts -> assertThat(valueCounts).containsEntry(fieldId, valueCount),
+            valueCounts -> assertThat(valueCounts).doesNotContainKey(fieldId));
+
+    assertThat(metrics.nullValueCounts())
+        .satisfiesAnyOf(
+            nullValueCounts -> assertThat(nullValueCounts).containsEntry(fieldId, nullValueCount),
+            nullValueCounts -> assertThat(nullValueCounts).doesNotContainKey(fieldId));
+
+    assertThat(metrics.nanValueCounts())
+        .satisfiesAnyOf(
+            nanValueCounts -> assertThat(nanValueCounts).containsEntry(fieldId, nanValueCount),
+            nanValueCounts -> assertThat(nanValueCounts).doesNotContainKey(fieldId));
   }
 
   protected <T> void assertBounds(
       int fieldId, Type type, T lowerBound, T upperBound, Metrics metrics) {
-    Map<Integer, ByteBuffer> lowerBounds = metrics.lowerBounds();
-    Map<Integer, ByteBuffer> upperBounds = metrics.upperBounds();
+    assertThat(metrics.lowerBounds())
+        .satisfiesAnyOf(
+            lowerBounds ->
+                assertThat(Optional.ofNullable(fromByteBuffer(type, lowerBounds.get(fieldId))))
+                    .get()
+                    .isEqualTo(lowerBound),
+            lowerBounds -> assertThat(lowerBounds).doesNotContainKey(fieldId));
 
-    Assert.assertEquals(
-        lowerBound,
-        lowerBounds.containsKey(fieldId) ? fromByteBuffer(type, lowerBounds.get(fieldId)) : null);
-    Assert.assertEquals(
-        upperBound,
-        upperBounds.containsKey(fieldId) ? fromByteBuffer(type, upperBounds.get(fieldId)) : null);
+    assertThat(metrics.upperBounds())
+        .satisfiesAnyOf(
+            upperBounds ->
+                assertThat(Optional.ofNullable(fromByteBuffer(type, upperBounds.get(fieldId))))
+                    .get()
+                    .isEqualTo(upperBound),
+            upperBounds -> assertThat(upperBounds).doesNotContainKey(fieldId));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -35,7 +35,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.InputFile;
@@ -781,15 +780,16 @@ public abstract class TestMetrics {
     Map<Integer, ByteBuffer> lowerBounds = metrics.lowerBounds();
     Map<Integer, ByteBuffer> upperBounds = metrics.upperBounds();
 
-    assertThat(
-            lowerBounds.containsKey(fieldId)
-                ? Optional.ofNullable(fromByteBuffer(type, lowerBounds.get(fieldId))).get()
-                : null)
-        .isEqualTo(lowerBound);
-    assertThat(
-            upperBounds.containsKey(fieldId)
-                ? Optional.ofNullable(fromByteBuffer(type, upperBounds.get(fieldId))).get()
-                : null)
-        .isEqualTo(upperBound);
+    if (lowerBounds.containsKey(fieldId)) {
+      assertThat((Object) fromByteBuffer(type, lowerBounds.get(fieldId))).isEqualTo(lowerBound);
+    } else {
+      assertThat(lowerBound).isNull();
+    }
+
+    if (upperBounds.containsKey(fieldId)) {
+      assertThat((Object) fromByteBuffer(type, upperBounds.get(fieldId))).isEqualTo(upperBound);
+    } else {
+      assertThat(upperBound).isNull();
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -771,38 +771,25 @@ public abstract class TestMetrics {
 
   protected void assertCounts(
       int fieldId, Long valueCount, Long nullValueCount, Long nanValueCount, Metrics metrics) {
-    assertThat(metrics.valueCounts())
-        .satisfiesAnyOf(
-            valueCounts -> assertThat(valueCounts).containsEntry(fieldId, valueCount),
-            valueCounts -> assertThat(valueCounts).doesNotContainKey(fieldId));
-
-    assertThat(metrics.nullValueCounts())
-        .satisfiesAnyOf(
-            nullValueCounts -> assertThat(nullValueCounts).containsEntry(fieldId, nullValueCount),
-            nullValueCounts -> assertThat(nullValueCounts).doesNotContainKey(fieldId));
-
-    assertThat(metrics.nanValueCounts())
-        .satisfiesAnyOf(
-            nanValueCounts -> assertThat(nanValueCounts).containsEntry(fieldId, nanValueCount),
-            nanValueCounts -> assertThat(nanValueCounts).doesNotContainKey(fieldId));
+    assertThat(metrics.valueCounts().get(fieldId)).isEqualTo(valueCount);
+    assertThat(metrics.nullValueCounts().get(fieldId)).isEqualTo(nullValueCount);
+    assertThat(metrics.nanValueCounts().get(fieldId)).isEqualTo(nanValueCount);
   }
 
   protected <T> void assertBounds(
       int fieldId, Type type, T lowerBound, T upperBound, Metrics metrics) {
-    assertThat(metrics.lowerBounds())
-        .satisfiesAnyOf(
-            lowerBounds ->
-                assertThat(Optional.ofNullable(fromByteBuffer(type, lowerBounds.get(fieldId))))
-                    .get()
-                    .isEqualTo(lowerBound),
-            lowerBounds -> assertThat(lowerBounds).doesNotContainKey(fieldId));
+    Map<Integer, ByteBuffer> lowerBounds = metrics.lowerBounds();
+    Map<Integer, ByteBuffer> upperBounds = metrics.upperBounds();
 
-    assertThat(metrics.upperBounds())
-        .satisfiesAnyOf(
-            upperBounds ->
-                assertThat(Optional.ofNullable(fromByteBuffer(type, upperBounds.get(fieldId))))
-                    .get()
-                    .isEqualTo(upperBound),
-            upperBounds -> assertThat(upperBounds).doesNotContainKey(fieldId));
+    assertThat(
+            lowerBounds.containsKey(fieldId)
+                ? Optional.ofNullable(fromByteBuffer(type, lowerBounds.get(fieldId))).get()
+                : null)
+        .isEqualTo(lowerBound);
+    assertThat(
+            upperBounds.containsKey(fieldId)
+                ? Optional.ofNullable(fromByteBuffer(type, upperBounds.get(fieldId))).get()
+                : null)
+        .isEqualTo(upperBound);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/actions/TestSizeBasedRewriter.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestSizeBasedRewriter.java
@@ -20,33 +20,31 @@ package org.apache.iceberg.actions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MockFileScanTask;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableTestBase;
+import org.apache.iceberg.TestBase;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestSizeBasedRewriter extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSizeBasedRewriter extends TestBase {
 
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestSizeBasedRewriter(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testSplitSizeLowerBound() {
     SizeBasedDataFileRewriterImpl rewriter = new SizeBasedDataFileRewriterImpl(table);
 

--- a/core/src/test/java/org/apache/iceberg/avro/AvroTestHelpers.java
+++ b/core/src/test/java/org/apache/iceberg/avro/AvroTestHelpers.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.avro;
 
 import static org.apache.iceberg.avro.AvroSchemaUtil.toOption;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,7 +29,6 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
 
 class AvroTestHelpers {
 
@@ -81,7 +81,7 @@ class AvroTestHelpers {
   static void assertEquals(Types.ListType list, List<?> expected, List<?> actual) {
     Type elementType = list.elementType();
 
-    Assertions.assertThat(actual).as("List size should match").hasSameSizeAs(expected);
+    assertThat(actual).as("List size should match").hasSameSizeAs(expected);
 
     for (int i = 0; i < expected.size(); i += 1) {
       Object expectedValue = expected.get(i);
@@ -94,7 +94,7 @@ class AvroTestHelpers {
   static void assertEquals(Types.MapType map, Map<?, ?> expected, Map<?, ?> actual) {
     Type valueType = map.valueType();
 
-    Assertions.assertThat(actual).as("Map keys should match").hasSameSizeAs(expected);
+    assertThat(actual).as("Map keys should match").hasSameSizeAs(expected);
 
     for (Object expectedKey : expected.keySet()) {
       Object expectedValue = expected.get(expectedKey);
@@ -123,25 +123,21 @@ class AvroTestHelpers {
       case FIXED:
       case BINARY:
       case DECIMAL:
-        Assertions.assertThat(actual)
-            .as("Primitive value should be equal to expected")
-            .isEqualTo(expected);
+        assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case STRUCT:
-        Assertions.assertThat(expected)
-            .as("Expected should be a Record")
-            .isInstanceOf(Record.class);
-        Assertions.assertThat(actual).as("Actual should be a Record").isInstanceOf(Record.class);
+        assertThat(expected).as("Expected should be a Record").isInstanceOf(Record.class);
+        assertThat(actual).as("Actual should be a Record").isInstanceOf(Record.class);
         assertEquals(type.asStructType(), (Record) expected, (Record) actual);
         break;
       case LIST:
-        Assertions.assertThat(expected).as("Expected should be a List").isInstanceOf(List.class);
-        Assertions.assertThat(actual).as("Actual should be a List").isInstanceOf(List.class);
+        assertThat(expected).as("Expected should be a List").isInstanceOf(List.class);
+        assertThat(actual).as("Actual should be a List").isInstanceOf(List.class);
         assertEquals(type.asListType(), (List) expected, (List) actual);
         break;
       case MAP:
-        Assertions.assertThat(expected).as("Expected should be a Map").isInstanceOf(Map.class);
-        Assertions.assertThat(actual).as("Actual should be a Map").isInstanceOf(Map.class);
+        assertThat(expected).as("Expected should be a Map").isInstanceOf(Map.class);
+        assertThat(actual).as("Actual should be a Map").isInstanceOf(Map.class);
         assertEquals(type.asMapType(), (Map<?, ?>) expected, (Map<?, ?>) actual);
         break;
       default:

--- a/core/src/test/java/org/apache/iceberg/avro/TestNameMappingWithAvroSchema.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestNameMappingWithAvroSchema.java
@@ -18,12 +18,13 @@
  */
 package org.apache.iceberg.avro;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.avro.Schema;
 import org.apache.iceberg.mapping.MappedField;
 import org.apache.iceberg.mapping.MappedFields;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestNameMappingWithAvroSchema {
   @Test
@@ -132,9 +133,9 @@ public class TestNameMappingWithAvroSchema {
                                     MappedField.of(13, "string"), MappedField.of(14, "int"))))),
                     MappedField.of(21, "timezone"),
                     MappedField.of(22, "bitmap"))));
-    Assert.assertEquals(
-        expected,
-        AvroWithPartnerByStructureVisitor.visit(
-            icebergSchema.asStruct(), schema, nameMappingWithAvroSchema));
+    assertThat(
+            AvroWithPartnerByStructureVisitor.visit(
+                icebergSchema.asStruct(), schema, nameMappingWithAvroSchema))
+        .isEqualTo(expected);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/encryption/TestStandardKeyMetadataParser.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestStandardKeyMetadataParser.java
@@ -18,11 +18,12 @@
  */
 package org.apache.iceberg.encryption;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestStandardKeyMetadataParser {
 
@@ -35,14 +36,14 @@ public class TestStandardKeyMetadataParser {
     ByteBuffer serialized = metadata.buffer();
 
     StandardKeyMetadata parsedMetadata = StandardKeyMetadata.parse(serialized);
-    Assert.assertEquals(parsedMetadata.encryptionKey(), encryptionKey);
-    Assert.assertEquals(parsedMetadata.aadPrefix(), aadPrefix);
+    assertThat(encryptionKey).isEqualTo(parsedMetadata.encryptionKey());
+    assertThat(aadPrefix).isEqualTo(parsedMetadata.aadPrefix());
   }
 
   @Test
   public void testUnsupportedVersion() {
     ByteBuffer badBuffer = ByteBuffer.wrap(new byte[] {0x02});
-    Assertions.assertThatThrownBy(() -> StandardKeyMetadata.parse(badBuffer))
+    assertThatThrownBy(() -> StandardKeyMetadata.parse(badBuffer))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("Cannot resolve schema for version: 2");
   }

--- a/core/src/test/java/org/apache/iceberg/io/TestOutputFileFactory.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestOutputFileFactory.java
@@ -18,36 +18,35 @@
  */
 package org.apache.iceberg.io;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.TableTestBase;
+import org.apache.iceberg.TestBase;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestOutputFileFactory extends TableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestOutputFileFactory extends TestBase {
 
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
   private static final int PARTITION_ID = 1;
   private static final int TASK_ID = 100;
 
-  public TestOutputFileFactory(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testOutputFileFactoryWithCustomFormat() {
     table.updateProperties().defaultFormat(FileFormat.ORC).commit();
 
@@ -55,11 +54,10 @@ public class TestOutputFileFactory extends TableTestBase {
         OutputFileFactory.builderFor(table, PARTITION_ID, TASK_ID).format(FileFormat.AVRO).build();
 
     String location = fileFactory.newOutputFile().encryptingOutputFile().location();
-    Assert.assertEquals(
-        "File format should be correct", FileFormat.AVRO, FileFormat.fromFileName(location));
+    assertThat(FileFormat.fromFileName(location)).isEqualTo(FileFormat.AVRO);
   }
 
-  @Test
+  @TestTemplate
   public void testOutputFileFactoryWithMultipleSpecs() {
     OutputFileFactory fileFactory =
         OutputFileFactory.builderFor(table, PARTITION_ID, TASK_ID).operationId("append").build();
@@ -67,18 +65,17 @@ public class TestOutputFileFactory extends TableTestBase {
     EncryptedOutputFile unpartitionedFile =
         fileFactory.newOutputFile(PartitionSpec.unpartitioned(), null);
     String unpartitionedFileLocation = unpartitionedFile.encryptingOutputFile().location();
-    Assert.assertTrue(unpartitionedFileLocation.endsWith("data/00001-100-append-00001.parquet"));
+    assertThat(unpartitionedFileLocation).endsWith("data/00001-100-append-00001.parquet");
 
     Record record = GenericRecord.create(table.schema()).copy(ImmutableMap.of("data", "aaa"));
     PartitionKey partitionKey = new PartitionKey(table.spec(), table.schema());
     partitionKey.partition(record);
     EncryptedOutputFile partitionedFile = fileFactory.newOutputFile(table.spec(), partitionKey);
     String partitionedFileLocation = partitionedFile.encryptingOutputFile().location();
-    Assert.assertTrue(
-        partitionedFileLocation.endsWith("data_bucket=7/00001-100-append-00002.parquet"));
+    assertThat(partitionedFileLocation).endsWith("data_bucket=7/00001-100-append-00002.parquet");
   }
 
-  @Test
+  @TestTemplate
   public void testWithCustomSuffix() {
     OutputFileFactory fileFactory =
         OutputFileFactory.builderFor(table, PARTITION_ID, TASK_ID)
@@ -89,15 +86,14 @@ public class TestOutputFileFactory extends TableTestBase {
     EncryptedOutputFile unpartitionedFile =
         fileFactory.newOutputFile(PartitionSpec.unpartitioned(), null);
     String unpartitionedFileLocation = unpartitionedFile.encryptingOutputFile().location();
-    Assertions.assertThat(unpartitionedFileLocation)
-        .endsWith("data/00001-100-append-00001-suffix.parquet");
+    assertThat(unpartitionedFileLocation).endsWith("data/00001-100-append-00001-suffix.parquet");
 
     Record record = GenericRecord.create(table.schema()).copy(ImmutableMap.of("data", "aaa"));
     PartitionKey partitionKey = new PartitionKey(table.spec(), table.schema());
     partitionKey.partition(record);
     EncryptedOutputFile partitionedFile = fileFactory.newOutputFile(table.spec(), partitionKey);
     String partitionedFileLocation = partitionedFile.encryptingOutputFile().location();
-    Assertions.assertThat(partitionedFileLocation)
+    assertThat(partitionedFileLocation)
         .endsWith("data_bucket=7/00001-100-append-00002-suffix.parquet");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/mapping/TestMappingUpdates.java
+++ b/core/src/test/java/org/apache/iceberg/mapping/TestMappingUpdates.java
@@ -19,28 +19,27 @@
 package org.apache.iceberg.mapping;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
+import java.util.List;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.TableTestBase;
+import org.apache.iceberg.TestBase;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestMappingUpdates extends TableTestBase {
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestMappingUpdates extends TestBase {
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(1, 2);
   }
 
-  public TestMappingUpdates(int formatVersion) {
-    super(formatVersion);
-  }
-
-  @Test
+  @TestTemplate
   public void testAddColumnMappingUpdate() {
     NameMapping mapping = MappingUtil.create(table.schema());
     table
@@ -48,22 +47,21 @@ public class TestMappingUpdates extends TableTestBase {
         .set(TableProperties.DEFAULT_NAME_MAPPING, NameMappingParser.toJson(mapping))
         .commit();
 
-    Assert.assertEquals(
-        MappedFields.of(MappedField.of(1, "id"), MappedField.of(2, "data")),
-        mapping.asMappedFields());
+    assertThat(mapping.asMappedFields())
+        .isEqualTo(MappedFields.of(MappedField.of(1, "id"), MappedField.of(2, "data")));
 
     table.updateSchema().addColumn("ts", Types.TimestampType.withZone()).commit();
 
     NameMapping updated =
         NameMappingParser.fromJson(table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
 
-    Assert.assertEquals(
-        MappedFields.of(
-            MappedField.of(1, "id"), MappedField.of(2, "data"), MappedField.of(3, "ts")),
-        updated.asMappedFields());
+    assertThat(updated.asMappedFields())
+        .isEqualTo(
+            MappedFields.of(
+                MappedField.of(1, "id"), MappedField.of(2, "data"), MappedField.of(3, "ts")));
   }
 
-  @Test
+  @TestTemplate
   public void testAddNestedColumnMappingUpdate() {
     NameMapping mapping = MappingUtil.create(table.schema());
     table
@@ -71,9 +69,8 @@ public class TestMappingUpdates extends TableTestBase {
         .set(TableProperties.DEFAULT_NAME_MAPPING, NameMappingParser.toJson(mapping))
         .commit();
 
-    Assert.assertEquals(
-        MappedFields.of(MappedField.of(1, "id"), MappedField.of(2, "data")),
-        mapping.asMappedFields());
+    assertThat(mapping.asMappedFields())
+        .isEqualTo(MappedFields.of(MappedField.of(1, "id"), MappedField.of(2, "data")));
 
     table
         .updateSchema()
@@ -86,32 +83,32 @@ public class TestMappingUpdates extends TableTestBase {
     NameMapping updated =
         NameMappingParser.fromJson(table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
 
-    Assert.assertEquals(
-        MappedFields.of(
-            MappedField.of(1, "id"),
-            MappedField.of(2, "data"),
-            MappedField.of(
-                3, "point", MappedFields.of(MappedField.of(4, "x"), MappedField.of(5, "y")))),
-        updated.asMappedFields());
+    assertThat(updated.asMappedFields())
+        .isEqualTo(
+            MappedFields.of(
+                MappedField.of(1, "id"),
+                MappedField.of(2, "data"),
+                MappedField.of(
+                    3, "point", MappedFields.of(MappedField.of(4, "x"), MappedField.of(5, "y")))));
 
     table.updateSchema().addColumn("point", "z", Types.DoubleType.get()).commit();
 
     NameMapping pointUpdated =
         NameMappingParser.fromJson(table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
 
-    Assert.assertEquals(
-        MappedFields.of(
-            MappedField.of(1, "id"),
-            MappedField.of(2, "data"),
-            MappedField.of(
-                3,
-                "point",
-                MappedFields.of(
-                    MappedField.of(4, "x"), MappedField.of(5, "y"), MappedField.of(6, "z")))),
-        pointUpdated.asMappedFields());
+    assertThat(pointUpdated.asMappedFields())
+        .isEqualTo(
+            MappedFields.of(
+                MappedField.of(1, "id"),
+                MappedField.of(2, "data"),
+                MappedField.of(
+                    3,
+                    "point",
+                    MappedFields.of(
+                        MappedField.of(4, "x"), MappedField.of(5, "y"), MappedField.of(6, "z")))));
   }
 
-  @Test
+  @TestTemplate
   public void testRenameMappingUpdate() {
     NameMapping mapping = MappingUtil.create(table.schema());
     table
@@ -119,22 +116,21 @@ public class TestMappingUpdates extends TableTestBase {
         .set(TableProperties.DEFAULT_NAME_MAPPING, NameMappingParser.toJson(mapping))
         .commit();
 
-    Assert.assertEquals(
-        MappedFields.of(MappedField.of(1, "id"), MappedField.of(2, "data")),
-        mapping.asMappedFields());
+    assertThat(mapping.asMappedFields())
+        .isEqualTo(MappedFields.of(MappedField.of(1, "id"), MappedField.of(2, "data")));
 
     table.updateSchema().renameColumn("id", "object_id").commit();
 
     NameMapping updated =
         NameMappingParser.fromJson(table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
 
-    Assert.assertEquals(
-        MappedFields.of(
-            MappedField.of(1, ImmutableList.of("id", "object_id")), MappedField.of(2, "data")),
-        updated.asMappedFields());
+    assertThat(updated.asMappedFields())
+        .isEqualTo(
+            MappedFields.of(
+                MappedField.of(1, ImmutableList.of("id", "object_id")), MappedField.of(2, "data")));
   }
 
-  @Test
+  @TestTemplate
   public void testRenameNestedFieldMappingUpdate() {
     NameMapping mapping = MappingUtil.create(table.schema());
     table
@@ -153,33 +149,33 @@ public class TestMappingUpdates extends TableTestBase {
     NameMapping updated =
         NameMappingParser.fromJson(table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
 
-    Assert.assertEquals(
-        MappedFields.of(
-            MappedField.of(1, "id"),
-            MappedField.of(2, "data"),
-            MappedField.of(
-                3, "point", MappedFields.of(MappedField.of(4, "x"), MappedField.of(5, "y")))),
-        updated.asMappedFields());
+    assertThat(updated.asMappedFields())
+        .isEqualTo(
+            MappedFields.of(
+                MappedField.of(1, "id"),
+                MappedField.of(2, "data"),
+                MappedField.of(
+                    3, "point", MappedFields.of(MappedField.of(4, "x"), MappedField.of(5, "y")))));
 
     table.updateSchema().renameColumn("point.x", "X").renameColumn("point.y", "Y").commit();
 
     NameMapping pointUpdated =
         NameMappingParser.fromJson(table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
 
-    Assert.assertEquals(
-        MappedFields.of(
-            MappedField.of(1, "id"),
-            MappedField.of(2, "data"),
-            MappedField.of(
-                3,
-                "point",
-                MappedFields.of(
-                    MappedField.of(4, ImmutableList.of("x", "X")),
-                    MappedField.of(5, ImmutableList.of("y", "Y"))))),
-        pointUpdated.asMappedFields());
+    assertThat(pointUpdated.asMappedFields())
+        .isEqualTo(
+            MappedFields.of(
+                MappedField.of(1, "id"),
+                MappedField.of(2, "data"),
+                MappedField.of(
+                    3,
+                    "point",
+                    MappedFields.of(
+                        MappedField.of(4, ImmutableList.of("x", "X")),
+                        MappedField.of(5, ImmutableList.of("y", "Y"))))));
   }
 
-  @Test
+  @TestTemplate
   public void testRenameComplexFieldMappingUpdate() {
     NameMapping mapping = MappingUtil.create(table.schema());
     table
@@ -198,27 +194,27 @@ public class TestMappingUpdates extends TableTestBase {
     NameMapping updated =
         NameMappingParser.fromJson(table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
 
-    Assert.assertEquals(
-        MappedFields.of(
-            MappedField.of(1, "id"),
-            MappedField.of(2, "data"),
-            MappedField.of(
-                3, "point", MappedFields.of(MappedField.of(4, "x"), MappedField.of(5, "y")))),
-        updated.asMappedFields());
+    assertThat(updated.asMappedFields())
+        .isEqualTo(
+            MappedFields.of(
+                MappedField.of(1, "id"),
+                MappedField.of(2, "data"),
+                MappedField.of(
+                    3, "point", MappedFields.of(MappedField.of(4, "x"), MappedField.of(5, "y")))));
 
     table.updateSchema().renameColumn("point", "p2").commit();
 
     NameMapping pointUpdated =
         NameMappingParser.fromJson(table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
 
-    Assert.assertEquals(
-        MappedFields.of(
-            MappedField.of(1, "id"),
-            MappedField.of(2, "data"),
-            MappedField.of(
-                3,
-                ImmutableList.of("point", "p2"),
-                MappedFields.of(MappedField.of(4, "x"), MappedField.of(5, "y")))),
-        pointUpdated.asMappedFields());
+    assertThat(pointUpdated.asMappedFields())
+        .isEqualTo(
+            MappedFields.of(
+                MappedField.of(1, "id"),
+                MappedField.of(2, "data"),
+                MappedField.of(
+                    3,
+                    ImmutableList.of("point", "p2"),
+                    MappedFields.of(MappedField.of(4, "x"), MappedField.of(5, "y")))));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/mapping/TestNameMapping.java
+++ b/core/src/test/java/org/apache/iceberg/mapping/TestNameMapping.java
@@ -19,12 +19,12 @@
 package org.apache.iceberg.mapping;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestNameMapping {
   @Test
@@ -36,7 +36,7 @@ public class TestNameMapping {
     MappedFields expected = MappedFields.of(MappedField.of(1, "id"), MappedField.of(2, "data"));
 
     NameMapping mapping = MappingUtil.create(schema);
-    Assert.assertEquals(expected, mapping.asMappedFields());
+    assertThat(mapping.asMappedFields()).isEqualTo(expected);
   }
 
   @Test
@@ -62,7 +62,7 @@ public class TestNameMapping {
                 MappedFields.of(MappedField.of(4, "latitude"), MappedField.of(5, "longitude"))));
 
     NameMapping mapping = MappingUtil.create(schema);
-    Assert.assertEquals(expected, mapping.asMappedFields());
+    assertThat(mapping.asMappedFields()).isEqualTo(expected);
   }
 
   @Test
@@ -84,7 +84,7 @@ public class TestNameMapping {
                 3, "map", MappedFields.of(MappedField.of(4, "key"), MappedField.of(5, "value"))));
 
     NameMapping mapping = MappingUtil.create(schema);
-    Assert.assertEquals(expected, mapping.asMappedFields());
+    assertThat(mapping.asMappedFields()).isEqualTo(expected);
   }
 
   @Test
@@ -117,7 +117,7 @@ public class TestNameMapping {
                     MappedField.of(5, "value"))));
 
     NameMapping mapping = MappingUtil.create(schema);
-    Assert.assertEquals(expected, mapping.asMappedFields());
+    assertThat(mapping.asMappedFields()).isEqualTo(expected);
   }
 
   @Test
@@ -152,7 +152,7 @@ public class TestNameMapping {
                         MappedFields.of(MappedField.of(6, "x"), MappedField.of(7, "y"))))));
 
     NameMapping mapping = MappingUtil.create(schema);
-    Assert.assertEquals(expected, mapping.asMappedFields());
+    assertThat(mapping.asMappedFields()).isEqualTo(expected);
   }
 
   @Test
@@ -170,13 +170,13 @@ public class TestNameMapping {
             MappedField.of(3, "list", MappedFields.of(MappedField.of(4, "element"))));
 
     NameMapping mapping = MappingUtil.create(schema);
-    Assert.assertEquals(expected, mapping.asMappedFields());
+    assertThat(mapping.asMappedFields()).isEqualTo(expected);
   }
 
   @Test
   public void testFailsDuplicateId() {
     // the schema can be created because ID indexing is lazy
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 new Schema(
                     required(1, "id", Types.LongType.get()),
@@ -187,7 +187,7 @@ public class TestNameMapping {
 
   @Test
   public void testFailsDuplicateName() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> new NameMapping(MappedFields.of(MappedField.of(1, "x"), MappedField.of(2, "x"))))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Multiple entries with same key: x=2 and x=1");
@@ -227,17 +227,17 @@ public class TestNameMapping {
 
     NameMapping mapping = MappingUtil.create(schema);
 
-    Assert.assertNull("Should not return a field mapping for a missing ID", mapping.find(100));
-    Assert.assertEquals(MappedField.of(2, "data"), mapping.find(2));
-    Assert.assertEquals(MappedField.of(6, "x"), mapping.find(6));
-    Assert.assertEquals(MappedField.of(9, "element"), mapping.find(9));
-    Assert.assertEquals(MappedField.of(11, "latitude"), mapping.find(11));
-    Assert.assertEquals(
-        MappedField.of(
-            10,
-            "location",
-            MappedFields.of(MappedField.of(11, "latitude"), MappedField.of(12, "longitude"))),
-        mapping.find(10));
+    assertThat(mapping.find(100)).as("Should not return a field mapping for a missing ID").isNull();
+    assertThat(mapping.find(2)).isEqualTo(MappedField.of(2, "data"));
+    assertThat(mapping.find(6)).isEqualTo(MappedField.of(6, "x"));
+    assertThat(mapping.find(9)).isEqualTo(MappedField.of(9, "element"));
+    assertThat(mapping.find(11)).isEqualTo(MappedField.of(11, "latitude"));
+    assertThat(mapping.find(10))
+        .isEqualTo(
+            MappedField.of(
+                10,
+                "location",
+                MappedFields.of(MappedField.of(11, "latitude"), MappedField.of(12, "longitude"))));
   }
 
   @Test
@@ -266,20 +266,27 @@ public class TestNameMapping {
 
     NameMapping mapping = MappingUtil.create(schema);
 
-    Assert.assertNull(
-        "Should not return a field mapping for a nested name", mapping.find("element"));
-    Assert.assertNull("Should not return a field mapping for a nested name", mapping.find("x"));
-    Assert.assertNull("Should not return a field mapping for a nested name", mapping.find("key"));
-    Assert.assertNull("Should not return a field mapping for a nested name", mapping.find("value"));
-    Assert.assertEquals(MappedField.of(2, "data"), mapping.find("data"));
-    Assert.assertEquals(MappedField.of(6, "x"), mapping.find("map", "value", "x"));
-    Assert.assertEquals(MappedField.of(9, "element"), mapping.find("list", "element"));
-    Assert.assertEquals(MappedField.of(11, "latitude"), mapping.find("location", "latitude"));
-    Assert.assertEquals(
-        MappedField.of(
-            10,
-            "location",
-            MappedFields.of(MappedField.of(11, "latitude"), MappedField.of(12, "longitude"))),
-        mapping.find("location"));
+    assertThat(mapping.find("element"))
+        .as("Should not return a field mapping for a nested name")
+        .isNull();
+    assertThat(mapping.find("x"))
+        .as("Should not return a field mapping for a nested name")
+        .isNull();
+    assertThat(mapping.find("key"))
+        .as("Should not return a field mapping for a nested name")
+        .isNull();
+    assertThat(mapping.find("value"))
+        .as("Should not return a field mapping for a nested name")
+        .isNull();
+    assertThat(mapping.find("data")).isEqualTo(MappedField.of(2, "data"));
+    assertThat(mapping.find("map", "value", "x")).isEqualTo(MappedField.of(6, "x"));
+    assertThat(mapping.find("list", "element")).isEqualTo(MappedField.of(9, "element"));
+    assertThat(mapping.find("location", "latitude")).isEqualTo(MappedField.of(11, "latitude"));
+    assertThat(mapping.find("location"))
+        .isEqualTo(
+            MappedField.of(
+                10,
+                "location",
+                MappedFields.of(MappedField.of(11, "latitude"), MappedField.of(12, "longitude"))));
   }
 }

--- a/data/src/test/java/org/apache/iceberg/parquet/TestParquetMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/parquet/TestParquetMetrics.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestMetrics;
@@ -37,23 +38,13 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.parquet.hadoop.ParquetFileReader;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /** Test Metrics for Parquet. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestParquetMetrics extends TestMetrics {
   private static final Map<String, String> SMALL_ROW_GROUP_CONFIG =
       ImmutableMap.of(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, "1600");
-
-  @Parameterized.Parameters(name = "formatVersion = {0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
-  }
-
-  public TestParquetMetrics(int formatVersion) {
-    super(formatVersion);
-  }
 
   @Override
   public FileFormat fileFormat() {
@@ -62,7 +53,7 @@ public class TestParquetMetrics extends TestMetrics {
 
   @Override
   protected OutputFile createOutputFile() throws IOException {
-    File tmpFolder = temp.newFolder("parquet");
+    File tmpFolder = java.nio.file.Files.createTempDirectory(temp, "parquet").toFile();
     String filename = UUID.randomUUID().toString();
     return Files.localOutput(new File(tmpFolder, FileFormat.PARQUET.addExtension(filename)));
   }


### PR DESCRIPTION
Migrate the following test classes in iceberg-core to JUnit 5 and AssertJ style for https://github.com/apache/iceberg/issues/9085.

## Current Progress 
- [x] `TestWapWorkflow`
- [x] `TestMetrics` (the following classes in `iceberg-data` are inheritors of this abstract class)
    - [x]  `TestOrcMetrics`
    - [x] `TestParquetMetrics`
- [x] `FilterFilesTestBase`