### PR TITLE
Parquet: Remove deprecated TestHelpers in parquet module

### DIFF
--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -40,7 +39,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.stream.IntStream;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.BoundSetPredicate;
@@ -49,7 +47,6 @@ import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.ByteBuffers;
-import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.Assertions;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
@@ -174,26 +171,6 @@ public class TestHelpers {
                       "Should be the same schema. Schema 1: %s, schema 2: %s", schema1, schema2))
               .isTrue();
         });
-  }
-
-  /**
-   * A convenience method to avoid a large number of @Test(expected=...) tests
-   *
-   * @param message A String message to describe this assertion
-   * @param expected An Exception class that the Runnable should throw
-   * @param containedInMessage A String that should be contained by the thrown exception's message
-   * @param callable A Callable that is expected to throw the exception
-   */
-  public static void assertThrows(
-      String message,
-      Class<? extends Exception> expected,
-      String containedInMessage,
-      Callable callable) {
-    AbstractThrowableAssert<?, ? extends Throwable> check =
-        assertThatThrownBy(callable::call).as(message).isInstanceOf(expected);
-    if (null != containedInMessage) {
-      check.hasMessageContaining(containedInMessage);
-    }
   }
 
   /**


### PR DESCRIPTION
Due to a gradle [issue](https://github.com/gradle/gradle/issues/21255), we should not have test classes with the same full-qualified class name. This commit tries to remove deprecated TestHelpers in parquet module.