### PR TITLE
Core, Parquet, ORC: Don't write column sizes when metrics mode is None

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -561,7 +561,7 @@ public abstract class TestMetrics {
             MetricsConfig.fromProperties(ImmutableMap.of("write.metadata.metrics.default", "none")),
             buildNestedTestRecord());
     assertThat(metrics.recordCount()).isEqualTo(1L);
-    assertThat(metrics.columnSizes()).doesNotContainValue(null);
+    assertThat(metrics.columnSizes()).isEmpty();
     assertCounts(1, null, null, metrics);
     assertBounds(1, Types.IntegerType.get(), null, null, metrics);
     assertCounts(3, null, null, metrics);
@@ -584,6 +584,7 @@ public abstract class TestMetrics {
             buildNestedTestRecord());
     assertThat(metrics.recordCount()).isEqualTo(1L);
     assertThat(metrics.columnSizes()).doesNotContainValue(null);
+    assertThat(metrics.columnSizes()).isNotEmpty();
     assertCounts(1, 1L, 0L, metrics);
     assertBounds(1, Types.IntegerType.get(), null, null, metrics);
     assertCounts(3, 1L, 0L, metrics);
@@ -605,6 +606,7 @@ public abstract class TestMetrics {
             buildNestedTestRecord());
     assertThat(metrics.recordCount()).isEqualTo(1L);
     assertThat(metrics.columnSizes()).doesNotContainValue(null);
+    assertThat(metrics.columnSizes()).isNotEmpty();
     assertCounts(1, 1L, 0L, metrics);
     assertBounds(1, Types.IntegerType.get(), Integer.MAX_VALUE, Integer.MAX_VALUE, metrics);
     assertCounts(3, 1L, 0L, metrics);
@@ -642,6 +644,7 @@ public abstract class TestMetrics {
     CharBuffer expectedMaxBound = CharBuffer.wrap("Lorem ipsv");
     assertThat(metrics.recordCount()).isEqualTo(1L);
     assertThat(metrics.columnSizes()).doesNotContainValue(null);
+    assertThat(metrics.columnSizes()).isNotEmpty();
     assertCounts(1, 1L, 0L, metrics);
     assertBounds(1, Types.StringType.get(), expectedMinBound, expectedMaxBound, metrics);
   }
@@ -666,6 +669,7 @@ public abstract class TestMetrics {
     ByteBuffer expectedMaxBounds = ByteBuffer.wrap(new byte[] {0x1, 0x2, 0x3, 0x4, 0x6});
     assertThat(metrics.recordCount()).isEqualTo(1L);
     assertThat(metrics.columnSizes()).doesNotContainValue(null);
+    assertThat(metrics.columnSizes()).isNotEmpty();
     assertCounts(1, 1L, 0L, metrics);
     assertBounds(1, Types.BinaryType.get(), expectedMinBounds, expectedMaxBounds, metrics);
   }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -160,11 +160,12 @@ public class OrcMetrics {
 
         final MetricsMode metricsMode =
             MetricsUtil.metricsMode(schema, effectiveMetricsConfig, icebergCol.fieldId());
-        columnSizes.put(fieldId, colStat.getBytesOnDisk());
 
         if (metricsMode == MetricsModes.None.get()) {
           continue;
         }
+
+        columnSizes.put(fieldId, colStat.getBytesOnDisk());
 
         if (statsColumns.contains(fieldId)) {
           // Since ORC does not track null values nor repeated ones, the value count for columns in

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -124,12 +124,12 @@ public class ParquetUtil {
           continue;
         }
 
-        increment(columnSizes, fieldId, column.getTotalSize());
-
         MetricsMode metricsMode = MetricsUtil.metricsMode(fileSchema, metricsConfig, fieldId);
         if (metricsMode == MetricsModes.None.get()) {
           continue;
         }
+
+        increment(columnSizes, fieldId, column.getTotalSize());
         increment(valueCounts, fieldId, column.getValueCount());
 
         Statistics stats = column.getStatistics();


### PR DESCRIPTION
Currently, the Iceberg Parquet and ORC writers will write out column sizes even when metrics are disabled. This should not be the case since column sizes are optional in the spec and we should respect the property for this case.