### PR TITLE
Spark: Coerce shorts and bytes into ints in Parquet Writer

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
@@ -49,9 +49,11 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -267,7 +269,7 @@ public class SparkParquetWriters {
         case BOOLEAN:
           return ParquetValueWriters.booleans(desc);
         case INT32:
-          return ParquetValueWriters.ints(desc);
+          return ints(sType, desc);
         case INT64:
           return ParquetValueWriters.longs(desc);
         case FLOAT:
@@ -278,6 +280,15 @@ public class SparkParquetWriters {
           throw new UnsupportedOperationException("Unsupported type: " + primitive);
       }
     }
+  }
+
+  private static PrimitiveWriter<?> ints(DataType type, ColumnDescriptor desc) {
+    if (type instanceof ByteType) {
+      return ParquetValueWriters.tinyints(desc);
+    } else if (type instanceof ShortType) {
+      return ParquetValueWriters.shorts(desc);
+    }
+    return ParquetValueWriters.ints(desc);
   }
 
   private static PrimitiveWriter<UTF8String> utf8Strings(ColumnDescriptor desc) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
@@ -1,24 +1,21 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg.spark.source;
 
 import org.apache.iceberg.FileFormat;

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
@@ -30,40 +30,40 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class TestDataFrameWriterV2Coercion extends SparkTestBaseWithCatalog {
 
-    private final FileFormat format;
-    private final String dataType;
+  private final FileFormat format;
+  private final String dataType;
 
-    public TestDataFrameWriterV2Coercion(FileFormat format, String dataType) {
-        this.format = format;
-        this.dataType = dataType;
-    }
+  public TestDataFrameWriterV2Coercion(FileFormat format, String dataType) {
+    this.format = format;
+    this.dataType = dataType;
+  }
 
-    @Parameterized.Parameters(name = "format = {0}, dataType = {1}")
-    public static Object[][] parameters() {
-        return new Object[][] {
-                new Object[] {FileFormat.AVRO, "byte"},
-                new Object[] {FileFormat.ORC, "byte"},
-                new Object[] {FileFormat.PARQUET, "byte"},
-                new Object[] {FileFormat.AVRO, "short"},
-                new Object[] {FileFormat.ORC, "short"},
-                new Object[] {FileFormat.PARQUET, "short"}
-        };
-    }
+  @Parameterized.Parameters(name = "format = {0}, dataType = {1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      new Object[] {FileFormat.AVRO, "byte"},
+      new Object[] {FileFormat.ORC, "byte"},
+      new Object[] {FileFormat.PARQUET, "byte"},
+      new Object[] {FileFormat.AVRO, "short"},
+      new Object[] {FileFormat.ORC, "short"},
+      new Object[] {FileFormat.PARQUET, "short"}
+    };
+  }
 
-    @Test
-    public void testByteAndShortCoercion() {
+  @Test
+  public void testByteAndShortCoercion() {
 
-        Dataset<Row> df =
-                jsonToDF(
-                        "id " + dataType + ", data string",
-                        "{ \"id\": 1, \"data\": \"a\" }",
-                        "{ \"id\": 2, \"data\": \"b\" }");
+    Dataset<Row> df =
+        jsonToDF(
+            "id " + dataType + ", data string",
+            "{ \"id\": 1, \"data\": \"a\" }",
+            "{ \"id\": 2, \"data\": \"b\" }");
 
-        df.writeTo(tableName).option("write-format", format.name()).createOrReplace();
+    df.writeTo(tableName).option("write-format", format.name()).createOrReplace();
 
-        assertEquals(
-                "Should have initial 2-column rows",
-                ImmutableList.of(row(1, "a"), row(2, "b")),
-                sql("select * from %s order by id", tableName));
-    }
+    assertEquals(
+        "Should have initial 2-column rows",
+        ImmutableList.of(row(1, "a"), row(2, "b")),
+        sql("select * from %s order by id", tableName));
+  }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestDataFrameWriterV2Coercion extends SparkTestBaseWithCatalog {
+
+    private final FileFormat format;
+    private final String dataType;
+
+    public TestDataFrameWriterV2Coercion(FileFormat format, String dataType) {
+        this.format = format;
+        this.dataType = dataType;
+    }
+
+    @Parameterized.Parameters(name = "format = {0}, dataType = {1}")
+    public static Object[][] parameters() {
+        return new Object[][] {
+                new Object[] {FileFormat.AVRO, "byte"},
+                new Object[] {FileFormat.ORC, "byte"},
+                new Object[] {FileFormat.PARQUET, "byte"},
+                new Object[] {FileFormat.AVRO, "short"},
+                new Object[] {FileFormat.ORC, "short"},
+                new Object[] {FileFormat.PARQUET, "short"}
+        };
+    }
+
+    @Test
+    public void testByteAndShortCoercion() {
+
+        Dataset<Row> df =
+                jsonToDF(
+                        "id " + dataType + ", data string",
+                        "{ \"id\": 1, \"data\": \"a\" }",
+                        "{ \"id\": 2, \"data\": \"b\" }");
+
+        df.writeTo(tableName).option("write-format", format.name()).createOrReplace();
+
+        assertEquals(
+                "Should have initial 2-column rows",
+                ImmutableList.of(row(1, "a"), row(2, "b")),
+                sql("select * from %s order by id", tableName));
+    }
+}

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
@@ -49,9 +49,11 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -267,7 +269,7 @@ public class SparkParquetWriters {
         case BOOLEAN:
           return ParquetValueWriters.booleans(desc);
         case INT32:
-          return ParquetValueWriters.ints(desc);
+          return ints(sType, desc);
         case INT64:
           return ParquetValueWriters.longs(desc);
         case FLOAT:
@@ -278,6 +280,15 @@ public class SparkParquetWriters {
           throw new UnsupportedOperationException("Unsupported type: " + primitive);
       }
     }
