### PR TITLE
Core: Add property to disable table initialization for JdbcCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -86,7 +86,7 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
   private Map<String, String> catalogProperties;
   private final Function<Map<String, String>, FileIO> ioBuilder;
   private final Function<Map<String, String>, JdbcClientPool> clientPoolBuilder;
-  private final boolean initializeCatalogTables;
+  private boolean initializeCatalogTables;
   private CloseableGroup closeableGroup;
   private JdbcUtil.SchemaVersion schemaVersion = JdbcUtil.SchemaVersion.V0;
 
@@ -137,6 +137,9 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
       this.connections = new JdbcClientPool(uri, properties);
     }
 
+    this.initializeCatalogTables =
+        PropertyUtil.propertyAsBoolean(
+            properties, JdbcUtil.INIT_CATALOG_TABLES_PROPERTY, initializeCatalogTables);
     if (initializeCatalogTables) {
       initializeCatalogTables();
     }

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
@@ -39,6 +39,9 @@ final class JdbcUtil {
   static final String STRICT_MODE_PROPERTY = JdbcCatalog.PROPERTY_PREFIX + "strict-mode";
   // property to control if view support is added to the existing database
   static final String SCHEMA_VERSION_PROPERTY = JdbcCatalog.PROPERTY_PREFIX + "schema-version";
+  // property to control if catalog tables are created during initialization
+  static final String INIT_CATALOG_TABLES_PROPERTY =
+      JdbcCatalog.PROPERTY_PREFIX + "init-catalog-tables";
 
   enum SchemaVersion {
     V0,

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
@@ -165,6 +166,46 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     // second initialization should not fail even if tables are already created
     jdbcCatalog.initialize("test_jdbc_catalog", properties);
     jdbcCatalog.initialize("test_jdbc_catalog", properties);
+  }
+
+  @Test
+  public void testDisableInitCatalogTablesOverridesDefault() throws Exception {
+    // as this test uses different connections, we can't use memory database (as it's per
+    // connection), but a file database instead
+    java.nio.file.Path dbFile = Files.createTempFile("icebergInitCatalogTables", "db");
+    String jdbcUrl = "jdbc:sqlite:" + dbFile.toAbsolutePath();
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(CatalogProperties.WAREHOUSE_LOCATION, this.tableDir.toAbsolutePath().toString());
+    properties.put(CatalogProperties.URI, jdbcUrl);
+    properties.put(JdbcUtil.INIT_CATALOG_TABLES_PROPERTY, "false");
+
+    JdbcCatalog jdbcCatalog = new JdbcCatalog();
+    jdbcCatalog.initialize("test_jdbc_catalog", properties);
+
+    assertThat(catalogTablesExist(jdbcUrl)).isFalse();
+
+    assertThatThrownBy(() -> jdbcCatalog.listNamespaces())
+        .isInstanceOf(UncheckedSQLException.class)
+        .hasMessage(String.format("Failed to execute query: %s", JdbcUtil.LIST_ALL_NAMESPACES_SQL));
+  }
+
+  @Test
+  public void testEnableInitCatalogTablesOverridesDefault() throws Exception {
+    // as this test uses different connections, we can't use memory database (as it's per
+    // connection), but a file database instead
+    java.nio.file.Path dbFile = Files.createTempFile("icebergInitCatalogTables", "db");
+    String jdbcUrl = "jdbc:sqlite:" + dbFile.toAbsolutePath();
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(CatalogProperties.WAREHOUSE_LOCATION, this.tableDir.toAbsolutePath().toString());
+    properties.put(CatalogProperties.URI, jdbcUrl);
+    properties.put(JdbcUtil.INIT_CATALOG_TABLES_PROPERTY, "true");
+
+    JdbcCatalog jdbcCatalog = new JdbcCatalog(null, null, false);
+    jdbcCatalog.initialize("test_jdbc_catalog", properties);
+
+    assertThat(catalogTablesExist(jdbcUrl)).isTrue();
   }
 
   @Test
@@ -1122,5 +1163,37 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
                   + "',null)")
           .execute();
     }
+  }
+
+  private boolean catalogTablesExist(String jdbcUrl) throws SQLException {
+    SQLiteDataSource dataSource = new SQLiteDataSource();
+    dataSource.setUrl(jdbcUrl);
+
+    boolean catalogTableExists = false;
+    boolean namespacePropertiesTableExists = false;
+
+    try (Connection connection = dataSource.getConnection()) {
+      DatabaseMetaData metadata = connection.getMetaData();
+      if (tableExists(metadata, JdbcUtil.CATALOG_TABLE_VIEW_NAME)) {
+        catalogTableExists = true;
+      }
+      if (tableExists(metadata, JdbcUtil.NAMESPACE_PROPERTIES_TABLE_NAME)) {
+        namespacePropertiesTableExists = true;
+      }
+    }
+
+    return catalogTableExists && namespacePropertiesTableExists;
+  }
+
+  private boolean tableExists(DatabaseMetaData metadata, String tableName) throws SQLException {
+    ResultSet resultSet = metadata.getTables(null, null, tableName, new String[] {"TABLE"});
+
+    while (resultSet.next()) {
+      if (tableName.equals(resultSet.getString("TABLE_NAME"))) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }


### PR DESCRIPTION
It would be helpful to disable the creation of the catalog tables used by the JdbcCatalog to maintain the principle of least privilege.  In my scenario, I would like to perform database migrations with a migration tool using a user with DDL privileges and use a separate user with only DML privileges for connecting the JdbcCatalog to the database.
