### PR TITLE
Core: Check compatibility of all partition specs when updating schema

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1444,7 +1444,10 @@ public class TableMetadata implements Serializable {
           changes.size());
 
       Schema schema = schemasById.get(currentSchemaId);
-      PartitionSpec.checkCompatibility(specsById.get(defaultSpecId), schema);
+      specsById.forEach(
+          (specId, spec) -> {
+            PartitionSpec.checkCompatibility(spec, schema);
+          });
       SortOrder.checkCompatibility(sortOrdersById.get(defaultSortOrderId), schema);
 
       List<MetadataLogEntry> metadataHistory;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -27,6 +28,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
@@ -538,7 +540,9 @@ public class TestAlterTablePartitionFields extends ExtensionsTestBase {
 
     sql("ALTER TABLE %s REPLACE PARTITION FIELD day_of_ts WITH days(ts)", tableName);
 
-    sql("ALTER TABLE %s DROP COLUMN day_of_ts", tableName);
+    assertThatThrownBy(() -> sql("ALTER TABLE %s DROP COLUMN day_of_ts", tableName))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot find source column for partition field: 1000: day_of_ts: identity(3)");
   }
 
   @TestTemplate
@@ -549,7 +553,9 @@ public class TestAlterTablePartitionFields extends ExtensionsTestBase {
 
     sql("ALTER TABLE %s REPLACE PARTITION FIELD day_of_ts WITH days(ts)", tableName);
 
-    sql("ALTER TABLE %s DROP COLUMN day_of_ts", tableName);
+    assertThatThrownBy(() -> sql("ALTER TABLE %s DROP COLUMN day_of_ts", tableName))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot find source column for partition field: 1000: day_of_ts: identity(3)");
   }
 
   private void assertPartitioningEquals(SparkTable table, int len, String transform) {


### PR DESCRIPTION
This fixes #10234