### PR TITLE
Docs: Remove link to Flink unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ gradle/wrapper/gradle-wrapper.jar
 lib/
 
 # web site build
+docs/site/
 site/site/
 site/docs/docs/
 site/docs/.asf.yaml

--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -103,8 +103,6 @@ FlinkSink.forRowData(input)
 env.execute("Test Iceberg DataStream");
 ```
 
-The iceberg API also allows users to write generic `DataStream<T>` to iceberg table, more example could be found in this [unit test](https://github.com/apache/iceberg/blob/main/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java).
-
 ### Overwrite data
 
 Set the `overwrite` flag in FlinkSink builder to overwrite the data in existing iceberg tables:


### PR DESCRIPTION
The link to flink 1.16 unit test is broken after https://github.com/apache/iceberg/pull/10154. I remove it in this PR since 

1. I don't see an example of `write generic `DataStream<T>` to iceberg table` from the unit test as the doc stated
2. We don't trigger links check on source code changes so it will break next if we only update the link to latest version

The PR also adds `docs/site` to `.gitignore` file.

cc @nastra @pvary @rodmeneses @Fokko 