### PR TITLE
Build: Move to `goooler` shadow plugin

### DIFF
--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -19,7 +19,7 @@
 
 project(":iceberg-aws-bundle") {
 
-  apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'io.github.goooler.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -19,7 +19,7 @@
 
 project(":iceberg-azure-bundle") {
 
-  apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'io.github.goooler.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'com.github.johnrengelman:shadow:8.1.1'
+    classpath 'io.github.goooler.shadow-gradle-plugin:shadow:8.1.7'
     classpath 'com.palantir.baseline:gradle-baseline-java:4.42.0'
     // com.palantir.baseline:gradle-baseline-java:4.42.0 (the last version supporting Java 8) pulls
     // in an old version of the errorprone, which doesn't work w/ Gradle 8, so bump errorpone as

--- a/build.gradle
+++ b/build.gradle
@@ -257,7 +257,7 @@ subprojects {
 }
 
 project(':iceberg-bundled-guava') {
-  apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'io.github.goooler.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/flink/v1.17/build.gradle
+++ b/flink/v1.17/build.gradle
@@ -125,7 +125,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 }
 
 project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
-  apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'io.github.goooler.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/flink/v1.18/build.gradle
+++ b/flink/v1.18/build.gradle
@@ -125,7 +125,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 }
 
 project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
-  apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'io.github.goooler.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/flink/v1.19/build.gradle
+++ b/flink/v1.19/build.gradle
@@ -127,7 +127,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 }
 
 project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
-  apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'io.github.goooler.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -19,7 +19,7 @@
 
 project(":iceberg-gcp-bundle") {
 
-  apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'io.github.goooler.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/hive-runtime/build.gradle
+++ b/hive-runtime/build.gradle
@@ -20,7 +20,7 @@
 def hiveVersions = (System.getProperty("hiveVersions") != null ? System.getProperty("hiveVersions") : System.getProperty("defaultHiveVersions")).split(",")
 
 project(':iceberg-hive-runtime') {
-  apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'io.github.goooler.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/hive3-orc-bundle/build.gradle
+++ b/hive3-orc-bundle/build.gradle
@@ -21,7 +21,7 @@
 // name. This is to be used by Hive3 for features including e.g. vectorization.
 project(':iceberg-hive3-orc-bundle') {
 
-  apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'io.github.goooler.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -177,7 +177,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
 }
 
 project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'io.github.goooler.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -180,7 +180,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
 }
 
 project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'io.github.goooler.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -184,7 +184,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
 }
 
 project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'io.github.goooler.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 


### PR DESCRIPTION
The version of Jackson that comes with Parquet 1.14.1 carries JDK 21 specific code. this is not suported by the current version of the shadow plugin: https://github.com/johnrengelman/shadow/pull/876 There is a fork that actually fixes this.