### PR TITLE
Core: Assume issued_token_type is access_token to fully comply with RFC 6749

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -738,7 +738,7 @@ public class OAuth2Util {
         long startTimeMillis,
         AuthSession parent,
         String credential) {
-      // issued token type is not present in every OAuth2 response:
+      // issued_token_type is required in RFC 8693 but not in RFC 6749, thus assume type is access_token for compatibility with RFC 6749.
       // assume type is access token if none provided.
       // See https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3
       // for an example of a response that does not include the issued token type.

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -738,8 +738,8 @@ public class OAuth2Util {
         long startTimeMillis,
         AuthSession parent,
         String credential) {
-      // issued_token_type is required in RFC 8693 but not in RFC 6749, thus assume type is access_token for compatibility with RFC 6749.
-      // assume type is access token if none provided.
+      // issued_token_type is required in RFC 8693 but not in RFC 6749,
+      // thus assume type is access_token for compatibility with RFC 6749.
       // See https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3
       // for an example of a response that does not include the issued token type.
       String issuedTokenType = response.issuedTokenType();

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -738,13 +738,21 @@ public class OAuth2Util {
         long startTimeMillis,
         AuthSession parent,
         String credential) {
+      // issued token type is not present in every OAuth2 response:
+      // assume type is access token if none provided.
+      // See https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3
+      // for an example of a response that does not include the issued token type.
+      String issuedTokenType = response.issuedTokenType();
+      if (issuedTokenType == null) {
+        issuedTokenType = OAuth2Properties.ACCESS_TOKEN_TYPE;
+      }
       AuthSession session =
           new AuthSession(
               parent.headers(),
               AuthConfig.builder()
                   .from(parent.config())
                   .token(response.token())
-                  .tokenType(response.issuedTokenType())
+                  .tokenType(issuedTokenType)
                   .credential(credential)
                   .build());
 

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -254,7 +254,6 @@ public class RESTCatalogAdapter implements RESTClient {
       case "client_credentials":
         return OAuthTokenResponse.builder()
             .withToken("client-credentials-token:sub=" + request.get("client_id"))
-            .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
             .withTokenType("Bearer")
             .build();
 


### PR DESCRIPTION
The REST client wrongly assumes that the `issued_token_type` field is present in all OAuth responses, but that isn't true: e.g. in the `client_credentials` flow, this field is undefined. See RFC 6749, section 4.4.3:

https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3

This causes the client to crash when creating a tokens exchange request, since the issued token type becomes the request's subject token type, which is mandatory.

This has been verified against a Keycloak 24.0 server.

This change fixes this issue by assuming that the issued token type is an access token, if the response did not specify any token type.

This change also fixes `RESTCatalogAdapter`: it was incorrectly including the `issued_token_type` field in `client_credentials` responses, thus masking many test failures, e.g. in `testCatalogTokenRefresh`.