### PR TITLE
Core: Retry connections in JDBC catalog with user configured error code list

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -55,6 +55,7 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
@@ -687,6 +688,11 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
           "Rename operation affected {} rows: the catalog view's primary key assumption has been violated",
           updatedRecords);
     }
+  }
+
+  @VisibleForTesting
+  JdbcClientPool connectionPool() {
+    return connections;
   }
 
   private int execute(String sql, String... args) {

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
@@ -21,16 +21,39 @@ package org.apache.iceberg.jdbc;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLTransientException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.ClientPoolImpl;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 public class JdbcClientPool extends ClientPoolImpl<Connection, SQLException> {
 
+  /**
+   * The following are common retryable SQLSTATEs error codes which are generic across vendors.
+   *
+   * <ul>
+   *   <li>08000: Generic Connection Exception
+   *   <li>08003: Connection does not exist
+   *   <li>08006: Connection failure
+   *   <li>08007: Transaction resolution unknown
+   *   <li>40001: Serialization failure due to deadlock
+   * </ul>
+   *
+   * See https://en.wikipedia.org/wiki/SQLSTATE for more details.
+   */
+  static final Set<String> COMMON_RETRYABLE_CONNECTION_SQL_STATES =
+      ImmutableSet.of("08000", "08003", "08006", "08007", "40001");
+
   private final String dbUrl;
   private final Map<String, String> properties;
+
+  private Set<String> retryableStatusCodes;
 
   public JdbcClientPool(String dbUrl, Map<String, String> props) {
     this(
@@ -43,8 +66,18 @@ public class JdbcClientPool extends ClientPoolImpl<Connection, SQLException> {
   }
 
   public JdbcClientPool(int poolSize, String dbUrl, Map<String, String> props) {
-    super(poolSize, SQLNonTransientConnectionException.class, true);
+    super(poolSize, SQLTransientException.class, true);
     properties = props;
+    retryableStatusCodes = Sets.newHashSet();
+    retryableStatusCodes.addAll(COMMON_RETRYABLE_CONNECTION_SQL_STATES);
+    String configuredRetryableStatuses = props.get(JdbcUtil.RETRYABLE_STATUS_CODES);
+    if (configuredRetryableStatuses != null) {
+      retryableStatusCodes.addAll(
+          Arrays.stream(configuredRetryableStatuses.split(","))
+              .map(status -> status.replaceAll("\\s+", ""))
+              .collect(Collectors.toSet()));
+    }
+
     this.dbUrl = dbUrl;
   }
 
@@ -71,5 +104,12 @@ public class JdbcClientPool extends ClientPoolImpl<Connection, SQLException> {
     } catch (SQLException e) {
       throw new UncheckedSQLException(e, "Failed to close connection");
     }
+  }
+
+  @Override
+  protected boolean isConnectionException(Exception e) {
+    return super.isConnectionException(e)
+        || (e instanceof SQLException
+            && retryableStatusCodes.contains(((SQLException) e).getSQLState()));
   }
 }

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
@@ -43,6 +43,8 @@ final class JdbcUtil {
   static final String INIT_CATALOG_TABLES_PROPERTY =
       JdbcCatalog.PROPERTY_PREFIX + "init-catalog-tables";
 
+  static final String RETRYABLE_STATUS_CODES = "retryable_status_codes";
+
   enum SchemaVersion {
     V0,
     V1

--- a/core/src/test/java/org/apache/iceberg/TestClientPoolImpl.java
+++ b/core/src/test/java/org/apache/iceberg/TestClientPoolImpl.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+public class TestClientPoolImpl {
+
+  @Test
+  public void testRetrySucceedsWithinMaxAttempts() throws Exception {
+    int maxRetries = 5;
+    int succeedAfterAttempts = 3;
+    try (MockClientPoolImpl mockClientPool =
+        new MockClientPoolImpl(2, RetryableException.class, true, maxRetries)) {
+      int actions = mockClientPool.run(client -> client.succeedAfter(succeedAfterAttempts));
+      assertThat(actions)
+          .as("There should be exactly one successful action invocation")
+          .isEqualTo(1);
+      assertThat(mockClientPool.reconnectionAttempts()).isEqualTo(succeedAfterAttempts - 1);
+    }
+  }
+
+  @Test
+  public void testRetriesExhaustedAndSurfacesFailure() {
+    int maxRetries = 3;
+    int succeedAfterAttempts = 5;
+    try (MockClientPoolImpl mockClientPool =
+        new MockClientPoolImpl(2, RetryableException.class, true, maxRetries)) {
+      assertThatThrownBy(
+              () -> mockClientPool.run(client -> client.succeedAfter(succeedAfterAttempts)))
+          .isInstanceOf(RetryableException.class);
+      assertThat(mockClientPool.reconnectionAttempts()).isEqualTo(maxRetries);
+    }
+  }
+
+  @Test
+  public void testNoRetryingNonRetryableException() {
+    try (MockClientPoolImpl mockClientPool =
+        new MockClientPoolImpl(2, RetryableException.class, true, 3)) {
+      assertThatThrownBy(() -> mockClientPool.run(MockClient::failWithNonRetryable, true))
+          .isInstanceOf(NonRetryableException.class);
+      assertThat(mockClientPool.reconnectionAttempts()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  public void testNoRetryingWhenDisabled() {
+    try (MockClientPoolImpl mockClientPool =
+        new MockClientPoolImpl(2, RetryableException.class, false, 3)) {
+      assertThatThrownBy(() -> mockClientPool.run(client -> client.succeedAfter(3)))
+          .isInstanceOf(RetryableException.class);
+      assertThat(mockClientPool.reconnectionAttempts()).isEqualTo(0);
+    }
+  }
+
+  static class RetryableException extends RuntimeException {}
+
+  static class NonRetryableException extends RuntimeException {}
+
+  static class MockClient {
+    boolean closed = false;
+
+    int actions = 0;
+
+    int retryableFailures = 0;
+
+    public void close() {
+      closed = true;
+    }
+
+    public int successfulAction() {
+      actions++;
+      return actions;
+    }
+
+    int succeedAfter(int succeedAfterAttempts) {
+      if (retryableFailures == succeedAfterAttempts - 1) {
+        return successfulAction();
+      }
+
+      retryableFailures++;
+      throw new RetryableException();
+    }
+
+    int failWithNonRetryable() {
+      throw new NonRetryableException();
+    }
+  }
+
+  static class MockClientPoolImpl extends ClientPoolImpl<MockClient, Exception> {
+
+    private int reconnectionAttempts;
+
+    MockClientPoolImpl(
+        int poolSize,
+        Class<? extends Exception> reconnectExc,
+        boolean retryByDefault,
+        int numRetries) {
+      super(poolSize, reconnectExc, retryByDefault, numRetries);
+    }
+
+    @Override
+    protected MockClient newClient() {
+      return new MockClient();
+    }
+
+    @Override
+    protected MockClient reconnect(MockClient client) {
+      reconnectionAttempts++;
+      return client;
+    }
+
+    @Override
+    protected void close(MockClient client) {
+      client.close();
+    }
+
+    int reconnectionAttempts() {
+      return reconnectionAttempts;
+    }
+  }
+}


### PR DESCRIPTION
This change is an alternative to https://github.com/apache/iceberg/pull/7561 for retrying JDBC connections.
First, we currently retry SQLNonTransientExceptions which is a bug. Those are non-retryable by definition, we should retry SQLTransientExceptions.

Next, this change also enables configuring multiple retries since just retrying once may not increase the chance of success sufficiently.

Lastly, this change introduces the ability for a user to configure which SQL error codes they want to retry on on top of the standard retryable error codes. The reason is there's so many different databases out there each with their own status codes that Iceberg shouldn't define all those in the library. This approach allows a user to specify the ones they want to retry via a catalog property called "retryable_status_codes" which is a comma separated list of status codes that are considered retryable.