### PR TITLE
Docs: Fix On-screen display issues and minor expressions on Branching and Tagging DDL

### DIFF
--- a/docs/docs/spark-ddl.md
+++ b/docs/docs/spark-ddl.md
@@ -478,10 +478,11 @@ Note that although the identifier is removed, the column will still exist in the
 #### `ALTER TABLE ... CREATE BRANCH`
 
 Branches can be created via the `CREATE BRANCH` statement with the following options:
+
 * Do not fail if the branch already exists with `IF NOT EXISTS`
 * Update the branch if it already exists with `CREATE OR REPLACE`
-* Create at a snapshot
-* Create with retention
+* Create a branch at a specific snapshot
+* Create a branch with a specified retention period
 
 ```sql
 -- CREATE audit-branch at current snapshot with default retention.
@@ -499,17 +500,18 @@ AS OF VERSION 1234
 
 -- CREATE audit-branch at snapshot 1234, retain audit-branch for 31 days, and retain the latest 31 days. The latest 3 snapshot snapshots, and 2 days worth of snapshots. 
 ALTER TABLE prod.db.sample CREATE BRANCH `audit-branch`
-AS OF VERSION 1234 RETAIN 30 DAYS 
+AS OF VERSION 1234 RETAIN 31 DAYS 
 WITH SNAPSHOT RETENTION 3 SNAPSHOTS 2 DAYS
 ```
 
 #### `ALTER TABLE ... CREATE TAG`
 
 Tags can be created via the `CREATE TAG` statement with the following options:
+
 * Do not fail if the tag already exists with `IF NOT EXISTS`
 * Update the tag if it already exists with `CREATE OR REPLACE`
-* Create at a snapshot
-* Create with retention
+* Create a tag at a specific snapshot
+* Create a tag with a specified retention period
 
 ```sql
 -- CREATE historical-tag at current snapshot with default retention.

--- a/docs/docs/spark-ddl.md
+++ b/docs/docs/spark-ddl.md
@@ -498,9 +498,9 @@ ALTER TABLE prod.db.sample CREATE OR REPLACE BRANCH `audit-branch`
 ALTER TABLE prod.db.sample CREATE BRANCH `audit-branch`
 AS OF VERSION 1234
 
--- CREATE audit-branch at snapshot 1234, retain audit-branch for 31 days, and retain the latest 31 days. The latest 3 snapshot snapshots, and 2 days worth of snapshots. 
+-- CREATE audit-branch at snapshot 1234, retain audit-branch for 30 days, and retain the latest 30 days. The latest 3 snapshot snapshots, and 2 days worth of snapshots. 
 ALTER TABLE prod.db.sample CREATE BRANCH `audit-branch`
-AS OF VERSION 1234 RETAIN 31 DAYS 
+AS OF VERSION 1234 RETAIN 30 DAYS 
 WITH SNAPSHOT RETENTION 3 SNAPSHOTS 2 DAYS
 ```
 


### PR DESCRIPTION
I propose following three modifications.

- Fix a broken bullet point display.
<img width="785" alt="Screenshot 2024-04-07 at 13 05 49" src="https://github.com/apache/iceberg/assets/70102274/1ce9bfe1-4424-4b59-baec-ccf7e6a3fec7">
<img width="783" alt="Screenshot 2024-04-07 at 13 05 56" src="https://github.com/apache/iceberg/assets/70102274/1e6e4e9a-7ecb-43df-9536-a682a7226096">

- Fix inconsistency between comment and SQL
> -- CREATE audit-branch at snapshot 1234, retain audit-branch for 31 days, and retain the latest 31 days. The latest 3
> snapshot snapshots, and 2 days worth of snapshots. 
> ALTER TABLE prod.db.sample CREATE BRANCH `audit-branch`
> AS OF VERSION 1234 RETAIN 30 DAYS 
> WITH SNAPSHOT RETENTION 3 SNAPSHOTS 2 DAYS
 
- A little clearer explanation of the respective options for DDLs.

I would be happy for you to review my proposal.