### PR TITLE
Kafka-connect: Handle namespace creation for auto table creation

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriterFactory.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriterFactory.java
@@ -121,6 +121,10 @@ public class IcebergWriterFactory {
 
   @VisibleForTesting
   static void createNamespaceIfNotExist(Catalog catalog, Namespace identifierNamespace) {
+    if (!(catalog instanceof SupportsNamespaces)) {
+      return;
+    }
+
     String[] levels = identifierNamespace.levels();
     for (int index = 0; index < levels.length; index++) {
       Namespace namespace = Namespace.of(Arrays.copyOfRange(levels, 0, index + 1));

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriterFactory.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriterFactory.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.types.Type;
@@ -125,7 +126,7 @@ public class IcebergWriterFactory {
       Namespace namespace = Namespace.of(Arrays.copyOfRange(levels, 0, index + 1));
       try {
         ((SupportsNamespaces) catalog).createNamespace(namespace);
-      } catch (AlreadyExistsException ex) {
+      } catch (AlreadyExistsException | ForbiddenException ex) {
         // Ignoring the error as forcefully creating the namespace even if it exists
         // to avoid double namespaceExists() check.
       }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/IcebergWriterFactoryTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/IcebergWriterFactoryTest.java
@@ -19,31 +19,29 @@
 package org.apache.iceberg.connect.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
-import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.TableSinkConfig;
-import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
-import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.StringType;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -54,7 +52,7 @@ public class IcebergWriterFactoryTest {
   @ValueSource(booleans = {true, false})
   @SuppressWarnings("unchecked")
   public void testAutoCreateTable(boolean partitioned) {
-    Catalog catalog = mock(InMemoryCatalog.class);
+    Catalog catalog = mock(Catalog.class, withSettings().extraInterfaces(SupportsNamespaces.class));
     when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
 
     TableSinkConfig tableConfig = mock(TableSinkConfig.class);
@@ -70,7 +68,7 @@ public class IcebergWriterFactoryTest {
     when(record.value()).thenReturn(ImmutableMap.of("id", 123, "data", "foo2"));
 
     IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
-    factory.autoCreateTable("db.tbl", record);
+    factory.autoCreateTable("foo1.foo2.foo3.bar", record);
 
     ArgumentCaptor<TableIdentifier> identCaptor = ArgumentCaptor.forClass(TableIdentifier.class);
     ArgumentCaptor<Schema> schemaCaptor = ArgumentCaptor.forClass(Schema.class);
@@ -84,32 +82,18 @@ public class IcebergWriterFactoryTest {
             specCaptor.capture(),
             propsCaptor.capture());
 
-    assertThat(identCaptor.getValue()).isEqualTo(TableIdentifier.of("db", "tbl"));
+    assertThat(identCaptor.getValue())
+        .isEqualTo(TableIdentifier.of(Namespace.of("foo1", "foo2", "foo3"), "bar"));
     assertThat(schemaCaptor.getValue().findField("id").type()).isEqualTo(LongType.get());
     assertThat(schemaCaptor.getValue().findField("data").type()).isEqualTo(StringType.get());
     assertThat(specCaptor.getValue().isPartitioned()).isEqualTo(partitioned);
     assertThat(propsCaptor.getValue()).containsKey("test-prop");
-  }
 
-  @Test
-  public void testNamespaceCreation() throws IOException {
-    TableIdentifier tableIdentifier =
-        TableIdentifier.of(Namespace.of("foo1", "foo2", "foo3"), "bar");
-    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.StringType.get()));
-
-    try (InMemoryCatalog catalog = new InMemoryCatalog()) {
-      catalog.initialize("in-memory-catalog", ImmutableMap.of());
-
-      assertThatThrownBy(() -> catalog.createTable(tableIdentifier, schema))
-          .isInstanceOf(NoSuchNamespaceException.class)
-          .hasMessage(
-              "Cannot create table foo1.foo2.foo3.bar. Namespace does not exist: foo1.foo2.foo3");
-
-      IcebergWriterFactory.createNamespaceIfNotExist(catalog, tableIdentifier.namespace());
-      assertThat(catalog.namespaceExists(Namespace.of("foo1"))).isTrue();
-      assertThat(catalog.namespaceExists(Namespace.of("foo1", "foo2"))).isTrue();
-      assertThat(catalog.namespaceExists(Namespace.of("foo1", "foo2", "foo3"))).isTrue();
-      assertThat(catalog.createTable(tableIdentifier, schema)).isNotNull();
-    }
+    ArgumentCaptor<Namespace> namespaceCaptor = ArgumentCaptor.forClass(Namespace.class);
+    verify((SupportsNamespaces) catalog, times(3)).createNamespace(namespaceCaptor.capture());
+    List<Namespace> capturedArguments = namespaceCaptor.getAllValues();
+    assertThat(capturedArguments.get(0)).isEqualTo(Namespace.of("foo1"));
+    assertThat(capturedArguments.get(1)).isEqualTo(Namespace.of("foo1", "foo2"));
+    assertThat(capturedArguments.get(2)).isEqualTo(Namespace.of("foo1", "foo2", "foo3"));
   }
 }


### PR DESCRIPTION
Some catalogs like Inmemory, Hive, Nessie, REST catalog expects the namespace to be present before creating the table. Hence, the auto table creation feature will not work currently for these catalogs if the namespace is missing. 

Added a support to create the missing namespace and its parents while auto creating the table. 