### PR TITLE
Allow Java 17 in contribute.md

### DIFF
--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -84,7 +84,7 @@ settle disagreements or to force a decision.
 
 ## Building the Project Locally
 
-Iceberg is built using Gradle with Java 8 or Java 11.
+Iceberg is built using Gradle with Java 8, 11, or 17.
 
 * To invoke a build and run tests: `./gradlew build`
 * To skip tests: `./gradlew build -x test -x integrationTest`


### PR DESCRIPTION
Java 17 is equally supported build-time JVM.
This syncs the wording between contribute.md and README.md.