### PR TITLE
REST: honor OAuth config sent by the server

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -215,6 +215,12 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     this.paths = ResourcePaths.forCatalogProperties(mergedProps);
 
     String token = mergedProps.get(OAuth2Properties.TOKEN);
+    // re-resolve these variables in case they were overridden by the config endpoint
+    credential = mergedProps.get(OAuth2Properties.CREDENTIAL);
+    scope = mergedProps.getOrDefault(OAuth2Properties.SCOPE, OAuth2Properties.CATALOG_SCOPE);
+    oauth2ServerUri =
+        mergedProps.getOrDefault(OAuth2Properties.OAUTH2_SERVER_URI, ResourcePaths.tokens());
+    optionalOAuthParams = OAuth2Util.buildOptionalParam(mergedProps);
     this.catalogAuth =
         new AuthSession(
             baseHeaders, null, null, credential, scope, oauth2ServerUri, optionalOAuthParams);

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -272,7 +272,15 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                               CatalogProperties.CACHE_ENABLED,
                               "false",
                               CatalogProperties.WAREHOUSE_LOCATION,
-                              queryParams.get(CatalogProperties.WAREHOUSE_LOCATION) + "warehouse"))
+                              queryParams.get(CatalogProperties.WAREHOUSE_LOCATION) + "warehouse",
+                              OAuth2Properties.OAUTH2_SERVER_URI,
+                              "https://auth.server.com:8080/oauth2/token",
+                              OAuth2Properties.SCOPE,
+                              "custom",
+                              OAuth2Properties.CREDENTIAL,
+                              "custom:secret",
+                              OAuth2Properties.AUDIENCE,
+                              "audience1"))
                       .build());
             }
             return super.get(path, queryParams, responseType, headers, errorHandler);
@@ -300,6 +308,41 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Assertions.assertThat(restCat.properties().get(CatalogProperties.WAREHOUSE_LOCATION))
         .as("Catalog should return final warehouse location")
         .isEqualTo("s3://bucket/warehouse");
+
+    Assertions.assertThat(restCat.properties().get(OAuth2Properties.OAUTH2_SERVER_URI))
+        .as("Catalog should return final oauth2 server uri")
+        .isEqualTo("https://auth.server.com:8080/oauth2/token");
+
+    Assertions.assertThat(restCat.properties().get(OAuth2Properties.SCOPE))
+        .as("Catalog should return final scope")
+        .isEqualTo("custom");
+
+    Assertions.assertThat(restCat.properties().get(OAuth2Properties.CREDENTIAL))
+        .as("Catalog should return final credential")
+        .isEqualTo("custom:secret");
+
+    Assertions.assertThat(restCat.properties().get(OAuth2Properties.AUDIENCE))
+        .as("Catalog should return final audience")
+        .isEqualTo("audience1");
+
+    OAuth2Util.AuthSession authSession = AuthSessionUtil.getCatalogAuthSession(restCat);
+    Assertions.assertThat(authSession).isNotNull();
+
+    Assertions.assertThat(authSession.oauth2ServerUri())
+        .as("Auth session should have the final oauth2 server uri")
+        .isEqualTo("https://auth.server.com:8080/oauth2/token");
+
+    Assertions.assertThat(authSession.scope())
+        .as("Auth session should have the final scope")
+        .isEqualTo("custom");
+
+    Assertions.assertThat(authSession.credential())
+        .as("Auth session should have the final credential")
+        .isEqualTo("custom:secret");
+
+    Assertions.assertThat(authSession.optionalOAuthParams().get(OAuth2Properties.AUDIENCE))
+        .as("Auth session should have the final audience")
+        .isEqualTo("audience1");
 
     restCat.close();
   }

--- a/core/src/test/java/org/apache/iceberg/rest/auth/AuthSessionUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/AuthSessionUtil.java
@@ -18,7 +18,11 @@
  */
 package org.apache.iceberg.rest.auth;
 
+import java.lang.reflect.Field;
+import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.rest.auth.OAuth2Util.AuthSession;
+import org.junit.jupiter.api.Assertions;
 
 /** Helper class to make the token refresh retries configurable for testing */
 public class AuthSessionUtil {
@@ -27,5 +31,18 @@ public class AuthSessionUtil {
 
   public static void setTokenRefreshNumRetries(int retries) {
     AuthSession.setTokenRefreshNumRetries(retries);
+  }
+
+  public static AuthSession getCatalogAuthSession(RESTCatalog catalog) {
+    try {
+      Field scf = catalog.getClass().getDeclaredField("sessionCatalog");
+      scf.setAccessible(true);
+      RESTSessionCatalog sc = (RESTSessionCatalog) scf.get(catalog);
+      Field caf = sc.getClass().getDeclaredField("catalogAuth");
+      caf.setAccessible(true);
+      return (AuthSession) caf.get(sc);
+    } catch (Exception e) {
+      return Assertions.fail("Failed to get AuthSession from RESTCatalog", e);
+    }
   }
 }


### PR DESCRIPTION
As mandated by the spec, in case the config endpoint overrides any auth-specific property, the overridden values should be taken into account when creating the catalog auth session instance.