### PR TITLE
Core: Uncached files not be materialized

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
@@ -115,17 +115,18 @@ public class BaseDeleteLoader implements DeleteLoader {
     long estimatedSize = estimateEqDeletesSize(deleteFile, projection);
     if (canCache(estimatedSize)) {
       String cacheKey = deleteFile.path().toString();
-      return getOrLoad(cacheKey, () -> readEqDeletes(deleteFile, projection), estimatedSize);
+      return getOrLoad(cacheKey, () -> readEqDeletes(deleteFile, projection, true), estimatedSize);
     } else {
-      return readEqDeletes(deleteFile, projection);
+      return readEqDeletes(deleteFile, projection, false);
     }
   }
 
-  private Iterable<StructLike> readEqDeletes(DeleteFile deleteFile, Schema projection) {
+  private Iterable<StructLike> readEqDeletes(
+      DeleteFile deleteFile, Schema projection, boolean materialize) {
     CloseableIterable<Record> deletes = openDeletes(deleteFile, projection);
     CloseableIterable<Record> copiedDeletes = CloseableIterable.transform(deletes, Record::copy);
     CloseableIterable<StructLike> copiedDeletesAsStructs = toStructs(copiedDeletes, projection);
-    return materialize(copiedDeletesAsStructs);
+    return materialize ? materialize(copiedDeletesAsStructs) : copiedDeletesAsStructs;
   }
 
   private CloseableIterable<StructLike> toStructs(


### PR DESCRIPTION
For large Eq delete files materialize will be cause large memory usage and read slower.

**Before:**

```
Benchmark                                               (numDeleteFile)  (percentDeleteRow)  Mode  Cnt   Score    Error  Units
IcebergSourceParquetMultiEqDeleteBenchmark.readIceberg                1                 0.5    ss    5   7.969 ±  0.954   s/op
IcebergSourceParquetMultiEqDeleteBenchmark.readIceberg                1                   1    ss    5  17.041 ± 11.893   s/op
IcebergSourceParquetMultiEqDeleteBenchmark.readIceberg                2                 0.5    ss    5  10.356 ±  7.600   s/op
IcebergSourceParquetMultiEqDeleteBenchmark.readIceberg                2                   1    ss    5  34.141 ± 13.103   s/op
```

**After:**

```
Benchmark                                               (numDeleteFile)  (percentDeleteRow)  Mode  Cnt   Score   Error  Units
IcebergSourceParquetMultiEqDeleteBenchmark.readIceberg                1                 0.5    ss    5   8.093 ± 1.155   s/op
IcebergSourceParquetMultiEqDeleteBenchmark.readIceberg                1                   1    ss    5  16.308 ± 8.903   s/op
IcebergSourceParquetMultiEqDeleteBenchmark.readIceberg                2                 0.5    ss    5  10.898 ± 7.780   s/op
IcebergSourceParquetMultiEqDeleteBenchmark.readIceberg                2                   1    ss    5  17.321 ± 5.475   s/op
```

percentDeleteRow=0.5 used cache
percentDeleteRow=1     not used cache

Benchmark code : 
```
public class IcebergSourceParquetMultiEqDeleteBenchmark extends IcebergSourceDeleteBenchmark {
  @Param({"0.5", "1"})
  private double percentDeleteRow;

  @Param({"1", "2"})
  private int numDeleteFile;

  @Override
  protected void appendData() throws IOException {
    for (int fileNum = 1; fileNum <= NUM_FILES; fileNum++) {
      writeData(fileNum);

      if (percentDeleteRow > 0) {
        // add equality deletes
        table().refresh();
        for (int i = 0; i < numDeleteFile; i++) {
          writeEqDeletes(NUM_ROWS, percentDeleteRow);
        }
      }
    }
  }

  @Override
  protected FileFormat fileFormat() {
    return FileFormat.PARQUET;
  }
}
```
