### PR TITLE
Core：Simplify newTableMetadata method in TableMetadata class

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -74,7 +74,7 @@ public class TableMetadata implements Serializable {
   public static TableMetadata newTableMetadata(
       Schema schema, PartitionSpec spec, String location, Map<String, String> properties) {
     SortOrder sortOrder = SortOrder.unsorted();
-    return newTableMetadata(schema, spec, sortOrder, location, properties);
+    return newTableMetadata(schema, spec, SortOrder.unsorted(), location, properties);
   }
 
   private static Map<String, String> unreservedProperties(Map<String, String> rawProperties) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -74,11 +74,7 @@ public class TableMetadata implements Serializable {
   public static TableMetadata newTableMetadata(
       Schema schema, PartitionSpec spec, String location, Map<String, String> properties) {
     SortOrder sortOrder = SortOrder.unsorted();
-    int formatVersion =
-        PropertyUtil.propertyAsInt(
-            properties, TableProperties.FORMAT_VERSION, DEFAULT_TABLE_FORMAT_VERSION);
-    return newTableMetadata(
-        schema, spec, sortOrder, location, persistedProperties(properties), formatVersion);
+    return newTableMetadata(schema, spec, sortOrder, location, persistedProperties(properties));
   }
 
   private static Map<String, String> unreservedProperties(Map<String, String> rawProperties) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -74,7 +74,7 @@ public class TableMetadata implements Serializable {
   public static TableMetadata newTableMetadata(
       Schema schema, PartitionSpec spec, String location, Map<String, String> properties) {
     SortOrder sortOrder = SortOrder.unsorted();
-    return newTableMetadata(schema, spec, sortOrder, location, persistedProperties(properties));
+    return newTableMetadata(schema, spec, sortOrder, location, properties);
   }
 
   private static Map<String, String> unreservedProperties(Map<String, String> rawProperties) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -73,7 +73,6 @@ public class TableMetadata implements Serializable {
 
   public static TableMetadata newTableMetadata(
       Schema schema, PartitionSpec spec, String location, Map<String, String> properties) {
-    SortOrder sortOrder = SortOrder.unsorted();
     return newTableMetadata(schema, spec, SortOrder.unsorted(), location, properties);
   }
 


### PR DESCRIPTION
This pr simplifies the newTableMetadata method call in Iceberg by removing the redundant TableMetadata class.
We can create `TableMetadata` object by using method 'org.apache.iceberg.TableMetadata#newTableMetadata(org.apache.iceberg.Schema, org.apache.iceberg.PartitionSpec, org.apache.iceberg.SortOrder, java.lang.String, java.util.Map<java.lang.String,java.lang.String>)' so that we can remove redundant code as follow： 
`int formatVersion =
        PropertyUtil.propertyAsInt(
            properties, TableProperties.FORMAT_VERSION, DEFAULT_TABLE_FORMAT_VERSION);`
