### PR TITLE
Parquet: page skipping using filtered row groups (vectorized and non-vectorized read)

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/BaseBatchReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/BaseBatchReader.java
@@ -41,10 +41,10 @@ public abstract class BaseBatchReader<T> implements VectorizedReader<T> {
 
   @Override
   public void setRowGroupInfo(
-      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData, long rowPosition) {
+      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData) {
     for (VectorizedArrowReader reader : readers) {
       if (reader != null) {
-        reader.setRowGroupInfo(pageStore, metaData, rowPosition);
+        reader.setRowGroupInfo(pageStore, metaData);
       }
     }
   }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/BaseBatchReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/BaseBatchReader.java
@@ -41,6 +41,12 @@ public abstract class BaseBatchReader<T> implements VectorizedReader<T> {
 
   @Override
   public void setRowGroupInfo(
+      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData, long rowPosition) {
+    setRowGroupInfo(pageStore, metaData);
+  }
+
+  @Override
+  public void setRowGroupInfo(
       PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData) {
     for (VectorizedArrowReader reader : readers) {
       if (reader != null) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -441,6 +441,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
     this.dictionary =
         vectorizedColumnIterator.setRowGroupInfo(
             source.getPageReader(columnDescriptor),
+            source.getRowIndexes(),
             !ParquetUtil.hasNonDictionaryPages(chunkMetaData));
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -430,6 +430,12 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
   }
 
   @Override
+  public void setRowGroupInfo(
+      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {
+    setRowGroupInfo(pageStore, metadata);
+  }
+
+  @Override
   public void setRowGroupInfo(PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata) {
     ColumnChunkMetaData chunkMetaData = metadata.get(ColumnPath.get(columnDescriptor.getPath()));
     this.dictionary =
@@ -469,6 +475,10 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
     public VectorHolder read(VectorHolder reuse, int numValsToRead) {
       return VectorHolder.dummyHolder(numValsToRead);
     }
+
+    @Override
+    public void setRowGroupInfo(
+        PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {}
 
     @Override
     public void setRowGroupInfo(
@@ -539,6 +549,12 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     @Override
     public void setRowGroupInfo(
+        PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {
+      setRowGroupInfo(pageStore, metadata);
+    }
+
+    @Override
+    public void setRowGroupInfo(
         PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata) {
       this.rowStart = source.getRowIndexOffset().orElse(0L);
     }
@@ -583,6 +599,10 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     @Override
     public void setRowGroupInfo(
+        PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {}
+
+    @Override
+    public void setRowGroupInfo(
         PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata) {}
 
     @Override
@@ -607,6 +627,10 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
     public VectorHolder read(VectorHolder reuse, int numValsToRead) {
       return VectorHolder.deletedVectorHolder(numValsToRead);
     }
+
+    @Override
+    public void setRowGroupInfo(
+        PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {}
 
     @Override
     public void setRowGroupInfo(

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -431,8 +431,8 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
   @Override
   public void setRowGroupInfo(
-      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {
-    setRowGroupInfo(pageStore, metadata);
+      PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {
+    setRowGroupInfo(source, metadata);
   }
 
   @Override
@@ -478,7 +478,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     @Override
     public void setRowGroupInfo(
-        PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {}
+        PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {}
 
     @Override
     public void setRowGroupInfo(
@@ -549,8 +549,8 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     @Override
     public void setRowGroupInfo(
-        PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {
-      setRowGroupInfo(pageStore, metadata);
+        PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {
+      setRowGroupInfo(source, metadata);
     }
 
     @Override
@@ -599,7 +599,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     @Override
     public void setRowGroupInfo(
-        PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {}
+        PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {}
 
     @Override
     public void setRowGroupInfo(
@@ -630,7 +630,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     @Override
     public void setRowGroupInfo(
-        PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {}
+        PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {}
 
     @Override
     public void setRowGroupInfo(

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -145,6 +145,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
       vec.setValueCount(0);
       nullabilityHolder.reset();
     }
+    vectorizedColumnIterator.newBatch();
     if (vectorizedColumnIterator.hasNext()) {
       if (dictEncoded) {
         vectorizedColumnIterator.dictionaryBatchReader().nextBatch(vec, -1, nullabilityHolder);

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -430,8 +430,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
   }
 
   @Override
-  public void setRowGroupInfo(
-      PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {
+  public void setRowGroupInfo(PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata) {
     ColumnChunkMetaData chunkMetaData = metadata.get(ColumnPath.get(columnDescriptor.getPath()));
     this.dictionary =
         vectorizedColumnIterator.setRowGroupInfo(
@@ -473,7 +472,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     @Override
     public void setRowGroupInfo(
-        PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {}
+        PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata) {}
 
     @Override
     public String toString() {
@@ -540,8 +539,8 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     @Override
     public void setRowGroupInfo(
-        PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {
-      this.rowStart = rowPosition;
+        PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata) {
+      this.rowStart = source.getRowIndexOffset().orElse(0L);
     }
 
     @Override
@@ -584,7 +583,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     @Override
     public void setRowGroupInfo(
-        PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {}
+        PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata) {}
 
     @Override
     public String toString() {
@@ -611,7 +610,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     @Override
     public void setRowGroupInfo(
-        PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {}
+        PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata) {}
 
     @Override
     public String toString() {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedColumnIterator.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedColumnIterator.java
@@ -213,13 +213,7 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
       while (rowsReadSoFar < batchSize && hasNext()) {
         advance();
         int rowsInThisBatch =
-            nextBatchOf(
-                fieldVector,
-                batchSize - rowsReadSoFar,
-                rowsReadSoFar,
-                typeWidth,
-                holder,
-                new ReadState());
+            nextBatchOf(fieldVector, batchSize - rowsReadSoFar, typeWidth, holder, new ReadState());
         rowsReadSoFar += rowsInThisBatch;
         triplesRead += rowsInThisBatch;
         fieldVector.setValueCount(currentOffset);
@@ -229,7 +223,6 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     protected abstract int nextBatchOf(
         FieldVector vector,
         int expectedBatchSize,
-        int numValsInVector,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState);
@@ -240,13 +233,12 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     protected int nextBatchOf(
         final FieldVector vector,
         final int expectedBatchSize,
-        final int numValsInVector,
         final int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       return vectorizedPageIterator
           .intPageReader()
-          .nextBatch(vector, expectedBatchSize, numValsInVector, typeWidth, holder, readState);
+          .nextBatch(vector, expectedBatchSize, typeWidth, holder, readState);
     }
   }
 
@@ -255,12 +247,11 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     protected int nextBatchOf(
         final FieldVector vector,
         final int expectedBatchSize,
-        final int numValsInVector,
         final int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       return vectorizedPageIterator.nextBatchDictionaryIds(
-          (IntVector) vector, expectedBatchSize, numValsInVector, holder, readState);
+          (IntVector) vector, expectedBatchSize, holder, readState);
     }
   }
 
@@ -269,13 +260,12 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     protected int nextBatchOf(
         final FieldVector vector,
         final int expectedBatchSize,
-        final int numValsInVector,
         final int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       return vectorizedPageIterator
           .longPageReader()
-          .nextBatch(vector, expectedBatchSize, numValsInVector, typeWidth, holder, readState);
+          .nextBatch(vector, expectedBatchSize, typeWidth, holder, readState);
     }
   }
 
@@ -284,13 +274,12 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     protected int nextBatchOf(
         final FieldVector vector,
         final int expectedBatchSize,
-        final int numValsInVector,
         final int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       return vectorizedPageIterator
           .timestampMillisPageReader()
-          .nextBatch(vector, expectedBatchSize, numValsInVector, typeWidth, holder, readState);
+          .nextBatch(vector, expectedBatchSize, typeWidth, holder, readState);
     }
   }
 
@@ -299,13 +288,12 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     protected int nextBatchOf(
         final FieldVector vector,
         final int expectedBatchSize,
-        final int numValsInVector,
         final int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       return vectorizedPageIterator
           .timestampInt96PageReader()
-          .nextBatch(vector, expectedBatchSize, numValsInVector, typeWidth, holder, readState);
+          .nextBatch(vector, expectedBatchSize, typeWidth, holder, readState);
     }
   }
 
@@ -314,13 +302,12 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     protected int nextBatchOf(
         final FieldVector vector,
         final int expectedBatchSize,
-        final int numValsInVector,
         final int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       return vectorizedPageIterator
           .floatPageReader()
-          .nextBatch(vector, expectedBatchSize, numValsInVector, typeWidth, holder, readState);
+          .nextBatch(vector, expectedBatchSize, typeWidth, holder, readState);
     }
   }
 
@@ -329,13 +316,12 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     protected int nextBatchOf(
         final FieldVector vector,
         final int expectedBatchSize,
-        final int numValsInVector,
         final int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       return vectorizedPageIterator
           .doublePageReader()
-          .nextBatch(vector, expectedBatchSize, numValsInVector, typeWidth, holder, readState);
+          .nextBatch(vector, expectedBatchSize, typeWidth, holder, readState);
     }
   }
 
@@ -344,13 +330,12 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     protected int nextBatchOf(
         final FieldVector vector,
         final int expectedBatchSize,
-        final int numValsInVector,
         final int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       return vectorizedPageIterator
           .fixedSizeBinaryPageReader()
-          .nextBatch(vector, expectedBatchSize, numValsInVector, typeWidth, holder, readState);
+          .nextBatch(vector, expectedBatchSize, typeWidth, holder, readState);
     }
   }
 
@@ -359,13 +344,12 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     protected int nextBatchOf(
         final FieldVector vector,
         final int expectedBatchSize,
-        final int numValsInVector,
         final int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       return vectorizedPageIterator
           .varWidthTypePageReader()
-          .nextBatch(vector, expectedBatchSize, numValsInVector, typeWidth, holder, readState);
+          .nextBatch(vector, expectedBatchSize, typeWidth, holder, readState);
     }
   }
 
@@ -374,13 +358,12 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     protected int nextBatchOf(
         final FieldVector vector,
         final int expectedBatchSize,
-        final int numValsInVector,
         final int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       return vectorizedPageIterator
           .fixedWidthBinaryPageReader()
-          .nextBatch(vector, expectedBatchSize, numValsInVector, typeWidth, holder, readState);
+          .nextBatch(vector, expectedBatchSize, typeWidth, holder, readState);
     }
   }
 
@@ -389,13 +372,12 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     protected int nextBatchOf(
         final FieldVector vector,
         final int expectedBatchSize,
-        final int numValsInVector,
         final int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       return vectorizedPageIterator
           .booleanPageReader()
-          .nextBatch(vector, expectedBatchSize, numValsInVector, typeWidth, holder, readState);
+          .nextBatch(vector, expectedBatchSize, typeWidth, holder, readState);
     }
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
@@ -27,6 +27,7 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.iceberg.arrow.vectorized.NullabilityHolder;
+import org.apache.iceberg.arrow.vectorized.parquet.VectorizedColumnIterator.ReadState;
 import org.apache.iceberg.parquet.ParquetUtil;
 import org.apache.parquet.column.Dictionary;
 
@@ -50,7 +51,8 @@ public class VectorizedDictionaryEncodedParquetValuesReader
         int numValuesToRead,
         Dictionary dict,
         NullabilityHolder nullabilityHolder,
-        int typeWidth) {
+        int typeWidth,
+        ReadState readState) {
       int left = numValuesToRead;
       int idx = startOffset;
       while (left > 0) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
@@ -43,6 +43,25 @@ public class VectorizedDictionaryEncodedParquetValuesReader
     super(maxDefLevel, setValidityVector);
   }
 
+  public void skipValues(int numValuesToSkip) {
+    int left = numValuesToSkip;
+    while (left > 0) {
+      if (this.currentCount == 0) {
+        this.readNextGroup();
+      }
+      int num = Math.min(left, this.currentCount);
+      switch (mode) {
+        case RLE:
+          break;
+        case PACKED:
+          packedValuesBufferIdx += num;
+          break;
+      }
+      currentCount -= num;
+      left -= num;
+    }
+  }
+
   abstract class BaseDictEncodedReader {
     public void nextBatch(
         FieldVector vector,

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
@@ -27,7 +27,6 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.iceberg.arrow.vectorized.NullabilityHolder;
-import org.apache.iceberg.arrow.vectorized.parquet.VectorizedColumnIterator.ReadState;
 import org.apache.iceberg.parquet.ParquetUtil;
 import org.apache.parquet.column.Dictionary;
 
@@ -51,8 +50,7 @@ public class VectorizedDictionaryEncodedParquetValuesReader
         int numValuesToRead,
         Dictionary dict,
         NullabilityHolder nullabilityHolder,
-        int typeWidth,
-        ReadState readState) {
+        int typeWidth) {
       int left = numValuesToRead;
       int idx = startOffset;
       while (left > 0) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPageIterator.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPageIterator.java
@@ -150,7 +150,6 @@ public class VectorizedPageIterator extends BasePageIterator {
   public int nextBatchDictionaryIds(
       final IntVector vector,
       final int expectedBatchSize,
-      final int numValsInVector,
       NullabilityHolder holder,
       ReadState readState) {
     final int actualBatchSize = getActualBatchSize(expectedBatchSize);
@@ -160,14 +159,7 @@ public class VectorizedPageIterator extends BasePageIterator {
     vectorizedDefinitionLevelReader
         .dictionaryIdReader()
         .nextDictEncodedBatch(
-            vector,
-            numValsInVector,
-            -1,
-            actualBatchSize,
-            holder,
-            dictionaryEncodedValuesReader,
-            null,
-            readState);
+            vector, -1, actualBatchSize, holder, dictionaryEncodedValuesReader, null, readState);
     triplesRead += actualBatchSize;
     this.hasNext = triplesRead < triplesCount;
     return actualBatchSize;
@@ -177,7 +169,6 @@ public class VectorizedPageIterator extends BasePageIterator {
     public int nextBatch(
         FieldVector vector,
         int expectedBatchSize,
-        int numValsInVector,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
@@ -186,9 +177,9 @@ public class VectorizedPageIterator extends BasePageIterator {
         return 0;
       }
       if (dictionaryDecodeMode == DictionaryDecodeMode.EAGER) {
-        nextDictEncodedVal(vector, actualBatchSize, numValsInVector, typeWidth, holder, readState);
+        nextDictEncodedVal(vector, actualBatchSize, typeWidth, holder, readState);
       } else {
-        nextVal(vector, actualBatchSize, numValsInVector, typeWidth, holder, readState);
+        nextVal(vector, actualBatchSize, typeWidth, holder, readState);
       }
       triplesRead += actualBatchSize;
       hasNext = triplesRead < triplesCount;
@@ -198,7 +189,6 @@ public class VectorizedPageIterator extends BasePageIterator {
     protected abstract void nextVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState);
@@ -206,7 +196,6 @@ public class VectorizedPageIterator extends BasePageIterator {
     protected abstract void nextDictEncodedVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState);
@@ -218,20 +207,18 @@ public class VectorizedPageIterator extends BasePageIterator {
     protected void nextVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       vectorizedDefinitionLevelReader
           .integerReader()
-          .nextBatch(vector, numVals, typeWidth, batchSize, holder, plainValuesReader, readState);
+          .nextBatch(vector, typeWidth, batchSize, holder, plainValuesReader, readState);
     }
 
     @Override
     protected void nextDictEncodedVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
@@ -239,7 +226,6 @@ public class VectorizedPageIterator extends BasePageIterator {
           .integerReader()
           .nextDictEncodedBatch(
               vector,
-              numVals,
               typeWidth,
               batchSize,
               holder,
@@ -256,20 +242,18 @@ public class VectorizedPageIterator extends BasePageIterator {
     protected void nextVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       vectorizedDefinitionLevelReader
           .longReader()
-          .nextBatch(vector, numVals, typeWidth, batchSize, holder, plainValuesReader, readState);
+          .nextBatch(vector, typeWidth, batchSize, holder, plainValuesReader, readState);
     }
 
     @Override
     protected void nextDictEncodedVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
@@ -277,7 +261,6 @@ public class VectorizedPageIterator extends BasePageIterator {
           .longReader()
           .nextDictEncodedBatch(
               vector,
-              numVals,
               typeWidth,
               batchSize,
               holder,
@@ -298,20 +281,18 @@ public class VectorizedPageIterator extends BasePageIterator {
     protected void nextVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       vectorizedDefinitionLevelReader
           .timestampMillisReader()
-          .nextBatch(vector, numVals, typeWidth, batchSize, holder, plainValuesReader, readState);
+          .nextBatch(vector, typeWidth, batchSize, holder, plainValuesReader, readState);
     }
 
     @Override
     protected void nextDictEncodedVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
@@ -319,7 +300,6 @@ public class VectorizedPageIterator extends BasePageIterator {
           .timestampMillisReader()
           .nextDictEncodedBatch(
               vector,
-              numVals,
               typeWidth,
               batchSize,
               holder,
@@ -335,20 +315,18 @@ public class VectorizedPageIterator extends BasePageIterator {
     protected void nextVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       vectorizedDefinitionLevelReader
           .timestampInt96Reader()
-          .nextBatch(vector, numVals, typeWidth, batchSize, holder, plainValuesReader, readState);
+          .nextBatch(vector, typeWidth, batchSize, holder, plainValuesReader, readState);
     }
 
     @Override
     protected void nextDictEncodedVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
@@ -356,7 +334,6 @@ public class VectorizedPageIterator extends BasePageIterator {
           .timestampInt96Reader()
           .nextDictEncodedBatch(
               vector,
-              numVals,
               typeWidth,
               batchSize,
               holder,
@@ -373,20 +350,18 @@ public class VectorizedPageIterator extends BasePageIterator {
     protected void nextVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       vectorizedDefinitionLevelReader
           .floatReader()
-          .nextBatch(vector, numVals, typeWidth, batchSize, holder, plainValuesReader, readState);
+          .nextBatch(vector, typeWidth, batchSize, holder, plainValuesReader, readState);
     }
 
     @Override
     protected void nextDictEncodedVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
@@ -394,7 +369,6 @@ public class VectorizedPageIterator extends BasePageIterator {
           .floatReader()
           .nextDictEncodedBatch(
               vector,
-              numVals,
               typeWidth,
               batchSize,
               holder,
@@ -411,20 +385,18 @@ public class VectorizedPageIterator extends BasePageIterator {
     protected void nextVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       vectorizedDefinitionLevelReader
           .doubleReader()
-          .nextBatch(vector, numVals, typeWidth, batchSize, holder, plainValuesReader, readState);
+          .nextBatch(vector, typeWidth, batchSize, holder, plainValuesReader, readState);
     }
 
     @Override
     protected void nextDictEncodedVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
@@ -432,7 +404,6 @@ public class VectorizedPageIterator extends BasePageIterator {
           .doubleReader()
           .nextDictEncodedBatch(
               vector,
-              numVals,
               typeWidth,
               batchSize,
               holder,
@@ -451,20 +422,18 @@ public class VectorizedPageIterator extends BasePageIterator {
     protected void nextVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       vectorizedDefinitionLevelReader
           .fixedSizeBinaryReader()
-          .nextBatch(vector, numVals, typeWidth, batchSize, holder, plainValuesReader, readState);
+          .nextBatch(vector, typeWidth, batchSize, holder, plainValuesReader, readState);
     }
 
     @Override
     protected void nextDictEncodedVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
@@ -472,7 +441,6 @@ public class VectorizedPageIterator extends BasePageIterator {
           .fixedSizeBinaryReader()
           .nextDictEncodedBatch(
               vector,
-              numVals,
               typeWidth,
               batchSize,
               holder,
@@ -488,20 +456,18 @@ public class VectorizedPageIterator extends BasePageIterator {
     protected void nextVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       vectorizedDefinitionLevelReader
           .varWidthReader()
-          .nextBatch(vector, numVals, typeWidth, batchSize, holder, plainValuesReader, readState);
+          .nextBatch(vector, typeWidth, batchSize, holder, plainValuesReader, readState);
     }
 
     @Override
     protected void nextDictEncodedVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
@@ -509,7 +475,6 @@ public class VectorizedPageIterator extends BasePageIterator {
           .varWidthReader()
           .nextDictEncodedBatch(
               vector,
-              numVals,
               typeWidth,
               batchSize,
               holder,
@@ -529,20 +494,18 @@ public class VectorizedPageIterator extends BasePageIterator {
     protected void nextVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       vectorizedDefinitionLevelReader
           .fixedWidthBinaryReader()
-          .nextBatch(vector, numVals, typeWidth, batchSize, holder, plainValuesReader, readState);
+          .nextBatch(vector, typeWidth, batchSize, holder, plainValuesReader, readState);
     }
 
     @Override
     protected void nextDictEncodedVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
@@ -550,7 +513,6 @@ public class VectorizedPageIterator extends BasePageIterator {
           .fixedWidthBinaryReader()
           .nextDictEncodedBatch(
               vector,
-              numVals,
               typeWidth,
               batchSize,
               holder,
@@ -566,20 +528,18 @@ public class VectorizedPageIterator extends BasePageIterator {
     protected void nextVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {
       vectorizedDefinitionLevelReader
           .booleanReader()
-          .nextBatch(vector, numVals, typeWidth, batchSize, holder, plainValuesReader, readState);
+          .nextBatch(vector, typeWidth, batchSize, holder, plainValuesReader, readState);
     }
 
     @Override
     protected void nextDictEncodedVal(
         FieldVector vector,
         int batchSize,
-        int numVals,
         int typeWidth,
         NullabilityHolder holder,
         ReadState readState) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -53,7 +53,6 @@ public final class VectorizedParquetDefinitionLevelReader
 
     private void nextCommonBatch(
         final FieldVector vector,
-        final int startOffset,
         final int typeWidth,
         final int numValsToRead,
         NullabilityHolder nullabilityHolder,
@@ -200,26 +199,17 @@ public final class VectorizedParquetDefinitionLevelReader
 
     public void nextBatch(
         final FieldVector vector,
-        final int startOffset,
         final int typeWidth,
         final int numValsToRead,
         NullabilityHolder nullabilityHolder,
         ValuesAsBytesReader valuesReader,
         ReadState readState) {
       nextCommonBatch(
-          vector,
-          startOffset,
-          typeWidth,
-          numValsToRead,
-          nullabilityHolder,
-          valuesReader,
-          null,
-          readState);
+          vector, typeWidth, numValsToRead, nullabilityHolder, valuesReader, null, readState);
     }
 
     public void nextDictEncodedBatch(
         final FieldVector vector,
-        final int startOffset,
         final int typeWidth,
         final int numValsToRead,
         NullabilityHolder nullabilityHolder,
@@ -227,14 +217,7 @@ public final class VectorizedParquetDefinitionLevelReader
         Dictionary dict,
         ReadState readState) {
       nextCommonBatch(
-          vector,
-          startOffset,
-          typeWidth,
-          numValsToRead,
-          nullabilityHolder,
-          valuesReader,
-          dict,
-          readState);
+          vector, typeWidth, numValsToRead, nullabilityHolder, valuesReader, dict, readState);
     }
 
     protected abstract void nextRleBatch(

--- a/parquet/src/main/java/org/apache/iceberg/parquet/BaseColumnIterator.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/BaseColumnIterator.java
@@ -85,8 +85,8 @@ public abstract class BaseColumnIterator {
                 page.getFirstRowIndex()
                     .orElseThrow(
                         () ->
-                            new IllegalArgumentException(
-                                "Missing page first row index for synchronizing values"));
+                            new IllegalStateException(
+                                "Index of first row in page is not available"));
             this.numValuesToSkip = 0;
             this.currentRowIndex = firstRowIndex - 1;
           }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/BaseColumnIterator.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/BaseColumnIterator.java
@@ -61,6 +61,9 @@ public abstract class BaseColumnIterator {
     this.needsSynchronizing = optionalRowIndexes.isPresent();
     if (needsSynchronizing) {
       this.rowIndexes = optionalRowIndexes.get();
+    } else {
+      // reset
+      this.rowIndexes = null;
     }
     BasePageIterator pageIterator = pageIterator();
     pageIterator.reset();

--- a/parquet/src/main/java/org/apache/iceberg/parquet/BasePageIterator.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/BasePageIterator.java
@@ -71,6 +71,10 @@ public abstract class BasePageIterator {
     this.hasNext = false;
   }
 
+  protected void skip(int numValuesToSkip) {
+    throw new UnsupportedOperationException();
+  }
+
   protected abstract void initDataReader(
       Encoding dataEncoding, ByteBufferInputStream in, int valueCount);
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PageIterator.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PageIterator.java
@@ -189,7 +189,7 @@ abstract class PageIterator<T> extends BasePageIterator implements TripleIterato
     return null;
   }
 
-  private void advance() {
+  protected void advance() {
     if (triplesRead < triplesCount) {
       this.currentDL = definitionLevels.nextInt();
       this.currentRL = repetitionLevels.nextInt();
@@ -200,6 +200,10 @@ abstract class PageIterator<T> extends BasePageIterator implements TripleIterato
       this.currentRL = -1;
       this.hasNext = false;
     }
+  }
+
+  protected void skip(int numValuesToSkip) {
+    values.skip(numValuesToSkip);
   }
 
   RuntimeException handleRuntimeException(RuntimeException exception) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PageIterator.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PageIterator.java
@@ -202,6 +202,7 @@ abstract class PageIterator<T> extends BasePageIterator implements TripleIterato
     }
   }
 
+  @Override
   protected void skip(int numValuesToSkip) {
     values.skip(numValuesToSkip);
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -105,6 +105,7 @@ import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.ParquetProperties.WriterVersion;
 import org.apache.parquet.crypto.FileDecryptionProperties;
 import org.apache.parquet.crypto.FileEncryptionProperties;
+import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
@@ -114,9 +115,13 @@ import org.apache.parquet.hadoop.api.ReadSupport;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.MessageType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Parquet {
   private Parquet() {}
+
+  private static final Logger LOG = LoggerFactory.getLogger(Parquet.class);
 
   private static final Collection<String> READ_PROPERTIES_TO_REMOVE =
       Sets.newHashSet(
@@ -1167,13 +1172,25 @@ public class Parquet {
 
         // TODO: for now, apply filter only for non-vectorized read
         if (filter != null && batchedReaderFunc == null) {
-          Schema fileSchema = getSchemaFromFile(fileDecryptionProperties);
-          optionsBuilder.useRecordFilter();
-          optionsBuilder.withRecordFilter(
-              ParquetFilters.convert(fileSchema, filter, caseSensitive));
+          MessageType type = getSchemaFromFile(fileDecryptionProperties);
+          Schema fileSchema = ParquetSchemaUtil.convert(type);
+          try {
+            FilterCompat.Filter convertedFilter =
+                ParquetFilters.convert(type, fileSchema, filter, caseSensitive);
+            optionsBuilder.useRecordFilter();
+            optionsBuilder.withRecordFilter(convertedFilter);
+          } catch (Exception e) {
+            // no record filter to use
+            optionsBuilder.useRecordFilter(false);
+            LOG.warn("ReadBuilder: filter conversion threw exception", e);
+          }
         }
 
         ParquetReadOptions options = optionsBuilder.build();
+        LOG.info(
+            "ReadBuilder: options: useRecordFilter: {}, recordFilter: {}",
+            options.useRecordFilter(),
+            options.getRecordFilter());
 
         NameMapping mapping;
         if (nameMapping != null) {
@@ -1226,7 +1243,8 @@ public class Parquet {
       if (filter != null) {
         // TODO: should not need to get the schema to push down before opening the file.
         // Parquet should allow setting a filter inside its read support
-        Schema fileSchema = getSchemaFromFile(fileDecryptionProperties);
+        MessageType type = getSchemaFromFile(fileDecryptionProperties);
+        Schema fileSchema = ParquetSchemaUtil.convert(type);
         builder
             .useStatsFilter()
             .useDictionaryFilter()
@@ -1261,7 +1279,7 @@ public class Parquet {
       return new ParquetIterable<>(builder);
     }
 
-    private Schema getSchemaFromFile(FileDecryptionProperties fileDecryptionProperties) {
+    private MessageType getSchemaFromFile(FileDecryptionProperties fileDecryptionProperties) {
       ParquetReadOptions decryptOptions =
           ParquetReadOptions.builder().withDecryption(fileDecryptionProperties).build();
       MessageType type;
@@ -1272,7 +1290,7 @@ public class Parquet {
         throw new RuntimeIOException(e);
       }
 
-      return ParquetSchemaUtil.convert(type);
+      return type;
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -1170,8 +1170,7 @@ public class Parquet {
           optionsBuilder.withDecryption(fileDecryptionProperties);
         }
 
-        // TODO: for now, apply filter only for non-vectorized read
-        if (filter != null && batchedReaderFunc == null) {
+        if (filter != null) {
           MessageType type = getSchemaFromFile(fileDecryptionProperties);
           Schema fileSchema = ParquetSchemaUtil.convert(type);
           try {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -1165,6 +1165,14 @@ public class Parquet {
           optionsBuilder.withDecryption(fileDecryptionProperties);
         }
 
+        // TODO: for now, apply filter only for non-vectorized read
+        if (filter != null && batchedReaderFunc == null) {
+          Schema fileSchema = getSchemaFromFile(fileDecryptionProperties);
+          optionsBuilder.useRecordFilter();
+          optionsBuilder.withRecordFilter(
+              ParquetFilters.convert(fileSchema, filter, caseSensitive));
+        }
+
         ParquetReadOptions options = optionsBuilder.build();
 
         NameMapping mapping;
@@ -1218,16 +1226,7 @@ public class Parquet {
       if (filter != null) {
         // TODO: should not need to get the schema to push down before opening the file.
         // Parquet should allow setting a filter inside its read support
-        ParquetReadOptions decryptOptions =
-            ParquetReadOptions.builder().withDecryption(fileDecryptionProperties).build();
-        MessageType type;
-        try (ParquetFileReader schemaReader =
-            ParquetFileReader.open(ParquetIO.file(file), decryptOptions)) {
-          type = schemaReader.getFileMetaData().getSchema();
-        } catch (IOException e) {
-          throw new RuntimeIOException(e);
-        }
-        Schema fileSchema = ParquetSchemaUtil.convert(type);
+        Schema fileSchema = getSchemaFromFile(fileDecryptionProperties);
         builder
             .useStatsFilter()
             .useDictionaryFilter()
@@ -1260,6 +1259,20 @@ public class Parquet {
       }
 
       return new ParquetIterable<>(builder);
+    }
+
+    private Schema getSchemaFromFile(FileDecryptionProperties fileDecryptionProperties) {
+      ParquetReadOptions decryptOptions =
+          ParquetReadOptions.builder().withDecryption(fileDecryptionProperties).build();
+      MessageType type;
+      try (ParquetFileReader schemaReader =
+          ParquetFileReader.open(ParquetIO.file(file), decryptOptions)) {
+        type = schemaReader.getFileMetaData().getSchema();
+      } catch (IOException e) {
+        throw new RuntimeIOException(e);
+      }
+
+      return ParquetSchemaUtil.convert(type);
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -140,10 +140,10 @@ class ParquetFilters {
       String errMsg = "Cannot convert to Parquet filter: " + pred;
       if (mType != null) {
         // We create a Parquet filter predicate and that predicate uses a Parquet column.
-        // We need to ensure that the Parquet column type converted from the Iceberg type of the
-        // column matches the Parquet type in the Parquet file. (If the filter is passed to
-        // Parquet and used by Parquet to filter row groups, Parquet checks that the type in
-        // predicate matches the type in the file as a validation step before filtering.)
+        // We need to ensure that the Parquet column type converted from the Iceberg type of
+        // the column matches the Parquet type in the Parquet file. (If the filter is passed
+        // to Parquet and used by Parquet to filter row groups, Parquet checks that the type
+        // in the predicate matches the type in the file as a validation step before filtering.)
         // If the two do not match, we abort the conversion.
         org.apache.parquet.schema.Type pType = mType.getType(path);
         if (!(pType instanceof PrimitiveType)) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -29,19 +29,23 @@ import org.apache.iceberg.expressions.ExpressionVisitors.ExpressionVisitor;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.types.Type;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.filter2.predicate.Operators;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
 
 class ParquetFilters {
 
   private ParquetFilters() {}
 
-  static FilterCompat.Filter convert(Schema schema, Expression expr, boolean caseSensitive) {
+  static FilterCompat.Filter convert(
+      MessageType mType, Schema schema, Expression expr, boolean caseSensitive) {
     FilterPredicate pred =
-        ExpressionVisitors.visit(expr, new ConvertFilterToParquet(schema, caseSensitive));
+        ExpressionVisitors.visit(expr, new ConvertFilterToParquet(mType, schema, caseSensitive));
     // TODO: handle AlwaysFalse.INSTANCE
     if (pred != null && pred != AlwaysTrue.INSTANCE) {
       // FilterCompat will apply LogicalInverseRewriter
@@ -51,11 +55,17 @@ class ParquetFilters {
     }
   }
 
+  static FilterCompat.Filter convert(Schema schema, Expression expr, boolean caseSensitive) {
+    return convert(null, schema, expr, caseSensitive);
+  }
+
   private static class ConvertFilterToParquet extends ExpressionVisitor<FilterPredicate> {
+    private final MessageType mType;
     private final Schema schema;
     private final boolean caseSensitive;
 
-    private ConvertFilterToParquet(Schema schema, boolean caseSensitive) {
+    private ConvertFilterToParquet(MessageType mType, Schema schema, boolean caseSensitive) {
+      this.mType = mType;
       this.schema = schema;
       this.caseSensitive = caseSensitive;
     }
@@ -127,6 +137,27 @@ class ParquetFilters {
         throw new UnsupportedOperationException("Cannot convert to Parquet filter: " + pred);
       }
 
+      String errMsg = "Cannot convert to Parquet filter: " + pred;
+      if (mType != null) {
+        // We create a Parquet filter predicate and that predicate uses a Parquet column.
+        // We need to ensure that the Parquet column type converted from the Iceberg type of the
+        // column matches the Parquet type in the Parquet file. (If the filter is passed to
+        // Parquet and used by Parquet to filter row groups, Parquet checks that the type in
+        // predicate matches the type in the file as a validation step before filtering.)
+        // If the two do not match, we abort the conversion.
+        org.apache.parquet.schema.Type pType = mType.getType(path);
+        if (!(pType instanceof PrimitiveType)) {
+          throw new UnsupportedOperationException(errMsg);
+        } else {
+          PrimitiveType.PrimitiveTypeName typeName = ((PrimitiveType) pType).getPrimitiveTypeName();
+          String expected = predicateType(typeName);
+          String actual = predicateType(ref.type().typeId());
+          if (!actual.equals(expected)) {
+            throw new UnsupportedOperationException(errMsg);
+          }
+        }
+      }
+
       switch (ref.type().typeId()) {
         case BOOLEAN:
           Operators.BooleanColumn col = FilterApi.booleanColumn(path);
@@ -156,7 +187,54 @@ class ParquetFilters {
           return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit));
       }
 
-      throw new UnsupportedOperationException("Cannot convert to Parquet filter: " + pred);
+      throw new UnsupportedOperationException(errMsg);
+    }
+
+    private String predicateType(PrimitiveType.PrimitiveTypeName typeName) {
+      switch (typeName) {
+        case BOOLEAN:
+          return "boolean";
+        case INT32:
+          return "int";
+        case INT64:
+          return "long";
+        case FLOAT:
+          return "float";
+        case DOUBLE:
+          return "double";
+        case INT96:
+        case FIXED_LEN_BYTE_ARRAY:
+        case BINARY:
+          return "binary";
+        default:
+          return "unsupported";
+      }
+    }
+
+    private String predicateType(Type.TypeID typeId) {
+      switch (typeId) {
+        case BOOLEAN:
+          return "boolean";
+        case INTEGER:
+        case DATE:
+          return "int";
+        case LONG:
+        case TIME:
+        case TIMESTAMP:
+          return "long";
+        case FLOAT:
+          return "float";
+        case DOUBLE:
+          return "double";
+        case STRING:
+        case UUID:
+        case FIXED:
+        case BINARY:
+        case DECIMAL:
+          return "binary";
+        default:
+          return "unsupported";
+      }
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -142,7 +142,7 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
 
       PageReadStore pages;
       try {
-        pages = reader.readNextRowGroup();
+        pages = reader.readNextFilteredRowGroup();
       } catch (IOException e) {
         throw new RuntimeIOException(e);
       }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -137,12 +137,11 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
     private void advance() {
       while (shouldSkip[nextRowGroup]) {
         nextRowGroup += 1;
-        reader.skipNextRowGroup();
       }
 
       PageReadStore pages;
       try {
-        pages = reader.readNextFilteredRowGroup();
+        pages = reader.readFilteredRowGroup(nextRowGroup);
       } catch (IOException e) {
         throw new RuntimeIOException(e);
       }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -99,7 +99,6 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
     private final ParquetValueReader<T> model;
     private final long totalValues;
     private final boolean reuseContainers;
-    private final long[] rowGroupsStartRowPos;
 
     private int nextRowGroup = 0;
     private long nextRowGroupStart = 0;
@@ -112,7 +111,6 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
       this.model = conf.model();
       this.totalValues = conf.totalValues();
       this.reuseContainers = conf.reuseContainers();
-      this.rowGroupsStartRowPos = conf.startRowPositions();
     }
 
     @Override
@@ -149,11 +147,10 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
         throw new RuntimeIOException(e);
       }
 
-      long rowPosition = rowGroupsStartRowPos[nextRowGroup];
       nextRowGroupStart += pages.getRowCount();
       nextRowGroup += 1;
 
-      model.setPageSource(pages, rowPosition);
+      model.setPageSource(pages);
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReader.java
@@ -28,5 +28,14 @@ public interface ParquetValueReader<T> {
 
   List<TripleIterator<?>> columns();
 
-  void setPageSource(PageReadStore pageStore);
+  /**
+   * @deprecated since 1.6.0, will be removed in 1.7.0; use setPageSource(PageReadStore) instead.
+   */
+  @Deprecated
+  void setPageSource(PageReadStore pageStore, long rowPosition);
+
+  default void setPageSource(PageReadStore pageStore) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " doesn't implement setPageSource(PageReadStore)");
+  }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReader.java
@@ -28,5 +28,5 @@ public interface ParquetValueReader<T> {
 
   List<TripleIterator<?>> columns();
 
-  void setPageSource(PageReadStore pageStore, long rowPosition);
+  void setPageSource(PageReadStore pageStore);
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -112,6 +112,9 @@ public class ParquetValueReaders {
     }
 
     @Override
+    public void setPageSource(PageReadStore pageStore, long rowPosition) {}
+
+    @Override
     public void setPageSource(PageReadStore pageStore) {}
   }
 
@@ -175,6 +178,9 @@ public class ParquetValueReaders {
     }
 
     @Override
+    public void setPageSource(PageReadStore pageStore, long rowPosition) {}
+
+    @Override
     public void setPageSource(PageReadStore pageStore) {}
   }
 
@@ -199,6 +205,11 @@ public class ParquetValueReaders {
     }
 
     @Override
+    public void setPageSource(PageReadStore pageStore, long rowPosition) {
+      setPageSource(pageStore);
+    }
+
+    @Override
     public void setPageSource(PageReadStore pageStore) {
       this.rowGroupStart = pageStore.getRowIndexOffset().orElse(0L);
       this.rowOffset = -1;
@@ -217,6 +228,11 @@ public class ParquetValueReaders {
       this.desc = desc;
       this.column = ColumnIterator.newIterator(desc, "");
       this.children = ImmutableList.of(column);
+    }
+
+    @Override
+    public void setPageSource(PageReadStore pageStore, long rowPosition) {
+      setPageSource(pageStore);
     }
 
     @Override
@@ -404,6 +420,11 @@ public class ParquetValueReaders {
     }
 
     @Override
+    public void setPageSource(PageReadStore pageStore, long rowPosition) {
+      setPageSource(pageStore);
+    }
+
+    @Override
     public void setPageSource(PageReadStore pageStore) {
       reader.setPageSource(pageStore);
     }
@@ -446,6 +467,11 @@ public class ParquetValueReaders {
       this.reader = reader;
       this.column = reader.column();
       this.children = reader.columns();
+    }
+
+    @Override
+    public void setPageSource(PageReadStore pageStore, long rowPosition) {
+      setPageSource(pageStore);
     }
 
     @Override
@@ -565,6 +591,11 @@ public class ParquetValueReaders {
               .addAll(keyReader.columns())
               .addAll(valueReader.columns())
               .build();
+    }
+
+    @Override
+    public void setPageSource(PageReadStore pageStore, long rowPosition) {
+      setPageSource(pageStore);
     }
 
     @Override
@@ -723,6 +754,11 @@ public class ParquetValueReaders {
 
       this.children = columnsBuilder.build();
       this.column = firstNonNullColumn(children);
+    }
+
+    @Override
+    public void setPageSource(PageReadStore pageStore, long rowPosition) {
+      setPageSource(pageStore);
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -112,7 +112,7 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {}
+    public void setPageSource(PageReadStore pageStore) {}
   }
 
   static class ConstantReader<C> implements ParquetValueReader<C> {
@@ -175,7 +175,7 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {}
+    public void setPageSource(PageReadStore pageStore) {}
   }
 
   static class PositionReader implements ParquetValueReader<Long> {
@@ -199,8 +199,8 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {
-      this.rowGroupStart = rowPosition;
+    public void setPageSource(PageReadStore pageStore) {
+      this.rowGroupStart = pageStore.getRowIndexOffset().orElse(0L);
       this.rowOffset = -1;
     }
   }
@@ -220,7 +220,7 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {
+    public void setPageSource(PageReadStore pageStore) {
       column.setPageSource(pageStore.getPageReader(desc));
     }
 
@@ -404,8 +404,8 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {
-      reader.setPageSource(pageStore, rowPosition);
+    public void setPageSource(PageReadStore pageStore) {
+      reader.setPageSource(pageStore);
     }
 
     @Override
@@ -449,8 +449,8 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {
-      reader.setPageSource(pageStore, rowPosition);
+    public void setPageSource(PageReadStore pageStore) {
+      reader.setPageSource(pageStore);
     }
 
     @Override
@@ -568,9 +568,9 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {
-      keyReader.setPageSource(pageStore, rowPosition);
-      valueReader.setPageSource(pageStore, rowPosition);
+    public void setPageSource(PageReadStore pageStore) {
+      keyReader.setPageSource(pageStore);
+      valueReader.setPageSource(pageStore);
     }
 
     @Override
@@ -726,9 +726,9 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public final void setPageSource(PageReadStore pageStore, long rowPosition) {
+    public final void setPageSource(PageReadStore pageStore) {
       for (ParquetValueReader<?> reader : readers) {
-        reader.setPageSource(pageStore, rowPosition);
+        reader.setPageSource(pageStore);
       }
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -757,7 +757,7 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {
+    public final void setPageSource(PageReadStore pageStore, long rowPosition) {
       setPageSource(pageStore);
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
@@ -116,15 +116,16 @@ class ReadConf<T> {
       }
     }
 
-    this.totalValues = computedTotalValues;
     if (readerFunc != null) {
       this.model = (ParquetValueReader<T>) readerFunc.apply(typeWithIds);
       this.vectorizedModel = null;
       this.columnChunkMetaDataForRowGroups = null;
+      this.totalValues = reader.getFilteredRecordCount();
     } else {
       this.model = null;
       this.vectorizedModel = (VectorizedReader<T>) batchedReaderFunc.apply(typeWithIds);
       this.columnChunkMetaDataForRowGroups = getColumnChunkMetadataForRowGroups();
+      this.totalValues = computedTotalValues;
     }
 
     this.reuseContainers = reuseContainers;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
@@ -116,20 +116,20 @@ class ReadConf<T> {
       }
     }
 
+    if (options.useRecordFilter()) {
+      this.totalValues = reader.getFilteredRecordCount();
+    } else {
+      this.totalValues = computedTotalValues;
+    }
+
     if (readerFunc != null) {
       this.model = (ParquetValueReader<T>) readerFunc.apply(typeWithIds);
       this.vectorizedModel = null;
       this.columnChunkMetaDataForRowGroups = null;
-      if (options.useRecordFilter()) {
-        this.totalValues = reader.getFilteredRecordCount();
-      } else {
-        this.totalValues = computedTotalValues;
-      }
     } else {
       this.model = null;
       this.vectorizedModel = (VectorizedReader<T>) batchedReaderFunc.apply(typeWithIds);
       this.columnChunkMetaDataForRowGroups = getColumnChunkMetadataForRowGroups();
-      this.totalValues = computedTotalValues;
     }
 
     this.reuseContainers = reuseContainers;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
@@ -120,7 +120,11 @@ class ReadConf<T> {
       this.model = (ParquetValueReader<T>) readerFunc.apply(typeWithIds);
       this.vectorizedModel = null;
       this.columnChunkMetaDataForRowGroups = null;
-      this.totalValues = reader.getFilteredRecordCount();
+      if (options.useRecordFilter()) {
+        this.totalValues = reader.getFilteredRecordCount();
+      } else {
+        this.totalValues = computedTotalValues;
+      }
     } else {
       this.model = null;
       this.vectorizedModel = (VectorizedReader<T>) batchedReaderFunc.apply(typeWithIds);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
@@ -19,13 +19,11 @@
 package org.apache.iceberg.parquet;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
@@ -33,9 +31,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.parquet.ParquetReadOptions;
-import org.apache.parquet.crypto.FileDecryptionProperties;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -59,7 +55,6 @@ class ReadConf<T> {
   private final long totalValues;
   private final boolean reuseContainers;
   private final Integer batchSize;
-  private final long[] startRowPositions;
 
   // List of column chunk metadata for each row group
   private final List<Map<ColumnPath, ColumnChunkMetaData>> columnChunkMetaDataForRowGroups;
@@ -95,10 +90,6 @@ class ReadConf<T> {
 
     this.rowGroups = reader.getRowGroups();
     this.shouldSkip = new boolean[rowGroups.size()];
-    this.startRowPositions = new long[rowGroups.size()];
-
-    // Fetch all row groups starting positions to compute the row offsets of the filtered row groups
-    Map<Long, Long> offsetToStartPos = generateOffsetToStartPos(expectedSchema);
 
     ParquetMetricsRowGroupFilter statsFilter = null;
     ParquetDictionaryRowGroupFilter dictFilter = null;
@@ -112,8 +103,6 @@ class ReadConf<T> {
     long computedTotalValues = 0L;
     for (int i = 0; i < shouldSkip.length; i += 1) {
       BlockMetaData rowGroup = rowGroups.get(i);
-      startRowPositions[i] =
-          offsetToStartPos == null ? 0 : offsetToStartPos.get(rowGroup.getStartingPos());
       boolean shouldRead =
           filter == null
               || (statsFilter.shouldRead(typeWithIds, rowGroup)
@@ -155,7 +144,6 @@ class ReadConf<T> {
     this.batchSize = toCopy.batchSize;
     this.vectorizedModel = toCopy.vectorizedModel;
     this.columnChunkMetaDataForRowGroups = toCopy.columnChunkMetaDataForRowGroups;
-    this.startRowPositions = toCopy.startRowPositions;
   }
 
   ParquetFileReader reader() {
@@ -179,38 +167,6 @@ class ReadConf<T> {
 
   boolean[] shouldSkip() {
     return shouldSkip;
-  }
-
-  private Map<Long, Long> generateOffsetToStartPos(Schema schema) {
-    if (schema.findField(MetadataColumns.ROW_POSITION.fieldId()) == null) {
-      return null;
-    }
-
-    FileDecryptionProperties decryptionProperties =
-        (options == null) ? null : options.getDecryptionProperties();
-
-    ParquetReadOptions readOptions =
-        ParquetReadOptions.builder().withDecryption(decryptionProperties).build();
-
-    try (ParquetFileReader fileReader = newReader(file, readOptions)) {
-      Map<Long, Long> offsetToStartPos = Maps.newHashMap();
-
-      long curRowCount = 0;
-      for (int i = 0; i < fileReader.getRowGroups().size(); i += 1) {
-        BlockMetaData meta = fileReader.getRowGroups().get(i);
-        offsetToStartPos.put(meta.getStartingPos(), curRowCount);
-        curRowCount += meta.getRowCount();
-      }
-
-      return offsetToStartPos;
-
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to create/close reader for file: " + file, e);
-    }
-  }
-
-  long[] startRowPositions() {
-    return startRowPositions;
   }
 
   long totalValues() {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TripleIterator.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TripleIterator.java
@@ -129,4 +129,16 @@ interface TripleIterator<T> extends Iterator<T> {
    * @throws java.util.NoSuchElementException if there are no more elements
    */
   <N> N nextNull();
+
+  /**
+   * Returns true when some triples in this iterator might need to be skipped.
+   *
+   * @return whether this iterator needs synchronizing
+   */
+  default boolean needsSynchronizing() {
+    return false;
+  }
+
+  /** Skips triples to synchronize the row reading. */
+  default void synchronize() {}
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ValuesAsBytesReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ValuesAsBytesReader.java
@@ -47,6 +47,14 @@ public class ValuesAsBytesReader extends ValuesReader {
     throw new UnsupportedOperationException();
   }
 
+  public void skipBytes(int toSkip) {
+    try {
+      valuesInputStream.skipFully(toSkip);
+    } catch (IOException e) {
+      throw new ParquetDecodingException("Failed to skip " + toSkip + " bytes", e);
+    }
+  }
+
   public ByteBuffer getBuffer(int length) {
     try {
       return valuesInputStream.slice(length).order(ByteOrder.LITTLE_ENDIAN);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedParquetReader.java
@@ -113,7 +113,6 @@ public class VectorizedParquetReader<T> extends CloseableGroup implements Closea
     private long nextRowGroupStart = 0;
     private long valuesRead = 0;
     private T last = null;
-    private final long[] rowGroupsStartRowPos;
 
     FileIterator(ReadConf conf) {
       this.reader = conf.reader();
@@ -124,7 +123,6 @@ public class VectorizedParquetReader<T> extends CloseableGroup implements Closea
       this.batchSize = conf.batchSize();
       this.model.setBatchSize(this.batchSize);
       this.columnChunkMetadata = conf.columnChunkMetadataForRowGroups();
-      this.rowGroupsStartRowPos = conf.startRowPositions();
     }
 
     @Override
@@ -165,8 +163,7 @@ public class VectorizedParquetReader<T> extends CloseableGroup implements Closea
         throw new RuntimeIOException(e);
       }
 
-      long rowPosition = rowGroupsStartRowPos[nextRowGroup];
-      model.setRowGroupInfo(pages, columnChunkMetadata.get(nextRowGroup), rowPosition);
+      model.setRowGroupInfo(pages, columnChunkMetadata.get(nextRowGroup));
       nextRowGroupStart += pages.getRowCount();
       nextRowGroup += 1;
     }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedParquetReader.java
@@ -154,11 +154,11 @@ public class VectorizedParquetReader<T> extends CloseableGroup implements Closea
     private void advance() {
       while (shouldSkip[nextRowGroup]) {
         nextRowGroup += 1;
-        reader.skipNextRowGroup();
       }
+
       PageReadStore pages;
       try {
-        pages = reader.readNextFilteredRowGroup();
+        pages = reader.readFilteredRowGroup(nextRowGroup);
       } catch (IOException e) {
         throw new RuntimeIOException(e);
       }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedParquetReader.java
@@ -158,7 +158,7 @@ public class VectorizedParquetReader<T> extends CloseableGroup implements Closea
       }
       PageReadStore pages;
       try {
-        pages = reader.readNextRowGroup();
+        pages = reader.readNextFilteredRowGroup();
       } catch (IOException e) {
         throw new RuntimeIOException(e);
       }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedReader.java
@@ -42,10 +42,8 @@ public interface VectorizedReader<T> {
    *
    * @param pages row group information for all the columns
    * @param metadata map of {@link ColumnPath} -&gt; {@link ColumnChunkMetaData} for the row group
-   * @param rowPosition the row group's row offset in the parquet file
    */
-  void setRowGroupInfo(
-      PageReadStore pages, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition);
+  void setRowGroupInfo(PageReadStore pages, Map<ColumnPath, ColumnChunkMetaData> metadata);
 
   /** Release any resources allocated. */
   void close();

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedReader.java
@@ -42,8 +42,25 @@ public interface VectorizedReader<T> {
    *
    * @param pages row group information for all the columns
    * @param metadata map of {@link ColumnPath} -&gt; {@link ColumnChunkMetaData} for the row group
+   * @param rowPosition the row group's row offset in the parquet file
+   * @deprecated since 1.6.0, will be removed in 1.7.0; use setRowGroupInfo(PageReadStore,
+   *     Map&lt;ColumnPath, ColumnChunkMetaData&gt;) instead.
    */
-  void setRowGroupInfo(PageReadStore pages, Map<ColumnPath, ColumnChunkMetaData> metadata);
+  @Deprecated
+  void setRowGroupInfo(
+      PageReadStore pages, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition);
+
+  /**
+   * Sets the row group information to be used with this reader
+   *
+   * @param pages row group information for all the columns
+   * @param metadata map of {@link ColumnPath} -&gt; {@link ColumnChunkMetaData} for the row group
+   */
+  default void setRowGroupInfo(PageReadStore pages, Map<ColumnPath, ColumnChunkMetaData> metadata) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName()
+            + " doesn't implement setRowGroupInfo(PageReadStore, Map<ColumnPath, ColumnChunkMetaData>)");
+  }
 
   /** Release any resources allocated. */
   void close();

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -132,7 +132,9 @@ public class SparkParquetReaders {
     @Override
     public ParquetValueReader<?> message(
         Types.StructType expected, MessageType message, List<ParquetValueReader<?>> fieldReaders) {
-      return struct(expected, message.asGroupType(), fieldReaders);
+      StructReader struct = (StructReader) struct(expected, message.asGroupType(), fieldReaders);
+      struct.topLevel();
+      return struct;
     }
 
     @Override

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -54,9 +54,9 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
 
   @Override
   public void setRowGroupInfo(
-      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData, long rowPosition) {
-    super.setRowGroupInfo(pageStore, metaData, rowPosition);
-    this.rowStartPosInBatch = rowPosition;
+      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData) {
+    super.setRowGroupInfo(pageStore, metaData);
+    this.rowStartPosInBatch = pageStore.getRowIndexOffset().orElse(0L);
   }
 
   public void setDeleteFilter(DeleteFilter<InternalRow> deleteFilter) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -54,6 +54,12 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
 
   @Override
   public void setRowGroupInfo(
+      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData, long rowPosition) {
+    setRowGroupInfo(pageStore, metaData);
+  }
+
+  @Override
+  public void setRowGroupInfo(
       PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData) {
     super.setRowGroupInfo(pageStore, metaData);
     this.rowStartPosInBatch = pageStore.getRowIndexOffset().orElse(0L);

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -132,7 +132,9 @@ public class SparkParquetReaders {
     @Override
     public ParquetValueReader<?> message(
         Types.StructType expected, MessageType message, List<ParquetValueReader<?>> fieldReaders) {
-      return struct(expected, message.asGroupType(), fieldReaders);
+      StructReader struct = (StructReader) struct(expected, message.asGroupType(), fieldReaders);
+      struct.topLevel();
+      return struct;
     }
 
     @Override

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -54,9 +54,9 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
 
   @Override
   public void setRowGroupInfo(
-      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData, long rowPosition) {
-    super.setRowGroupInfo(pageStore, metaData, rowPosition);
-    this.rowStartPosInBatch = rowPosition;
+      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData) {
+    super.setRowGroupInfo(pageStore, metaData);
+    this.rowStartPosInBatch = pageStore.getRowIndexOffset().orElse(0L);
   }
 
   public void setDeleteFilter(DeleteFilter<InternalRow> deleteFilter) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -54,6 +54,12 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
 
   @Override
   public void setRowGroupInfo(
+      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData, long rowPosition) {
+    setRowGroupInfo(pageStore, metaData);
+  }
+
+  @Override
+  public void setRowGroupInfo(
       PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData) {
     super.setRowGroupInfo(pageStore, metaData);
     this.rowStartPosInBatch = pageStore.getRowIndexOffset().orElse(0L);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -132,7 +132,9 @@ public class SparkParquetReaders {
     @Override
     public ParquetValueReader<?> message(
         Types.StructType expected, MessageType message, List<ParquetValueReader<?>> fieldReaders) {
-      return struct(expected, message.asGroupType(), fieldReaders);
+      StructReader struct = (StructReader) struct(expected, message.asGroupType(), fieldReaders);
+      struct.topLevel();
+      return struct;
     }
 
     @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -54,9 +54,9 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
 
   @Override
   public void setRowGroupInfo(
-      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData, long rowPosition) {
-    super.setRowGroupInfo(pageStore, metaData, rowPosition);
-    this.rowStartPosInBatch = rowPosition;
+      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData) {
+    super.setRowGroupInfo(pageStore, metaData);
+    this.rowStartPosInBatch = pageStore.getRowIndexOffset().orElse(0L);
   }
 
   public void setDeleteFilter(DeleteFilter<InternalRow> deleteFilter) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -54,6 +54,12 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
 
   @Override
   public void setRowGroupInfo(
+      PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData, long rowPosition) {
+    setRowGroupInfo(pageStore, metaData);
+  }
+
+  @Override
+  public void setRowGroupInfo(
       PageReadStore pageStore, Map<ColumnPath, ColumnChunkMetaData> metaData) {
     super.setRowGroupInfo(pageStore, metaData);
     this.rowStartPosInBatch = pageStore.getRowIndexOffset().orElse(0L);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetPageSkipping.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetPageSkipping.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data;
+
+import static org.apache.iceberg.TableProperties.PARQUET_DICT_SIZE_BYTES;
+import static org.apache.iceberg.TableProperties.PARQUET_PAGE_SIZE_BYTES;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.avro.generic.GenericData;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.parquet.ParquetAvroWriter;
+import org.apache.iceberg.relocated.com.google.common.base.Function;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestSparkParquetPageSkipping {
+
+  private static final Types.StructType PRIMITIVES =
+      Types.StructType.of(
+          required(0, "_long", Types.LongType.get()),
+          optional(1, "_string", Types.StringType.get()), // var width
+          required(2, "_bool", Types.BooleanType.get()),
+          optional(3, "_int", Types.IntegerType.get()),
+          optional(4, "_float", Types.FloatType.get()),
+          required(5, "_double", Types.DoubleType.get()),
+          optional(6, "_date", Types.DateType.get()),
+          required(7, "_ts", Types.TimestampType.withZone()),
+          required(8, "_fixed", Types.FixedType.ofLength(7)),
+          optional(9, "_bytes", Types.BinaryType.get()), // var width
+          required(10, "_dec_9_0", Types.DecimalType.of(9, 0)), // int
+          required(11, "_dec_11_2", Types.DecimalType.of(11, 2)), // long
+          required(12, "_dec_38_10", Types.DecimalType.of(38, 10)) // fixed
+          );
+
+  private static final Schema PRIMITIVES_SCHEMA = new Schema(PRIMITIVES.fields());
+
+  private static final Types.StructType LIST =
+      Types.StructType.of(
+          optional(13, "_list", Types.ListType.ofOptional(14, Types.StringType.get())));
+  private static final Types.StructType MAP =
+      Types.StructType.of(
+          optional(
+              15,
+              "_map",
+              Types.MapType.ofOptional(16, 17, Types.StringType.get(), Types.StringType.get())));
+  private static final Schema COMPLEX_SCHEMA =
+      new Schema(
+          Lists.newArrayList(Iterables.concat(PRIMITIVES.fields(), LIST.fields(), MAP.fields())));
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  private File testFile;
+  private List<GenericData.Record> allRecords = Lists.newArrayList();
+  private List<GenericData.Record> rowGroup0;
+
+  /* Column and offset indexes info of `_long` column in `testFile` copied from text printed by parquet-cli's
+  column-index command:
+
+  row-group 0:
+  column index for column _long:
+  Boudary order: ASCENDING
+                      null count  min                                       max
+  page-0                         0  0                                         56
+  page-1                         0  57                                        113
+  page-2                         0  114                                       170
+  page-3                         0  171                                       227
+  page-4                         0  228                                       284
+  page-5                         0  285                                       341
+  page-6                         0  342                                       398
+  page-7                         0  399                                       455
+  page-8                         0  456                                       512
+  page-9                         0  513                                       569
+  page-10                        0  570                                       592
+
+  offset index for column _long:
+  offset   compressed size       first row index
+  page-0                         4               137                     0
+  page-1                       141               138                    57
+  page-2                       279               137                   114
+  page-3                       416               138                   171
+  page-4                       554               137                   228
+  page-5                       691               141                   285
+  page-6                       832               140                   342
+  page-7                       972               141                   399
+  page-8                      1113               141                   456
+  page-9                      1254               140                   513
+  page-10                     1394                92                   570
+
+
+  row-group 1:
+  column index for column _long:
+  Boudary order: ASCENDING
+                      null count  min                                       max
+  page-0                         0  593                                       649
+  page-1                         0  650                                       706
+  page-2                         0  707                                       763
+  page-3                         0  764                                       820
+  page-4                         0  821                                       877
+  page-5                         0  878                                       934
+  page-6                         0  935                                       991
+  page-7                         0  992                                       999
+
+  offset index for column _long:
+  offset   compressed size       first row index
+  page-0                    498681               140                     0
+  page-1                    498821               140                    57
+  page-2                    498961               141                   114
+  page-3                    499102               141                   171
+  page-4                    499243               141                   228
+  page-5                    499384               140                   285
+  page-6                    499524               142                   342
+  page-7                    499666                68                   399
+  */
+
+  private long index = -1;
+  private static final int ABOVE_INT_COL_MAX_VALUE = Integer.MAX_VALUE;
+
+  @Before
+  public void generateFile() throws IOException {
+    testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    Function<GenericData.Record, GenericData.Record> transform =
+        record -> {
+          index += 1;
+          if (record.get("_long") != null) {
+            record.put("_long", index);
+          }
+
+          if (Objects.equals(record.get("_int"), ABOVE_INT_COL_MAX_VALUE)) {
+            record.put("_int", ABOVE_INT_COL_MAX_VALUE - 1);
+          }
+
+          return record;
+        };
+
+    int numRecords = 1000;
+    allRecords =
+        RandomData.generateList(COMPLEX_SCHEMA, numRecords, 0).stream()
+            .map(transform)
+            .collect(Collectors.toList());
+    rowGroup0 = selectRecords(allRecords, Pair.of(0, 593));
+
+    try (FileAppender<GenericData.Record> writer =
+        Parquet.write(Files.localOutput(testFile))
+            .createWriterFunc(ParquetAvroWriter::buildWriter)
+            .schema(COMPLEX_SCHEMA)
+            .set(PARQUET_PAGE_SIZE_BYTES, "500")
+            .set(PARQUET_ROW_GROUP_SIZE_BYTES, "500000") // 2 row groups
+            .set(PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT, "1")
+            .set(PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT, "1")
+            .set(PARQUET_DICT_SIZE_BYTES, "1")
+            .named("pages_unaligned_file")
+            .build()) {
+      writer.addAll(allRecords);
+    }
+  }
+
+  @Parameterized.Parameters(name = "vectorized = {0}")
+  public static Object[] parameters() {
+    return new Object[] {false, true};
+  }
+
+  private final boolean vectorized;
+
+  public TestSparkParquetPageSkipping(boolean vectorized) {
+    this.vectorized = vectorized;
+  }
+
+  @Test
+  public void testSinglePageMatch() {
+    Expression filter =
+        Expressions.and(
+            Expressions.greaterThanOrEqual("_long", 57),
+            Expressions.lessThan("_long", 114)); // exactly page-1  -> row ranges: [57, 113]
+
+    List<GenericData.Record> expected = selectRecords(allRecords, Pair.of(57, 114));
+    readAndValidate(filter, expected, rowGroup0);
+  }
+
+  @Test
+  public void testMultiplePagesMatch() {
+    Expression filter =
+        Expressions.or(
+            // page-1  -> row ranges: [57, 113]
+            Expressions.and(
+                Expressions.greaterThanOrEqual("_long", 57), Expressions.lessThan("_long", 114)),
+
+            // page-3, page-4 in row group 0  -> row ranges[171, 284]
+            Expressions.and(
+                Expressions.greaterThanOrEqual("_long", 173), Expressions.lessThan("_long", 260)));
+
+    List<GenericData.Record> expected =
+        selectRecords(allRecords, Pair.of(57, 114), Pair.of(171, 285));
+    readAndValidate(filter, expected, rowGroup0);
+  }
+
+  @Test
+  public void testMultipleRowGroupsMatch() {
+    Expression filter =
+        Expressions.or(
+            // page-1  -> row ranges: [57, 113]
+            Expressions.and(
+                Expressions.greaterThanOrEqual("_long", 57), Expressions.lessThan("_long", 114)),
+
+            // page-3, page-4 in row group 0  -> row ranges[171, 284]
+            Expressions.and(
+                Expressions.greaterThanOrEqual("_long", 173), Expressions.lessThan("_long", 260)));
+
+    filter =
+        Expressions.or(
+            filter,
+            // page-10 in row group 0 and page-0, page-1 in row group 1 -> row ranges: [570, 706]
+            Expressions.and(
+                Expressions.greaterThanOrEqual("_long", 572), Expressions.lessThan("_long", 663)));
+
+    List<GenericData.Record> expected =
+        selectRecords(allRecords, Pair.of(57, 114), Pair.of(171, 285), Pair.of(570, 707));
+    readAndValidate(filter, expected, allRecords);
+  }
+
+  @Test
+  public void testOnlyFilterPagesOnOneRowGroup() {
+    Expression filter =
+        Expressions.and(
+            Expressions.greaterThanOrEqual("_long", 57),
+            Expressions.lessThan("_long", 114)); // exactly page-1  -> row ranges: [57, 113]
+
+    filter =
+        Expressions.or(
+            filter,
+            // page-9, page-10 in row group 0 -> row ranges: [513, 592]
+            // and all pages in row group 1
+            Expressions.greaterThanOrEqual("_long", 569));
+
+    // some pages of row group 0 and all pages of row group 1
+    List<GenericData.Record> expected =
+        selectRecords(allRecords, Pair.of(57, 114), Pair.of(513, 593), Pair.of(593, 1000));
+
+    readAndValidate(filter, expected, allRecords);
+  }
+
+  @Test
+  public void testNoRowsMatch() {
+    Expression filter =
+        Expressions.and(
+            Expressions.and(
+                Expressions.greaterThan("_long", 40), Expressions.lessThan("_long", 46)),
+            Expressions.equal("_int", ABOVE_INT_COL_MAX_VALUE));
+
+    readAndValidate(filter, ImmutableList.of(), ImmutableList.of());
+  }
+
+  @Test
+  public void testAllRowsMatch() {
+    Expression filter = Expressions.greaterThanOrEqual("_long", Long.MIN_VALUE);
+    readAndValidate(filter, allRecords, allRecords);
+  }
+
+  private Schema readSchema() {
+    return vectorized ? PRIMITIVES_SCHEMA : COMPLEX_SCHEMA;
+  }
+
+  private void readAndValidate(
+      Expression filter,
+      List<GenericData.Record> expected,
+      List<GenericData.Record> vectorizedExpected) {
+    Schema projected = readSchema();
+
+    Parquet.ReadBuilder builder =
+        Parquet.read(Files.localInput(testFile)).project(projected).filter(filter);
+
+    Types.StructType struct = projected.asStruct();
+
+    if (vectorized) {
+      CloseableIterable<ColumnarBatch> batches =
+          builder
+              .createBatchedReaderFunc(
+                  type ->
+                      VectorizedSparkParquetReaders.buildReader(
+                          projected, type, ImmutableMap.of(), null))
+              .build();
+
+      Iterator<GenericData.Record> expectedIterator = vectorizedExpected.iterator();
+      for (ColumnarBatch batch : batches) {
+        TestHelpers.assertEqualsBatch(struct, expectedIterator, batch);
+      }
+
+      Assert.assertFalse(
+          "The expected records is more than the actual result", expectedIterator.hasNext());
+    } else {
+      CloseableIterable<InternalRow> reader =
+          builder
+              .createReaderFunc(type -> SparkParquetReaders.buildReader(projected, type))
+              .build();
+      CloseableIterator<InternalRow> actualRows = reader.iterator();
+
+      for (GenericData.Record record : expected) {
+        Assert.assertTrue("Should have expected number of rows", actualRows.hasNext());
+        InternalRow row = actualRows.next();
+        TestHelpers.assertEqualsUnsafe(struct, record, row);
+      }
+
+      Assert.assertFalse("Should not have extra rows", actualRows.hasNext());
+    }
+  }
+
+  private List<GenericData.Record> selectRecords(
+      List<GenericData.Record> records, Pair<Integer, Integer>... ranges) {
+    return Arrays.stream(ranges)
+        .map(range -> records.subList(range.first(), range.second()))
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
This resolves https://github.com/apache/iceberg/issues/193.

This is the 3rd cumulative PR that builds on top of https://github.com/apache/iceberg/pull/10228 and https://github.com/apache/iceberg/pull/10107.
https://github.com/apache/iceberg/pull/10228 implements page skipping for the non-vectorized read path and this PR picks up from there and implements it for the vectorized read path.

The implementation of the vectorized case is based on the implementation in Spark's Parquet reader (see https://github.com/apache/spark/pull/32753), which is in Spark 3.2.
As already implemented in https://github.com/apache/iceberg/pull/10228, we convert an Iceberg filter to a Parquet filter and use the Parquet filter to filter row groups, calling `ParquetFileReader#readFilteredRowGroup`. We get row indexes from the returned `PageReadStore` by calling `PageReadStore#getRowIndexes`. Following the Spark implementation, we construct row ranges (using a simple `RowRange` (not the internal Parquet `RowRange`) class capturing start and end indexes) from the row indexes (a `PrimitiveIterator.OfLong`).
In order to synchronize the reading of the columns (since different columns can have different number of pages and thus pages in different columns start at different row indexes), we get the index of the first row in a page by calling `DataPage#getFirstRowIndex` and we need to track the current row index in the column and the current offset in the Arrow vector we are reading the column values into. Previously, the read state only needed to account for the number of rows read so far and the number of rows left to read, but now "reading" includes both actual reading into the Arrow vector and skipping rows. We therefore use a `ReadState` object (following Spark's `ParquetReadState`) to track the offset and row index as well as the current row range to read, and to advance them.
There is a lot of structurally similar code in several places in `VectorizedParquetDefinitionLevelReader`. I have refactored the similar code into one place in `VectorizedParquetDefinitionLevelReader`. Then I can modify the logic in this one place to perform the synchronization (skipping rows to the start of the row range). The rest of the changes implement how to skip rows for different column types.
