### PR TITLE
Aliyun: Add loading oss file into memory option to OSS client properties

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
@@ -75,12 +75,14 @@ public class AliyunProperties implements Serializable {
    * java.io.tmpdir.
    */
   public static final String OSS_STAGING_DIRECTORY = "oss.staging-dir";
+  public static final String OSS_LOAD_BEFORE_READING = "oss.load-before-reading";
 
   private final String ossEndpoint;
   private final String accessKeyId;
   private final String accessKeySecret;
   private final String securityToken;
   private final String ossStagingDirectory;
+  private final boolean ossLoadBeforeReading;
 
   public AliyunProperties() {
     this(ImmutableMap.of());
@@ -94,8 +96,11 @@ public class AliyunProperties implements Serializable {
     this.securityToken = properties.get(CLIENT_SECURITY_TOKEN);
 
     this.ossStagingDirectory =
-        PropertyUtil.propertyAsString(
-            properties, OSS_STAGING_DIRECTORY, System.getProperty("java.io.tmpdir"));
+            PropertyUtil.propertyAsString(
+                    properties, OSS_STAGING_DIRECTORY, System.getProperty("java.io.tmpdir"));
+    this.ossLoadBeforeReading =
+            PropertyUtil.propertyAsBoolean(
+                    properties, OSS_LOAD_BEFORE_READING, false);
   }
 
   public String ossEndpoint() {
@@ -116,5 +121,9 @@ public class AliyunProperties implements Serializable {
 
   public String ossStagingDirectory() {
     return ossStagingDirectory;
+  }
+
+  public boolean ossLoadBeforeReading() {
+    return ossLoadBeforeReading;
   }
 }

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
@@ -75,6 +75,7 @@ public class AliyunProperties implements Serializable {
    * java.io.tmpdir.
    */
   public static final String OSS_STAGING_DIRECTORY = "oss.staging-dir";
+
   public static final String OSS_LOAD_BEFORE_READING = "oss.load-before-reading";
 
   private final String ossEndpoint;
@@ -96,11 +97,10 @@ public class AliyunProperties implements Serializable {
     this.securityToken = properties.get(CLIENT_SECURITY_TOKEN);
 
     this.ossStagingDirectory =
-            PropertyUtil.propertyAsString(
-                    properties, OSS_STAGING_DIRECTORY, System.getProperty("java.io.tmpdir"));
+        PropertyUtil.propertyAsString(
+            properties, OSS_STAGING_DIRECTORY, System.getProperty("java.io.tmpdir"));
     this.ossLoadBeforeReading =
-            PropertyUtil.propertyAsBoolean(
-                    properties, OSS_LOAD_BEFORE_READING, false);
+        PropertyUtil.propertyAsBoolean(properties, OSS_LOAD_BEFORE_READING, false);
   }
 
   public String ossEndpoint() {

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputFile.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputFile.java
@@ -34,11 +34,11 @@ class OSSInputFile extends BaseOSSFile implements InputFile {
   }
 
   OSSInputFile(
-          OSS client,
-          OSSURI uri,
-          AliyunProperties aliyunProperties,
-          long length,
-          MetricsContext metrics) {
+      OSS client,
+      OSSURI uri,
+      AliyunProperties aliyunProperties,
+      long length,
+      MetricsContext metrics) {
     super(client, uri, aliyunProperties, metrics);
     ValidationException.check(length >= 0, "Invalid file length: %s", length);
     this.length = length;

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputFile.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputFile.java
@@ -34,11 +34,11 @@ class OSSInputFile extends BaseOSSFile implements InputFile {
   }
 
   OSSInputFile(
-      OSS client,
-      OSSURI uri,
-      AliyunProperties aliyunProperties,
-      long length,
-      MetricsContext metrics) {
+          OSS client,
+          OSSURI uri,
+          AliyunProperties aliyunProperties,
+          long length,
+          MetricsContext metrics) {
     super(client, uri, aliyunProperties, metrics);
     ValidationException.check(length >= 0, "Invalid file length: %s", length);
     this.length = length;
@@ -54,6 +54,6 @@ class OSSInputFile extends BaseOSSFile implements InputFile {
 
   @Override
   public SeekableInputStream newStream() {
-    return new OSSInputStream(client(), uri(), metrics());
+    return new OSSInputStream(client(), uri(), metrics(), aliyunProperties());
   }
 }

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.aliyun.oss;
 
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.model.GetObjectRequest;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;


### PR DESCRIPTION
OSS will close connections that have not sent or received data for more than 1 minute. When the backpressure time of Flink is too long, it will throw an exception and cause the Flink task to crash. Consulting with Alibaba Cloud official, it was found that the OSS client does not have a configuration option to increase timeout time. Therefore, a configuration option was added to load all OSS files into memory first, and then read data from memory.

There was already an issue about Spark before
https://github.com/apache/iceberg/issues/5963