### PR TITLE
Run revapi workflow on workflow/build system changes

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -27,6 +27,9 @@ on:
       - 'apache-iceberg-**'
   pull_request:
     paths:
+      - '.github/workflows/api-binary-compatibility.yml'
+      - '*.gradle'
+      - 'gradle*'
       - 'api/**'
       - '.palantir/revapi.yml'
 


### PR DESCRIPTION
a PR updating gradle (https://github.com/apache/iceberg/pull/10474) should not have green CI because of the revapi problem outlined here https://github.com/apache/iceberg/pull/10476#issuecomment-2160331173. run the revapi checks when CI workflows or build system configuration changes