### PR TITLE
Migrate AWS tests to JUnit5

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -145,7 +145,9 @@
                 org.apache.spark.sql.functions.*,
                 org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command.*,
                 org.apache.spark.sql.connector.write.RowLevelOperation.Command.*,
-                org.junit.Assert.*"/>
+                org.junit.Assert.*,
+                org.assertj.core.api.Assertions.*,
+                org.assertj.core.api.Assumptions.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>

--- a/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.aws;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
@@ -26,13 +29,11 @@ import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.exception.SdkServiceException;
@@ -57,7 +58,7 @@ public class TestAssumeRoleAwsClientFactory {
   private Map<String, String> assumeRoleProperties;
   private String policyName;
 
-  @Before
+  @BeforeEach
   public void before() {
     roleName = UUID.randomUUID().toString();
     iam =
@@ -95,7 +96,7 @@ public class TestAssumeRoleAwsClientFactory {
     policyName = UUID.randomUUID().toString();
   }
 
-  @After
+  @AfterEach
   public void after() {
     iam.deleteRolePolicy(
         DeleteRolePolicyRequest.builder().roleName(roleName).policyName(policyName).build());
@@ -134,7 +135,7 @@ public class TestAssumeRoleAwsClientFactory {
     GlueCatalog glueCatalog = new GlueCatalog();
     assumeRoleProperties.put("warehouse", "s3://path");
     glueCatalog.initialize("test", assumeRoleProperties);
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 glueCatalog.createNamespace(
                     Namespace.of("denied_" + UUID.randomUUID().toString().replace("-", ""))))
@@ -177,7 +178,7 @@ public class TestAssumeRoleAwsClientFactory {
 
     S3FileIO s3FileIO = new S3FileIO();
     s3FileIO.initialize(assumeRoleProperties);
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 s3FileIO
                     .newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/denied/file")
@@ -189,7 +190,7 @@ public class TestAssumeRoleAwsClientFactory {
 
     InputFile inputFile =
         s3FileIO.newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/allowed/file");
-    Assert.assertFalse("should be able to access file", inputFile.exists());
+    assertThat(inputFile.exists()).isFalse();
   }
 
   private void waitForIamConsistency() {
@@ -199,7 +200,7 @@ public class TestAssumeRoleAwsClientFactory {
         .ignoreExceptions()
         .untilAsserted(
             () ->
-                Assertions.assertThat(
+                assertThat(
                         iam.getRolePolicy(
                             GetRolePolicyRequest.builder()
                                 .roleName(roleName)

--- a/aws/src/integration/java/org/apache/iceberg/aws/TestDefaultAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestDefaultAwsClientFactory.java
@@ -18,11 +18,12 @@
  */
 package org.apache.iceberg.aws;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.Map;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
@@ -39,7 +40,7 @@ public class TestDefaultAwsClientFactory {
     properties.put(AwsProperties.GLUE_CATALOG_ENDPOINT, "https://unknown:1234");
     AwsClientFactory factory = AwsClientFactories.from(properties);
     GlueClient glueClient = factory.glue();
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> glueClient.getDatabase(GetDatabaseRequest.builder().name("TEST").build()))
         .cause()
         .isInstanceOf(SdkClientException.class)
@@ -52,7 +53,7 @@ public class TestDefaultAwsClientFactory {
     properties.put(S3FileIOProperties.ENDPOINT, "https://unknown:1234");
     AwsClientFactory factory = AwsClientFactories.from(properties);
     S3Client s3Client = factory.s3();
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 s3Client.getObject(GetObjectRequest.builder().bucket("bucket").key("key").build()))
         .cause()
@@ -67,7 +68,7 @@ public class TestDefaultAwsClientFactory {
     properties.put(S3FileIOProperties.SECRET_ACCESS_KEY, "unknown");
     AwsClientFactory factory = AwsClientFactories.from(properties);
     S3Client s3Client = factory.s3();
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 s3Client.getObject(
                     GetObjectRequest.builder()
@@ -84,7 +85,7 @@ public class TestDefaultAwsClientFactory {
     properties.put(AwsProperties.DYNAMODB_ENDPOINT, "https://unknown:1234");
     AwsClientFactory factory = AwsClientFactories.from(properties);
     DynamoDbClient dynamoDbClient = factory.dynamo();
-    Assertions.assertThatThrownBy(dynamoDbClient::listTables)
+    assertThatThrownBy(dynamoDbClient::listTables)
         .cause()
         .isInstanceOf(SdkClientException.class)
         .hasMessageContaining("Unable to execute HTTP request: unknown");

--- a/aws/src/integration/java/org/apache/iceberg/aws/dynamodb/TestDynamoDbCatalog.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/dynamodb/TestDynamoDbCatalog.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.aws.dynamodb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -42,11 +45,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
@@ -67,7 +68,7 @@ public class TestDynamoDbCatalog {
   private static DynamoDbCatalog catalog;
   private static String testBucket;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     catalogTableName = genRandomName();
     AwsClientFactory clientFactory = AwsClientFactories.defaultFactory();
@@ -84,7 +85,7 @@ public class TestDynamoDbCatalog {
             "s3://" + testBucket + "/" + genRandomName()));
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     dynamo.deleteTable(DeleteTableRequest.builder().tableName(catalogTableName).build());
   }
@@ -99,22 +100,23 @@ public class TestDynamoDbCatalog {
                 .tableName(catalogTableName)
                 .key(DynamoDbCatalog.namespacePrimaryKey(namespace))
                 .build());
-    Assert.assertTrue("namespace must exist", response.hasItem());
-    Assert.assertEquals(
-        "namespace must be stored in DynamoDB",
-        namespace.toString(),
-        response.item().get("namespace").s());
-    Assertions.assertThatThrownBy(() -> catalog.createNamespace(namespace))
+    assertThat(response.hasItem()).as("namespace must exist").isTrue();
+    assertThat(response.item())
+        .as("namespace must be stored in DynamoDB")
+        .hasEntrySatisfying(
+            "namespace",
+            attributeValue -> assertThat(attributeValue.s()).isEqualTo(namespace.toString()));
+    assertThatThrownBy(() -> catalog.createNamespace(namespace))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessageContaining("already exists");
   }
 
   @Test
   public void testCreateNamespaceBadName() {
-    Assertions.assertThatThrownBy(() -> catalog.createNamespace(Namespace.of("a", "", "b")))
+    assertThatThrownBy(() -> catalog.createNamespace(Namespace.of("a", "", "b")))
         .isInstanceOf(ValidationException.class)
         .hasMessageContaining("must not be empty");
-    Assertions.assertThatThrownBy(() -> catalog.createNamespace(Namespace.of("a", "b.c")))
+    assertThatThrownBy(() -> catalog.createNamespace(Namespace.of("a", "b.c")))
         .isInstanceOf(ValidationException.class)
         .hasMessageContaining("must not contain dot");
   }
@@ -128,7 +130,7 @@ public class TestDynamoDbCatalog {
             .collect(Collectors.toList());
     catalog.createNamespace(parent);
     namespaceList.forEach(ns -> catalog.createNamespace(ns));
-    Assert.assertEquals(4, catalog.listNamespaces(parent).size());
+    assertThat(catalog.listNamespaces(parent)).hasSize(4);
   }
 
   @Test
@@ -138,16 +140,16 @@ public class TestDynamoDbCatalog {
     properties.put("key1", "val1");
     properties.put("key2", "val2");
     catalog.createNamespace(namespace, properties);
-    Assert.assertEquals(properties, catalog.loadNamespaceMetadata(namespace));
+    assertThat(catalog.loadNamespaceMetadata(namespace)).isEqualTo(properties);
 
     properties.put("key3", "val3");
     properties.put("key2", "val2-1");
     catalog.setProperties(namespace, properties);
-    Assert.assertEquals(properties, catalog.loadNamespaceMetadata(namespace));
+    assertThat(catalog.loadNamespaceMetadata(namespace)).isEqualTo(properties);
 
     properties.remove("key3");
     catalog.removeProperties(namespace, Sets.newHashSet("key3"));
-    Assert.assertEquals(properties, catalog.loadNamespaceMetadata(namespace));
+    assertThat(catalog.loadNamespaceMetadata(namespace)).isEqualTo(properties);
   }
 
   @Test
@@ -162,16 +164,17 @@ public class TestDynamoDbCatalog {
                 .tableName(catalogTableName)
                 .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier))
                 .build());
-    Assert.assertTrue("table must exist", response.hasItem());
-    Assert.assertEquals(
-        "table must be stored in DynamoDB with table identifier as partition key",
-        tableIdentifier.toString(),
-        response.item().get("identifier").s());
-    Assert.assertEquals(
-        "table must be stored in DynamoDB with namespace as sort key",
-        namespace.toString(),
-        response.item().get("namespace").s());
-    Assertions.assertThatThrownBy(() -> catalog.createTable(tableIdentifier, SCHEMA))
+    assertThat(response.hasItem()).as("table must exist").isTrue();
+    assertThat(response.item())
+        .as("table must be stored in DynamoDB with table identifier as partition key")
+        .hasEntrySatisfying(
+            "identifier",
+            attributeValue -> assertThat(attributeValue.s()).isEqualTo(tableIdentifier.toString()))
+        .as("table must be stored in DynamoDB with namespace as sort key")
+        .hasEntrySatisfying(
+            "namespace",
+            attributeValue -> assertThat(attributeValue.s()).isEqualTo(namespace.toString()));
+    assertThatThrownBy(() -> catalog.createTable(tableIdentifier, SCHEMA))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessageContaining("already exists");
   }
@@ -180,12 +183,11 @@ public class TestDynamoDbCatalog {
   public void testCreateTableBadName() {
     Namespace namespace = Namespace.of(genRandomName());
     catalog.createNamespace(namespace);
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> catalog.createTable(TableIdentifier.of(Namespace.empty(), "a"), SCHEMA))
         .isInstanceOf(ValidationException.class)
         .hasMessageContaining("Table namespace must not be empty");
-    Assertions.assertThatThrownBy(
-            () -> catalog.createTable(TableIdentifier.of(namespace, "a.b"), SCHEMA))
+    assertThatThrownBy(() -> catalog.createTable(TableIdentifier.of(namespace, "a.b"), SCHEMA))
         .isInstanceOf(ValidationException.class)
         .hasMessageContaining("must not contain dot");
   }
@@ -199,7 +201,7 @@ public class TestDynamoDbCatalog {
             .mapToObj(i -> TableIdentifier.of(namespace, genRandomName()))
             .collect(Collectors.toList());
     tableIdentifiers.forEach(id -> catalog.createTable(id, SCHEMA));
-    Assert.assertEquals(3, catalog.listTables(namespace).size());
+    assertThat(catalog.listTables(namespace)).hasSize(3);
   }
 
   @Test
@@ -219,16 +221,17 @@ public class TestDynamoDbCatalog {
             .get("p.metadata_location")
             .s();
     catalog.dropTable(tableIdentifier, true);
-    Assert.assertFalse(
-        "table entry should not exist in dynamo",
-        dynamo
-            .getItem(
-                GetItemRequest.builder()
-                    .tableName(catalogTableName)
-                    .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier))
-                    .build())
-            .hasItem());
-    Assertions.assertThatThrownBy(
+    assertThat(
+            dynamo
+                .getItem(
+                    GetItemRequest.builder()
+                        .tableName(catalogTableName)
+                        .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier))
+                        .build())
+                .hasItem())
+        .as("table entry should not exist in dynamo")
+        .isFalse();
+    assertThatThrownBy(
             () ->
                 s3.headObject(
                     HeadObjectRequest.builder()
@@ -251,12 +254,12 @@ public class TestDynamoDbCatalog {
     TableIdentifier tableIdentifier = TableIdentifier.of(namespace, genRandomName());
     catalog.createTable(tableIdentifier, SCHEMA);
     TableIdentifier tableIdentifier2 = TableIdentifier.of(namespace2, genRandomName());
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () -> catalog.renameTable(TableIdentifier.of(namespace, "a"), tableIdentifier2))
         .isInstanceOf(NoSuchTableException.class)
         .hasMessageContaining("does not exist");
 
-    Assertions.assertThatThrownBy(() -> catalog.renameTable(tableIdentifier, tableIdentifier))
+    assertThatThrownBy(() -> catalog.renameTable(tableIdentifier, tableIdentifier))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessageContaining("already exists");
 
@@ -284,10 +287,9 @@ public class TestDynamoDbCatalog {
             .get("p.metadata_location")
             .s();
 
-    Assert.assertEquals(
-        "metadata location should be copied to new table entry",
-        metadataLocation,
-        metadataLocation2);
+    assertThat(metadataLocation2)
+        .as("metadata location should be copied to new table entry")
+        .isEqualTo(metadataLocation);
   }
 
   @Test
@@ -299,7 +301,7 @@ public class TestDynamoDbCatalog {
     Table table = catalog.loadTable(tableIdentifier);
     table.updateSchema().addColumn("data", Types.StringType.get()).commit();
     table.refresh();
-    Assert.assertEquals(2, table.schema().columns().size());
+    assertThat(table.schema().columns()).hasSize(2);
   }
 
   @Test
@@ -326,7 +328,7 @@ public class TestDynamoDbCatalog {
                         }))
         .get();
 
-    Assert.assertEquals(2, table.schema().columns().size());
+    assertThat(table.schema().columns()).hasSize(2);
   }
 
   @Test
@@ -340,7 +342,7 @@ public class TestDynamoDbCatalog {
                 .tableName(catalogTableName)
                 .key(DynamoDbCatalog.namespacePrimaryKey(namespace))
                 .build());
-    Assert.assertFalse("namespace must not exist", response.hasItem());
+    assertThat(response.hasItem()).as("namespace must not exist").isFalse();
   }
 
   @Test
@@ -350,17 +352,17 @@ public class TestDynamoDbCatalog {
     TableIdentifier identifier = TableIdentifier.of(namespace, catalogTableName);
     catalog.createTable(identifier, SCHEMA);
     Table registeringTable = catalog.loadTable(identifier);
-    Assertions.assertThat(catalog.dropTable(identifier, false)).isTrue();
+    assertThat(catalog.dropTable(identifier, false)).isTrue();
     TableOperations ops = ((HasTableOperations) registeringTable).operations();
     String metadataLocation = ((DynamoDbTableOperations) ops).currentMetadataLocation();
     Table registeredTable = catalog.registerTable(identifier, metadataLocation);
-    Assertions.assertThat(registeredTable).isNotNull();
+    assertThat(registeredTable).isNotNull();
     String expectedMetadataLocation =
         ((HasTableOperations) registeredTable).operations().current().metadataFileLocation();
-    Assertions.assertThat(metadataLocation).isEqualTo(expectedMetadataLocation);
-    Assertions.assertThat(catalog.loadTable(identifier)).isNotNull();
-    Assertions.assertThat(catalog.dropTable(identifier, true)).isTrue();
-    Assertions.assertThat(catalog.dropNamespace(namespace)).isTrue();
+    assertThat(metadataLocation).isEqualTo(expectedMetadataLocation);
+    assertThat(catalog.loadTable(identifier)).isNotNull();
+    assertThat(catalog.dropTable(identifier, true)).isTrue();
+    assertThat(catalog.dropNamespace(namespace)).isTrue();
   }
 
   @Test
@@ -373,8 +375,7 @@ public class TestDynamoDbCatalog {
     properties.put(DynamoDbCatalog.defaultLocationProperty(), defaultLocation);
     catalog.createNamespace(namespace, properties);
     String tableName = genRandomName();
-    Assertions.assertThat(
-            catalog.defaultWarehouseLocation(TableIdentifier.of(namespaceName, tableName)))
+    assertThat(catalog.defaultWarehouseLocation(TableIdentifier.of(namespaceName, tableName)))
         .isEqualTo(defaultLocation + "/" + tableName);
   }
 
@@ -387,11 +388,11 @@ public class TestDynamoDbCatalog {
     Table registeringTable = catalog.loadTable(identifier);
     TableOperations ops = ((HasTableOperations) registeringTable).operations();
     String metadataLocation = ((DynamoDbTableOperations) ops).currentMetadataLocation();
-    Assertions.assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation))
+    assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessageContaining("already exists");
-    Assertions.assertThat(catalog.dropTable(identifier, true)).isTrue();
-    Assertions.assertThat(catalog.dropNamespace(namespace)).isTrue();
+    assertThat(catalog.dropTable(identifier, true)).isTrue();
+    assertThat(catalog.dropNamespace(namespace)).isTrue();
   }
 
   private static String genRandomName() {

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -34,8 +34,8 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.glue.GlueClient;
@@ -75,7 +75,7 @@ public class GlueTestBase {
 
   static final String testBucketPath = "s3://" + testBucketName + "/" + testPathPrefix;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     glueCatalog = new GlueCatalog();
     AwsProperties awsProperties = new AwsProperties();
@@ -103,7 +103,7 @@ public class GlueTestBase {
         ImmutableMap.of());
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     AwsIntegTestUtil.cleanGlueCatalog(glue, namespaces);
     AwsIntegTestUtil.cleanS3Bucket(s3, testBucketName, testPathPrefix);

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.aws.glue;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.File;
 import java.util.Map;
 import org.apache.iceberg.BaseMetastoreTableOperations;
@@ -32,9 +35,7 @@ import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.metrics.MetricCollector;
@@ -60,14 +61,16 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps, new CommitFailedException("Datacenter on fire"));
-    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .isInstanceOf(CommitFailedException.class)
         .hasMessageContaining("Datacenter on fire");
 
     ops.refresh();
-    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
-    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
-    Assert.assertEquals("No new metadata files should exist", 2, metadataFileCount(ops.current()));
+    assertThat(ops.current()).as("Current metadata should not have changed").isEqualTo(metadataV2);
+    assertThat(metadataFileExists(metadataV2)).isTrue();
+    assertThat(metadataFileCount(ops.current()))
+        .as("No new metadata files should exist")
+        .isEqualTo(2);
   }
 
   @Test
@@ -80,18 +83,17 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps);
-    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .isInstanceOf(CommitStateUnknownException.class)
         .hasMessageContaining("Datacenter on fire");
     Mockito.verify(spyOps, Mockito.times(1)).refresh();
 
     ops.refresh();
-    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
-    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
-    Assert.assertEquals(
-        "Client could not determine outcome so new metadata file should also exist",
-        3,
-        metadataFileCount(ops.current()));
+    assertThat(ops.current()).as("Current metadata should not have changed").isEqualTo(metadataV2);
+    assertThat(metadataFileExists(metadataV2)).isTrue();
+    assertThat(metadataFileCount(ops.current()))
+        .as("Client could not determine outcome so new metadata file should also exist")
+        .isEqualTo(3);
   }
 
   @Test