+  }
+
+  private static PrimitiveWriter<?> ints(DataType type, ColumnDescriptor desc) {
+    if (type instanceof ByteType) {
+      return ParquetValueWriters.tinyints(desc);
+    } else if (type instanceof ShortType) {
+      return ParquetValueWriters.shorts(desc);
+    }
+    return ParquetValueWriters.ints(desc);
   }
 
   private static PrimitiveWriter<UTF8String> utf8Strings(ColumnDescriptor desc) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
@@ -1,24 +1,21 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg.spark.source;
 
 import org.apache.iceberg.FileFormat;

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
@@ -30,40 +30,40 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class TestDataFrameWriterV2Coercion extends SparkTestBaseWithCatalog {
 
-    private final FileFormat format;
-    private final String dataType;
+  private final FileFormat format;
+  private final String dataType;
 
-    public TestDataFrameWriterV2Coercion(FileFormat format, String dataType) {
-        this.format = format;
-        this.dataType = dataType;
-    }
+  public TestDataFrameWriterV2Coercion(FileFormat format, String dataType) {
+    this.format = format;
+    this.dataType = dataType;
+  }
 
-    @Parameterized.Parameters(name = "format = {0}, dataType = {1}")
-    public static Object[][] parameters() {
-        return new Object[][] {
-                new Object[] {FileFormat.AVRO, "byte"},
-                new Object[] {FileFormat.ORC, "byte"},
-                new Object[] {FileFormat.PARQUET, "byte"},
-                new Object[] {FileFormat.AVRO, "short"},
-                new Object[] {FileFormat.ORC, "short"},
-                new Object[] {FileFormat.PARQUET, "short"}
-        };
-    }
+  @Parameterized.Parameters(name = "format = {0}, dataType = {1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      new Object[] {FileFormat.AVRO, "byte"},
+      new Object[] {FileFormat.ORC, "byte"},
+      new Object[] {FileFormat.PARQUET, "byte"},
+      new Object[] {FileFormat.AVRO, "short"},
+      new Object[] {FileFormat.ORC, "short"},
+      new Object[] {FileFormat.PARQUET, "short"}
+    };
+  }
 
