### PR TITLE
Spec: Make NDV blob metadata property required

### DIFF
--- a/format/puffin-spec.md
+++ b/format/puffin-spec.md
@@ -119,7 +119,7 @@ DataSketches](https://datasketches.apache.org/) library. The sketch is obtained 
 constructing Alpha family sketch with default seed, and feeding it with individual
 distinct values converted to bytes using Iceberg's single-value serialization.
 
-The blob metadata for this blob may include following properties:
+The blob metadata for this blob must include the following properties:
 
 - `ndv`: estimate of number of distinct values, derived from the sketch.
 


### PR DESCRIPTION
Based on discussion stemming from: https://github.com/apache/iceberg/pull/10288/files#discussion_r1622775896

The current consensus is on making the NDV property in blob metadata required for theta sketch blob types. The main advantage is that engines don't have to deserialize the sketch and compute the NDV themselves. Furthermore, there's not really any extra lift to store it in properties from writers; when engines write out the theta sketch, they'll already be able to compute the NDV and store it in properties.