### PR TITLE
Spec: Add context query parameter for all REST APIs

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -63,6 +63,8 @@ security:
 
 paths:
   /v1/config:
+    parameters:
+      - $ref: '#/components/parameters/context'
 
     get:
       tags:
@@ -130,6 +132,8 @@ paths:
           $ref: '#/components/responses/ServerErrorResponse'
 
   /v1/oauth/tokens:
+    parameters:
+      - $ref: '#/components/parameters/context'
 
     post:
       tags:
@@ -188,6 +192,7 @@ paths:
   /v1/{prefix}/namespaces:
     parameters:
       - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/context'
 
     get:
       tags:
@@ -285,6 +290,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/context'
 
     get:
       tags:
@@ -383,6 +389,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/context'
 
     post:
       tags:
@@ -446,6 +453,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/context'
 
     get:
       tags:
@@ -545,6 +553,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/context'
 
     post:
       tags:
@@ -599,6 +608,7 @@ paths:
       - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
       - $ref: '#/components/parameters/table'
+      - $ref: '#/components/parameters/context'
 
     get:
       tags:
@@ -853,6 +863,7 @@ paths:
   /v1/{prefix}/tables/rename:
     parameters:
       - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/context'
 
     post:
       tags:
@@ -917,6 +928,7 @@ paths:
       - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
       - $ref: '#/components/parameters/table'
+      - $ref: '#/components/parameters/context'
 
     post:
       tags:
@@ -959,6 +971,7 @@ paths:
   /v1/{prefix}/transactions/commit:
     parameters:
       - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/context'
 
     post:
       tags:
@@ -1074,6 +1087,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/context'
 
     get:
       tags:
@@ -1161,6 +1175,7 @@ paths:
       - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
       - $ref: '#/components/parameters/view'
+      - $ref: '#/components/parameters/context'
 
     get:
       tags:
@@ -1366,6 +1381,7 @@ paths:
   /v1/{prefix}/views/rename:
     parameters:
       - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/context'
 
     post:
       tags:
@@ -1516,6 +1532,20 @@ components:
       schema:
         type: integer
         minimum: 1
+
+    context:
+      name: context
+      in: query
+      description:
+        A free-form key value map to provide engine or catalog-specific information for a request.
+        The information is serialized in unexploded form format in OpenAPI specification, for example
+        `GET /tables/t1?context=engine,spark,access,read` describes the context `{engine=spark,access=read}`.
+      required: false
+      explode: false
+      schema:
+        type: object
+        additionalProperties:
+          type: string
 
   ##############################
   # Application Schema Objects #


### PR DESCRIPTION
This PR proposes adding a `context` query parameter for all requests.

This was briefly described as something desirable in https://docs.google.com/document/d/14nmuxxfzQsYo59o0Fbpb-pxOlzS6bVtduL8P8pwKZ6U.

I later realized that the feature has other important use cases:
1. **view execution role switch**: a view might be accessed through a different role from the original user, and engine needs to get this information through LoadView, and then pass in this role-related context to access LoadTable.
2. **pass in access intentions**: we want our engine to pass in some flags to change API response. For example, if engine pass in a flag READ_ONLY, the vended credentials will only has read access even if the user has full access. This avoids users to unintentionally distribute full access credentials.

We want to add contexts for the related catalog level APIs like LoadTable, LoadView, etc. to pass in this information

Curious if this is something others also see beneficial to add.

@rdblue @danielcweeks @jbonofre @RussellSpitzer 