-    @Test
-    public void testByteAndShortCoercion() {
+  @Test
+  public void testByteAndShortCoercion() {
 
-        Dataset<Row> df =
-                jsonToDF(
-                        "id " + dataType + ", data string",
-                        "{ \"id\": 1, \"data\": \"a\" }",
-                        "{ \"id\": 2, \"data\": \"b\" }");
+    Dataset<Row> df =
+        jsonToDF(
+            "id " + dataType + ", data string",
+            "{ \"id\": 1, \"data\": \"a\" }",
+            "{ \"id\": 2, \"data\": \"b\" }");
 
-        df.writeTo(tableName).option("write-format", format.name()).createOrReplace();
+    df.writeTo(tableName).option("write-format", format.name()).createOrReplace();
 
-        assertEquals(
-                "Should have initial 2-column rows",
-                ImmutableList.of(row(1, "a"), row(2, "b")),
-                sql("select * from %s order by id", tableName));
-    }
+    assertEquals(
+        "Should have initial 2-column rows",
+        ImmutableList.of(row(1, "a"), row(2, "b")),
+        sql("select * from %s order by id", tableName));
+  }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestDataFrameWriterV2Coercion extends SparkTestBaseWithCatalog {
+
+    private final FileFormat format;
+    private final String dataType;
+
+    public TestDataFrameWriterV2Coercion(FileFormat format, String dataType) {
+        this.format = format;
+        this.dataType = dataType;
+    }
+
+    @Parameterized.Parameters(name = "format = {0}, dataType = {1}")
+    public static Object[][] parameters() {
+        return new Object[][] {
+                new Object[] {FileFormat.AVRO, "byte"},
+                new Object[] {FileFormat.ORC, "byte"},
+                new Object[] {FileFormat.PARQUET, "byte"},
+                new Object[] {FileFormat.AVRO, "short"},
+                new Object[] {FileFormat.ORC, "short"},
+                new Object[] {FileFormat.PARQUET, "short"}
+        };
+    }
+
+    @Test
+    public void testByteAndShortCoercion() {
+
+        Dataset<Row> df =
+                jsonToDF(
+                        "id " + dataType + ", data string",
+                        "{ \"id\": 1, \"data\": \"a\" }",
+                        "{ \"id\": 2, \"data\": \"b\" }");
+
+        df.writeTo(tableName).option("write-format", format.name()).createOrReplace();
+
+        assertEquals(
+                "Should have initial 2-column rows",
+                ImmutableList.of(row(1, "a"), row(2, "b")),
+                sql("select * from %s order by id", tableName));
+    }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
@@ -49,9 +49,11 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -266,7 +268,7 @@ public class SparkParquetWriters {
         case BOOLEAN:
           return ParquetValueWriters.booleans(desc);
         case INT32:
-          return ParquetValueWriters.ints(desc);
+          return ints(sType, desc);
         case INT64:
           return ParquetValueWriters.longs(desc);
         case FLOAT:
@@ -277,6 +279,15 @@ public class SparkParquetWriters {
           throw new UnsupportedOperationException("Unsupported type: " + primitive);
       }
     }
+  }
+
+  private static PrimitiveWriter<?> ints(DataType type, ColumnDescriptor desc) {
+    if (type instanceof ByteType) {
+      return ParquetValueWriters.tinyints(desc);
+    } else if (type instanceof ShortType) {
+      return ParquetValueWriters.shorts(desc);
+    }
+    return ParquetValueWriters.ints(desc);
   }
 
   private static PrimitiveWriter<UTF8String> utf8Strings(ColumnDescriptor desc) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
@@ -1,24 +1,21 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg.spark.source;
 
 import org.apache.iceberg.FileFormat;
@@ -36,48 +33,49 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestDataFrameWriterV2Coercion extends TestBaseWithCatalog {
 
-    @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, format = {3}, dataType = {4}")
-    public static Object[][] parameters() {
-        return new Object[][] {
-                parameter(FileFormat.AVRO, "byte"),
-                parameter(FileFormat.ORC, "byte"),
-                parameter(FileFormat.PARQUET, "byte"),
-                parameter(FileFormat.AVRO, "short"),
-                parameter(FileFormat.ORC, "short"),
-                parameter(FileFormat.PARQUET, "short")
-        };
-    }
+  @Parameters(
+      name = "catalogName = {0}, implementation = {1}, config = {2}, format = {3}, dataType = {4}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      parameter(FileFormat.AVRO, "byte"),
+      parameter(FileFormat.ORC, "byte"),
+      parameter(FileFormat.PARQUET, "byte"),
+      parameter(FileFormat.AVRO, "short"),
+      parameter(FileFormat.ORC, "short"),
+      parameter(FileFormat.PARQUET, "short")
+    };
+  }
 
-    private static Object[] parameter(FileFormat fileFormat, String dataType) {
-        return new Object[] {
-                SparkCatalogConfig.HADOOP.catalogName(),
-                SparkCatalogConfig.HADOOP.implementation(),
-                SparkCatalogConfig.HADOOP.properties(),
-                fileFormat,
-                dataType
-        };
-    }
+  private static Object[] parameter(FileFormat fileFormat, String dataType) {
+    return new Object[] {
+      SparkCatalogConfig.HADOOP.catalogName(),
+      SparkCatalogConfig.HADOOP.implementation(),
+      SparkCatalogConfig.HADOOP.properties(),
+      fileFormat,
+      dataType
+    };
+  }
 
