### PR TITLE
Remove deprecated methods from ContentCache

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1024,6 +1024,14 @@ acceptedBreaks:
       old: "class org.apache.iceberg.types.Types.NestedField"
       new: "class org.apache.iceberg.types.Types.NestedField"
       justification: "new Constructor added"
+    org.apache.iceberg:iceberg-core:
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.io.ContentCache.CacheEntry org.apache.iceberg.io.ContentCache::get(java.lang.String,\
+        \ java.util.function.Function<java.lang.String, org.apache.iceberg.io.ContentCache.FileContent>)"
+      justification: "the returned type was private so the method was never an API"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.io.ContentCache.CacheEntry org.apache.iceberg.io.ContentCache::getIfPresent(java.lang.String)"
+      justification: "the returned type was private so the method was never an API"
   apache-iceberg-0.14.0:
     org.apache.iceberg:iceberg-api:
     - code: "java.class.defaultSerializationChanged"

--- a/core/src/main/java/org/apache/iceberg/io/ContentCache.java
+++ b/core/src/main/java/org/apache/iceberg/io/ContentCache.java
@@ -28,7 +28,6 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.List;
-import java.util.function.Function;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
@@ -113,18 +112,6 @@ public class ContentCache {
 
   /** @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead */
   @Deprecated
-  public CacheEntry get(String key, Function<String, FileContent> mappingFunction) {
-    return cache.get(key, mappingFunction);
-  }
-
-  /** @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead */
-  @Deprecated
-  public CacheEntry getIfPresent(String location) {
-    return cache.getIfPresent(location);
-  }
-
-  /** @deprecated will be removed in 1.7; use {@link #tryCache(InputFile)} instead */
-  @Deprecated
   public InputFile tryCache(FileIO io, String location, long length) {
     return tryCache(io.newInputFile(location, length));
   }
@@ -173,11 +160,7 @@ public class ContentCache {
         .toString();
   }
 
-  /** @deprecated will be removed in 1.7; use {@link FileContent} instead. */
-  @Deprecated
-  private static class CacheEntry {}
-
-  private static class FileContent extends CacheEntry {
+  private static class FileContent {
     private final long length;
     private final List<ByteBuffer> buffers;
 


### PR DESCRIPTION
They are deprecated, unused and not part of API.