### PR TITLE
Core: Use TestTemplate instead of Test annotation in TestPartitionSpecParser/Info

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestPartitionSpecInfo.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitionSpecInfo.java
@@ -31,7 +31,7 @@ import java.util.List;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -62,7 +62,7 @@ public class TestPartitionSpecInfo {
     TestTables.clearTables();
   }
 
-  @Test
+  @TestTemplate
   public void testSpecIsUnpartitionedForVoidTranforms() {
     PartitionSpec spec =
         PartitionSpec.builderFor(schema).alwaysNull("id").alwaysNull("data").build();
@@ -70,7 +70,7 @@ public class TestPartitionSpecInfo {
     assertThat(spec.isUnpartitioned()).isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testSpecInfoUnpartitionedTable() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     TestTables.TestTable table = TestTables.create(tableDir, "test", schema, spec, formatVersion);
@@ -83,7 +83,7 @@ public class TestPartitionSpecInfo {
         .doesNotContainKey(Integer.MAX_VALUE);
   }
 
-  @Test
+  @TestTemplate
   public void testSpecInfoPartitionedTable() {
     PartitionSpec spec = PartitionSpec.builderFor(schema).identity("data").build();
     TestTables.TestTable table = TestTables.create(tableDir, "test", schema, spec, formatVersion);
@@ -95,7 +95,7 @@ public class TestPartitionSpecInfo {
         .doesNotContainKey(Integer.MAX_VALUE);
   }
 
-  @Test
+  @TestTemplate
   public void testColumnDropWithPartitionSpecEvolution() {
     PartitionSpec spec = PartitionSpec.builderFor(schema).identity("id").build();
     TestTables.TestTable table = TestTables.create(tableDir, "test", schema, spec, formatVersion);
@@ -119,7 +119,7 @@ public class TestPartitionSpecInfo {
     assertThat(table.schema().asStruct()).isEqualTo(expectedSchema.asStruct());
   }
 
-  @Test
+  @TestTemplate
   public void testSpecInfoPartitionSpecEvolutionForV1Table() {
     PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("data", 4).build();
     TestTables.TestTable table = TestTables.create(tableDir, "test", schema, spec, formatVersion);

--- a/core/src/test/java/org/apache/iceberg/TestPartitionSpecParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitionSpecParser.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ParameterizedTestExtension.class)
@@ -32,7 +32,7 @@ public class TestPartitionSpecParser extends TestBase {
     return Arrays.asList(1);
   }
 
-  @Test
+  @TestTemplate
   public void testToJsonForV1Table() {
     String expected =
         "{\n"
@@ -69,7 +69,7 @@ public class TestPartitionSpecParser extends TestBase {
     assertThat(PartitionSpecParser.toJson(table.spec(), true)).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testFromJsonWithFieldId() {
     String specString =
         "{\n"
@@ -95,7 +95,7 @@ public class TestPartitionSpecParser extends TestBase {
     assertThat(spec.fields().get(1).fieldId()).isEqualTo(1000);
   }
 
-  @Test
+  @TestTemplate
   public void testFromJsonWithoutFieldId() {
     String specString =
         "{\n"
@@ -119,7 +119,7 @@ public class TestPartitionSpecParser extends TestBase {
     assertThat(spec.fields().get(1).fieldId()).isEqualTo(1001);
   }
 
-  @Test
+  @TestTemplate
   public void testTransforms() {
     for (PartitionSpec spec : PartitionSpecTestBase.SPECS) {
       assertThat(roundTripJSON(spec)).isEqualTo(spec);


### PR DESCRIPTION
I've noticed that the `formatVersion` parameter wasn't properly initialized for this test class because the tests weren't annotated with `@TestTemplate`