### PR TITLE
Migrate TableTestBase related classes to JUnit5

### DIFF
--- a/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,7 +50,6 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -163,13 +163,13 @@ public class TestTableScanUtil {
         TableScanUtil.planTaskGroups(CloseableIterable.withNoopClose(baseFileScanTasks), 1, 1, 0)) {
       for (FileScanTask fileScanTask : task.tasks()) {
         DataFile taskDataFile = fileScanTask.file();
-        Assertions.assertThat(taskDataFile.splitOffsets()).isNull();
+        assertThat(taskDataFile.splitOffsets()).isNull();
         taskCount++;
       }
     }
 
     // 10 tasks since the split offsets are ignored and there are 1 byte splits for a 10 byte file
-    Assertions.assertThat(taskCount).isEqualTo(10);
+    assertThat(taskCount).isEqualTo(10);
   }
 
   @Test
@@ -280,7 +280,7 @@ public class TestTableScanUtil {
         ImmutableList.of(
             taskWithPartition(SPEC1, PARTITION1, 128), taskWithPartition(SPEC2, PARTITION2, 128));
 
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> TableScanUtil.planTaskGroups(tasks2, 128, 10, 4, SPEC2.partitionType()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot find field");

--- a/data/src/test/java/org/apache/iceberg/io/TestPositionDeltaWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestPositionDeltaWriters.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.io;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -34,7 +36,6 @@ import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.util.StructLikeSet;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,7 +68,7 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
   @BeforeEach
   public void setupTable() throws Exception {
     this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    Assert.assertTrue(tableDir.delete()); // created during table creation
+    assertThat(tableDir.delete()).isTrue(); // created during table creation
 
     this.metadataDir = new File(tableDir, "metadata");
     this.table = create(SCHEMA, PartitionSpec.unpartitioned());
@@ -94,9 +95,9 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
     DeleteFile[] deleteFiles = result.deleteFiles();
     CharSequence[] referencedDataFiles = result.referencedDataFiles();
 
-    Assert.assertEquals("Must be 1 data files", 1, dataFiles.length);
-    Assert.assertEquals("Must be no delete files", 0, deleteFiles.length);
-    Assert.assertEquals("Must not reference data files", 0, referencedDataFiles.length);
+    assertThat(dataFiles).hasSize(1);
+    assertThat(deleteFiles).isEmpty();
+    assertThat(referencedDataFiles).isEmpty();
   }
 
   @TestTemplate
@@ -121,9 +122,9 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
     DeleteFile[] deleteFiles = result.deleteFiles();
     CharSequence[] referencedDataFiles = result.referencedDataFiles();
 
-    Assert.assertEquals("Must be 1 data files", 1, dataFiles.length);
-    Assert.assertEquals("Must be no delete files", 0, deleteFiles.length);
-    Assert.assertEquals("Must not reference data files", 0, referencedDataFiles.length);
+    assertThat(dataFiles).hasSize(1);
+    assertThat(deleteFiles).isEmpty();
+    assertThat(referencedDataFiles).isEmpty();
 
     RowDelta rowDelta = table.newRowDelta();
     for (DataFile dataFile : dataFiles) {
@@ -132,7 +133,7 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
     rowDelta.commit();
 
     List<T> expectedRows = ImmutableList.of(toRow(1, "aaa"));
-    Assert.assertEquals("Records should match", toSet(expectedRows), actualRowSet("*"));
+    assertThat(actualRowSet("*")).isEqualTo(toSet(expectedRows));
   }
 
   @TestTemplate
@@ -177,10 +178,9 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
     DeleteFile[] deleteFiles = result.deleteFiles();
     CharSequence[] referencedDataFiles = result.referencedDataFiles();
 
-    Assert.assertEquals("Must be 0 data files", 0, dataFiles.length);
-    Assert.assertEquals("Must be 2 delete files", 2, deleteFiles.length);
-    Assert.assertEquals("Must reference 2 data files", 2, referencedDataFiles.length);
-
+    assertThat(dataFiles).isEmpty();
+    assertThat(deleteFiles).hasSize(2);
+    assertThat(referencedDataFiles).hasSize(2);
     RowDelta rowDelta = table.newRowDelta();
     for (DeleteFile deleteFile : deleteFiles) {
       rowDelta.addDeletes(deleteFile);
@@ -188,7 +188,7 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
     rowDelta.commit();
 
     List<T> expectedRows = ImmutableList.of(toRow(1, "aaa"), toRow(2, "aaa"), toRow(3, "bbb"));
-    Assert.assertEquals("Records should match", toSet(expectedRows), actualRowSet("*"));
+    assertThat(actualRowSet("*")).isEqualTo(toSet(expectedRows));
   }
 
   @TestTemplate
@@ -234,9 +234,9 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
     DeleteFile[] deleteFiles = result.deleteFiles();
     CharSequence[] referencedDataFiles = result.referencedDataFiles();
 
-    Assert.assertEquals("Must be 1 data files", 1, dataFiles.length);
-    Assert.assertEquals("Must be 2 delete files", 2, deleteFiles.length);
-    Assert.assertEquals("Must reference 2 data files", 2, referencedDataFiles.length);
+    assertThat(dataFiles).hasSize(1);
+    assertThat(deleteFiles).hasSize(2);
+    assertThat(referencedDataFiles).hasSize(2);
 
     RowDelta rowDelta = table.newRowDelta();
     for (DataFile dataFile : dataFiles) {
@@ -249,6 +249,6 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
 
     List<T> expectedRows =
         ImmutableList.of(toRow(1, "aaa"), toRow(2, "aaa"), toRow(3, "bbb"), toRow(10, "ccc"));
-    Assert.assertEquals("Records should match", toSet(expectedRows), actualRowSet("*"));
+    assertThat(actualRowSet("*")).isEqualTo(toSet(expectedRows));
   }
 }

--- a/data/src/test/java/org/apache/iceberg/io/TestRollingFileWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestRollingFileWriters.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.io;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -33,7 +35,6 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,7 +75,7 @@ public abstract class TestRollingFileWriters<T> extends WriterTestBase<T> {
   @BeforeEach
   public void setupTable() throws Exception {
     this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    Assert.assertTrue(tableDir.delete()); // created during table creation
+    assertThat(tableDir.delete()).isTrue(); // created during table creation
 
     this.metadataDir = new File(tableDir, "metadata");
 
@@ -97,10 +98,10 @@ public abstract class TestRollingFileWriters<T> extends WriterTestBase<T> {
             writerFactory, fileFactory, table.io(), DEFAULT_FILE_SIZE, table.spec(), partition);
 
     writer.close();
-    Assert.assertEquals("Must be no data files", 0, writer.result().dataFiles().size());
+    assertThat(writer.result().dataFiles()).isEmpty();
 
     writer.close();
-    Assert.assertEquals("Must be no data files", 0, writer.result().dataFiles().size());
+    assertThat(writer.result().dataFiles()).isEmpty();
   }
 
   @TestTemplate
@@ -122,7 +123,7 @@ public abstract class TestRollingFileWriters<T> extends WriterTestBase<T> {
     // call close again to ensure it is idempotent
     writer.close();
 
-    Assert.assertEquals(4, writer.result().dataFiles().size());
+    assertThat(writer.result().dataFiles()).hasSize(4);
   }
 
   @TestTemplate
@@ -136,14 +137,14 @@ public abstract class TestRollingFileWriters<T> extends WriterTestBase<T> {
             writerFactory, fileFactory, table.io(), DEFAULT_FILE_SIZE, table.spec(), partition);
 
     writer.close();
-    Assert.assertEquals(0, writer.result().deleteFiles().size());
-    Assert.assertEquals(0, writer.result().referencedDataFiles().size());
-    Assert.assertFalse(writer.result().referencesDataFiles());
+    assertThat(writer.result().deleteFiles()).isEmpty();
+    assertThat(writer.result().referencedDataFiles()).isEmpty();
+    assertThat(writer.result().referencesDataFiles()).isFalse();
 
     writer.close();
-    Assert.assertEquals(0, writer.result().deleteFiles().size());
-    Assert.assertEquals(0, writer.result().referencedDataFiles().size());
-    Assert.assertFalse(writer.result().referencesDataFiles());
+    assertThat(writer.result().deleteFiles()).isEmpty();
+    assertThat(writer.result().referencedDataFiles()).isEmpty();
+    assertThat(writer.result().referencesDataFiles()).isFalse();
   }
 
   @TestTemplate
@@ -169,9 +170,9 @@ public abstract class TestRollingFileWriters<T> extends WriterTestBase<T> {
     writer.close();
 
     DeleteWriteResult result = writer.result();
-    Assert.assertEquals(4, result.deleteFiles().size());
-    Assert.assertEquals(0, result.referencedDataFiles().size());
-    Assert.assertFalse(result.referencesDataFiles());
+    assertThat(writer.result().deleteFiles()).hasSize(4);
+    assertThat(writer.result().referencedDataFiles()).isEmpty();
+    assertThat(writer.result().referencesDataFiles()).isFalse();
   }
 
   @TestTemplate
@@ -182,14 +183,14 @@ public abstract class TestRollingFileWriters<T> extends WriterTestBase<T> {
             writerFactory, fileFactory, table.io(), DEFAULT_FILE_SIZE, table.spec(), partition);
 
     writer.close();
-    Assert.assertEquals(0, writer.result().deleteFiles().size());
-    Assert.assertEquals(0, writer.result().referencedDataFiles().size());
-    Assert.assertFalse(writer.result().referencesDataFiles());
+    assertThat(writer.result().deleteFiles()).isEmpty();
+    assertThat(writer.result().referencedDataFiles()).isEmpty();
+    assertThat(writer.result().referencesDataFiles()).isFalse();
 
     writer.close();
-    Assert.assertEquals(0, writer.result().deleteFiles().size());
-    Assert.assertEquals(0, writer.result().referencedDataFiles().size());
-    Assert.assertFalse(writer.result().referencesDataFiles());
+    assertThat(writer.result().deleteFiles()).isEmpty();
+    assertThat(writer.result().referencedDataFiles()).isEmpty();
+    assertThat(writer.result().referencesDataFiles()).isFalse();
   }
 
   @TestTemplate
