### PR TITLE
Docs: Don't check links on Release page

### DIFF
--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -39,7 +39,6 @@ The latest version of Iceberg is [{{ icebergVersion }}](https://github.com/apach
 * [{{ icebergVersion }} gcp-bundle Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-gcp-bundle/{{ icebergVersion }}/iceberg-gcp-bundle-{{ icebergVersion }}.jar)
 * [{{ icebergVersion }} azure-bundle Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-azure-bundle/{{ icebergVersion }}/iceberg-azure-bundle-{{ icebergVersion }}.jar)
 
-<!-- markdown-link-check-enable -->
 
 To use Iceberg in Spark or Flink, download the runtime JAR for your engine version and add it to the jars folder of your installation.
 
@@ -977,3 +976,5 @@ A more exhaustive list of changes is available under the [0.10.0 release milesto
 ### 0.7.0
 
 * Git tag: [apache-iceberg-0.7.0-incubating](https://github.com/apache/iceberg/releases/tag/apache-iceberg-0.7.0-incubating)
+
+<!-- markdown-link-check-enable -->


### PR DESCRIPTION
@pvary had different random failures on the Release page in https://github.com/apache/iceberg/pull/10200, so I'd suggest that we completely skip checking links on this particular site