-    @Parameter(index = 3)
-    private FileFormat format;
+  @Parameter(index = 3)
+  private FileFormat format;
 
-    @Parameter(index = 4)
-    private String dataType;
+  @Parameter(index = 4)
+  private String dataType;
 
-    @TestTemplate
-    public void testByteAndShortCoercion() {
+  @TestTemplate
+  public void testByteAndShortCoercion() {
 
-        Dataset<Row> df =
-                jsonToDF(
-                        "id " + dataType + ", data string",
-                        "{ \"id\": 1, \"data\": \"a\" }",
-                        "{ \"id\": 2, \"data\": \"b\" }");
+    Dataset<Row> df =
+        jsonToDF(
+            "id " + dataType + ", data string",
+            "{ \"id\": 1, \"data\": \"a\" }",
+            "{ \"id\": 2, \"data\": \"b\" }");
 
-        df.writeTo(tableName).option("write-format", format.name()).createOrReplace();
+    df.writeTo(tableName).option("write-format", format.name()).createOrReplace();
 
-        assertEquals(
-                "Should have initial 2-column rows",
-                ImmutableList.of(row(1, "a"), row(2, "b")),
-                sql("select * from %s order by id", tableName));
-    }
+    assertEquals(
+        "Should have initial 2-column rows",
+        ImmutableList.of(row(1, "a"), row(2, "b")),
+        sql("select * from %s order by id", tableName));
+  }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2Coercion.java
@@ -1,0 +1,83 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestDataFrameWriterV2Coercion extends TestBaseWithCatalog {
+
+    @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, format = {3}, dataType = {4}")
+    public static Object[][] parameters() {
+        return new Object[][] {
+                parameter(FileFormat.AVRO, "byte"),
+                parameter(FileFormat.ORC, "byte"),
+                parameter(FileFormat.PARQUET, "byte"),
+                parameter(FileFormat.AVRO, "short"),
+                parameter(FileFormat.ORC, "short"),
+                parameter(FileFormat.PARQUET, "short")
+        };
+    }
+
+    private static Object[] parameter(FileFormat fileFormat, String dataType) {
+        return new Object[] {
+                SparkCatalogConfig.HADOOP.catalogName(),
+                SparkCatalogConfig.HADOOP.implementation(),
+                SparkCatalogConfig.HADOOP.properties(),
+                fileFormat,
+                dataType
+        };
+    }
+
+    @Parameter(index = 3)
+    private FileFormat format;
+
+    @Parameter(index = 4)
+    private String dataType;
+
+    @TestTemplate
+    public void testByteAndShortCoercion() {
+
+        Dataset<Row> df =
+                jsonToDF(
+                        "id " + dataType + ", data string",
+                        "{ \"id\": 1, \"data\": \"a\" }",
+                        "{ \"id\": 2, \"data\": \"b\" }");
+
+        df.writeTo(tableName).option("write-format", format.name()).createOrReplace();
+
+        assertEquals(
+                "Should have initial 2-column rows",
+                ImmutableList.of(row(1, "a"), row(2, "b")),
+                sql("select * from %s order by id", tableName));
+    }
+}


### PR DESCRIPTION
Fixes #10225 

#9440 refactored the Spark Parquet writer to move to a visitor pattern. During this move, it [removed some code](https://github.com/apache/iceberg/blame/9f979a1ff187ebd69ef3b027d857ee697fd9c52c/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java#L204-L211) required for coercion from bytes/shorts to int. This PR adds back the coercion code along with unit tests validating the change.

Note that even without coercion code, the tests succeed in Spark 3.5 but not in 3.3 and 3.4. It succeeds in 3.5 due to https://github.com/apache/spark/pull/40734 which routes CTAS/RTAS through `AppendData`, in which case Spark adds its own projection to handle coercion [here](https://github.com/apache/spark/blob/1a454287c01eb2ddda3e11afcc8c4885abc095b2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala#L3386).

So the change is not strictly necessary for Spark 3.5 but I add it anyway to:
1. keep the code consistent between 3.3/3.4/3.5
2. future proofing in case Spark removes the auto-coercion at some point