### PR TITLE
Core: Replace deprecated Roaring64Bitmap#add call with addRange

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -38,7 +38,7 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
 
   @Override
   public void delete(long posStart, long posEnd) {
-    roaring64Bitmap.add(posStart, posEnd);
+    roaring64Bitmap.addRange(posStart, posEnd);
   }
 
   @Override


### PR DESCRIPTION
I was going through our delete file indexing logic, and noticed Roaring64BitMap#add(start, end) is deprecated in favor of addRange, so this change just addresses that.