### PR TITLE
REST: convert RESTException to CommitStateUnknownException to avoid incorrect cleanup of metadata files due to network error

### DIFF
--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
@@ -18,22 +18,29 @@
  */
 package org.apache.iceberg.inmemory;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.Pair;
 
-public class InMemoryFileIO implements FileIO {
+public class InMemoryFileIO implements FileIO, SupportsPrefixOperations {
 
-  private static final Map<String, byte[]> IN_MEMORY_FILES = Maps.newConcurrentMap();
+  private static final Map<String, Pair<FileInfo, byte[]>> IN_MEMORY_FILES =
+      Maps.newConcurrentMap();
   private boolean closed = false;
 
   public void addFile(String location, byte[] contents) {
     Preconditions.checkState(!closed, "Cannot call addFile after calling close()");
-    IN_MEMORY_FILES.put(location, contents);
+    FileInfo fileInfo = new FileInfo(location, contents.length, System.currentTimeMillis());
+    IN_MEMORY_FILES.put(location, Pair.of(fileInfo, contents));
   }
 
   public boolean fileExists(String location) {
@@ -43,11 +50,11 @@ public class InMemoryFileIO implements FileIO {
   @Override
   public InputFile newInputFile(String location) {
     Preconditions.checkState(!closed, "Cannot call newInputFile after calling close()");
-    byte[] contents = IN_MEMORY_FILES.get(location);
-    if (null == contents) {
+    Pair<FileInfo, byte[]> file = IN_MEMORY_FILES.get(location);
+    if (null == file) {
       throw new NotFoundException("No in-memory file found for location: %s", location);
     }
-    return new InMemoryInputFile(location, contents);
+    return new InMemoryInputFile(location, file.second());
   }
 
   @Override
@@ -71,5 +78,24 @@ public class InMemoryFileIO implements FileIO {
   @Override
   public void close() {
     closed = true;
+  }
+
+  @Override
+  public Iterable<FileInfo> listPrefix(String prefix) {
+    return IN_MEMORY_FILES.entrySet().stream()
+        .filter(entry -> entry.getKey().startsWith(prefix))
+        .map(entry -> entry.getValue().first())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void deletePrefix(String prefix) {
+    List<String> matchedFiles =
+        IN_MEMORY_FILES.keySet().stream()
+            .filter(key -> key.startsWith(prefix))
+            .collect(Collectors.toList());
+    for (String toDelete : matchedFiles) {
+      IN_MEMORY_FILES.remove(toDelete);
+    }
   }
 }


### PR DESCRIPTION
Otherwise, network I/O exception can lead to incorrect cleanup of metadata files (like snapshot) when the commit on the REST server side completed successfully.