### PR TITLE
Extend HTTPClient Builder to allow setting a proxy server

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -527,10 +527,10 @@ public class HTTPClient implements RESTClient {
       return this;
     }
 
-    public Builder withProxyCredentialsProvider(CredentialsProvider proxyCredentialsProvider) {
+    public Builder withProxyCredentialsProvider(CredentialsProvider credentialsProvider) {
       Preconditions.checkNotNull(
-          proxyCredentialsProvider, "Invalid credentials provider for http client proxy: null");
-      this.proxyCredentialsProvider = proxyCredentialsProvider;
+          credentialsProvider, "Invalid credentials provider for http client proxy: null");
+      this.proxyCredentialsProvider = credentialsProvider;
       return this;
     }
 
@@ -559,7 +559,7 @@ public class HTTPClient implements RESTClient {
         interceptor = loadInterceptorDynamically(SIGV4_REQUEST_INTERCEPTOR_IMPL, properties);
       }
 
-      if (proxyCredentialsProvider != null) {
+      if (this.proxyCredentialsProvider != null) {
         Preconditions.checkNotNull(
             proxy, "Invalid http client proxy for proxy credentials provider: null");
       }

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -95,7 +95,7 @@ public class HTTPClient implements RESTClient {
   private HTTPClient(
       String uri,
       HttpHost proxy,
-      CredentialsProvider credsProvider,
+      CredentialsProvider proxyCredsProvider,
       Map<String, String> baseHeaders,
       ObjectMapper objectMapper,
       HttpRequestInterceptor requestInterceptor,
@@ -123,8 +123,8 @@ public class HTTPClient implements RESTClient {
     clientBuilder.setRetryStrategy(new ExponentialHttpRequestRetryStrategy(maxRetries));
 
     if (proxy != null) {
-      if (credsProvider != null) {
-        clientBuilder.setDefaultCredentialsProvider(credsProvider);
+      if (proxyCredsProvider != null) {
+        clientBuilder.setDefaultCredentialsProvider(proxyCredsProvider);
       }
 
       clientBuilder.setProxy(proxy);

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -509,7 +509,7 @@ public class HTTPClient implements RESTClient {
     private String uri;
     private ObjectMapper mapper = RESTObjectMapper.mapper();
     private HttpHost proxy;
-    private CredentialsProvider credentialsProvider;
+    private CredentialsProvider proxyCredentialsProvider;
 
     private Builder(Map<String, String> properties) {
       this.properties = properties;
@@ -527,10 +527,10 @@ public class HTTPClient implements RESTClient {
       return this;
     }
 
-    public Builder withProxyCredentialsProvider(CredentialsProvider credentialsProvider) {
+    public Builder withProxyCredentialsProvider(CredentialsProvider proxyCredentialsProvider) {
       Preconditions.checkNotNull(
-          credentialsProvider, "Invalid credentials provider for http client proxy: null");
-      this.credentialsProvider = credentialsProvider;
+          proxyCredentialsProvider, "Invalid credentials provider for http client proxy: null");
+      this.proxyCredentialsProvider = proxyCredentialsProvider;
       return this;
     }
 
@@ -559,10 +559,15 @@ public class HTTPClient implements RESTClient {
         interceptor = loadInterceptorDynamically(SIGV4_REQUEST_INTERCEPTOR_IMPL, properties);
       }
 
+      if (proxyCredentialsProvider != null) {
+        Preconditions.checkNotNull(
+            proxy, "Invalid http client proxy for proxy credentials provider: null");
+      }
+
       return new HTTPClient(
           uri,
           proxy,
-          credentialsProvider,
+          proxyCredentialsProvider,
           baseHeaders,
           mapper,
           interceptor,

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -134,7 +134,7 @@ public class TestHTTPClient {
   }
 
   @Test
-  public void testHttpClientProxyServer() throws IOException {
+  public void testProxyServer() throws IOException {
     int proxyPort = 1070;
     String proxyHostName = "localhost";
     try (ClientAndServer proxyServer = startClientAndServer(proxyPort);
@@ -181,7 +181,7 @@ public class TestHTTPClient {
   }
 
   @Test
-  public void testHttpClientProxyAuthenticationFailure() throws IOException {
+  public void testProxyAuthenticationFailure() throws IOException {
     int proxyPort = 1070;
     String proxyHostName = "localhost";
     String authorizedUsername = "test-username";

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -136,12 +136,11 @@ public class TestHTTPClient {
   @Test
   public void testProxyServer() throws IOException {
     int proxyPort = 1070;
-    String proxyHostName = "localhost";
     try (ClientAndServer proxyServer = startClientAndServer(proxyPort);
         RESTClient clientWithProxy =
             HTTPClient.builder(ImmutableMap.of())
                 .uri(URI)
-                .withProxy(proxyHostName, proxyPort)
+                .withProxy("localhost", proxyPort)
                 .build()) {
       String path = "v1/config";
 
@@ -159,16 +158,12 @@ public class TestHTTPClient {
   }
 
   @Test
-  public void testProxyCredentialProviderWithoutProxyServerFailsBuild() throws IOException {
-    int proxyPort = 1070;
-    String proxyHostName = "localhost";
-    String authorizedUsername = "test-username";
-    String authorizedPassword = "test-password";
-    HttpHost proxy = new HttpHost(proxyHostName, proxyPort);
+  public void testProxyCredentialProviderWithoutProxyServer() {
+    HttpHost proxy = new HttpHost("localhost", 1070);
     BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     credentialsProvider.setCredentials(
         new AuthScope(proxy),
-        new UsernamePasswordCredentials(authorizedUsername, authorizedPassword.toCharArray()));
+        new UsernamePasswordCredentials("test-username", "test-password".toCharArray()));
     Assertions.assertThatThrownBy(
             () -> {
               HTTPClient.builder(ImmutableMap.of())
@@ -178,6 +173,16 @@ public class TestHTTPClient {
             })
         .isInstanceOf(NullPointerException.class)
         .hasMessage("Invalid http client proxy for proxy credentials provider: null");
+  }
+
+  @Test
+  public void testProxyServerWithNullHostname() {
+    Assertions.assertThatThrownBy(
+            () -> {
+              HTTPClient.builder(ImmutableMap.of()).uri(URI).withProxy(null, 1070).build();
+            })
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Invalid hostname for http client proxy: null");
   }
 
   @Test


### PR DESCRIPTION
This PR includes code changes to extend the capability of the existing rest HTTPClient to allow setting a proxy server with basic username/password authentication. The requests made by the HTTPClient will be routed via the proxy server if the HTTPClient is configured with one. If the HTTPClient is not configured with a proxy we default to the current behavior. 