### PR TITLE
Spark 3.5: Support camel case session configs and options

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkConfParser.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkConfParser.java
@@ -270,12 +270,22 @@ class SparkConfParser {
         if (optionValue != null) {
           return conversion.apply(optionValue);
         }
+
+        String sparkOptionValue = options.get(toCamelCase(optionName));
+        if (sparkOptionValue != null) {
+          return conversion.apply(sparkOptionValue);
+        }
       }
 
       if (sessionConfName != null) {
         String sessionConfValue = sessionConf.get(sessionConfName, null);
         if (sessionConfValue != null) {
           return conversion.apply(sessionConfValue);
+        }
+
+        String sparkSessionConfValue = sessionConf.get(toCamelCase(sessionConfName), null);
+        if (sparkSessionConfValue != null) {
+          return conversion.apply(sparkSessionConfValue);
         }
       }
 
@@ -287,6 +297,24 @@ class SparkConfParser {
       }
 
       return defaultValue;
+    }
+
+    private String toCamelCase(String key) {
+      StringBuilder transformedKey = new StringBuilder();
+      boolean capitalizeNext = false;
+
+      for (char character : key.toCharArray()) {
+        if (character == '-') {
+          capitalizeNext = true;
+        } else if (capitalizeNext) {
+          transformedKey.append(Character.toUpperCase(character));
+          capitalizeNext = false;
+        } else {
+          transformedKey.append(character);
+        }
+      }
+
+      return transformedKey.toString();
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -89,6 +89,32 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void testCamelCaseSparkSessionConf() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    String confName = "spark.sql.iceberg.some-int-conf";
+    String sparkConfName = "spark.sql.iceberg.someIntConf";
+
+    withSQLConf(
+        ImmutableMap.of(sparkConfName, "1"),
+        () -> {
+          SparkConfParser parser = new SparkConfParser(spark, table, ImmutableMap.of());
+          Integer value = parser.intConf().sessionConf(confName).parseOptional();
+          assertThat(value).isEqualTo(1);
+        });
+  }
+
+  @TestTemplate
+  public void testCamelCaseSparkOption() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    String option = "some-int-option";
+    String sparkOption = "someIntOption";
+    Map<String, String> options = ImmutableMap.of(sparkOption, "1");
+    SparkConfParser parser = new SparkConfParser(spark, table, options);
+    Integer value = parser.intConf().option(option).parseOptional();
+    assertThat(value).isEqualTo(1);
+  }
+
+  @TestTemplate
   public void testDurationConf() {
     Table table = validationCatalog.loadTable(tableIdent);
     String confName = "spark.sql.iceberg.some-duration-conf";


### PR DESCRIPTION
This PR adds support for parsing camel case session configs and options. Our keys contain `-` but all built-in Spark configs follow the camel case style. Apart from the inconsistency, setting Iceberg SQL configs requires escaping the keys, which makes it confusing for the users.

The following statement throws an error and requires the user to manually deal with `-`.

```
SET spark.sql.iceberg.planning.preserve-data-grouping = false
```

After this change, users will be able to set SQL properties and options either using `-` or camel case.

```
SET spark.sql.iceberg.planning.preserveDataGrouping = false
SET `spark.sql.iceberg.planning.preserve-data-grouping` = false
```

We already have a precedent for this in `SparkWriteOptions`.

```
public static final String MERGE_SCHEMA = "merge-schema";
public static final String SPARK_MERGE_SCHEMA = "mergeSchema";
```