### PR TITLE
Open-API: TableRequirements should use union of subclasses

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -360,6 +360,87 @@ class RemovePartitionStatisticsUpdate(BaseUpdate):
     snapshot_id: int = Field(..., alias='snapshot-id')
 
 
+class AssertCreate(BaseModel):
+    """
+    The table must not already exist; used for create transactions
+    """
+
+    type: Literal['assert-create']
+
+
+class AssertTableUUID(BaseModel):
+    """
+    The table UUID must match the requirement's `uuid`
+    """
+
+    type: Literal['assert-table-uuid']
+    uuid: str
+
+
+class AssertRefSnapshotId(BaseModel):
+    """
+    The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; if `snapshot-id` is `null` or missing, the ref must not already exist
+    """
+
+    type: Literal['assert-ref-snapshot-id']
+    ref: str
+    snapshot_id: int = Field(..., alias='snapshot-id')
+
+
+class AssertLastAssignedFieldId(BaseModel):
+    """
+    The table's last assigned column id must match the requirement's `last-assigned-field-id`
+    """
+
+    type: Literal['assert-last-assigned-field-id']
+    last_assigned_field_id: int = Field(..., alias='last-assigned-field-id')
+
+
+class AssertCurrentSchemaId(BaseModel):
+    """
+    The table's current schema id must match the requirement's `current-schema-id`
+    """
+
+    type: Literal['assert-current-schema-id']
+    current_schema_id: int = Field(..., alias='current-schema-id')
+
+
+class AssertLastAssignedPartitionId(BaseModel):
+    """
+    The table's last assigned partition id must match the requirement's `last-assigned-partition-id`
+    """
+
+    type: Literal['assert-last-assigned-partition-id']
+    last_assigned_partition_id: int = Field(..., alias='last-assigned-partition-id')
+
+
+class AssertDefaultSpecId(BaseModel):
+    """
+    The table's default spec id must match the requirement's `default-spec-id`
+    """
+
+    type: Literal['assert-default-spec-id']
+    default_spec_id: int = Field(..., alias='default-spec-id')
+
+
+class AssertDefaultSortOrderId(BaseModel):
+    """
+    The table's default sort order id must match the requirement's `default-sort-order-id`
+    """
+
+    type: Literal['assert-default-sort-order-id']
+    default_sort_order_id: int = Field(..., alias='default-sort-order-id')
+
+
+class AssertViewUUID(BaseModel):
+    """
+    The view UUID must match the requirement's `uuid`
+    """
+
+    type: Literal['assert-view-uuid']
+    uuid: str
+
+
 class RegisterTableRequest(BaseModel):
     name: str
     metadata_location: str = Field(..., alias='metadata-location')
@@ -754,6 +835,23 @@ class SetPartitionStatisticsUpdate(BaseUpdate):
     )
 
 
+class TableRequirement(BaseModel):
+    __root__: Union[
+        AssertCreate,
+        AssertTableUUID,
+        AssertRefSnapshotId,
+        AssertLastAssignedFieldId,
+        AssertCurrentSchemaId,
+        AssertLastAssignedPartitionId,
+        AssertDefaultSpecId,
+        AssertDefaultSortOrderId,
+    ] = Field(..., discriminator='type')
+
+
+class ViewRequirement(BaseModel):
+    __root__: AssertViewUUID = Field(..., discriminator='type')
+
+
 class ReportMetricsRequest2(CommitReport):
     report_type: str = Field(..., alias='report-type')
 
@@ -975,23 +1073,6 @@ class ViewUpdate(BaseModel):
     ]
 
 
