### PR TITLE
Core: Allow manifest file cache to be configurable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -79,6 +79,17 @@ public class CatalogProperties {
   public static final boolean IO_MANIFEST_CACHE_ENABLED_DEFAULT = false;
 
   /**
+   * Overrides the default {@link org.apache.iceberg.io.ContentCacheManager} implementation.
+   *
+   * <p>The supplied {@link org.apache.iceberg.io.ContentCacheManager} must have a static method named {@code create}
+   * which takes in a map representing the catalog properties.
+   */
+  public static final String IO_MANIFEST_CACHE_CONTENT_CACHE_MANAGER_IMPL = "io.manifest.cache.content-caches-impl";
+
+  public static final String IO_MANIFEST_CACHE_CONTENT_CACHE_MANAGER_IMPL_DEFAULT =
+          "org.apache.iceberg.io.InMemoryContentCacheManager";
+
+  /**
    * Controls the maximum duration for which an entry stays in the manifest cache.
    *
    * <p>Must be a non-negative value. Following are specific behaviors of this config:

--- a/core/src/main/java/org/apache/iceberg/io/ContentCacheManager.java
+++ b/core/src/main/java/org/apache/iceberg/io/ContentCacheManager.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+/**
+ * Manages content caches for FileIO implementations, capable of creating or retrieving
+ * a {@link ContentCache} given a {@link FileIO}, or dropping a cache for a {@link FileIO}.
+ */
+public interface ContentCacheManager {
+
+    /**
+     * Create or retrieve a content cache object for a FileIO.
+     * @param io the FileIO to create or retrieve a content cache for
+     * @return the content cache
+     */
+    FileIOContentCache contentCache(FileIO io);
+
+    /**
+     * Drop manifest file cache object for a FileIO if exists.
+     * @param fileIO the FileIO to drop cache for
+     * */
+    void dropCache(FileIO fileIO);
+}

--- a/core/src/main/java/org/apache/iceberg/io/FileIOContentCache.java
+++ b/core/src/main/java/org/apache/iceberg/io/FileIOContentCache.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+/**
+ * Class that provides file-content caching during reading.
+ *
+ * <p>The file-content caching is initiated by calling {@link FileIOContentCache#tryCache(InputFile)}.
+ * Given a FileIO, a file location string, and file length that is within allowed limit,
+ * ContentCache will return an implementation of a {@link InputFile} that may be cached.
+ */
+public interface FileIOContentCache {
+
+    /**
+     * Try to cache the input file.  Returns an implementation of {@link InputFile} that may be cached.
+     * @param input the input file to cache
+     * @return an implementation of {@link InputFile} that may be cached, or the input if it cannot be cached
+     */
+    InputFile tryCache(InputFile input);
+
+    /**
+     * Invalidate the cache for the given key.
+     * @param key the cache key
+     */
+    void invalidate(String key);
+
+    /**
+     * Invalidate all entries in the cache.
+     */
+    void invalidateAll();
+
+    /**
+     * Estimate the size of the cache in this application's memory in bytes.
+     */
+    long estimatedCacheSize();
+}

--- a/core/src/main/java/org/apache/iceberg/io/InMemoryContentCacheManager.java
+++ b/core/src/main/java/org/apache/iceberg/io/InMemoryContentCacheManager.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Map;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.SystemConfigs;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class InMemoryContentCacheManager implements ContentCacheManager {
+    private static final Logger LOG = LoggerFactory.getLogger(InMemoryContentCacheManager.class);
+    private final Cache<Object, InMemoryContentCache> cache = newManifestCacheBuilder().build();
+    private static final InMemoryContentCacheManager DEFAULT_CONTENT_CACHES = new InMemoryContentCacheManager();
+
+    private InMemoryContentCacheManager() {
+        // singleton
+    }
+
+    public static InMemoryContentCacheManager create(Map<String, String> unused) {
+        return DEFAULT_CONTENT_CACHES;
+    }
+
+    @Override
+    public FileIOContentCache contentCache(FileIO io) {
+        return cache.get(
+                io,
+                fileIO -> new InMemoryContentCache(cacheDurationMs(io), cacheTotalBytes(io), cacheMaxContentLength(io)));
+    }
+
+    @Override
+    public synchronized void dropCache(FileIO fileIO) {
+        cache.invalidate(fileIO);
+        cache.cleanUp();
+    }
+
+    static long cacheDurationMs(FileIO io) {
+        return PropertyUtil.propertyAsLong(
+                io.properties(),
+                CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS,
+                CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
+    }
+
+    static long cacheTotalBytes(FileIO io) {
+        return PropertyUtil.propertyAsLong(
+                io.properties(),
+                CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES,
+                CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT);
+    }
+
+    static long cacheMaxContentLength(FileIO io) {
+        return PropertyUtil.propertyAsLong(
+                io.properties(),
+                CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH,
+                CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT);
+    }
+
+    @VisibleForTesting
+    static Caffeine<Object, Object> newManifestCacheBuilder() {
+        int maxSize = SystemConfigs.IO_MANIFEST_CACHE_MAX_FILEIO.value();
+        return Caffeine.newBuilder()
+                .weakKeys()
+                .softValues()
+                .maximumSize(maxSize)
+                .removalListener(
+                        (io, contentCache, cause) ->
+                                LOG.debug("Evicted {} from FileIO-level cache ({})", io, cause))
+                .recordStats();
+    }
+}


### PR DESCRIPTION
Refactor manifest file caching logic in ManifestFiles class to split out cache management and allow for customizable cache manager.

This is one approach to fix #9991.  By allowing users to inject their own cache management, users can monitor cache metrics independently, influence caching behavior, and provide application-specific caching that is currently difficult using the built in cache manager.

Note that `DefaultContentCache` is renamed from `ContentCache`, and the code is mostly the same.  `ContentCach` is a new interface derived from `ContentCache`.  Most of the code in `ContentCacheManager` is derived from `ManifestFiles` and is meant to allow the logic inside `ManifestFiles` to be customized or overridden.