### PR TITLE
Core,Api: Deprecate `appendManifest`

### DIFF
--- a/api/src/main/java/org/apache/iceberg/AppendFiles.java
+++ b/api/src/main/java/org/apache/iceberg/AppendFiles.java
@@ -55,6 +55,8 @@ public interface AppendFiles extends SnapshotUpdate<AppendFiles> {
    *
    * @param file a manifest file
    * @return this for method chaining
+   * @deprecated since 1.6.0, will be removed in 2.0.0
    */
+  @Deprecated
   AppendFiles appendManifest(ManifestFile file);
 }

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -95,7 +95,9 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
     return this;
   }
 
+  /** @deprecated since 1.6.0, will be removed in 2.0.0 */
   @Override
+  @Deprecated
   public FastAppend appendManifest(ManifestFile manifest) {
     Preconditions.checkArgument(
         !manifest.hasExistingFiles(), "Cannot append manifest with existing files");

--- a/core/src/main/java/org/apache/iceberg/MergeAppend.java
+++ b/core/src/main/java/org/apache/iceberg/MergeAppend.java
@@ -54,7 +54,9 @@ class MergeAppend extends MergingSnapshotProducer<AppendFiles> implements Append
     return this;
   }
 
+  /** @deprecated since 1.6.0, will be removed in 2.0.0 */
   @Override
+  @Deprecated
   public AppendFiles appendManifest(ManifestFile manifest) {
     Preconditions.checkArgument(
         !manifest.hasExistingFiles(), "Cannot append manifest with existing files");

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -259,7 +259,12 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     }
   }
 
-  /** Add all files in a manifest to the new snapshot. */
+  /**
+   * Add all files in a manifest to the new snapshot.
+   *
+   * @deprecated since 1.6.0, will be removed in 2.0.0
+   */
+  @Deprecated
   protected void add(ManifestFile manifest) {
     Preconditions.checkArgument(
         manifest.content() == ManifestContent.DATA, "Cannot append delete manifest: %s", manifest);


### PR DESCRIPTION
Adding manifests produces invalid summaries and I don't think that's a good practice. This PR deprecates the method (which simplifies `MergingSnapshotProducer`).

The method is mostly used in tests and when importing a table in Spark. If we agree to remove this, we can see how we can scale out the writing of the manifests.