-class TableRequirement(BaseModel):
-    __root__: Union[
-        AssertCreate,
-        AssertTableUUID,
-        AssertRefSnapshotId,
-        AssertLastAssignedFieldId,
-        AssertCurrentSchemaId,
-        AssertLastAssignedPartitionId,
-        AssertDefaultSpecId,
-        AssertDefaultSortOrderId,
-    ] = Field(..., discriminator='type')
-
-
-class ViewRequirement(BaseModel):
-    __root__: AssertViewUUID = Field(..., discriminator='type')
-
-
 class LoadTableResult(BaseModel):
     """
     Result used when a table is successfully loaded.
@@ -1123,87 +1204,6 @@ class Schema(StructType):
     )
 
 
-class AssertCreate(BaseModel):
-    """
-    The table must not already exist; used for create transactions
-    """
-
-    type: Literal['assert-create']
-
-
-class AssertTableUUID(BaseModel):
-    """
-    The table UUID must match the requirement's `uuid`
-    """
-
-    type: Literal['assert-table-uuid']
-    uuid: str
-
-
-class AssertRefSnapshotId(BaseModel):
-    """
-    The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; if `snapshot-id` is `null` or missing, the ref must not already exist
-    """
-
-    type: Literal['assert-ref-snapshot-id']
-    ref: str
-    snapshot_id: int = Field(..., alias='snapshot-id')
-
-
-class AssertLastAssignedFieldId(BaseModel):
-    """
-    The table's last assigned column id must match the requirement's `last-assigned-field-id`
-    """
-
-    type: Literal['assert-last-assigned-field-id']
-    last_assigned_field_id: int = Field(..., alias='last-assigned-field-id')
-
-
-class AssertCurrentSchemaId(BaseModel):
-    """
-    The table's current schema id must match the requirement's `current-schema-id`
-    """
-
-    type: Literal['assert-current-schema-id']
-    current_schema_id: int = Field(..., alias='current-schema-id')
-
-
-class AssertLastAssignedPartitionId(BaseModel):
-    """
-    The table's last assigned partition id must match the requirement's `last-assigned-partition-id`
-    """
-
-    type: Literal['assert-last-assigned-partition-id']
-    last_assigned_partition_id: int = Field(..., alias='last-assigned-partition-id')
-
-
-class AssertDefaultSpecId(BaseModel):
-    """
-    The table's default spec id must match the requirement's `default-spec-id`
-    """
-
-    type: Literal['assert-default-spec-id']
-    default_spec_id: int = Field(..., alias='default-spec-id')
-
-
-class AssertDefaultSortOrderId(BaseModel):
-    """
-    The table's default sort order id must match the requirement's `default-sort-order-id`
-    """
-
-    type: Literal['assert-default-sort-order-id']
-    default_sort_order_id: int = Field(..., alias='default-sort-order-id')
-
-
-class AssertViewUUID(BaseModel):
-    """
-    The view UUID must match the requirement's `uuid`
-    """
-
-    type: Literal['assert-view-uuid']
-    uuid: str
-
-
 class ReportMetricsRequest1(ScanReport):
     report_type: str = Field(..., alias='report-type')
 
@@ -1215,17 +1215,6 @@ Expression.update_forward_refs()
 TableMetadata.update_forward_refs()
 ViewMetadata.update_forward_refs()
 AddSchemaUpdate.update_forward_refs()
-TableRequirement.update_forward_refs()
-ViewRequirement.update_forward_refs()
 CreateTableRequest.update_forward_refs()
 CreateViewRequest.update_forward_refs()
 ReportMetricsRequest.update_forward_refs()
-AssertCreate.update_forward_refs()
-AssertTableUUID.update_forward_refs()
-AssertRefSnapshotId.update_forward_refs()
-AssertLastAssignedFieldId.update_forward_refs()
-AssertCurrentSchemaId.update_forward_refs()
-AssertLastAssignedPartitionId.update_forward_refs()
-AssertDefaultSpecId.update_forward_refs()
-AssertDefaultSortOrderId.update_forward_refs()
-AssertViewUUID.update_forward_refs()

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -437,7 +437,7 @@ class AssertDefaultSortOrderId(TableRequirement):
 
 
 class ViewRequirement(BaseModel):
-    type: str
+    type: Literal['assert-view-uuid']
 
 
 class AssertViewUUID(ViewRequirement):
@@ -445,7 +445,6 @@ class AssertViewUUID(ViewRequirement):
     The view UUID must match the requirement's `uuid`
     """
 
