### PR TITLE
Core: Assign fresh IDs to view schema

### DIFF
--- a/core/src/test/java/org/apache/iceberg/view/TestViewMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestViewMetadata.java
@@ -1181,4 +1181,118 @@ public class TestViewMetadata {
                 + "Previous dialects: [trino]\n"
                 + "New dialects: [spark]");
   }
+
+  @Test
+  public void assignFreshSchemaIdWhereNewSchemasFieldIdIsSmallerThanHighestFieldId() {
+    Schema schemaOne = new Schema(Types.NestedField.required(1, "x", Types.LongType.get()));
+    Schema schemaTwo = new Schema(Types.NestedField.required(2, "y", Types.LongType.get()));
+    Schema schemaThree = new Schema(Types.NestedField.required(3, "z", Types.LongType.get()));
+    Schema newSchema = new Schema(Types.NestedField.required(1, "a", Types.LongType.get()));
+
+    ViewMetadata metadata =
+        ViewMetadata.builder()
+            .setLocation("custom-location")
+            .addSchema(schemaOne)
+            .addSchema(schemaTwo)
+            .addSchema(schemaThree)
+            .setCurrentVersion(
+                ImmutableViewVersion.builder()
+                    .versionId(1)
+                    .schemaId(0)
+                    .timestampMillis(System.currentTimeMillis())
+                    .defaultNamespace(Namespace.empty())
+                    .build(),
+                schemaOne)
+            .build();
+
+    ViewMetadata replacement =
+        ViewMetadata.buildFrom(metadata)
+            .setCurrentVersion(
+                ImmutableViewVersion.builder()
+                    .versionId(2)
+                    .schemaId(0)
+                    .timestampMillis(System.currentTimeMillis())
+                    .defaultNamespace(Namespace.empty())
+                    .build(),
+                newSchema)
+            .build();
+
+    assertThat(replacement.schema().highestFieldId()).isEqualTo(4);
+  }
+
+  @Test
+  public void assignFreshSchemaIdWhereNewSchemasFieldIdIsGreaterThanHighestFieldId() {
+    Schema schemaOne = new Schema(Types.NestedField.required(1, "x", Types.LongType.get()));
+    Schema schemaTwo = new Schema(Types.NestedField.required(2, "y", Types.LongType.get()));
+    Schema schemaThree = new Schema(Types.NestedField.required(3, "z", Types.LongType.get()));
+    Schema newSchema = new Schema(Types.NestedField.required(12, "a", Types.LongType.get()));
+
+    ViewMetadata metadata =
+        ViewMetadata.builder()
+            .setLocation("custom-location")
+            .addSchema(schemaOne)
+            .addSchema(schemaTwo)
+            .addSchema(schemaThree)
+            .setCurrentVersion(
+                ImmutableViewVersion.builder()
+                    .versionId(1)
+                    .schemaId(0)
+                    .timestampMillis(System.currentTimeMillis())
+                    .defaultNamespace(Namespace.empty())
+                    .build(),
+                schemaOne)
+            .build();
+
+    ViewMetadata replacement =
+        ViewMetadata.buildFrom(metadata)
+            .setCurrentVersion(
+                ImmutableViewVersion.builder()
+                    .versionId(2)
+                    .schemaId(0)
+                    .timestampMillis(System.currentTimeMillis())
+                    .defaultNamespace(Namespace.empty())
+                    .build(),
+                newSchema)
+            .build();
+
+    assertThat(replacement.schema().highestFieldId()).isEqualTo(4);
+  }
+
+  @Test
+  public void assignFreshSchemaIdWhereNewSchemasFieldIdSameAsHighestFieldId() {
+    Schema schemaOne = new Schema(Types.NestedField.required(1, "x", Types.LongType.get()));
+    Schema schemaTwo = new Schema(Types.NestedField.required(2, "y", Types.LongType.get()));
+    Schema schemaThree = new Schema(Types.NestedField.required(3, "z", Types.LongType.get()));
+    Schema newSchema = new Schema(Types.NestedField.required(3, "a", Types.LongType.get()));
+
+    ViewMetadata metadata =
+        ViewMetadata.builder()
+            .setLocation("custom-location")
+            .addSchema(schemaOne)
+            .addSchema(schemaTwo)
+            .addSchema(schemaThree)
+            .setCurrentVersion(
+                ImmutableViewVersion.builder()
+                    .versionId(1)
+                    .schemaId(0)
+                    .timestampMillis(System.currentTimeMillis())
+                    .defaultNamespace(Namespace.empty())
+                    .build(),
+                schemaOne)
+            .build();
+
+    ViewMetadata replacement =
+        ViewMetadata.buildFrom(metadata)
+            .setCurrentVersion(
+                ImmutableViewVersion.builder()
+                    .versionId(2)
+                    .schemaId(0)
+                    .timestampMillis(System.currentTimeMillis())
+                    .defaultNamespace(Namespace.empty())
+                    .build(),
+                newSchema)
+            .build();
+
+    assertThat(replacement.schema().highestFieldId()).isEqualTo(4);
+  }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -1761,8 +1761,9 @@ public class TestViews extends SparkExtensionsTestBase {
     assertThat(view.schema().asStruct())
         .isEqualTo(
             new Schema(
-                    Types.NestedField.optional(0, "new_id", Types.IntegerType.get(), "some ID"),
-                    Types.NestedField.optional(1, "new_data", Types.StringType.get(), "some data"))
+                    0,
+                    Types.NestedField.optional(1, "new_id", Types.IntegerType.get(), "some ID"),
+                    Types.NestedField.optional(2, "new_data", Types.StringType.get(), "some data"))
                 .asStruct());
 
     sql("CREATE OR REPLACE VIEW %s (updated_id COMMENT 'updated ID') AS %s", viewName, updatedSql);
@@ -1776,8 +1777,9 @@ public class TestViews extends SparkExtensionsTestBase {
     assertThat(view.schema().asStruct())
         .isEqualTo(
             new Schema(
+                    1,
                     Types.NestedField.optional(
-                        0, "updated_id", Types.IntegerType.get(), "updated ID"))
+                        3, "updated_id", Types.IntegerType.get(), "updated ID"))
                 .asStruct());
   }
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -1798,8 +1798,9 @@ public class TestViews extends ExtensionsTestBase {
     assertThat(view.schema().asStruct())
         .isEqualTo(
             new Schema(
-                    Types.NestedField.optional(0, "new_id", Types.IntegerType.get(), "some ID"),
-                    Types.NestedField.optional(1, "new_data", Types.StringType.get(), "some data"))
+                    0,
+                    Types.NestedField.optional(1, "new_id", Types.IntegerType.get(), "some ID"),
+                    Types.NestedField.optional(2, "new_data", Types.StringType.get(), "some data"))
                 .asStruct());
 
     sql("CREATE OR REPLACE VIEW %s (updated_id COMMENT 'updated ID') AS %s", viewName, updatedSql);
@@ -1813,8 +1814,9 @@ public class TestViews extends ExtensionsTestBase {
     assertThat(view.schema().asStruct())
         .isEqualTo(
             new Schema(
+                    1,
                     Types.NestedField.optional(
-                        0, "updated_id", Types.IntegerType.get(), "updated ID"))
+                        3, "updated_id", Types.IntegerType.get(), "updated ID"))
                 .asStruct());
   }
 


### PR DESCRIPTION
This addresses https://github.com/apache/iceberg/pull/9596#discussion_r1473187177 and assigns fresh IDs to a View's schema when creating/replacing a view