### PR TITLE
OpenAPI: Deprecate `oauth/tokens` endpoint

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -462,8 +462,7 @@ class TokenType(BaseModel):
 
 class OAuthClientCredentialsRequest(BaseModel):
     """
-    The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
-
+    The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec, see description of the endpoint.
 
     OAuth2 client credentials request
 
@@ -484,7 +483,7 @@ class OAuthClientCredentialsRequest(BaseModel):
 
 class OAuthTokenExchangeRequest(BaseModel):
     """
-    The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+    The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec, see description of the endpoint.
 
     OAuth2 token exchange request
 
@@ -507,7 +506,7 @@ class OAuthTokenExchangeRequest(BaseModel):
 class OAuthTokenRequest(BaseModel):
     __root__: Union[OAuthClientCredentialsRequest, OAuthTokenExchangeRequest] = Field(
         ...,
-        description='The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.',
+        description='The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec, see description of the endpoint.',
     )
 
 
@@ -541,7 +540,7 @@ class CommitReport(BaseModel):
 
 class OAuthError(BaseModel):
     """
-    The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+    The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec, see description of the endpoint.
     """
 
     error: Literal[
@@ -558,7 +557,7 @@ class OAuthError(BaseModel):
 
 class OAuthTokenResponse(BaseModel):
     """
-    The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+    The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec, see description of the endpoint.
     """
 
     access_token: str = Field(

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -462,6 +462,9 @@ class TokenType(BaseModel):
 
 class OAuthClientCredentialsRequest(BaseModel):
     """
+    The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+
+
     OAuth2 client credentials request
 
     See https://datatracker.ietf.org/doc/html/rfc6749#section-4.4
@@ -481,6 +484,8 @@ class OAuthClientCredentialsRequest(BaseModel):
 
 class OAuthTokenExchangeRequest(BaseModel):
     """
+    The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+
     OAuth2 token exchange request
 
     See https://datatracker.ietf.org/doc/html/rfc8693
@@ -500,7 +505,10 @@ class OAuthTokenExchangeRequest(BaseModel):
 
 
 class OAuthTokenRequest(BaseModel):
-    __root__: Union[OAuthClientCredentialsRequest, OAuthTokenExchangeRequest]
+    __root__: Union[OAuthClientCredentialsRequest, OAuthTokenExchangeRequest] = Field(
+        ...,
+        description='The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.',
+    )
 
 
 class CounterResult(BaseModel):
@@ -532,6 +540,10 @@ class CommitReport(BaseModel):
 
 
 class OAuthError(BaseModel):
+    """
+    The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+    """
+
     error: Literal[
         'invalid_request',
         'invalid_client',
@@ -545,6 +557,10 @@ class OAuthError(BaseModel):
 
 
 class OAuthTokenResponse(BaseModel):
+    """
+    The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+    """
+
     access_token: str = Field(
         ..., description='The access token, for client credentials or token exchange'
     )

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -145,7 +145,7 @@ paths:
         to the correct OAuth endpoint.
 
         Deprecated since Iceberg (Java) 1.6.0. The endpoint and related types will be removed from
-        this spec in Iceberg (Java) 1.8.0.
+        this spec in Iceberg (Java) 2.0, whichever is released sooner.
 
         See [Security improvements in the Iceberg REST specification](https://github.com/apache/iceberg/issues/10537)
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -140,8 +140,13 @@ paths:
       description:
         The `oauth/tokens` endpoint is **DEPRECATED for REMOVAL**. It is _not_ recommended to
         implement this endpoint, unless you are fully aware of the potential security implications.
+
         All clients are encouraged to explicitly set the configuration property `oauth2-server-uri`
         to the correct OAuth endpoint.
+
+        Deprecated since Iceberg (Java) 1.6.0. The endpoint and related types will be removed from
+        this spec in Iceberg (Java) 1.8.0.
+
         See [Security improvements in the Iceberg REST specification](https://github.com/apache/iceberg/issues/10537)
 
 
@@ -2932,8 +2937,8 @@ components:
     OAuthClientCredentialsRequest:
       deprecated: true
       description: 
-        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
-        
+        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this
+        spec, see description of the endpoint.
 
 
         OAuth2 client credentials request
@@ -2972,7 +2977,8 @@ components:
     OAuthTokenExchangeRequest:
       deprecated: true
       description:
-        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this
+        spec, see description of the endpoint.
 
 
         OAuth2 token exchange request
@@ -3007,7 +3013,8 @@ components:
     OAuthTokenRequest:
       deprecated: true
       description:
-        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this
+        spec, see description of the endpoint.
       anyOf:
         - $ref: '#/components/schemas/OAuthClientCredentialsRequest'
         - $ref: '#/components/schemas/OAuthTokenExchangeRequest'
@@ -3164,7 +3171,8 @@ components:
     OAuthError:
       deprecated: true
       description:
-        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this
+        spec, see description of the endpoint.
       type: object
       required:
         - error
@@ -3186,7 +3194,8 @@ components:
     OAuthTokenResponse:
       deprecated: true
       description:
-        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this
+        spec, see description of the endpoint.
       type: object
       required:
         - access_token

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -145,7 +145,7 @@ paths:
         to the correct OAuth endpoint.
 
         Deprecated since Iceberg (Java) 1.6.0. The endpoint and related types will be removed from
-        this spec in Iceberg (Java) 2.0, whichever is released sooner.
+        this spec in Iceberg (Java) 2.0.
 
         See [Security improvements in the Iceberg REST specification](https://github.com/apache/iceberg/issues/10537)
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -134,9 +134,17 @@ paths:
     post:
       tags:
         - OAuth2 API
-      summary: Get a token using an OAuth2 flow
+      summary: Get a token using an OAuth2 flow (DEPRECATED for REMOVAL)
+      deprecated: true
       operationId: getToken
       description:
+        The `oauth/tokens` endpoint is **DEPRECATED for REMOVAL**. It is _not_ recommended to
+        implement this endpoint, unless you are fully aware of the potential security implications.
+        All clients are encouraged to explicitly set the configuration property `oauth2-server-uri`
+        to the correct OAuth endpoint.
+        See [Security improvements in the Iceberg REST specification](https://github.com/apache/iceberg/issues/10537)
+
+
         Exchange credentials for a token using the OAuth2 client credentials flow or token exchange.
 
 
@@ -2922,7 +2930,12 @@ components:
         See https://datatracker.ietf.org/doc/html/rfc8693#section-3
 
     OAuthClientCredentialsRequest:
-      description:
+      deprecated: true
+      description: 
+        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+        
+
+
         OAuth2 client credentials request
 
 
@@ -2957,7 +2970,11 @@ components:
             a Basic Authorization header.
 
     OAuthTokenExchangeRequest:
+      deprecated: true
       description:
+        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
+
+
         OAuth2 token exchange request
 
 
@@ -2988,6 +3005,9 @@ components:
           $ref: '#/components/schemas/TokenType'
 
     OAuthTokenRequest:
+      deprecated: true
+      description:
+        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
       anyOf:
         - $ref: '#/components/schemas/OAuthClientCredentialsRequest'
         - $ref: '#/components/schemas/OAuthTokenExchangeRequest'
@@ -3142,6 +3162,9 @@ components:
             type: string
 
     OAuthError:
+      deprecated: true
+      description:
+        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
       type: object
       required:
         - error
@@ -3161,6 +3184,9 @@ components:
           type: string
 
     OAuthTokenResponse:
+      deprecated: true
+      description:
+        The `oauth/tokens` endpoint and related schemas are **DEPRECATED for REMOVAL** from this spec.
       type: object
       required:
         - access_token


### PR DESCRIPTION
This PR implements "M1" of [this document](https://docs.google.com/document/d/1Xi5MRk8WdBWFC3N_eSmVcrLhk3yu5nJ9x_wC0ec6kVQ/), see #10537.