### PR TITLE
Core: pushdown data_file.content when filter manifests in entries table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -210,14 +210,8 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       public <T> Boolean eq(BoundReference<T> ref, Literal<T> lit) {
         if (fileContent(ref)) {
           Literal<Integer> intLit = lit.to(Types.IntegerType.get());
-          Integer fileContentId = intLit.value();
-          if (FileContent.DATA.id() == fileContentId) {
-            return ManifestContent.DATA.id() == manifestContentId;
-          } else if ((FileContent.EQUALITY_DELETES.id() == fileContentId)
-              || (FileContent.POSITION_DELETES.id() == fileContentId)) {
-            return ManifestContent.DELETES.id() == manifestContentId;
-          } else {
-            return ROWS_MIGHT_MATCH;
+          if (!contentMatch(intLit.value())) {
+            return ROWS_CANNOT_MATCH;
           }
         }
         return ROWS_MIGHT_MATCH;
@@ -227,14 +221,8 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       public <T> Boolean notEq(BoundReference<T> ref, Literal<T> lit) {
         if (fileContent(ref)) {
           Literal<Integer> intLit = lit.to(Types.IntegerType.get());
-          Integer fileContentId = intLit.value();
-          if (FileContent.DATA.id() == fileContentId) {
-            return ManifestContent.DATA.id() != manifestContentId;
-          } else if (FileContent.EQUALITY_DELETES.id() == fileContentId
-              || FileContent.POSITION_DELETES.id() == fileContentId) {
-            return ManifestContent.DELETES.id() != manifestContentId;
-          } else {
-            return ROWS_MIGHT_MATCH;
+          if (contentMatch(intLit.value())) {
+            return ROWS_CANNOT_MATCH;
           }
         }
         return ROWS_MIGHT_MATCH;
@@ -267,6 +255,17 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
 
       private <T> boolean fileContent(BoundReference<T> ref) {
         return ref.fieldId() == DataFile.CONTENT.fieldId();
+      }
+
+      private <T> boolean contentMatch(Integer fileContentId) {
+        if (FileContent.DATA.id() == fileContentId) {
+          return ManifestContent.DATA.id() == manifestContentId;
+        } else if (FileContent.EQUALITY_DELETES.id() == fileContentId
+            || FileContent.POSITION_DELETES.id() == fileContentId) {
+          return ManifestContent.DELETES.id() == manifestContentId;
+        } else {
+          return false;
+        }
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -231,10 +231,9 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       @Override
       public <T> Boolean in(BoundReference<T> ref, Set<T> literalSet) {
         if (fileContent(ref)) {
-          if (literalSet.stream().anyMatch(lit -> contentMatch((Integer) lit))) {
-            return ROWS_MIGHT_MATCH;
+          if (literalSet.stream().noneMatch(lit -> contentMatch((Integer) lit))) {
+            return ROWS_CANNOT_MATCH;
           }
-          return ROWS_CANNOT_MATCH;
         }
         return ROWS_MIGHT_MATCH;
       }
@@ -245,7 +244,6 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
           if (literalSet.stream().anyMatch(lit -> contentMatch((Integer) lit))) {
             return ROWS_CANNOT_MATCH;
           }
-          return ROWS_MIGHT_MATCH;
         }
         return ROWS_MIGHT_MATCH;
       }

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -231,15 +231,26 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       @Override
       public <T> Boolean in(BoundReference<T> ref, Set<T> literalSet) {
         if (fileContent(ref)) {
-          if (!literalSet.contains(manifestContentId)) {
-            return ROWS_CANNOT_MATCH;
+          for (T lit : literalSet) {
+            if (contentMatch((Integer) lit)) {
+              return ROWS_MIGHT_MATCH;
+            }
           }
+          return ROWS_CANNOT_MATCH;
         }
         return ROWS_MIGHT_MATCH;
       }
 
       @Override
       public <T> Boolean notIn(BoundReference<T> ref, Set<T> literalSet) {
+        if (fileContent(ref)) {
+          for (T lit : literalSet) {
+            if (contentMatch((Integer) lit)) {
+              return ROWS_CANNOT_MATCH;
+            }
+          }
+          return ROWS_MIGHT_MATCH;
+        }
         return ROWS_MIGHT_MATCH;
       }
 

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -211,10 +211,13 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
         if (fileContent(ref)) {
           Literal<Integer> intLit = lit.to(Types.IntegerType.get());
           Integer fileContentId = intLit.value();
-          if (fileContentId == FileContent.DATA.id()) {
-            return manifestContentId == ManifestContent.DATA.id();
+          if (FileContent.DATA.id() == fileContentId) {
+            return ManifestContent.DATA.id() == manifestContentId;
+          } else if ((FileContent.EQUALITY_DELETES.id() == fileContentId)
+              || (FileContent.POSITION_DELETES.id() == fileContentId)) {
+            return ManifestContent.DELETES.id() == manifestContentId;
           } else {
-            return manifestContentId == ManifestContent.DELETES.id();
+            return ROWS_MIGHT_MATCH;
           }
         }
         return ROWS_MIGHT_MATCH;
@@ -222,6 +225,18 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
 
       @Override
       public <T> Boolean notEq(BoundReference<T> ref, Literal<T> lit) {
+        if (fileContent(ref)) {
+          Literal<Integer> intLit = lit.to(Types.IntegerType.get());
+          Integer fileContentId = intLit.value();
+          if (FileContent.DATA.id() == fileContentId) {
+            return ManifestContent.DATA.id() != manifestContentId;
+          } else if (FileContent.EQUALITY_DELETES.id() == fileContentId
+              || FileContent.POSITION_DELETES.id() == fileContentId) {
+            return ManifestContent.DELETES.id() != manifestContentId;
+          } else {
+            return ROWS_MIGHT_MATCH;
+          }
+        }
         return ROWS_MIGHT_MATCH;
       }
 

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -231,10 +231,8 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       @Override
       public <T> Boolean in(BoundReference<T> ref, Set<T> literalSet) {
         if (fileContent(ref)) {
-          for (T lit : literalSet) {
-            if (contentMatch((Integer) lit)) {
-              return ROWS_MIGHT_MATCH;
-            }
+          if (literalSet.stream().anyMatch(lit -> contentMatch((Integer) lit))) {
+            return ROWS_MIGHT_MATCH;
           }
           return ROWS_CANNOT_MATCH;
         }
@@ -244,10 +242,8 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       @Override
       public <T> Boolean notIn(BoundReference<T> ref, Set<T> literalSet) {
         if (fileContent(ref)) {
-          for (T lit : literalSet) {
-            if (contentMatch((Integer) lit)) {
-              return ROWS_CANNOT_MATCH;
-            }
+          if (literalSet.stream().anyMatch(lit -> contentMatch((Integer) lit))) {
+            return ROWS_CANNOT_MATCH;
           }
           return ROWS_MIGHT_MATCH;
         }

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -56,8 +56,8 @@ public abstract class MetadataTableScanTestBase extends TestBase {
 
   protected Set<String> scanToPath(TableScan scan, Function<FileScanTask, String> func) {
     return StreamSupport.stream(scan.planFiles().spliterator(), false)
-            .map(func)
-            .collect(Collectors.toSet());
+        .map(func)
+        .collect(Collectors.toSet());
   }
 
   protected Set<String> expectedManifestListPaths(
@@ -68,7 +68,6 @@ public abstract class MetadataTableScanTestBase extends TestBase {
         .map(Snapshot::manifestListLocation)
         .collect(Collectors.toSet());
   }
-
 
   protected void validateTaskScanResiduals(TableScan scan, boolean ignoreResiduals)
       throws IOException {

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.iceberg.expressions.Expressions;
@@ -44,19 +43,9 @@ public abstract class MetadataTableScanTestBase extends TestBase {
     return Arrays.asList(1, 2);
   }
 
-  protected Set<String> actualManifestListPaths(TableScan allManifestsTableScan) {
-    Function<FileScanTask, String> toManifestListPath = t -> t.file().path().toString();
-    return scanToPath(allManifestsTableScan, toManifestListPath);
-  }
-
-  protected Set<String> actualManifestPaths(TableScan entriesTableScan) {
-    Function<FileScanTask, String> toManifestPath = t -> t.file().path().toString();
-    return scanToPath(entriesTableScan, toManifestPath);
-  }
-
-  protected Set<String> scanToPath(TableScan scan, Function<FileScanTask, String> func) {
+  protected Set<String> scannedPaths(TableScan scan) {
     return StreamSupport.stream(scan.planFiles().spliterator(), false)
-        .map(func)
+        .map(t -> t.file().path().toString())
         .collect(Collectors.toSet());
   }
 

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -59,6 +59,12 @@ public abstract class MetadataTableScanTestBase extends TestBase {
         .collect(Collectors.toSet());
   }
 
+  protected Set<String> actualManifestPaths(TableScan tableScan) {
+    return StreamSupport.stream(tableScan.planFiles().spliterator(), false)
+        .map(t -> t.file().path().toString())
+        .collect(Collectors.toSet());
+  }
+
   protected void validateTaskScanResiduals(TableScan scan, boolean ignoreResiduals)
       throws IOException {
     try (CloseableIterable<CombinedScanTask> tasks = scan.planTasks()) {

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -227,79 +227,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @TestTemplate
-  public void testEntriesTableDateFileContentLt() {
-    preparePartitionedTable();
-
-    Table entriesTable = new ManifestEntriesTable(table);
-
-    Expression dataOnly = Expressions.lessThan("data_file.content", 1);
-    TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
-    Set<String> expected =
-        table.currentSnapshot().dataManifests(table.io()).stream()
-            .map(ManifestFile::path)
-            .collect(Collectors.toSet());
-
-    assertThat(actualManifestPaths(entriesTableScan))
-        .as("Expected manifest filter by data file content does not match")
-        .isEqualTo(expected);
-  }
-
-  @TestTemplate
-  public void testEntriesTableDateFileContentLte() {
-    preparePartitionedTable();
-
-    Table entriesTable = new ManifestEntriesTable(table);
-
-    Expression dataOnly = Expressions.lessThanOrEqual("data_file.content", 0);
-    TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
-    Set<String> expected =
-        table.currentSnapshot().dataManifests(table.io()).stream()
-            .map(ManifestFile::path)
-            .collect(Collectors.toSet());
-
-    assertThat(actualManifestPaths(entriesTableScan))
-        .as("Expected manifest filter by data file content does not match")
-        .isEqualTo(expected);
-  }
-
-  @TestTemplate
-  public void testEntriesTableDateFileContentGt() {
-    preparePartitionedTable();
-
-    Table entriesTable = new ManifestEntriesTable(table);
-
-    Expression dataOnly = Expressions.greaterThan("data_file.content", 0);
-    TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
-    Set<String> expected =
-        table.currentSnapshot().deleteManifests(table.io()).stream()
-            .map(ManifestFile::path)
-            .collect(Collectors.toSet());
-
-    assertThat(actualManifestPaths(entriesTableScan))
-        .as("Expected manifest filter by data file content does not match")
-        .isEqualTo(expected);
-  }
-
-  @TestTemplate
-  public void testEntriesTableDateFileContentGte() {
-    preparePartitionedTable();
-
-    Table entriesTable = new ManifestEntriesTable(table);
-
-    Expression dataOnly = Expressions.greaterThanOrEqual("data_file.content", 1);
-    TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
-    Set<String> expected =
-        table.currentSnapshot().deleteManifests(table.io()).stream()
-            .map(ManifestFile::path)
-            .collect(Collectors.toSet());
-
-    assertThat(actualManifestPaths(entriesTableScan))
-        .as("Expected manifest filter by data file content does not match")
-        .isEqualTo(expected);
-  }
-
-  @TestTemplate
-  public void testEntriesTableDateFileContentEq() {
+  public void testEntriesTableDataFileContentEq() {
     preparePartitionedTable();
 
     Table entriesTable = new ManifestEntriesTable(table);
@@ -317,67 +245,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @TestTemplate
-  public void testEntriesTableDateFileContentNotEq() {
-    preparePartitionedTable();
-
-    Table entriesTable = new ManifestEntriesTable(table);
-
-    Expression dataOnly = Expressions.notEqual("data_file.content", 0);
-    TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
-    Set<String> expected =
-        table.currentSnapshot().deleteManifests(table.io()).stream()
-            .map(ManifestFile::path)
-            .collect(Collectors.toSet());
-
-    assertThat(actualManifestPaths(entriesTableScan))
-        .as("Expected manifest filter by data file content does not match")
-        .isEqualTo(expected);
-  }
-
-  @TestTemplate
-  public void testEntriesTableDateFileContentIn() {
+  public void testEntriesTableDataFileContentIn() {
     preparePartitionedTable();
 
     Table entriesTable = new ManifestEntriesTable(table);
 
     Expression dataOnly = Expressions.in("data_file.content", 1, 2);
     TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
-    Set<String> expected =
-        table.currentSnapshot().deleteManifests(table.io()).stream()
-            .map(ManifestFile::path)
-            .collect(Collectors.toSet());
-
-    assertThat(actualManifestPaths(entriesTableScan))
-        .as("Expected manifest filter by data file content does not match")
-        .isEqualTo(expected);
-  }
-
-  @TestTemplate
-  public void testEntriesTableDateFileContentNotIn() {
-    preparePartitionedTable();
-
-    Table entriesTable = new ManifestEntriesTable(table);
-
-    Expression notIn = Expressions.notIn("data_file.content", 1, 2);
-    TableScan entriesTableScan = entriesTable.newScan().filter(notIn);
-    Set<String> expected =
-        table.currentSnapshot().dataManifests(table.io()).stream()
-            .map(ManifestFile::path)
-            .collect(Collectors.toSet());
-
-    assertThat(actualManifestPaths(entriesTableScan))
-        .as("Expected manifest filter by data file content does not match")
-        .isEqualTo(expected);
-  }
-
-  @TestTemplate
-  public void testEntriesTableDateFileContentNot() {
-    preparePartitionedTable();
-
-    Table entriesTable = new ManifestEntriesTable(table);
-
-    Expression notData = Expressions.not(Expressions.equal("data_file.content", 0));
-    TableScan entriesTableScan = entriesTable.newScan().filter(notData);
     Set<String> expected =
         table.currentSnapshot().deleteManifests(table.io()).stream()
             .map(ManifestFile::path)

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -240,13 +240,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             .map(ManifestFile::path)
             .collect(Collectors.toSet());
 
-    assertThat(actualManifestPaths(entriesTableScan))
+    assertThat(scannedPaths(entriesTableScan))
         .as("Expected manifest filter by data file content does not match")
         .isEqualTo(expected);
 
     assertThat(
-            actualManifestPaths(
-                entriesTable.newScan().filter(Expressions.equal("data_file.content", 3))))
+            scannedPaths(entriesTable.newScan().filter(Expressions.equal("data_file.content", 3))))
         .as("Expected manifest filter by data file content does not match")
         .isEmpty();
   }
@@ -264,7 +263,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             .map(ManifestFile::path)
             .collect(Collectors.toSet());
 
-    assertThat(actualManifestPaths(entriesTableScan))
+    assertThat(scannedPaths(entriesTableScan))
         .as("Expected manifest filter by data file content does not match")
         .isEqualTo(expected);
 
@@ -273,7 +272,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             .map(ManifestFile::path)
             .collect(Collectors.toSet());
     assertThat(
-            actualManifestPaths(
+            scannedPaths(
                 entriesTable.newScan().filter(Expressions.notEqual("data_file.content", 3))))
         .as("Expected manifest filter by data file content does not match")
         .isEqualTo(allManifests);
@@ -290,7 +289,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         table.currentSnapshot().dataManifests(table.io()).stream()
             .map(ManifestFile::path)
             .collect(Collectors.toSet());
-    assertThat(actualManifestPaths(scan1))
+    assertThat(scannedPaths(scan1))
         .as("Expected manifest filter by data file content does not match")
         .isEqualTo(expectedDataManifestPath);
 
@@ -300,18 +299,18 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         table.currentSnapshot().deleteManifests(table.io()).stream()
             .map(ManifestFile::path)
             .collect(Collectors.toSet());
-    assertThat(actualManifestPaths(scan2))
+    assertThat(scannedPaths(scan2))
         .as("Expected manifest filter by data file content does not match")
         .isEqualTo(expectedDeleteManifestPath);
 
     Expression inAll = Expressions.in("data_file.content", 0, 1, 2);
     Set<String> allManifests = Sets.union(expectedDataManifestPath, expectedDeleteManifestPath);
-    assertThat(actualManifestPaths(entriesTable.newScan().filter(inAll)))
+    assertThat(scannedPaths(entriesTable.newScan().filter(inAll)))
         .as("Expected manifest filter by data file content does not match")
         .isEqualTo(allManifests);
 
     Expression inNeither = Expressions.in("data_file.content", 3, 4);
-    assertThat(actualManifestPaths(entriesTable.newScan().filter(inNeither)))
+    assertThat(scannedPaths(entriesTable.newScan().filter(inNeither)))
         .as("Expected manifest filter by data file content does not match")
         .isEmpty();
   }
@@ -327,7 +326,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         table.currentSnapshot().deleteManifests(table.io()).stream()
             .map(ManifestFile::path)
             .collect(Collectors.toSet());
-    assertThat(actualManifestPaths(scan1))
+    assertThat(scannedPaths(scan1))
         .as("Expected manifest filter by data file content does not match")
         .isEqualTo(expectedDeleteManifestPath);
 
@@ -337,18 +336,18 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         table.currentSnapshot().dataManifests(table.io()).stream()
             .map(ManifestFile::path)
             .collect(Collectors.toSet());
-    assertThat(actualManifestPaths(scan2))
+    assertThat(scannedPaths(scan2))
         .as("Expected manifest filter by data file content does not match")
         .isEqualTo(expectedDataManifestPath);
 
     Expression notInNeither = Expressions.notIn("data_file.content", 3);
     Set<String> allManifests = Sets.union(expectedDataManifestPath, expectedDeleteManifestPath);
-    assertThat(actualManifestPaths(entriesTable.newScan().filter(notInNeither)))
+    assertThat(scannedPaths(entriesTable.newScan().filter(notInNeither)))
         .as("Expected manifest filter by data file content does not match")
         .isEqualTo(allManifests);
 
     Expression notInAll = Expressions.notIn("data_file.content", 0, 1, 2);
-    assertThat(actualManifestPaths(entriesTable.newScan().filter(notInAll)))
+    assertThat(scannedPaths(entriesTable.newScan().filter(notInAll)))
         .as("Expected manifest filter by data file content does not match")
         .isEmpty();
   }
@@ -1207,7 +1206,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.greaterThan("reference_snapshot_id", 2));
 
-    assertThat(actualManifestListPaths(manifestsTableScan))
+    assertThat(scannedPaths(manifestsTableScan))
         .as("Expected snapshots do not match")
         .isEqualTo(expectedManifestListPaths(table.snapshots(), 3L, 4L));
   }
@@ -1221,7 +1220,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.greaterThanOrEqual("reference_snapshot_id", 3));
 
-    assertThat(actualManifestListPaths(manifestsTableScan))
+    assertThat(scannedPaths(manifestsTableScan))
         .as("Expected snapshots do not match")
         .isEqualTo(expectedManifestListPaths(table.snapshots(), 3L, 4L));
   }
@@ -1235,7 +1234,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.lessThan("reference_snapshot_id", 3));
 
-    assertThat(actualManifestListPaths(manifestsTableScan))
+    assertThat(scannedPaths(manifestsTableScan))
         .as("Expected snapshots do not match")
         .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 2L));
   }
@@ -1249,7 +1248,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.lessThanOrEqual("reference_snapshot_id", 2));
 
-    assertThat(actualManifestListPaths(manifestsTableScan))
+    assertThat(scannedPaths(manifestsTableScan))
         .as("Expected snapshots do not match")
         .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 2L));
   }
@@ -1263,7 +1262,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.equal("reference_snapshot_id", 2));
 
-    assertThat(actualManifestListPaths(manifestsTableScan))
+    assertThat(scannedPaths(manifestsTableScan))
         .as("Expected snapshots do not match")
         .isEqualTo(expectedManifestListPaths(table.snapshots(), 2L));
   }
@@ -1277,7 +1276,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.notEqual("reference_snapshot_id", 2));
 
-    assertThat(actualManifestListPaths(manifestsTableScan))
+    assertThat(scannedPaths(manifestsTableScan))
         .as("Expected snapshots do not match")
         .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 3L, 4L));
   }
