### PR TITLE
Flink-1.19: Fix the file offset mismatch when Flink reader first seek…

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
@@ -85,6 +85,7 @@ public class DataIterator<T> implements CloseableIterator<T> {
         combinedTask);
     for (long i = 0L; i < startingFileOffset; ++i) {
       tasks.next();
+      fileOffset += 1;
     }
 
     updateCurrentIterator();
@@ -99,9 +100,6 @@ public class DataIterator<T> implements CloseableIterator<T> {
                 startingRecordOffset, startingFileOffset, combinedTask));
       }
     }
-
-    fileOffset = startingFileOffset;
-    recordOffset = startingRecordOffset;
   }
 
   @Override

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
@@ -60,6 +60,22 @@ public class ReaderUtil {
       FileFormat fileFormat,
       FileAppenderFactory<Record> appenderFactory)
       throws IOException {
+
+    return createFileTask(
+        records,
+        file,
+        fileFormat,
+        appenderFactory,
+        ResidualEvaluator.unpartitioned(Expressions.alwaysTrue()));
+  }
+
+  public static FileScanTask createFileTask(
+      List<Record> records,
+      File file,
+      FileFormat fileFormat,
+      FileAppenderFactory<Record> appenderFactory,
+      ResidualEvaluator residuals)
+      throws IOException {
     FileAppender<Record> appender =
         appenderFactory.newAppender(Files.localOutput(file), fileFormat);
     try {
@@ -77,7 +93,6 @@ public class ReaderUtil {
             .withMetrics(appender.metrics())
             .build();
 
-    ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(Expressions.alwaysTrue());
     return new BaseFileScanTask(
         dataFile,
         null,

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
@@ -45,7 +45,6 @@ import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.flink.source.DataIterator;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.junit.Test;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -381,16 +380,16 @@ public class TestArrayPoolDataIteratorBatcherRowData {
     FileScanTask fileTask0 =
         ReaderUtil.createFileTask(
             ImmutableList.of(record0),
-            TEMPORARY_FOLDER.newFile(),
-            fileFormat,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
             appenderFactory,
             residuals);
 
     FileScanTask fileTask1 =
         ReaderUtil.createFileTask(
             ImmutableList.of(record1),
-            TEMPORARY_FOLDER.newFile(),
-            fileFormat,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
             appenderFactory,
             residuals);
 


### PR DESCRIPTION
…s position.

When `DataIterator` first seeks position (`startingFileOffset=0 & startingRecordOffset=0`) on a split, `fileOffset` might be assigned incorrectly. This can lead to Flink consuming data repeatedly when recovering from ckpt or to not being able to recover from ckpt because of `IllegalStateException: Invalid starting record offset...`
Here is an example:
Suppose there is a `CombinedScanTask` that contains three `FileScanTask` with the following metrics and residual filters:
- fileScanTask-0: 1 < ts < 10, residual filter: ts > 10
- fileScanTask-1: 100 < ts < 200, residual filter: ts > 10
- fileScanTask-2: 100 < ts < 200, residual filter: ts > 10

When `DataIterator` initializes for the first time, it calls `#seek` with `startingFileOffset=0 and startingRecordOffset=0`. In `#updateCurrentIterator`, when `currentIterator` is moved to file 0 (fileScanTask-0) , the subsequent while condition `!currentIterator.hasNext()` will still be true because parquet row-group filters evaluate that fileScanTask-0 can be skipped. Therefore, `currentIterator` will be moved to fileScanTask-1. This also increases `fileOffset`, which is the correct offset by now.
```java
private void updateCurrentIterator() {
  try {
    while (!currentIterator.hasNext() && tasks.hasNext()) {
      currentIterator.close();
      currentIterator = openTaskIterator(tasks.next());
      fileOffset += 1;
      recordOffset = 0L;
    }
  } catch (IOException e) {
    throw new UncheckedIOException(e);
  }
}
```

However, when returning to the `#seek` method, `fileOffset` will be assigned the value of `startingFileOffset`(0, the actual value is 1), which is wrong:
```java
fileOffset = startingFileOffset;
recordOffset = startingRecordOffset;
```
This results in the following:
Suppose Flink sets a ckpt at record offset 50 of fileScanTask-2. The ckpt record would be (`fileOffset = 1, recordOffset=50`), while the real value should be (`fileOffset = 2, recordOffset=50`). When the job attempts to recover from this ckpt, it will try to start reading records again from (`fileOffset = 1, recordOffset=50`). 
- If the number of records in fileScanTask-1 is less than 50, an  exception `IllegalStateException: Invalid starting record offset...` will be thrown, and the job cannot recover
- If the number of records in fileScanTask-1 is greater than or equal to 50, although recovery is successful, the records will be consumed repeatedly.

cc @pvary @stevenzwu could you take a look at this? thanks!