### PR TITLE
Flink: Prevent setting endTag/endSnapshotId for streaming source

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
@@ -45,12 +45,8 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class FlinkSource {
-  private static final Logger LOG = LoggerFactory.getLogger(FlinkSource.class);
-
   private FlinkSource() {}
 
   /**
@@ -263,8 +259,9 @@ public class FlinkSource {
 
       contextBuilder.resolveConfig(table, readOptions, readableConfig);
 
-      return new FlinkInputFormat(
-          tableLoader, icebergSchema, io, encryption, contextBuilder.build());
+      ScanContext context = contextBuilder.build();
+      context.validate();
+      return new FlinkInputFormat(tableLoader, icebergSchema, io, encryption, context);
     }
 
     public DataStream<RowData> build() {

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -500,6 +500,7 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
       }
 
       ScanContext context = contextBuilder.build();
+      context.validate();
       if (readerFunction == null) {
         if (table instanceof BaseMetadataTable) {
           MetaDataReaderFunction rowDataReaderFunction =

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
@@ -99,7 +99,8 @@ public class ScanContext implements Serializable {
       String branch,
       String tag,
       String startTag,
-      String endTag) {
+      String endTag,
+      boolean skipValidate) {
     this.caseSensitive = caseSensitive;
     this.snapshotId = snapshotId;
     this.tag = tag;
@@ -130,7 +131,9 @@ public class ScanContext implements Serializable {
     this.watermarkColumn = watermarkColumn;
     this.watermarkColumnTimeUnit = watermarkColumnTimeUnit;
 
-    validate();
+    if (!skipValidate) {
+      validate();
+    }
   }
 
   private void validate() {
@@ -317,6 +320,7 @@ public class ScanContext implements Serializable {
         .maxAllowedPlanningFailures(maxAllowedPlanningFailures)
         .watermarkColumn(watermarkColumn)
         .watermarkColumnTimeUnit(watermarkColumnTimeUnit)
+        .skipValidate()
         .build();
   }
 
@@ -348,6 +352,7 @@ public class ScanContext implements Serializable {
         .maxAllowedPlanningFailures(maxAllowedPlanningFailures)
         .watermarkColumn(watermarkColumn)
         .watermarkColumnTimeUnit(watermarkColumnTimeUnit)
+        .skipValidate()
         .build();
   }
 
@@ -391,6 +396,7 @@ public class ScanContext implements Serializable {
     private String watermarkColumn = FlinkReadOptions.WATERMARK_COLUMN_OPTION.defaultValue();
     private TimeUnit watermarkColumnTimeUnit =
         FlinkReadOptions.WATERMARK_COLUMN_TIME_UNIT_OPTION.defaultValue();
+    private boolean skipValidate = false;
 
     private Builder() {}
 
@@ -534,6 +540,11 @@ public class ScanContext implements Serializable {
       return this;
     }
 
+    public Builder skipValidate() {
+      this.skipValidate = true;
+      return this;
+    }
+
     public Builder resolveConfig(
         Table table, Map<String, String> readOptions, ReadableConfig readableConfig) {
       FlinkReadConf flinkReadConf = new FlinkReadConf(table, readOptions, readableConfig);
@@ -593,7 +604,8 @@ public class ScanContext implements Serializable {
           branch,
           tag,
           startTag,
-          endTag);
+          endTag,
+          skipValidate);
     }
   }
 }

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
@@ -155,6 +155,13 @@ public class ScanContext implements Serializable {
       Preconditions.checkArgument(
           tag == null,
           String.format("Cannot scan table using ref %s configured for streaming reader", tag));
+      Preconditions.checkArgument(
+          snapshotId == null, "Cannot set snapshot-id option for streaming reader");
+      Preconditions.checkArgument(
+          asOfTimestamp == null, "Cannot set as-of-timestamp option for streaming reader");
+      Preconditions.checkArgument(
+          endSnapshotId == null, "Cannot set end-snapshot-id option for streaming reader");
+      Preconditions.checkArgument(endTag == null, "Cannot set end-tag option for streaming reader");
     }
 
     Preconditions.checkArgument(

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
@@ -99,8 +99,7 @@ public class ScanContext implements Serializable {
       String branch,
       String tag,
       String startTag,
-      String endTag,
-      boolean skipValidate) {
+      String endTag) {
     this.caseSensitive = caseSensitive;
     this.snapshotId = snapshotId;
     this.tag = tag;
@@ -130,13 +129,9 @@ public class ScanContext implements Serializable {
     this.maxAllowedPlanningFailures = maxAllowedPlanningFailures;
     this.watermarkColumn = watermarkColumn;
     this.watermarkColumnTimeUnit = watermarkColumnTimeUnit;
-
-    if (!skipValidate) {
-      validate();
-    }
   }
 
-  private void validate() {
+  void validate() {
     if (isStreaming) {
       if (startingStrategy == StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID) {
         Preconditions.checkArgument(
@@ -320,7 +315,6 @@ public class ScanContext implements Serializable {
         .maxAllowedPlanningFailures(maxAllowedPlanningFailures)
         .watermarkColumn(watermarkColumn)
         .watermarkColumnTimeUnit(watermarkColumnTimeUnit)
-        .skipValidate()
         .build();
   }
 
@@ -352,7 +346,6 @@ public class ScanContext implements Serializable {
         .maxAllowedPlanningFailures(maxAllowedPlanningFailures)
         .watermarkColumn(watermarkColumn)
         .watermarkColumnTimeUnit(watermarkColumnTimeUnit)
-        .skipValidate()
         .build();
   }
 
@@ -396,7 +389,6 @@ public class ScanContext implements Serializable {
     private String watermarkColumn = FlinkReadOptions.WATERMARK_COLUMN_OPTION.defaultValue();
     private TimeUnit watermarkColumnTimeUnit =
         FlinkReadOptions.WATERMARK_COLUMN_TIME_UNIT_OPTION.defaultValue();
-    private boolean skipValidate = false;
 
     private Builder() {}
 
@@ -540,11 +532,6 @@ public class ScanContext implements Serializable {
       return this;
     }
 
-    public Builder skipValidate() {
-      this.skipValidate = true;
-      return this;
-    }
-
     public Builder resolveConfig(
         Table table, Map<String, String> readOptions, ReadableConfig readableConfig) {
       FlinkReadConf flinkReadConf = new FlinkReadConf(table, readOptions, readableConfig);
@@ -604,8 +591,7 @@ public class ScanContext implements Serializable {
           branch,
           tag,
           startTag,
-          endTag,
-          skipValidate);
+          endTag);
     }
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -471,6 +472,20 @@ public class TestIcebergSourceContinuous {
       resultMain = waitForResult(iter, 2);
       TestHelpers.assertRecords(resultMain, batchMain2, tableResource.table().schema());
     }
+  }
+
+  @Test
+  public void testValidation() {
+    assertThatThrownBy(
+            () ->
+                IcebergSource.forRowData()
+                    .tableLoader(tableResource.tableLoader())
+                    .assignerFactory(new SimpleSplitAssignerFactory())
+                    .streaming(true)
+                    .endTag("tag")
+                    .build())
+        .hasMessage("Cannot set end-tag option for streaming reader")
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   private DataStream<Row> createStream(ScanContext scanContext) throws Exception {

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestScanContext.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestScanContext.java
@@ -24,100 +24,88 @@ import org.junit.jupiter.api.Test;
 class TestScanContext {
   @Test
   void testIncrementalFromSnapshotId() {
-    Assertions.assertThatThrownBy(
-            () ->
-                ScanContext.builder()
-                    .streaming(true)
-                    .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
-                    .build())
-        .hasMessage("Invalid starting snapshot id for SPECIFIC_START_SNAPSHOT_ID strategy: null")
-        .isInstanceOf(IllegalArgumentException.class);
+    ScanContext context =
+        ScanContext.builder()
+            .streaming(true)
+            .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
+            .build();
+    assertException(
+        context, "Invalid starting snapshot id for SPECIFIC_START_SNAPSHOT_ID strategy: null");
 
-    Assertions.assertThatThrownBy(
-            () ->
-                ScanContext.builder()
-                    .streaming(true)
-                    .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
-                    .startSnapshotId(1L)
-                    .startSnapshotTimestamp(1L)
-                    .build())
-        .hasMessage(
-            "Invalid starting snapshot timestamp for SPECIFIC_START_SNAPSHOT_ID strategy: not null")
-        .isInstanceOf(IllegalArgumentException.class);
+    context =
+        ScanContext.builder()
+            .streaming(true)
+            .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
+            .startSnapshotId(1L)
+            .startSnapshotTimestamp(1L)
+            .build();
+    assertException(
+        context,
+        "Invalid starting snapshot timestamp for SPECIFIC_START_SNAPSHOT_ID strategy: not null");
   }
 
   @Test
   void testIncrementalFromSnapshotTimestamp() {
-    Assertions.assertThatThrownBy(
-            () ->
-                ScanContext.builder()
-                    .streaming(true)
-                    .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
-                    .build())
-        .hasMessage(
-            "Invalid starting snapshot timestamp for SPECIFIC_START_SNAPSHOT_TIMESTAMP strategy: null")
-        .isInstanceOf(IllegalArgumentException.class);
+    ScanContext context =
+        ScanContext.builder()
+            .streaming(true)
+            .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
+            .build();
+    assertException(
+        context,
+        "Invalid starting snapshot timestamp for SPECIFIC_START_SNAPSHOT_TIMESTAMP strategy: null");
 
-    Assertions.assertThatThrownBy(
-            () ->
-                ScanContext.builder()
-                    .streaming(true)
-                    .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
-                    .startSnapshotId(1L)
-                    .startSnapshotTimestamp(1L)
-                    .build())
-        .hasMessage(
-            "Invalid starting snapshot id for SPECIFIC_START_SNAPSHOT_ID strategy: not null")
-        .isInstanceOf(IllegalArgumentException.class);
+    context =
+        ScanContext.builder()
+            .streaming(true)
+            .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
+            .startSnapshotId(1L)
+            .startSnapshotTimestamp(1L)
+            .build();
+    assertException(
+        context, "Invalid starting snapshot id for SPECIFIC_START_SNAPSHOT_ID strategy: not null");
   }
 
   @Test
   void testStreaming() {
-    Assertions.assertThatThrownBy(() -> ScanContext.builder().streaming(true).useTag("tag").build())
-        .hasMessage("Cannot scan table using ref tag configured for streaming reader")
-        .isInstanceOf(IllegalArgumentException.class);
+    ScanContext context = ScanContext.builder().streaming(true).useTag("tag").build();
+    assertException(context, "Cannot scan table using ref tag configured for streaming reader");
 
-    Assertions.assertThatThrownBy(
-            () -> ScanContext.builder().streaming(true).useSnapshotId(1L).build())
-        .hasMessage("Cannot set snapshot-id option for streaming reader")
-        .isInstanceOf(IllegalArgumentException.class);
+    context = ScanContext.builder().streaming(true).useSnapshotId(1L).build();
+    assertException(context, "Cannot set snapshot-id option for streaming reader");
 
-    Assertions.assertThatThrownBy(
-            () -> ScanContext.builder().streaming(true).asOfTimestamp(1L).build())
-        .hasMessage("Cannot set as-of-timestamp option for streaming reader")
-        .isInstanceOf(IllegalArgumentException.class);
+    context = ScanContext.builder().streaming(true).asOfTimestamp(1L).build();
+    assertException(context, "Cannot set as-of-timestamp option for streaming reader");
 
-    Assertions.assertThatThrownBy(
-            () -> ScanContext.builder().streaming(true).endSnapshotId(1L).build())
-        .hasMessage("Cannot set end-snapshot-id option for streaming reader")
-        .isInstanceOf(IllegalArgumentException.class);
+    context = ScanContext.builder().streaming(true).endSnapshotId(1L).build();
+    assertException(context, "Cannot set end-snapshot-id option for streaming reader");
 
-    Assertions.assertThatThrownBy(() -> ScanContext.builder().streaming(true).endTag("tag").build())
-        .hasMessage("Cannot set end-tag option for streaming reader")
-        .isInstanceOf(IllegalArgumentException.class);
+    context = ScanContext.builder().streaming(true).endTag("tag").build();
+    assertException(context, "Cannot set end-tag option for streaming reader");
   }
 
   @Test
   void testStartConflict() {
-    Assertions.assertThatThrownBy(
-            () -> ScanContext.builder().startTag("tag").startSnapshotId(1L).build())
-        .hasMessage("START_SNAPSHOT_ID and START_TAG cannot both be set.")
-        .isInstanceOf(IllegalArgumentException.class);
+    ScanContext context = ScanContext.builder().startTag("tag").startSnapshotId(1L).build();
+    assertException(context, "START_SNAPSHOT_ID and START_TAG cannot both be set.");
   }
 
   @Test
   void testEndConflict() {
-    Assertions.assertThatThrownBy(
-            () -> ScanContext.builder().endTag("tag").endSnapshotId(1L).build())
-        .hasMessage("END_SNAPSHOT_ID and END_TAG cannot both be set.")
-        .isInstanceOf(IllegalArgumentException.class);
+    ScanContext context = ScanContext.builder().endTag("tag").endSnapshotId(1L).build();
+    assertException(context, "END_SNAPSHOT_ID and END_TAG cannot both be set.");
   }
 
   @Test
   void testMaxAllowedPlanningFailures() {
-    Assertions.assertThatThrownBy(
-            () -> ScanContext.builder().maxAllowedPlanningFailures(-2).build())
-        .hasMessage("Cannot set maxAllowedPlanningFailures to a negative number other than -1.")
+    ScanContext context = ScanContext.builder().maxAllowedPlanningFailures(-2).build();
+    assertException(
+        context, "Cannot set maxAllowedPlanningFailures to a negative number other than -1.");
+  }
+
+  private void assertException(ScanContext context, String message) {
+    Assertions.assertThatThrownBy(() -> context.validate())
+        .hasMessage(message)
         .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestScanContext.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestScanContext.java
@@ -30,7 +30,7 @@ class TestScanContext {
                     .streaming(true)
                     .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
                     .build())
-        .hasMessageContaining("Invalid starting snapshot id for")
+        .hasMessage("Invalid starting snapshot id for SPECIFIC_START_SNAPSHOT_ID strategy: null")
         .isInstanceOf(IllegalArgumentException.class);
 
     Assertions.assertThatThrownBy(
@@ -41,7 +41,8 @@ class TestScanContext {
                     .startSnapshotId(1L)
                     .startSnapshotTimestamp(1L)
                     .build())
-        .hasMessageContaining("Invalid starting snapshot timestamp for")
+        .hasMessage(
+            "Invalid starting snapshot timestamp for SPECIFIC_START_SNAPSHOT_ID strategy: not null")
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -53,7 +54,8 @@ class TestScanContext {
                     .streaming(true)
                     .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
                     .build())
-        .hasMessageContaining("Invalid starting snapshot timestamp for")
+        .hasMessage(
+            "Invalid starting snapshot timestamp for SPECIFIC_START_SNAPSHOT_TIMESTAMP strategy: null")
         .isInstanceOf(IllegalArgumentException.class);
 
     Assertions.assertThatThrownBy(
@@ -64,34 +66,34 @@ class TestScanContext {
                     .startSnapshotId(1L)
                     .startSnapshotTimestamp(1L)
                     .build())
-        .hasMessageContaining("Invalid starting snapshot id for")
+        .hasMessage(
+            "Invalid starting snapshot id for SPECIFIC_START_SNAPSHOT_ID strategy: not null")
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void testStreaming() {
     Assertions.assertThatThrownBy(() -> ScanContext.builder().streaming(true).useTag("tag").build())
-        .hasMessageContaining("Cannot scan table using ref")
-        .hasMessageContaining("for streaming reader")
+        .hasMessage("Cannot scan table using ref tag configured for streaming reader")
         .isInstanceOf(IllegalArgumentException.class);
 
     Assertions.assertThatThrownBy(
             () -> ScanContext.builder().streaming(true).useSnapshotId(1L).build())
-        .hasMessageContaining("Cannot set snapshot-id option for streaming reader")
+        .hasMessage("Cannot set snapshot-id option for streaming reader")
         .isInstanceOf(IllegalArgumentException.class);
 
     Assertions.assertThatThrownBy(
             () -> ScanContext.builder().streaming(true).asOfTimestamp(1L).build())
-        .hasMessageContaining("Cannot set as-of-timestamp option for streaming reader")
+        .hasMessage("Cannot set as-of-timestamp option for streaming reader")
         .isInstanceOf(IllegalArgumentException.class);
 
     Assertions.assertThatThrownBy(
             () -> ScanContext.builder().streaming(true).endSnapshotId(1L).build())
-        .hasMessageContaining("Cannot set end-snapshot-id option for streaming reader")
+        .hasMessage("Cannot set end-snapshot-id option for streaming reader")
         .isInstanceOf(IllegalArgumentException.class);
 
     Assertions.assertThatThrownBy(() -> ScanContext.builder().streaming(true).endTag("tag").build())
-        .hasMessageContaining("Cannot set end-tag option for streaming reader")
+        .hasMessage("Cannot set end-tag option for streaming reader")
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -99,7 +101,7 @@ class TestScanContext {
   void testStartConflict() {
     Assertions.assertThatThrownBy(
             () -> ScanContext.builder().startTag("tag").startSnapshotId(1L).build())
-        .hasMessageContaining("START_SNAPSHOT_ID and START_TAG cannot both be set.")
+        .hasMessage("START_SNAPSHOT_ID and START_TAG cannot both be set.")
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -107,7 +109,7 @@ class TestScanContext {
   void testEndConflict() {
     Assertions.assertThatThrownBy(
             () -> ScanContext.builder().endTag("tag").endSnapshotId(1L).build())
-        .hasMessageContaining("END_SNAPSHOT_ID and END_TAG cannot both be set.")
+        .hasMessage("END_SNAPSHOT_ID and END_TAG cannot both be set.")
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -115,7 +117,7 @@ class TestScanContext {
   void testMaxAllowedPlanningFailures() {
     Assertions.assertThatThrownBy(
             () -> ScanContext.builder().maxAllowedPlanningFailures(-2).build())
-        .hasMessageContaining("annot set maxAllowedPlanningFailures to a negative number")
+        .hasMessage("Cannot set maxAllowedPlanningFailures to a negative number other than -1.")
         .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestScanContext.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestScanContext.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestScanContext {
+  @Test
+  void testIncrementalFromSnapshotId() {
+    Assertions.assertThatThrownBy(
+            () ->
+                ScanContext.builder()
+                    .streaming(true)
+                    .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
+                    .build())
+        .hasMessageContaining("Invalid starting snapshot id for")
+        .isInstanceOf(IllegalArgumentException.class);
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ScanContext.builder()
+                    .streaming(true)
+                    .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
+                    .startSnapshotId(1L)
+                    .startSnapshotTimestamp(1L)
+                    .build())
+        .hasMessageContaining("Invalid starting snapshot timestamp for")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void testIncrementalFromSnapshotTimestamp() {
+    Assertions.assertThatThrownBy(
+            () ->
+                ScanContext.builder()
+                    .streaming(true)
+                    .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
+                    .build())
+        .hasMessageContaining("Invalid starting snapshot timestamp for")
+        .isInstanceOf(IllegalArgumentException.class);
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ScanContext.builder()
+                    .streaming(true)
+                    .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
+                    .startSnapshotId(1L)
+                    .startSnapshotTimestamp(1L)
+                    .build())
+        .hasMessageContaining("Invalid starting snapshot id for")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void testStreaming() {
+    Assertions.assertThatThrownBy(() -> ScanContext.builder().streaming(true).useTag("tag").build())
+        .hasMessageContaining("Cannot scan table using ref")
+        .hasMessageContaining("for streaming reader")
+        .isInstanceOf(IllegalArgumentException.class);
+
+    Assertions.assertThatThrownBy(
+            () -> ScanContext.builder().streaming(true).useSnapshotId(1L).build())
+        .hasMessageContaining("Cannot set snapshot-id option for streaming reader")
+        .isInstanceOf(IllegalArgumentException.class);
+
+    Assertions.assertThatThrownBy(
+            () -> ScanContext.builder().streaming(true).asOfTimestamp(1L).build())
+        .hasMessageContaining("Cannot set as-of-timestamp option for streaming reader")
+        .isInstanceOf(IllegalArgumentException.class);
+
+    Assertions.assertThatThrownBy(
+            () -> ScanContext.builder().streaming(true).endSnapshotId(1L).build())
+        .hasMessageContaining("Cannot set end-snapshot-id option for streaming reader")
+        .isInstanceOf(IllegalArgumentException.class);
+
+    Assertions.assertThatThrownBy(() -> ScanContext.builder().streaming(true).endTag("tag").build())
+        .hasMessageContaining("Cannot set end-tag option for streaming reader")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void testStartConflict() {
+    Assertions.assertThatThrownBy(
+            () -> ScanContext.builder().startTag("tag").startSnapshotId(1L).build())
+        .hasMessageContaining("START_SNAPSHOT_ID and START_TAG cannot both be set.")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void testEndConflict() {
+    Assertions.assertThatThrownBy(
+            () -> ScanContext.builder().endTag("tag").endSnapshotId(1L).build())
+        .hasMessageContaining("END_SNAPSHOT_ID and END_TAG cannot both be set.")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void testMaxAllowedPlanningFailures() {
+    Assertions.assertThatThrownBy(
+            () -> ScanContext.builder().maxAllowedPlanningFailures(-2).build())
+        .hasMessageContaining("annot set maxAllowedPlanningFailures to a negative number")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamScanSql.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamScanSql.java
@@ -48,7 +48,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.Timeout;
 
+@Timeout(60)
 public class TestStreamScanSql extends CatalogTestBase {
   private static final String TABLE = "test_table";
   private static final FileFormat FORMAT = FileFormat.PARQUET;


### PR DESCRIPTION
Tried to hack around issues with setting `endSnapshotId` for a streaming job. It turns out the code is silently overwriting the values set in the context.

Since it doesn't make sense to set `end` for the streaming case, I propose to add validation to prevent these cases.
The `Preconditions` are copied from `StreamingMonitorFunction` used by the old FlinkSource implementation.