### PR TITLE
Parquet: Make row-group filters cooperate to filter

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -367,7 +367,6 @@ public class ExpressionVisitors {
         case OR:
           Or or = (Or) expr;
           return visitor.or(visit(or.left(), visitor), visit(or.right(), visitor));
-
         default:
           throw new UnsupportedOperationException("Unknown operation: " + expr.op());
       }

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -27,12 +27,6 @@ public class ExpressionVisitors {
 
   private ExpressionVisitors() {}
 
-  public interface SupportsLazyEvaluation<R> {
-    R and(Supplier<R> left, Supplier<R> right);
-
-    R or(Supplier<R> left, Supplier<R> right);
-  }
-
   public abstract static class ExpressionVisitor<R> {
     public R alwaysTrue() {
       return null;
@@ -369,20 +363,11 @@ public class ExpressionVisitors {
           return visitor.not(visit(not.child(), visitor));
         case AND:
           And and = (And) expr;
-          if (visitor instanceof SupportsLazyEvaluation) {
-            return ((SupportsLazyEvaluation<R>) visitor)
-                .and(() -> visit(and.left(), visitor), () -> visit(and.right(), visitor));
-          } else {
-            return visitor.and(visit(and.left(), visitor), visit(and.right(), visitor));
-          }
+          return visitor.and(visit(and.left(), visitor), visit(and.right(), visitor));
         case OR:
           Or or = (Or) expr;
-          if (visitor instanceof SupportsLazyEvaluation) {
-            return ((SupportsLazyEvaluation<R>) visitor)
-                .or(() -> visit(or.left(), visitor), () -> visit(or.right(), visitor));
-          } else {
-            return visitor.or(visit(or.left(), visitor), visit(or.right(), visitor));
-          }
+          return visitor.or(visit(or.left(), visitor), visit(or.right(), visitor));
+
         default:
           throw new UnsupportedOperationException("Unknown operation: " + expr.op());
       }
@@ -619,8 +604,7 @@ public class ExpressionVisitors {
     }
   }
 
-  public abstract static class FindsResidualVisitor extends BoundExpressionVisitor<Expression>
-      implements SupportsLazyEvaluation<Expression> {
+  public abstract static class FindsResidualVisitor extends BoundExpressionVisitor<Expression> {
     protected static final Expression ROWS_CANNOT_MATCH = Expressions.alwaysFalse();
     protected static final Expression ROWS_ALL_MATCH = Expressions.alwaysTrue();
     protected static final Expression ROWS_MIGHT_MATCH = null;

--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -955,7 +955,7 @@ public class TestMetricsRowGroupFilter {
 
   @Test
   public void testParquetFindsResidual() {
-    Assume.assumeTrue("Only valid for Parquet", format == FileFormat.PARQUET);
+    Assumptions.assumeThat(format).isEqualTo(FileFormat.PARQUET);
 
     Expression mightMatch = notEqual("some_nulls", "some");
     Expression cannotMatch = equal("id", INT_MIN_VALUE - 25);
@@ -965,17 +965,15 @@ public class TestMetricsRowGroupFilter {
         new ParquetMetricsRowGroupFilter(SCHEMA, Expressions.or(mightMatch, cannotMatch), true);
     Expression actual = filter.residualFor(parquetSchema, rowGroupMetadata);
 
-    Assert.assertTrue(
-        String.format("Expected actual: %s, actual: %s", expected.toString(), actual.toString()),
-        actual.isEquivalentTo(expected));
+    Assertions.assertThat(actual.isEquivalentTo(expected))
+        .overridingErrorMessage("Expected: %s, actual: %s", expected, actual);
 
     filter =
         new ParquetMetricsRowGroupFilter(SCHEMA, Expressions.and(mightMatch, cannotMatch), true);
     expected = Expressions.alwaysFalse();
     actual = filter.residualFor(parquetSchema, rowGroupMetadata);
-    Assert.assertTrue(
-        String.format("Expected actual: %s, actual: %s", expected.toString(), actual.toString()),
-        actual.isEquivalentTo(expected));
+    Assertions.assertThat(actual.isEquivalentTo(expected))
+        .overridingErrorMessage("Expected: %s, actual: %s", expected, actual);
   }
 
   private boolean shouldRead(Expression expression) {

--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -56,7 +56,9 @@ import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.orc.GenericOrcReader;
 import org.apache.iceberg.data.orc.GenericOrcWriter;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.InputFile;
@@ -949,6 +951,31 @@ public class TestMetricsRowGroupFilter {
     Assertions.assertThat(shouldRead)
         .as("Should read: filter contains non-reference evaluate as True")
         .isTrue();
+  }
+
+  @Test
+  public void testParquetFindsResidual() {
+    Assume.assumeTrue("Only valid for Parquet", format == FileFormat.PARQUET);
+
+    Expression mightMatch = notEqual("some_nulls", "some");
+    Expression cannotMatch = equal("id", INT_MIN_VALUE - 25);
+
+    Expression expected = Binder.bind(SCHEMA.asStruct(), Expressions.rewriteNot(mightMatch), true);
+    ParquetMetricsRowGroupFilter filter =
+        new ParquetMetricsRowGroupFilter(SCHEMA, Expressions.or(mightMatch, cannotMatch), true);
+    Expression actual = filter.residualFor(parquetSchema, rowGroupMetadata);
+
+    Assert.assertTrue(
+        String.format("Expected actual: %s, actual: %s", expected.toString(), actual.toString()),
+        actual.isEquivalentTo(expected));
+
+    filter =
+        new ParquetMetricsRowGroupFilter(SCHEMA, Expressions.and(mightMatch, cannotMatch), true);
+    expected = Expressions.alwaysFalse();
+    actual = filter.residualFor(parquetSchema, rowGroupMetadata);
+    Assert.assertTrue(
+        String.format("Expected actual: %s, actual: %s", expected.toString(), actual.toString()),
+        actual.isEquivalentTo(expected));
   }
 
   private boolean shouldRead(Expression expression) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
@@ -23,7 +23,6 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Supplier;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Bound;
@@ -157,23 +156,13 @@ public class ParquetBloomRowGroupFilter {
     }
 
     @Override
-    public Expression and(Supplier<Expression> left, Supplier<Expression> right) {
-      Expression leftResult = left.get();
-      if (leftResult == ROWS_CANNOT_MATCH) {
-        return leftResult;
-      }
-
-      return Expressions.and(leftResult, right.get());
+    public Expression and(Expression leftResult, Expression rightResult) {
+      return Expressions.and(leftResult, rightResult);
     }
 
     @Override
-    public Expression or(Supplier<Expression> left, Supplier<Expression> right) {
-      Expression leftResult = left.get();
-      if (leftResult == ROWS_ALL_MATCH) {
-        return leftResult;
-      }
-
-      return Expressions.or(leftResult, right.get());
+    public Expression or(Expression leftResult, Expression rightResult) {
+      return Expressions.or(leftResult, rightResult);
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -23,7 +23,6 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Binder;
@@ -142,23 +141,13 @@ public class ParquetDictionaryRowGroupFilter {
     }
 
     @Override
-    public Expression and(Supplier<Expression> left, Supplier<Expression> right) {
-      Expression leftResult = left.get();
-      if (leftResult == ROWS_CANNOT_MATCH) {
-        return leftResult;
-      }
-
-      return Expressions.and(leftResult, right.get());
+    public Expression and(Expression leftResult, Expression rightResult) {
+      return Expressions.and(leftResult, rightResult);
     }
 
     @Override
-    public Expression or(Supplier<Expression> left, Supplier<Expression> right) {
-      Expression leftResult = left.get();
-      if (leftResult == ROWS_ALL_MATCH) {
-        return leftResult;
-      }
-
-      return Expressions.or(leftResult, right.get());
+    public Expression or(Expression leftResult, Expression rightResult) {
+      return Expressions.or(leftResult, rightResult);
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -24,7 +24,6 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Binder;
@@ -125,23 +124,13 @@ public class ParquetMetricsRowGroupFilter {
     }
 
     @Override
-    public Expression and(Supplier<Expression> left, Supplier<Expression> right) {
-      Expression leftResult = left.get();
-      if (leftResult == ROWS_CANNOT_MATCH) {
-        return leftResult;
-      }
-
-      return Expressions.and(leftResult, right.get());
+    public Expression and(Expression leftResult, Expression rightResult) {
+      return Expressions.and(leftResult, rightResult);
     }
 
     @Override
-    public Expression or(Supplier<Expression> left, Supplier<Expression> right) {
-      Expression leftResult = left.get();
-      if (leftResult == ROWS_ALL_MATCH) {
-        return leftResult;
-      }
-
-      return Expressions.or(leftResult, right.get());
+    public Expression or(Expression leftResult, Expression rightResult) {
+      return Expressions.or(leftResult, rightResult);
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Binder;
@@ -31,7 +32,7 @@ import org.apache.iceberg.expressions.Bound;
 import org.apache.iceberg.expressions.BoundReference;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ExpressionVisitors;
-import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
+import org.apache.iceberg.expressions.ExpressionVisitors.FindsResidualVisitor;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -52,14 +53,18 @@ public class ParquetMetricsRowGroupFilter {
   private final Schema schema;
   private final Expression expr;
 
-  public ParquetMetricsRowGroupFilter(Schema schema, Expression unbound) {
-    this(schema, unbound, true);
+  public ParquetMetricsRowGroupFilter(Schema schema, Expression expr) {
+    this(schema, expr, true);
   }
 
-  public ParquetMetricsRowGroupFilter(Schema schema, Expression unbound, boolean caseSensitive) {
+  public ParquetMetricsRowGroupFilter(Schema schema, Expression expr, boolean caseSensitive) {
     this.schema = schema;
     StructType struct = schema.asStruct();
-    this.expr = Binder.bind(struct, Expressions.rewriteNot(unbound), caseSensitive);
+    if (Binder.isBound(expr)) {
+      this.expr = Expressions.rewriteNot(expr);
+    } else {
+      this.expr = Binder.bind(struct, Expressions.rewriteNot(expr), caseSensitive);
+    }
   }
 
   /**
@@ -70,18 +75,19 @@ public class ParquetMetricsRowGroupFilter {
    * @return false if the file cannot contain rows that match the expression, true otherwise.
    */
   public boolean shouldRead(MessageType fileSchema, BlockMetaData rowGroup) {
+    return residualFor(fileSchema, rowGroup) != Expressions.alwaysFalse();
+  }
+
+  public Expression residualFor(MessageType fileSchema, BlockMetaData rowGroup) {
     return new MetricsEvalVisitor().eval(fileSchema, rowGroup);
   }
 
-  private static final boolean ROWS_MIGHT_MATCH = true;
-  private static final boolean ROWS_CANNOT_MATCH = false;
-
-  private class MetricsEvalVisitor extends BoundExpressionVisitor<Boolean> {
+  private class MetricsEvalVisitor extends FindsResidualVisitor {
     private Map<Integer, Statistics<?>> stats = null;
     private Map<Integer, Long> valueCounts = null;
     private Map<Integer, Function<Object, Object>> conversions = null;
 
-    private boolean eval(MessageType fileSchema, BlockMetaData rowGroup) {
+    private Expression eval(MessageType fileSchema, BlockMetaData rowGroup) {
       if (rowGroup.getRowCount() <= 0) {
         return ROWS_CANNOT_MATCH;
       }
@@ -100,36 +106,46 @@ public class ParquetMetricsRowGroupFilter {
         }
       }
 
-      return ExpressionVisitors.visitEvaluator(expr, this);
+      return ExpressionVisitors.visit(expr, this);
     }
 
     @Override
-    public Boolean alwaysTrue() {
-      return ROWS_MIGHT_MATCH; // all rows match
+    public Expression alwaysTrue() {
+      return ROWS_ALL_MATCH; // all rows match
     }
 
     @Override
-    public Boolean alwaysFalse() {
+    public Expression alwaysFalse() {
       return ROWS_CANNOT_MATCH; // all rows fail
     }
 
     @Override
-    public Boolean not(Boolean result) {
-      return !result;
+    public Expression not(Expression result) {
+      throw new UnsupportedOperationException("This path shouldn't be reached.");
     }
 
     @Override
-    public Boolean and(Boolean leftResult, Boolean rightResult) {
-      return leftResult && rightResult;
+    public Expression and(Supplier<Expression> left, Supplier<Expression> right) {
+      Expression leftResult = left.get();
+      if (leftResult == ROWS_CANNOT_MATCH) {
+        return leftResult;
+      }
+
+      return Expressions.and(leftResult, right.get());
     }
 
     @Override
-    public Boolean or(Boolean leftResult, Boolean rightResult) {
-      return leftResult || rightResult;
+    public Expression or(Supplier<Expression> left, Supplier<Expression> right) {
+      Expression leftResult = left.get();
+      if (leftResult == ROWS_ALL_MATCH) {
+        return leftResult;
+      }
+
+      return Expressions.or(leftResult, right.get());
     }
 
     @Override
-    public <T> Boolean isNull(BoundReference<T> ref) {
+    public <T> Expression isNull(BoundReference<T> ref) {
       // no need to check whether the field is required because binding evaluates that case
       // if the column has no null values, the expression cannot match
       int id = ref.fieldId();
@@ -150,7 +166,7 @@ public class ParquetMetricsRowGroupFilter {
     }
 
     @Override
-    public <T> Boolean notNull(BoundReference<T> ref) {
+    public <T> Expression notNull(BoundReference<T> ref) {
       // no need to check whether the field is required because binding evaluates that case
       // if the column has no non-null values, the expression cannot match
       int id = ref.fieldId();
@@ -178,7 +194,7 @@ public class ParquetMetricsRowGroupFilter {
     }
 
     @Override
-    public <T> Boolean isNaN(BoundReference<T> ref) {
+    public <T> Expression isNaN(BoundReference<T> ref) {
       int id = ref.fieldId();
 
       Long valueCount = valueCounts.get(id);
@@ -197,12 +213,12 @@ public class ParquetMetricsRowGroupFilter {
     }
 
     @Override
-    public <T> Boolean notNaN(BoundReference<T> ref) {
+    public <T> Expression notNaN(BoundReference<T> ref) {
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean lt(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression lt(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
 
       Long valueCount = valueCounts.get(id);
@@ -232,7 +248,7 @@ public class ParquetMetricsRowGroupFilter {
     }
 
     @Override
-    public <T> Boolean ltEq(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression ltEq(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
 
       Long valueCount = valueCounts.get(id);
@@ -262,7 +278,7 @@ public class ParquetMetricsRowGroupFilter {
     }
 
     @Override
-    public <T> Boolean gt(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression gt(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
 
       Long valueCount = valueCounts.get(id);
@@ -292,7 +308,7 @@ public class ParquetMetricsRowGroupFilter {
     }
 
     @Override
-    public <T> Boolean gtEq(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression gtEq(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
 
       Long valueCount = valueCounts.get(id);
@@ -322,7 +338,7 @@ public class ParquetMetricsRowGroupFilter {
     }
 
     @Override
-    public <T> Boolean eq(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression eq(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
 
       // When filtering nested types notNull() is implicit filter passed even though complex
@@ -365,14 +381,14 @@ public class ParquetMetricsRowGroupFilter {
     }
 
     @Override
-    public <T> Boolean notEq(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression notEq(BoundReference<T> ref, Literal<T> lit) {
       // because the bounds are not necessarily a min or max value, this cannot be answered using
       // them. notEq(col, X) with (X, Y) doesn't guarantee that X is a value in col.
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean in(BoundReference<T> ref, Set<T> literalSet) {
+    public <T> Expression in(BoundReference<T> ref, Set<T> literalSet) {
       int id = ref.fieldId();
 
       // When filtering nested types notNull() is implicit filter passed even though complex
@@ -430,7 +446,7 @@ public class ParquetMetricsRowGroupFilter {
     }
 
     @Override
-    public <T> Boolean notIn(BoundReference<T> ref, Set<T> literalSet) {
+    public <T> Expression notIn(BoundReference<T> ref, Set<T> literalSet) {
       // because the bounds are not necessarily a min or max value, this cannot be answered using
       // them. notIn(col, {X, ...}) with (X, Y) doesn't guarantee that X is a value in col.
       return ROWS_MIGHT_MATCH;
@@ -438,7 +454,7 @@ public class ParquetMetricsRowGroupFilter {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> Boolean startsWith(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression startsWith(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
 
       Long valueCount = valueCounts.get(id);
@@ -487,7 +503,7 @@ public class ParquetMetricsRowGroupFilter {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> Boolean notStartsWith(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression notStartsWith(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
       Long valueCount = valueCounts.get(id);
 
@@ -560,7 +576,7 @@ public class ParquetMetricsRowGroupFilter {
     }
 
     @Override
-    public <T> Boolean handleNonReference(Bound<T> term) {
+    public <T> Expression handleNonReference(Bound<T> term) {
       return ROWS_MIGHT_MATCH;
     }
   }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestBloomRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestBloomRowGroupFilter.java
@@ -57,7 +57,9 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
@@ -183,6 +185,7 @@ public class TestBloomRowGroupFilter {
   private MessageType parquetSchema = null;
   private BlockMetaData rowGroupMetadata = null;
   private BloomFilterReader bloomStore = null;
+  private ParquetFileReader reader;
 
   @TempDir private File temp;
 
@@ -266,7 +269,7 @@ public class TestBloomRowGroupFilter {
 
     InputFile inFile = Files.localInput(temp);
 
-    ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(inFile));
+    reader = ParquetFileReader.open(ParquetIO.file(inFile));
 
     assertThat(reader.getRowGroups()).as("Should create only one row group").hasSize(1);
     rowGroupMetadata = reader.getRowGroups().get(0);
@@ -1188,5 +1191,41 @@ public class TestBloomRowGroupFilter {
     assertThat(shouldRead)
         .as("Should read: filter contains non-reference evaluate as True")
         .isTrue();
+  }
+
+  @Test
+  public void testParquetFindsResidual() {
+    // `string` col has no dict, this should be eliminated by bloom filter
+    Expression bloom = equal("string", "BINARY测试_301");
+    // should be eliminated by dictionary filter
+    Expression dict = equal("no_stats", "a");
+    // should be eliminated by bloom filter
+    Expression metric = greaterThan("id", INT_MAX_VALUE);
+    Expression expr = or(bloom, or(dict, metric));
+
+    Expression expected = Binder.bind(SCHEMA.asStruct(), Expressions.or(bloom, dict), true);
+    ParquetMetricsRowGroupFilter metricFilter = new ParquetMetricsRowGroupFilter(SCHEMA, expr);
+    Expression metricResidual = metricFilter.residualFor(parquetSchema, rowGroupMetadata);
+    assertThat(expected.isEquivalentTo(metricResidual))
+        .as("Expected residual: %s, actual residual: %s", expected, metricResidual);
+
+    expected = Binder.bind(SCHEMA.asStruct(), bloom, true);
+    ParquetDictionaryRowGroupFilter dictFilter =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, metricResidual);
+    Expression dictResidual =
+        dictFilter.residualFor(
+            parquetSchema, rowGroupMetadata, reader.getDictionaryReader(rowGroupMetadata));
+
+    assertThat(expected.isEquivalentTo(dictResidual))
+        .as("Expected residual: %s, actual residual: %s", expected, dictResidual);
+
+    expected = Expressions.alwaysFalse();
+    ParquetBloomRowGroupFilter bloomFilter = new ParquetBloomRowGroupFilter(SCHEMA, dictResidual);
+    Expression bloomResidual =
+        bloomFilter.residualFor(
+            parquetSchema, rowGroupMetadata, reader.getBloomFilterDataReader(rowGroupMetadata));
+
+    assertThat(expected.isEquivalentTo(bloomResidual))
+        .as("Expected residual: %s, actual residual: %s", expected, bloomResidual);
   }
 }


### PR DESCRIPTION
This PR refactors three Parquet row-group filters into a form that computes residual expressions, allowing it to return a residual expression for the given row-groups. The residual computed by the previous filter can be passed to the next filter, allowing the three Parquet row-group filters to work together. This improves the handling of some `OR` condition queries.

For example: Let's assume we have a query `a = 'foo' OR b = 'bar'`, where column a is dictionary-encoded in a Parquet row-group, while column b is not entirely dictionary-encoded in all data pages but has a bloom filter. Therefore, `a = 'foo'` can only be evaluated by the dictionary filter, and `b = 'bar'` can only be evaluated by the bloom filter. In the current situation, even if both filters evaluate the expressions as `ROWS_CANNOT_MATCH` individually, because each filter can only evaluate one sub-expression, the final output would still be `ROWS_MIGHT_MATCH` (let's assume the metric filter evaluates both sub-expressions as `ROWS_MIGHT_MATCH`).
After refactoring into the form of computing residuals, the dictionary filter will compute the residual for `a = 'foo' OR b = 'bar'` as `b = 'bar'`. Then this residual expression will be passed to the bloom filter and evaluated as `Expressions.alwaysFalse()`. As a result, the reading of this row-group can be skipped.

This is a revive of #6893, and can close #10029.

cc @cccs-jc  @rdblue @huaxingao @amogh-jahagirdar @RussellSpitzer Could you please review this? Thanks!