### PR TITLE
Fix incorrect metrics calculation for iceberg table due to column name transformation with special characters.

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1018,6 +1018,34 @@ acceptedBreaks:
       old: "method void org.apache.iceberg.PositionDeletesTable.PositionDeletesBatchScan::<init>(org.apache.iceberg.Table,\
         \ org.apache.iceberg.Schema, org.apache.iceberg.TableScanContext)"
       justification: "Removing deprecated code"
+  "1.5.0":
+    org.apache.iceberg:iceberg-core:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method org.apache.iceberg.MetricsConfig org.apache.iceberg.MetricsConfig::fromProperties(java.util.Map<java.lang.String,\
+        \ java.lang.String>)"
+      new: "method org.apache.iceberg.MetricsConfig org.apache.iceberg.MetricsConfig::fromProperties(org.apache.iceberg.Schema,\
+        \ java.util.Map<java.lang.String, java.lang.String>)"
+      justification: "change MetricsConfig columnModes from Map[colName, MetricsMode]\
+        \ to Map[fieldId, MetricsMode]"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter org.apache.iceberg.MetricsModes.MetricsMode org.apache.iceberg.MetricsConfig::columnMode(===java.lang.String===)"
+      new: "parameter org.apache.iceberg.MetricsModes.MetricsMode org.apache.iceberg.MetricsConfig::columnMode(===int===)"
+      justification: "change MetricsConfig columnModes from Map[colName, MetricsMode]\
+        \ to Map[fieldId, MetricsMode]"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.MetricsModes.MetricsMode org.apache.iceberg.MetricsUtil::metricsMode(org.apache.iceberg.Schema,\
+        \ org.apache.iceberg.MetricsConfig, int)"
+      justification: "change MetricsConfig columnModes from Map[colName, MetricsMode]\
+        \ to Map[fieldId, MetricsMode]"
+    - code: "java.method.removed"
+      old: "method void org.apache.iceberg.MetricsConfig::validateReferencedColumns(org.apache.iceberg.Schema)"
+      justification: "change MetricsConfig columnModes from Map[colName, MetricsMode]\
+        \ to Map[fieldId, MetricsMode]"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method java.util.Set<java.lang.String> org.apache.iceberg.util.SortOrderUtil::orderPreservingSortedColumns(org.apache.iceberg.SortOrder)"
+      new: "method java.util.Set<java.lang.Integer> org.apache.iceberg.util.SortOrderUtil::orderPreservingSortedColumns(org.apache.iceberg.SortOrder)"
+      justification: "change MetricsConfig columnModes from Map[colName, MetricsMode]\
+        \ to Map[fieldId, MetricsMode]"
   apache-iceberg-0.14.0:
     org.apache.iceberg:iceberg-api:
     - code: "java.class.defaultSerializationChanged"

--- a/core/src/main/java/org/apache/iceberg/MetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsUtil.java
@@ -102,20 +102,8 @@ public class MetricsUtil {
     }
 
     return fieldMetrics
-        .filter(
-            metrics ->
-                metricsMode(inputSchema, metricsConfig, metrics.id()) != MetricsModes.None.get())
+        .filter(metrics -> metricsConfig.columnMode(metrics.id()) != MetricsModes.None.get())
         .collect(Collectors.toMap(FieldMetrics::id, FieldMetrics::nanValueCount));
-  }
-
-  /** Extract MetricsMode for the given field id from metrics config. */
-  public static MetricsModes.MetricsMode metricsMode(
-      Schema inputSchema, MetricsConfig metricsConfig, int fieldId) {
-    Preconditions.checkNotNull(inputSchema, "inputSchema is required");
-    Preconditions.checkNotNull(metricsConfig, "metricsConfig is required");
-
-    String columnName = inputSchema.findColumnName(fieldId);
-    return metricsConfig.columnMode(columnName);
   }
 
   public static final List<ReadableMetricColDefinition> READABLE_METRIC_COLS =

