### PR TITLE
Fix `ADLSFileIO.listPrefix()` behavior

### DIFF
--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
@@ -182,7 +182,7 @@ public class ADLSFileIO implements DelegateFileIO {
             .map(
                 pathItem ->
                     new FileInfo(
-                        pathItem.getName(),
+                        location.root() + pathItem.getName(),
                         pathItem.getContentLength(),
                         pathItem.getCreationTime().toInstant().toEpochMilli()))
             .iterator();

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSLocation.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSLocation.java
@@ -35,8 +35,9 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  * Support</a>
  */
 class ADLSLocation {
-  private static final Pattern URI_PATTERN = Pattern.compile("^abfss?://([^/?#]+)(.*)?$");
+  private static final Pattern URI_PATTERN = Pattern.compile("^(abfss?://([^/?#]+))(.*)?$");
 
+  private final String root;
   private final String storageAccount;
   private final String container;
   private final String path;
@@ -53,7 +54,9 @@ class ADLSLocation {
 
     ValidationException.check(matcher.matches(), "Invalid ADLS URI: %s", location);
 
-    String authority = matcher.group(1);
+    this.root = matcher.group(1) + '/';
+
+    String authority = matcher.group(2);
     String[] parts = authority.split("@", -1);
     if (parts.length > 1) {
       this.container = parts[0];
@@ -63,7 +66,7 @@ class ADLSLocation {
       this.storageAccount = authority;
     }
 
-    String uriPath = matcher.group(2);
+    String uriPath = matcher.group(3);
     uriPath = uriPath == null ? "" : uriPath.startsWith("/") ? uriPath.substring(1) : uriPath;
     this.path = uriPath.split("\\?", -1)[0].split("#", -1)[0];
   }
@@ -81,5 +84,10 @@ class ADLSLocation {
   /** Returns ADLS path. */
   public String path() {
     return path;
+  }
+
+  /** Returns the ADLS location without any path. */
+  public String root() {
+    return root;
   }
 }

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/ADLSFileIOTest.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/ADLSFileIOTest.java
@@ -104,7 +104,8 @@ public class ADLSFileIOTest extends BaseAzuriteTest {
   @SuppressWarnings("unchecked")
   @Test
   public void testListPrefixOperations() {
-    String prefix = "abfs://container@account.dfs.core.windows.net/dir";
+    String root = "abfs://container@account.dfs.core.windows.net/";
+    String prefix = root + "dir";
 
     OffsetDateTime now = OffsetDateTime.now();
     PathItem dir =
@@ -129,7 +130,7 @@ public class ADLSFileIOTest extends BaseAzuriteTest {
 
     // assert that only files were returned and not directories
     FileInfo fileInfo = result.next();
-    assertThat(fileInfo.location()).isEqualTo("dir/file");
+    assertThat(fileInfo.location()).isEqualTo(root + "dir/file");
     assertThat(fileInfo.size()).isEqualTo(123L);
     assertThat(fileInfo.createdAtMillis()).isEqualTo(now.toInstant().toEpochMilli());
 

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/ADLSLocationTest.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/ADLSLocationTest.java
@@ -36,6 +36,7 @@ public class ADLSLocationTest {
     assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("path/to/file");
+    assertThat(location.root()).isEqualTo(scheme + "://container@account.dfs.core.windows.net/");
   }
 
   @Test
@@ -46,6 +47,7 @@ public class ADLSLocationTest {
     assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("path%20to%20file");
+    assertThat(location.root()).isEqualTo("abfs://container@account.dfs.core.windows.net/");
   }
 
   @Test


### PR DESCRIPTION
Unlike all other FileIO implementations of `listPrefix()`, the `ADLSFileIO` only returns the path without a leading `/`. This change fixes this inconsistent behavior.

For example, S3, GCS and Hadoop return paths like this: `s3://bucket/path/path/path/path/file`, but ADSL only `path/path/path/path/file`.