### PR TITLE
Docs: Ignore link-checking for Apache mailing list and GNU website

### DIFF
--- a/site/link-checker-config.json
+++ b/site/link-checker-config.json
@@ -11,6 +11,12 @@
     },
     {
       "pattern": "^https://search.maven.org/"
+    },
+    {
+      "pattern": "^http://mail-archives.apache.org/"
+    },
+    {
+      "pattern": "^https://www.gnu.org/"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
The link check has been failing frequently.

```
[✖] http://mail-archives.apache.org/mod_mbox/flink-dev/202008.mbox/%3cCABi+2jQCo3MsOa4+ywaxV5J-Z8TGKNZDX-pQLYB-dG+dVUMiMw@mail.gmail.com%3e → Status: 0 Error: ESOCKETTIMEDOUT
    at ClientRequest.<anonymous> (/usr/local/lib/node_modules/markdown-link-check/node_modules/request/request.js:816:19)
    at Object.onceWrapper (node:events:633:28)
    at ClientRequest.emit (node:events:519:28)
    at TLSSocket.emitRequestTimeout (node:_http_client:845:9)
    at Object.onceWrapper (node:events:633:28)
    at TLSSocket.emit (node:events:531:35)
    at Socket._onTimeout (node:net:590:8)
    at listOnTimeout (node:internal/timers:573:17)
    at process.processTimers (node:internal/timers:514:7) {
  code: 'ESOCKETTIMEDOUT',
  connect: false
```

```
[✖] https://www.gnu.org/software/make/manual/make.html → Status: 0 Error: connect ECONNREFUSED 209.51.188.116:443
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1606:16) {
  errno: -111,
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '209.51.188.116',
  port: 443
}
```