-    type: Literal['assert-view-uuid']
     uuid: str
 
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -361,7 +361,16 @@ class RemovePartitionStatisticsUpdate(BaseUpdate):
 
 
 class TableRequirement(BaseModel):
-    type: str
+    type: Literal[
+        'assert-create',
+        'assert-table-uuid',
+        'assert-ref-snapshot-id',
+        'assert-last-assigned-field-id',
+        'assert-current-schema-id',
+        'assert-last-assigned-partition-id',
+        'assert-default-spec-id',
+        'assert-default-sort-order-id',
+    ]
 
 
 class AssertCreate(TableRequirement):
@@ -369,15 +378,12 @@ class AssertCreate(TableRequirement):
     The table must not already exist; used for create transactions
     """
 
-    type: Literal['assert-create']
-
 
 class AssertTableUUID(TableRequirement):
     """
     The table UUID must match the requirement's `uuid`
     """
 
-    type: Literal['assert-table-uuid']
     uuid: str
 
 
@@ -386,7 +392,6 @@ class AssertRefSnapshotId(TableRequirement):
     The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; if `snapshot-id` is `null` or missing, the ref must not already exist
     """
 
-    type: Literal['assert-ref-snapshot-id']
     ref: str
     snapshot_id: int = Field(..., alias='snapshot-id')
 
@@ -396,7 +401,6 @@ class AssertLastAssignedFieldId(TableRequirement):
     The table's last assigned column id must match the requirement's `last-assigned-field-id`
     """
 
-    type: Literal['assert-last-assigned-field-id']
     last_assigned_field_id: int = Field(..., alias='last-assigned-field-id')
 
 
@@ -405,7 +409,6 @@ class AssertCurrentSchemaId(TableRequirement):
     The table's current schema id must match the requirement's `current-schema-id`
     """
 
-    type: Literal['assert-current-schema-id']
     current_schema_id: int = Field(..., alias='current-schema-id')
 
 
@@ -414,7 +417,6 @@ class AssertLastAssignedPartitionId(TableRequirement):
     The table's last assigned partition id must match the requirement's `last-assigned-partition-id`
     """
 
-    type: Literal['assert-last-assigned-partition-id']
     last_assigned_partition_id: int = Field(..., alias='last-assigned-partition-id')
 
 
@@ -423,7 +425,6 @@ class AssertDefaultSpecId(TableRequirement):
     The table's default spec id must match the requirement's `default-spec-id`
     """
 
-    type: Literal['assert-default-spec-id']
     default_spec_id: int = Field(..., alias='default-spec-id')
 
 
