### PR TITLE
reduce enum array allocation

### DIFF
--- a/api/src/main/java/org/apache/iceberg/FileFormat.java
+++ b/api/src/main/java/org/apache/iceberg/FileFormat.java
@@ -32,6 +32,8 @@ public enum FileFormat {
   private final String ext;
   private final boolean splittable;
 
+  private static final FileFormat[] VALUES = values();
+
   FileFormat(String ext, boolean splittable) {
     this.ext = "." + ext;
     this.splittable = splittable;
@@ -55,7 +57,7 @@ public enum FileFormat {
   }
 
   public static FileFormat fromFileName(CharSequence filename) {
-    for (FileFormat format : FileFormat.values()) {
+    for (FileFormat format : VALUES) {
       int extStart = filename.length() - format.ext.length();
       if (Comparators.charSequences()
               .compare(format.ext, filename.subSequence(extStart, filename.length()))

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -45,6 +45,7 @@ abstract class BaseFile<F>
         StructLike,
         SpecificData.SchemaConstructable,
         Serializable {
+  private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
   static final Types.StructType EMPTY_STRUCT_TYPE = Types.StructType.of();
   static final PartitionData EMPTY_PARTITION_DATA =
       new PartitionData(EMPTY_STRUCT_TYPE) {
@@ -268,7 +269,7 @@ abstract class BaseFile<F>
     }
     switch (pos) {
       case 0:
-        this.content = value != null ? FileContent.values()[(Integer) value] : FileContent.DATA;
+        this.content = value != null ? FILE_CONTENT_VALUES[(Integer) value] : FileContent.DATA;
         return;
       case 1:
         // always coerce to String for Serializable

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CachingCatalog implements Catalog {
   private static final Logger LOG = LoggerFactory.getLogger(CachingCatalog.class);
+  private static final MetadataTableType[] METADATA_TABLE_TYPE_VALUES = MetadataTableType.values();
 
   public static Catalog wrap(Catalog catalog) {
     return wrap(catalog, CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_OFF);
@@ -197,7 +198,7 @@ public class CachingCatalog implements Catalog {
   private Iterable<TableIdentifier> metadataTableIdentifiers(TableIdentifier ident) {
     ImmutableList.Builder<TableIdentifier> builder = ImmutableList.builder();
 
-    for (MetadataTableType type : MetadataTableType.values()) {
+    for (MetadataTableType type : METADATA_TABLE_TYPE_VALUES) {
       // metadata table resolution is case insensitive right now
       builder.add(TableIdentifier.parse(ident + "." + type.name()));
       builder.add(TableIdentifier.parse(ident + "." + type.name().toLowerCase(Locale.ROOT)));

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.types.Types;
 
 class GenericManifestEntry<F extends ContentFile<F>>
     implements ManifestEntry<F>, IndexedRecord, SpecificData.SchemaConstructable, StructLike {
+  private static final Status[] STATUS_VALUES = Status.values();
   private final org.apache.avro.Schema schema;
   private Status status = Status.EXISTING;
   private Long snapshotId = null;
@@ -151,7 +152,7 @@ class GenericManifestEntry<F extends ContentFile<F>>
   public void put(int i, Object v) {
     switch (i) {
       case 0:
-        this.status = Status.values()[(Integer) v];
+        this.status = STATUS_VALUES[(Integer) v];
         return;
       case 1:
         this.snapshotId = (Long) v;

--- a/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
@@ -39,6 +39,7 @@ public class GenericManifestFile
     implements ManifestFile, StructLike, IndexedRecord, SchemaConstructable, Serializable {
   private static final Schema AVRO_SCHEMA =
       AvroSchemaUtil.convert(ManifestFile.schema(), "manifest_file");
+  private static final ManifestContent[] MANIFEST_CONTENT_VALUES = ManifestContent.values();
 
   private transient Schema avroSchema; // not final for Java serialization
   private int[] fromProjectionPos;
@@ -339,7 +340,7 @@ public class GenericManifestFile
         return;
       case 3:
         this.content =
-            value != null ? ManifestContent.values()[(Integer) value] : ManifestContent.DATA;
+            value != null ? MANIFEST_CONTENT_VALUES[(Integer) value] : ManifestContent.DATA;
         return;
       case 4:
         this.sequenceNumber = value != null ? (Long) value : 0;

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -60,6 +60,8 @@ import org.slf4j.LoggerFactory;
 public class HadoopTableOperations implements TableOperations {
   private static final Logger LOG = LoggerFactory.getLogger(HadoopTableOperations.class);
   private static final Pattern VERSION_PATTERN = Pattern.compile("v([^\\.]*)\\..*");
+  private static final TableMetadataParser.Codec[] TABLE_METADATA_PARSER_CODEC_VALUES =
+      TableMetadataParser.Codec.values();
 
   private final Configuration conf;
   private final Path location;
@@ -235,7 +237,7 @@ public class HadoopTableOperations implements TableOperations {
 
   @VisibleForTesting
   Path getMetadataFile(int metadataVersion) throws IOException {
-    for (TableMetadataParser.Codec codec : TableMetadataParser.Codec.values()) {
+    for (TableMetadataParser.Codec codec : TABLE_METADATA_PARSER_CODEC_VALUES) {
       Path metadataFile = metadataFilePath(metadataVersion, codec);
       FileSystem fs = getFileSystem(metadataFile, conf);
       if (fs.exists(metadataFile)) {

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Event.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Event.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.util.DateTimeUtil;
  */
 public class Event implements IndexedRecord {
 
+  private static final PayloadType[] PAYLOAD_TYPE_VALUES = PayloadType.values();
   private UUID id;
   private PayloadType type;
   private OffsetDateTime timestamp;
@@ -115,7 +116,7 @@ public class Event implements IndexedRecord {
         this.id = (UUID) v;
         return;
       case TYPE:
-        this.type = v == null ? null : PayloadType.values()[(Integer) v];
+        this.type = v == null ? null : PAYLOAD_TYPE_VALUES[(Integer) v];
         return;
       case TIMESTAMP:
         this.timestamp = v == null ? null : DateTimeUtil.timestamptzFromMicros((Long) v);

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -35,6 +35,8 @@ import org.apache.spark.sql.types.StructType;
 
 public abstract class SparkContentFile<F> implements ContentFile<F> {
 
+  private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
+
   private final int fileContentPosition;
   private final int filePathPosition;
   private final int fileFormatPosition;
@@ -126,7 +128,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     if (wrapped.isNullAt(fileContentPosition)) {
       return null;
     }
-    return FileContent.values()[wrapped.getInt(fileContentPosition)];
+    return FILE_CONTENT_VALUES[wrapped.getInt(fileContentPosition)];
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -35,6 +35,8 @@ import org.apache.spark.sql.types.StructType;
 
 public abstract class SparkContentFile<F> implements ContentFile<F> {
 
+  private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
+
   private final int fileContentPosition;
   private final int filePathPosition;
   private final int fileFormatPosition;
@@ -126,7 +128,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     if (wrapped.isNullAt(fileContentPosition)) {
       return null;
     }
-    return FileContent.values()[wrapped.getInt(fileContentPosition)];
+    return FILE_CONTENT_VALUES[wrapped.getInt(fileContentPosition)];
   }
 
   @Override


### PR DESCRIPTION
## Motivation

reduce enum array allocation

## Modifications

cache enum .values() in a static variable


## Additional context

https://www.gamlor.info/wordpress/2017/08/javas-enum-values-hidden-allocations/

