### PR TITLE
Flink 1.19: Fix flaky `TestIcebergSourceFailover > testBoundedWithSavepoint`

### DIFF
--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceFailover.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceFailover.java
@@ -124,7 +124,7 @@ public class TestIcebergSourceFailover {
     GenericAppenderHelper dataAppender =
         new GenericAppenderHelper(
             sourceTableResource.table(), FileFormat.PARQUET, TEMPORARY_FOLDER);
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < 20; ++i) {
       List<Record> records = generateRecords(2, i);
       expectedRecords.addAll(records);
       dataAppender.appendToTable(records);


### PR DESCRIPTION
This attempts to fix #10356 