### PR TITLE
API: add resultSchema() method to StructTransform

### DIFF
--- a/api/src/main/java/org/apache/iceberg/StructTransform.java
+++ b/api/src/main/java/org/apache/iceberg/StructTransform.java
@@ -69,11 +69,15 @@ class StructTransform implements StructLike, Serializable {
       this.accessors[i] = accessor;
       this.transforms[i] = transform.bind(accessor.type());
       Type transformedType = transform.getResultType(sourceField.type());
+      // There could be multiple transformations on the same source column,
+      // like in the PartitionKey case. To resolve the collision,
+      // field id is set to transform index and
+      // field name is set to sourceFieldName_transformIndex
       Types.NestedField transformedField =
           Types.NestedField.of(
-              sourceFieldId,
+              i,
               sourceField.isOptional(),
-              sourceField.name(),
+              sourceField.name() + '_' + i,
               transformedType,
               sourceField.doc());
       transformedFields.add(transformedField);

--- a/api/src/main/java/org/apache/iceberg/StructTransform.java
+++ b/api/src/main/java/org/apache/iceberg/StructTransform.java
@@ -26,7 +26,6 @@ import java.util.function.Function;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.transforms.Transform;
-import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SerializableFunction;
@@ -148,14 +147,7 @@ class StructTransform implements StructLike, Serializable {
     return Arrays.hashCode(transformedTuple);
   }
 
-  /**
-   * The transform result type is useful for building a comparator for the transformed struct (like
-   * {@link SortKey} using {@link Comparators#forType(Types.StructType)}.
-   *
-   * <p>
-   *
-   * @return the schema of transformed fields (a flattened structure)
-   */
+  /** Return the schema of transformed result (a flattened structure) */
   public Schema resultSchema() {
     return resultSchema;
   }

--- a/api/src/test/java/org/apache/iceberg/TestStructTransform.java
+++ b/api/src/test/java/org/apache/iceberg/TestStructTransform.java
@@ -73,9 +73,9 @@ public class TestStructTransform {
     assertThat(structTransform.resultSchema().asStruct())
         .isEqualTo(
             Types.StructType.of(
-                Types.NestedField.required(2, "ratio", Types.DoubleType.get()),
-                Types.NestedField.required(12, "ts", Types.IntegerType.get()),
-                Types.NestedField.optional(13, "device_id", Types.IntegerType.get()),
-                Types.NestedField.required(103, "blob", Types.BinaryType.get())));
+                Types.NestedField.required(0, "ratio_0", Types.DoubleType.get()),
+                Types.NestedField.required(1, "ts_1", Types.IntegerType.get()),
+                Types.NestedField.optional(2, "device_id_2", Types.IntegerType.get()),
+                Types.NestedField.required(3, "blob_3", Types.BinaryType.get())));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/TestStructTransform.java
+++ b/api/src/test/java/org/apache/iceberg/TestStructTransform.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestStructTransform {
+  @Test
+  public void testInvalidSourceField() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.StringType.get()),
+            Types.NestedField.optional(2, "int", Types.IntegerType.get()));
+    List<StructTransform.FieldTransform> fieldTransforms =
+        Arrays.asList(new StructTransform.FieldTransform(3, Transforms.identity()));
+    assertThatThrownBy(() -> new StructTransform(schema, fieldTransforms))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot find source field: 3");
+  }
+
+  @Test
+  public void testResultSchema() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.StringType.get()),
+            Types.NestedField.required(2, "ratio", Types.DoubleType.get()),
+            Types.NestedField.optional(
+                3,
+                "user",
+                Types.StructType.of(
+                    Types.NestedField.required(11, "name", Types.StringType.get()),
+                    Types.NestedField.required(12, "ts", Types.TimestampType.withoutZone()),
+                    Types.NestedField.optional(13, "device_id", Types.UUIDType.get()),
+                    Types.NestedField.optional(
+                        14,
+                        "location",
+                        Types.StructType.of(
+                            Types.NestedField.required(101, "lat", Types.FloatType.get()),
+                            Types.NestedField.required(102, "long", Types.FloatType.get()),
+                            Types.NestedField.required(103, "blob", Types.BinaryType.get()))))));
+
+    List<StructTransform.FieldTransform> fieldTransforms =
+        Arrays.asList(
+            new StructTransform.FieldTransform(2, Transforms.identity()),
+            new StructTransform.FieldTransform(12, Transforms.hour()),
+            new StructTransform.FieldTransform(13, Transforms.bucket(16)),
+            new StructTransform.FieldTransform(103, Transforms.truncate(16)));
+
+    StructTransform structTransform = new StructTransform(schema, fieldTransforms);
+    assertThat(structTransform.resultSchema().asStruct())
+        .isEqualTo(
+            Types.StructType.of(
+                Types.NestedField.required(2, "ratio", Types.DoubleType.get()),
+                Types.NestedField.required(12, "ts", Types.IntegerType.get()),
+                Types.NestedField.optional(13, "device_id", Types.IntegerType.get()),
+                Types.NestedField.required(103, "blob", Types.BinaryType.get())));
+  }
+}


### PR DESCRIPTION
This can be used to build `Comparator` for `SortKey`, which contains the transformed view of the original struct. `SortOrderComparators` only works with the original struct.