### PR TITLE
Run CI checks on all supported JDKs

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -90,20 +90,26 @@ jobs:
 
   build-checks:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        jvm: [8, 11, 17]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: 8
+        java-version: ${{ matrix.jvm }}
     - run: ./gradlew -DallModules build -x test -x javadoc -x integrationTest
 
   build-javadoc:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        jvm: [8, 11, 17]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: 8
+        java-version: ${{ matrix.jvm }}
     - run: ./gradlew -Pquick=true javadoc


### PR DESCRIPTION
This guarantees the build will succeed locally.