@@ -432,7 +433,6 @@ class AssertDefaultSortOrderId(TableRequirement):
     The table's default sort order id must match the requirement's `default-sort-order-id`
     """
 
-    type: Literal['assert-default-sort-order-id']
     default_sort_order_id: int = Field(..., alias='default-sort-order-id')
 
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -360,94 +360,6 @@ class RemovePartitionStatisticsUpdate(BaseUpdate):
     snapshot_id: int = Field(..., alias='snapshot-id')
 
 
-class TableRequirement(BaseModel):
-    type: Literal[
-        'assert-create',
-        'assert-table-uuid',
-        'assert-ref-snapshot-id',
-        'assert-last-assigned-field-id',
-        'assert-current-schema-id',
-        'assert-last-assigned-partition-id',
-        'assert-default-spec-id',
-        'assert-default-sort-order-id',
-    ]
-
-
-class AssertCreate(TableRequirement):
-    """
-    The table must not already exist; used for create transactions
-    """
-
-
-class AssertTableUUID(TableRequirement):
-    """
-    The table UUID must match the requirement's `uuid`
-    """
-
-    uuid: str
-
-
-class AssertRefSnapshotId(TableRequirement):
-    """
-    The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; if `snapshot-id` is `null` or missing, the ref must not already exist
-    """
-
-    ref: str
-    snapshot_id: int = Field(..., alias='snapshot-id')
-
-
-class AssertLastAssignedFieldId(TableRequirement):
-    """
-    The table's last assigned column id must match the requirement's `last-assigned-field-id`
-    """
-
-    last_assigned_field_id: int = Field(..., alias='last-assigned-field-id')
-
-
-class AssertCurrentSchemaId(TableRequirement):
-    """
-    The table's current schema id must match the requirement's `current-schema-id`
-    """
-
-    current_schema_id: int = Field(..., alias='current-schema-id')
-
-
-class AssertLastAssignedPartitionId(TableRequirement):
-    """
-    The table's last assigned partition id must match the requirement's `last-assigned-partition-id`
-    """
-
-    last_assigned_partition_id: int = Field(..., alias='last-assigned-partition-id')
-
-
-class AssertDefaultSpecId(TableRequirement):
-    """
-    The table's default spec id must match the requirement's `default-spec-id`
-    """
-
-    default_spec_id: int = Field(..., alias='default-spec-id')
-
-
-class AssertDefaultSortOrderId(TableRequirement):
-    """
-    The table's default sort order id must match the requirement's `default-sort-order-id`
-    """
-
-    default_sort_order_id: int = Field(..., alias='default-sort-order-id')
-
-
-class ViewRequirement(BaseModel):
-    type: Literal['assert-view-uuid']
-
-
-class AssertViewUUID(ViewRequirement):
-    """
-    The view UUID must match the requirement's `uuid`
-    """
-
-    uuid: str
-
-
 class RegisterTableRequest(BaseModel):
     name: str
     metadata_location: str = Field(..., alias='metadata-location')
@@ -1063,6 +975,23 @@ class ViewUpdate(BaseModel):
     ]
 
 
+class TableRequirement(BaseModel):
+    __root__: Union[
+        AssertCreate,
+        AssertTableUUID,
+        AssertRefSnapshotId,
+        AssertLastAssignedFieldId,
+        AssertCurrentSchemaId,
+        AssertLastAssignedPartitionId,
+        AssertDefaultSpecId,
+        AssertDefaultSortOrderId,
+    ] = Field(..., discriminator='type')
+
+
+class ViewRequirement(BaseModel):
+    __root__: AssertViewUUID = Field(..., discriminator='type')
+
+
 class LoadTableResult(BaseModel):
     """
     Result used when a table is successfully loaded.
@@ -1194,6 +1123,87 @@ class Schema(StructType):
     )
 
 
+class AssertCreate(BaseModel):
+    """
+    The table must not already exist; used for create transactions
+    """
+
+    type: Literal['assert-create']
+
+
+class AssertTableUUID(BaseModel):
+    """
+    The table UUID must match the requirement's `uuid`
+    """
+
+    type: Literal['assert-table-uuid']
+    uuid: str
+
+
+class AssertRefSnapshotId(BaseModel):
+    """
+    The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; if `snapshot-id` is `null` or missing, the ref must not already exist
+    """
+
+    type: Literal['assert-ref-snapshot-id']
+    ref: str
+    snapshot_id: int = Field(..., alias='snapshot-id')
+
+
+class AssertLastAssignedFieldId(BaseModel):
+    """
+    The table's last assigned column id must match the requirement's `last-assigned-field-id`
+    """
+
+    type: Literal['assert-last-assigned-field-id']
+    last_assigned_field_id: int = Field(..., alias='last-assigned-field-id')
+
+
+class AssertCurrentSchemaId(BaseModel):
+    """
+    The table's current schema id must match the requirement's `current-schema-id`
+    """
+
+    type: Literal['assert-current-schema-id']
+    current_schema_id: int = Field(..., alias='current-schema-id')
+
+
+class AssertLastAssignedPartitionId(BaseModel):
+    """
+    The table's last assigned partition id must match the requirement's `last-assigned-partition-id`
+    """
+
+    type: Literal['assert-last-assigned-partition-id']
+    last_assigned_partition_id: int = Field(..., alias='last-assigned-partition-id')
+
+
+class AssertDefaultSpecId(BaseModel):
+    """
+    The table's default spec id must match the requirement's `default-spec-id`
+    """
+
+    type: Literal['assert-default-spec-id']
+    default_spec_id: int = Field(..., alias='default-spec-id')
+
+
+class AssertDefaultSortOrderId(BaseModel):
+    """
+    The table's default sort order id must match the requirement's `default-sort-order-id`
+    """
+
+    type: Literal['assert-default-sort-order-id']
+    default_sort_order_id: int = Field(..., alias='default-sort-order-id')
+
+
+class AssertViewUUID(BaseModel):
+    """
+    The view UUID must match the requirement's `uuid`
+    """
+
+    type: Literal['assert-view-uuid']
+    uuid: str
+
+
 class ReportMetricsRequest1(ScanReport):
     report_type: str = Field(..., alias='report-type')
 
