### PR TITLE
Kafka Connect: Add table to topics mapping property

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -63,7 +63,7 @@ for exactly-once semantics. This requires Kafka 2.5 or later.
 | iceberg.tables                             | Comma-separated list of destination tables                                                                       |
 | iceberg.tables.dynamic-enabled             | Set to `true` to route to a table specified in `routeField` instead of using `routeRegex`, default is `false`    |
 | iceberg.tables.route-field                 | For multi-table fan-out, the name of the field used to route records to tables                                   |
-| iceberg.tables.topic-to-table-mapping      | For topic to table mapping, statically map topic name to table identifier to route records                       |
+| iceberg.tables.topic-to-table-map          | For topic to table mapping, statically map topic name to table identifier to route records                       |
 | iceberg.tables.default-commit-branch       | Default branch for commits, main is used if not specified                                                        |
 | iceberg.tables.default-id-columns          | Default comma-separated list of columns that identify a row in tables (primary key)                              |
 | iceberg.tables.default-partition-by        | Default comma-separated list of partition field names to use when creating tables                                |
@@ -383,7 +383,7 @@ PARTITIONED BY (hours(ts));
     "connector.class": "org.apache.iceberg.connect.IcebergSinkConnector",
     "tasks.max": "2",
     "topics": "events_list,events_create",
-    "iceberg.tables.topic-to-table-mapping": "event_list:db.event_get_log,events_create:db.event_add_log",
+    "iceberg.tables.topic-to-table-map": "event_list:db.event_get_log,events_create:db.event_add_log",
     "iceberg.catalog.type": "rest",
     "iceberg.catalog.uri": "https://localhost",
     "iceberg.catalog.credential": "<credential>",

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -65,6 +65,8 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String WRITE_PROP_PREFIX = "iceberg.tables.write-props.";
 
   private static final String CATALOG_NAME_PROP = "iceberg.catalog";
+  private static final String TOPIC_TO_TABLES_MAPPING_PROP =
+      "iceberg.tables.topic-to-table-mapping";
   private static final String TABLES_PROP = "iceberg.tables";
   private static final String TABLES_DYNAMIC_PROP = "iceberg.tables.dynamic-enabled";
   private static final String TABLES_ROUTE_FIELD_PROP = "iceberg.tables.route-field";