@@ -104,7 +106,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps, ConcurrentModificationException.builder().build());
-    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .isInstanceOf(CommitFailedException.class)
         .hasMessageContaining("Glue detected concurrent update")
         .cause()
@@ -112,9 +114,11 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     Mockito.verify(spyOps, Mockito.times(0)).refresh();
 
     ops.refresh();
-    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
-    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
-    Assert.assertEquals("No new metadata files should exist", 2, metadataFileCount(ops.current()));
+    assertThat(ops.current()).as("Current metadata should not have changed").isEqualTo(metadataV2);
+    assertThat(metadataFileExists(metadataV2)).isTrue();
+    assertThat(metadataFileCount(ops.current()))
+        .as("No new metadata files should exist")
+        .isEqualTo(2);
   }
 
   @Test
@@ -133,10 +137,13 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     simulateRetriedCommit(spyOps, true /* report retry */);
     updateTable(table, spyOps);
 
-    Assert.assertNotEquals("Current metadata should have changed", metadataV1, spyOps.current());
-    Assert.assertTrue("Current metadata should still exist", metadataFileExists(spyOps.current()));
-    Assert.assertEquals(
-        "No new metadata files should exist", 2, metadataFileCount(spyOps.current()));
+    assertThat(spyOps.current())
+        .as("Current metadata should have changed")
+        .isNotEqualTo(metadataV1);
+    assertThat(metadataFileExists(spyOps.current())).isTrue();
+    assertThat(metadataFileCount(spyOps.current()))
+        .as("No new metadata files should exist")
+        .isEqualTo(2);
   }
 
   @Test
