### PR TITLE
Flink, Spark: Replace Boolean.getBoolean() with Boolean.parseBoolean()

### DIFF
--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkSource.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkSource.java
@@ -60,7 +60,7 @@ public abstract class TestFlinkSource extends TestFlinkScan {
   protected List<Row> runWithOptions(Map<String, String> options) throws Exception {
     FlinkSource.Builder builder = FlinkSource.forRowData();
     Optional.ofNullable(options.get("case-sensitive"))
-        .ifPresent(value -> builder.caseSensitive(Boolean.getBoolean(value)));
+        .ifPresent(value -> builder.caseSensitive(Boolean.parseBoolean(value)));
     Optional.ofNullable(options.get("snapshot-id"))
         .ifPresent(value -> builder.snapshotId(Long.parseLong(value)));
     Optional.ofNullable(options.get("tag")).ifPresent(value -> builder.tag(value));

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkSource.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkSource.java
@@ -60,7 +60,7 @@ public abstract class TestFlinkSource extends TestFlinkScan {
   protected List<Row> runWithOptions(Map<String, String> options) throws Exception {
     FlinkSource.Builder builder = FlinkSource.forRowData();
     Optional.ofNullable(options.get("case-sensitive"))
-        .ifPresent(value -> builder.caseSensitive(Boolean.getBoolean(value)));
+        .ifPresent(value -> builder.caseSensitive(Boolean.parseBoolean(value)));
     Optional.ofNullable(options.get("snapshot-id"))
         .ifPresent(value -> builder.snapshotId(Long.parseLong(value)));
     Optional.ofNullable(options.get("tag")).ifPresent(value -> builder.tag(value));

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkSource.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkSource.java
@@ -60,7 +60,7 @@ public abstract class TestFlinkSource extends TestFlinkScan {
   protected List<Row> runWithOptions(Map<String, String> options) throws Exception {
     FlinkSource.Builder builder = FlinkSource.forRowData();
     Optional.ofNullable(options.get("case-sensitive"))
-        .ifPresent(value -> builder.caseSensitive(Boolean.getBoolean(value)));
+        .ifPresent(value -> builder.caseSensitive(Boolean.parseBoolean(value)));
     Optional.ofNullable(options.get("snapshot-id"))
         .ifPresent(value -> builder.snapshotId(Long.parseLong(value)));
     Optional.ofNullable(options.get("tag")).ifPresent(value -> builder.tag(value));

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -754,7 +754,7 @@ public class SparkTableUtil {
     return PropertyUtil.propertyAsBoolean(
         table.properties(),
         TableProperties.WRITE_AUDIT_PUBLISH_ENABLED,
-        Boolean.getBoolean(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT));
+        Boolean.parseBoolean(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT));
   }
 
   /** Class representing a table partition. */

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -705,7 +705,7 @@ public class SparkTableUtil {
     return PropertyUtil.propertyAsBoolean(
         table.properties(),
         TableProperties.WRITE_AUDIT_PUBLISH_ENABLED,
-        Boolean.getBoolean(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT));
+        Boolean.parseBoolean(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT));
   }
 
   /** Class representing a table partition. */

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -770,7 +770,7 @@ public class SparkTableUtil {
     return PropertyUtil.propertyAsBoolean(
         table.properties(),
         TableProperties.WRITE_AUDIT_PUBLISH_ENABLED,
-        Boolean.getBoolean(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT));
+        Boolean.parseBoolean(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT));
   }
 
   /** Class representing a table partition. */


### PR DESCRIPTION
`Boolean.getBoolean()` will look for a system property of the given name, whereas `Boolean.parseBoolean()` will parse the given string to a boolean.