@@ -108,6 +110,12 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   private static ConfigDef newConfigDef() {
     ConfigDef configDef = new ConfigDef();
+    configDef.define(
+        TOPIC_TO_TABLES_MAPPING_PROP,
+        Type.LIST,
+        null,
+        Importance.LOW,
+        "Comma-delimited list of topic to table mappings");
     configDef.define(
         TABLES_PROP,
         ConfigDef.Type.LIST,
@@ -296,6 +304,18 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public String catalogName() {
     return getString(CATALOG_NAME_PROP);
+  }
+
+  public Map<String, String> topicToTableMap() {
+    Map<String, String> topicToTableMap = Maps.newHashMap();
+    for (String topicToTable : getList(TOPIC_TO_TABLES_MAPPING_PROP)) {
+      String[] propsplit = topicToTable.trim().split(":");
+      if (propsplit.length == 2) {
+        topicToTableMap.put(propsplit[0].trim(), propsplit[1].trim());
+      }
+    }
+    LOG.debug("Config: topicToTableMap: {}", topicToTableMap);
+    return topicToTableMap;
   }
 
   public List<String> tables() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -112,7 +112,7 @@ public class IcebergSinkConfig extends AbstractConfig {
     ConfigDef configDef = new ConfigDef();
     configDef.define(
         TOPIC_TO_TABLES_MAPPING_PROP,
-        Type.LIST,
+        ConfigDef.Type.LIST,
         null,
         Importance.LOW,
         "Comma-delimited list of topic to table mappings");
@@ -309,9 +309,9 @@ public class IcebergSinkConfig extends AbstractConfig {
   public Map<String, String> topicToTableMap() {
     Map<String, String> topicToTableMap = Maps.newHashMap();
     for (String topicToTable : getList(TOPIC_TO_TABLES_MAPPING_PROP)) {
-      String[] propsplit = topicToTable.trim().split(":");
-      if (propsplit.length == 2) {
-        topicToTableMap.put(propsplit[0].trim(), propsplit[1].trim());
+      List<String> propsplit = Splitter.on(':').splitToList(topicToTable.trim());
+      if (propsplit.size() == 2) {
+        topicToTableMap.put(propsplit.get(0).trim(), propsplit.get(1).trim());
       }
     }
     LOG.debug("Config: topicToTableMap: {}", topicToTableMap);

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -65,8 +65,8 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String WRITE_PROP_PREFIX = "iceberg.tables.write-props.";
 
   private static final String CATALOG_NAME_PROP = "iceberg.catalog";
-  private static final String TOPIC_TO_TABLES_MAPPING_PROP =
-      "iceberg.tables.topic-to-table-mapping";
+  private static final String TOPIC_TO_TABLE_MAP_PROP =
+      "iceberg.tables.topic-to-table-map";
   private static final String TABLES_PROP = "iceberg.tables";
   private static final String TABLES_DYNAMIC_PROP = "iceberg.tables.dynamic-enabled";
   private static final String TABLES_ROUTE_FIELD_PROP = "iceberg.tables.route-field";
@@ -111,7 +111,7 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static ConfigDef newConfigDef() {
     ConfigDef configDef = new ConfigDef();
     configDef.define(
-        TOPIC_TO_TABLES_MAPPING_PROP,
+        TOPIC_TO_TABLE_MAP_PROP,
         ConfigDef.Type.LIST,
         null,
         Importance.LOW,
@@ -308,7 +308,7 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public Map<String, String> topicToTableMap() {
     Map<String, String> topicToTableMap = Maps.newHashMap();
-    for (String topicToTable : getList(TOPIC_TO_TABLES_MAPPING_PROP)) {
+    for (String topicToTable : getList(TOPIC_TO_TABLE_MAP_PROP)) {
       List<String> propsplit = Splitter.on(':').splitToList(topicToTable.trim());
       if (propsplit.size() == 2) {
         topicToTableMap.put(propsplit.get(0).trim(), propsplit.get(1).trim());

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SinkWriter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SinkWriter.java
@@ -81,9 +81,24 @@ public class SinkWriter {
 
     if (config.dynamicTablesEnabled()) {
       routeRecordDynamically(record);
+    } else if (config.topicToTableMap().size() > 0) {
+      routeRecordByMap(record);
     } else {
       routeRecordStatically(record);
     }
+  }
+
+  private void routeRecordByMap(SinkRecord record) {
+    Map<String, String> topicToTableMap = config.topicToTableMap();
+    String topicName = record.topic();
+    String tableName = topicToTableMap.get(topicName);
+
+    if (tableName == null) {
+      routeRecordStatically(record);
+      return;
+    }
+
+    writerForTable(tableName, record, false).write(record);
   }
 
   private void routeRecordStatically(SinkRecord record) {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/SinkWriterTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/SinkWriterTest.java
@@ -171,9 +171,11 @@ public class SinkWriterTest {
   @Test
   public void testTopicToTableMapRoute() {
     IcebergSinkConfig config = mock(IcebergSinkConfig.class);
-    when(config.topicToTableMap()).thenReturn(ImmutableMap.of(TOPIC_NAME, TABLE_IDENTIFIER));
+    when(config.topicToTableMap())
+        .thenReturn(ImmutableMap.of(TOPIC_NAME, TABLE_IDENTIFIER.toString()));
+    when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
 
-    Map<String, Object> value = ImmutableMap.of(TOPIC_NAME, TABLE_IDENTIFIER);
+    Map<String, Object> value = ImmutableMap.of(TOPIC_NAME, TABLE_IDENTIFIER.toString());
 
     List<IcebergWriterResult> writerResults = sinkWriterTest(value, config);
     assertThat(writerResults.size()).isEqualTo(1);


### PR DESCRIPTION
The property which allows mapping Kafka topics to Iceberg tables:

An example config would look like:
`iceberg.tables.topic-to-table-mapping=some_topic0:table_name0,some_topic1:table_name1`

Similar approach implemented in SnowflakeSink, [ClickhouseSink](https://github.com/ClickHouse/clickhouse-kafka-connect/pull/211/files), [Aiven JdbcSink](https://github.com/Aiven-Open/jdbc-connector-for-apache-kafka/pull/38/files). Probably I can call it a standard way of static routing data in sink connectors at the moment.
The reason I stated thinking of implementing this because it isn't obvious from the config (or readme) how one should map the topics to tables in the original version because there is no clear indication of where the `.route-regex` is applied.

This could be done for `.partition-by` and `.id-columns` configs as well, but using tables as map keys is such case.

I am making the same PR as the one in the https://github.com/tabular-io/iceberg-kafka-connect/pull/223 because I was told that it is being moved to this core repository. 
It seems that the code hasn't been fully migrated to this core repository yet and I am aware of there should be further tasks such as adding the rest of functionality from the above PR into IcebergSinkTask (as I see it), but would like to share the idea and get initial feedback. Thanks!