### PR TITLE
Spark 3.5: Check table existence to determine which catalog for drop table

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -275,18 +275,20 @@ public class SparkSessionCatalog<T extends TableCatalog & FunctionCatalog & Supp
 
   @Override
   public boolean dropTable(Identifier ident) {
-    // no need to check table existence to determine which catalog to use. if a table doesn't exist
-    // then both are
-    // required to return false.
-    return icebergCatalog.dropTable(ident) || getSessionCatalog().dropTable(ident);
+    if (icebergCatalog.tableExists(ident)) {
+      return icebergCatalog.dropTable(ident);
+    } else {
+      return getSessionCatalog().dropTable(ident);
+    }
   }
 
   @Override
   public boolean purgeTable(Identifier ident) {
-    // no need to check table existence to determine which catalog to use. if a table doesn't exist
-    // then both are
-    // required to return false.
-    return icebergCatalog.purgeTable(ident) || getSessionCatalog().purgeTable(ident);
+    if (icebergCatalog.tableExists(ident)) {
+      return icebergCatalog.purgeTable(ident);
+    } else {
+      return getSessionCatalog().purgeTable(ident);
+    }
   }
 
   @Override

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
@@ -107,8 +107,9 @@ public class TestSparkSessionCatalog extends TestBase {
   @Test
   public void testDropHiveTable() throws NoSuchTableException {
     spark.sql("CREATE TABLE test_table (id INT)");
-    Identifier tableIdentifier = Identifier.of(new String[]{"default"}, "test_table");
-    SparkSessionCatalog catalog = (SparkSessionCatalog) spark.sessionState().catalogManager().currentCatalog();
+    Identifier tableIdentifier = Identifier.of(new String[] {"default"}, "test_table");
+    SparkSessionCatalog catalog =
+        (SparkSessionCatalog) spark.sessionState().catalogManager().currentCatalog();
     Table table = catalog.loadTable(tableIdentifier);
     assertThat(table).isInstanceOf(V1Table.class);
     File tableLocation = new File(((V1Table) table).catalogTable().storage().locationUri().get());


### PR DESCRIPTION
As commented in https://github.com/apache/iceberg/issues/9990#issuecomment-2049244909, the logic of icebergCatalog drop table may be inconsistent with sessionCatalog. We should not use `icebergCatalog` to drop a non-iceberg table.