### PR TITLE
Run Hive3 tests on Java 11 and 17 too

### DIFF
--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -94,6 +94,9 @@ jobs:
 
   hive3-tests:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        jvm: [8, 11, 17]
     env:
       SPARK_LOCAL_IP: localhost
     steps:
@@ -101,7 +104,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: 8
+        java-version: ${{ matrix.jvm }}
     - uses: actions/cache@v4
       with:
         path: |

--- a/settings.gradle
+++ b/settings.gradle
@@ -184,14 +184,11 @@ if (hiveVersions.contains("2") || hiveVersions.contains("3")) {
   project(':hive-runtime').name = 'iceberg-hive-runtime'
 }
 
-if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
-  if (hiveVersions.contains("3")) {
-    include 'hive3'
-    include 'hive3-orc-bundle'
-
-    project(':hive3').name = 'iceberg-hive3'
-    project(':hive3-orc-bundle').name = 'iceberg-hive3-orc-bundle'
-  }
+if (hiveVersions.contains("3")) {
+  include 'hive3'
+  include 'hive3-orc-bundle'
+  project(':hive3').name = 'iceberg-hive3'
+  project(':hive3-orc-bundle').name = 'iceberg-hive3-orc-bundle'
 }
 
 include ":iceberg-kafka-connect:kafka-connect-events"


### PR DESCRIPTION
Project supports building with 8, 11 and 17. In most CI scripts we run the jobs on all supported Java versions, let's do same here to ensure the build would work locally too.

Relates to: https://github.com/apache/iceberg/pull/10477