### PR TITLE
Spark: Simplify SparkSchemaUtil#schemaForTable

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -59,9 +59,7 @@ public class SparkSchemaUtil {
    * @return a Schema for the table, if found
    */
   public static Schema schemaForTable(SparkSession spark, String name) {
-    StructType sparkType = spark.table(name).schema();
-    Type converted = SparkTypeVisitor.visit(sparkType, new SparkTypeToType(sparkType));
-    return new Schema(converted.asNestedType().asStructType().fields());
+    return convert(spark.table(name).schema());
   }
 
   /**

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -59,9 +59,7 @@ public class SparkSchemaUtil {
    * @return a Schema for the table, if found
    */
   public static Schema schemaForTable(SparkSession spark, String name) {
-    StructType sparkType = spark.table(name).schema();
-    Type converted = SparkTypeVisitor.visit(sparkType, new SparkTypeToType(sparkType));
-    return new Schema(converted.asNestedType().asStructType().fields());
+    return convert(spark.table(name).schema());
   }
 
   /**

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -59,9 +59,7 @@ public class SparkSchemaUtil {
    * @return a Schema for the table, if found
    */
   public static Schema schemaForTable(SparkSession spark, String name) {
-    StructType sparkType = spark.table(name).schema();
-    Type converted = SparkTypeVisitor.visit(sparkType, new SparkTypeToType(sparkType));
-    return new Schema(converted.asNestedType().asStructType().fields());
+    return convert(spark.table(name).schema());
   }
 
   /**


### PR DESCRIPTION
Small refactoring of SparkSchemaUtil#schemaForTable, I noticed when doing #10133  we can just use the existing convert method