### PR TITLE
Data: Adopt EncryptingFileIO in Java read API

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import org.apache.iceberg.Accessor;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import org.apache.iceberg.Accessor;
-import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;

--- a/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.data;
 
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
@@ -48,5 +49,10 @@ public class GenericDeleteFilter extends DeleteFilter<Record> {
   @Override
   protected InputFile getInputFile(String location) {
     return io.newInputFile(location);
+  }
+
+  @Override
+  protected InputFile loadInputFile(DeleteFile deleteFile) {
+    return io.newInputFile(deleteFile);
   }
 }


### PR DESCRIPTION
### Note to reviewers
 - One of our customers would like to read PME-encrypted tables in JVM application.
 - Therefore, switching to `EncryptingFileIO` as https://github.com/apache/iceberg/pull/9592 did for `org.apache.iceberg.spark.source.BaseReader.java` in Spark v3.5.
 - I also think `GenericDeleteFilter` might have to adopt the more specific `newInputFile` method in `EncryptingFileIO`, please let me know if that sound right to you:

```java
  @Override
  public InputFile newInputFile(DeleteFile file) {
    return newInputFile((ContentFile<?>) file);
  }
```