### PR TITLE
AWS: Retain Glue Catalog table description after updating Iceberg table

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -136,7 +136,8 @@ public class GlueTestBase {
   }
 
   // Directly call Glue API to update table description
-  public static void updateTableDescription(String namespace, String tableName, String description) {
+  public static void updateTableDescription(
+      String namespace, String tableName, String description) {
     GetTableResponse response =
         glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
     Table table = response.table();

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -39,6 +39,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTableResponse;
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TableInput;
+import software.amazon.awssdk.services.glue.model.UpdateTableRequest;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @SuppressWarnings({"VisibilityModifier", "HideUtilityClassConstructor"})
@@ -128,5 +133,28 @@ public class GlueTestBase {
   public static String createTable(String namespace, String tableName) {
     glueCatalog.createTable(TableIdentifier.of(namespace, tableName), schema, partitionSpec);
     return tableName;
+  }
+
+  // Directly use Glue API to update table description
+  public static void updateDescription(String namespace, String tableName, String description) {
+    GetTableResponse response =
+        glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
+    Table table = response.table();
+    UpdateTableRequest request =
+        UpdateTableRequest.builder()
+            .catalogId(table.catalogId())
+            .databaseName(table.databaseName())
+            .tableInput(
+                TableInput.builder()
+                    .description(description)
+                    .name(table.name())
+                    .partitionKeys(table.partitionKeys())
+                    .tableType(table.tableType())
+                    .owner(table.owner())
+                    .parameters(table.parameters())
+                    .storageDescriptor(table.storageDescriptor())
+                    .build())
+            .build();
+    glue.updateTable(request);
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -135,8 +135,8 @@ public class GlueTestBase {
     return tableName;
   }
 
-  // Directly use Glue API to update table description
-  public static void updateDescription(String namespace, String tableName, String description) {
+  // Directly call Glue API to update table description
+  public static void updateTableDescription(String namespace, String tableName, String description) {
     GetTableResponse response =
         glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
     Table table = response.table();

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -210,13 +210,15 @@ public class TestGlueCatalogTable extends GlueTestBase {
     assertThat(response.table().partitionKeys()).hasSameSizeAs(partitionSpec.fields());
     assertThat(response.table().description()).isEqualTo(description);
 
-    // Make sure adding a comment updates the existing table description
-    String comment = "Test comment";
-    table.updateProperties().set(IcebergToGlueConverter.GLUE_DESCRIPTION_KEY, comment).commit();
+    String updatedComment = "test updated comment";
+    table
+        .updateProperties()
+        .set(IcebergToGlueConverter.GLUE_DESCRIPTION_KEY, updatedComment)
+        .commit();
     // check table in Glue
     response =
         glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
-    assertThat(response.table().description()).isEqualTo(comment);
+    assertThat(response.table().description()).isEqualTo(updatedComment);
   }
 
   @Test

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -183,7 +183,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
     // create table, refresh should update
     createTable(namespace, tableName);
     String description = "test description";
-    updateDescription(namespace, tableName, description);
+    updateTableDescription(namespace, tableName, description);
     current = ops.refresh();
     assertThat(current.schema()).asString().isEqualTo(schema.toString());
     assertThat(current.spec()).isEqualTo(partitionSpec);

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -209,6 +209,14 @@ public class TestGlueCatalogTable extends GlueTestBase {
     assertThat(response.table().storageDescriptor().columns()).hasSameSizeAs(schema.columns());
     assertThat(response.table().partitionKeys()).hasSameSizeAs(partitionSpec.fields());
     assertThat(response.table().description()).isEqualTo(description);
+
+    // Make sure adding a comment updates the existing table description
+    String comment = "Test comment";
+    table.updateProperties().set(IcebergToGlueConverter.GLUE_DESCRIPTION_KEY, comment).commit();
+    // check table in Glue
+    response =
+        glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
+    assertThat(response.table().description()).isEqualTo(comment);
   }
 
   @Test

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -182,6 +182,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
     assertThat(current).isNull();
     // create table, refresh should update
     createTable(namespace, tableName);
+    String description = "test description";
+    updateDescription(namespace, tableName, description);
     current = ops.refresh();
     assertThat(current.schema()).asString().isEqualTo(schema.toString());
     assertThat(current.spec()).isEqualTo(partitionSpec);
@@ -206,6 +208,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
         .isEqualTo("EXTERNAL_TABLE");
     assertThat(response.table().storageDescriptor().columns()).hasSameSizeAs(schema.columns());
     assertThat(response.table().partitionKeys()).hasSameSizeAs(partitionSpec.fields());
+    assertThat(response.table().description()).isEqualTo(description);
   }
 
   @Test

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -316,13 +316,17 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
               .skipArchive(awsProperties.glueCatalogSkipArchive())
               .tableInput(
                   TableInput.builder()
+                      // Keep the existing table description
+                      .description(glueTable.description())
+                      // This overwrites the existing table description if there's a comment like
+                      // ALTER TABLE prod.db.sample SET TBLPROPERTIES (
+                      //    'comment' = 'A table description.')
                       .applyMutation(
                           builder ->
                               IcebergToGlueConverter.setTableInputInformation(builder, metadata))
                       .name(tableName)
                       .tableType(GLUE_EXTERNAL_TABLE_TYPE)
                       .parameters(parameters)
-                      .description(glueTable.description())
                       .build());
       // Use Optimistic locking with table version id while updating table
       if (!SET_VERSION_ID.isNoop() && lockManager == null) {

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -316,11 +316,9 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
               .skipArchive(awsProperties.glueCatalogSkipArchive())
               .tableInput(
                   TableInput.builder()
-                      // Keep the existing table description
+                      // Call description earlier than applyMutation to allow applyMutation to
+                      // overwrite the description if the description is specified in the query
                       .description(glueTable.description())
-                      // This overwrites the existing table description if there's a comment like
-                      // ALTER TABLE prod.db.sample SET TBLPROPERTIES (
-                      //    'comment' = 'A table description.')
                       .applyMutation(
                           builder ->
                               IcebergToGlueConverter.setTableInputInformation(builder, metadata))

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -322,6 +322,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
                       .name(tableName)
                       .tableType(GLUE_EXTERNAL_TABLE_TYPE)
                       .parameters(parameters)
+                      .description(glueTable.description())
                       .build());
       // Use Optimistic locking with table version id while updating table
       if (!SET_VERSION_ID.isNoop() && lockManager == null) {

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -316,8 +316,8 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
               .skipArchive(awsProperties.glueCatalogSkipArchive())
               .tableInput(
                   TableInput.builder()
-                      // Call description earlier than applyMutation to allow applyMutation to
-                      // overwrite the description if the description is specified in the query
+                      // Call description before applyMutation so that applyMutation overwrites the
+                      // description with the comment specified in the query
                       .description(glueTable.description())
                       .applyMutation(
                           builder ->


### PR DESCRIPTION
## Problem

In AWS Glue Catalog, user can set arbitrary description to the table and its columns via Web UI or even from Amazon Athena. However, the descriptions will be removed after upgrading the table.

## What this PR do

This patch is to keep the original table description when calling `UpdateTable` API. Keeping column description is hard and I think we can open a different PR to do this.

## Testing

Manually tested. Also, added an integration test and it passed on my environment.