### PR TITLE
Mr: Optimize schema string retrieval in Iceberg

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -151,7 +151,7 @@ public final class Catalogs {
   public static Table createTable(Configuration conf, Properties props) {
     String schemaString = props.getProperty(InputFormatConfig.TABLE_SCHEMA);
     Preconditions.checkNotNull(schemaString, "Table schema not set");
-    Schema schema = SchemaParser.fromJson(props.getProperty(InputFormatConfig.TABLE_SCHEMA));
+    Schema schema = SchemaParser.fromJson(schemaString);
 
     String specString = props.getProperty(InputFormatConfig.PARTITION_SPEC);
     PartitionSpec spec = PartitionSpec.unpartitioned();


### PR DESCRIPTION
This PR optimizes the retrieval of the schema string in Iceberg. Instead of calling `props.getProperty(InputFormatConfig.TABLE_SCHEMA)` twice, the method is now called once and the result is stored in the schemaString variable. This variable is then used for parsing the schema, reducing unnecessary method calls and improving code efficiency.