### PR TITLE
Flink: Backport #10200 to v1.19 and v1.17

### DIFF
--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.deletes.DeleteGranularity;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.RowDataWrapper;
 import org.apache.iceberg.flink.data.RowDataProjection;
@@ -109,7 +110,7 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<RowData> {
 
   protected class RowDataDeltaWriter extends BaseEqualityDeltaWriter {
     RowDataDeltaWriter(PartitionKey partition) {
-      super(partition, schema, deleteSchema);
+      super(partition, schema, deleteSchema, DeleteGranularity.FILE);
     }
 
     @Override

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.deletes.DeleteGranularity;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.RowDataWrapper;
 import org.apache.iceberg.flink.data.RowDataProjection;
@@ -109,7 +110,7 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<RowData> {
 
   protected class RowDataDeltaWriter extends BaseEqualityDeltaWriter {
     RowDataDeltaWriter(PartitionKey partition) {
-      super(partition, schema, deleteSchema);
+      super(partition, schema, deleteSchema, DeleteGranularity.FILE);
     }
 
     @Override


### PR DESCRIPTION
Clean backport of #10200 to Flink v1.19 and v1.17
```
g d 1757577937d0e9c385ace059b8e8f7f1f75d5fc1^ 1757577937d0e9c385ace059b8e8f7f1f75d5fc1|sed "s/v1.18/v1.19/g" | g apply -3 -p1 
g d 1757577937d0e9c385ace059b8e8f7f1f75d5fc1^ 1757577937d0e9c385ace059b8e8f7f1f75d5fc1|sed "s/v1.18/v1.17/g" | g apply -3 -p1 
```