### PR TITLE
Core, Spark 3.4: Remove redundant output in tests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/metrics/TestCommitMetricsResultParser.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestCommitMetricsResultParser.java
@@ -231,7 +231,6 @@ public class TestCommitMetricsResultParser {
     String expectedJson = "{ }";
 
     String json = CommitMetricsResultParser.toJson(commitMetricsResult, true);
-    System.out.println(json);
     assertThat(json).isEqualTo(expectedJson);
     assertThat(CommitMetricsResultParser.fromJson(json))
         .isEqualTo(ImmutableCommitMetricsResult.builder().build());

--- a/core/src/test/java/org/apache/iceberg/metrics/TestScanMetricsResultParser.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestScanMetricsResultParser.java
@@ -324,7 +324,6 @@ public class TestScanMetricsResultParser {
     String expectedJson = "{ }";
 
     String json = ScanMetricsResultParser.toJson(scanMetricsResult, true);
-    System.out.println(json);
     Assertions.assertThat(json).isEqualTo(expectedJson);
     Assertions.assertThat(ScanMetricsResultParser.fromJson(json))
         .isEqualTo(ImmutableScanMetricsResult.builder().build());

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSystemFunctionPushDownInRowLevelOperations.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSystemFunctionPushDownInRowLevelOperations.java
@@ -317,8 +317,6 @@ public class TestSystemFunctionPushDownInRowLevelOperations extends SparkExtensi
   private List<Expression> executeAndCollectFunctionCalls(String query, Object... args) {
     CommandResultExec command = (CommandResultExec) executeAndKeepPlan(query, args);
     V2TableWriteExec write = (V2TableWriteExec) command.commandPhysicalPlan();
-    System.out.println("!!! WRITE PLAN !!!");
-    System.out.println(write.toString());
     return SparkPlanUtil.collectExprs(
         write.query(),
         expr -> expr instanceof StaticInvoke || expr instanceof ApplyFunctionExpression);


### PR DESCRIPTION
This PR removes redundant output in tests.