### PR TITLE
Fix CI script inclusion of release branches (v2)

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -20,9 +20,8 @@
 name: "API Binary Compatibility Checks"
 on:
   push:
-    branches:
-      - 'main'
-      - '0.**'
+    branches-ignore:
+      - 'dependabot/**'
     tags:
       - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -20,9 +20,8 @@
 name: "Delta Conversion CI"
 on:
   push:
-    branches:
-      - 'main'
-      - '0.**'
+    branches-ignore:
+      - 'dependabot/**'
     tags:
       - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -20,9 +20,8 @@
 name: "Flink CI"
 on:
   push:
-    branches:
-    - 'main'
-    - '0.**'
+    branches-ignore:
+    - 'dependabot/**'
     tags:
     - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -20,9 +20,8 @@
 name: "Hive CI"
 on:
   push:
-    branches:
-    - 'main'
-    - '0.**'
+    branches-ignore:
+    - 'dependabot/**'
     tags:
     - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -20,9 +20,8 @@
 name: "Java CI"
 on:
   push:
-    branches:
-    - 'main'
-    - '0.**'
+    branches-ignore:
+    - 'dependabot/**'
     tags:
     - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/open-api.yml
+++ b/.github/workflows/open-api.yml
@@ -20,9 +20,8 @@
 name: "Open-API"
 on:
   push:
-    branches:
-      - 'main'
-      - '0.**'
+    branches-ignore:
+    - 'dependabot/**'
     tags:
       - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -20,9 +20,8 @@
 name: "Spark CI"
 on:
   push:
-    branches:
-    - 'main'
-    - '0.**'
+    branches-ignore:
+    - 'dependabot/**'
     tags:
     - 'apache-iceberg-**'
   pull_request:


### PR DESCRIPTION
The CI scripts are meant to run on release maintenance branches such as 1.5.x. They were run for releases up to 1.0 because of the `0.*` pattern. This commit fixes this by replacing branch allow-list with a deny-list for triggering the builds.

Alternative to https://github.com/apache/iceberg/pull/10514