### PR TITLE
Core: Improve size check in CatalogTests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -2746,9 +2746,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   public void assertPreviousMetadataFileCount(Table table, int metadataFileCount) {
     TableOperations ops = ((BaseTable) table).operations();
-    Assertions.assertThat(ops.current().previousFiles().size())
+    Assertions.assertThat(ops.current().previousFiles())
         .as("Table should have correct number of previous metadata locations")
-        .isEqualTo(metadataFileCount);
+        .hasSize(metadataFileCount);
   }
 
   public void assertNoFiles(Table table) {
@@ -2766,9 +2766,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
               .map(FileScanTask::file)
               .map(DataFile::path)
               .collect(Collectors.toList());
-      Assertions.assertThat(paths.size())
+      Assertions.assertThat(paths)
           .as("Should contain expected number of data files")
-          .isEqualTo(files.length);
+          .hasSize(files.length);
       Assertions.assertThat(CharSequenceSet.of(paths))
           .as("Should contain correct file paths")
           .isEqualTo(CharSequenceSet.of(Iterables.transform(Arrays.asList(files), DataFile::path)));


### PR DESCRIPTION
These assertions failed for me in a different context and the only info they would print is `0 != 1`. I've slightly updated the check so that when the assertion fails, you'll get more context:

```
[Table should have correct number of previous metadata locations] 
Expected size: 0 but was: 1 in:
[MetadataLogEntry{timestampMillis=1713510157942, file=path-to-metadata.json}]
```