### PR TITLE
Docs: update Apache Doris  dead links

### DIFF
--- a/1.4.0/mkdocs.yml
+++ b/1.4.0/mkdocs.yml
@@ -57,7 +57,7 @@ nav:
   - Amazon Athena: https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html
   - Amazon EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
-  - Doris: https://doris.apache.org/docs/dev/lakehouse/multi-catalog/iceberg
+  - Doris: https://doris.apache.org/docs/lakehouse/datalake-analytics/iceberg
   - Integrations:
     - aws.md
     - dell.md

--- a/1.4.0/mkdocs.yml
+++ b/1.4.0/mkdocs.yml
@@ -57,7 +57,7 @@ nav:
   - Amazon Athena: https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html
   - Amazon EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
-  - Doris: https://doris.apache.org/docs/lakehouse/datalake-analytics/iceberg
+  - Doris: https://doris.apache.org/docs/dev/lakehouse/datalake-analytics/iceberg
   - Integrations:
     - aws.md
     - dell.md

--- a/1.4.1/mkdocs.yml
+++ b/1.4.1/mkdocs.yml
@@ -57,7 +57,7 @@ nav:
   - Amazon Athena: https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html
   - Amazon EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
-  - Doris: https://doris.apache.org/docs/dev/lakehouse/multi-catalog/iceberg
+  - Doris: https://doris.apache.org/docs/lakehouse/datalake-analytics/iceberg
   - Integrations:
     - aws.md
     - dell.md

--- a/1.4.1/mkdocs.yml
+++ b/1.4.1/mkdocs.yml
@@ -57,7 +57,7 @@ nav:
   - Amazon Athena: https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html
   - Amazon EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
-  - Doris: https://doris.apache.org/docs/lakehouse/datalake-analytics/iceberg
+  - Doris: https://doris.apache.org/docs/dev/lakehouse/datalake-analytics/iceberg
   - Integrations:
     - aws.md
     - dell.md

--- a/1.4.2/mkdocs.yml
+++ b/1.4.2/mkdocs.yml
@@ -57,7 +57,7 @@ nav:
   - Amazon Athena: https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html
   - Amazon EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
-  - Doris: https://doris.apache.org/docs/dev/lakehouse/multi-catalog/iceberg
+  - Doris: https://doris.apache.org/docs/dev/lakehouse/datalake-analytics/iceberg
   - Integrations:
     - aws.md
     - dell.md

--- a/1.4.3/mkdocs.yml
+++ b/1.4.3/mkdocs.yml
@@ -57,7 +57,7 @@ nav:
   - Amazon Athena: https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html
   - Amazon EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
-  - Doris: https://doris.apache.org/docs/dev/lakehouse/multi-catalog/iceberg
+  - Doris: https://doris.apache.org/docs/dev/lakehouse/datalake-analytics/iceberg
   - Integrations:
     - aws.md
     - dell.md

--- a/1.5.0/mkdocs.yml
+++ b/1.5.0/mkdocs.yml
@@ -59,7 +59,7 @@ nav:
   - Amazon EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
   - Snowflake: https://docs.snowflake.com/en/user-guide/tables-iceberg
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
-  - Doris: https://doris.apache.org/docs/dev/lakehouse/multi-catalog/iceberg
+  - Doris: https://doris.apache.org/docs/dev/lakehouse/datalake-analytics/iceberg
   - Integrations:
     - aws.md
     - dell.md

--- a/1.5.1/mkdocs.yml
+++ b/1.5.1/mkdocs.yml
@@ -59,7 +59,7 @@ nav:
   - Amazon EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
   - Snowflake: https://docs.snowflake.com/en/user-guide/tables-iceberg
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
-  - Doris: https://doris.apache.org/docs/dev/lakehouse/multi-catalog/iceberg
+  - Doris: https://doris.apache.org/docs/dev/lakehouse/datalake-analytics/iceberg
   - Integrations:
     - aws.md
     - dell.md

--- a/1.5.2/mkdocs.yml
+++ b/1.5.2/mkdocs.yml
@@ -59,7 +59,7 @@ nav:
   - Amazon EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
   - Snowflake: https://docs.snowflake.com/en/user-guide/tables-iceberg
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
-  - Doris: https://doris.apache.org/docs/dev/lakehouse/multi-catalog/iceberg
+  - Doris: https://doris.apache.org/docs/dev/lakehouse/datalake-analytics/iceberg
   - Integrations:
     - aws.md
     - dell.md


### PR DESCRIPTION
"dev" refers to the documentation for the master branch of Apache Doris.