@@ -1291,7 +1290,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.in("reference_snapshot_id", 1, 3));
-    assertThat(actualManifestListPaths(manifestsTableScan))
+    assertThat(scannedPaths(manifestsTableScan))
         .as("Expected snapshots do not match")
         .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 3L));
   }
@@ -1305,7 +1304,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.notIn("reference_snapshot_id", 1, 3));
 
-    assertThat(actualManifestListPaths(manifestsTableScan))
+    assertThat(scannedPaths(manifestsTableScan))
         .as("Expected snapshots do not match")
         .isEqualTo(expectedManifestListPaths(table.snapshots(), 2L, 4L));
   }
@@ -1324,7 +1323,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                 Expressions.and(
                     Expressions.equal("reference_snapshot_id", 2),
                     Expressions.greaterThan("length", 0)));
-    assertThat(actualManifestListPaths(manifestsTableScan))
+    assertThat(scannedPaths(manifestsTableScan))
         .as("Expected snapshots do not match")
         .isEqualTo(expectedManifestListPaths(table.snapshots(), 2L));
   }
@@ -1343,7 +1342,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                 Expressions.or(
                     Expressions.equal("reference_snapshot_id", 2),
                     Expressions.equal("reference_snapshot_id", 4)));
-    assertThat(actualManifestListPaths(manifestsTableScan))
+    assertThat(scannedPaths(manifestsTableScan))
         .as("Expected snapshots do not match")
         .isEqualTo(expectedManifestListPaths(table.snapshots(), 2L, 4L));
   }
