### PR TITLE
Relax client.credentials-provider requirements

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -22,7 +22,6 @@ import java.io.Serializable;
 import java.util.Map;
 import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynMethods;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -164,12 +163,6 @@ public class AwsClientProperties implements Serializable {
               "Cannot load class %s, it does not exist in the classpath", credentialsProviderClass),
           e);
     }
-
-    Preconditions.checkArgument(
-        AwsCredentialsProvider.class.isAssignableFrom(providerClass),
-        String.format(
-            "Cannot initialize %s, it does not implement %s.",
-            credentialsProviderClass, AwsCredentialsProvider.class.getName()));
 
     try {
       return createCredentialsProvider(providerClass);


### PR DESCRIPTION
As a workaround for the issue described in https://github.com/apache/iceberg/issues/10614, I tried to build a custom AWS credentials provider. I couldn't find the user-facing documentation on how do do that, so I resorted to reading the source code.

My understanding is that the class referenced by the `client.credentials-provider` property has to return an `AwsCredentialsProvider` instance from its `create()` method and also implement the `AwsCredentialsProvider` interface itself. The former makes sense, since this class effectively acts as a factory, the latter doesn't because the class in question is not a credentials provider, it's a credentials provider _factory_.

Even the `DummyValidProvider`, in order to satisfy the requirements, effectively reimplements the `StaticCredentialsProvider` class from the AWS SDK.

With this constraint removed, instead of having to implement both the `AwsCredentialsProvider` methods and the static `create()` method, the provider/factory could implement only the latter:

**Before**:
https://github.com/apache/iceberg/blob/7071dc18ed66454542f466b5bfe8821028f2db0c/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java#L243-L253

**After**: https://github.com/apache/iceberg/blob/2cf0b367dae7500044a52866545b51c970ecc7d4/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java#L263-L269

Note that even if/when the original issue is addressed, it would still make sense to relax these constraints to improve the developer experience.