### PR TITLE
(1.5.x) Fix running CI on release branch

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -23,6 +23,7 @@ on:
     branches:
       - 'main'
       - '0.**'
+      - '1.**'
     tags:
       - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -23,6 +23,7 @@ on:
     branches:
       - 'main'
       - '0.**'
+      - '1.**'
     tags:
       - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -23,6 +23,7 @@ on:
     branches:
     - 'main'
     - '0.**'
+    - '1.**'
     tags:
     - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -23,6 +23,7 @@ on:
     branches:
     - 'main'
     - '0.**'
+    - '1.**'
     tags:
     - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -23,6 +23,7 @@ on:
     branches:
     - 'main'
     - '0.**'
+    - '1.**'
     tags:
     - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/open-api.yml
+++ b/.github/workflows/open-api.yml
@@ -23,6 +23,7 @@ on:
     branches:
       - 'main'
       - '0.**'
+      - '1.**'
     tags:
       - 'apache-iceberg-**'
   pull_request:

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -23,6 +23,7 @@ on:
     branches:
     - 'main'
     - '0.**'
+    - '1.**'
     tags:
     - 'apache-iceberg-**'
   pull_request:


### PR DESCRIPTION
Relates to https://github.com/apache/iceberg/pull/10515 and https://github.com/apache/iceberg/pull/10514. Minimal version to make the CI run on the 1.5.x branch.

Same as https://github.com/apache/iceberg/pull/10579 but for different branch