### PR TITLE
Hive: Return new scan after applying column project parameter

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -125,11 +125,9 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     }
     String schemaStr = conf.get(InputFormatConfig.READ_SCHEMA);
     if (schemaStr != null) {
-      scan.project(SchemaParser.fromJson(schemaStr));
-    }
-    String[] selectedColumns = conf.getStrings(InputFormatConfig.SELECTED_COLUMNS);
-    if (selectedColumns != null) {
-      scan.select(selectedColumns);
+      scan = scan.project(SchemaParser.fromJson(schemaStr));
+    } else if (conf.getStrings(InputFormatConfig.SELECTED_COLUMNS) != null) {
+      scan = scan.select(conf.getStrings(InputFormatConfig.SELECTED_COLUMNS));
     }
 
     // TODO add a filter parser to get rid of Serialization

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -234,6 +234,8 @@ public class TestIcebergInputFormats {
 
     Schema projection = TypeUtil.select(SCHEMA, ImmutableSet.of(1));
     builder.project(projection);
+    // project() is the first to be applied on scan, so the select() won't take effect.
+    builder.select("id");
 
     List<Record> outputRecords = testInputFormat.create(builder.conf()).getRecords();
 


### PR DESCRIPTION
1. Shoud return a new scan after applying column project parameter, Otherwise it doesn't make any sense

2. `scan.project()` and `scan.select()` can not be specified at the same time
Check this:
https://github.com/apache/iceberg/pull/1353/files#diff-a94dee2a22a2890689a84529a978a769bdc3b084f35d79caf9608d49b2e1cc1b