### PR TITLE
spec: Fix formatting of Default values

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -201,8 +201,9 @@ For details on how to serialize a schema to JSON, see Appendix C.
 #### Default values
 
 Default values can be tracked for struct fields (both nested structs and the top-level schema's struct). There can be two defaults with a field:
-- `initial-default` is used to populate the field's value for all records that were written before the field was added to the schema
-- `write-default` is used to populate the field's value for any records written after the field was added to the schema, if the writer does not supply the field's value
+
+* `initial-default` is used to populate the field's value for all records that were written before the field was added to the schema
+* `write-default` is used to populate the field's value for any records written after the field was added to the schema, if the writer does not supply the field's value
 
 The `initial-default` is set only when a field is added to an existing schema. The `write-default` is initially set to the same value as `initial-default` and can be changed through schema evolution. If either default is not set for an optional field, then the default value is null for compatibility with older spec versions.
 


### PR DESCRIPTION
The list doesn't seem to work with a `-`, a `*` seems to do the trick (also used below).

![image](https://github.com/apache/iceberg/assets/1134248/0a853650-6adf-42c8-b1b1-aca3076d1c71)
