### PR TITLE
AWS: Fix S3FileIO tests failing on ListObjects for Express buckets

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/AwsIntegTestUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/AwsIntegTestUtil.java
@@ -98,7 +98,7 @@ public class AwsIntegTestUtil {
     while (hasContent) {
       ListObjectsV2Response response =
           s3.listObjectsV2(
-              ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix).build());
+              ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix + "/").build());
       hasContent = response.hasContents();
       if (hasContent) {
         s3.deleteObjects(

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -407,7 +407,7 @@ public class TestS3FileIOIntegration {
             });
 
     long totalFiles = scaleSizes.stream().mapToLong(Integer::longValue).sum();
-    assertThat(s3FileIO.listPrefix(listPrefix)).hasSize((int) totalFiles);
+    assertThat(s3FileIO.listPrefix(listPrefix + "/")).hasSize((int) totalFiles);
   }
 
   @SuppressWarnings("DangerousParallelStreamUsage")


### PR DESCRIPTION
When S3FileIO integration tests were being ran against an S3 Express bucket, they were failing due to a change in Express requiring all ListObjects requests end with a delimiter (`/`). 
I'm avoiding changing `s3FileIO.listPrefix` here in case the previous functionality is required for external integrations.