### PR TITLE
AWS: Fix TestGlueCatalogTable#testCreateTable

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -94,7 +94,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
     assertThat(response.table().storageDescriptor().columns()).hasSameSizeAs(schema.columns());
     assertThat(response.table().partitionKeys()).hasSameSizeAs(partitionSpec.fields());
     assertThat(response.table().storageDescriptor().additionalLocations())
-        .isEqualTo(tableLocationProperties.values());
+        .containsExactlyInAnyOrderElementsOf(tableLocationProperties.values());
     // verify metadata file exists in S3
     String metaLocation =
         response.table().parameters().get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);


### PR DESCRIPTION
## Problem

TestGlueCatalogTable#testCreateTable failed by the following assertion error:

```
org.opentest4j.AssertionFailedError: 
expected: 
  ["s3://iceberg-integ-684001615763-ap-northeast-3/writeDataLoc",
      "s3://iceberg-integ-684001615763-ap-northeast-3/writeMetaDataLoc",
      "s3://iceberg-integ-684001615763-ap-northeast-3/writeFolderStorageLoc"]
 but was: 
  ["s3://iceberg-integ-684001615763-ap-northeast-3/writeFolderStorageLoc",
      "s3://iceberg-integ-684001615763-ap-northeast-3/writeDataLoc",
      "s3://iceberg-integ-684001615763-ap-northeast-3/writeMetaDataLoc"]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at org.apache.iceberg.aws.glue.TestGlueCatalogTable.testCreateTable(TestGlueCatalogTable.java:97)
```

It's caused by the JUnit 5 upgrade #10086. After this change, the elements are not sorted before comparing the list.

## Solution

Use containsExactlyInAnyOrderElementsOf method: https://www.javadoc.io/doc/org.assertj/assertj-core/latest/org/assertj/core/api/AbstractIterableAssert.html#containsExactlyInAnyOrderElementsOf(java.lang.Iterable).

## Testing

Ran the integration test manually and it passed.