### PR TITLE
Nessie: Make handleExceptionsForCommits public in NessieUtil

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -215,7 +215,7 @@ public final class NessieUtil {
         .build();
   }
 
-  static Optional<RuntimeException> handleExceptionsForCommits(
+  public static Optional<RuntimeException> handleExceptionsForCommits(
       Exception exception, String refName, Content.Type type) {
     if (exception instanceof NessieConflictException) {
       if (exception instanceof NessieReferenceConflictException) {


### PR DESCRIPTION
Request to make `handleExceptionsForCommits` public in NessieUtil so it can be reused. 