### PR TITLE
Repair manifest action

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteManifests.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteManifests.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -86,4 +87,7 @@ public interface RewriteManifests extends SnapshotUpdate<RewriteManifests> {
    * @return this for method chaining
    */
   RewriteManifests addManifest(ManifestFile manifest);
+
+  RewriteManifests validateWith(BiFunction<Long, Long, Void> func);
+
 }

--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -47,6 +47,12 @@ public interface ActionsProvider {
         this.getClass().getName() + " does not implement rewriteManifests");
   }
 
+  /** Instantiates an action to repair manifests. */
+  default RepairManifests repairManifests(Table table) {
+    throw new UnsupportedOperationException(
+            this.getClass().getName() + " does not implement repairManifests");
+  }
+
   /** Instantiates an action to rewrite data files. */
   default RewriteDataFiles rewriteDataFiles(Table table) {
     throw new UnsupportedOperationException(

--- a/api/src/main/java/org/apache/iceberg/actions/RepairManifests.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RepairManifests.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import org.apache.iceberg.ManifestFile;
+
+public interface RepairManifests extends SnapshotUpdate<RepairManifests, RepairManifests.Result> {
+
+    /**
+     * Passes a location where the staged manifests should be written.
+     *
+     * <p>If not set, defaults to the table's metadata location.
+     *
+     * @param stagingLocation a staging location
+     * @return this for method chaining
+     */
+    RepairManifests stagingLocation(String stagingLocation);
+
+    RepairManifests dryRun(boolean value);
+
+    interface Result {
+        /** Returns rewritten manifests. */
+        Iterable<ManifestFile> rewrittenManifests();
+
+        /** Returns added manifests. */
+        Iterable<ManifestFile> addedManifests();
+
+        /** Returns count of duplicate files removed */
+        Long duplicateFilesRemoved();
+
+        /** Returns count of missing files removed */
+        Long missingFilesRemoved();
+    }
+}

--- a/api/src/main/java/org/apache/iceberg/actions/RepairManifests.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RepairManifests.java
@@ -32,6 +32,14 @@ public interface RepairManifests extends SnapshotUpdate<RepairManifests, RepairM
      */
     RepairManifests stagingLocation(String stagingLocation);
 
+    /**
+     * Toggle writing manifests or only seeing potential results
+     *
+     * <p>If not set, defaults false
+     *
+     * @param value boolean
+     * @return this for method chaining
+     */
     RepairManifests dryRun(boolean value);
 
     interface Result {

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRepairManifests.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRepairManifests.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import org.immutables.value.Value;
+
+@Value.Enclosing
+@SuppressWarnings("ImmutablesStyle")
+@Value.Style(
+    typeImmutableEnclosing = "ImmutableRepairManifests",
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
+interface BaseRepairManifests extends RepairManifests {
+
+  @Value.Immutable
+  interface Result extends RepairManifests.Result {}
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseManifestUpdateSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseManifestUpdateSparkAction.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestContent;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Partitioning;
+import org.apache.iceberg.RollingManifestWriter;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.spark.SparkContentFile;
+import org.apache.iceberg.spark.SparkDataFile;
+import org.apache.iceberg.spark.SparkDeleteFile;
+import org.apache.iceberg.spark.source.SerializableTableWithSize;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.ThreadPools;
+import org.apache.spark.api.java.function.MapPartitionsFunction;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoder;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+abstract class BaseManifestUpdateSparkAction<T> extends BaseSnapshotUpdateSparkAction<T> {
+
+  private final Table table;
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseManifestUpdateSparkAction.class);
+
+  public static final String USE_CACHING = "use-caching";
+  public static final boolean USE_CACHING_DEFAULT = false;
+
+  private PartitionSpec spec = null;
+
+  private final int formatVersion;
+
+  protected BaseManifestUpdateSparkAction(SparkSession spark, Table table) {
+    super(spark);
+    this.table = table;
+    this.spec = table.spec();
+    TableOperations ops = ((HasTableOperations) table).operations();
+    this.formatVersion = ops.current().formatVersion();
+  }
+
+  protected void validateManifest(ManifestFile manifest) {
+    ValidationException.check(
+        hasFileCounts(manifest), "No file counts in manifest: %s", manifest.path());
+  }
+
+  private boolean hasFileCounts(ManifestFile manifest) {
+    return manifest.addedFilesCount() != null
+        && manifest.existingFilesCount() != null
+        && manifest.deletedFilesCount() != null;
+  }
+
+  protected <T, U> U withReusableDS(Dataset<T> ds, Function<Dataset<T>, U> func) {
+    boolean useCaching =
+        PropertyUtil.propertyAsBoolean(options(), USE_CACHING, USE_CACHING_DEFAULT);
+    Dataset<T> reusableDS = useCaching ? ds.cache() : ds;
+
+    try {
+      return func.apply(reusableDS);
+    } finally {
+      if (useCaching) {
+        reusableDS.unpersist(false);
+      }
+    }
+  }
+
+  protected WriteManifests<?> newWriteManifestsFunc(
+      ManifestContent content,
+      StructType sparkType,
+      String outputLocation,
+      long targetManifestSizeBytes,
+      String fileNamePrefix) {
+    ManifestWriterFactory writers =
+        manifestWriters(outputLocation, targetManifestSizeBytes, fileNamePrefix);
+
+    StructType sparkFileType = (StructType) sparkType.apply("data_file").dataType();
+    Types.StructType combinedFileType = DataFile.getType(Partitioning.partitionType(table));
+    Types.StructType fileType = DataFile.getType(spec.partitionType());
+
+    if (content == ManifestContent.DATA) {
+      return new WriteDataManifests(writers, combinedFileType, fileType, sparkFileType);
+    } else {
+      return new WriteDeleteManifests(writers, combinedFileType, fileType, sparkFileType);
+    }
+  }
+
+  protected ManifestWriterFactory manifestWriters(
+      String outputLocation, long targetManifestSizeBytes, String fileNamePrefix) {
+    return new ManifestWriterFactory(
+        sparkContext().broadcast(SerializableTableWithSize.copyOf(table)),
+        formatVersion,
+        spec.specId(),
+        outputLocation,
+        // allow the actual size of manifests to be 20% higher as the estimation is not precise
+        (long) (1.2 * targetManifestSizeBytes),
+        fileNamePrefix);
+  }
+
+  protected List<ManifestFile> loadManifests(
+      ManifestContent content, Snapshot snapshot, Function<ManifestFile, Boolean> filter) {
+
+    List<ManifestFile> manifests;
+
+    if (snapshot == null) {
+      manifests = ImmutableList.of();
+    } else {
+      switch (content) {
+        case DATA:
+          manifests = snapshot.dataManifests(table.io());
+          break;
+        case DELETES:
+          manifests = snapshot.deleteManifests(table.io());
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown manifest content: " + content);
+      }
+    }
+
+    return manifests.stream().filter(filter::apply).collect(Collectors.toList());
+  }
+
+  protected void replaceManifests(
+      Iterable<ManifestFile> deletedManifests,
+      Iterable<ManifestFile> addedManifests,
+      boolean shouldStageManifests) {
+
+    BiFunction<Long, Long, Void> comparisonFn =
+        (createdManifestsFilesCount, replacedManifestsFilesCount) -> {
+          if (!createdManifestsFilesCount.equals(replacedManifestsFilesCount)) {
+            throw new ValidationException(
+                "Replaced and created manifests must have the same number of active files: %d (new), %d (old)",
+                createdManifestsFilesCount, replacedManifestsFilesCount);
+          }
+          return null;
+        };
+
+    replaceManifests(deletedManifests, addedManifests, shouldStageManifests, comparisonFn);
+  }
+
+  protected void replaceManifests(
+      Iterable<ManifestFile> deletedManifests,
+      Iterable<ManifestFile> addedManifests,
+      boolean shouldStageManifests,
+      BiFunction<Long, Long, Void> comparisonFunction) {
+    try {
+
+      org.apache.iceberg.RewriteManifests rewriteManifests = table.rewriteManifests();
+      rewriteManifests.validateWith(comparisonFunction);
+
+      deletedManifests.forEach(rewriteManifests::deleteManifest);
+      addedManifests.forEach(rewriteManifests::addManifest);
+      commit(rewriteManifests);
+
+      if (shouldStageManifests) {
+        // delete new manifests as they were rewritten before the commit
+        deleteFiles(Iterables.transform(addedManifests, ManifestFile::path));
+      }
+    } catch (CommitStateUnknownException commitStateUnknownException) {
+      // don't clean up added manifest files, because they may have been successfully committed.
+      throw commitStateUnknownException;
+    } catch (Exception e) {
+      // delete all new manifests because the rewrite failed
+      deleteFiles(Iterables.transform(addedManifests, ManifestFile::path));
+      throw e;
+    }
+  }
+
+  private void deleteFiles(Iterable<String> locations) {
+    Tasks.foreach(locations)
+        .executeWith(ThreadPools.getWorkerPool())
+        .noRetry()
+        .suppressFailureWhenFinished()
+        .onFailure((location, exc) -> LOG.warn("Failed to delete: {}", location, exc))
+        .run(location -> table.io().deleteFile(location));
+  }
+
+  protected static class WriteDataManifests extends WriteManifests<DataFile> {
+
+    WriteDataManifests(
+        ManifestWriterFactory manifestWriters,
+        Types.StructType combinedPartitionType,
+        Types.StructType partitionType,
+        StructType sparkFileType) {
+      super(manifestWriters, combinedPartitionType, partitionType, sparkFileType);
+    }
+
+    @Override
+    protected SparkDataFile newFileWrapper() {
+      return new SparkDataFile(combinedFileType(), fileType(), sparkFileType());
+    }
+
+    @Override
+    protected RollingManifestWriter<DataFile> newManifestWriter() {
+      return writers().newRollingManifestWriter();
+    }
+  }
+
+  protected static class WriteDeleteManifests extends WriteManifests<DeleteFile> {
+
+    WriteDeleteManifests(
+        ManifestWriterFactory manifestWriters,
+        Types.StructType combinedFileType,
+        Types.StructType fileType,
+        StructType sparkFileType) {
+      super(manifestWriters, combinedFileType, fileType, sparkFileType);
+    }
+
+    @Override
+    protected SparkDeleteFile newFileWrapper() {
+      return new SparkDeleteFile(combinedFileType(), fileType(), sparkFileType());
+    }
+
+    @Override
+    protected RollingManifestWriter<DeleteFile> newManifestWriter() {
+      return writers().newRollingDeleteManifestWriter();
+    }
+  }
+
+  protected abstract static class WriteManifests<F extends ContentFile<F>>
+      implements MapPartitionsFunction<Row, ManifestFile> {
+
+    private static final Encoder<ManifestFile> MANIFEST_ENCODER =
+        Encoders.javaSerialization(ManifestFile.class);
+
+    private final ManifestWriterFactory writers;
+    private final Types.StructType combinedFileType;
+    private final Types.StructType fileType;
+    private final StructType sparkFileType;
+
+    WriteManifests(
+        ManifestWriterFactory writers,
+        Types.StructType combinedFileType,
+        Types.StructType fileType,
+        StructType sparkFileType) {
+      this.writers = writers;
+      this.combinedFileType = combinedFileType;
+      this.fileType = fileType;
+      this.sparkFileType = sparkFileType;
+    }
+
+    protected abstract SparkContentFile<F> newFileWrapper();
+
+    protected abstract RollingManifestWriter<F> newManifestWriter();
+
+    public Dataset<ManifestFile> apply(Dataset<Row> input) {
+      return input.mapPartitions(this, MANIFEST_ENCODER);
+    }
+
+    @Override
+    public Iterator<ManifestFile> call(Iterator<Row> rows) throws Exception {
+      SparkContentFile<F> fileWrapper = newFileWrapper();
+      RollingManifestWriter<F> writer = newManifestWriter();
+
+      try {
+        while (rows.hasNext()) {
+          Row row = rows.next();
+          long snapshotId = row.getLong(0);
+          long sequenceNumber = row.getLong(1);
+          Long fileSequenceNumber = row.isNullAt(2) ? null : row.getLong(2);
+          Row file = row.getStruct(3);
+          writer.existing(fileWrapper.wrap(file), snapshotId, sequenceNumber, fileSequenceNumber);
+        }
+      } finally {
+        writer.close();
+      }
+
+      return writer.toManifestFiles().iterator();
+    }
+
+    protected ManifestWriterFactory writers() {
+      return writers;
+    }
+
+    protected Types.StructType combinedFileType() {
+      return combinedFileType;
+    }
+
+    protected Types.StructType fileType() {
+      return fileType;
+    }
+
+    protected StructType sparkFileType() {
+      return sparkFileType;
+    }
+  }
+
+  protected static class ManifestWriterFactory implements Serializable {
+    private final Broadcast<Table> tableBroadcast;
+    private final int formatVersion;
+    private final int specId;
+    private final String outputLocation;
+    private final long maxManifestSizeBytes;
+
+    private final String fileNamePrefix;
+
+    ManifestWriterFactory(
+        Broadcast<Table> tableBroadcast,
+        int formatVersion,
+        int specId,
+        String outputLocation,
+        long maxManifestSizeBytes,
+        String fileNamePrefix) {
+      this.tableBroadcast = tableBroadcast;
+      this.formatVersion = formatVersion;
+      this.specId = specId;
+      this.outputLocation = outputLocation;
+      this.maxManifestSizeBytes = maxManifestSizeBytes;
+      this.fileNamePrefix = fileNamePrefix;
+    }
+
+    public RollingManifestWriter<DataFile> newRollingManifestWriter() {
+      return new RollingManifestWriter<>(this::newManifestWriter, maxManifestSizeBytes);
+    }
+
+    private ManifestWriter<DataFile> newManifestWriter() {
+      return ManifestFiles.write(formatVersion, spec(), newOutputFile(), null);
+    }
+
+    public RollingManifestWriter<DeleteFile> newRollingDeleteManifestWriter() {
+      return new RollingManifestWriter<>(this::newDeleteManifestWriter, maxManifestSizeBytes);
+    }
+
+    private ManifestWriter<DeleteFile> newDeleteManifestWriter() {
+      return ManifestFiles.writeDeleteManifest(formatVersion, spec(), newOutputFile(), null);
+    }
+
+    private PartitionSpec spec() {
+      return table().specs().get(specId);
+    }
+
+    private OutputFile newOutputFile() {
+      return table().io().newOutputFile(newManifestLocation());
+    }
+
+    private String newManifestLocation() {
+      String fileName = FileFormat.AVRO.addExtension(fileNamePrefix + UUID.randomUUID());
+      Path filePath = new Path(outputLocation, fileName);
+      return filePath.toString();
+    }
+
+    private Table table() {
+      return tableBroadcast.value();
+    }
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileInfo.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import org.apache.spark.sql.Encoder;
+import org.apache.spark.sql.Encoders;
+
+public class ManifestFileInfo {
+  public static final Encoder<ManifestFileInfo> ENCODER = Encoders.bean(ManifestFileInfo.class);
+
+  private String manifest;
+
+  private int manifestContent;
+
+  public ManifestFileInfo(String manifest, int manifestContent) {
+    this.manifest = manifest;
+    this.manifestContent = manifestContent;
+  }
+
+  public ManifestFileInfo() {}
+
+  public String getManifest() {
+    return manifest;
+  }
+
+  public void setManifest(String manifest) {
+    this.manifest = manifest;
+  }
+
+  public int getManifestContent() {
+    return manifestContent;
+  }
+
+  public void setManifestContent(int manifestContent) {
+    this.manifestContent = manifestContent;
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RepairManifestsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RepairManifestsSparkAction.java
@@ -1,0 +1,751 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import static org.apache.iceberg.MetadataTableType.ENTRIES;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.shaded.com.google.common.collect.Maps;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestContent;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.actions.ImmutableRepairManifests;
+import org.apache.iceberg.actions.RepairManifests;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.expressions.UserDefinedFunction;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RepairManifestsSparkAction
+    extends BaseManifestUpdateSparkAction<RepairManifestsSparkAction> implements RepairManifests {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RepairManifestsSparkAction.class);
+
+  protected static final RepairManifests.Result EMPTY_RESULT =
+      ImmutableRepairManifests.Result.builder()
+          .rewrittenManifests(ImmutableList.of())
+          .addedManifests(ImmutableList.of())
+          .missingFilesRemoved(0L)
+          .duplicateFilesRemoved(0L)
+          .build();
+
+  private final Table table;
+
+  private PartitionSpec spec = null;
+
+  private final long targetManifestSizeBytes;
+
+  private String outputLocation = null;
+
+  private final int formatVersion;
+
+  private final boolean shouldStageManifests;
+
+  private boolean dryRunOnly = false;
+
+  private boolean shouldRemoveMissingFiles = false;
+
+  private boolean shouldDeduplicate = false;
+
+  RepairManifestsSparkAction(SparkSession spark, Table table) {
+    super(spark, table);
+    this.table = table;
+    this.spec = table.spec();
+    this.targetManifestSizeBytes =
+        PropertyUtil.propertyAsLong(
+            table.properties(),
+            TableProperties.MANIFEST_TARGET_SIZE_BYTES,
+            TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFAULT);
+
+    // default the output location to the metadata location
+    TableOperations ops = ((HasTableOperations) table).operations();
+    Path metadataFilePath = new Path(ops.metadataFileLocation("file"));
+    this.outputLocation = metadataFilePath.getParent().toString();
+
+    // use the current table format version for new manifests
+    this.formatVersion = ops.current().formatVersion();
+
+    boolean snapshotIdInheritanceEnabled =
+        PropertyUtil.propertyAsBoolean(
+            table.properties(),
+            TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED,
+            TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT);
+    this.shouldStageManifests = formatVersion == 1 && !snapshotIdInheritanceEnabled;
+  }
+
+  public RepairManifestsSparkAction dryRun() {
+    this.dryRunOnly = true;
+    return this;
+  }
+
+  public RepairManifestsSparkAction removeMissingFiles() {
+    this.shouldRemoveMissingFiles = true;
+    return this;
+  }
+
+  public RepairManifestsSparkAction removeDuplicateCommittedFiles() {
+    this.shouldDeduplicate = true;
+    return this;
+  }
+
+  @Override
+  protected RepairManifestsSparkAction self() {
+    return this;
+  }
+
+  @Override
+  public RepairManifests.Result execute() {
+    return withJobGroupInfo(newJobGroupInfo("REPAIR-MANIFEST-FILES", jobDesc()), this::doExecute);
+  }
+
+  private RepairManifests.Result doExecute() {
+    Snapshot snapshot = table.currentSnapshot();
+    RepairManifests.Result dataResult = rewriteManifestAction(ManifestContent.DATA, snapshot);
+    RepairManifests.Result deleteResult = rewriteManifestAction(ManifestContent.DELETES, snapshot);
+
+    List<ManifestFile> rewrittenManifests = Lists.newArrayList();
+    List<ManifestFile> addedManifests = Lists.newArrayList();
+    Long numberDuplicatesRemoved = 0L;
+    Long numberMissingFilesRemoved = 0L;
+
+    dataResult.rewrittenManifests().forEach(rewrittenManifests::add);
+    dataResult.addedManifests().forEach(addedManifests::add);
+    numberDuplicatesRemoved += dataResult.duplicateFilesRemoved();
+    numberMissingFilesRemoved += dataResult.missingFilesRemoved();
+    deleteResult.rewrittenManifests().forEach(rewrittenManifests::add);
+    deleteResult.addedManifests().forEach(addedManifests::add);
+    numberDuplicatesRemoved += deleteResult.duplicateFilesRemoved();
+    numberMissingFilesRemoved += deleteResult.missingFilesRemoved();
+
+    LOG.info(
+        "RepairAction: replaced {} manifests, added {} manifests, removed {} duplicate files, removed {} missing files",
+        rewrittenManifests.size(),
+        addedManifests.size(),
+        numberDuplicatesRemoved,
+        numberMissingFilesRemoved);
+
+    return ImmutableRepairManifests.Result.builder()
+        .rewrittenManifests(rewrittenManifests)
+        .addedManifests(addedManifests)
+        .duplicateFilesRemoved(numberDuplicatesRemoved)
+        .missingFilesRemoved(numberMissingFilesRemoved)
+        .build();
+  }
+
+  private Dataset<Row> baseDataframe(List<ManifestFile> manifests) {
+    Dataset<Row> manifestDF =
+        spark()
+            .createDataset(Lists.transform(manifests, ManifestFile::path), Encoders.STRING())
+            .toDF("manifest");
+
+    Dataset<Row> manifestEntryDF =
+        loadMetadataTable(table, ENTRIES)
+            .filter("status < 2") // select only live entries
+            .selectExpr(
+                "input_file_name() as manifest",
+                "snapshot_id",
+                "sequence_number",
+                "file_sequence_number",
+                "data_file",
+                "status");
+
+    Column joinCond = manifestDF.col("manifest").equalTo(manifestEntryDF.col("manifest"));
+    return manifestEntryDF
+        .join(manifestDF, joinCond, "left_semi")
+        .select(
+            "manifest",
+            "snapshot_id",
+            "sequence_number",
+            "file_sequence_number",
+            "data_file",
+            "status");
+  }
+
+  private Dataset<Row> withFileExists(Dataset<Row> base) {
+    FileIO io = table.io();
+    UserDefinedFunction fileExists =
+        functions
+            .udf(
+                (String path) -> {
+                  if (path == null || path.isEmpty()) {
+                    return false;
+                  } else {
+                    return io.newInputFile(path).exists();
+                  }
+                },
+                DataTypes.BooleanType)
+            .withName("FILE_EXISTS_AT_LOCATION");
+
+    return base.withColumn("file_exists", fileExists.apply(base.col("data_file.file_path")));
+  }
+
+  private Pair<List<ManifestFile>, Dataset<Row>> manifestsAndRowsDF(
+      ManifestContent content, Snapshot snapshot) {
+    List<ManifestFile> contentManifests = loadManifests(content, snapshot, unused -> true);
+
+    if (contentManifests.isEmpty()) {
+      return null;
+    }
+
+    // All files
+    Dataset<Row> manifestEntryDF = baseDataframe(contentManifests);
+    if (shouldRemoveMissingFiles) {
+      manifestEntryDF = withFileExists(manifestEntryDF);
+    }
+
+    manifestEntryDF.cache();
+    return Pair.of(contentManifests, manifestEntryDF);
+  }
+
+  private RepairManifests.Result rewriteManifestAction(ManifestContent content, Snapshot snapshot) {
+    Pair<List<ManifestFile>, Dataset<Row>> manifestsAndDF = manifestsAndRowsDF(content, snapshot);
+    if (manifestsAndDF == null) {
+      return EMPTY_RESULT;
+    }
+    Dataset<Row> manifestEntryDF = manifestsAndDF.second();
+
+    List<ManifestFile> contentManifests = manifestsAndDF.first();
+    Map<String, ManifestFile> manifestsByPath = Maps.newHashMap();
+    contentManifests.forEach(manifest -> manifestsByPath.put(manifest.path(), manifest));
+
+    if (shouldRemoveMissingFiles && !shouldDeduplicate) {
+      ReplaceManifestHelper procedure =
+          new RemoveMissingFilesHelper(
+              manifestEntryDF, manifestsByPath, spec.isUnpartitioned(), content);
+      return procedure.apply();
+    } else if (shouldDeduplicate && !shouldRemoveMissingFiles) {
+      ReplaceManifestHelper procedure =
+          new DeduplicateHelper(
+              manifestEntryDF, manifestsByPath, spec.isUnpartitioned(), content) {};
+      return procedure.apply();
+    } else if (shouldDeduplicate && shouldRemoveMissingFiles) {
+      DeduplicateHelper deduplicateProcedure =
+          new DeduplicateHelper(
+              manifestEntryDF, manifestsByPath, spec.isUnpartitioned(), content) {};
+
+      RemoveMissingFilesHelper missingFilesProcedure =
+          new RemoveMissingFilesHelper(
+              manifestEntryDF, manifestsByPath, spec.isUnpartitioned(), content);
+      return new CombinationRewriteHelper(
+              manifestEntryDF, deduplicateProcedure, missingFilesProcedure)
+          .apply();
+    } else {
+      return EMPTY_RESULT;
+    }
+  }
+
+  private List<ManifestFile> writeUnpartitionedManifests(
+      ManifestContent content, Dataset<Row> manifestEntryDF, int numManifests, String filePrefix) {
+
+    WriteManifests<?> writeFunc =
+        newWriteManifestsFunc(
+            content, manifestEntryDF.schema(), outputLocation, targetManifestSizeBytes, filePrefix);
+    Dataset<Row> transformedManifestEntryDF = manifestEntryDF.repartition(numManifests);
+    return writeFunc.apply(transformedManifestEntryDF).collectAsList();
+  }
+
+  private List<ManifestFile> writePartitionedManifests(
+      ManifestContent content, Dataset<Row> manifestEntryDF, int numManifests, String filePrefix) {
+
+    return withReusableDS(
+        manifestEntryDF,
+        df -> {
+          WriteManifests<?> writeFunc =
+              newWriteManifestsFunc(
+                  content, df.schema(), outputLocation, targetManifestSizeBytes, filePrefix);
+          Column partitionColumn = df.col("data_file.partition");
+          Dataset<Row> transformedDF = repartitionAndSort(df, partitionColumn, numManifests);
+          return writeFunc.apply(transformedDF).collectAsList();
+        });
+  }
+
+  private Dataset<Row> repartitionAndSort(Dataset<Row> df, Column col, int numPartitions) {
+    return df.repartitionByRange(numPartitions, col).sortWithinPartitions(col);
+  }
+
+  private String jobDesc() {
+    List<String> options = Lists.newArrayList();
+    options.add("dryRun=" + dryRunOnly);
+    options.add("removeMissingFile=" + shouldRemoveMissingFiles);
+    options.add("removeDuplicateFiles=" + shouldDeduplicate);
+    String optionsAsString = COMMA_JOINER.join(options);
+    return String.format("Repairing manifest files from %s (%s)", table.name(), optionsAsString);
+  }
+
+  @Override
+  public RepairManifests stagingLocation(String newStagingLocation) {
+    if (shouldStageManifests) {
+      this.outputLocation = newStagingLocation;
+    } else {
+      LOG.warn("Ignoring provided staging location as new manifests will be committed directly");
+    }
+    return this;
+  }
+
+  @Override
+  public RepairManifests dryRun(boolean value) {
+    if (value) {
+      dryRun();
+    }
+    return this;
+  }
+
+  private interface ReplaceManifestHelper {
+    RepairManifests.Result apply();
+  }
+
+  private class DeduplicateHelper implements ReplaceManifestHelper {
+
+    private final Dataset<Row> manifestEntryDF;
+    private final Map<String, ManifestFile> manifestsByPath;
+
+    private final ManifestContent manifestContent;
+
+    private final boolean isUnpartitioned;
+
+    private static final String FILE_PREFIX = "deduped-m-";
+
+    DeduplicateHelper(
+        Dataset<Row> manifestEntryDF,
+        Map<String, ManifestFile> manifestsByPath,
+        boolean isUnpartitioned,
+        ManifestContent manifestContent) {
+      this.manifestEntryDF = manifestEntryDF;
+      this.manifestsByPath = manifestsByPath;
+      this.isUnpartitioned = isUnpartitioned;
+      this.manifestContent = manifestContent;
+    }
+
+    @Override
+    public Result apply() {
+
+      Pair<Long, Dataset<Row>> groupedByFilePathPair = groupedByFilePathResult();
+      if (groupedByFilePathPair == null) {
+        return EMPTY_RESULT;
+      }
+
+      long numDuplicateFiles = groupedByFilePathPair.first();
+      Dataset<Row> groupedByFilePath = groupedByFilePathPair.second();
+      Dataset<Row> duplicatedFilesWithManifests =
+          groupedByFilePath
+              .withColumn("manifest", functions.explode(functions.col("manifests")))
+              .cache();
+
+      Dataset<Row> existingManifestsToRewriteDF =
+          existingManifestsToRewrite(duplicatedFilesWithManifests);
+      Dataset<Row> filesToWriteNewManifestsEarliestSequenceDF =
+          newManifestRowsToWrite(duplicatedFilesWithManifests);
+
+      List<ManifestFile> allManifestsToRewrite = manifestsToRemove(duplicatedFilesWithManifests);
+
+      BiFunction<Long, Long, Void> comparisonFunction =
+          (createdManifestsFilesCount, replacedManifestsFilesCount) -> {
+            if ((createdManifestsFilesCount + numDuplicateFiles) != replacedManifestsFilesCount) {
+              throw new ValidationException(
+                  "Replaced and created manifests must have the same number of active files: %d (new), %d (old) accounting for %d duplicates",
+                  createdManifestsFilesCount, replacedManifestsFilesCount, numDuplicateFiles);
+            }
+            return null;
+          };
+
+      return applyManifests(
+          allManifestsToRewrite,
+          existingManifestsToRewriteDF,
+          filesToWriteNewManifestsEarliestSequenceDF,
+          numDuplicateFiles,
+          0L,
+          comparisonFunction,
+          FILE_PREFIX);
+    }
+
+    protected Pair<Long, Dataset<Row>> groupedByFilePathResult() {
+      Dataset<Row> groupedByFilePath =
+          manifestEntryDF
+              .select(
+                  functions.col("data_file.file_path").as("data_file_path"),
+                  functions.col("manifest"))
+              .groupBy("data_file_path")
+              .agg(functions.collect_list("manifest").as("manifests"))
+              .filter("size(manifests) > 1")
+              .cache();
+
+      if (groupedByFilePath.isEmpty()) {
+        return null;
+      }
+
+      long numDuplicateFiles =
+          groupedByFilePath
+              .select("manifests")
+              .withColumn("num_elements", functions.array_size(functions.col("manifests")).minus(1))
+              .agg(functions.sum("num_elements"))
+              .head()
+              .getLong(0);
+
+      return Pair.of(numDuplicateFiles, groupedByFilePath);
+    }
+
+    protected List<ManifestFile> manifestsToRemove(Dataset<Row> df) {
+      return df.select("manifest").distinct().collectAsList().stream()
+          .map(row -> manifestsByPath.get(row.getString(0)))
+          .collect(Collectors.toList());
+    }
+
+    protected Dataset<Row> existingManifestsToRewrite(Dataset<Row> duplicatedFilesWithManifests) {
+      return manifestEntryDF
+          .join(
+              duplicatedFilesWithManifests,
+              duplicatedFilesWithManifests.col("manifest").equalTo(manifestEntryDF.col("manifest")),
+              "left_semi")
+          .join(
+              duplicatedFilesWithManifests,
+              duplicatedFilesWithManifests
+                  .col("data_file_path")
+                  .equalTo(manifestEntryDF.col("data_file.file_path")),
+              "left_anti")
+          .withColumn("data_file_path", functions.col("data_file.file_path"))
+          .dropDuplicates("data_file_path");
+    }
+
+    protected Dataset<Row> newManifestRowsToWrite(Dataset<Row> duplicatedFilesWithManifests) {
+      Dataset<Row> filesToWriteNewManifestsDF =
+          manifestEntryDF
+              .join(
+                  duplicatedFilesWithManifests,
+                  duplicatedFilesWithManifests
+                      .col("data_file_path")
+                      .equalTo(manifestEntryDF.col("data_file.file_path")),
+                  "left_semi")
+              .withColumn("data_file_path", functions.col("data_file.file_path"))
+              .cache();
+
+      return filesToWriteNewManifestsDF
+          .groupBy("data_file_path")
+          .agg(functions.min("sequence_number").alias("min_seq"))
+          .join(
+              filesToWriteNewManifestsDF,
+              functions.expr(
+                  "data_file.file_path = data_file.file_path AND sequence_number = min_seq"))
+          .withColumn("data_file_path", functions.col("data_file.file_path"))
+          .dropDuplicates("data_file_path");
+    }
+
+    protected long numManifestsFromHistory(List<ManifestFile> manifests, long numberDuplicates) {
+      List<ManifestFile> sample = manifests.stream().limit(20).collect(Collectors.toList());
+      List<Integer> manifestFileCount =
+          sample.stream().map(ManifestFile::addedFilesCount).collect(Collectors.toList());
+      int total = manifestFileCount.stream().mapToInt(Integer::intValue).sum();
+      int numFilesPerManifest = Math.max(1, total / sample.size());
+      return Math.max(1, numberDuplicates / numFilesPerManifest);
+    }
+
+    protected RepairManifests.Result applyManifests(
+        List<ManifestFile> rewrittenManifests,
+        Dataset<Row> existingManifestFilesToRewrite,
+        Dataset<Row> filesForNewManifests,
+        long numDuplicates,
+        long numFilesRemoved,
+        BiFunction<Long, Long, Void> comparisonFunction,
+        String filePrefix) {
+      Dataset<Row> reformattedStrippedDF =
+          existingManifestFilesToRewrite.select(
+              "snapshot_id", "sequence_number", "file_sequence_number", "data_file");
+      Dataset<Row> reformattedReAddedFilesDf =
+          filesForNewManifests.select(
+              "snapshot_id", "sequence_number", "file_sequence_number", "data_file");
+
+      List<ManifestFile> newStrippedManifests;
+      List<ManifestFile> newReAddedFilesManifests;
+
+      int numManifests =
+          Math.toIntExact(numManifestsFromHistory(rewrittenManifests, numDuplicates));
+
+      if (isUnpartitioned) {
+        newStrippedManifests =
+            writeUnpartitionedManifests(
+                manifestContent, reformattedStrippedDF, rewrittenManifests.size(), filePrefix);
+        newReAddedFilesManifests =
+            writeUnpartitionedManifests(
+                manifestContent, reformattedReAddedFilesDf, numManifests, filePrefix);
+      } else {
+        newStrippedManifests =
+            writePartitionedManifests(
+                manifestContent, reformattedStrippedDF, rewrittenManifests.size(), filePrefix);
+        newReAddedFilesManifests =
+            writePartitionedManifests(
+                manifestContent, reformattedReAddedFilesDf, numManifests, filePrefix);
+      }
+
+      List<ManifestFile> allAddedManifests =
+          Stream.concat(newStrippedManifests.stream(), newReAddedFilesManifests.stream())
+              .collect(Collectors.toList());
+
+      if (!dryRunOnly) {
+        replaceManifests(
+            rewrittenManifests, allAddedManifests, shouldStageManifests, comparisonFunction);
+      }
+
+      return ImmutableRepairManifests.Result.builder()
+          .rewrittenManifests(rewrittenManifests)
+          .addedManifests(allAddedManifests)
+          .duplicateFilesRemoved(numDuplicates)
+          .missingFilesRemoved(numFilesRemoved)
+          .build();
+    }
+  }
+
+  private class RemoveMissingFilesHelper implements ReplaceManifestHelper {
+
+    private final Dataset<Row> manifestEntryDF;
+    private final Map<String, ManifestFile> manifestsByPath;
+
+    private final ManifestContent manifestContent;
+
+    private final boolean isUnpartitioned;
+
+    private static final String FILE_PREFIX = "stripped-m-";
+
+    RemoveMissingFilesHelper(
+        Dataset<Row> manifestEntryDF,
+        Map<String, ManifestFile> manifestsByPath,
+        boolean isUnpartitioned,
+        ManifestContent manifestContent) {
+      this.manifestEntryDF = manifestEntryDF;
+      this.manifestsByPath = manifestsByPath;
+      this.isUnpartitioned = isUnpartitioned;
+      this.manifestContent = manifestContent;
+    }
+
+    @Override
+    public Result apply() {
+      Dataset<Row> missingDataFilesDF = manifestEntryDF.filter("file_exists == false").cache();
+
+      // number removed files
+      long numDataFilesRemoved = missingDataFilesDF.count();
+      if (numDataFilesRemoved == 0) {
+        return EMPTY_RESULT;
+      }
+
+      List<ManifestFile> filesAndManifestsToRewriteManifests =
+          manifestFileFromRow(manifestsByPath, missingDataFilesDF);
+
+      Dataset<Row> filesAndManifestsToRewriteDF =
+          manifestEntryDF
+              .join(
+                  missingDataFilesDF,
+                  missingDataFilesDF.col("manifest").equalTo(manifestEntryDF.col("manifest")),
+                  "left_semi")
+              .filter("file_exists == true")
+              .withColumn("data_file_path", functions.col("data_file.file_path"))
+              .dropDuplicates("manifest", "data_file_path")
+              .select("snapshot_id", "sequence_number", "file_sequence_number", "data_file");
+
+      return writeManifests(
+          filesAndManifestsToRewriteManifests, filesAndManifestsToRewriteDF, numDataFilesRemoved);
+    }
+
+    private RepairManifests.Result writeManifests(
+        List<ManifestFile> rewrittenManifests, Dataset<Row> strippedDF, long numDataFilesRemoved) {
+
+      List<ManifestFile> newStrippedManifests;
+
+      if (isUnpartitioned) {
+        newStrippedManifests =
+            writeUnpartitionedManifests(
+                manifestContent, strippedDF, rewrittenManifests.size(), FILE_PREFIX);
+      } else {
+        newStrippedManifests =
+            writePartitionedManifests(
+                manifestContent, strippedDF, rewrittenManifests.size(), FILE_PREFIX);
+      }
+
+      BiFunction<Long, Long, Void> comparisonFn =
+          (createdManifestsFilesCount, replacedManifestsFilesCount) -> {
+            if (!((createdManifestsFilesCount + numDataFilesRemoved)
+                == replacedManifestsFilesCount)) {
+              throw new ValidationException(
+                  "Replaced and created manifests must have the same number of active files: %d (new), %d (old) accounting for %d non-existing files removed",
+                  createdManifestsFilesCount, replacedManifestsFilesCount);
+            }
+            return null;
+          };
+
+      if (!dryRunOnly) {
+        replaceManifests(
+            rewrittenManifests, newStrippedManifests, shouldStageManifests, comparisonFn);
+      }
+      return ImmutableRepairManifests.Result.builder()
+          .rewrittenManifests(rewrittenManifests)
+          .addedManifests(Lists.newArrayList())
+          .duplicateFilesRemoved(0L)
+          .missingFilesRemoved(numDataFilesRemoved)
+          .build();
+    }
+
+    private List<ManifestFile> manifestFileFromRow(
+        Map<String, ManifestFile> allManifests, Dataset<Row> df) {
+      return df.select("manifest").distinct().collectAsList().stream()
+          .map(row -> allManifests.get(row.getString(0)))
+          .collect(Collectors.toList());
+    }
+  }
+
+  class CombinationRewriteHelper implements ReplaceManifestHelper {
+
+    private final DeduplicateHelper dedupeProc;
+
+    private final RemoveMissingFilesHelper missingFilesProc;
+    private final Dataset<Row> manifestEntryDF;
+
+    private static final String FILE_PREFIX = "combo-m-";
+
+    CombinationRewriteHelper(
+        Dataset<Row> manifestEntryDF,
+        DeduplicateHelper dedupeProc,
+        RemoveMissingFilesHelper missingFilesProc) {
+      this.dedupeProc = dedupeProc;
+      this.manifestEntryDF = manifestEntryDF;
+      this.missingFilesProc = missingFilesProc;
+    }
+
+    @Override
+    public Result apply() {
+      Pair<Long, Dataset<Row>> groupedByFilePathPair = dedupeProc.groupedByFilePathResult();
+      if (groupedByFilePathPair == null) {
+        return missingFilesProc.apply();
+      } else {
+        long numDuplicateFiles = groupedByFilePathPair.first();
+
+        Dataset<Row> missingDataFilesDF =
+            manifestEntryDF
+                .filter("file_exists == false")
+                .withColumn("data_file_path", functions.col("data_file.file_path"))
+                .cache();
+
+        long numDataFilesRemoved = missingDataFilesDF.count();
+
+        Dataset<Row> rowsFromManifestsWithMissingFilesDF =
+            manifestEntryDF
+                .join(
+                    missingDataFilesDF,
+                    missingDataFilesDF.col("manifest").equalTo(manifestEntryDF.col("manifest")),
+                    "left_semi")
+                .filter("file_exists == true")
+                .withColumn("data_file_path", functions.col("data_file.file_path"))
+                .select(
+                    "snapshot_id",
+                    "sequence_number",
+                    "file_sequence_number",
+                    "data_file",
+                    "data_file_path");
+
+        Dataset<Row> groupedByFilePath = groupedByFilePathPair.second();
+        Dataset<Row> duplicatedFilesWithManifests =
+            groupedByFilePath
+                .withColumn("manifest", functions.explode(functions.col("manifests")))
+                .cache();
+
+        Dataset<Row> existingManifestsToRewriteDupesDF =
+            dedupeProc
+                .existingManifestsToRewrite(duplicatedFilesWithManifests)
+                .select(
+                    "snapshot_id",
+                    "sequence_number",
+                    "file_sequence_number",
+                    "data_file",
+                    "data_file_path");
+
+        Dataset<Row> allExistingManifestRowsToRewriteDF =
+            existingManifestsToRewriteDupesDF
+                .union(rowsFromManifestsWithMissingFilesDF)
+                .dropDuplicates("data_file_path");
+
+        Dataset<Row> deduplicatedRowsForNewManifest =
+            dedupeProc.newManifestRowsToWrite(duplicatedFilesWithManifests);
+
+        // remove any missing files that are also dupes
+        Dataset<Row> uniqueDeduplicatedRowsForNewManifest =
+            deduplicatedRowsForNewManifest
+                .join(
+                    missingDataFilesDF,
+                    missingDataFilesDF
+                        .col("data_file.file_path")
+                        .equalTo(deduplicatedRowsForNewManifest.col("data_file.file_path")),
+                    "left_anti")
+                .cache();
+
+        List<ManifestFile> dedupeManifestsToRewrite =
+            dedupeProc.manifestsToRemove(duplicatedFilesWithManifests);
+        List<ManifestFile> missingFilesManifestsToRemove =
+            dedupeProc.manifestsToRemove(missingDataFilesDF);
+
+        // count of missing and/or deduplicated
+        long numFilesRemovedAllSources =
+            missingDataFilesDF.dropDuplicates("data_file_path").count() + numDuplicateFiles;
+
+        System.out.println(numFilesRemovedAllSources);
+
+        dedupeManifestsToRewrite.addAll(missingFilesManifestsToRemove);
+
+        BiFunction<Long, Long, Void> comparisonFunction =
+            (createdManifestsFilesCount, replacedManifestsFilesCount) -> {
+              if ((createdManifestsFilesCount + numFilesRemovedAllSources)
+                  != replacedManifestsFilesCount) {
+                throw new ValidationException(
+                    "Replaced and created manifests must have the same number of active files: %d (new), %d (old) accounting for %d duplicates/missing files",
+                    createdManifestsFilesCount,
+                    replacedManifestsFilesCount,
+                    numFilesRemovedAllSources);
+              }
+              return null;
+            };
+
+        return dedupeProc.applyManifests(
+            dedupeManifestsToRewrite.stream().distinct().collect(Collectors.toList()),
+            allExistingManifestRowsToRewriteDF,
+            uniqueDeduplicatedRowsForNewManifest,
+            numDuplicateFiles,
+            numDataFilesRemoved,
+            comparisonFunction,
+            FILE_PREFIX);
+      }
+    }
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -20,57 +20,31 @@ package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.MetadataTableType.ENTRIES;
 
-import java.io.Serializable;
-import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
-import org.apache.iceberg.ContentFile;
-import org.apache.iceberg.DataFile;
-import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
-import org.apache.iceberg.ManifestFiles;
-import org.apache.iceberg.ManifestWriter;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Partitioning;
-import org.apache.iceberg.RollingManifestWriter;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.ImmutableRewriteManifests;
 import org.apache.iceberg.actions.RewriteManifests;
-import org.apache.iceberg.exceptions.CommitStateUnknownException;
-import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.JobGroupInfo;
-import org.apache.iceberg.spark.SparkContentFile;
-import org.apache.iceberg.spark.SparkDataFile;
-import org.apache.iceberg.spark.SparkDeleteFile;
-import org.apache.iceberg.spark.source.SerializableTableWithSize;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.PropertyUtil;
-import org.apache.iceberg.util.Tasks;
-import org.apache.iceberg.util.ThreadPools;
-import org.apache.spark.api.java.function.MapPartitionsFunction;
-import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Encoder;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,10 +59,12 @@ import org.slf4j.LoggerFactory;
  * cases, the manifests are always written to the metadata folder and committed without staging.
  */
 public class RewriteManifestsSparkAction
-    extends BaseSnapshotUpdateSparkAction<RewriteManifestsSparkAction> implements RewriteManifests {
+    extends BaseManifestUpdateSparkAction<RewriteManifestsSparkAction> implements RewriteManifests {
 
   public static final String USE_CACHING = "use-caching";
   public static final boolean USE_CACHING_DEFAULT = false;
+
+  private static final String FILENAME_PREFIX = "optimized-m-";
 
   private static final Logger LOG = LoggerFactory.getLogger(RewriteManifestsSparkAction.class);
   private static final RewriteManifests.Result EMPTY_RESULT =
@@ -107,7 +83,7 @@ public class RewriteManifestsSparkAction
   private String outputLocation = null;
 
   RewriteManifestsSparkAction(SparkSession spark, Table table) {
-    super(spark);
+    super(spark, table);
     this.table = table;
     this.spec = table.spec();
     this.targetManifestSizeBytes =
@@ -183,7 +159,7 @@ public class RewriteManifestsSparkAction
       return EMPTY_RESULT;
     }
 
-    replaceManifests(rewrittenManifests, addedManifests);
+    replaceManifests(rewrittenManifests, addedManifests, shouldStageManifests);
 
     return ImmutableRewriteManifests.Result.builder()
         .rewrittenManifests(rewrittenManifests)
@@ -242,7 +218,13 @@ public class RewriteManifestsSparkAction
   private List<ManifestFile> writeUnpartitionedManifests(
       ManifestContent content, Dataset<Row> manifestEntryDF, int numManifests) {
 
-    WriteManifests<?> writeFunc = newWriteManifestsFunc(content, manifestEntryDF.schema());
+    WriteManifests<?> writeFunc =
+        newWriteManifestsFunc(
+            content,
+            manifestEntryDF.schema(),
+            outputLocation,
+            targetManifestSizeBytes,
+            FILENAME_PREFIX);
     Dataset<Row> transformedManifestEntryDF = manifestEntryDF.repartition(numManifests);
     return writeFunc.apply(transformedManifestEntryDF).collectAsList();
   }
@@ -253,43 +235,17 @@ public class RewriteManifestsSparkAction
     return withReusableDS(
         manifestEntryDF,
         df -> {
-          WriteManifests<?> writeFunc = newWriteManifestsFunc(content, df.schema());
+          WriteManifests<?> writeFunc =
+              newWriteManifestsFunc(
+                  content, df.schema(), outputLocation, targetManifestSizeBytes, FILENAME_PREFIX);
           Column partitionColumn = df.col("data_file.partition");
           Dataset<Row> transformedDF = repartitionAndSort(df, partitionColumn, numManifests);
           return writeFunc.apply(transformedDF).collectAsList();
         });
   }
 
-  private WriteManifests<?> newWriteManifestsFunc(ManifestContent content, StructType sparkType) {
-    ManifestWriterFactory writers = manifestWriters();
-
-    StructType sparkFileType = (StructType) sparkType.apply("data_file").dataType();
-    Types.StructType combinedFileType = DataFile.getType(Partitioning.partitionType(table));
-    Types.StructType fileType = DataFile.getType(spec.partitionType());
-
-    if (content == ManifestContent.DATA) {
-      return new WriteDataManifests(writers, combinedFileType, fileType, sparkFileType);
-    } else {
-      return new WriteDeleteManifests(writers, combinedFileType, fileType, sparkFileType);
-    }
-  }
-
   private Dataset<Row> repartitionAndSort(Dataset<Row> df, Column col, int numPartitions) {
     return df.repartitionByRange(numPartitions, col).sortWithinPartitions(col);
-  }
-
-  private <T, U> U withReusableDS(Dataset<T> ds, Function<Dataset<T>, U> func) {
-    boolean useCaching =
-        PropertyUtil.propertyAsBoolean(options(), USE_CACHING, USE_CACHING_DEFAULT);
-    Dataset<T> reusableDS = useCaching ? ds.cache() : ds;
-
-    try {
-      return func.apply(reusableDS);
-    } finally {
-      if (useCaching) {
-        reusableDS.unpersist(false);
-      }
-    }
   }
 
   private List<ManifestFile> findMatchingManifests(ManifestContent content) {
@@ -299,22 +255,15 @@ public class RewriteManifestsSparkAction
       return ImmutableList.of();
     }
 
-    List<ManifestFile> manifests = loadManifests(content, currentSnapshot);
+    List<ManifestFile> manifests =
+        loadManifests(
+            content,
+            currentSnapshot,
+            manifest -> manifest.partitionSpecId() == spec.specId() && predicate.test(manifest));
 
     return manifests.stream()
         .filter(manifest -> manifest.partitionSpecId() == spec.specId() && predicate.test(manifest))
         .collect(Collectors.toList());
-  }
-
-  private List<ManifestFile> loadManifests(ManifestContent content, Snapshot snapshot) {
-    switch (content) {
-      case DATA:
-        return snapshot.dataManifests(table.io());
-      case DELETES:
-        return snapshot.deleteManifests(table.io());
-      default:
-        throw new IllegalArgumentException("Unknown manifest content: " + content);
-    }
   }
 
   private int targetNumManifests(long totalSizeBytes) {
@@ -325,223 +274,10 @@ public class RewriteManifestsSparkAction
     long totalSizeBytes = 0L;
 
     for (ManifestFile manifest : manifests) {
-      ValidationException.check(
-          hasFileCounts(manifest), "No file counts in manifest: %s", manifest.path());
+      validateManifest(manifest);
       totalSizeBytes += manifest.length();
     }
 
     return totalSizeBytes;
-  }
-
-  private boolean hasFileCounts(ManifestFile manifest) {
-    return manifest.addedFilesCount() != null
-        && manifest.existingFilesCount() != null
-        && manifest.deletedFilesCount() != null;
-  }
-
-  private void replaceManifests(
-      Iterable<ManifestFile> deletedManifests, Iterable<ManifestFile> addedManifests) {
-    try {
-      org.apache.iceberg.RewriteManifests rewriteManifests = table.rewriteManifests();
-      deletedManifests.forEach(rewriteManifests::deleteManifest);
-      addedManifests.forEach(rewriteManifests::addManifest);
-      commit(rewriteManifests);
-
-      if (shouldStageManifests) {
-        // delete new manifests as they were rewritten before the commit
-        deleteFiles(Iterables.transform(addedManifests, ManifestFile::path));
-      }
-    } catch (CommitStateUnknownException commitStateUnknownException) {
-      // don't clean up added manifest files, because they may have been successfully committed.
-      throw commitStateUnknownException;
-    } catch (Exception e) {
-      // delete all new manifests because the rewrite failed
-      deleteFiles(Iterables.transform(addedManifests, ManifestFile::path));
-      throw e;
-    }
-  }
-
-  private void deleteFiles(Iterable<String> locations) {
-    Tasks.foreach(locations)
-        .executeWith(ThreadPools.getWorkerPool())
-        .noRetry()
-        .suppressFailureWhenFinished()
-        .onFailure((location, exc) -> LOG.warn("Failed to delete: {}", location, exc))
-        .run(location -> table.io().deleteFile(location));
-  }
-
-  private ManifestWriterFactory manifestWriters() {
-    return new ManifestWriterFactory(
-        sparkContext().broadcast(SerializableTableWithSize.copyOf(table)),
-        formatVersion,
-        spec.specId(),
-        outputLocation,
-        // allow the actual size of manifests to be 20% higher as the estimation is not precise
-        (long) (1.2 * targetManifestSizeBytes));
-  }
-
-  private static class WriteDataManifests extends WriteManifests<DataFile> {
-
-    WriteDataManifests(
-        ManifestWriterFactory manifestWriters,
-        Types.StructType combinedPartitionType,
-        Types.StructType partitionType,
-        StructType sparkFileType) {
-      super(manifestWriters, combinedPartitionType, partitionType, sparkFileType);
-    }
-
-    @Override
-    protected SparkDataFile newFileWrapper() {
-      return new SparkDataFile(combinedFileType(), fileType(), sparkFileType());
-    }
-
-    @Override
-    protected RollingManifestWriter<DataFile> newManifestWriter() {
-      return writers().newRollingManifestWriter();
-    }
-  }
-
-  private static class WriteDeleteManifests extends WriteManifests<DeleteFile> {
-
-    WriteDeleteManifests(
-        ManifestWriterFactory manifestWriters,
-        Types.StructType combinedFileType,
-        Types.StructType fileType,
-        StructType sparkFileType) {
-      super(manifestWriters, combinedFileType, fileType, sparkFileType);
-    }
-
-    @Override
-    protected SparkDeleteFile newFileWrapper() {
-      return new SparkDeleteFile(combinedFileType(), fileType(), sparkFileType());
-    }
-
-    @Override
-    protected RollingManifestWriter<DeleteFile> newManifestWriter() {
-      return writers().newRollingDeleteManifestWriter();
-    }
-  }
-
-  private abstract static class WriteManifests<F extends ContentFile<F>>
-      implements MapPartitionsFunction<Row, ManifestFile> {
-
-    private static final Encoder<ManifestFile> MANIFEST_ENCODER =
-        Encoders.javaSerialization(ManifestFile.class);
-
-    private final ManifestWriterFactory writers;
-    private final Types.StructType combinedFileType;
-    private final Types.StructType fileType;
-    private final StructType sparkFileType;
-
-    WriteManifests(
-        ManifestWriterFactory writers,
-        Types.StructType combinedFileType,
-        Types.StructType fileType,
-        StructType sparkFileType) {
-      this.writers = writers;
-      this.combinedFileType = combinedFileType;
-      this.fileType = fileType;
-      this.sparkFileType = sparkFileType;
-    }
-
-    protected abstract SparkContentFile<F> newFileWrapper();
-
-    protected abstract RollingManifestWriter<F> newManifestWriter();
-
-    public Dataset<ManifestFile> apply(Dataset<Row> input) {
-      return input.mapPartitions(this, MANIFEST_ENCODER);
-    }
-
-    @Override
-    public Iterator<ManifestFile> call(Iterator<Row> rows) throws Exception {
-      SparkContentFile<F> fileWrapper = newFileWrapper();
-      RollingManifestWriter<F> writer = newManifestWriter();
-
-      try {
-        while (rows.hasNext()) {
-          Row row = rows.next();
-          long snapshotId = row.getLong(0);
-          long sequenceNumber = row.getLong(1);
-          Long fileSequenceNumber = row.isNullAt(2) ? null : row.getLong(2);
-          Row file = row.getStruct(3);
-          writer.existing(fileWrapper.wrap(file), snapshotId, sequenceNumber, fileSequenceNumber);
-        }
-      } finally {
-        writer.close();
-      }
-
-      return writer.toManifestFiles().iterator();
-    }
-
-    protected ManifestWriterFactory writers() {
-      return writers;
-    }
-
-    protected Types.StructType combinedFileType() {
-      return combinedFileType;
-    }
-
-    protected Types.StructType fileType() {
-      return fileType;
-    }
-
-    protected StructType sparkFileType() {
-      return sparkFileType;
-    }
-  }
-
-  private static class ManifestWriterFactory implements Serializable {
-    private final Broadcast<Table> tableBroadcast;
-    private final int formatVersion;
-    private final int specId;
-    private final String outputLocation;
-    private final long maxManifestSizeBytes;
-
-    ManifestWriterFactory(
-        Broadcast<Table> tableBroadcast,
-        int formatVersion,
-        int specId,
-        String outputLocation,
-        long maxManifestSizeBytes) {
-      this.tableBroadcast = tableBroadcast;
-      this.formatVersion = formatVersion;
-      this.specId = specId;
-      this.outputLocation = outputLocation;
-      this.maxManifestSizeBytes = maxManifestSizeBytes;
-    }
-
-    public RollingManifestWriter<DataFile> newRollingManifestWriter() {
-      return new RollingManifestWriter<>(this::newManifestWriter, maxManifestSizeBytes);
-    }
-
-    private ManifestWriter<DataFile> newManifestWriter() {
-      return ManifestFiles.write(formatVersion, spec(), newOutputFile(), null);
-    }
-
-    public RollingManifestWriter<DeleteFile> newRollingDeleteManifestWriter() {
-      return new RollingManifestWriter<>(this::newDeleteManifestWriter, maxManifestSizeBytes);
-    }
-
-    private ManifestWriter<DeleteFile> newDeleteManifestWriter() {
-      return ManifestFiles.writeDeleteManifest(formatVersion, spec(), newOutputFile(), null);
-    }
-
-    private PartitionSpec spec() {
-      return table().specs().get(specId);
-    }
-
-    private OutputFile newOutputFile() {
-      return table().io().newOutputFile(newManifestLocation());
-    }
-
-    private String newManifestLocation() {
-      String fileName = FileFormat.AVRO.addExtension("optimized-m-" + UUID.randomUUID());
-      Path filePath = new Path(outputLocation, fileName);
-      return filePath.toString();
-    }
-
-    private Table table() {
-      return tableBroadcast.value();
-    }
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
@@ -83,6 +83,11 @@ public class SparkActions implements ActionsProvider {
   }
 
   @Override
+  public RepairManifestsSparkAction repairManifests(Table table) {
+    return new RepairManifestsSparkAction(spark, table);
+  }
+
+  @Override
   public ExpireSnapshotsSparkAction expireSnapshots(Table table) {
     return new ExpireSnapshotsSparkAction(spark, table);
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RepairManifestsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RepairManifestsProcedure.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.procedures;
+
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.RepairManifests;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.spark.actions.RepairManifestsSparkAction;
+import org.apache.iceberg.spark.actions.RewriteManifestsSparkAction;
+import org.apache.iceberg.spark.actions.SparkActions;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * A procedure that repairs manifests with one or both of the following: duplicate files committed
+ * to the table, files referenced by the table that do not exist on disk. Care should be taken with
+ * the latter to investigate the underlying cause and recover files if possible. The
+ * remove_missing_files procedure exists for emergency purposes only.
+ *
+ * <p><em>Note:</em> this procedure invalidates all cached Spark plans that reference the affected
+ * table.
+ *
+ * @see SparkActions#repairManifests(Table) ()
+ */
+class RepairManifestsProcedure extends BaseProcedure {
+
+  private static final ProcedureParameter[] PARAMETERS =
+      new ProcedureParameter[] {
+        ProcedureParameter.required("table", DataTypes.StringType),
+        ProcedureParameter.optional("use_caching", DataTypes.BooleanType),
+        ProcedureParameter.optional("dry_run", DataTypes.BooleanType),
+        ProcedureParameter.optional("remove_duplicate_files", DataTypes.BooleanType),
+        ProcedureParameter.optional("remove_missing_files", DataTypes.BooleanType)
+      };
+
+  // counts are not nullable since the action result is never null
+  private static final StructType OUTPUT_TYPE =
+      new StructType(
+          new StructField[] {
+            new StructField(
+                "rewritten_manifests_count", DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField(
+                "added_manifests_count", DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField(
+                "duplicate_files_removed_count", DataTypes.LongType, false, Metadata.empty()),
+            new StructField(
+                "missing_files_removed_count", DataTypes.LongType, false, Metadata.empty())
+          });
+
+  public static SparkProcedures.ProcedureBuilder builder() {
+    return new BaseProcedure.Builder<RepairManifestsProcedure>() {
+      @Override
+      protected RepairManifestsProcedure doBuild() {
+        return new RepairManifestsProcedure(tableCatalog());
+      }
+    };
+  }
+
+  private RepairManifestsProcedure(TableCatalog tableCatalog) {
+    super(tableCatalog);
+  }
+
+  @Override
+  public ProcedureParameter[] parameters() {
+    return PARAMETERS;
+  }
+
+  @Override
+  public StructType outputType() {
+    return OUTPUT_TYPE;
+  }
+
+  @Override
+  public InternalRow[] call(InternalRow args) {
+    Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
+    Boolean useCaching = args.isNullAt(1) ? null : args.getBoolean(1);
+    Boolean dryRun = args.isNullAt(2) ? null : args.getBoolean(2);
+    Boolean removeDuplicates = args.isNullAt(3) ? null : args.getBoolean(3);
+    Boolean removeMissingFiles = args.isNullAt(4) ? null : args.getBoolean(4);
+
+    return modifyIcebergTable(
+        tableIdent,
+        table -> {
+          RepairManifestsSparkAction action = actions().repairManifests(table);
+
+          if (useCaching != null) {
+            action.option(RewriteManifestsSparkAction.USE_CACHING, useCaching.toString());
+          }
+
+          if (dryRun != null) {
+            action.dryRun(dryRun);
+          }
+          if (removeDuplicates != null && removeDuplicates) {
+            action.removeDuplicateCommittedFiles();
+          }
+          if (removeMissingFiles != null && removeMissingFiles) {
+            action.removeMissingFiles();
+          }
+
+          RepairManifests.Result result = action.execute();
+
+          return toOutputRows(result);
+        });
+  }
+
+  private InternalRow[] toOutputRows(RepairManifests.Result result) {
+    int rewrittenManifestsCount = Iterables.size(result.rewrittenManifests());
+    int addedManifestsCount = Iterables.size(result.addedManifests());
+    InternalRow row =
+        newInternalRow(
+            rewrittenManifestsCount,
+            addedManifestsCount,
+            result.duplicateFilesRemoved(),
+            result.duplicateFilesRemoved());
+    return new InternalRow[] {row};
+  }
+
+  @Override
+  public String description() {
+    return "RepairManifestsProcedure";
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -45,6 +45,7 @@ public class SparkProcedures {
     mapBuilder.put("cherrypick_snapshot", CherrypickSnapshotProcedure::builder);
     mapBuilder.put("rewrite_data_files", RewriteDataFilesProcedure::builder);
     mapBuilder.put("rewrite_manifests", RewriteManifestsProcedure::builder);
+    mapBuilder.put("repair_manifests", RepairManifestsProcedure::builder);
     mapBuilder.put("remove_orphan_files", RemoveOrphanFilesProcedure::builder);
     mapBuilder.put("expire_snapshots", ExpireSnapshotsProcedure::builder);
     mapBuilder.put("migrate", MigrateTableProcedure::builder);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRepairManifestsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRepairManifestsAction.java
@@ -1,0 +1,1243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.actions.RepairManifests;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkTableUtil;
+import org.apache.iceberg.spark.SparkWriteOptions;
+import org.apache.iceberg.spark.TestBase;
+import org.apache.iceberg.spark.source.ThreeColumnRecord;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.CharSequenceSet;
+import org.apache.iceberg.util.Pair;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRepairManifestsAction extends TestBase {
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  private static final Schema SCHEMA =
+      new Schema(
+          optional(1, "c1", Types.IntegerType.get()),
+          optional(2, "c2", Types.StringType.get()),
+          optional(3, "c3", Types.StringType.get()));
+
+  @Parameters(
+      name =
+          "snapshotIdInheritanceEnabled = {0}, useCaching = {1}, shouldStageManifests = {2}, formatVersion = {3}")
+  public static Object[] parameters() {
+    return new Object[][] {
+      new Object[] {"true", "true", false, 1},
+      new Object[] {"false", "true", true, 1},
+      new Object[] {"true", "false", false, 2},
+      new Object[] {"false", "false", false, 2}
+    };
+  }
+
+  @Parameter private String snapshotIdInheritanceEnabled;
+
+  @Parameter(index = 1)
+  private String useCaching;
+
+  @Parameter(index = 2)
+  private boolean shouldStageManifests;
+
+  @Parameter(index = 3)
+  private int formatVersion;
+
+  private String tableLocation = null;
+
+  @TempDir private Path temp;
+
+  @BeforeEach
+  public void setupTableLocation() {
+    File tableDir = temp.resolve("junit").toFile();
+    this.tableLocation = tableDir.toURI().toString();
+  }
+
+  @TestTemplate
+  public void testRemoveDuplicatesManifestsEmptyTable() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
+
+    SparkActions actions = SparkActions.get();
+
+    actions
+        .repairManifests(table)
+        .removeDuplicateCommittedFiles()
+        .option(RepairManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    assertThat(table.currentSnapshot()).as("Table must stay empty").isNull();
+  }
+
+  @TestTemplate
+  public void testRemoveMissingFilesManifestsEmptyTable() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
+
+    SparkActions actions = SparkActions.get();
+
+    actions
+        .repairManifests(table)
+        .removeMissingFiles()
+        .option(RepairManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    assertThat(table.currentSnapshot()).as("Table must stay empty").isNull();
+  }
+
+  @TestTemplate
+  public void testRemoveDuplicatesNoDuplicates() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    List<ThreeColumnRecord> records1 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(1, null, "AAAA"), new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB"));
+    writeRecords(records1);
+    table.refresh();
+
+    List<ManifestFile> manifestsBeforeAction = table.currentSnapshot().allManifests(table.io());
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeDuplicateCommittedFiles()
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.addedManifests().iterator().hasNext()).isFalse();
+    assertThat(result.rewrittenManifests().iterator().hasNext()).isFalse();
+
+    table.refresh();
+    List<ManifestFile> manifestsAfterAction = table.currentSnapshot().allManifests(table.io());
+
+    assertThat(manifestsBeforeAction).isEqualTo(manifestsAfterAction);
+  }
+
+  @TestTemplate
+  public void testRepairManifestsEmptyTableRemoveMissingRemoveDupes() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
+
+    SparkActions actions = SparkActions.get();
+
+    actions
+        .repairManifests(table)
+        .removeMissingFiles()
+        .removeDuplicateCommittedFiles()
+        .option(RepairManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    assertThat(table.currentSnapshot()).as("Table must stay empty").isNull();
+  }
+
+  @TestTemplate
+  public void testRepairNoDuplicatesNoMissingFiles() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    List<ThreeColumnRecord> records1 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(1, null, "AAAA"), new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB"));
+    writeRecords(records1);
+    table.refresh();
+
+    List<ManifestFile> manifestsBeforeAction = table.currentSnapshot().allManifests(table.io());
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeDuplicateCommittedFiles()
+            .removeMissingFiles()
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.addedManifests().iterator().hasNext()).isFalse();
+    assertThat(result.rewrittenManifests().iterator().hasNext()).isFalse();
+
+    table.refresh();
+    List<ManifestFile> manifestsAfterAction = table.currentSnapshot().allManifests(table.io());
+
+    assertThat(manifestsBeforeAction).isEqualTo(manifestsAfterAction);
+  }
+
+  @TestTemplate
+  public void testRemoveMissingFilesNoMissingFiles() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    List<ThreeColumnRecord> records1 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(1, null, "AAAA"), new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB"));
+    writeRecords(records1);
+    table.refresh();
+
+    List<ManifestFile> manifestsBeforeAction = table.currentSnapshot().allManifests(table.io());
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeMissingFiles()
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.addedManifests().iterator().hasNext()).isFalse();
+    assertThat(result.rewrittenManifests().iterator().hasNext()).isFalse();
+
+    table.refresh();
+    List<ManifestFile> manifestsAfterAction = table.currentSnapshot().allManifests(table.io());
+
+    assertThat(manifestsBeforeAction).isEqualTo(manifestsAfterAction);
+  }
+
+  @TestTemplate
+  public void testRemoveDuplicatesSmallManifestsNonPartitionedTable() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    List<ThreeColumnRecord> records1 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(1, null, "AAAA"), new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB"));
+    writeRecords(records1);
+    table.refresh();
+
+    DataFile duplicate = Iterables.getLast(table.currentSnapshot().addedDataFiles(table.io()));
+    table.newFastAppend().appendFile(duplicate).commit();
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.addAll(records1);
+    Dataset<Row> validateDuplicatesExist = spark.read().format("iceberg").load(tableLocation);
+    List<ThreeColumnRecord> hasDuplicates =
+        validateDuplicatesExist
+            .sort("c1", "c2")
+            .as(Encoders.bean(ThreeColumnRecord.class))
+            .collectAsList();
+    assertThat(hasDuplicates).as("Rows must contain duplicates").isNotEqualTo(expectedRecords);
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeDuplicateCommittedFiles()
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    List<Boolean> manifestFileStartsWithDeduped = Lists.newArrayList();
+    result
+        .addedManifests()
+        .forEach(
+            manifest -> manifestFileStartsWithDeduped.add(manifest.path().contains("deduped-m")));
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifests").hasSize(2);
+    assertThat(result.addedManifests()).as("Action should add 2 manifests").hasSize(2);
+    assertManifestsLocation(result.addedManifests());
+    assertThat(manifestFileStartsWithDeduped)
+        .as("Rewritten files should start with deduped-m")
+        .contains(true, true);
+
+    List<Row> finalFiles =
+        SparkTableUtil.loadMetadataTable(spark, table, MetadataTableType.ENTRIES).collectAsList();
+    assertThat(finalFiles).isNotEmpty();
+
+    List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(newManifests).as("Should have 2 manifests after deduping").hasSize(2);
+
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<ThreeColumnRecord> recordsPostDeduping =
+        resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+    assertThat(recordsPostDeduping).as("Rows must match").isEqualTo(expectedRecords);
+  }
+
+  @TestTemplate
+  public void testRemoveDuplicatesSmallManifestsNonPartitionedTableDryRun() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    List<ThreeColumnRecord> records1 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(1, null, "AAAA"), new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB"));
+    writeRecords(records1);
+
+    DataFile duplicate = Iterables.getLast(table.currentSnapshot().addedDataFiles(table.io()));
+    table.newFastAppend().appendFile(duplicate).commit();
+
+    table.refresh();
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeDuplicateCommittedFiles()
+            .dryRun()
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifests").hasSize(2);
+    assertThat(result.addedManifests()).as("Action should add 2 manifests").hasSize(2);
+
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<ThreeColumnRecord> recordsPostDeduping =
+        resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+
+    List<ThreeColumnRecord> recordsWithoutDupes = Lists.newArrayList();
+    recordsWithoutDupes.addAll(records1);
+    // deduplication did not happen due to dryRun()
+    assertThat(recordsPostDeduping).as("Rows must match").isNotEqualTo(recordsWithoutDupes);
+  }
+
+  @TestTemplate
+  public void testRemoveDuplicatesSmallManifestsPartitionedTable() {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    List<ThreeColumnRecord> records1 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(1, null, "AAAA"), new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB"));
+    writeRecords(records1);
+
+    List<ThreeColumnRecord> records2 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(2, "CCCCCCCCCC", "CCCC"),
+            new ThreeColumnRecord(2, "DDDDDDDDDD", "DDDD"));
+    writeRecords(records2);
+
+    List<ThreeColumnRecord> records3 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(3, "EEEEEEEEEE", "EEEE"), // becomes a duplicate
+            new ThreeColumnRecord(3, "FFFFFFFFFF", "FFFF"));
+    writeRecords(records3);
+
+    List<ThreeColumnRecord> records4 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(4, "GGGGGGGGGG", "GGGG"),
+            new ThreeColumnRecord(4, "HHHHHHHHHG", "HHHH"));
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.addAll(records1);
+    expectedRecords.addAll(records2);
+    expectedRecords.addAll(records3);
+    expectedRecords.addAll(records4);
+
+    writeRecords(records4);
+
+    table.refresh();
+
+    List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(manifests).as("Should have 4 manifests before rewrite").hasSize(4);
+
+    DataFile duplicate = Iterables.getLast(table.currentSnapshot().addedDataFiles(table.io()));
+
+    table.newFastAppend().appendFile(duplicate).commit();
+    table.refresh();
+
+    List<ThreeColumnRecord> validateRecordsContainDuplicates =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .sort("c1", "c2")
+            .as(Encoders.bean(ThreeColumnRecord.class))
+            .collectAsList();
+
+    assertThat(expectedRecords).isNotEqualTo(validateRecordsContainDuplicates.size());
+
+    SparkActions actions = SparkActions.get();
+
+    // we will expect to have 2 manifests with 4 entries in each after rewrite
+    long manifestEntrySizeBytes = computeManifestEntrySizeBytes(manifests);
+    long targetManifestSizeBytes = (long) (1.05 * 4 * manifestEntrySizeBytes);
+
+    table
+        .updateProperties()
+        .set(TableProperties.MANIFEST_TARGET_SIZE_BYTES, String.valueOf(targetManifestSizeBytes))
+        .commit();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeDuplicateCommittedFiles()
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifests").hasSize(2);
+    assertThat(result.addedManifests()).as("Action should add 2 manifests").hasSize(2);
+    assertManifestsLocation(result.addedManifests());
+
+    table.refresh();
+
+    List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
+
+    assertThat(newManifests)
+        .as("Should have 5 manifests after repairing: 3 with no problems plus 2 rewritten")
+        .hasSize(5);
+
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<ThreeColumnRecord> actualRecords =
+        resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
+  }
+
+  @TestTemplate
+  public void testRemoveDuplicatesDuplicateFilesSameManifest() throws IOException {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    DataFile datafile = newDataFile(table, TestHelpers.Row.of(new Object[] {null}));
+
+    // append the same file three times in the same manifest
+    List<DataFile> dataFiles = Lists.newArrayList(datafile, datafile, datafile);
+    ManifestFile appendManifestSameFile = writeManifest(table, dataFiles);
+    table.newFastAppend().appendManifest(appendManifestSameFile).commit();
+
+    // cause a duplicate in another file
+    ManifestFile appendManifestDuplicate =
+        writeManifest(
+            table,
+            Lists.newArrayList(
+                datafile, newDataFile(table, TestHelpers.Row.of(new Object[] {null}))));
+    table.newFastAppend().appendManifest(appendManifestDuplicate).commit();
+
+    table.refresh();
+    // ensure test is setup properly
+    List<Integer> addedFilesCheck = Lists.newArrayList();
+    table
+        .snapshots()
+        .forEach(
+            snapshot -> addedFilesCheck.add(Iterables.size(snapshot.addedDataFiles(table.io()))));
+    assertThat(addedFilesCheck).isEqualTo(Lists.newArrayList(3, 2));
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeDuplicateCommittedFiles()
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 1 manifests").hasSize(2);
+    assertThat(result.addedManifests()).as("Action should add 1 manifests").hasSize(2);
+
+    // we end up with two manifests:
+    // the first manifest only contains duplicates, so it was removed entirely
+    // the second manifest gets rewritten as it contained an additional row beside the duplicate
+    // that was also in the first manifest
+    // a new manifest containing the duplicate
+    // so each data manifest should have 1 existing file only
+    assertThat(table.currentSnapshot().dataManifests(table.io()).get(0).existingFilesCount())
+        .isEqualTo(1);
+    assertThat(table.currentSnapshot().dataManifests(table.io()).get(0).addedFilesCount())
+        .isEqualTo(0);
+    assertThat(table.currentSnapshot().dataManifests(table.io()).get(0).deletedFilesCount())
+        .isEqualTo(0);
+
+    assertThat(table.currentSnapshot().dataManifests(table.io()).get(1).existingFilesCount())
+        .isEqualTo(1);
+    assertThat(table.currentSnapshot().dataManifests(table.io()).get(1).addedFilesCount())
+        .isEqualTo(0);
+    assertThat(table.currentSnapshot().dataManifests(table.io()).get(1).deletedFilesCount())
+        .isEqualTo(0);
+
+    assertThat(table.currentSnapshot().dataManifests(table.io()).size()).isEqualTo(2);
+  }
+
+  @TestTemplate
+  public void testRemoveDuplicatesLargeManifestsEvolvedUnpartitionedV1Table() throws IOException {
+    assumeThat(formatVersion).isEqualTo(1);
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c3").build();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    table.updateSpec().removeField("c3").commit();
+
+    assertThat(table.spec().fields()).hasSize(1).allMatch(field -> field.transform().isVoid());
+
+    List<DataFile> dataFiles = Lists.newArrayList();
+    for (int fileOrdinal = 0; fileOrdinal < 1000; fileOrdinal++) {
+      dataFiles.add(newDataFile(table, TestHelpers.Row.of(new Object[] {null})));
+    }
+    ManifestFile appendManifest = writeManifest(table, dataFiles);
+    table.newFastAppend().appendManifest(appendManifest).commit();
+
+    // insert 40 duplicates
+    List<DataFile> duplicates = dataFiles.stream().limit(20).collect(Collectors.toList());
+    ManifestFile appendDuplicates1x = writeManifest(table, duplicates);
+    table.newFastAppend().appendManifest(appendDuplicates1x).commit();
+    ManifestFile appendDuplicates2x = writeManifest(table, duplicates);
+    table.newFastAppend().appendManifest(appendDuplicates2x).commit();
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeDuplicateCommittedFiles()
+            .option(RepairManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    // original manifest, duplicate manifest, second duplicate manifest
+    assertThat(result.rewrittenManifests()).hasSize(3);
+
+    assertThat(result.addedManifests()).hasSize(4);
+    assertManifestsLocation(result.addedManifests());
+
+    List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(manifests).hasSizeGreaterThanOrEqualTo(4);
+  }
+  //
+  @TestTemplate
+  public void testRemoveDuplicatesSmallDeleteManifestsNonPartitionedTable() throws IOException {
+    assumeThat(formatVersion).isGreaterThan(1);
+
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    // commit data records
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(
+            new ThreeColumnRecord(1, null, "AAAA"),
+            new ThreeColumnRecord(2, "BBBBBBBBBB", "BBBB"),
+            new ThreeColumnRecord(3, "CCCCCCCCCC", "CCCC"),
+            new ThreeColumnRecord(4, "DDDDDDDDDD", "DDDD"));
+
+    writeRecords(records);
+
+    table.refresh();
+
+    DataFile duplicateDataFile =
+        Iterables.getLast(table.currentSnapshot().addedDataFiles(table.io()));
+    table.newFastAppend().appendFile(duplicateDataFile).commit();
+
+    // commit a position delete file to remove records where c1 = 1 OR c1 = 2
+    List<Pair<CharSequence, Long>> posDeletes = generatePosDeletes("c1 = 1 OR c1 = 2");
+    Pair<DeleteFile, CharSequenceSet> posDeleteWriteResult = writePosDeletes(table, posDeletes);
+    table
+        .newRowDelta()
+        .addDeletes(posDeleteWriteResult.first())
+        .validateDataFilesExist(posDeleteWriteResult.second())
+        .commit();
+
+    // duplicate position delete file
+    table
+        .newRowDelta()
+        .addDeletes(posDeleteWriteResult.first())
+        .validateDataFilesExist(posDeleteWriteResult.second())
+        .commit();
+
+    // commit an equality delete file to remove all records where c1 = 3
+    DeleteFile eqDeleteFile = writeEqDeletes(table, "c1", 3, 5);
+    table.newRowDelta().addDeletes(eqDeleteFile).commit();
+
+    // add a file that would get filtered out if the equality delete is duplicated _after_ this
+    // commit
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(3, "SHOULD_NOT_BE_FILTERED", "CCCC")));
+
+    // duplicate the equality delete file
+    table.newRowDelta().addDeletes(eqDeleteFile).commit();
+
+    // a duplicate file after all the delete files
+    table.newFastAppend().appendFile(duplicateDataFile).commit();
+
+    table.refresh();
+
+    List<ManifestFile> originalManifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(originalManifests).hasSize(8);
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeDuplicateCommittedFiles()
+            .option(RepairManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.rewrittenManifests()).hasSize(7);
+    assertThat(result.addedManifests()).hasSize(4);
+    assertManifestsLocation(result.addedManifests());
+
+    List<ThreeColumnRecord> expectedRecords =
+        Lists.newArrayList(
+            new ThreeColumnRecord(3, "SHOULD_NOT_BE_FILTERED", "CCCC"),
+            new ThreeColumnRecord(4, "DDDDDDDDDD", "DDDD"));
+    assertThat(actualRecords()).isEqualTo(expectedRecords);
+
+    // All data file manifests have been replaced, even the duplicated one committed after the
+    // delete files
+    // the min sequence number should be the minimum of the file containing the dupe, which is 1L
+    // the last datafile is the one that should not be filtered of 6L which is unchanged (never
+    // rewritten)
+    List<Long> dataManifests =
+        table.currentSnapshot().dataManifests(table.io()).stream()
+            .map(ManifestFile::minSequenceNumber)
+            .collect(Collectors.toList());
+    assertThat(dataManifests).isEqualTo(Lists.newArrayList(1L, 1L, 6L));
+  }
+
+  @TestTemplate
+  public void testRemoveDuplicatesDeleteManifestsPartitionedTable() throws IOException {
+    assumeThat(formatVersion).isGreaterThan(1);
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c3").build();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    options.put(TableProperties.MANIFEST_MERGE_ENABLED, "false");
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    // commit data records
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(
+            new ThreeColumnRecord(1, null, "AAAA"),
+            new ThreeColumnRecord(2, "BBBBBBBBBB", "BBBB"),
+            new ThreeColumnRecord(3, "CCCCCCCCCC", "CCCC"),
+            new ThreeColumnRecord(4, "DDDDDDDDDD", "DDDD"),
+            new ThreeColumnRecord(5, "EEEEEEEEEE", "EEEE"));
+    writeRecords(records);
+
+    // duplicate the data file
+    DataFile duplicateDataFile =
+        Iterables.getLast(table.currentSnapshot().addedDataFiles(table.io()));
+    table.newFastAppend().appendFile(duplicateDataFile).commit();
+
+    // commit the first position delete file to remove records where c1 = 1
+    List<Pair<CharSequence, Long>> posDeletes1 = generatePosDeletes("c1 = 1");
+    Pair<DeleteFile, CharSequenceSet> posDeleteWriteResult1 =
+        writePosDeletes(table, TestHelpers.Row.of("AAAA"), posDeletes1);
+    table
+        .newRowDelta()
+        .addDeletes(posDeleteWriteResult1.first())
+        .validateDataFilesExist(posDeleteWriteResult1.second())
+        .commit();
+
+    // commit the second position delete file to remove records where c1 = 2
+    List<Pair<CharSequence, Long>> posDeletes2 = generatePosDeletes("c1 = 2");
+    Pair<DeleteFile, CharSequenceSet> positionDeleteWriteResult2 =
+        writePosDeletes(table, TestHelpers.Row.of("BBBB"), posDeletes2);
+    table
+        .newRowDelta()
+        .addDeletes(positionDeleteWriteResult2.first())
+        .validateDataFilesExist(positionDeleteWriteResult2.second())
+        .commit();
+
+    // commit the first equality delete file to remove records where c1 = 3
+    DeleteFile eqDeleteFile1 = writeEqDeletes(table, TestHelpers.Row.of("CCCC"), "c1", 3);
+    table.newRowDelta().addDeletes(eqDeleteFile1).commit();
+
+    // commit the second equality delete file to remove records where c1 = 4
+    DeleteFile eqDeleteFile2 = writeEqDeletes(table, TestHelpers.Row.of("DDDD"), "c1", 4);
+    table.newRowDelta().addDeletes(eqDeleteFile2).commit();
+
+    // duplicate the datafile a second time after all the deletes
+    table.newFastAppend().appendFile(duplicateDataFile).commit();
+
+    // if the wrong equality delete is kept based on sequence number, this would get filtered out
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(3, "SHOULD_NOT_FILTER", "CCCC")));
+
+    // duplicate one of the equality delete files
+    table.newRowDelta().addDeletes(eqDeleteFile1).commit();
+
+    // duplicate one of the equality delete files again
+    table.newRowDelta().addDeletes(eqDeleteFile1).commit();
+
+    // duplicate one of the position delete files
+    table
+        .newRowDelta()
+        .addDeletes(positionDeleteWriteResult2.first())
+        .validateDataFilesExist(positionDeleteWriteResult2.second())
+        .commit();
+
+    // the table must have 4 data manifest (two of which ahve dupes) and 7 delete manifests (3 of
+    // which have dupes)
+    List<ManifestFile> originalManifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(originalManifests).hasSize(11);
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeDuplicateCommittedFiles()
+            .option(RepairManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.rewrittenManifests()).hasSize(8);
+    assertThat(result.addedManifests()).hasSize(6);
+    assertManifestsLocation(result.addedManifests());
+
+    // there were 6 delete manifests but now just 4 since the two duplicates have been removed
+    List<ManifestFile> deleteManifests = table.currentSnapshot().deleteManifests(table.io());
+    assertThat(deleteManifests).hasSize(4);
+
+    // the table must produce expected records after the rewrite
+    List<ThreeColumnRecord> expectedRecords =
+        Lists.newArrayList(
+            new ThreeColumnRecord(3, "SHOULD_NOT_FILTER", "CCCC"),
+            new ThreeColumnRecord(5, "EEEEEEEEEE", "EEEE"));
+    assertThat(actualRecords()).isEqualTo(expectedRecords);
+  }
+
+  @TestTemplate
+  public void testNoDuplicatesIfDataFileAddedDeletedAddedAgain() throws IOException {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    // add the file
+    // delete the file
+    // add the file again
+    // should not count as a duplicate
+    List<DataFile> targetDatafile =
+        Lists.newArrayList(newDataFile(table, TestHelpers.Row.of(new Object[] {null})));
+    ManifestFile appendManifest = writeManifest(table, targetDatafile);
+    table.newFastAppend().appendManifest(appendManifest).commit();
+    table.newDelete().deleteFile(targetDatafile.get(0)).commit();
+    table.newFastAppend().appendFile(targetDatafile.get(0)).commit();
+
+    table.refresh();
+
+    // 3 snapshots: add, delete, add again
+    // but only two manifests, the delete call removes the first one
+    assertThat(Iterables.size(table.snapshots())).isEqualTo(3);
+    List<ManifestFile> originalManifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(originalManifests).hasSize(2);
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeDuplicateCommittedFiles()
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 0 manifests").hasSize(0);
+    assertThat(result.addedManifests()).as("Action should add 0 manifests").hasSize(0);
+  }
+
+  @TestTemplate
+  public void testRewriteDuplicatesAfterDeletesIfReal() throws IOException {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    // add the file
+    // delete the file
+    // add the file again
+    // should not count as a duplicate
+    List<DataFile> targetDatafile =
+        Lists.newArrayList(newDataFile(table, TestHelpers.Row.of(new Object[] {null})));
+    ManifestFile appendManifest = writeManifest(table, targetDatafile);
+    table.newFastAppend().appendManifest(appendManifest).commit();
+    table.newDelete().deleteFile(targetDatafile.get(0)).commit();
+    table.newFastAppend().appendFile(targetDatafile.get(0)).commit();
+    // duplicate the data file again
+    table.newFastAppend().appendFile(targetDatafile.get(0)).commit();
+
+    table.refresh();
+
+    assertThat(Iterables.size(table.snapshots())).isEqualTo(4);
+    List<ManifestFile> originalManifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(originalManifests).hasSize(3);
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeDuplicateCommittedFiles()
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifests").hasSize(2);
+    assertThat(result.addedManifests()).as("Action should add 1 manifests").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testMissingFilesRemoved() {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    List<ThreeColumnRecord> records1 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(1, null, "AAAA"), new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB"));
+    writeRecords(records1);
+
+    List<ThreeColumnRecord> records2 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(2, "CCCCCCCCCC", "CCCC"),
+            new ThreeColumnRecord(2, "DDDDDDDDDD", "DDDD"));
+    writeRecords(records2);
+
+    table.refresh();
+
+    List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(manifests).as("Should have 2 manifests before rewrite").hasSize(2);
+
+    DataFile dataFileToDelete =
+        Iterables.getLast(table.currentSnapshot().addedDataFiles(table.io()));
+
+    // this file contains this row ThreeColumnRecord(2, "DDDDDDDDDD", "DDDD"));
+    File fileToDelete = new File(dataFileToDelete.path().toString().substring(5));
+
+    if (fileToDelete.exists()) {
+      if (!fileToDelete.delete()) {
+        throw new RuntimeException("could not delete file during test");
+      }
+    } else {
+      throw new RuntimeException("file was not created during test");
+    }
+
+    table.refresh();
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeMissingFiles()
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 1 manifests").hasSize(1);
+    assertThat(result.addedManifests()).as("Action should add 0 manifests").hasSize(0);
+    assertThat(result.duplicateFilesRemoved()).isEqualTo(0L);
+    assertThat(result.missingFilesRemoved()).isEqualTo(1);
+    assertManifestsLocation(result.addedManifests());
+
+    table.refresh();
+
+    List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
+
+    assertThat(newManifests).as("Should have 2 manifests after repairing").hasSize(2);
+
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<ThreeColumnRecord> actualRecords =
+        resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.addAll(records1);
+    expectedRecords.add(new ThreeColumnRecord(2, "CCCCCCCCCC", "CCCC"));
+    // is missing row ThreeColumnRecord(2, "DDDDDDDDDD", "DDDD"))
+    assertThat(actualRecords).isEqualTo(expectedRecords);
+  }
+
+  @TestTemplate
+  public void testMissingFilesRemovedDryRun() {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    List<ThreeColumnRecord> records1 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(1, null, "AAAA"), new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB"));
+    writeRecords(records1);
+
+    List<ThreeColumnRecord> records2 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(2, "CCCCCCCCCC", "CCCC"),
+            new ThreeColumnRecord(2, "DDDDDDDDDD", "DDDD"));
+    writeRecords(records2);
+
+    table.refresh();
+
+    DataFile dataFileToDelete =
+        Iterables.getLast(table.currentSnapshot().addedDataFiles(table.io()));
+
+    // this file contains this row ThreeColumnRecord(2, "DDDDDDDDDD", "DDDD"));
+    File fileToDelete = new File(dataFileToDelete.path().toString().substring(5));
+
+    if (fileToDelete.exists()) {
+      if (!fileToDelete.delete()) {
+        throw new RuntimeException("could not delete file during test");
+      }
+    } else {
+      throw new RuntimeException("file was not created during test");
+    }
+
+    table.refresh();
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeMissingFiles()
+            .dryRun()
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 1 manifests").hasSize(1);
+    assertThat(result.addedManifests()).as("Action should add 0 manifests").hasSize(0);
+    assertThat(result.duplicateFilesRemoved()).isEqualTo(0L);
+    assertThat(result.missingFilesRemoved()).isEqualTo(1);
+
+    table.refresh();
+
+    // since the file was never removed an exception is thrown when trying to read the table
+    assertThatThrownBy(() -> spark.read().format("iceberg").load(tableLocation).collectAsList())
+        .isInstanceOf(org.apache.spark.SparkException.class);
+  }
+
+  @TestTemplate
+  public void testMissingFilesRemovedDuplicates() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    List<ThreeColumnRecord> records1 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(1, null, "AAAA"), new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB"));
+    writeRecords(records1);
+
+    List<ThreeColumnRecord> records2 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(2, "CCCCCCCCCC", "CCCC"),
+            new ThreeColumnRecord(2, "DDDDDDDDDD", "DDDD"));
+    writeRecords(records2);
+
+    List<ThreeColumnRecord> records3 =
+        Lists.newArrayList(new ThreeColumnRecord(3, "EEEEEEEEEE", "EEEE"));
+
+    writeRecords(records3);
+
+    List<ThreeColumnRecord> records4 =
+        Lists.newArrayList(
+            new ThreeColumnRecord(3, "FFFFFFFFFF", "FFFF"), // this gets deleted
+            new ThreeColumnRecord(4, "GGGGGGGGGG", "GGGG")); // this does not
+
+    writeRecords(records4);
+
+    table.refresh();
+
+    List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(manifests).as("Should have 4 manifests before rewrite").hasSize(4);
+
+    List<DataFile> dataFiles = Lists.newArrayList();
+    table
+        .snapshots()
+        .forEach(snapshot -> snapshot.addedDataFiles(table.io()).forEach(dataFiles::add));
+
+    DataFile duplicateFile = dataFiles.get(1);
+    table.newFastAppend().appendFile(duplicateFile).commit();
+    table.newFastAppend().appendFile(duplicateFile).commit();
+    table.newFastAppend().appendFile(duplicateFile).commit();
+
+    DataFile dataFileToDelete = dataFiles.get(dataFiles.size() - 2);
+
+    assertThat(duplicateFile.path().toString()).isNotEqualTo(dataFileToDelete.path().toString());
+
+    // this file contains this row ThreeColumnRecord(3, "FFFFFFFFFF", "FFFF");
+    File fileToDelete = new File(dataFileToDelete.path().toString().substring(5));
+
+    // duplicate append the file that will be missing twice
+    table.newFastAppend().appendFile(dataFileToDelete).commit();
+    table.newFastAppend().appendFile(dataFileToDelete).commit();
+
+    table.refresh();
+
+    if (fileToDelete.exists()) {
+      if (!fileToDelete.delete()) {
+        throw new RuntimeException("could not delete file during test");
+      }
+    } else {
+      throw new RuntimeException("file was not created during test");
+    }
+
+    table.refresh();
+
+    SparkActions actions = SparkActions.get();
+
+    RepairManifests.Result result =
+        actions
+            .repairManifests(table)
+            .removeDuplicateCommittedFiles()
+            .removeMissingFiles()
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 7 manifests").hasSize(7);
+    assertThat(result.addedManifests()).as("Action should add 3 manifests").hasSize(3);
+    assertThat(result.duplicateFilesRemoved()).isEqualTo(5L);
+    assertThat(result.missingFilesRemoved()).isEqualTo(3L);
+
+    table.refresh();
+
+    List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
+
+    assertThat(newManifests).as("Should have 5 manifests after repairing").hasSize(5);
+
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<ThreeColumnRecord> actualRecords =
+        resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.addAll(records1);
+    expectedRecords.addAll(records2);
+    expectedRecords.add(new ThreeColumnRecord(3, "EEEEEEEEEE", "EEEE"));
+    expectedRecords.add(new ThreeColumnRecord(4, "GGGGGGGGGG", "GGGG"));
+    // is missing row  ThreeColumnRecord(3, "FFFFFFFFFF", "FFFF")
+    assertThat(actualRecords).isEqualTo(expectedRecords);
+  }
+
+  private List<ThreeColumnRecord> actualRecords() {
+    return spark
+        .read()
+        .format("iceberg")
+        .load(tableLocation)
+        .as(Encoders.bean(ThreeColumnRecord.class))
+        .sort("c1", "c2", "c3")
+        .collectAsList();
+  }
+
+  private void writeRecords(List<ThreeColumnRecord> records) {
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class);
+    writeDF(df);
+  }
+
+  private void writeDF(Dataset<Row> df) {
+    df.select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .option(SparkWriteOptions.DISTRIBUTION_MODE, TableProperties.WRITE_DISTRIBUTION_MODE_NONE)
+        .mode("append")
+        .save(tableLocation);
+  }
+
+  private long computeManifestEntrySizeBytes(List<ManifestFile> manifests) {
+    long totalSize = 0L;
+    int numEntries = 0;
+
+    for (ManifestFile manifest : manifests) {
+      totalSize += manifest.length();
+      numEntries +=
+          manifest.addedFilesCount() + manifest.existingFilesCount() + manifest.deletedFilesCount();
+    }
+
+    return totalSize / numEntries;
+  }
+
+  private void assertManifestsLocation(Iterable<ManifestFile> manifests) {
+    assertManifestsLocation(manifests, null);
+  }
+
+  private void assertManifestsLocation(Iterable<ManifestFile> manifests, String stagingLocation) {
+    if (shouldStageManifests && stagingLocation != null) {
+      assertThat(manifests).allMatch(manifest -> manifest.path().startsWith(stagingLocation));
+    } else {
+      assertThat(manifests).allMatch(manifest -> manifest.path().startsWith(tableLocation));
+    }
+  }
+
+  private ManifestFile writeManifest(Table table, List<DataFile> files) throws IOException {
+    File manifestFile = File.createTempFile("generated-manifest", ".avro", temp.toFile());
+    assertThat(manifestFile.delete()).isTrue();
+    OutputFile outputFile = table.io().newOutputFile(manifestFile.getCanonicalPath());
+
+    ManifestWriter<DataFile> writer =
+        ManifestFiles.write(formatVersion, table.spec(), outputFile, null);
+
+    try {
+      for (DataFile file : files) {
+        writer.add(file);
+      }
+    } finally {
+      writer.close();
+    }
+
+    return writer.toManifestFile();
+  }
+
+  private DataFile newDataFile(Table table, StructLike partition) {
+    return newDataFileBuilder(table).withPartition(partition).build();
+  }
+
+  private DataFiles.Builder newDataFileBuilder(Table table) {
+    return DataFiles.builder(table.spec())
+        .withPath("/path/to/data-" + UUID.randomUUID() + ".parquet")
+        .withFileSizeInBytes(10)
+        .withRecordCount(1);
+  }
+
+  private DeleteFile newDeleteFile(Table table, String partitionPath) {
+    return FileMetadata.deleteFileBuilder(table.spec())
+        .ofPositionDeletes()
+        .withPath("/path/to/pos-deletes-" + UUID.randomUUID() + ".parquet")
+        .withFileSizeInBytes(5)
+        .withPartitionPath(partitionPath)
+        .withRecordCount(1)
+        .build();
+  }
+
+  private List<Pair<CharSequence, Long>> generatePosDeletes(String predicate) {
+    List<Row> rows =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_file", "_pos")
+            .where(predicate)
+            .collectAsList();
+
+    List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
+
+    for (Row row : rows) {
+      deletes.add(Pair.of(row.getString(0), row.getLong(1)));
+    }
+
+    return deletes;
+  }
+
+  private Pair<DeleteFile, CharSequenceSet> writePosDeletes(
+      Table table, List<Pair<CharSequence, Long>> deletes) throws IOException {
+    return writePosDeletes(table, null, deletes);
+  }
+
+  private Pair<DeleteFile, CharSequenceSet> writePosDeletes(
+      Table table, StructLike partition, List<Pair<CharSequence, Long>> deletes)
+      throws IOException {
+    OutputFile outputFile = Files.localOutput(File.createTempFile("junit", null, temp.toFile()));
+    return FileHelpers.writeDeleteFile(table, outputFile, partition, deletes);
+  }
+
+  private DeleteFile writeEqDeletes(Table table, String key, Object... values) throws IOException {
+    return writeEqDeletes(table, null, key, values);
+  }
+
+  private DeleteFile writeEqDeletes(Table table, StructLike partition, String key, Object... values)
+      throws IOException {
+    List<Record> deletes = Lists.newArrayList();
+    Schema deleteSchema = table.schema().select(key);
+    Record delete = GenericRecord.create(deleteSchema);
+
+    for (Object value : values) {
+      deletes.add(delete.copy(key, value));
+    }
+
+    OutputFile outputFile = Files.localOutput(File.createTempFile("junit", null, temp.toFile()));
+    return FileHelpers.writeDeleteFile(table, outputFile, partition, deletes, deleteSchema);
+  }
+}


### PR DESCRIPTION
introduces a spark action to tackle two corrupt manifest issues:

- duplicate files existing within the same manifest, or between manifests
- missing files referenced by a manifest (configurable, for emergency purposes only)
- implements a dryRun option