### PR TITLE
Spark: Remove useless code in TestRemoveOrphanFilesProcedure

### DIFF
--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -302,7 +302,6 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
 
     Table table = validationCatalog.loadTable(tableIdent);
 
-    String metadataLocation = table.location() + "/metadata";
     String dataLocation = table.location() + "/data";
 
     // produce orphan files in the data location using parquet

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -297,7 +297,6 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
 
     Table table = validationCatalog.loadTable(tableIdent);
 
-    String metadataLocation = table.location() + "/metadata";
     String dataLocation = table.location() + "/data";
 
     // produce orphan files in the data location using parquet

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -285,7 +285,6 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
 
     Table table = validationCatalog.loadTable(tableIdent);
 
-    String metadataLocation = table.location() + "/metadata";
     String dataLocation = table.location() + "/data";
 
     // produce orphan files in the data location using parquet


### PR DESCRIPTION
This PR remove the useless code in test case `TestRemoveOrphanFilesProcedure.testConcurrentRemoveOrphanFiles()` for Spark 3.5, 3.4 and 3.3. The variable `metadataLocation` is declared and assigned a value, but not used anywhere.