### PR TITLE
Core: Fix create v1 table on REST Catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -986,7 +986,7 @@ public class TableMetadata implements Serializable {
 
     // it is only safe to set the format version directly while creating tables
     // in all other cases, use upgradeFormatVersion
-    private Builder setInitialFormatVersion(int newFormatVersion) {
+    public Builder setInitialFormatVersion(int newFormatVersion) {
       Preconditions.checkArgument(
           newFormatVersion <= SUPPORTED_TABLE_FORMAT_VERSION,
           "Unsupported format version: v%s (supported: v%s)",

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -853,7 +853,11 @@ public class TableMetadata implements Serializable {
   }
 
   public static Builder buildFromEmpty() {
-    return new Builder();
+    return new Builder(DEFAULT_TABLE_FORMAT_VERSION);
+  }
+
+  public static Builder buildFromEmpty(int formatVersion) {
+    return new Builder(formatVersion);
   }
 
   public static class Builder {
@@ -903,8 +907,12 @@ public class TableMetadata implements Serializable {
     private final Map<Integer, SortOrder> sortOrdersById;
 
     private Builder() {
+      this(DEFAULT_TABLE_FORMAT_VERSION);
+    }
+
+    public Builder(int formatVersion) {
       this.base = null;
-      this.formatVersion = DEFAULT_TABLE_FORMAT_VERSION;
+      this.formatVersion = formatVersion;
       this.lastSequenceNumber = INITIAL_SEQUENCE_NUMBER;
       this.uuid = UUID.randomUUID().toString();
       this.schemas = Lists.newArrayList();
@@ -986,7 +994,7 @@ public class TableMetadata implements Serializable {
 
     // it is only safe to set the format version directly while creating tables
     // in all other cases, use upgradeFormatVersion
-    public Builder setInitialFormatVersion(int newFormatVersion) {
+    private Builder setInitialFormatVersion(int newFormatVersion) {
       Preconditions.checkArgument(
           newFormatVersion <= SUPPORTED_TABLE_FORMAT_VERSION,
           "Unsupported format version: v%s (supported: v%s)",

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -27,6 +27,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -374,19 +375,15 @@ public class CatalogHandlers {
   private static TableMetadata create(TableOperations ops, UpdateTableRequest request) {
     // the only valid requirement is that the table will be created
     request.requirements().forEach(requirement -> requirement.validate(ops.current()));
+    Optional<Integer> formatVersion =
+        request.updates().stream()
+            .filter(update -> update instanceof UpgradeFormatVersion)
+            .map(update -> ((UpgradeFormatVersion) update).formatVersion())
+            .findFirst();
 
-    TableMetadata.Builder builder = TableMetadata.buildFromEmpty();
-    request
-        .updates()
-        .forEach(
-            update -> {
-              if (update instanceof UpgradeFormatVersion) {
-                builder.setInitialFormatVersion(((UpgradeFormatVersion) update).formatVersion());
-              } else {
-                update.applyTo(builder);
-              }
-            });
-
+    TableMetadata.Builder builder =
+        formatVersion.map(TableMetadata::buildFromEmpty).orElseGet(TableMetadata::buildFromEmpty);
+    request.updates().forEach(update -> update.applyTo(builder));
     // create transactions do not retry. if the table exists, retrying is not a solution
     ops.commit(null, builder.build());
 


### PR DESCRIPTION
This PR fix the problems of `Cannot downgrade v2 table to v1` when creating v1 table on REST Catalog.

Fix issue: #8756 