### PR TITLE
Prevent deadlock in Jackson

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3ObjectMapper.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3ObjectMapper.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
@@ -57,7 +57,7 @@ public class S3ObjectMapper {
           // even though using new PropertyNamingStrategy.KebabCaseStrategy() is deprecated
           // and PropertyNamingStrategies.KebabCaseStrategy.INSTANCE (introduced in jackson 2.14) is
           // recommended, we can't use it because Spark still relies on jackson 2.13.x stuff
-          MAPPER.setPropertyNamingStrategy(new PropertyNamingStrategy.KebabCaseStrategy());
+          MAPPER.setPropertyNamingStrategy(new PropertyNamingStrategies.KebabCaseStrategy());
           MAPPER.registerModule(initModule());
           isInitialized = true;
         }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTObjectMapper.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTObjectMapper.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 class RESTObjectMapper {
   private static final JsonFactory FACTORY = new JsonFactory();
@@ -38,7 +38,7 @@ class RESTObjectMapper {
         if (!isInitialized) {
           MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
           MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-          MAPPER.setPropertyNamingStrategy(new PropertyNamingStrategy.KebabCaseStrategy());
+          MAPPER.setPropertyNamingStrategy(new PropertyNamingStrategies.KebabCaseStrategy());
           RESTSerializers.registerAll(MAPPER);
           isInitialized = true;
         }


### PR DESCRIPTION
Following warning is always printed when using Iceberg REST clients:
```
PropertyNamingStrategy.KebabCaseStrategy is used but it has been deprecated due to risk of deadlock. Consider using PropertyNamingStrategies.KebabCaseStrategy instead. See https://github.com/FasterXML/jackson-databind/issues/2715 for more details.
```