@@ -1205,6 +1215,17 @@ Expression.update_forward_refs()
 TableMetadata.update_forward_refs()
 ViewMetadata.update_forward_refs()
 AddSchemaUpdate.update_forward_refs()
+TableRequirement.update_forward_refs()
+ViewRequirement.update_forward_refs()
 CreateTableRequest.update_forward_refs()
 CreateViewRequest.update_forward_refs()
 ReportMetricsRequest.update_forward_refs()
+AssertCreate.update_forward_refs()
+AssertTableUUID.update_forward_refs()
+AssertRefSnapshotId.update_forward_refs()
+AssertLastAssignedFieldId.update_forward_refs()
+AssertCurrentSchemaId.update_forward_refs()
+AssertLastAssignedPartitionId.update_forward_refs()
+AssertDefaultSpecId.update_forward_refs()
+AssertDefaultSortOrderId.update_forward_refs()
+AssertViewUUID.update_forward_refs()

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2587,20 +2587,6 @@ components:
 
     TableRequirement:
       type: object
-      required:
-        - type
-      properties:
-        type:
-          type: "string"
-          enum:
-          - "assert-create"
-          - "assert-table-uuid"
-          - "assert-ref-snapshot-id"
-          - "assert-last-assigned-field-id"
-          - "assert-current-schema-id"
-          - "assert-last-assigned-partition-id"
-          - "assert-default-spec-id"
-          - "assert-default-sort-order-id"
       discriminator:
         propertyName: type
         mapping:
@@ -2612,20 +2598,39 @@ components:
           assert-last-assigned-partition-id: '#/components/schemas/AssertLastAssignedPartitionId'
           assert-default-spec-id: '#/components/schemas/AssertDefaultSpecId'
           assert-default-sort-order-id: '#/components/schemas/AssertDefaultSortOrderId'
+      oneOf:
+        - $ref: '#/components/schemas/AssertCreate'
+        - $ref: '#/components/schemas/AssertTableUUID'
+        - $ref: '#/components/schemas/AssertRefSnapshotId'
+        - $ref: '#/components/schemas/AssertLastAssignedFieldId'
+        - $ref: '#/components/schemas/AssertCurrentSchemaId'
+        - $ref: '#/components/schemas/AssertLastAssignedPartitionId'
+        - $ref: '#/components/schemas/AssertDefaultSpecId'
+        - $ref: '#/components/schemas/AssertDefaultSortOrderId'
 
     AssertCreate:
       allOf:
         - $ref: "#/components/schemas/TableRequirement"
       type: object
       description: The table must not already exist; used for create transactions
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: ["assert-create"]
 
     AssertTableUUID:
       allOf:
         - $ref: "#/components/schemas/TableRequirement"
       description: The table UUID must match the requirement's `uuid`
       required:
+        - type
         - uuid
       properties:
+        type:
+          type: string
+          enum: ["assert-table-uuid"]
         uuid:
           type: string
 
@@ -2636,9 +2641,13 @@ components:
         The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; 
         if `snapshot-id` is `null` or missing, the ref must not already exist
       required:
+        - type
         - ref
         - snapshot-id
       properties:
+        type:
+          type: string
+          enum: [ "assert-ref-snapshot-id" ]
         ref:
           type: string
         snapshot-id:
@@ -2651,8 +2660,12 @@ components:
       description:
         The table's last assigned column id must match the requirement's `last-assigned-field-id`
       required:
