### PR TITLE
CI: Run Markdown links checker only when `{docs,site}/**` changes

### DIFF
--- a/.github/workflows/docs-check-links.yml
+++ b/.github/workflows/docs-check-links.yml
@@ -27,6 +27,9 @@ on:
     branches:
       - 'main'
   pull_request:
+    paths:
+      - docs/**
+      - site/**
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Hopefully this generates less requests, causing the CI to fail due to 429's