### PR TITLE
Docs: Fix links of `Get Started` and `Community` sections in footer

### DIFF
--- a/site/overrides/partials/footer.html
+++ b/site/overrides/partials/footer.html
@@ -48,12 +48,12 @@
       <div class="col-lg-2 col-md-2 footer-links">
         <h4>Get Started</h4>
         <ul>
-          <li><a href="spark-quickstart">Spark Quickstart</a></li>
-          <li><a href="hive-quickstart">Hive Quickstart</a></li>
-          <li><a href="spec/">Open Table Spec</a></li>
-          <li><a href="docs/latest">Docs</a></li>
-          <li><a href="blogs/">Blogs</a></li>
-          <li><a href="talks/">Talks</a></li>
+          <li><a href="/spark-quickstart">Spark Quickstart</a></li>
+          <li><a href="/hive-quickstart">Hive Quickstart</a></li>
+          <li><a href="/spec/">Open Table Spec</a></li>
+          <li><a href="/docs/latest">Docs</a></li>
+          <li><a href="/blogs/">Blogs</a></li>
+          <li><a href="/talks/">Talks</a></li>
         </ul>
         <br />
       </div>
@@ -61,14 +61,14 @@
       <div class="col-lg-2 col-md-2 footer-links">
         <h4>Community</h4>
         <ul>
-          <li><a href="community/#slack">Support</a></li>
-          <li><a href="community/#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/community/#slack">Support</a></li>
+          <li><a href="/community/#mailing-lists">Mailing Lists</a></li>
           <li>
-            <a href="community/#iceberg-community-events">Iceberg Events</a>
+            <a href="/community/#iceberg-community-events">Iceberg Events</a>
           </li>
-          <li><a href="community/#issues">Issues</a></li>
-          <li><a href="community/#contribute">Contribute</a></li>
-          <li><a href="community/#community-guidelines">Guidelines</a></li>
+          <li><a href="/community/#issues">Issues</a></li>
+          <li><a href="/community/#contribute">Contribute</a></li>
+          <li><a href="/community/#community-guidelines">Guidelines</a></li>
           <!-- li><a href="/logos-and-assets.html">Solr Logos and Assets</a></li -->
         </ul>
       </div>


### PR DESCRIPTION
Fixed the issue #10099 by using absolute links instead of relative links.