### PR TITLE
Spark: Use compressed trie for storing set of files to remove on driver for orphan files

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -162,7 +162,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
             .execute();
     assertThat(result2.orphanFileLocations())
         .as("Action should find 1 file")
-        .isEqualTo(invalidFiles);
+        .containsAll(invalidFiles);
     assertThat(fs.exists(new Path(invalidFiles.get(0))))
         .as("Invalid file should be present")
         .isTrue();
@@ -171,7 +171,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
     assertThat(result3.orphanFileLocations())
         .as("Action should delete 1 file")
-        .isEqualTo(invalidFiles);
+        .containsAll(invalidFiles);
     assertThat(fs.exists(new Path(invalidFiles.get(0))))
         .as("Invalid file should not be present")
         .isFalse();
@@ -666,7 +666,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
             .execute();
     assertThat(result.orphanFileLocations())
         .as("Action should find 1 file")
-        .isEqualTo(invalidFiles);
+        .containsAll(invalidFiles);
     assertThat(fs.exists(new Path(invalidFiles.get(0))))
         .as("Invalid file should be present")
         .isTrue();
@@ -839,7 +839,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
             .execute();
     assertThat(result2.orphanFileLocations())
         .as("Action should find 1 file")
-        .isEqualTo(invalidFilePaths);
+        .containsAll(invalidFilePaths);
     assertThat(fs.exists(new Path(invalidFilePaths.get(0))))
         .as("Invalid file should be present")
         .isTrue();
@@ -852,7 +852,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
             .execute();
     assertThat(result3.orphanFileLocations())
         .as("Action should delete 1 file")
-        .isEqualTo(invalidFilePaths);
+        .containsAll(invalidFilePaths);
     assertThat(fs.exists(new Path(invalidFilePaths.get(0))))
         .as("Invalid file should not be present")
         .isFalse();
@@ -1085,9 +1085,9 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     Dataset<String> validFileDS = spark.createDataset(validFiles, Encoders.STRING());
     Dataset<String> actualFileDS = spark.createDataset(actualFiles, Encoders.STRING());
 
-    List<String> orphanFiles =
+    Set<String> orphanFiles =
         DeleteOrphanFilesSparkAction.findOrphanFiles(
             spark, toFileUri.apply(actualFileDS), toFileUri.apply(validFileDS), mode);
-    assertThat(orphanFiles).isEqualTo(expectedOrphanFiles);
+    assertThat(orphanFiles.stream().collect(Collectors.toList())).containsAll(expectedOrphanFiles);
   }
 }


### PR DESCRIPTION
Still testing to see the efficacy, but I think for orphan file removal if there's a large list of files which will have common prefixes on the driver it will be more memory efficient to use a compressed trie (radix tree). This can help prevent driver OOMs.

Another approach would be to perform distributed deletes (so the file paths are distributed across executors), but I remember in the past there wasn't consensus on this since folks were worried about hitting the storage layer too hard. Another benefit of optimizing how files are maintained on the driver is it frees up the executor resources for other purposes.