### PR TITLE
Speed up Spark + Flink unit test execution

### DIFF
--- a/flink/v1.17/build.gradle
+++ b/flink/v1.17/build.gradle
@@ -121,6 +121,13 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
   test {
     useJUnitPlatform()
+
+    // See `gradle.properties` and `$HOME/.gradle/gradle.properties`
+    maxParallelForks = Math.max(
+            Math.min(
+                    Integer.getInteger("iceberg.maxFlinkTestParallelism", 2),
+                    (Runtime.runtime.availableProcessors() / 2).intValue()).intValue(),
+            1)
   }
 }
 

--- a/flink/v1.18/build.gradle
+++ b/flink/v1.18/build.gradle
@@ -121,6 +121,13 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
   test {
     useJUnitPlatform()
+
+    // See `gradle.properties` and `$HOME/.gradle/gradle.properties`
+    maxParallelForks = Math.max(
+            Math.min(
+                    Integer.getInteger("iceberg.maxFlinkTestParallelism", 2),
+                    (Runtime.runtime.availableProcessors() / 2).intValue()).intValue(),
+            1)
   }
 }
 

--- a/flink/v1.19/build.gradle
+++ b/flink/v1.19/build.gradle
@@ -123,6 +123,13 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
   test {
     useJUnitPlatform()
+
+    // See `gradle.properties` and `$HOME/.gradle/gradle.properties`
+    maxParallelForks = Math.max(
+            Math.min(
+                    Integer.getInteger("iceberg.maxFlinkTestParallelism", 2),
+                    (Runtime.runtime.availableProcessors() / 2).intValue()).intValue(),
+            1)
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,9 @@ systemProp.defaultScalaVersion=2.12
 systemProp.knownScalaVersions=2.12,2.13
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx1024m
+
+# The maximum allowed test forks for Spark + Flink tests.
+# The number of `Test.maxParallelForks` is computed like this:
+#   max(min(Integer.getInteger("iceberg.maxSparkTestParallelism", 2), Runtime.runtime.availableProcessors() / 2), 1)
+systemProp.iceberg.maxSparkTestParallelism=1
+systemProp.iceberg.maxFlinkTestParallelism=1

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -36,6 +36,17 @@ configure(sparkProjects) {
       }
     }
   }
+
+  tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+
+    // See `gradle.properties` and `$HOME/.gradle/gradle.properties`
+    maxParallelForks = Math.max(
+            Math.min(
+                    Integer.getInteger("iceberg.maxSparkTestParallelism", 2),
+                    (Runtime.runtime.availableProcessors() / 2).intValue()).intValue(),
+            1)
+  }
 }
 
 project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
@@ -103,10 +114,6 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
     testImplementation libs.sqlite.jdbc
     testImplementation libs.awaitility
-  }
-
-  test {
-    useJUnitPlatform()
   }
 
   tasks.withType(Test) {
@@ -280,15 +287,15 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     archiveClassifier.set(null)
   }
 
-  task integrationTest(type: Test) {
+  tasks.register("integrationTest", Test).configure {
     description = "Test Spark3 Runtime Jar against Spark ${sparkMajorVersion}"
     group = "verification"
     jvmArgs += project.property('extraJvmArgs')
     testClassesDirs = sourceSets.integration.output.classesDirs
     classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)
     inputs.file(shadowJar.archiveFile.get().asFile.path)
+    dependsOn shadowJar
   }
-  integrationTest.dependsOn shadowJar
   check.dependsOn integrationTest
 
   jar {

--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -36,6 +36,17 @@ configure(sparkProjects) {
       }
     }
   }
+
+  tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+
+    // See `gradle.properties` and `$HOME/.gradle/gradle.properties`
+    maxParallelForks = Math.max(
+            Math.min(
+                    Integer.getInteger("iceberg.maxSparkTestParallelism", 2),
+                    (Runtime.runtime.availableProcessors() / 2).intValue()).intValue(),
+            1)
+  }
 }
 
 project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
@@ -104,10 +115,6 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
     testImplementation libs.sqlite.jdbc
     testImplementation libs.awaitility
-  }
-
-  test {
-    useJUnitPlatform()
   }
 
   tasks.withType(Test) {
@@ -283,15 +290,15 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     archiveClassifier.set(null)
   }
 
-  task integrationTest(type: Test) {
+  tasks.register("integrationTest", Test).configure {
     description = "Test Spark3 Runtime Jar against Spark ${sparkMajorVersion}"
     group = "verification"
     jvmArgs += project.property('extraJvmArgs')
     testClassesDirs = sourceSets.integration.output.classesDirs
     classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)
     inputs.file(shadowJar.archiveFile.get().asFile.path)
+    dependsOn shadowJar
   }
-  integrationTest.dependsOn shadowJar
   check.dependsOn integrationTest
 
   jar {

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -36,6 +36,17 @@ configure(sparkProjects) {
       }
     }
   }
+
+  tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+
+    // See `gradle.properties` and `$HOME/.gradle/gradle.properties`
+    maxParallelForks = Math.max(
+            Math.min(
+                    Integer.getInteger("iceberg.maxSparkTestParallelism", 2),
+                    (Runtime.runtime.availableProcessors() / 2).intValue()).intValue(),
+            1)
+  }
 }
 
 project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
@@ -106,10 +117,6 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     testImplementation libs.awaitility
   }
 
-  test {
-    useJUnitPlatform()
-  }
-
   tasks.withType(Test) {
     // Vectorized reads need more memory
     maxHeapSize '2560m'
@@ -171,10 +178,6 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
     // Required because we remove antlr plugin dependencies from the compile configuration, see note above
     runtimeOnly libs.antlr.runtime
     antlr libs.antlr.antlr4
-  }
-
-  test {
-    useJUnitPlatform()
   }
 
   generateGrammarSource {
@@ -288,16 +291,15 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     archiveClassifier.set(null)
   }
 
-  task integrationTest(type: Test) {
-    useJUnitPlatform()
+  tasks.register("integrationTest", Test).configure {
     description = "Test Spark3 Runtime Jar against Spark ${sparkMajorVersion}"
     group = "verification"
     jvmArgs += project.property('extraJvmArgs')
     testClassesDirs = sourceSets.integration.output.classesDirs
     classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)
     inputs.file(shadowJar.archiveFile.get().asFile.path)
+    dependsOn shadowJar
   }
-  integrationTest.dependsOn shadowJar
   check.dependsOn integrationTest
 
   jar {


### PR DESCRIPTION
`test` task execution for Spark and Flink is rather slow. Gradle allows forking multiple JVMs to parallelize test execution, test _classes_ are distributed amount the available test worker JVMs.

This change allows more than one parallel fork (test worker JVM). The maximum number of workers is calculated like this:`max(min(Integer.getInteger("iceberg.maxSparkTestParallelism", 2), Runtime.runtime.availableProcessors() / 2), 1)`.

The default max settings for Spark and Flink are configured in `gradle.properties` to `2`, but this can be overridden in `~/.gradle/gradle.properties`.

This change does not affect CI, because in CI the number of "CPUs" on GitHub free hosted runners is 2, divided by 2 = 1.