@@ -158,14 +165,14 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     // still work. If or when that happens, we can re-evaluate whether the mechanism is still
     // necessary.
     simulateRetriedCommit(spyOps, false /* hide retry */);
-    Assertions.assertThatThrownBy(() -> updateTable(table, spyOps))
+    assertThatThrownBy(() -> updateTable(table, spyOps))
         .as("Hidden retry causes writer to conflict with itself")
         .isInstanceOf(CommitFailedException.class)
         .hasMessageContaining("Glue detected concurrent update")
         .cause()
         .isInstanceOf(ConcurrentModificationException.class);
 
-    Assertions.assertThatThrownBy(() -> glueCatalog.loadTable(tableId))
+    assertThatThrownBy(() -> glueCatalog.loadTable(tableId))
         .as("Table still accessible despite hidden retry, underlying assumptions may have changed")
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("Location does not exist");
@@ -206,13 +213,11 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     spyOps.commit(metadataV2, metadataV1);
 
     ops.refresh();
-    Assert.assertNotEquals("Current metadata should have changed", metadataV2, ops.current());
-    Assert.assertTrue(
-        "Current metadata file should still exist", metadataFileExists(ops.current()));
-    Assert.assertEquals(
-        "Commit should have been successful and new metadata file should be made",
-        3,
-        metadataFileCount(ops.current()));
+    assertThat(ops.current()).as("Current metadata should have changed").isNotEqualTo(metadataV2);
+    assertThat(metadataFileExists(ops.current())).isTrue();
+    assertThat(metadataFileCount(ops.current()))
+        .as("Commit should have been successful and new metadata file should be made")
+        .isEqualTo(3);
   }
 
   @Test
@@ -226,19 +231,17 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps);
     breakFallbackCatalogCommitCheck(spyOps);
-    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .isInstanceOf(CommitStateUnknownException.class)
         .hasMessageContaining("Datacenter on fire");
 
     ops.refresh();
 
-    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
-    Assert.assertTrue(
-        "Current metadata file should still exist", metadataFileExists(ops.current()));
-    Assert.assertEquals(
-        "Client could not determine outcome so new metadata file should also exist",
-        3,
-        metadataFileCount(ops.current()));
+    assertThat(ops.current()).as("Current metadata should not have changed").isEqualTo(metadataV2);
+    assertThat(metadataFileExists(ops.current())).isTrue();
+    assertThat(metadataFileCount(ops.current()))
+        .as("Client could not determine outcome so new metadata file should also exist")
+        .isEqualTo(3);
   }
 
   @Test
@@ -252,14 +255,13 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     GlueTableOperations spyOps = Mockito.spy(ops);
     commitAndThrowException(ops, spyOps);
     breakFallbackCatalogCommitCheck(spyOps);
-    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .isInstanceOf(CommitStateUnknownException.class)
         .hasMessageContaining("Datacenter on fire");
     ops.refresh();
 
