### PR TITLE
Don't let `o.a.i.util.Tasks` log unnecessary stack traces

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -453,7 +453,11 @@ public class Tasks {
               (int) Math.min(minSleepTimeMs * Math.pow(scaleFactor, attempt - 1), maxSleepTimeMs);
           int jitter = ThreadLocalRandom.current().nextInt(Math.max(1, (int) (delayMs * 0.1)));
 
-          LOG.warn("Retrying task after failure: {}", e.getMessage(), e);
+          if (LOG.isDebugEnabled()) {
+            LOG.warn("Retrying task after failure: {}", e.getMessage(), e);
+          } else {
+            LOG.warn("Retrying task after failure: {}", e.getMessage());
+          }
 
           try {
             TimeUnit.MILLISECONDS.sleep(delayMs + jitter);
@@ -484,7 +488,11 @@ public class Tasks {
             future.get();
 
           } catch (InterruptedException e) {
-            LOG.warn("Interrupted while getting future results", e);
+            if (LOG.isDebugEnabled()) {
+              LOG.warn("Interrupted while getting future results", e);
+            } else {
+              LOG.warn("Interrupted while getting future results");
+            }
             for (Throwable t : uncaught) {
               e.addSuppressed(t);
             }
@@ -517,7 +525,11 @@ public class Tasks {
         try {
           Thread.sleep(10);
         } catch (InterruptedException e) {
-          LOG.warn("Interrupted while waiting for tasks to finish", e);
+          if (LOG.isDebugEnabled()) {
+            LOG.warn("Interrupted while waiting for tasks to finish", e);
+          } else {
+            LOG.warn("Interrupted while waiting for tasks to finish");
+          }
 
           for (Future<?> future : futures) {
             future.cancel(true);


### PR DESCRIPTION
When retries happen, each retry produces a full stack trace on the console (or log file), which is, in the vast majority of all cases, just not needed and unnecessarily confuses users, because users assume that something went terribly wrong, when they see a stack trace.

This change removes the logging of the stack trace from the normal "retry warning", which is still logged at "warning" level. If debug logging is enables, those logs will emit the stack trace.