### PR TITLE
Support In and notIn operators in ParquetFilters.ConvertFilterToParquet

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -164,6 +164,10 @@ public class Schema implements Serializable {
     this(schemaId, Arrays.asList(columns));
   }
 
+  public Schema(Map<String, Integer> aliases, NestedField... columns) {
+    this(Arrays.asList(columns), aliases);
+  }
+
   private Map<Integer, NestedField> lazyIdToField() {
     if (idToField == null) {
       this.idToField = TypeUtil.indexById(struct);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.parquet;
 
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.Set;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.BoundPredicate;
@@ -143,21 +144,21 @@ class ParquetFilters {
           break;
         case INTEGER:
         case DATE:
-          return pred(op, FilterApi.intColumn(path), getParquetPrimitive(lit), litSet);
+          return pred(op, FilterApi.intColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
         case LONG:
         case TIME:
         case TIMESTAMP:
-          return pred(op, FilterApi.longColumn(path), getParquetPrimitive(lit), litSet);
+          return pred(op, FilterApi.longColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
         case FLOAT:
-          return pred(op, FilterApi.floatColumn(path), getParquetPrimitive(lit), litSet);
+          return pred(op, FilterApi.floatColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
         case DOUBLE:
-          return pred(op, FilterApi.doubleColumn(path), getParquetPrimitive(lit), litSet);
+          return pred(op, FilterApi.doubleColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
         case STRING:
         case UUID:
         case FIXED:
         case BINARY:
         case DECIMAL:
-          return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit), litSet);
+          return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
       }
 
       throw new UnsupportedOperationException("Cannot convert to Parquet filter: " + pred);

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
@@ -57,13 +57,12 @@ public class TestParquetFilters {
 
   @TestTemplate
   public void testIntegerInFilter() {
-    Object abc = ParquetFilters.convert(SCHEMA, in("id", 1, 2, 3), true);
-    FilterCompat.Filter bcf = (FilterCompat.Filter) abc;
+    FilterCompat.Filter filter = (FilterCompat.Filter)  ParquetFilters.convert(SCHEMA, in("id", 1, 2, 3), true);
 
     try {
-      java.lang.reflect.Field privateField = bcf.getClass().getDeclaredField("filterPredicate");
+      java.lang.reflect.Field privateField = filter.getClass().getDeclaredField("filterPredicate");
       privateField.setAccessible(true);
-      assertThat(privateField.get(bcf).toString().equalsIgnoreCase("in(id, 1, 2, 3)")).isTrue();
+      assertThat(privateField.get(filter).toString().equalsIgnoreCase("in(id, 1, 2, 3)")).isTrue();
     } catch (Exception e) {
       assertThat(true).isFalse();
     }
@@ -71,13 +70,12 @@ public class TestParquetFilters {
 
   @TestTemplate
   public void testDoubleNotInFilter() {
-    Object abc = ParquetFilters.convert(SCHEMA, notIn("age", 1.0, 2.0, 3.0), true);
-    FilterCompat.Filter bcf = (FilterCompat.Filter) abc;
+    FilterCompat.Filter filter = (FilterCompat.Filter)  ParquetFilters.convert(SCHEMA, notIn("age", 1.0, 2.0, 3.0), true);
 
     try {
-      java.lang.reflect.Field privateField = bcf.getClass().getDeclaredField("filterPredicate");
+      java.lang.reflect.Field privateField = filter.getClass().getDeclaredField("filterPredicate");
       privateField.setAccessible(true);
-      assertThat(privateField.get(bcf).toString().equalsIgnoreCase("notin(age, 1.0, 2.0, 3.0)"))
+      assertThat(privateField.get(filter).toString().equalsIgnoreCase("notin(age, 1.0, 2.0, 3.0)"))
           .isTrue();
     } catch (Exception e) {
       assertThat(true).isFalse();

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.apache.iceberg.expressions.Expressions.in;
+import static org.apache.iceberg.expressions.Expressions.notIn;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types.DoubleType;
+import org.apache.iceberg.types.Types.IntegerType;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestParquetFilters {
+
+  private static final java.util.Map<String, Integer> aliases =
+      new java.util.HashMap<String, Integer>() {
+        {
+          put("id", 1);
+          put("age", 2);
+        }
+      };
+
+  private static final Schema SCHEMA =
+      new Schema(
+          aliases, required(1, "id", IntegerType.get()), required(2, "age", DoubleType.get()));
+
+  @Parameters(name = "writerVersion={0}")
+  public static Collection<WriterVersion> parameters() {
+    return Arrays.asList(WriterVersion.PARQUET_1_0, WriterVersion.PARQUET_2_0);
+  }
+
+  @TestTemplate
+  public void testIntegerInFilter() {
+    Object abc = ParquetFilters.convert(SCHEMA, in("id", 1, 2, 3), true);
+    FilterCompat.Filter bcf = (FilterCompat.Filter) abc;
+
+    try {
+      java.lang.reflect.Field privateField = bcf.getClass().getDeclaredField("filterPredicate");
+      privateField.setAccessible(true);
+      assertThat(privateField.get(bcf).toString().equalsIgnoreCase("in(id, 1, 2, 3)")).isTrue();
+    } catch (Exception e) {
+      assertThat(true).isFalse();
+    }
+  }
+
+  @TestTemplate
+  public void testDoubleNotInFilter() {
+    Object abc = ParquetFilters.convert(SCHEMA, notIn("age", 1.0, 2.0, 3.0), true);
+    FilterCompat.Filter bcf = (FilterCompat.Filter) abc;
+
+    try {
+      java.lang.reflect.Field privateField = bcf.getClass().getDeclaredField("filterPredicate");
+      privateField.setAccessible(true);
+      assertThat(privateField.get(bcf).toString().equalsIgnoreCase("notin(age, 1.0, 2.0, 3.0)"))
+          .isTrue();
+    } catch (Exception e) {
+      assertThat(true).isFalse();
+    }
+  }
+}

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
@@ -57,7 +57,8 @@ public class TestParquetFilters {
 
   @TestTemplate
   public void testIntegerInFilter() {
-    FilterCompat.Filter filter = (FilterCompat.Filter)  ParquetFilters.convert(SCHEMA, in("id", 1, 2, 3), true);
+    FilterCompat.Filter filter =
+        (FilterCompat.Filter) ParquetFilters.convert(SCHEMA, in("id", 1, 2, 3), true);
 
     try {
       java.lang.reflect.Field privateField = filter.getClass().getDeclaredField("filterPredicate");
@@ -70,7 +71,8 @@ public class TestParquetFilters {
 
   @TestTemplate
   public void testDoubleNotInFilter() {
-    FilterCompat.Filter filter = (FilterCompat.Filter)  ParquetFilters.convert(SCHEMA, notIn("age", 1.0, 2.0, 3.0), true);
+    FilterCompat.Filter filter =
+        (FilterCompat.Filter) ParquetFilters.convert(SCHEMA, notIn("age", 1.0, 2.0, 3.0), true);
 
     try {
       java.lang.reflect.Field privateField = filter.getClass().getDeclaredField("filterPredicate");


### PR DESCRIPTION
ParquetFilters.ConvertFilterToParquet performs conversion from an Iceberg filter (Expression) to a Parquet FilterPredicate. It currently only handles IS_NULL, NOT_NULL, IS_NAN, NOT_NAN, EQ, NOT_EQ, GT, GT_EQ, LT, LT_EQ. It does not handle, e.g., IN and NOT_IN, which would be useful to have.

This conversion can be used for setting a record filter in Parquet and then using that to filter row groups when reading Parquet files.