@@ -1359,7 +1358,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             .newScan()
             .filter(Expressions.not(Expressions.equal("reference_snapshot_id", 2)));
 
-    assertThat(actualManifestListPaths(manifestsTableScan))
+    assertThat(scannedPaths(manifestsTableScan))
         .as("Expected snapshots do not match")
         .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 3L, 4L));
   }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -245,6 +245,24 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @TestTemplate
+  public void testEntriesTableDateFileContentNotEq() {
+    preparePartitionedTable();
+
+    Table entriesTable = new ManifestEntriesTable(table);
+
+    Expression notData = Expressions.notEqual("data_file.content", 0);
+    TableScan entriesTableScan = entriesTable.newScan().filter(notData);
+    Set<String> expected =
+        table.currentSnapshot().deleteManifests(table.io()).stream()
+            .map(ManifestFile::path)
+            .collect(Collectors.toSet());
+
+    assertThat(actualManifestPaths(entriesTableScan))
+        .as("Expected manifest filter by data file content does not match")
+        .isEqualTo(expected);
+  }
+
+  @TestTemplate
   public void testEntriesTableDataFileContentIn() {
     preparePartitionedTable();
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -227,6 +227,168 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @TestTemplate
+  public void testEntriesTableDateFileContentLt() {
+    preparePartitionedTable();
+
+    Table entriesTable = new ManifestEntriesTable(table);
+
+    Expression dataOnly = Expressions.lessThan("data_file.content", 1);
+    TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
+    Set<String> expected =
+        table.currentSnapshot().dataManifests(table.io()).stream()
+            .map(ManifestFile::path)
+            .collect(Collectors.toSet());
+
+    assertThat(actualManifestPaths(entriesTableScan))
+        .as("Expected manifest filter by data file content does not match")
+        .isEqualTo(expected);
+  }
+
+  @TestTemplate
+  public void testEntriesTableDateFileContentLte() {
+    preparePartitionedTable();
+
+    Table entriesTable = new ManifestEntriesTable(table);
+
+    Expression dataOnly = Expressions.lessThanOrEqual("data_file.content", 0);
+    TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
+    Set<String> expected =
+        table.currentSnapshot().dataManifests(table.io()).stream()
+            .map(ManifestFile::path)
+            .collect(Collectors.toSet());
+
+    assertThat(actualManifestPaths(entriesTableScan))
+        .as("Expected manifest filter by data file content does not match")
+        .isEqualTo(expected);
+  }
+
+  @TestTemplate
+  public void testEntriesTableDateFileContentGt() {
+    preparePartitionedTable();
+
+    Table entriesTable = new ManifestEntriesTable(table);
+
+    Expression dataOnly = Expressions.greaterThan("data_file.content", 0);
+    TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
+    Set<String> expected =
+        table.currentSnapshot().deleteManifests(table.io()).stream()
+            .map(ManifestFile::path)
+            .collect(Collectors.toSet());
+
+    assertThat(actualManifestPaths(entriesTableScan))
+        .as("Expected manifest filter by data file content does not match")
+        .isEqualTo(expected);
+  }
+
+  @TestTemplate
+  public void testEntriesTableDateFileContentGte() {
+    preparePartitionedTable();
+
+    Table entriesTable = new ManifestEntriesTable(table);
+
+    Expression dataOnly = Expressions.greaterThanOrEqual("data_file.content", 1);
+    TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
+    Set<String> expected =
+        table.currentSnapshot().deleteManifests(table.io()).stream()
+            .map(ManifestFile::path)
+            .collect(Collectors.toSet());
+
+    assertThat(actualManifestPaths(entriesTableScan))
+        .as("Expected manifest filter by data file content does not match")
+        .isEqualTo(expected);
+  }
+
+  @TestTemplate
+  public void testEntriesTableDateFileContentEq() {
+    preparePartitionedTable();
+
+    Table entriesTable = new ManifestEntriesTable(table);
+
+    Expression dataOnly = Expressions.equal("data_file.content", 0);
+    TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
+    Set<String> expected =
+        table.currentSnapshot().dataManifests(table.io()).stream()
+            .map(ManifestFile::path)
+            .collect(Collectors.toSet());
+
+    assertThat(actualManifestPaths(entriesTableScan))
+        .as("Expected manifest filter by data file content does not match")
+        .isEqualTo(expected);
+  }
+
+  @TestTemplate
+  public void testEntriesTableDateFileContentNotEq() {
+    preparePartitionedTable();
+
+    Table entriesTable = new ManifestEntriesTable(table);
+
+    Expression dataOnly = Expressions.notEqual("data_file.content", 0);
+    TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
+    Set<String> expected =
+        table.currentSnapshot().deleteManifests(table.io()).stream()
+            .map(ManifestFile::path)
+            .collect(Collectors.toSet());
+
+    assertThat(actualManifestPaths(entriesTableScan))
+        .as("Expected manifest filter by data file content does not match")
+        .isEqualTo(expected);
+  }
+
+  @TestTemplate
+  public void testEntriesTableDateFileContentIn() {
+    preparePartitionedTable();
+
+    Table entriesTable = new ManifestEntriesTable(table);
+
+    Expression dataOnly = Expressions.in("data_file.content", 1, 2);
+    TableScan entriesTableScan = entriesTable.newScan().filter(dataOnly);
+    Set<String> expected =
+        table.currentSnapshot().deleteManifests(table.io()).stream()
+            .map(ManifestFile::path)
+            .collect(Collectors.toSet());
+
+    assertThat(actualManifestPaths(entriesTableScan))
+        .as("Expected manifest filter by data file content does not match")
+        .isEqualTo(expected);
+  }
+
+  @TestTemplate
+  public void testEntriesTableDateFileContentNotIn() {
+    preparePartitionedTable();
+
+    Table entriesTable = new ManifestEntriesTable(table);
+
+    Expression notIn = Expressions.notIn("data_file.content", 1, 2);
+    TableScan entriesTableScan = entriesTable.newScan().filter(notIn);
+    Set<String> expected =
+        table.currentSnapshot().dataManifests(table.io()).stream()
+            .map(ManifestFile::path)
+            .collect(Collectors.toSet());
+
+    assertThat(actualManifestPaths(entriesTableScan))
+        .as("Expected manifest filter by data file content does not match")
+        .isEqualTo(expected);
+  }
+
+  @TestTemplate
+  public void testEntriesTableDateFileContentNot() {
+    preparePartitionedTable();
+
+    Table entriesTable = new ManifestEntriesTable(table);
+
+    Expression notData = Expressions.not(Expressions.equal("data_file.content", 0));
+    TableScan entriesTableScan = entriesTable.newScan().filter(notData);
+    Set<String> expected =
+        table.currentSnapshot().deleteManifests(table.io()).stream()
+            .map(ManifestFile::path)
+            .collect(Collectors.toSet());
+
+    assertThat(actualManifestPaths(entriesTableScan))
+        .as("Expected manifest filter by data file content does not match")
+        .isEqualTo(expected);
+  }
+
+  @TestTemplate
   public void testAllDataFilesTableHonorsIgnoreResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 


### PR DESCRIPTION
Skip either data or delete manifest when reading entries table by filter on its `data_file.content`. Build a  new ManifestContentEvaluator in entries metadata table.

Can you take a look ? @szehon-ho @aokolnychyi 