-    Assert.assertNotEquals("Current metadata should have changed", ops.current(), metadataV2);
-    Assert.assertTrue(
-        "Current metadata file should still exist", metadataFileExists(ops.current()));
+    assertThat(ops.current()).as("Current metadata should have changed").isNotEqualTo(metadataV2);
+    assertThat(metadataFileExists(ops.current())).isTrue();
   }
 
   /**
@@ -293,13 +295,11 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     spyOps.commit(metadataV2, metadataV1);
 
     ops.refresh();
-    Assert.assertNotEquals("Current metadata should have changed", metadataV2, ops.current());
-    Assert.assertTrue(
-        "Current metadata file should still exist", metadataFileExists(ops.current()));
-    Assert.assertEquals(
-        "The column addition from the concurrent commit should have been successful",
-        2,
-        ops.current().schema().columns().size());
+    assertThat(ops.current()).as("Current metadata should have changed").isNotEqualTo(metadataV2);
+    assertThat(metadataFileExists(ops.current())).isTrue();
+    assertThat(ops.current().schema().columns())
+        .as("The column addition from the concurrent commit should have been successful")
+        .hasSize(2);
   }
 
   @SuppressWarnings("unchecked")
@@ -340,14 +340,16 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps, EntityNotFoundException.builder().build());
-    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("because Glue cannot find the requested entity");
 
     ops.refresh();
-    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
-    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
-    Assert.assertEquals("No new metadata files should exist", 2, metadataFileCount(ops.current()));
+    assertThat(ops.current()).as("Current metadata should not have changed").isEqualTo(metadataV2);
+    assertThat(metadataFileExists(metadataV2)).isTrue();
+    assertThat(metadataFileCount(ops.current()))
+        .as("No new metadata files should exist")
+        .isEqualTo(2);
   }
 
   @Test
@@ -360,13 +362,15 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps, AccessDeniedException.builder().build());
-    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("because Glue cannot access the requested resources");
     ops.refresh();
-    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
-    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
-    Assert.assertEquals("No new metadata files should exist", 2, metadataFileCount(ops.current()));
+    assertThat(ops.current()).as("Current metadata should not have changed").isEqualTo(metadataV2);
+    assertThat(metadataFileExists(metadataV2)).isTrue();
+    assertThat(metadataFileCount(ops.current()))
+        .as("No new metadata files should exist")
+        .isEqualTo(2);
   }
 
   @Test
@@ -379,15 +383,17 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps, ValidationException.builder().build());
-    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .isInstanceOf(org.apache.iceberg.exceptions.ValidationException.class)
         .hasMessageContaining(
             "because Glue encountered a validation exception while accessing requested resources");
 
     ops.refresh();
-    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
-    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
-    Assert.assertEquals("No new metadata files should exist", 2, metadataFileCount(ops.current()));
+    assertThat(ops.current()).as("Current metadata should not have changed").isEqualTo(metadataV2);
+    assertThat(metadataFileExists(metadataV2)).isTrue();
+    assertThat(metadataFileCount(ops.current()))
+        .as("No new metadata files should exist")
+        .isEqualTo(2);
   }
 
   @Test
@@ -400,13 +406,15 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps, S3Exception.builder().statusCode(300).build());
-    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .isInstanceOf(S3Exception.class)
         .hasMessage(null);
     ops.refresh();
-    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
-    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
-    Assert.assertEquals("No new metadata files should exist", 2, metadataFileCount(ops.current()));
+    assertThat(ops.current()).as("Current metadata should not have changed").isEqualTo(metadataV2);
+    assertThat(metadataFileExists(metadataV2)).isTrue();
+    assertThat(metadataFileCount(ops.current()))
+        .as("No new metadata files should exist")
+        .isEqualTo(2);
   }
 
   @Test
@@ -419,14 +427,16 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps, GlueException.builder().statusCode(300).build());
-    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .isInstanceOf(GlueException.class)
         .hasMessage(null);
 
     ops.refresh();
-    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
-    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
-    Assert.assertEquals("No new metadata files should exist", 2, metadataFileCount(ops.current()));
+    assertThat(ops.current()).as("Current metadata should not have changed").isEqualTo(metadataV2);
+    assertThat(metadataFileExists(metadataV2)).isTrue();
+    assertThat(metadataFileCount(ops.current()))
+        .as("No new metadata files should exist")
+        .isEqualTo(2);
   }
 
   @Test
@@ -439,14 +449,16 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps, GlueException.builder().statusCode(500).build());
-    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .isInstanceOf(CommitFailedException.class)
         .hasMessage(null);
 
     ops.refresh();
-    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
-    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
-    Assert.assertEquals("No new metadata files should exist", 2, metadataFileCount(ops.current()));
+    assertThat(ops.current()).as("Current metadata should not have changed").isEqualTo(metadataV2);
+    assertThat(metadataFileExists(metadataV2)).isTrue();
+    assertThat(metadataFileCount(ops.current()))
+        .as("No new metadata files should exist")
+        .isEqualTo(2);
   }
 
   private Table setupTable() {
@@ -462,7 +474,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
     TableMetadata metadataV2 = ops.current();
 
-    Assert.assertEquals(2, metadataV2.schema().columns().size());
+    assertThat(metadataV2.schema().columns()).hasSize(2);
     return metadataV2;
   }
 

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogLock.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogLock.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.aws.glue;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
@@ -40,10 +42,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.util.Tasks;
 import org.awaitility.Awaitility;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
 
@@ -52,7 +53,7 @@ public class TestGlueCatalogLock extends GlueTestBase {
   private static String lockTableName;
   private static DynamoDbClient dynamo;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     GlueTestBase.beforeClass();
     String testBucketPath = "s3://" + testBucketName + "/" + testPathPrefix;
@@ -71,7 +72,7 @@ public class TestGlueCatalogLock extends GlueTestBase {
         ImmutableMap.of());
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     GlueTestBase.afterClass();
     dynamo.deleteTable(DeleteTableRequest.builder().tableName(lockTableName).build());
@@ -107,12 +108,8 @@ public class TestGlueCatalogLock extends GlueTestBase {
         .run(i -> pendingCommits.get(i).commit());
 
     table.refresh();
-    Assert.assertEquals(
-        "Commits should all succeed sequentially", nThreads, table.history().size());
-    Assert.assertEquals(
-        "Should have all manifests",
-        nThreads,
-        table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.history()).as("Commits should all succeed sequentially").hasSize(nThreads);
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(nThreads);
   }
 
   @Test
@@ -153,8 +150,7 @@ public class TestGlueCatalogLock extends GlueTestBase {
             });
 
     table.refresh();
-    Assert.assertEquals("Commits should all succeed sequentially", 20, table.history().size());
-    Assert.assertEquals(
-        "should have 20 manifests", 20, table.currentSnapshot().allManifests(table.io()).size());
+    assertThat(table.history()).as("Commits should all succeed sequentially").hasSize(20);
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(20);
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogNamespace.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogNamespace.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.aws.glue;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -29,9 +32,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.glue.model.CreateTableRequest;
 import software.amazon.awssdk.services.glue.model.Database;
 import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
@@ -44,8 +45,7 @@ public class TestGlueCatalogNamespace extends GlueTestBase {
   public void testCreateNamespace() {
     String namespace = getRandomName();
     namespaces.add(namespace);
-    Assertions.assertThatThrownBy(
-            () -> glue.getDatabase(GetDatabaseRequest.builder().name(namespace).build()))
+    assertThatThrownBy(() -> glue.getDatabase(GetDatabaseRequest.builder().name(namespace).build()))
         .as("namespace does not exist before create")
         .isInstanceOf(EntityNotFoundException.class)
         .hasMessageContaining("not found");
@@ -61,20 +61,17 @@ public class TestGlueCatalogNamespace extends GlueTestBase {
     glueCatalog.createNamespace(ns, properties);
     Database database =
         glue.getDatabase(GetDatabaseRequest.builder().name(namespace).build()).database();
-    Assert.assertEquals("namespace must equal database name", namespace, database.name());
-    Assert.assertEquals(
-        "namespace description should be set", "description", database.description());
-    Assert.assertEquals(
-        "namespace location should be set", "s3://location", database.locationUri());
-    Assert.assertEquals(
-        "namespace parameters should be set", ImmutableMap.of("key", "val"), database.parameters());
-    Assert.assertEquals(properties, glueCatalog.loadNamespaceMetadata(ns));
+    assertThat(database.name()).isEqualTo(namespace);
+    assertThat(database.description()).isEqualTo("description");
+    assertThat(database.locationUri()).isEqualTo("s3://location");
+    assertThat(database.parameters()).containsEntry("key", "val");
+    assertThat(glueCatalog.loadNamespaceMetadata(ns)).isEqualTo(properties);
   }
 
   @Test
   public void testCreateDuplicate() {
     String namespace = createNamespace();
-    Assertions.assertThatThrownBy(() -> glueCatalog.createNamespace(Namespace.of(namespace)))
+    assertThatThrownBy(() -> glueCatalog.createNamespace(Namespace.of(namespace)))
         .as("should not create namespace with the same name")
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessageContaining("it already exists in Glue");
@@ -86,7 +83,7 @@ public class TestGlueCatalogNamespace extends GlueTestBase {
         Lists.newArrayList(Namespace.of("db-1"), Namespace.of("db", "db2"));
 
     for (Namespace namespace : invalidNamespaces) {
-      Assertions.assertThatThrownBy(() -> glueCatalog.createNamespace(namespace))
+      assertThatThrownBy(() -> glueCatalog.createNamespace(namespace))
           .as("should not create namespace with invalid or nested names")
           .isInstanceOf(ValidationException.class)
           .hasMessageContaining("Cannot convert namespace");
@@ -96,17 +93,17 @@ public class TestGlueCatalogNamespace extends GlueTestBase {
   @Test
   public void testNamespaceExists() {
     String namespace = createNamespace();
-    Assert.assertTrue(glueCatalog.namespaceExists(Namespace.of(namespace)));
+    assertThat(glueCatalog.namespaceExists(Namespace.of(namespace))).isTrue();
   }
 
   @Test
   public void testListNamespace() {
     String namespace = createNamespace();
     List<Namespace> namespaceList = glueCatalog.listNamespaces();
-    Assert.assertFalse(namespaceList.isEmpty());
-    Assert.assertTrue(namespaceList.contains(Namespace.of(namespace)));
+    assertThat(namespaceList).isNotEmpty();
+    assertThat(namespaceList).contains(Namespace.of(namespace));
     namespaceList = glueCatalog.listNamespaces(Namespace.of(namespace));
-    Assert.assertTrue(namespaceList.isEmpty());
+    assertThat(namespaceList).isEmpty();
   }
 
   @Test
@@ -121,12 +118,9 @@ public class TestGlueCatalogNamespace extends GlueTestBase {
     glueCatalog.setProperties(Namespace.of(namespace), properties);
     Database database =
         glue.getDatabase(GetDatabaseRequest.builder().name(namespace).build()).database();
-    Assert.assertTrue(database.parameters().containsKey("key"));
-    Assert.assertEquals("val", database.parameters().get("key"));
-    Assert.assertTrue(database.parameters().containsKey("key2"));
-    Assert.assertEquals("val2", database.parameters().get("key2"));
-    Assert.assertEquals("s3://test", database.locationUri());
-    Assert.assertEquals("description", database.description());
+    assertThat(database.parameters()).containsEntry("key", "val").containsEntry("key2", "val2");
+    assertThat(database.locationUri()).isEqualTo("s3://test");
+    assertThat(database.description()).isEqualTo("description");
     // remove properties
     glueCatalog.removeProperties(
         Namespace.of(namespace),
@@ -135,11 +129,9 @@ public class TestGlueCatalogNamespace extends GlueTestBase {
             IcebergToGlueConverter.GLUE_DB_LOCATION_KEY,
             IcebergToGlueConverter.GLUE_DESCRIPTION_KEY));
     database = glue.getDatabase(GetDatabaseRequest.builder().name(namespace).build()).database();
-    Assert.assertFalse(database.parameters().containsKey("key"));
-    Assert.assertTrue(database.parameters().containsKey("key2"));
-    Assert.assertEquals("val2", database.parameters().get("key2"));
-    Assert.assertNull(database.locationUri());
-    Assert.assertNull(database.description());
+    assertThat(database.parameters()).doesNotContainKey("key").containsEntry("key2", "val2");
+    assertThat(database.locationUri()).isNull();
+    assertThat(database.description()).isNull();
     // add back
     properties = Maps.newHashMap();
     properties.put("key", "val");
@@ -147,20 +139,16 @@ public class TestGlueCatalogNamespace extends GlueTestBase {
     properties.put(IcebergToGlueConverter.GLUE_DESCRIPTION_KEY, "description2");
     glueCatalog.setProperties(Namespace.of(namespace), properties);
     database = glue.getDatabase(GetDatabaseRequest.builder().name(namespace).build()).database();
-    Assert.assertTrue(database.parameters().containsKey("key"));
-    Assert.assertEquals("val", database.parameters().get("key"));
-    Assert.assertTrue(database.parameters().containsKey("key2"));
-    Assert.assertEquals("val2", database.parameters().get("key2"));
-    Assert.assertEquals("s3://test2", database.locationUri());
-    Assert.assertEquals("description2", database.description());
+    assertThat(database.parameters()).containsEntry("key", "val").containsEntry("key2", "val2");
+    assertThat(database.locationUri()).isEqualTo("s3://test2");
+    assertThat(database.description()).isEqualTo("description2");
   }
 
   @Test
   public void testDropNamespace() {
     String namespace = createNamespace();
     glueCatalog.dropNamespace(Namespace.of(namespace));
-    Assertions.assertThatThrownBy(
-            () -> glue.getDatabase(GetDatabaseRequest.builder().name(namespace).build()))
+    assertThatThrownBy(() -> glue.getDatabase(GetDatabaseRequest.builder().name(namespace).build()))
         .as("namespace should not exist after deletion")
         .isInstanceOf(EntityNotFoundException.class)
         .hasMessageContaining("not found");
@@ -170,7 +158,7 @@ public class TestGlueCatalogNamespace extends GlueTestBase {
   public void testDropNamespaceThatContainsOnlyIcebergTable() {
     String namespace = createNamespace();
     createTable(namespace);
-    Assertions.assertThatThrownBy(() -> glueCatalog.dropNamespace(Namespace.of(namespace)))
+    assertThatThrownBy(() -> glueCatalog.dropNamespace(Namespace.of(namespace)))
         .as("namespace should not be dropped when still has Iceberg table")
         .isInstanceOf(NamespaceNotEmptyException.class)
         .hasMessageContaining("still contains Iceberg tables");
@@ -184,7 +172,7 @@ public class TestGlueCatalogNamespace extends GlueTestBase {
             .databaseName(namespace)
             .tableInput(TableInput.builder().name(UUID.randomUUID().toString()).build())
             .build());
-    Assertions.assertThatThrownBy(() -> glueCatalog.dropNamespace(Namespace.of(namespace)))
+    assertThatThrownBy(() -> glueCatalog.dropNamespace(Namespace.of(namespace)))
         .as("namespace should not be dropped when still has non-Iceberg table")
         .isInstanceOf(NamespaceNotEmptyException.class)
         .hasMessageContaining("still contains non-Iceberg tables");

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.aws.glue;
 
 import static org.apache.iceberg.expressions.Expressions.truncate;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Locale;
@@ -49,9 +51,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.util.LockManagers;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.glue.model.Column;
 import software.amazon.awssdk.services.glue.model.CreateTableRequest;
 import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
@@ -84,43 +84,35 @@ public class TestGlueCatalogTable extends GlueTestBase {
     // verify table exists in Glue
     GetTableResponse response =
         glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
-    Assert.assertEquals(namespace, response.table().databaseName());
-    Assert.assertEquals(tableName, response.table().name());
-    Assert.assertEquals(
-        BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH),
-        response.table().parameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP));
-    Assert.assertTrue(
-        response
-            .table()
-            .parameters()
-            .containsKey(BaseMetastoreTableOperations.METADATA_LOCATION_PROP));
-    Assert.assertEquals(
-        schema.columns().size(), response.table().storageDescriptor().columns().size());
-    Assert.assertEquals(partitionSpec.fields().size(), response.table().partitionKeys().size());
-    Assert.assertEquals(
-        "additionalLocations should match",
-        tableLocationProperties.values().stream().sorted().collect(Collectors.toList()),
-        response.table().storageDescriptor().additionalLocations().stream()
-            .sorted()
-            .collect(Collectors.toList()));
+    assertThat(response.table().databaseName()).isEqualTo(namespace);
+    assertThat(response.table().name()).isEqualTo(tableName);
+    assertThat(response.table().parameters())
+        .containsEntry(
+            BaseMetastoreTableOperations.TABLE_TYPE_PROP,
+            BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH))
+        .containsKey(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
+    assertThat(response.table().storageDescriptor().columns()).hasSameSizeAs(schema.columns());
+    assertThat(response.table().partitionKeys()).hasSameSizeAs(partitionSpec.fields());
+    assertThat(response.table().storageDescriptor().additionalLocations())
+        .isEqualTo(tableLocationProperties.values());
     // verify metadata file exists in S3
     String metaLocation =
         response.table().parameters().get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
     String key = metaLocation.split(testBucketName, -1)[1].substring(1);
     s3.headObject(HeadObjectRequest.builder().bucket(testBucketName).key(key).build());
     Table table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
-    Assert.assertEquals(partitionSpec, table.spec());
-    Assert.assertEquals(schema.toString(), table.schema().toString());
-    Assert.assertEquals(
-        tableDescription, table.properties().get(IcebergToGlueConverter.GLUE_DESCRIPTION_KEY));
-    Assert.assertEquals(tableDescription, response.table().description());
+    assertThat(table.spec()).isEqualTo(partitionSpec);
+    assertThat(table.schema()).asString().isEqualTo(schema.toString());
+    assertThat(table.properties())
+        .containsEntry(IcebergToGlueConverter.GLUE_DESCRIPTION_KEY, tableDescription);
+    assertThat(response.table().description()).isEqualTo(tableDescription);
   }
 
   @Test
   public void testCreateTableDuplicate() {
     String namespace = createNamespace();
     String tableName = createTable(namespace);
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 glueCatalog.createTable(
                     TableIdentifier.of(namespace, tableName), schema, partitionSpec))
@@ -132,7 +124,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
   @Test
   public void testCreateTableBadName() {
     String namespace = createNamespace();
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 glueCatalog.createTable(
                     TableIdentifier.of(namespace, "table-1"), schema, partitionSpec))
@@ -167,20 +159,17 @@ public class TestGlueCatalogTable extends GlueTestBase {
   @Test
   public void testListTables() {
     String namespace = createNamespace();
-    Assert.assertTrue(
-        "list namespace should have nothing before table creation",
-        glueCatalog.listTables(Namespace.of(namespace)).isEmpty());
+    assertThat(glueCatalog.listTables(Namespace.of(namespace))).isEmpty();
     String tableName = createTable(namespace);
     List<TableIdentifier> tables = glueCatalog.listTables(Namespace.of(namespace));
-    Assert.assertEquals(1, tables.size());
-    Assert.assertEquals(TableIdentifier.of(namespace, tableName), tables.get(0));
+    assertThat(tables).hasSize(1).first().isEqualTo(TableIdentifier.of(namespace, tableName));
   }
 
   @Test
   public void testTableExists() {
     String namespace = createNamespace();
     String tableName = createTable(namespace);
-    Assert.assertTrue(glueCatalog.tableExists(TableIdentifier.of(namespace, tableName)));
+    assertThat(glueCatalog.tableExists(TableIdentifier.of(namespace, tableName))).isTrue();
   }
 
   @Test
@@ -190,14 +179,14 @@ public class TestGlueCatalogTable extends GlueTestBase {
     // current should be null
     TableOperations ops = glueCatalog.newTableOps(TableIdentifier.of(namespace, tableName));
     TableMetadata current = ops.current();
-    Assert.assertNull(current);
+    assertThat(current).isNull();
     // create table, refresh should update
     createTable(namespace, tableName);
     current = ops.refresh();
-    Assert.assertEquals(schema.toString(), current.schema().toString());
-    Assert.assertEquals(partitionSpec, current.spec());
+    assertThat(current.schema()).asString().isEqualTo(schema.toString());
+    assertThat(current.spec()).isEqualTo(partitionSpec);
     Table table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
-    Assert.assertTrue("initial table history should be empty", table.history().isEmpty());
+    assertThat(table.history()).isEmpty();
     // commit new version, should create a new snapshot
     table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
     DataFile dataFile =
@@ -208,15 +197,15 @@ public class TestGlueCatalogTable extends GlueTestBase {
             .build();
     table.newAppend().appendFile(dataFile).commit();
     table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
-    Assert.assertEquals("commit should create a new table version", 1, table.history().size());
+    assertThat(table.history()).hasSize(1);
     // check table in Glue
     GetTableResponse response =
         glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
-    Assert.assertEquals(
-        "external table type is set after update", "EXTERNAL_TABLE", response.table().tableType());
-    Assert.assertEquals(
-        schema.columns().size(), response.table().storageDescriptor().columns().size());
-    Assert.assertEquals(partitionSpec.fields().size(), response.table().partitionKeys().size());
+    assertThat(response.table().tableType())
+        .as("external table type is set after update")
+        .isEqualTo("EXTERNAL_TABLE");
+    assertThat(response.table().storageDescriptor().columns()).hasSameSizeAs(schema.columns());
+    assertThat(response.table().partitionKeys()).hasSameSizeAs(partitionSpec.fields());
   }
 
   @Test
@@ -229,10 +218,10 @@ public class TestGlueCatalogTable extends GlueTestBase {
     glueCatalog.renameTable(
         TableIdentifier.of(namespace, tableName), TableIdentifier.of(namespace, newTableName));
     Table renamedTable = glueCatalog.loadTable(TableIdentifier.of(namespace, newTableName));
-    Assert.assertEquals(table.location(), renamedTable.location());
-    Assert.assertEquals(table.schema().toString(), renamedTable.schema().toString());
-    Assert.assertEquals(table.spec(), renamedTable.spec());
-    Assert.assertEquals(table.currentSnapshot(), renamedTable.currentSnapshot());
+    assertThat(renamedTable.location()).isEqualTo(table.location());
+    assertThat(renamedTable.schema()).asString().isEqualTo(table.schema().toString());
+    assertThat(renamedTable.spec()).isEqualTo(table.spec());
+    assertThat(renamedTable.currentSnapshot()).isEqualTo(table.currentSnapshot());
   }
 
   @Test
@@ -248,7 +237,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
             .databaseName(namespace)
             .tableInput(TableInput.builder().name(newTableName).build())
             .build());
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 glueCatalog.renameTable(
                     TableIdentifier.of(namespace, tableName),
@@ -258,10 +247,10 @@ public class TestGlueCatalogTable extends GlueTestBase {
         .hasMessageContaining("Table already exists");
     // old table can still be read with same metadata
     Table oldTable = glueCatalog.loadTable(id);
-    Assert.assertEquals(table.location(), oldTable.location());
-    Assert.assertEquals(table.schema().toString(), oldTable.schema().toString());
-    Assert.assertEquals(table.spec(), oldTable.spec());
-    Assert.assertEquals(table.currentSnapshot(), oldTable.currentSnapshot());
+    assertThat(oldTable.location()).isEqualTo(table.location());
+    assertThat(oldTable.schema()).asString().isEqualTo(table.schema().toString());
+    assertThat(oldTable.spec()).isEqualTo(table.spec());
+    assertThat(oldTable.currentSnapshot()).isEqualTo(table.currentSnapshot());
   }
 
   @Test
@@ -277,7 +266,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
             .databaseName(namespace)
             .tableInput(TableInput.builder().name(tableName).parameters(Maps.newHashMap()).build())
             .build());
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 glueCatalog.renameTable(
                     TableIdentifier.of(namespace, tableName),
@@ -285,7 +274,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
         .isInstanceOf(ValidationException.class)
         .as("should fail to rename")
         .hasMessageContaining("Input Glue table is not an iceberg table");
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 glue.getTable(
                     GetTableRequest.builder().databaseName(namespace).name(newTableName).build()))
@@ -299,8 +288,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
     String namespace = createNamespace();
     String tableName = createTable(namespace);
     glueCatalog.dropTable(TableIdentifier.of(namespace, tableName), false);
-    Assertions.assertThatThrownBy(
-            () -> glueCatalog.loadTable(TableIdentifier.of(namespace, tableName)))
+    assertThatThrownBy(() -> glueCatalog.loadTable(TableIdentifier.of(namespace, tableName)))
         .isInstanceOf(NoSuchTableException.class)
         .as("should not have table")
         .hasMessageContaining("Table does not exist");
@@ -313,7 +301,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
                 .bucket(testBucketName)
                 .prefix(prefix + "/metadata/")
                 .build());
-    Assert.assertTrue(response.hasContents());
+    assertThat(response.hasContents()).isTrue();
     boolean hasMetaFile = false;
     for (S3Object s3Object : response.contents()) {
       if (s3Object.key().contains(".json")) {
@@ -321,7 +309,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
         break;
       }
     }
-    Assert.assertTrue("metadata json file exists after delete without purge", hasMetaFile);
+    assertThat(hasMetaFile).as("metadata json file exists after delete without purge").isTrue();
   }
 
   @Test
@@ -353,8 +341,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
     txn.commitTransaction();
 
     glueCatalog.dropTable(TableIdentifier.of(namespace, tableName));
-    Assertions.assertThatThrownBy(
-            () -> glueCatalog.loadTable(TableIdentifier.of(namespace, tableName)))
+    assertThatThrownBy(() -> glueCatalog.loadTable(TableIdentifier.of(namespace, tableName)))
         .isInstanceOf(NoSuchTableException.class)
         .as("should not have table")
         .hasMessageContaining("Table does not exist");
@@ -368,8 +355,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
       // might have directory markers left
       for (S3Object s3Object : response.contents()) {
         Optional<Long> size = s3Object.getValueForField("Size", Long.class);
-        Assert.assertTrue(size.isPresent());
-        Assert.assertEquals(0L, (long) size.get());
+        assertThat(size.isPresent()).isTrue();
+        assertThat(size.get()).isEqualTo(0);
       }
     }
   }
@@ -403,31 +390,29 @@ public class TestGlueCatalogTable extends GlueTestBase {
             .withRecordCount(1)
             .build();
     table.newAppend().appendFile(dataFile).commit();
-    Assert.assertEquals(
-        2,
-        glue.getTableVersions(
-                GetTableVersionsRequest.builder()
-                    .databaseName(namespace)
-                    .tableName(tableName)
-                    .build())
-            .tableVersions()
-            .size());
+    assertThat(
+            glue.getTableVersions(
+                    GetTableVersionsRequest.builder()
+                        .databaseName(namespace)
+                        .tableName(tableName)
+                        .build())
+                .tableVersions())
+        .hasSize(2);
     // create table and commit with skip
     tableName = getRandomName();
     glueCatalog.initialize(catalogName, ImmutableMap.of());
     glueCatalog.createTable(TableIdentifier.of(namespace, tableName), schema, partitionSpec);
     table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
     table.newAppend().appendFile(dataFile).commit();
-    Assert.assertEquals(
-        "skipArchive should not create new version",
-        1,
-        glue.getTableVersions(
-                GetTableVersionsRequest.builder()
-                    .databaseName(namespace)
-                    .tableName(tableName)
-                    .build())
-            .tableVersions()
-            .size());
+    assertThat(
+            glue.getTableVersions(
+                    GetTableVersionsRequest.builder()
+                        .databaseName(namespace)
+                        .tableName(tableName)
+                        .build())
+                .tableVersions())
+        .as("skipArchive should not create new version")
+        .hasSize(1);
   }
 
   @Test
@@ -440,8 +425,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
         TableIdentifier.of(namespace, tableName), schema, partitionSpec, tableLocationProperties);
     GetTableResponse response =
         glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
-    Assert.assertEquals(namespace, response.table().databaseName());
-    Assert.assertEquals(tableName, response.table().name());
+    assertThat(response.table().databaseName()).isEqualTo(namespace);
+    assertThat(response.table().name()).isEqualTo(tableName);
   }
 
   @Test
@@ -513,7 +498,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
                         IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "true",
                         IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "false"))
                 .build());
-    Assert.assertEquals("Columns do not match", expectedColumns, actualColumns);
+    assertThat(actualColumns).isEqualTo(expectedColumns);
   }
 
   @Test
@@ -545,28 +530,19 @@ public class TestGlueCatalogTable extends GlueTestBase {
             .withProperty("key5", "table-key5")
             .create();
 
-    Assert.assertEquals(
-        "Table defaults set for the catalog must be added to the table properties.",
-        "catalog-default-key1",
-        table.properties().get("key1"));
-    Assert.assertEquals(
-        "Table property must override table default properties set at catalog level.",
-        "table-key2",
-        table.properties().get("key2"));
-    Assert.assertEquals(
-        "Table property override set at catalog level must override table default"
-            + " properties set at catalog level and table property specified.",
-        "catalog-override-key3",
-        table.properties().get("key3"));
-    Assert.assertEquals(
-        "Table override not in table props or defaults should be added to table properties",
-        "catalog-override-key4",
-        table.properties().get("key4"));
-    Assert.assertEquals(
-        "Table properties without any catalog level default or override should be added to table"
-            + " properties.",
-        "table-key5",
-        table.properties().get("key5"));
+    assertThat(table.properties())
+        .as("Table defaults set for the catalog must be added to the table properties.")
+        .containsEntry("key1", "catalog-default-key1")
+        .as("Table property must override table default properties set at catalog level.")
+        .containsEntry("key2", "table-key2")
+        .as(
+            "Table property override set at catalog level must override table default properties set at catalog level and table property specified.")
+        .containsEntry("key3", "catalog-override-key3")
+        .as("Table override not in table props or defaults should be added to table properties")
+        .containsEntry("key4", "catalog-override-key4")
+        .as(
+            "Table properties without any catalog level default or override should be added to table properties")
+        .containsEntry("key5", "table-key5");
   }
 
   @Test
@@ -577,15 +553,15 @@ public class TestGlueCatalogTable extends GlueTestBase {
     TableIdentifier identifier = TableIdentifier.of(namespace, tableName);
     Table table = glueCatalog.loadTable(identifier);
     String metadataLocation = ((BaseTable) table).operations().current().metadataFileLocation();
-    Assertions.assertThat(glueCatalog.dropTable(identifier, false)).isTrue();
+    assertThat(glueCatalog.dropTable(identifier, false)).isTrue();
     Table registeredTable = glueCatalog.registerTable(identifier, metadataLocation);
-    Assertions.assertThat(registeredTable).isNotNull();
+    assertThat(registeredTable).isNotNull();
     String expectedMetadataLocation =
         ((BaseTable) table).operations().current().metadataFileLocation();
-    Assertions.assertThat(metadataLocation).isEqualTo(expectedMetadataLocation);
-    Assertions.assertThat(glueCatalog.loadTable(identifier)).isNotNull();
-    Assertions.assertThat(glueCatalog.dropTable(identifier, true)).isTrue();
-    Assertions.assertThat(glueCatalog.dropNamespace(Namespace.of(namespace))).isTrue();
+    assertThat(metadataLocation).isEqualTo(expectedMetadataLocation);
+    assertThat(glueCatalog.loadTable(identifier)).isNotNull();
+    assertThat(glueCatalog.dropTable(identifier, true)).isTrue();
+    assertThat(glueCatalog.dropNamespace(Namespace.of(namespace))).isTrue();
   }
 
   @Test
@@ -596,10 +572,10 @@ public class TestGlueCatalogTable extends GlueTestBase {
     TableIdentifier identifier = TableIdentifier.of(namespace, tableName);
     Table table = glueCatalog.loadTable(identifier);
     String metadataLocation = ((BaseTable) table).operations().current().metadataFileLocation();
-    Assertions.assertThatThrownBy(() -> glueCatalog.registerTable(identifier, metadataLocation))
+    assertThatThrownBy(() -> glueCatalog.registerTable(identifier, metadataLocation))
         .isInstanceOf(AlreadyExistsException.class);
-    Assertions.assertThat(glueCatalog.dropTable(identifier, true)).isTrue();
-    Assertions.assertThat(glueCatalog.dropNamespace(Namespace.of(namespace))).isTrue();
+    assertThat(glueCatalog.dropTable(identifier, true)).isTrue();
+    assertThat(glueCatalog.dropNamespace(Namespace.of(namespace))).isTrue();
   }
 
   @Test
@@ -634,9 +610,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
             .tagSet();
     Map<String, String> tagMap = tags.stream().collect(Collectors.toMap(Tag::key, Tag::value));
 
-    Assert.assertTrue(tagMap.containsKey(S3FileIOProperties.S3_TAG_ICEBERG_TABLE));
-    Assert.assertEquals(tableName, tagMap.get(S3FileIOProperties.S3_TAG_ICEBERG_TABLE));
-    Assert.assertTrue(tagMap.containsKey(S3FileIOProperties.S3_TAG_ICEBERG_NAMESPACE));
-    Assert.assertEquals(namespace, tagMap.get(S3FileIOProperties.S3_TAG_ICEBERG_NAMESPACE));
+    assertThat(tagMap)
+        .containsEntry(S3FileIOProperties.S3_TAG_ICEBERG_TABLE, tableName)
+        .containsEntry(S3FileIOProperties.S3_TAG_ICEBERG_NAMESPACE, namespace);
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/LakeFormationTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/LakeFormationTestBase.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.aws.lakeformation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -38,10 +40,9 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
@@ -125,7 +126,7 @@ public class LakeFormationTestBase {
   static LakeFormationClient lakeformation;
   static GlueClient glue;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     lfRegisterPathRoleName = LF_REGISTER_PATH_ROLE_PREFIX + UUID.randomUUID().toString();
     lfPrivilegedRoleName = LF_PRIVILEGED_ROLE_PREFIX + UUID.randomUUID().toString();
@@ -256,7 +257,7 @@ public class LakeFormationTestBase {
     registerResource(testBucketPath);
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     GetDataLakeSettingsResponse getDataLakeSettingsResponse =
         lakeformation.getDataLakeSettings(GetDataLakeSettingsRequest.builder().build());
@@ -367,7 +368,7 @@ public class LakeFormationTestBase {
         .atMost(Duration.ofSeconds(10))
         .untilAsserted(
             () ->
-                Assertions.assertThat(
+                assertThat(
                         iam.getRolePolicy(
                             GetRolePolicyRequest.builder()
                                 .roleName(roleName)
@@ -438,7 +439,7 @@ public class LakeFormationTestBase {
           .ignoreExceptions()
           .untilAsserted(
               () ->
-                  Assertions.assertThat(
+                  assertThat(
                           lakeformation
                               .describeResource(
                                   DescribeResourceRequest.builder().resourceArn(arn).build())

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
@@ -18,8 +18,8 @@
  */
 package org.apache.iceberg.aws.lakeformation;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 import java.time.Duration;
 import java.util.Map;
