### PR TITLE
Run Flink tests on Java 17 too

### DIFF
--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -71,8 +71,12 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        jvm: [8, 11]
+        jvm: [8, 11, 17]
         flink: ['1.17', '1.18', '1.19']
+        exclude:
+          # Flink 1.17 does not support Java 17.
+          - jvm: 17
+            flink: '1.17'
     env:
       SPARK_LOCAL_IP: localhost
     steps:


### PR DESCRIPTION
Project supports building with 8, 11 and 17. In most CI scripts we run the jobs on all supported Java versions, let's do same here to ensure the build would work locally too.