### PR TITLE
Spark: Reconcile derived partitioning from source table with target table specs in AddFilesProcedure

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -59,9 +59,7 @@ public class SparkSchemaUtil {
    * @return a Schema for the table, if found
    */
   public static Schema schemaForTable(SparkSession spark, String name) {
-    StructType sparkType = spark.table(name).schema();
-    Type converted = SparkTypeVisitor.visit(sparkType, new SparkTypeToType(sparkType));
-    return new Schema(converted.asNestedType().asStructType().fields());
+    return convert(spark.table(name).schema());
   }
 
   /**

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -426,8 +426,14 @@ public class SparkTableUtil {
     }
 
     try {
-      PartitionSpec spec =
+      PartitionSpec derivedSpec =
           SparkSchemaUtil.specForTable(spark, sourceTableIdentWithDB.unquotedString());
+
+      PartitionSpec spec =
+          targetTable.specs().values().stream()
+              .filter(targetTableSpec -> targetTableSpec.compatibleWith(derivedSpec))
+              .findFirst()
+              .orElse(derivedSpec);
 
       if (Objects.equal(spec, PartitionSpec.unpartitioned())) {
         importUnpartitionedSparkTable(


### PR DESCRIPTION
Fixes #10008

Currently the Spark add files procedure will derive a partition spec from the Hive style table and then use that as a spec when writing manifests as part of the import. However, unless the partitioning on the target Iceberg table is correctly defined upfront, then there is unexpected behavior after adding the file. Currently, what happens is:

1.) User creates target table with some partitioning
2.) User updates the partitioning on the target Iceberg table to "align" with what's in Hive. Say for example adds an identity column
3.) User runs the procedure. 
4.) Internally the procedure derives a partition spec from the Hive table, and this ends up with a spec ID of 0. 
5.) The manifests get written with spec ID of 0 , however this is the original partitioning of the table, and not the evolved partition spec that we would expect to get used. This leads to unexpected results when the target table is queried since the new partition field will be missing.

This change fixes this issue by reconciling the derived spec from 4 with what's a spec that's already in the target table since there's some sane inference we can do here.

If a compatible spec in the target table is found the procedure will use that spec as the spec to use when writing the manifests as part of the import. If a compatible spec is not found, the procedure will use the derived spec as before.