### PR TITLE
Core: Exclude unexpected namespaces JdbcCatalog.listNamespaces

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -466,6 +466,8 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
                         Arrays.stream(n.levels())
                             .limit(subNamespaceLevelLength)
                             .toArray(String[]::new)))
+            // remove duplicates
+            .distinct()
             // exclude fuzzy matches when `namespace` contains `%` or `_`
             .filter(
                 n -> {
@@ -476,8 +478,6 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
                   }
                   return true;
                 })
-            // remove duplicates
-            .distinct()
             .collect(Collectors.toList());
 
     return namespaces;

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -466,8 +466,6 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
                         Arrays.stream(n.levels())
                             .limit(subNamespaceLevelLength)
                             .toArray(String[]::new)))
-            // remove duplicates
-            .distinct()
             // exclude fuzzy matches when `namespace` contains `%` or `_`
             .filter(
                 n -> {
@@ -478,6 +476,8 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
                   }
                   return true;
                 })
+            // remove duplicates
+            .distinct()
             .collect(Collectors.toList());
 
     return namespaces;

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -468,6 +468,16 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
                             .toArray(String[]::new)))
             // remove duplicates
             .distinct()
+            // exclude fuzzy matches when `namespace` contains `%` or `_`
+            .filter(
+                n -> {
+                  for (int i = 0; i < namespace.levels().length; i++) {
+                    if (!n.levels()[i].equals(namespace.levels()[i])) {
+                      return false;
+                    }
+                  }
+                  return true;
+                })
             .collect(Collectors.toList());
 
     return namespaces;

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -753,8 +753,11 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     TableIdentifier tbl4 = TableIdentifier.of("db", "metadata");
     TableIdentifier tbl5 = TableIdentifier.of("db2", "metadata");
     TableIdentifier tbl6 = TableIdentifier.of("tbl6");
+    TableIdentifier tbl7 = TableIdentifier.of("db2", "ns4", "tbl5");
+    TableIdentifier tbl8 = TableIdentifier.of("d_", "ns5", "tbl6");
+    TableIdentifier tbl9 = TableIdentifier.of("d%", "ns6", "tbl7");
 
-    Lists.newArrayList(tbl1, tbl2, tbl3, tbl4, tbl5, tbl6)
+    Lists.newArrayList(tbl1, tbl2, tbl3, tbl4, tbl5, tbl6, tbl7, tbl8, tbl9)
         .forEach(t -> catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned()));
 
     List<Namespace> nsp1 = catalog.listNamespaces(Namespace.of("db"));
@@ -768,11 +771,19 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
 
     List<Namespace> nsp3 = catalog.listNamespaces();
     Set<String> tblSet2 = Sets.newHashSet(nsp3.stream().map(Namespace::toString).iterator());
-    assertThat(tblSet2).hasSize(3).contains("db", "db2", "");
+    assertThat(tblSet2).hasSize(5).contains("db", "db2", "d_", "d%", "");
 
     List<Namespace> nsp4 = catalog.listNamespaces();
     Set<String> tblSet3 = Sets.newHashSet(nsp4.stream().map(Namespace::toString).iterator());
-    assertThat(tblSet3).hasSize(3).contains("db", "db2", "");
+    assertThat(tblSet3).hasSize(5).contains("db", "db2", "d_", "d%", "");
+
+    List<Namespace> nsp5 = catalog.listNamespaces(Namespace.of("d_"));
+    assertThat(nsp5).hasSize(1);
+    assertThat(nsp5.get(0)).hasToString("d_.ns5");
+
+    List<Namespace> nsp6 = catalog.listNamespaces(Namespace.of("d%"));
+    assertThat(nsp6).hasSize(1);
+    assertThat(nsp6.get(0)).hasToString("d%.ns6");
 
     Assertions.assertThatThrownBy(() -> catalog.listNamespaces(Namespace.of("db", "db2", "ns2")))
         .isInstanceOf(NoSuchNamespaceException.class)


### PR DESCRIPTION
JdbcCatalog.listNamespaces returned unexpected namespaces because of `LIKE` with `%`. 

The updated `testListNamespace` test fails without this change:
```java
    List<Namespace> nsp1 = catalog.listNamespaces(Namespace.of("db"));
    assertThat(nsp1).hasSize(3);

Expected size: 3 but was: 4 in:
[db.ns1, db.ns2, db.ns3, db2.ns4]
java.lang.AssertionError: 
Expected size: 3 but was: 4 in:
[db.ns1, db.ns2, db.ns3, db2.ns4]
```

Fixes #10213