### PR TITLE
Spark 3.5: Fix the setting of equalAuthorities in RemoveOrphanFilesProcedure

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -128,7 +128,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
               DataTypes.StringType,
               DataTypes.StringType,
               (k, v) -> {
-                equalSchemes.put(k.toString(), v.toString());
+                equalAuthorities.put(k.toString(), v.toString());
                 return BoxedUnit.UNIT;
               });
     }


### PR DESCRIPTION
This PR correct the setting of procedure parameter `equalAuthorities` for `RemoveOrphanFilesProcedure`. Previously it seems to be wrongly set.