### PR TITLE
Drop table purge issue for parquet tables with SparkSessionCatalog

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -101,7 +101,7 @@ public class TestAddFilesProcedure extends ExtensionsTestBase {
 
   @AfterEach
   public void dropTables() {
-    sql("DROP TABLE IF EXISTS %s PURGE", sourceTableName);
+    sql("DROP TABLE IF EXISTS %s", sourceTableName);
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
@@ -42,7 +42,7 @@ public class TestSnapshotTableProcedure extends ExtensionsTestBase {
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
-    sql("DROP TABLE IF EXISTS %s PURGE", sourceName);
+    sql("DROP TABLE IF EXISTS %s", sourceName);
   }
 
   @TestTemplate

--- a/spark/v3.5/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
+++ b/spark/v3.5/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
@@ -50,7 +50,7 @@ public class SmokeTest extends ExtensionsTestBase {
         .as("Should have inserted 3 rows")
         .isEqualTo(3L);
 
-    sql("DROP TABLE IF EXISTS source PURGE");
+    sql("DROP TABLE IF EXISTS source");
     sql(
         "CREATE TABLE source (id bigint, data string) USING parquet LOCATION '%s'",
         Files.createTempDirectory(temp, "junit"));
@@ -61,7 +61,7 @@ public class SmokeTest extends ExtensionsTestBase {
         .as("Table should now have 4 rows")
         .isEqualTo(4L);
 
-    sql("DROP TABLE IF EXISTS updates PURGE");
+    sql("DROP TABLE IF EXISTS updates");
     sql(
         "CREATE TABLE updates (id bigint, data string) USING parquet LOCATION '%s'",
         Files.createTempDirectory(temp, "junit"));

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -275,10 +275,11 @@ public class SparkSessionCatalog<T extends TableCatalog & FunctionCatalog & Supp
 
   @Override
   public boolean dropTable(Identifier ident) {
-    // no need to check table existence to determine which catalog to use. if a table doesn't exist
-    // then both are
-    // required to return false.
-    return icebergCatalog.dropTable(ident) || getSessionCatalog().dropTable(ident);
+    if (icebergCatalog.tableExists(ident)) {
+      return icebergCatalog.dropTable(ident);
+    } else {
+      return getSessionCatalog().dropTable(ident);
+    }
   }
 
   @Override


### PR DESCRIPTION
Drop table purge issue for parquet tables with SparkSessionCatalog. 
This was identified in Iceberg 1.4.3 + Spark 3.4.1 + SPARK-43203(On patch) in our environment

https://github.com/apache/iceberg/issues/10157
