### PR TITLE
Core: Use Failsafe in ClientPoolImpl retry logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,6 +342,7 @@ project(':iceberg-core') {
     api project(':iceberg-api')
     implementation project(':iceberg-common')
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+    implementation libs.failsafe
     annotationProcessor libs.immutables.value
     compileOnly libs.immutables.value
 
@@ -355,6 +356,7 @@ project(':iceberg-core') {
     implementation libs.jackson.core
     implementation libs.jackson.databind
     implementation libs.caffeine
+    implementation libs.failsafe
     implementation libs.roaringbitmap
     compileOnly(libs.hadoop2.client) {
       exclude group: 'org.apache.avro', module: 'avro'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ delta-standalone = "3.1.0"
 delta-spark = "3.2.0"
 esotericsoftware-kryo = "4.0.3"
 errorprone-annotations = "2.28.0"
+failsafe = "3.3.2"
 findbugs-jsr305 = "3.0.2"
 flink117 = { strictly = "1.17.2"}
 flink118 =  { strictly = "1.18.1"}
@@ -106,6 +107,7 @@ calcite-druid = { module = "org.apache.calcite:calcite-druid", version.ref = "ca
 datasketches = { module = "org.apache.datasketches:datasketches-java", version.ref = "datasketches" }
 delta-standalone = { module = "io.delta:delta-standalone_2.12", version.ref = "delta-standalone" }
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorprone-annotations" }
+failsafe = { module = "dev.failsafe:failsafe", version.ref = "failsafe"}
 findbugs-jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "findbugs-jsr305" }
 flink117-avro = { module = "org.apache.flink:flink-avro", version.ref = "flink117" }
 flink117-connector-base = { module = "org.apache.flink:flink-connector-base", version.ref = "flink117" }


### PR DESCRIPTION
This change is stemming from https://github.com/apache/iceberg/pull/10433#discussion_r1624930096.

This PR introduces Failsafe https://failsafe.dev/ as a dependency and integrates that into `ClientPoolImpl` where there is currently custom retry logic. The intent is to simplify the custom retry logic that currently exists by just using this dependency, which could also be used in other areas in the Iceberg codebase.