@@ -213,8 +214,8 @@ public abstract class TestRollingFileWriters<T> extends WriterTestBase<T> {
     writer.close();
 
     DeleteWriteResult result = writer.result();
-    Assert.assertEquals(4, result.deleteFiles().size());
-    Assert.assertEquals(1, result.referencedDataFiles().size());
-    Assert.assertTrue(result.referencesDataFiles());
+    assertThat(writer.result().deleteFiles()).hasSize(4);
+    assertThat(writer.result().referencedDataFiles()).hasSize(1);
+    assertThat(writer.result().referencesDataFiles()).isTrue();
   }
 }

--- a/data/src/test/java/org/apache/iceberg/io/TestRollingFileWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestRollingFileWriters.java
@@ -169,7 +169,6 @@ public abstract class TestRollingFileWriters<T> extends WriterTestBase<T> {
     // call close again to ensure it is idempotent
     writer.close();
 
-    DeleteWriteResult result = writer.result();
     assertThat(writer.result().deleteFiles()).hasSize(4);
     assertThat(writer.result().referencedDataFiles()).isEmpty();
     assertThat(writer.result().referencesDataFiles()).isFalse();
@@ -213,7 +212,6 @@ public abstract class TestRollingFileWriters<T> extends WriterTestBase<T> {
     // call close again to ensure it is idempotent
     writer.close();
 
-    DeleteWriteResult result = writer.result();
     assertThat(writer.result().deleteFiles()).hasSize(4);
     assertThat(writer.result().referencedDataFiles()).hasSize(1);
     assertThat(writer.result().referencesDataFiles()).isTrue();

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -24,6 +24,7 @@ import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
 import static org.apache.iceberg.flink.SimpleDataUtil.createUpdateAfter;
 import static org.apache.iceberg.flink.SimpleDataUtil.createUpdateBefore;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,11 +64,8 @@ import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -90,7 +88,7 @@ public class TestDeltaTaskWriter extends TestBase {
   @BeforeEach
   public void setupTable() throws IOException {
     this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    Assert.assertTrue(tableDir.delete()); // created by table create
+    assertThat(tableDir.delete()).isTrue(); // created by table create
 
     this.metadataDir = new File(tableDir, "metadata");
   }
@@ -132,18 +130,17 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(3, "ccc")); // 1 pos-delete and 1 eq-delete.
 
     WriteResult result = writer.complete();
-    Assert.assertEquals(partitioned ? 7 : 1, result.dataFiles().length);
-    Assert.assertEquals(partitioned ? 3 : 1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(partitioned ? 7 : 1);
+    assertThat(result.deleteFiles()).hasSize(partitioned ? 3 : 1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records.",
-        expectedRowSet(
-            createRecord(1, "eee"),
-            createRecord(2, "ddd"),
-            createRecord(4, "fff"),
-            createRecord(5, "ggg")),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .isEqualTo(
+            expectedRowSet(
+                createRecord(1, "eee"),
+                createRecord(2, "ddd"),
+                createRecord(4, "fff"),
+                createRecord(5, "ggg")));
 
     // Start the 2nd transaction.
     writer = taskWriterFactory.create();
@@ -160,14 +157,13 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(4, "fff")); // 1 eq-delete.
 
     result = writer.complete();
-    Assert.assertEquals(partitioned ? 2 : 1, result.dataFiles().length);
-    Assert.assertEquals(partitioned ? 3 : 1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(partitioned ? 2 : 1);
+    assertThat(result.deleteFiles()).hasSize(partitioned ? 3 : 1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(createRecord(1, "eee"), createRecord(5, "iii"), createRecord(6, "hhh")),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .isEqualTo(
+            expectedRowSet(createRecord(1, "eee"), createRecord(5, "iii"), createRecord(6, "hhh")));
   }
 
   @TestTemplate
@@ -194,11 +190,11 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(3, "ccc"));
 
     WriteResult result = writer.complete();
-    Assert.assertEquals(0, result.dataFiles().length);
-    Assert.assertEquals(partitioned ? 3 : 1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).isEmpty();
+    assertThat(result.deleteFiles()).hasSize(partitioned ? 3 : 1);
     commitTransaction(result);
 
-    Assert.assertEquals("Should have no record", expectedRowSet(), actualRowSet("*"));
+    assertThat(actualRowSet("*")).isEqualTo(expectedRowSet());
   }
 
   @TestTemplate
@@ -232,14 +228,11 @@ public class TestDeltaTaskWriter extends TestBase {
             .filter(p -> p.toFile().isFile())
             .filter(p -> !p.toString().endsWith(".crc"))
             .collect(Collectors.toList());
-    Assert.assertEquals(
-        "Should have expected file count, but files are: " + files,
-        partitioned ? 4 : 2,
-        files.size());
+    assertThat(files).hasSize(partitioned ? 4 : 2);
 
     writer.abort();
     for (Path file : files) {
-      Assert.assertFalse(Files.exists(file));
+      assertThat(file).doesNotExist();
     }
   }
 
@@ -268,14 +261,13 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createInsert(4, "ccc"));
 
     WriteResult result = writer.complete();
-    Assert.assertEquals(3, result.dataFiles().length);
-    Assert.assertEquals(1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(3);
+    assertThat(result.deleteFiles()).hasSize(1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(createRecord(2, "aaa"), createRecord(3, "bbb"), createRecord(4, "ccc")),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .isEqualTo(
+            expectedRowSet(createRecord(2, "aaa"), createRecord(3, "bbb"), createRecord(4, "ccc")));
 
     // Start the 2nd transaction.
     writer = taskWriterFactory.create();
@@ -284,18 +276,17 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(7, "ccc")); // 1 eq-delete.
 
     result = writer.complete();
-    Assert.assertEquals(2, result.dataFiles().length);
-    Assert.assertEquals(1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(2);
+    assertThat(result.deleteFiles()).hasSize(1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(
-            createRecord(2, "aaa"),
-            createRecord(5, "aaa"),
-            createRecord(3, "bbb"),
-            createRecord(6, "bbb")),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .isEqualTo(
+            expectedRowSet(
+                createRecord(2, "aaa"),
+                createRecord(5, "aaa"),
+                createRecord(3, "bbb"),
+                createRecord(6, "bbb")));
   }
 
   @TestTemplate
@@ -312,15 +303,12 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(2, "aaa")); // 1 pos-delete.
 
     WriteResult result = writer.complete();
-    Assert.assertEquals(1, result.dataFiles().length);
-    Assert.assertEquals(1, result.deleteFiles().length);
-    Assert.assertEquals(
-        Sets.newHashSet(FileContent.POSITION_DELETES),
-        Sets.newHashSet(result.deleteFiles()[0].content()));
+    assertThat(result.dataFiles()).hasSize(1);
+    assertThat(result.deleteFiles()).hasSize(1);
+    assertThat(result.deleteFiles()[0].content()).isEqualTo(FileContent.POSITION_DELETES);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records", expectedRowSet(createRecord(1, "aaa")), actualRowSet("*"));
+    assertThat(actualRowSet("*")).isEqualTo(expectedRowSet(createRecord(1, "aaa")));
   }
 
   @TestTemplate
@@ -361,14 +349,14 @@ public class TestDeltaTaskWriter extends TestBase {
 
     WriteResult result = writer.complete();
     // One data file
-    Assertions.assertThat(result.dataFiles().length).isEqualTo(1);
+    assertThat(result.dataFiles()).hasSize(1);
     // One eq delete file + one pos delete file
-    Assertions.assertThat(result.deleteFiles().length).isEqualTo(2);
-    Assertions.assertThat(
+    assertThat(result.deleteFiles()).hasSize(2);
+    assertThat(
             Arrays.stream(result.deleteFiles())
                 .map(ContentFile::content)
                 .collect(Collectors.toSet()))
-        .isEqualTo(Sets.newHashSet(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES));
+        .containsExactly(FileContent.EQUALITY_DELETES, FileContent.POSITION_DELETES);
     commitTransaction(result);
 
     Record expectedRecord = GenericRecord.create(tableSchema);
@@ -376,7 +364,7 @@ public class TestDeltaTaskWriter extends TestBase {
     int cutPrecisionNano = start.getNano() / 1000000 * 1000000;
     expectedRecord.setField("ts", start.withNano(cutPrecisionNano));
 
-    Assertions.assertThat(actualRowSet("*")).isEqualTo(expectedRowSet(expectedRecord));
+    assertThat(actualRowSet("*")).isEqualTo(expectedRowSet(expectedRecord));
   }
 
   private void commitTransaction(WriteResult result) {

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -64,6 +64,7 @@ import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
 import org.junit.jupiter.api.BeforeEach;
@@ -356,7 +357,7 @@ public class TestDeltaTaskWriter extends TestBase {
             Arrays.stream(result.deleteFiles())
                 .map(ContentFile::content)
                 .collect(Collectors.toSet()))
-        .containsExactly(FileContent.EQUALITY_DELETES, FileContent.POSITION_DELETES);
+        .isEqualTo(Sets.newHashSet(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES));
     commitTransaction(result);
 
     Record expectedRecord = GenericRecord.create(tableSchema);

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -24,6 +24,7 @@ import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
 import static org.apache.iceberg.flink.SimpleDataUtil.createUpdateAfter;
 import static org.apache.iceberg.flink.SimpleDataUtil.createUpdateBefore;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,11 +64,8 @@ import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -90,7 +88,7 @@ public class TestDeltaTaskWriter extends TestBase {
   @BeforeEach
   public void setupTable() throws IOException {
     this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    Assert.assertTrue(tableDir.delete()); // created by table create
+    assertThat(tableDir.delete()).isTrue(); // created by table create
 
     this.metadataDir = new File(tableDir, "metadata");
   }
@@ -132,18 +130,17 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(3, "ccc")); // 1 pos-delete and 1 eq-delete.
 
     WriteResult result = writer.complete();
-    Assert.assertEquals(partitioned ? 7 : 1, result.dataFiles().length);
-    Assert.assertEquals(partitioned ? 3 : 1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(partitioned ? 7 : 1);
+    assertThat(result.deleteFiles()).hasSize(partitioned ? 3 : 1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records.",
-        expectedRowSet(
-            createRecord(1, "eee"),
-            createRecord(2, "ddd"),
-            createRecord(4, "fff"),
-            createRecord(5, "ggg")),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .isEqualTo(
+            expectedRowSet(
+                createRecord(1, "eee"),
+                createRecord(2, "ddd"),
+                createRecord(4, "fff"),
+                createRecord(5, "ggg")));
 
     // Start the 2nd transaction.
     writer = taskWriterFactory.create();
@@ -160,14 +157,13 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(4, "fff")); // 1 eq-delete.
 
     result = writer.complete();
-    Assert.assertEquals(partitioned ? 2 : 1, result.dataFiles().length);
-    Assert.assertEquals(partitioned ? 3 : 1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(partitioned ? 2 : 1);
+    assertThat(result.deleteFiles()).hasSize(partitioned ? 3 : 1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(createRecord(1, "eee"), createRecord(5, "iii"), createRecord(6, "hhh")),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .isEqualTo(
+            expectedRowSet(createRecord(1, "eee"), createRecord(5, "iii"), createRecord(6, "hhh")));
   }
 
   @TestTemplate
@@ -194,11 +190,11 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(3, "ccc"));
 
     WriteResult result = writer.complete();
-    Assert.assertEquals(0, result.dataFiles().length);
-    Assert.assertEquals(partitioned ? 3 : 1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).isEmpty();
+    assertThat(result.deleteFiles()).hasSize(partitioned ? 3 : 1);
     commitTransaction(result);
 
-    Assert.assertEquals("Should have no record", expectedRowSet(), actualRowSet("*"));
+    assertThat(actualRowSet("*")).isEqualTo(expectedRowSet());
   }
 
   @TestTemplate
@@ -232,14 +228,11 @@ public class TestDeltaTaskWriter extends TestBase {
             .filter(p -> p.toFile().isFile())
             .filter(p -> !p.toString().endsWith(".crc"))
             .collect(Collectors.toList());
-    Assert.assertEquals(
-        "Should have expected file count, but files are: " + files,
-        partitioned ? 4 : 2,
-        files.size());
+    assertThat(files).hasSize(partitioned ? 4 : 2);
 
     writer.abort();
     for (Path file : files) {
-      Assert.assertFalse(Files.exists(file));
+      assertThat(file).doesNotExist();
     }
   }
 
@@ -268,14 +261,13 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createInsert(4, "ccc"));
 
     WriteResult result = writer.complete();
-    Assert.assertEquals(3, result.dataFiles().length);
-    Assert.assertEquals(1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(3);
+    assertThat(result.deleteFiles()).hasSize(1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(createRecord(2, "aaa"), createRecord(3, "bbb"), createRecord(4, "ccc")),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .isEqualTo(
+            expectedRowSet(createRecord(2, "aaa"), createRecord(3, "bbb"), createRecord(4, "ccc")));
 
     // Start the 2nd transaction.
     writer = taskWriterFactory.create();
@@ -284,18 +276,17 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(7, "ccc")); // 1 eq-delete.
 
     result = writer.complete();
-    Assert.assertEquals(2, result.dataFiles().length);
-    Assert.assertEquals(1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(2);
+    assertThat(result.deleteFiles()).hasSize(1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(
-            createRecord(2, "aaa"),
-            createRecord(5, "aaa"),
-            createRecord(3, "bbb"),
-            createRecord(6, "bbb")),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .isEqualTo(
+            expectedRowSet(
+                createRecord(2, "aaa"),
+                createRecord(5, "aaa"),
+                createRecord(3, "bbb"),
+                createRecord(6, "bbb")));
   }
 
   @TestTemplate
@@ -312,15 +303,12 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(2, "aaa")); // 1 pos-delete.
 
     WriteResult result = writer.complete();
-    Assert.assertEquals(1, result.dataFiles().length);
-    Assert.assertEquals(1, result.deleteFiles().length);
-    Assert.assertEquals(
-        Sets.newHashSet(FileContent.POSITION_DELETES),
-        Sets.newHashSet(result.deleteFiles()[0].content()));
+    assertThat(result.dataFiles()).hasSize(1);
+    assertThat(result.deleteFiles()).hasSize(1);
+    assertThat(result.deleteFiles()[0].content()).isEqualTo(FileContent.POSITION_DELETES);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records", expectedRowSet(createRecord(1, "aaa")), actualRowSet("*"));
+    assertThat(actualRowSet("*")).isEqualTo(expectedRowSet(createRecord(1, "aaa")));
   }
 
   @TestTemplate
@@ -361,14 +349,14 @@ public class TestDeltaTaskWriter extends TestBase {
 
     WriteResult result = writer.complete();
     // One data file
-    Assertions.assertThat(result.dataFiles().length).isEqualTo(1);
+    assertThat(result.dataFiles()).hasSize(1);
     // One eq delete file + one pos delete file
-    Assertions.assertThat(result.deleteFiles().length).isEqualTo(2);
-    Assertions.assertThat(
+    assertThat(result.deleteFiles()).hasSize(2);
+    assertThat(
             Arrays.stream(result.deleteFiles())
                 .map(ContentFile::content)
                 .collect(Collectors.toSet()))
-        .isEqualTo(Sets.newHashSet(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES));
+        .containsExactly(FileContent.EQUALITY_DELETES, FileContent.POSITION_DELETES);
     commitTransaction(result);
 
     Record expectedRecord = GenericRecord.create(tableSchema);
@@ -376,7 +364,7 @@ public class TestDeltaTaskWriter extends TestBase {
     int cutPrecisionNano = start.getNano() / 1000000 * 1000000;
     expectedRecord.setField("ts", start.withNano(cutPrecisionNano));
 
-    Assertions.assertThat(actualRowSet("*")).isEqualTo(expectedRowSet(expectedRecord));
+    assertThat(actualRowSet("*")).isEqualTo(expectedRowSet(expectedRecord));
   }
 
   private void commitTransaction(WriteResult result) {

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -64,6 +64,7 @@ import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
 import org.junit.jupiter.api.BeforeEach;
@@ -356,7 +357,7 @@ public class TestDeltaTaskWriter extends TestBase {
             Arrays.stream(result.deleteFiles())
                 .map(ContentFile::content)
                 .collect(Collectors.toSet()))
-        .containsExactly(FileContent.EQUALITY_DELETES, FileContent.POSITION_DELETES);
+        .isEqualTo(Sets.newHashSet(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES));
     commitTransaction(result);
 
     Record expectedRecord = GenericRecord.create(tableSchema);

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,9 +52,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.ThreadPools;
-import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -78,7 +77,7 @@ public class TestStreamingMonitorFunction extends TestBase {
   public void setupTable() throws IOException {
     this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.metadataDir = new File(tableDir, "metadata");
-    Assert.assertTrue(tableDir.delete());
+    assertThat(tableDir.delete()).isTrue();
 
     // Construct the iceberg table.
     table = create(SCHEMA, PartitionSpec.unpartitioned());
@@ -250,7 +249,7 @@ public class TestStreamingMonitorFunction extends TestBase {
             .maxPlanningSnapshotCount(0)
             .build();
 
-    Assertions.assertThatThrownBy(() -> createFunction(scanContext1))
+    assertThatThrownBy(() -> createFunction(scanContext1))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("The max-planning-snapshot-count must be greater than zero");
 
@@ -260,7 +259,7 @@ public class TestStreamingMonitorFunction extends TestBase {
             .maxPlanningSnapshotCount(-10)
             .build();
 
-    Assertions.assertThatThrownBy(() -> createFunction(scanContext2))
+    assertThatThrownBy(() -> createFunction(scanContext2))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("The max-planning-snapshot-count must be greater than zero");
   }
@@ -283,7 +282,7 @@ public class TestStreamingMonitorFunction extends TestBase {
     FlinkInputSplit[] expectedSplits =
         FlinkSplitPlanner.planInputSplits(table, scanContext, ThreadPools.getWorkerPool());
 
-    Assert.assertEquals("should produce 9 splits", 9, expectedSplits.length);
+    assertThat(expectedSplits).hasSize(9);
 
     // This covers three cases that maxPlanningSnapshotCount is less than, equal or greater than the
     // total splits number
@@ -307,10 +306,7 @@ public class TestStreamingMonitorFunction extends TestBase {
         function.monitorAndForwardSplits();
 
         if (maxPlanningSnapshotCount < 10) {
-          Assert.assertEquals(
-              "Should produce same splits as max-planning-snapshot-count",
-              maxPlanningSnapshotCount,
-              sourceContext.splits.size());
+          assertThat(sourceContext.splits).hasSize(maxPlanningSnapshotCount);
         }
       }
     }

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -356,7 +356,7 @@ public class TestDeltaTaskWriter extends TestBase {
             Arrays.stream(result.deleteFiles())
                 .map(ContentFile::content)
                 .collect(Collectors.toSet()))
-        .containsExactly(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES);
+        .containsExactly(FileContent.EQUALITY_DELETES, FileContent.POSITION_DELETES);
     commitTransaction(result);
 
     Record expectedRecord = GenericRecord.create(tableSchema);

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -24,6 +24,7 @@ import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
 import static org.apache.iceberg.flink.SimpleDataUtil.createUpdateAfter;
 import static org.apache.iceberg.flink.SimpleDataUtil.createUpdateBefore;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,11 +64,8 @@ import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -90,7 +88,7 @@ public class TestDeltaTaskWriter extends TestBase {
   @BeforeEach
   public void setupTable() throws IOException {
     this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    Assert.assertTrue(tableDir.delete()); // created by table create
+    assertThat(tableDir.delete()).isTrue(); // created by table create
 
     this.metadataDir = new File(tableDir, "metadata");
   }
@@ -132,18 +130,17 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(3, "ccc")); // 1 pos-delete and 1 eq-delete.
 
     WriteResult result = writer.complete();
-    Assert.assertEquals(partitioned ? 7 : 1, result.dataFiles().length);
-    Assert.assertEquals(partitioned ? 3 : 1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(partitioned ? 7 : 1);
+    assertThat(result.deleteFiles()).hasSize(partitioned ? 3 : 1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records.",
-        expectedRowSet(
-            createRecord(1, "eee"),
-            createRecord(2, "ddd"),
-            createRecord(4, "fff"),
-            createRecord(5, "ggg")),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .isEqualTo(
+            expectedRowSet(
+                createRecord(1, "eee"),
+                createRecord(2, "ddd"),
+                createRecord(4, "fff"),
+                createRecord(5, "ggg")));
 
     // Start the 2nd transaction.
     writer = taskWriterFactory.create();
@@ -160,14 +157,13 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(4, "fff")); // 1 eq-delete.
 
     result = writer.complete();
-    Assert.assertEquals(partitioned ? 2 : 1, result.dataFiles().length);
-    Assert.assertEquals(partitioned ? 3 : 1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(partitioned ? 2 : 1);
+    assertThat(result.deleteFiles()).hasSize(partitioned ? 3 : 1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(createRecord(1, "eee"), createRecord(5, "iii"), createRecord(6, "hhh")),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .isEqualTo(
+            expectedRowSet(createRecord(1, "eee"), createRecord(5, "iii"), createRecord(6, "hhh")));
   }
 
   @TestTemplate
@@ -194,11 +190,11 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(3, "ccc"));
 
     WriteResult result = writer.complete();
-    Assert.assertEquals(0, result.dataFiles().length);
-    Assert.assertEquals(partitioned ? 3 : 1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).isEmpty();
+    assertThat(result.deleteFiles()).hasSize(partitioned ? 3 : 1);
     commitTransaction(result);
 
-    Assert.assertEquals("Should have no record", expectedRowSet(), actualRowSet("*"));
+    assertThat(actualRowSet("*")).isEqualTo(expectedRowSet());
   }
 
   @TestTemplate
@@ -232,14 +228,11 @@ public class TestDeltaTaskWriter extends TestBase {
             .filter(p -> p.toFile().isFile())
             .filter(p -> !p.toString().endsWith(".crc"))
             .collect(Collectors.toList());
-    Assert.assertEquals(
-        "Should have expected file count, but files are: " + files,
-        partitioned ? 4 : 2,
-        files.size());
+    assertThat(files).hasSize(partitioned ? 4 : 2);
 
     writer.abort();
     for (Path file : files) {
-      Assert.assertFalse(Files.exists(file));
+      assertThat(file).doesNotExist();
     }
   }
 
@@ -268,14 +261,13 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createInsert(4, "ccc"));
 
     WriteResult result = writer.complete();
-    Assert.assertEquals(3, result.dataFiles().length);
-    Assert.assertEquals(1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(3);
+    assertThat(result.deleteFiles()).hasSize(1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(createRecord(2, "aaa"), createRecord(3, "bbb"), createRecord(4, "ccc")),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .isEqualTo(
+            expectedRowSet(createRecord(2, "aaa"), createRecord(3, "bbb"), createRecord(4, "ccc")));
 
     // Start the 2nd transaction.
     writer = taskWriterFactory.create();
@@ -284,18 +276,17 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(7, "ccc")); // 1 eq-delete.
 
     result = writer.complete();
-    Assert.assertEquals(2, result.dataFiles().length);
-    Assert.assertEquals(1, result.deleteFiles().length);
+    assertThat(result.dataFiles()).hasSize(2);
+    assertThat(result.deleteFiles()).hasSize(1);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records",
-        expectedRowSet(
-            createRecord(2, "aaa"),
-            createRecord(5, "aaa"),
-            createRecord(3, "bbb"),
-            createRecord(6, "bbb")),
-        actualRowSet("*"));
+    assertThat(actualRowSet("*"))
+        .isEqualTo(
+            expectedRowSet(
+                createRecord(2, "aaa"),
+                createRecord(5, "aaa"),
+                createRecord(3, "bbb"),
+                createRecord(6, "bbb")));
   }
 
   @TestTemplate
@@ -312,15 +303,12 @@ public class TestDeltaTaskWriter extends TestBase {
     writer.write(createDelete(2, "aaa")); // 1 pos-delete.
 
     WriteResult result = writer.complete();
-    Assert.assertEquals(1, result.dataFiles().length);
-    Assert.assertEquals(1, result.deleteFiles().length);
-    Assert.assertEquals(
-        Sets.newHashSet(FileContent.POSITION_DELETES),
-        Sets.newHashSet(result.deleteFiles()[0].content()));
+    assertThat(result.dataFiles()).hasSize(1);
+    assertThat(result.deleteFiles()).hasSize(1);
+    assertThat(result.deleteFiles()[0].content()).isEqualTo(FileContent.POSITION_DELETES);
     commitTransaction(result);
 
-    Assert.assertEquals(
-        "Should have expected records", expectedRowSet(createRecord(1, "aaa")), actualRowSet("*"));
+    assertThat(actualRowSet("*")).isEqualTo(expectedRowSet(createRecord(1, "aaa")));
   }
 
   @TestTemplate
@@ -361,14 +349,14 @@ public class TestDeltaTaskWriter extends TestBase {
 
     WriteResult result = writer.complete();
     // One data file
-    Assertions.assertThat(result.dataFiles().length).isEqualTo(1);
+    assertThat(result.dataFiles()).hasSize(1);
     // One eq delete file + one pos delete file
-    Assertions.assertThat(result.deleteFiles().length).isEqualTo(2);
-    Assertions.assertThat(
+    assertThat(result.deleteFiles()).hasSize(2);
+    assertThat(
             Arrays.stream(result.deleteFiles())
                 .map(ContentFile::content)
                 .collect(Collectors.toSet()))
-        .isEqualTo(Sets.newHashSet(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES));
+        .containsExactly(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES);
     commitTransaction(result);
 
     Record expectedRecord = GenericRecord.create(tableSchema);
@@ -376,7 +364,7 @@ public class TestDeltaTaskWriter extends TestBase {
     int cutPrecisionNano = start.getNano() / 1000000 * 1000000;
     expectedRecord.setField("ts", start.withNano(cutPrecisionNano));
 
-    Assertions.assertThat(actualRowSet("*")).isEqualTo(expectedRowSet(expectedRecord));
+    assertThat(actualRowSet("*")).isEqualTo(expectedRowSet(expectedRecord));
   }
 
   private void commitTransaction(WriteResult result) {

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -64,6 +64,7 @@ import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
 import org.junit.jupiter.api.BeforeEach;
@@ -356,7 +357,7 @@ public class TestDeltaTaskWriter extends TestBase {
             Arrays.stream(result.deleteFiles())
                 .map(ContentFile::content)
                 .collect(Collectors.toSet()))
-        .containsExactly(FileContent.EQUALITY_DELETES, FileContent.POSITION_DELETES);
+        .isEqualTo(Sets.newHashSet(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES));
     commitTransaction(result);
 
     Record expectedRecord = GenericRecord.create(tableSchema);

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,9 +52,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.ThreadPools;
-import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -78,7 +77,7 @@ public class TestStreamingMonitorFunction extends TestBase {
   public void setupTable() throws IOException {
     this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.metadataDir = new File(tableDir, "metadata");
-    Assert.assertTrue(tableDir.delete());
+    assertThat(tableDir.delete()).isTrue();
 
     // Construct the iceberg table.
     table = create(SCHEMA, PartitionSpec.unpartitioned());
@@ -250,7 +249,7 @@ public class TestStreamingMonitorFunction extends TestBase {
             .maxPlanningSnapshotCount(0)
             .build();
 
-    Assertions.assertThatThrownBy(() -> createFunction(scanContext1))
+    assertThatThrownBy(() -> createFunction(scanContext1))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("The max-planning-snapshot-count must be greater than zero");
 
@@ -260,7 +259,7 @@ public class TestStreamingMonitorFunction extends TestBase {
             .maxPlanningSnapshotCount(-10)
             .build();
 
-    Assertions.assertThatThrownBy(() -> createFunction(scanContext2))
+    assertThatThrownBy(() -> createFunction(scanContext2))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("The max-planning-snapshot-count must be greater than zero");
   }
@@ -283,7 +282,7 @@ public class TestStreamingMonitorFunction extends TestBase {
     FlinkInputSplit[] expectedSplits =
         FlinkSplitPlanner.planInputSplits(table, scanContext, ThreadPools.getWorkerPool());
 
-    Assert.assertEquals("should produce 9 splits", 9, expectedSplits.length);
+    assertThat(expectedSplits).hasSize(9);
 
     // This covers three cases that maxPlanningSnapshotCount is less than, equal or greater than the
     // total splits number
@@ -307,10 +306,7 @@ public class TestStreamingMonitorFunction extends TestBase {
         function.monitorAndForwardSplits();
 
         if (maxPlanningSnapshotCount < 10) {
-          Assert.assertEquals(
-              "Should produce same splits as max-planning-snapshot-count",
-              maxPlanningSnapshotCount,
-              sourceContext.splits.size());
+          assertThat(sourceContext.splits).hasSize(maxPlanningSnapshotCount);
         }
       }
     }


### PR DESCRIPTION
Migrate the following test classes to delete `TableTestBase`  for https://github.com/apache/iceberg/issues/9085.

This PR is for the migration of `TableTestBase` related classes in https://github.com/apache/iceberg/pull/10063.

## Current Progress

Core:
- [x] (skipped) `TestContentFileParser`
- [x] (skipped) `TestFileScanTaskParser` 
- [x] `util/TestTableScanUtil`


- [x] `WriterTestBase`
  - [x] `TestFileWriterFactory`
    - [x] `TestGenericFileWriterFactory`
    - [x] `TestSparkFileWriterFactory` for the versions: v3.3, v3.4, v3.5
    - [x] `TestFlinkFileWriterFactory` for the versions: v1.16, v.1.17, v1.18
  - [x] `TestPartitioningWriters`
    - [x] `TestSparkPartitioningWriters` for the versions: v3.3, v3.4, v3.5
    - [x] `TestFlinkPartitioningWriters` for the versions: v1.16, v.1.17, v1.18
  - [x] `TestPositionDeltaWriters`
    - [x] `TestSparkPositionDeltaWriters` for the versions: v3.3, v3.4, v3.5
    - [x] `TestFlinkPositionDeltaWriters` for the versions: v1.16, v.1.17, v1.18
  - [x] `TestRollingFileWriters`
    - [x] `TestSparkRollingFileWriters` for the versions: v3.3, v3.4, v3.5
    - [x] `TestFlinkRollingFileWriters` for the versions: v1.16, v.1.17, v1.18

`iceberg-flink` for the versions: v1.16, v.1.17, v1.18
- [x] `TestStreamingReaderOperator` 
- [x] `TestStreamingMonitorFunction`
- [x] `TestIcebergFilesCommitter`
- [x] `TestDeltaTaskWriter`
