### PR TITLE
AWS: close underlying executor for DynamoDb LockManager

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbLockManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbLockManager.java
@@ -312,10 +312,12 @@ public class DynamoDbLockManager extends LockManagers.BaseLockManager {
   }
 
   @Override
-  public void close() {
+  public void close() throws Exception {
     dynamo.close();
     heartbeats.values().forEach(DynamoDbHeartbeat::cancel);
     heartbeats.clear();
+
+    super.close();
   }
 
   /**


### PR DESCRIPTION
With the new close method added to BaseLockManager, I noticed that DynamoDbLockManager was not reusing inherited `close` and, hence, not closing the underlying executor.

It's my first PR here, so let me know if I'm missing some guidelines. Thx.