### PR TITLE
Open-API: `AssertRefSnapshotId` type should be `branch` or `tag`

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -386,7 +386,7 @@ class AssertRefSnapshotId(TableRequirement):
     The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; if `snapshot-id` is `null` or missing, the ref must not already exist
     """
 
-    type: Literal['assert-ref-snapshot-id']
+    type: Literal['tag', 'branch']
     ref: str
     snapshot_id: int = Field(..., alias='snapshot-id')
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2643,7 +2643,7 @@ components:
       properties:
         type:
           type: string
-          enum: [ "assert-ref-snapshot-id" ]
+          enum: ["tag", "branch"]
         ref:
           type: string
         snapshot-id:


### PR DESCRIPTION
I found this while reviewing a PyIceberg PR.