### PR TITLE
API, AWS: Retry S3InputStream reads

### DIFF
--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestFlakyS3InputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestFlakyS3InputStream.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import javax.net.ssl.SSLException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+public class TestFlakyS3InputStream extends TestS3InputStream {
+
+  @ParameterizedTest
+  @MethodSource("retryableExceptions")
+  public void testReadWithFlakyStreamRetrySucceed(IOException exception) throws Exception {
+    testRead(flakyStreamClient(new AtomicInteger(3), exception));
+  }
+
+  @ParameterizedTest
+  @MethodSource("retryableExceptions")
+  public void testReadWithFlakyStreamExhaustedRetries(IOException exception) {
+    assertThatThrownBy(() -> testRead(flakyStreamClient(new AtomicInteger(5), exception)))
+        .isInstanceOf(exception.getClass())
+        .hasMessage(exception.getMessage());
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonRetryableExceptions")
+  public void testReadWithFlakyStreamNonRetryableException(IOException exception) {
+    assertThatThrownBy(() -> testRead(flakyStreamClient(new AtomicInteger(3), exception)))
+        .isInstanceOf(exception.getClass())
+        .hasMessage(exception.getMessage());
+  }
+
+  @ParameterizedTest
+  @MethodSource("retryableExceptions")
+  public void testSeekWithFlakyStreamRetrySucceed(IOException exception) throws Exception {
+    testSeek(flakyStreamClient(new AtomicInteger(3), exception));
+  }
+
+  @ParameterizedTest
+  @MethodSource("retryableExceptions")
+  public void testSeekWithFlakyStreamExhaustedRetries(IOException exception) {
+    assertThatThrownBy(() -> testSeek(flakyStreamClient(new AtomicInteger(5), exception)))
+        .isInstanceOf(exception.getClass())
+        .hasMessage(exception.getMessage());
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonRetryableExceptions")
+  public void testSeekWithFlakyStreamNonRetryableException(IOException exception) {
+    assertThatThrownBy(() -> testSeek(flakyStreamClient(new AtomicInteger(3), exception)))
+        .isInstanceOf(exception.getClass())
+        .hasMessage(exception.getMessage());
+  }
+
+  private static Stream<Arguments> retryableExceptions() {
+    return Stream.of(
+        Arguments.of(
+            new SocketTimeoutException("socket timeout exception"),
+            new SSLException("some ssl exception")));
+  }
+
+  private static Stream<Arguments> nonRetryableExceptions() {
+    return Stream.of(Arguments.of(new IOException("some generic non-retryable IO exception")));
+  }
+
+  private S3ClientWrapper flakyStreamClient(AtomicInteger counter, IOException failure) {
+    S3ClientWrapper flakyClient = spy(new S3ClientWrapper(s3Client()));
+    doAnswer(invocation -> new FlakyInputStream(invocation.callRealMethod(), counter, failure))
+        .when(flakyClient)
+        .getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+    return flakyClient;
+  }
+
+  /** Wrapper for S3 client, used to mock the final class DefaultS3Client */
+  public static class S3ClientWrapper implements S3Client {
+
+    private final S3Client delegate;
+
+    public S3ClientWrapper(S3Client delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public String serviceName() {
+      return delegate.serviceName();
+    }
+
+    @Override
+    public void close() {
+      delegate.close();
+    }
+
+    @Override
+    public <ReturnT> ReturnT getObject(
+        GetObjectRequest getObjectRequest,
+        ResponseTransformer<GetObjectResponse, ReturnT> responseTransformer)
+        throws AwsServiceException, SdkClientException {
+      return delegate.getObject(getObjectRequest, responseTransformer);
+    }
+
+    @Override
+    public HeadObjectResponse headObject(HeadObjectRequest headObjectRequest)
+        throws AwsServiceException, SdkClientException {
+      return delegate.headObject(headObjectRequest);
+    }
+
+    @Override
+    public PutObjectResponse putObject(PutObjectRequest putObjectRequest, RequestBody requestBody)
+        throws AwsServiceException, SdkClientException {
+      return delegate.putObject(putObjectRequest, requestBody);
+    }
+
+    @Override
+    public CreateBucketResponse createBucket(CreateBucketRequest createBucketRequest)
+        throws AwsServiceException, SdkClientException {
+      return delegate.createBucket(createBucketRequest);
+    }
+  }
+
+  static class FlakyInputStream extends InputStream {
+    private final ResponseInputStream<GetObjectResponse> delegate;
+    private final AtomicInteger counter;
+    private final int round;
+    private final IOException exception;
+
+    FlakyInputStream(Object invocationResponse, AtomicInteger counter, IOException exception) {
+      this.delegate = (ResponseInputStream<GetObjectResponse>) invocationResponse;
+      this.counter = counter;
+      this.round = counter.get();
+      this.exception = exception;
+    }
+
+    private void checkCounter() throws IOException {
+      // for every round of n invocations, only the last call succeeds
+      if (counter.decrementAndGet() == 0) {
+        counter.set(round);
+      } else {
+        throw exception;
+      }
+    }
+
+    @Override
+    public int read() throws IOException {
+      checkCounter();
+      return delegate.read();
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+      checkCounter();
+      return delegate.read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      checkCounter();
+      return delegate.read(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
@@ -54,16 +54,18 @@ public class TestS3InputStream {
 
   @Test
   public void testRead() throws Exception {
+    testRead(s3);
+  }
+
+  protected void testRead(S3Client s3Client) throws Exception {
     S3URI uri = new S3URI("s3://bucket/path/to/read.dat");
     int dataSize = 1024 * 1024 * 10;
     byte[] data = randomData(dataSize);
 
     writeS3Data(uri, data);
 
-    try (SeekableInputStream in = new S3InputStream(s3, uri)) {
+    try (SeekableInputStream in = new S3InputStream(s3Client, uri)) {
       int readSize = 1024;
-      byte[] actual = new byte[readSize];
-
       readAndCheck(in, in.getPos(), readSize, data, false);
       readAndCheck(in, in.getPos(), readSize, data, true);
 
@@ -111,6 +113,10 @@ public class TestS3InputStream {
 
   @Test
   public void testRangeRead() throws Exception {
+    testRangeRead(s3);
+  }
+
+  protected void testRangeRead(S3Client s3Client) throws Exception {
     S3URI uri = new S3URI("s3://bucket/path/to/range-read.dat");
     int dataSize = 1024 * 1024 * 10;
     byte[] expected = randomData(dataSize);
@@ -122,7 +128,7 @@ public class TestS3InputStream {
 
     writeS3Data(uri, expected);
 
-    try (RangeReadable in = new S3InputStream(s3, uri)) {
+    try (RangeReadable in = new S3InputStream(s3Client, uri)) {
       // first 1k
       position = 0;
       offset = 0;
@@ -163,12 +169,16 @@ public class TestS3InputStream {
 
   @Test
   public void testSeek() throws Exception {
+    testSeek(s3);
+  }
+
+  protected void testSeek(S3Client s3Client) throws Exception {
     S3URI uri = new S3URI("s3://bucket/path/to/seek.dat");
     byte[] expected = randomData(1024 * 1024);
 
     writeS3Data(uri, expected);
 
-    try (SeekableInputStream in = new S3InputStream(s3, uri)) {
+    try (SeekableInputStream in = new S3InputStream(s3Client, uri)) {
       in.seek(expected.length / 2);
       byte[] actual = new byte[expected.length / 2];
       IOUtil.readFully(in, actual, 0, expected.length / 2);
@@ -199,5 +209,9 @@ public class TestS3InputStream {
     } catch (BucketAlreadyExistsException | BucketAlreadyOwnedByYouException e) {
       // don't do anything
     }
+  }
+
+  protected S3Client s3Client() {
+    return s3;
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -347,6 +347,7 @@ project(':iceberg-core') {
     implementation libs.jackson.core
     implementation libs.jackson.databind
     implementation libs.caffeine
+    implementation libs.failsafe
     implementation libs.roaringbitmap
     compileOnly(libs.hadoop2.client) {
       exclude group: 'org.apache.avro', module: 'avro'
@@ -462,6 +463,7 @@ project(':iceberg-aws') {
     annotationProcessor libs.immutables.value
     compileOnly libs.immutables.value
     implementation libs.caffeine
+    implementation libs.failsafe
     implementation platform(libs.jackson.bom)
     implementation libs.jackson.core
     implementation libs.jackson.databind

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ delta-standalone = "3.2.0"
 delta-spark = "3.2.0"
 esotericsoftware-kryo = "4.0.3"
 errorprone-annotations = "2.31.0"
+failsafe = "3.3.2"
 findbugs-jsr305 = "3.0.2"
 flink118 =  { strictly = "1.18.1"}
 flink119 =  { strictly = "1.19.0"}
@@ -109,6 +110,7 @@ calcite-druid = { module = "org.apache.calcite:calcite-druid", version.ref = "ca
 datasketches = { module = "org.apache.datasketches:datasketches-java", version.ref = "datasketches" }
 delta-standalone = { module = "io.delta:delta-standalone_2.12", version.ref = "delta-standalone" }
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorprone-annotations" }
+failsafe = { module = "dev.failsafe:failsafe", version.ref = "failsafe"}
 findbugs-jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "findbugs-jsr305" }
 flink118-avro = { module = "org.apache.flink:flink-avro", version.ref = "flink118" }
 flink118-connector-base = { module = "org.apache.flink:flink-connector-base", version.ref = "flink118" }


### PR DESCRIPTION
Fixes #10340 

This is an alternative approach to https://github.com/apache/iceberg/pull/4912/files and https://github.com/apache/iceberg/pull/8221/files#diff-0b632866a3b10fac55c442b08178ec0ac72b3b600878243e15d788a8bd031054

for retrying failures encountered when retrying on the reading of input streams.

This approach defines a `RetryableInputStream` class which will wrap underlying input streams returned by object store APIs.
Upon failures a new stream will be created. Custom exceptions can be passed in, but the default retries are on SocketTimeoutException and SSLException. This change integrates this input stream implementation with S3InputStream, but RetryableINputStream should be able to be used for the other input streams implementations that are provided by Iceberg.


This change relies on the [Failsafe dependency](https://failsafe.dev/).