+        - type
         - last-assigned-field-id
       properties:
+        type:
+          type: string
+          enum: [ "assert-last-assigned-field-id" ]
         last-assigned-field-id:
           type: integer
 
@@ -2662,8 +2675,12 @@ components:
       description:
         The table's current schema id must match the requirement's `current-schema-id`
       required:
+        - type
         - current-schema-id
       properties:
+        type:
+          type: string
+          enum: [ "assert-current-schema-id" ]
         current-schema-id:
           type: integer
 
@@ -2673,8 +2690,12 @@ components:
       description:
         The table's last assigned partition id must match the requirement's `last-assigned-partition-id`
       required:
+        - type
         - last-assigned-partition-id
       properties:
+        type:
+          type: string
+          enum: [ "assert-last-assigned-partition-id" ]
         last-assigned-partition-id:
           type: integer
 
@@ -2684,8 +2705,12 @@ components:
       description:
         The table's default spec id must match the requirement's `default-spec-id`
       required:
+        - type
         - default-spec-id
       properties:
+        type:
+          type: string
+          enum: [ "assert-default-spec-id" ]
         default-spec-id:
           type: integer
 
@@ -2695,30 +2720,35 @@ components:
       description:
         The table's default sort order id must match the requirement's `default-sort-order-id`
       required:
+        - type
         - default-sort-order-id
       properties:
+        type:
+          type: string
+          enum: [ "assert-default-sort-order-id" ]
         default-sort-order-id:
           type: integer
 
     ViewRequirement:
       type: object
-      required:
-        - type
-      properties:
-        type:
-          enum: [ "assert-view-uuid" ]
       discriminator:
         propertyName: type
         mapping:
           assert-view-uuid: '#/components/schemas/AssertViewUUID'
+      oneOf:
+        - $ref: '#/components/schemas/AssertViewUUID'
 
     AssertViewUUID:
       allOf:
         - $ref: "#/components/schemas/ViewRequirement"
       description: The view UUID must match the requirement's `uuid`
       required:
+        - type
         - uuid
       properties:
+        type:
+          type: string
+          enum: [ "assert-view-uuid" ]
         uuid:
           type: string
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2586,17 +2586,6 @@ components:
         - $ref: '#/components/schemas/SetCurrentViewVersionUpdate'
 
     TableRequirement:
-      discriminator:
-        propertyName: type
-        mapping:
-          assert-create: '#/components/schemas/AssertCreate'
-          assert-table-uuid: '#/components/schemas/AssertTableUUID'
-          assert-ref-snapshot-id: '#/components/schemas/AssertRefSnapshotId'
-          assert-last-assigned-field-id: '#/components/schemas/AssertLastAssignedFieldId'
-          assert-current-schema-id: '#/components/schemas/AssertCurrentSchemaId'
-          assert-last-assigned-partition-id: '#/components/schemas/AssertLastAssignedPartitionId'
-          assert-default-spec-id: '#/components/schemas/AssertDefaultSpecId'
-          assert-default-sort-order-id: '#/components/schemas/AssertDefaultSortOrderId'
       type: object
       required:
         - type
@@ -2612,6 +2601,17 @@ components:
           - "assert-last-assigned-partition-id"
           - "assert-default-spec-id"
           - "assert-default-sort-order-id"
+      discriminator:
+        propertyName: type
+        mapping:
+          assert-create: '#/components/schemas/AssertCreate'
+          assert-table-uuid: '#/components/schemas/AssertTableUUID'
+          assert-ref-snapshot-id: '#/components/schemas/AssertRefSnapshotId'
+          assert-last-assigned-field-id: '#/components/schemas/AssertLastAssignedFieldId'
+          assert-current-schema-id: '#/components/schemas/AssertCurrentSchemaId'
+          assert-last-assigned-partition-id: '#/components/schemas/AssertLastAssignedPartitionId'
+          assert-default-spec-id: '#/components/schemas/AssertDefaultSpecId'
+          assert-default-sort-order-id: '#/components/schemas/AssertDefaultSortOrderId'
 
     AssertCreate:
       allOf:
