### PR TITLE
Build: Declare avro as an api dependency of iceberg-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -348,7 +348,7 @@ project(':iceberg-core') {
     annotationProcessor libs.immutables.value
     compileOnly libs.immutables.value
 
-    implementation(libs.avro.avro) {
+    api(libs.avro.avro) {
       exclude group: 'org.tukaani' // xz compression is not supported
     }
 


### PR DESCRIPTION
iceberg-core should declare an api dependency on avro. For example, the public class `org.apache.iceberg.PartitionData` extends avro-specific types. In addition, there are public methods that deal with avro types, see `org.apache.iceberg.avro.AvroSchemaUtil`