### PR TITLE
DO-NOT-MERGE: Jackson access issue

### DIFF
--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -57,16 +57,18 @@ project(':iceberg-mr') {
 
     implementation libs.caffeine
 
+    testImplementation(libs.calcite.core) {
+      // before CALCITE-1224 (1.9.0), it contains un-relocated Jackson classes
+      exclude group: 'org.apache.calcite.avatica', module: 'avatica'
+    }
+    testImplementation libs.calcite.druid
+
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
 
     testImplementation libs.avro.avro
-    testImplementation(libs.calcite.core) {
-      // before CALCITE-1224 (1.9.0), it contains un-relocated Jackson classes
-      exclude group: 'org.apache.calcite.avatica', module: 'avatica'
-    }
     testImplementation libs.kryo.shaded
     testImplementation platform(libs.jackson.bom)
     testImplementation libs.jackson.annotations

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -57,16 +57,16 @@ project(':iceberg-mr') {
 
     implementation libs.caffeine
 
-    testImplementation libs.calcite.core
-    testImplementation libs.calcite.druid
-
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
 
     testImplementation libs.avro.avro
-    testImplementation libs.calcite.core
+    testImplementation(libs.calcite.core) {
+      // before CALCITE-1224 (1.9.0), it contains un-relocated Jackson classes
+      exclude group: 'org.apache.calcite.avatica', module: 'avatica'
+    }
     testImplementation libs.kryo.shaded
     testImplementation platform(libs.jackson.bom)
     testImplementation libs.jackson.annotations

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -21,6 +21,8 @@ project(':iceberg-mr') {
   configurations {
     testImplementation {
       exclude group: 'org.apache.parquet', module: 'parquet-hadoop-bundle'
+      // before CALCITE-1224 (1.9.0), it contains un-relocated Jackson classes
+      exclude group: 'org.apache.calcite.avatica', module: 'avatica'
     }
   }
   test {
@@ -46,7 +48,6 @@ project(':iceberg-mr') {
       exclude group: 'com.google.guava'
       exclude group: 'com.google.protobuf', module: 'protobuf-java'
       exclude group: 'org.apache.avro', module: 'avro'
-      exclude group: 'org.apache.calcite.avatica'
       exclude group: 'org.apache.hive', module: 'hive-llap-tez'
       exclude group: 'org.apache.logging.log4j'
       exclude group: 'org.pentaho' // missing dependency
@@ -57,10 +58,7 @@ project(':iceberg-mr') {
 
     implementation libs.caffeine
 
-    testImplementation(libs.calcite.core) {
-      // before CALCITE-1224 (1.9.0), it contains un-relocated Jackson classes
-      exclude group: 'org.apache.calcite.avatica', module: 'avatica'
-    }
+    testImplementation libs.calcite.core
     testImplementation libs.calcite.druid
 
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')

--- a/mr/src/test/java/org/apache/iceberg/mr/TestJackson.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestJackson.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.mr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import org.junit.jupiter.api.Test;
+
+public class TestJackson {
+
+  @Test
+  public void testAccessJsonReadFeatureEnum() {
+    assertThat(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS).isNotNull();
+  }
+}


### PR DESCRIPTION
While investigating https://github.com/apache/iceberg/pull/10447, I suspect there are something wrong within Gradle itself.

This simple change produces the following errors.

```
> Task :iceberg-mr:test FAILED
TestJackson > testAccessJsonReadFeatureEnum() FAILED
    java.lang.NoSuchFieldError: ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS
        at com.fasterxml.jackson.core.json.JsonReadFeature.<clinit>(JsonReadFeature.java:121)
        at org.apache.iceberg.mr.TestJackson.testAccessJsonReadFeatureEnum(TestJackson.java:30)
```