@@ -2701,16 +2701,16 @@ components:
           type: integer
 
     ViewRequirement:
-      discriminator:
-        propertyName: type
-        mapping:
-          assert-view-uuid: '#/components/schemas/AssertViewUUID'
       type: object
       required:
         - type
       properties:
         type:
           enum: [ "assert-view-uuid" ]
+      discriminator:
+        propertyName: type
+        mapping:
+          assert-view-uuid: '#/components/schemas/AssertViewUUID'
 
     AssertViewUUID:
       allOf:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2598,15 +2598,8 @@ components:
           assert-default-spec-id: '#/components/schemas/AssertDefaultSpecId'
           assert-default-sort-order-id: '#/components/schemas/AssertDefaultSortOrderId'
       type: object
-      required:
-        - type
-      properties:
-        type:
-          type: "string"
 
     AssertCreate:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       type: object
       description: The table must not already exist; used for create transactions
       required:
@@ -2617,8 +2610,6 @@ components:
           enum: ["assert-create"]
 
     AssertTableUUID:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description: The table UUID must match the requirement's `uuid`
       required:
         - type
@@ -2631,8 +2622,6 @@ components:
           type: string
 
     AssertRefSnapshotId:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; 
         if `snapshot-id` is `null` or missing, the ref must not already exist
@@ -2651,8 +2640,6 @@ components:
           format: int64
 
     AssertLastAssignedFieldId:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's last assigned column id must match the requirement's `last-assigned-field-id`
       required:
@@ -2666,8 +2653,6 @@ components:
           type: integer
 
     AssertCurrentSchemaId:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's current schema id must match the requirement's `current-schema-id`
       required:
@@ -2681,8 +2666,6 @@ components:
           type: integer
 
     AssertLastAssignedPartitionId:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's last assigned partition id must match the requirement's `last-assigned-partition-id`
       required:
@@ -2696,8 +2679,6 @@ components:
           type: integer
 
     AssertDefaultSpecId:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's default spec id must match the requirement's `default-spec-id`
       required:
@@ -2711,8 +2692,6 @@ components:
           type: integer
 
     AssertDefaultSortOrderId:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's default sort order id must match the requirement's `default-sort-order-id`
       required:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2598,6 +2598,11 @@ components:
           assert-default-spec-id: '#/components/schemas/AssertDefaultSpecId'
           assert-default-sort-order-id: '#/components/schemas/AssertDefaultSortOrderId'
       type: object
+      required:
+        - type
+      properties:
+        type:
+          type: "string"
 
     AssertCreate:
       type: object

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2609,8 +2609,6 @@ components:
         - $ref: '#/components/schemas/AssertDefaultSortOrderId'
 
     AssertCreate:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       type: object
       description: The table must not already exist; used for create transactions
       required:
@@ -2621,8 +2619,6 @@ components:
           enum: ["assert-create"]
 
     AssertTableUUID:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description: The table UUID must match the requirement's `uuid`
       required:
         - type
@@ -2635,8 +2631,6 @@ components:
           type: string
 
     AssertRefSnapshotId:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; 
         if `snapshot-id` is `null` or missing, the ref must not already exist
@@ -2655,8 +2649,6 @@ components:
           format: int64
 
     AssertLastAssignedFieldId:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's last assigned column id must match the requirement's `last-assigned-field-id`
       required:
@@ -2670,8 +2662,6 @@ components:
           type: integer
 
     AssertCurrentSchemaId:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's current schema id must match the requirement's `current-schema-id`
       required:
@@ -2685,8 +2675,6 @@ components:
           type: integer
 
     AssertLastAssignedPartitionId:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's last assigned partition id must match the requirement's `last-assigned-partition-id`
       required:
@@ -2700,8 +2688,6 @@ components:
           type: integer
 
     AssertDefaultSpecId:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's default spec id must match the requirement's `default-spec-id`
       required:
@@ -2715,8 +2701,6 @@ components:
           type: integer
 
     AssertDefaultSortOrderId:
