### PR TITLE
Fix CI script inclusion of release branches

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -22,7 +22,9 @@ on:
   push:
     branches:
       - 'main'
-      - '0.**'
+      - '0.*'
+      - '1.*'
+      - '2.*'
     tags:
       - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -22,7 +22,9 @@ on:
   push:
     branches:
       - 'main'
-      - '0.**'
+      - '0.*'
+      - '1.*'
+      - '2.*'
     tags:
       - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -22,7 +22,9 @@ on:
   push:
     branches:
     - 'main'
-    - '0.**'
+    - '0.*'
+    - '1.*'
+    - '2.*'
     tags:
     - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -22,7 +22,9 @@ on:
   push:
     branches:
     - 'main'
-    - '0.**'
+    - '0.*'
+    - '1.*'
+    - '2.*'
     tags:
     - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -22,7 +22,9 @@ on:
   push:
     branches:
     - 'main'
-    - '0.**'
+    - '0.*'
+    - '1.*'
+    - '2.*'
     tags:
     - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/open-api.yml
+++ b/.github/workflows/open-api.yml
@@ -22,7 +22,9 @@ on:
   push:
     branches:
       - 'main'
-      - '0.**'
+      - '0.*'
+      - '1.*'
+      - '2.*'
     tags:
       - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -22,7 +22,9 @@ on:
   push:
     branches:
     - 'main'
-    - '0.**'
+    - '0.*'
+    - '1.*'
+    - '2.*'
     tags:
     - 'apache-iceberg-**'
   pull_request:


### PR DESCRIPTION
The CI scripts are meant to run on release maintenance branches such as 1.5.x. They were run for releases up to 1.0 because of the `0.*` pattern

This commit:

- includes `1.*` branches (but that's likely needs to be propagated to existing branches)
- includes `2.*` branches foreseeing imminent 2.0 release
- changes the `0.**` pattern to `0.*`. Multiple asterisks are needed to match branch names including `/` but release branche naming convention do not expect such branch names.