@@ -162,11 +162,9 @@ public class TestLakeFormationAwsClientFactory {
     Namespace allowedNamespace =
         Namespace.of("allowed_" + UUID.randomUUID().toString().replace("-", ""));
     try {
-      glueCatalog.createNamespace(allowedNamespace);
+      assertThatNoException().isThrownBy(() -> glueCatalog.createNamespace(allowedNamespace));
     } catch (GlueException e) {
       LOG.error("fail to create Glue database", e);
-
-      fail("create namespace should succeed");
     } finally {
       glueCatalog.dropNamespace(allowedNamespace);
       try {

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.glue.model.AccessDeniedException;
-import software.amazon.awssdk.services.glue.model.GlueException;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.iam.model.CreateRoleRequest;
 import software.amazon.awssdk.services.iam.model.CreateRoleResponse;
@@ -163,8 +162,6 @@ public class TestLakeFormationAwsClientFactory {
         Namespace.of("allowed_" + UUID.randomUUID().toString().replace("-", ""));
     try {
       assertThatNoException().isThrownBy(() -> glueCatalog.createNamespace(allowedNamespace));
-    } catch (GlueException e) {
-      LOG.error("fail to create Glue database", e);
     } finally {
       glueCatalog.dropNamespace(allowedNamespace);
       try {

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.aws.lakeformation;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
 import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
@@ -29,10 +32,9 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
@@ -59,7 +61,7 @@ public class TestLakeFormationAwsClientFactory {
   private Map<String, String> assumeRoleProperties;
   private String policyName;
 
-  @Before
+  @BeforeEach
   public void before() {
     roleName = UUID.randomUUID().toString();
     iam =
@@ -97,7 +99,7 @@ public class TestLakeFormationAwsClientFactory {
     policyName = UUID.randomUUID().toString();
   }
 
-  @After
+  @AfterEach
   public void after() {
     iam.deleteRolePolicy(
         DeleteRolePolicyRequest.builder().roleName(roleName).policyName(policyName).build());
@@ -150,10 +152,8 @@ public class TestLakeFormationAwsClientFactory {
     Namespace deniedNamespace =
         Namespace.of("denied_" + UUID.randomUUID().toString().replace("-", ""));
     try {
-      glueCatalog.createNamespace(deniedNamespace);
-      Assert.fail("Access to Glue should be denied");
-    } catch (GlueException e) {
-      Assert.assertEquals(AccessDeniedException.class, e.getClass());
+      assertThatThrownBy(() -> glueCatalog.createNamespace(deniedNamespace))
+          .isInstanceOf(AccessDeniedException.class);
     } catch (AssertionError e) {
       glueCatalog.dropNamespace(deniedNamespace);
       throw e;
@@ -165,7 +165,8 @@ public class TestLakeFormationAwsClientFactory {
       glueCatalog.createNamespace(allowedNamespace);
     } catch (GlueException e) {
       LOG.error("fail to create Glue database", e);
-      Assert.fail("create namespace should succeed");
+
+      fail("create namespace should succeed");
     } finally {
       glueCatalog.dropNamespace(allowedNamespace);
       try {

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationDataOperations.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationDataOperations.java
@@ -18,16 +18,17 @@
  */
 package org.apache.iceberg.aws.lakeformation;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ForbiddenException;
-import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 import software.amazon.awssdk.services.lakeformation.model.Permission;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -37,7 +38,7 @@ public class TestLakeFormationDataOperations extends LakeFormationTestBase {
   private static String testDbName;
   private static String testTableName;
 
-  @Before
+  @BeforeEach
   public void before() {
     testDbName = getRandomDbName();
     testTableName = getRandomTableName();
@@ -45,7 +46,7 @@ public class TestLakeFormationDataOperations extends LakeFormationTestBase {
     lfRegisterPathRoleCreateTable(testDbName, testTableName);
   }
 
-  @After
+  @AfterEach
   public void after() {
     lfRegisterPathRoleDeleteTable(testDbName, testTableName);
     lfRegisterPathRoleDeleteDb(testDbName);
@@ -53,7 +54,7 @@ public class TestLakeFormationDataOperations extends LakeFormationTestBase {
 
   @Test
   public void testLoadTableWithNoTableAccess() {
-    Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 glueCatalogPrivilegedRole.loadTable(
                     TableIdentifier.of(Namespace.of(testDbName), testTableName)))
@@ -81,7 +82,7 @@ public class TestLakeFormationDataOperations extends LakeFormationTestBase {
             .withFileSizeInBytes(10)
             .withRecordCount(1)
             .build();
-    Assertions.assertThatThrownBy(() -> table.newAppend().appendFile(dataFile).commit())
+    assertThatThrownBy(() -> table.newAppend().appendFile(dataFile).commit())
         .as("attempt to insert to a table without INSERT permission should fail")
         .isInstanceOf(S3Exception.class)
         .hasMessageContaining("Access Denied");
@@ -117,7 +118,7 @@ public class TestLakeFormationDataOperations extends LakeFormationTestBase {
             .withFileSizeInBytes(10)
             .withRecordCount(1)
             .build();
-    Assertions.assertThatThrownBy(() -> table.newDelete().deleteFile(dataFile).commit())
+    assertThatThrownBy(() -> table.newDelete().deleteFile(dataFile).commit())
         .as("attempt to delete without DATA_LOCATION_ACCESS permission should fail")
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("Glue cannot access the requested resources");

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationMetadataOperations.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationMetadataOperations.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.aws.lakeformation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.Table;
@@ -27,9 +30,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 import software.amazon.awssdk.services.lakeformation.model.Permission;
 
@@ -48,8 +49,7 @@ public class TestLakeFormationMetadataOperations extends LakeFormationTestBase {
   @Test
   public void testCreateDatabaseNoPrivileges() {
     String testDbName = getRandomDbName();
-    Assertions.assertThatThrownBy(
-            () -> glueCatalogPrivilegedRole.createNamespace(Namespace.of(testDbName)))
+    assertThatThrownBy(() -> glueCatalogPrivilegedRole.createNamespace(Namespace.of(testDbName)))
         .as("attempt to create a database without CREATE_DATABASE permission should fail")
         .isInstanceOf(AccessDeniedException.class)
         .hasMessageContaining("Insufficient Lake Formation permission(s)");
@@ -60,8 +60,7 @@ public class TestLakeFormationMetadataOperations extends LakeFormationTestBase {
     String testDbName = getRandomDbName();
     lfRegisterPathRoleCreateDb(testDbName);
     try {
-      Assertions.assertThatThrownBy(
-              () -> glueCatalogPrivilegedRole.dropNamespace(Namespace.of(testDbName)))
+      assertThatThrownBy(() -> glueCatalogPrivilegedRole.dropNamespace(Namespace.of(testDbName)))
           .as("attempt to drop a database without DROP permission should fail")
           .isInstanceOf(AccessDeniedException.class)
           .hasMessageContaining("Insufficient Lake Formation permission(s)");
@@ -77,7 +76,7 @@ public class TestLakeFormationMetadataOperations extends LakeFormationTestBase {
     grantDatabasePrivileges(testDbName, Permission.ALTER);
     try {
       List<Namespace> namespaces = glueCatalogPrivilegedRole.listNamespaces();
-      Assert.assertTrue(namespaces.contains(Namespace.of(testDbName)));
+      assertThat(namespaces).contains(Namespace.of(testDbName));
     } finally {
       lfRegisterPathRoleDeleteDb(testDbName);
     }
@@ -92,7 +91,7 @@ public class TestLakeFormationMetadataOperations extends LakeFormationTestBase {
     String tableLocation = getTableLocation(testTableName);
     grantDataPathPrivileges(tableLocation);
     try {
-      Assertions.assertThatThrownBy(
+      assertThatThrownBy(
               () ->
                   glueCatalogPrivilegedRole.createTable(
                       TableIdentifier.of(testDbName, testTableName),
@@ -117,8 +116,7 @@ public class TestLakeFormationMetadataOperations extends LakeFormationTestBase {
     grantTablePrivileges(testDbName, testTableName, Permission.ALTER);
     try {
       List<TableIdentifier> tables = glueCatalogPrivilegedRole.listTables(Namespace.of(testDbName));
-      Assert.assertTrue(
-          tables.contains(TableIdentifier.of(Namespace.of(testDbName), testTableName)));
+      assertThat(tables).contains(TableIdentifier.of(Namespace.of(testDbName), testTableName));
     } finally {
       lfRegisterPathRoleDeleteTable(testDbName, testTableName);
       lfRegisterPathRoleDeleteDb(testDbName);
@@ -132,8 +130,7 @@ public class TestLakeFormationMetadataOperations extends LakeFormationTestBase {
     lfRegisterPathRoleCreateDb(testDbName);
     lfRegisterPathRoleCreateTable(testDbName, testTableName);
     try {
-      Assertions.assertThatThrownBy(
-              () -> glueCatalogPrivilegedRole.listTables(Namespace.of(testDbName)))
+      assertThatThrownBy(() -> glueCatalogPrivilegedRole.listTables(Namespace.of(testDbName)))
           .as("attempt to show tables without any permissions should fail")
           .isInstanceOf(AccessDeniedException.class)
           .hasMessageContaining("Insufficient Lake Formation permission(s)");
@@ -150,7 +147,7 @@ public class TestLakeFormationMetadataOperations extends LakeFormationTestBase {
     lfRegisterPathRoleCreateDb(testDbName);
     grantDatabasePrivileges(testDbName, Permission.CREATE_TABLE);
     try {
-      Assertions.assertThatThrownBy(
+      assertThatThrownBy(
               () ->
                   glueCatalogPrivilegedRole.createTable(
                       TableIdentifier.of(testDbName, testTableName),
@@ -210,7 +207,7 @@ public class TestLakeFormationMetadataOperations extends LakeFormationTestBase {
     lfRegisterPathRoleCreateTable(testDbName, testTableName);
     grantTablePrivileges(testDbName, testTableName, Permission.SELECT);
     try {
-      Assertions.assertThatThrownBy(
+      assertThatThrownBy(
               () ->
                   glueCatalogPrivilegedRole.dropTable(
                       TableIdentifier.of(testDbName, testTableName), false))
@@ -265,7 +262,7 @@ public class TestLakeFormationMetadataOperations extends LakeFormationTestBase {
           TableProperties.DEFAULT_FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
       UpdateProperties updateProperties = table.updateProperties();
       properties.forEach(updateProperties::set);
-      Assertions.assertThatThrownBy(updateProperties::commit)
+      assertThatThrownBy(updateProperties::commit)
           .as("attempt to alter a table without ALTER permission should fail")
           .isInstanceOf(ForbiddenException.class)
           .hasMessageContaining("Glue cannot access the requested resources");
@@ -283,7 +280,7 @@ public class TestLakeFormationMetadataOperations extends LakeFormationTestBase {
     lfRegisterPathRoleCreateTable(testDbName, testTableName);
     grantDataPathPrivileges(getTableLocation(testTableName));
     try {
-      Assertions.assertThatThrownBy(
+      assertThatThrownBy(
               () ->
                   glueCatalogPrivilegedRole.loadTable(
                       TableIdentifier.of(Namespace.of(testDbName), testTableName)))
@@ -313,7 +310,7 @@ public class TestLakeFormationMetadataOperations extends LakeFormationTestBase {
           TableProperties.DEFAULT_FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
       UpdateProperties updateProperties = table.updateProperties();
       properties.forEach(updateProperties::set);
-      Assertions.assertThatThrownBy(updateProperties::commit)
+      assertThatThrownBy(updateProperties::commit)
           .as("attempt to alter a table without ALTER privileges should fail")
           .isInstanceOf(ForbiddenException.class)
           .hasMessageContaining("Glue cannot access the requested resources");

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.aws.s3;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -41,14 +41,10 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.relocated.com.google.common.collect.Streams;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.PartitionMetadata;
 import software.amazon.awssdk.regions.Region;
@@ -89,7 +85,7 @@ public class TestS3FileIOIntegration {
   private String objectKey;
   private String objectUri;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     clientFactory = AwsClientFactories.defaultFactory();
     s3 = clientFactory.s3();
@@ -112,7 +108,7 @@ public class TestS3FileIOIntegration {
         crossRegionS3Control, crossRegionAccessPointName, crossRegionBucketName);
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     AwsIntegTestUtil.cleanS3Bucket(s3, bucketName, prefix);
     AwsIntegTestUtil.deleteAccessPoint(s3Control, accessPointName);
@@ -121,14 +117,10 @@ public class TestS3FileIOIntegration {
         ScheduleKeyDeletionRequest.builder().keyId(kmsKeyArn).pendingWindowInDays(7).build());
   }
 
-  @Before
-  public void before() {
-    objectKey = String.format("%s/%s", prefix, UUID.randomUUID().toString());
-    objectUri = String.format("s3://%s/%s", bucketName, objectKey);
-  }
-
   @BeforeEach
   public void beforeEach() {
+    objectKey = String.format("%s/%s", prefix, UUID.randomUUID().toString());
+    objectUri = String.format("s3://%s/%s", bucketName, objectKey);
     clientFactory.initialize(Maps.newHashMap());
   }
 
@@ -209,7 +201,7 @@ public class TestS3FileIOIntegration {
         s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build());
     String result = IoUtils.toUtf8String(stream);
     stream.close();
-    Assert.assertEquals(content, result);
+    assertThat(result).isEqualTo(content);
   }
 
   @Test
@@ -224,7 +216,7 @@ public class TestS3FileIOIntegration {
         s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build());
     String result = IoUtils.toUtf8String(stream);
     stream.close();
-    Assert.assertEquals(content, result);
+    assertThat(result).isEqualTo(content);
   }
 
   @Test
@@ -247,7 +239,7 @@ public class TestS3FileIOIntegration {
                 .build());
     String result = IoUtils.toUtf8String(stream);
     stream.close();
-    Assert.assertEquals(content, result);
+    assertThat(result).isEqualTo(content);
   }
 
   @Test
@@ -260,7 +252,7 @@ public class TestS3FileIOIntegration {
     GetObjectResponse response =
         s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build())
             .response();
-    Assert.assertEquals(ServerSideEncryption.AES256, response.serverSideEncryption());
+    assertThat(response.serverSideEncryption()).isEqualTo(ServerSideEncryption.AES256);
   }
 
   @Test
@@ -274,8 +266,8 @@ public class TestS3FileIOIntegration {
     GetObjectResponse response =
         s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build())
             .response();
-    Assert.assertEquals(ServerSideEncryption.AWS_KMS, response.serverSideEncryption());
-    Assert.assertEquals(response.ssekmsKeyId(), kmsKeyArn);
+    assertThat(response.serverSideEncryption()).isEqualTo(ServerSideEncryption.AWS_KMS);
+    assertThat(kmsKeyArn).isEqualTo(response.ssekmsKeyId());
   }
 
   @Test
@@ -288,12 +280,15 @@ public class TestS3FileIOIntegration {
     GetObjectResponse response =
         s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build())
             .response();
-    Assert.assertEquals(ServerSideEncryption.AWS_KMS, response.serverSideEncryption());
+    assertThat(response.serverSideEncryption()).isEqualTo(ServerSideEncryption.AWS_KMS);
     ListAliasesResponse listAliasesResponse =
         kms.listAliases(ListAliasesRequest.builder().keyId(response.ssekmsKeyId()).build());
-    Assert.assertTrue(listAliasesResponse.hasAliases());
-    Assert.assertEquals(1, listAliasesResponse.aliases().size());
-    Assert.assertEquals("alias/aws/s3", listAliasesResponse.aliases().get(0).aliasName());
+    assertThat(listAliasesResponse.hasAliases()).isTrue();
+    assertThat(listAliasesResponse.aliases())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            aliasListEntry -> assertThat(aliasListEntry.aliasName()).isEqualTo("alias/aws/s3"));
   }
 
   @Test
@@ -326,9 +321,9 @@ public class TestS3FileIOIntegration {
                     .sseCustomerKeyMD5(md5)
                     .build())
             .response();
-    Assert.assertNull(response.serverSideEncryption());
-    Assert.assertEquals(ServerSideEncryption.AES256.name(), response.sseCustomerAlgorithm());
-    Assert.assertEquals(md5, response.sseCustomerKeyMD5());
+    assertThat(response.serverSideEncryption()).isNull();
+    assertThat(response.sseCustomerAlgorithm()).isEqualTo(ServerSideEncryption.AES256.toString());
+    assertThat(response.sseCustomerKeyMD5()).isEqualTo(md5);
   }
 
   @Test
@@ -340,9 +335,11 @@ public class TestS3FileIOIntegration {
     validateRead(s3FileIO);
     GetObjectAclResponse response =
         s3.getObjectAcl(GetObjectAclRequest.builder().bucket(bucketName).key(objectKey).build());
-    Assert.assertTrue(response.hasGrants());
-    Assert.assertEquals(1, response.grants().size());
-    Assert.assertEquals(Permission.FULL_CONTROL, response.grants().get(0).permission());
+    assertThat(response.hasGrants()).isTrue();
+    assertThat(response.grants())
+        .hasSize(1)
+        .first()
+        .satisfies(grant -> assertThat(grant.permission()).isEqualTo(Permission.FULL_CONTROL));
   }
 
   @Test
@@ -406,11 +403,11 @@ public class TestS3FileIOIntegration {
             scale -> {
               String scalePrefix = String.format("%s/%s/", listPrefix, scale);
               createRandomObjects(scalePrefix, scale);
-              assertEquals((long) scale, Streams.stream(s3FileIO.listPrefix(scalePrefix)).count());
+              assertThat(s3FileIO.listPrefix(scalePrefix)).hasSize(scale);
             });
 
     long totalFiles = scaleSizes.stream().mapToLong(Integer::longValue).sum();
-    Assertions.assertEquals(totalFiles, Streams.stream(s3FileIO.listPrefix(listPrefix)).count());
+    assertThat(s3FileIO.listPrefix(listPrefix)).hasSize((int) totalFiles);
   }
 
   @SuppressWarnings("DangerousParallelStreamUsage")
@@ -429,7 +426,7 @@ public class TestS3FileIOIntegration {
               String scalePrefix = String.format("%s/%s/", deletePrefix, scale);
               createRandomObjects(scalePrefix, scale);
               s3FileIO.deletePrefix(scalePrefix);
-              assertEquals(0L, Streams.stream(s3FileIO.listPrefix(scalePrefix)).count());
+              assertThat(s3FileIO.listPrefix(scalePrefix)).isEmpty();
             });
   }
 
@@ -448,7 +445,7 @@ public class TestS3FileIOIntegration {
     }
     s3FileIO.deleteFiles(paths);
     for (String path : paths) {
-      Assert.assertFalse(s3FileIO.newInputFile(path).exists());
+      assertThat(s3FileIO.newInputFile(path).exists()).isFalse();
     }
   }
 
@@ -465,11 +462,11 @@ public class TestS3FileIOIntegration {
 
   private void validateRead(S3FileIO s3FileIO) throws Exception {
     InputFile file = s3FileIO.newInputFile(objectUri);
-    Assert.assertEquals(contentBytes.length, file.getLength());
+    assertThat(file.getLength()).isEqualTo(contentBytes.length);
     InputStream stream = file.newStream();
     String result = IoUtils.toUtf8String(stream);
     stream.close();
-    Assert.assertEquals(content, result);
+    assertThat(result).isEqualTo(content);
   }
 
   private String testAccessPointARN(String region, String accessPoint) {

--- a/build.gradle
+++ b/build.gradle
@@ -529,6 +529,7 @@ project(':iceberg-aws') {
   }
 
   task integrationTest(type: Test) {
+    useJUnitPlatform()
     testClassesDirs = sourceSets.integration.output.classesDirs
     classpath = sourceSets.integration.runtimeClasspath
     jvmArgs += project.property('extraJvmArgs')


### PR DESCRIPTION
Migrate AWS integration tests to JUnit 5 for https://github.com/apache/iceberg/issues/9080

All tests in `iceberg-aws/test` already use JUnit5 and AssertJ.

The following integration tests need to be migrated.

`iceberg-aws/integration/java/org.apache.iceberg.aws/`:
* [x] `dynamodb/`
  * [x] `TestDynamoDbCatalog`
  * [x] `TestDynamoDbLockManager`
* [x] `glue/`
  * [x] `GlueTestBase`
  * [x] `TestGlueCatalogCommitFailure` 
  * [x] `TestGlueCatalogLock`
  * [x] `TestGlueCatalogNamespace`
  * [x] `TestGlueCatalogTable`
* [x] `lakeformation/`
  * [x] `LakeFormationTestBase`
  * [x] `TestLakeFormationAwsClientFactory`
  * [x] `TestLakeFormationDataOperations`
  * [x] `TestLakeFormationMetadataOperations`
* [x] `s3/`
  * `S3TestUtil` (not a test file)
  * [x] `TestS3FileIOIntegration`
  * [x] `TestS3MultipartUpload`
* `AwsIntegTestUtil` (not a test file)
- [x] `TestAssumeRoleAwsClientFactory`
- [x] `TestDefaultAwsClientFactory`
