### PR TITLE
Core: Reword exception message in RewriteManifests 

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -810,7 +810,10 @@ public class TestRewriteManifests extends TestBase {
 
     assertThatThrownBy(rewriteManifests::commit)
         .isInstanceOf(ValidationException.class)
-        .hasMessageStartingWith("Manifest is missing");
+        .hasMessageStartingWith(
+            String.format(
+                "Deleted manifest %s could not be found in the latest snapshot %d",
+                firstSnapshotManifest.path(), table.currentSnapshot().snapshotId()));
   }
 
   @TestTemplate
@@ -1604,7 +1607,10 @@ public class TestRewriteManifests extends TestBase {
     // the rewrite must fail as the original delete manifest was replaced concurrently
     assertThatThrownBy(rewriteManifests::commit)
         .isInstanceOf(ValidationException.class)
-        .hasMessageStartingWith("Manifest is missing");
+        .hasMessageStartingWith(
+            String.format(
+                "Deleted manifest %s could not be found in the latest snapshot %d",
+                originalDeleteManifest.path(), table.currentSnapshot().snapshotId()));
   }
 
   @TestTemplate


### PR DESCRIPTION
Users are assuming it is File not found error and it is better to have a message that clarifies that it is missing in metadata but not in the disk. 

https://apache-iceberg.slack.com/archives/C03LG1D563F/p1717453961622069