### PR TITLE
Remove unnecessary class-level synchronized in ManifestFiles

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -81,7 +81,7 @@ public class ManifestFiles {
   }
 
   /** Drop manifest file cache object for a FileIO if exists. */
-  public static synchronized void dropCache(FileIO fileIO) {
+  public static void dropCache(FileIO fileIO) {
     CONTENT_CACHES.invalidate(fileIO);
     CONTENT_CACHES.cleanUp();
   }


### PR DESCRIPTION
It was guarding `CONTENT_CACHES` access, but this field is a concurrent data structure (`Caffeine`) and does not need external synchronization.