### PR TITLE
Doc: Spark quickstart needs to create context directory first

### DIFF
--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -117,7 +117,7 @@ networks:
 
 Next, start up the docker containers with this command:
 ```sh
-docker-compose up
+mkdir spark && docker-compose up
 ```
 
 You can then run any of the following commands to start a Spark session.


### PR DESCRIPTION
I'm new to Iceberg. When I try it following the [quickstart](https://iceberg.apache.org/spark-quickstart/#docker-compose), the below error occurrs.
```
# docker-compose up
ERROR: build path /root/iceberg/spark either does not exist, is not accessible, or is not a valid URL.
```

That's because the build context directory is not created in advance. I think it would better to fix it.