--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -90,7 +90,7 @@ class PropertiesUpdate implements UpdateProperties {
 
     // Validate the metrics
     if (base != null && base.schema() != null) {
-      MetricsConfig.fromProperties(newProperties).validateReferencedColumns(base.schema());
+      MetricsConfig.fromProperties(base.schema(), newProperties);
     }
 
     return newProperties;

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -136,7 +136,7 @@ public class TableMetadata implements Serializable {
 
     // Validate the metrics configuration. Note: we only do this on new tables to we don't
     // break existing tables.
-    MetricsConfig.fromProperties(properties).validateReferencedColumns(schema);
+    MetricsConfig.fromProperties(schema, properties);
 
     return new Builder()
         .setInitialFormatVersion(formatVersion)

--- a/core/src/main/java/org/apache/iceberg/util/SortOrderUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SortOrderUtil.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.util;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.PartitionField;
@@ -131,15 +130,14 @@ public class SortOrderUtil {
     return requiredClusteringFields;
   }
 
-  public static Set<String> orderPreservingSortedColumns(SortOrder sortOrder) {
+  public static Set<Integer> orderPreservingSortedColumns(SortOrder sortOrder) {
     if (sortOrder == null) {
       return Collections.emptySet();
     } else {
       return sortOrder.fields().stream()
           .filter(f -> f.transform().preservesOrder())
           .map(SortField::sourceId)
-          .map(sid -> sortOrder.schema().findColumnName(sid))
-          .filter(Objects::nonNull)
+          .filter(sid -> sortOrder.schema().findColumnName(sid) != null)
           .collect(Collectors.toSet());
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
@@ -78,30 +78,34 @@ public class TestMetricsModes {
 
   @TestTemplate
   public void testInvalidColumnModeValue() {
+    String colName = "col";
+    Schema schema = new Schema(required(1, colName, Types.StringType.get()));
     Map<String, String> properties =
         ImmutableMap.of(
             TableProperties.DEFAULT_WRITE_METRICS_MODE,
             "full",
-            TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col",
+            TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + colName,
             "troncate(5)");
 
-    MetricsConfig config = MetricsConfig.fromProperties(properties);
-    assertThat(config.columnMode("col"))
+    MetricsConfig config = MetricsConfig.fromProperties(schema, properties);
+    assertThat(config.columnMode(1))
         .as("Invalid mode should be defaulted to table default (full)")
         .isEqualTo(MetricsModes.Full.get());
   }
 
   @TestTemplate
   public void testInvalidDefaultColumnModeValue() {
+    String colName = "col";
+    Schema schema = new Schema(required(1, colName, Types.StringType.get()));
     Map<String, String> properties =
         ImmutableMap.of(
             TableProperties.DEFAULT_WRITE_METRICS_MODE,
             "fuull",
-            TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col",
+            TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + colName,
             "troncate(5)");
 
-    MetricsConfig config = MetricsConfig.fromProperties(properties);
-    assertThat(config.columnMode("col"))
+    MetricsConfig config = MetricsConfig.fromProperties(schema, properties);
+    assertThat(config.columnMode(1))
         .as("Invalid mode should be defaulted to library default (truncate(16))")
         .isEqualTo(MetricsModes.Truncate.withLength(16));
   }
@@ -129,16 +133,16 @@ public class TestMetricsModes {
         .commit();
 
     MetricsConfig config = MetricsConfig.forTable(testTable);
-    assertThat(config.columnMode("col1"))
+    assertThat(config.columnMode(1))
         .as("Non-sorted existing column should not be overridden")
         .isEqualTo(Counts.get());
-    assertThat(config.columnMode("col2"))
+    assertThat(config.columnMode(2))
         .as("Sorted column defaults should not override user specified config")
         .isEqualTo(None.get());
-    assertThat(config.columnMode("col3"))
+    assertThat(config.columnMode(3))
         .as("Unspecified sorted column should use default")
         .isEqualTo(Truncate.withLength(16));
-    assertThat(config.columnMode("col4"))
+    assertThat(config.columnMode(4))
         .as("Unspecified normal column should use default")
         .isEqualTo(Counts.get());
   }
@@ -165,10 +169,10 @@ public class TestMetricsModes {
         .commit();
 
     MetricsConfig config = MetricsConfig.forTable(testTable);
-    assertThat(config.columnMode("col1"))
+    assertThat(config.columnMode(1))
         .as("Non-sorted existing column should not be overridden by sorted column")
         .isEqualTo(Full.get());
-    assertThat(config.columnMode("col2"))
+    assertThat(config.columnMode(2))
         .as("Original default applies as user entered invalid mode for sorted column")
         .isEqualTo(Counts.get());
   }
@@ -201,8 +205,8 @@ public class TestMetricsModes {
 
     MetricsConfig config = MetricsConfig.forTable(table);
 
-    assertThat(config.columnMode("col1")).isEqualTo(Truncate.withLength(16));
-    assertThat(config.columnMode("col2")).isEqualTo(Truncate.withLength(16));
-    assertThat(config.columnMode("col3")).isEqualTo(None.get());
+    assertThat(config.columnMode(1)).isEqualTo(Truncate.withLength(16));
+    assertThat(config.columnMode(2)).isEqualTo(Truncate.withLength(16));
+    assertThat(config.columnMode(3)).isEqualTo(None.get());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSortOrder.java
+++ b/core/src/test/java/org/apache/iceberg/TestSortOrder.java
@@ -333,8 +333,8 @@ public class TestSortOrder {
   public void testSortedColumnNames() {
     SortOrder order =
         SortOrder.builderFor(SCHEMA).withOrderId(10).asc("s.id").desc(truncate("data", 10)).build();
-    Set<String> sortedCols = SortOrderUtil.orderPreservingSortedColumns(order);
-    assertThat(sortedCols).containsExactly("s.id", "data");
+    Set<Integer> sortedCols = SortOrderUtil.orderPreservingSortedColumns(order);
+    assertThat(sortedCols).containsExactly(17, 11);
   }
 
   @TestTemplate
@@ -345,8 +345,8 @@ public class TestSortOrder {
             .asc(bucket("s.id", 5))
             .desc(truncate("data", 10))
             .build();
-    Set<String> sortedCols = SortOrderUtil.orderPreservingSortedColumns(order);
-    assertThat(sortedCols).containsExactly("data");
+    Set<Integer> sortedCols = SortOrderUtil.orderPreservingSortedColumns(order);
+    assertThat(sortedCols).containsExactly(11);
   }
 
   @TestTemplate

--- a/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
@@ -91,7 +91,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
   @Override
   public FileAppender<Record> newAppender(
       EncryptedOutputFile encryptedOutputFile, FileFormat fileFormat) {
-    MetricsConfig metricsConfig = MetricsConfig.fromProperties(config);
+    MetricsConfig metricsConfig = MetricsConfig.fromProperties(schema, config);
     try {
       switch (fileFormat) {
         case AVRO:
@@ -152,7 +152,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
         eqDeleteRowSchema,
         "Equality delete row schema shouldn't be null when creating equality-delete writer");
 
-    MetricsConfig metricsConfig = MetricsConfig.fromProperties(config);
+    MetricsConfig metricsConfig = MetricsConfig.fromProperties(eqDeleteRowSchema, config);
 
     try {
       switch (format) {
@@ -206,7 +206,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
   @Override
   public PositionDeleteWriter<Record> newPosDeleteWriter(
       EncryptedOutputFile file, FileFormat format, StructLike partition) {
-    MetricsConfig metricsConfig = MetricsConfig.fromProperties(config);
+    MetricsConfig metricsConfig = MetricsConfig.fromProperties(posDeleteRowSchema, config);
 
     try {
       switch (format) {

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -158,8 +158,7 @@ public class OrcMetrics {
         final Types.NestedField icebergCol = icebergColOpt.get();
         final int fieldId = icebergCol.fieldId();
 
-        final MetricsMode metricsMode =
-            MetricsUtil.metricsMode(schema, effectiveMetricsConfig, icebergCol.fieldId());
+        final MetricsMode metricsMode = effectiveMetricsConfig.columnMode(icebergCol.fieldId());
         columnSizes.put(fieldId, colStat.getBytesOnDisk());
 
         if (metricsMode == MetricsModes.None.get()) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -126,7 +126,7 @@ public class ParquetUtil {
 
         increment(columnSizes, fieldId, column.getTotalSize());
 
-        MetricsMode metricsMode = MetricsUtil.metricsMode(fileSchema, metricsConfig, fieldId);
+        MetricsMode metricsMode = metricsConfig.columnMode(fieldId);
         if (metricsMode == MetricsModes.None.get()) {
           continue;
         }
@@ -189,7 +189,7 @@ public class ParquetUtil {
             entry -> {
               int fieldId = entry.getKey();
               FieldMetrics<?> metrics = entry.getValue();
-              MetricsMode metricsMode = MetricsUtil.metricsMode(schema, metricsConfig, fieldId);
+              MetricsMode metricsMode = metricsConfig.columnMode(fieldId);
 
               // only check for MetricsModes.None, since we don't truncate float/double values.
               if (metricsMode != MetricsModes.None.get()) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -583,7 +583,7 @@ public class SparkTableUtil {
         Math.min(
             partitions.size(), spark.sessionState().conf().parallelPartitionDiscoveryParallelism());
     int numShufflePartitions = spark.sessionState().conf().numShufflePartitions();
-    MetricsConfig metricsConfig = MetricsConfig.fromProperties(targetTable.properties());
+    MetricsConfig metricsConfig = MetricsConfig.forTable(targetTable);
     String nameMappingString = targetTable.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
     NameMapping nameMapping =
         nameMappingString != null ? NameMappingParser.fromJson(nameMappingString) : null;

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
@@ -162,7 +162,7 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
 
   @Override
   public FileAppender<InternalRow> newAppender(OutputFile file, FileFormat fileFormat) {
-    MetricsConfig metricsConfig = MetricsConfig.fromProperties(properties);
+    MetricsConfig metricsConfig = MetricsConfig.fromProperties(writeSchema, properties);
     try {
       switch (fileFormat) {
         case PARQUET:

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -310,7 +310,8 @@ public class SparkScanBuilder
     for (BoundAggregate aggregate : aggregates) {
       String colName = aggregate.columnName();
       if (!colName.equals("*")) {
-        MetricsModes.MetricsMode mode = config.columnMode(colName);
+        MetricsModes.MetricsMode mode =
+            config.columnMode(table.schema().findField(colName).fieldId());
         if (mode instanceof MetricsModes.None) {
           LOG.info("Skipping aggregate pushdown: No metrics for column {}", colName);
           return false;

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -546,7 +546,7 @@ public class SparkTableUtil {
         Math.min(
             partitions.size(), spark.sessionState().conf().parallelPartitionDiscoveryParallelism());
     int numShufflePartitions = spark.sessionState().conf().numShufflePartitions();
-    MetricsConfig metricsConfig = MetricsConfig.fromProperties(targetTable.properties());
+    MetricsConfig metricsConfig = MetricsConfig.forTable(targetTable);
     String nameMappingString = targetTable.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
     NameMapping nameMapping =
         nameMappingString != null ? NameMappingParser.fromJson(nameMappingString) : null;

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
@@ -168,7 +168,7 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
 
   @Override
   public FileAppender<InternalRow> newAppender(EncryptedOutputFile file, FileFormat fileFormat) {
-    MetricsConfig metricsConfig = MetricsConfig.fromProperties(properties);
+    MetricsConfig metricsConfig = MetricsConfig.fromProperties(writeSchema, properties);
     try {
       switch (fileFormat) {
         case PARQUET:

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -314,7 +314,8 @@ public class SparkScanBuilder
     for (BoundAggregate aggregate : aggregates) {
       String colName = aggregate.columnName();
       if (!colName.equals("*")) {
-        MetricsModes.MetricsMode mode = config.columnMode(colName);
+        MetricsModes.MetricsMode mode =
+            config.columnMode(table.schema().findField(colName).fieldId());
         if (mode instanceof MetricsModes.None) {
           LOG.info("Skipping aggregate pushdown: No metrics for column {}", colName);
           return false;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -606,7 +606,7 @@ public class SparkTableUtil {
         Math.min(
             partitions.size(), spark.sessionState().conf().parallelPartitionDiscoveryParallelism());
     int numShufflePartitions = spark.sessionState().conf().numShufflePartitions();
-    MetricsConfig metricsConfig = MetricsConfig.fromProperties(targetTable.properties());
+    MetricsConfig metricsConfig = MetricsConfig.forTable(targetTable);
     String nameMappingString = targetTable.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
     NameMapping nameMapping =
         nameMappingString != null ? NameMappingParser.fromJson(nameMappingString) : null;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
@@ -168,7 +168,7 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
 
   @Override
   public FileAppender<InternalRow> newAppender(EncryptedOutputFile file, FileFormat fileFormat) {
-    MetricsConfig metricsConfig = MetricsConfig.fromProperties(properties);
+    MetricsConfig metricsConfig = MetricsConfig.fromProperties(writeSchema, properties);
     try {
       switch (fileFormat) {
         case PARQUET:

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -314,7 +314,8 @@ public class SparkScanBuilder
     for (BoundAggregate aggregate : aggregates) {
       String colName = aggregate.columnName();
       if (!colName.equals("*")) {
-        MetricsModes.MetricsMode mode = config.columnMode(colName);
+        MetricsModes.MetricsMode mode =
+            config.columnMode(table.schema().findField(colName).fieldId());
         if (mode instanceof MetricsModes.None) {
           LOG.info("Skipping aggregate pushdown: No metrics for column {}", colName);
           return false;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark;
 
+import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -25,10 +26,12 @@ import java.util.Map;
 import org.apache.iceberg.KryoHelpers;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.MetricsModes;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 public class TestSparkTableUtil {
@@ -56,6 +59,12 @@ public class TestSparkTableUtil {
 
   @Test
   public void testMetricsConfigKryoSerialization() throws Exception {
+    Schema schema =
+        new Schema(
+            required(1, "col1", Types.StringType.get()),
+            required(2, "col2", Types.StringType.get()),
+            required(3, "col3", Types.StringType.get()));
+
     Map<String, String> metricsConfig =
         ImmutableMap.of(
             TableProperties.DEFAULT_WRITE_METRICS_MODE,
@@ -65,19 +74,24 @@ public class TestSparkTableUtil {
             TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col2",
             "truncate(16)");
 
-    MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
+    MetricsConfig config = MetricsConfig.fromProperties(schema, metricsConfig);
     MetricsConfig deserialized = KryoHelpers.roundTripSerialize(config);
 
-    assertThat(deserialized.columnMode("col1").toString())
-        .isEqualTo(MetricsModes.Full.get().toString());
-    assertThat(deserialized.columnMode("col2").toString())
+    assertThat(deserialized.columnMode(1).toString()).isEqualTo(MetricsModes.Full.get().toString());
+    assertThat(deserialized.columnMode(2).toString())
         .isEqualTo(MetricsModes.Truncate.withLength(16).toString());
-    assertThat(deserialized.columnMode("col3").toString())
+    assertThat(deserialized.columnMode(3).toString())
         .isEqualTo(MetricsModes.Counts.get().toString());
   }
 
   @Test
   public void testMetricsConfigJavaSerialization() throws Exception {
+    Schema schema =
+        new Schema(
+            required(1, "col1", Types.StringType.get()),
+            required(2, "col2", Types.StringType.get()),
+            required(3, "col3", Types.StringType.get()));
+
     Map<String, String> metricsConfig =
         ImmutableMap.of(
             TableProperties.DEFAULT_WRITE_METRICS_MODE,
@@ -87,14 +101,13 @@ public class TestSparkTableUtil {
             TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col2",
             "truncate(16)");
 
-    MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
+    MetricsConfig config = MetricsConfig.fromProperties(schema, metricsConfig);
     MetricsConfig deserialized = TestHelpers.roundTripSerialize(config);
 
-    assertThat(deserialized.columnMode("col1").toString())
-        .isEqualTo(MetricsModes.Full.get().toString());
-    assertThat(deserialized.columnMode("col2").toString())
+    assertThat(deserialized.columnMode(1).toString()).isEqualTo(MetricsModes.Full.get().toString());
+    assertThat(deserialized.columnMode(2).toString())
         .isEqualTo(MetricsModes.Truncate.withLength(16).toString());
-    assertThat(deserialized.columnMode("col3").toString())
+    assertThat(deserialized.columnMode(3).toString())
         .isEqualTo(MetricsModes.Counts.get().toString());
   }
 }


### PR DESCRIPTION
Here are the main changes to fix [#10115](https://github.com/apache/iceberg/issues/10115)
1. change MetricsConfig.columnModes from map[colName, MetricsMode] to map[fieldId, MetricsMode]
2. add schema param for MetricsConfig.fromProperties
3. change MetricsConfig.columnMode param from columnAlias to fieldId
4. remove MetricsConfig.validateReferencedColumns