### PR TITLE
Core: Simplify loadCatalog method call in Iceberg

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -307,7 +307,7 @@ public class CatalogUtil {
           catalogImpl);
     }
 
-    return CatalogUtil.loadCatalog(catalogImpl, name, options, conf);
+    return loadCatalog(catalogImpl, name, options, conf);
   }
 
   /**


### PR DESCRIPTION
This PR simplifies the loadCatalog method call in Iceberg by removing the redundant CatalogUtil class qualifier. The change improves code readability.