### PR TITLE
Build: Require approving review

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,6 +35,9 @@ github:
 
   protected_branches:
     main:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+
       required_linear_history: true
   
   features:


### PR DESCRIPTION
It is _very_ easy to accidentally write to the `main` branch through the GitHub UI:

![image](https://github.com/apache/iceberg/assets/1134248/f0db2d2c-c28e-4e09-bb6c-61e93049f976)

This happened to me just now 😭  https://github.com/apache/iceberg/commit/23eb5941cd599183be63676c9d1379ba102b1a97 While through the GitHub UI, the changes will probably be minor, I think it is good to avoid accidents and require explicit approval. After setting this, you'll get:

![image](https://github.com/apache/iceberg/assets/1134248/d170f07e-a669-44e8-a1e7-7171dad2eb33)

We have the required approval for [PyIceberg](https://github.com/apache/iceberg-python/blob/31c6c23d428a3237589ebada2b4cd64bf37b1aef/.asf.yaml#L37-L38), [iceberg-rust](https://github.com/apache/iceberg-rust/blob/1aa05e0e12f7152bb473101cfb06feeb76b7c66f/.asf.yaml#L41) and [iceberg-go](https://github.com/apache/iceberg-go/blob/60da61cc0368b889b74dbcc070f835a3cfb76914/.asf.yaml#L38).
