### PR TITLE
Build: Bump Hive 2.3.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ guava = "33.2.1-jre"
 hadoop2 = "2.7.3"
 hadoop3-client = "3.3.6"
 httpcomponents-httpclient5 = "5.3.1"
-hive2 = { strictly = "2.3.9"} # see rich version usage explanation above
+hive2 = { strictly = "2.3.10"} # see rich version usage explanation above
 hive3 = "3.1.3"
 immutables-value = "2.10.1"
 jackson-bom = "2.14.2"

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -49,7 +49,6 @@ project(':iceberg-mr') {
       exclude group: 'org.apache.calcite.avatica'
       exclude group: 'org.apache.hive', module: 'hive-llap-tez'
       exclude group: 'org.apache.logging.log4j'
-      exclude group: 'org.pentaho' // missing dependency
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }
     compileOnly libs.hive2.metastore
@@ -68,8 +67,7 @@ project(':iceberg-mr') {
     testImplementation libs.avro.avro
     testImplementation libs.calcite.core
     testImplementation libs.kryo.shaded
-    testImplementation platform(libs.jackson.bom)
-    testImplementation libs.jackson.annotations
+    testImplementation enforcedPlatform(libs.jackson212.bom)
     testImplementation(libs.hive2.service) {
       exclude group: 'org.apache.hive', module: 'hive-exec'
     }


### PR DESCRIPTION
Hive 2.3.10 is the final release of branch-2.3, which focuses on mitigating CVE dependencies.

https://github.com/apache/hive/blob/rel/release-2.3.10/RELEASE_NOTES.txt

Spark upgraded Hive 2.3.10 in 4.0.0-preview1 via SPARK-47018