-      allOf:
-        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's default sort order id must match the requirement's `default-sort-order-id`
       required:
@@ -2739,8 +2723,6 @@ components:
         - $ref: '#/components/schemas/AssertViewUUID'
 
     AssertViewUUID:
-      allOf:
-        - $ref: "#/components/schemas/ViewRequirement"
       description: The view UUID must match the requirement's `uuid`
       required:
         - type

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2603,41 +2603,42 @@ components:
       properties:
         type:
           type: "string"
+          enum:
+          - "assert-create"
+          - "assert-table-uuid"
+          - "assert-ref-snapshot-id"
+          - "assert-last-assigned-field-id"
+          - "assert-current-schema-id"
+          - "assert-last-assigned-partition-id"
+          - "assert-default-spec-id"
+          - "assert-default-sort-order-id"
 
     AssertCreate:
+      allOf:
+        - $ref: "#/components/schemas/TableRequirement"
       type: object
       description: The table must not already exist; used for create transactions
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum: ["assert-create"]
 
     AssertTableUUID:
+      allOf:
+        - $ref: "#/components/schemas/TableRequirement"
       description: The table UUID must match the requirement's `uuid`
       required:
-        - type
         - uuid
       properties:
-        type:
-          type: string
-          enum: ["assert-table-uuid"]
         uuid:
           type: string
 
     AssertRefSnapshotId:
+      allOf:
+        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; 
         if `snapshot-id` is `null` or missing, the ref must not already exist
       required:
-        - type
         - ref
         - snapshot-id
       properties:
-        type:
-          type: string
-          enum: [ "assert-ref-snapshot-id" ]
         ref:
           type: string
         snapshot-id:
@@ -2645,67 +2646,57 @@ components:
           format: int64
 
     AssertLastAssignedFieldId:
+      allOf:
+        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's last assigned column id must match the requirement's `last-assigned-field-id`
       required:
-        - type
         - last-assigned-field-id
       properties:
-        type:
-          type: string
-          enum: [ "assert-last-assigned-field-id" ]
         last-assigned-field-id:
           type: integer
 
     AssertCurrentSchemaId:
+      allOf:
+        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's current schema id must match the requirement's `current-schema-id`
       required:
-        - type
         - current-schema-id
       properties:
-        type:
-          type: string
-          enum: [ "assert-current-schema-id" ]
         current-schema-id:
           type: integer
 
     AssertLastAssignedPartitionId:
+      allOf:
+        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's last assigned partition id must match the requirement's `last-assigned-partition-id`
       required:
-        - type
         - last-assigned-partition-id
       properties:
-        type:
-          type: string
-          enum: [ "assert-last-assigned-partition-id" ]
         last-assigned-partition-id:
           type: integer
 
     AssertDefaultSpecId:
+      allOf:
+        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's default spec id must match the requirement's `default-spec-id`
       required:
-        - type
         - default-spec-id
       properties:
-        type:
-          type: string
-          enum: [ "assert-default-spec-id" ]
         default-spec-id:
           type: integer
 
     AssertDefaultSortOrderId:
+      allOf:
+        - $ref: "#/components/schemas/TableRequirement"
       description:
         The table's default sort order id must match the requirement's `default-sort-order-id`
       required:
-        - type
         - default-sort-order-id
       properties:
-        type:
-          type: string
-          enum: [ "assert-default-sort-order-id" ]
         default-sort-order-id:
           type: integer
 
@@ -2719,19 +2710,15 @@ components:
         - type
       properties:
         type:
-          type: "string"
+          enum: [ "assert-view-uuid" ]
 
     AssertViewUUID:
       allOf:
         - $ref: "#/components/schemas/ViewRequirement"
       description: The view UUID must match the requirement's `uuid`
       required:
-        - type
         - uuid
       properties:
-        type:
-          type: string
-          enum: [ "assert-view-uuid" ]
         uuid:
           type: string
 


### PR DESCRIPTION
Since we are using the [discriminator](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/) field, the type property is inherited from TableRequirements. This PR removed redundant `type` properties in child classes.