### PR TITLE
Ability to build for all Scala versions

### DIFF
--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -88,7 +88,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-      - run: ./gradlew -DsparkVersions=3.5 -DscalaVersion=2.12 -DhiveVersions= -DflinkVersions= :iceberg-delta-lake:check -Pquick=true -x javadoc
+      - run: ./gradlew -DsparkVersions=3.5 -DscalaVersions=2.12 -DhiveVersions= -DflinkVersions= :iceberg-delta-lake:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -117,7 +117,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-      - run: ./gradlew -DsparkVersions=3.5 -DscalaVersion=2.13 -DhiveVersions= -DflinkVersions= :iceberg-delta-lake:check -Pquick=true -x javadoc
+      - run: ./gradlew -DsparkVersions=3.5 -DscalaVersions=2.13 -DhiveVersions= -DflinkVersions= :iceberg-delta-lake:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -101,7 +101,7 @@ jobs:
       with:
         distribution: zulu
         java-version: ${{ matrix.jvm }}
-    - run: ./gradlew -DallModules build -x test -x javadoc -x integrationTest
+    - run: ./gradlew -DallModules=true -DallScalaVersions=true build -x test -x javadoc -x integrationTest
 
   build-javadoc:
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -40,5 +40,4 @@ jobs:
           java-version: 11
       - run: |
           ./gradlew printVersion
-          ./gradlew -DallModules publishApachePublicationToMavenRepository -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}
-          ./gradlew -DflinkVersions= -DsparkVersions=3.3,3.4,3.5 -DscalaVersion=2.13 -DhiveVersions= publishApachePublicationToMavenRepository -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}
+          ./gradlew -DallModules=true -DallScalaVersions=true publishApachePublicationToMavenRepository -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -101,7 +101,7 @@ jobs:
           tool-cache: false
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - run: |
-          ./gradlew -DsparkVersions=${{ matrix.spark }} -DscalaVersion=${{ matrix.scala }} -DhiveVersions= -DflinkVersions= \
+          ./gradlew -DsparkVersions=${{ matrix.spark }} -DscalaVersions=${{ matrix.scala }} -DhiveVersions= -DflinkVersions= \
             :iceberg-spark:iceberg-spark-${{ matrix.spark }}_${{ matrix.scala }}:check \
             :iceberg-spark:iceberg-spark-extensions-${{ matrix.spark }}_${{ matrix.scala }}:check \
             :iceberg-spark:iceberg-spark-runtime-${{ matrix.spark }}_${{ matrix.scala }}:check \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Iceberg is built using Gradle with Java 11, 17, or 21.
 * To invoke a build and run tests: `./gradlew build`
 * To skip tests: `./gradlew build -x test -x integrationTest`
 * To fix code style for default versions: `./gradlew spotlessApply`
-* To fix code style for all versions of Spark/Hive/Flink:`./gradlew spotlessApply -DallModules`
+* To fix code style for all versions of Spark/Hive/Flink:`./gradlew spotlessApply -DallModules=true`
 
 Iceberg table support is organized in library modules:
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,10 +45,6 @@ buildscript {
   }
 }
 
-String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
-String sparkVersionsString = System.getProperty("sparkVersions") != null ? System.getProperty("sparkVersions") : System.getProperty("defaultSparkVersions")
-List<String> sparkVersions = sparkVersionsString != null && !sparkVersionsString.isEmpty() ? sparkVersionsString.split(",") : []
-
 try {
   // apply these plugins in a try-catch block so that we can handle cases without .git directory
   apply plugin: 'com.palantir.git-version'
@@ -575,6 +571,10 @@ project(':iceberg-delta-lake') {
     integrationRuntime.extendsFrom testRuntimeOnly
   }
 
+  List<String> sparkVersions = (System.getProperty("sparkVersions") != null ? System.getProperty("sparkVersions") : System.getProperty("defaultSparkVersions")).split(",").toList().findAll { !it.empty }
+  List<String> scalaVersions = System.getProperty("scalaVersions").split(",").findAll { !it.empty }
+  String scalaVersion = scalaVersions[0]
+
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     api project(':iceberg-api')
@@ -1021,39 +1021,24 @@ apply from: 'tasks.gradle'
 
 project(':iceberg-bom') {
   apply plugin: 'java-platform'
+}
 
-  dependencies {
-    constraints {
-      // The Iceberg-Build builds for only one Scala version at a time, so the BOM would also
-      // only contain artifacts for that single Scala version. The following code ensures that
-      // the BOM references the artifacts for all Scala versions.
-      def sparkScalaPattern = ~"(.*)-([0-9][.][0-9]+)_([0-9][.][0-9]+)"
-      def sparkScalaVersions = [
-        "3.3": ["2.12", "2.13"],
-        "3.4": ["2.12", "2.13"],
-        "3.5": ["2.12", "2.13"],
-      ]
-      rootProject.allprojects.forEach {
-        // Do not include ':iceberg-spark', the bom itself and the root project.
-        if (it.name != 'iceberg-bom' && it != rootProject && it.childProjects.isEmpty()) {
-          if (it.name.startsWith("iceberg-spark-")) {
-            def sparkScalaMatcher = sparkScalaPattern.matcher(it.name)
-            if (!sparkScalaMatcher.find()) {
-              throw new GradleException("Expected a Spark/Scala version combination in Gradle project name ${it.name}")
-            }
-            def prjName = sparkScalaMatcher.group(1)
-            def sparkVer = sparkScalaMatcher.group(2)
-            for (def scalaVer in sparkScalaVersions[sparkVer]) {
-              add("api", "${it.group}:$prjName-${sparkVer}_$scalaVer:${it.version}")
-            }
-          } else {
-            add("api", project(it.path))
-          }
-        }
-      }
-    }
-  }
+def cleanSite = tasks.register("cleanSite", Delete) {
+  group = "Build"
+  description = "Cleans build directories in site/"
+  delete("site/.cache")
+  delete("site/docs/docs")
+  delete("site/docs/javadoc")
+  delete("site/site")
+  delete("site/venv")
+}
 
-  // Needed to get the "faked" Scala artifacts into the bom
-  javaPlatform { allowDependencies() }
+def cleanOpenapi = tasks.register("cleanOpenapi", Delete) {
+  group = "Build"
+  description = "Cleans build directories in open-api/"
+  delete("open-api/venv")
+}
+
+tasks.register("clean") {
+  dependsOn(cleanSite, cleanOpenapi)
 }

--- a/dev/stage-binaries.sh
+++ b/dev/stage-binaries.sh
@@ -18,16 +18,4 @@
 # under the License.
 #
 
-SCALA_VERSION=2.12
-FLINK_VERSIONS=1.17,1.18,1.19
-SPARK_VERSIONS=3.3,3.4,3.5
-HIVE_VERSIONS=2,3
-
-./gradlew -Prelease -DscalaVersion=$SCALA_VERSION -DflinkVersions=$FLINK_VERSIONS -DsparkVersions=$SPARK_VERSIONS -DhiveVersions=$HIVE_VERSIONS publishApachePublicationToMavenRepository
-
-# Also publish Scala 2.13 Artifacts for versions that support it.
-# Flink does not yet support 2.13 (and is largely dropping a user-facing dependency on Scala). Hive doesn't need a Scala specification.
-./gradlew -Prelease -DscalaVersion=2.13 -DsparkVersions=3.3 :iceberg-spark:iceberg-spark-3.3_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-extensions-3.3_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-runtime-3.3_2.13:publishApachePublicationToMavenRepository
-./gradlew -Prelease -DscalaVersion=2.13 -DsparkVersions=3.4 :iceberg-spark:iceberg-spark-3.4_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-extensions-3.4_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-runtime-3.4_2.13:publishApachePublicationToMavenRepository
-./gradlew -Prelease -DscalaVersion=2.13 -DsparkVersions=3.5 :iceberg-spark:iceberg-spark-3.5_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-extensions-3.5_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-runtime-3.5_2.13:publishApachePublicationToMavenRepository
-
+./gradlew -Prelease -DallModules=true -DallScalaVersions=true publishApachePublicationToMavenRepository

--- a/flink/build.gradle
+++ b/flink/build.gradle
@@ -17,17 +17,8 @@
  * under the License.
  */
 
-def flinkVersions = (System.getProperty("flinkVersions") != null ? System.getProperty("flinkVersions") : System.getProperty("defaultFlinkVersions")).split(",")
+List<String> flinkVersions = System.getProperty("flinkVersions", System.getProperty("defaultFlinkVersions")).split(",").findAll { !it.empty }
 
-
-if (flinkVersions.contains("1.17")) {
-  apply from: file("$projectDir/v1.17/build.gradle")
-}
-
-if (flinkVersions.contains("1.18")) {
-  apply from: file("$projectDir/v1.18/build.gradle")
-}
-
-if (flinkVersions.contains("1.19")) {
-  apply from: file("$projectDir/v1.19/build.gradle")
+for (ver in flinkVersions) {
+  apply from: file("$projectDir/v${ver}/build.gradle")
 }

--- a/flink/v1.17/build.gradle
+++ b/flink/v1.17/build.gradle
@@ -18,7 +18,8 @@
  */
 
 String flinkMajorVersion = '1.17'
-String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
+List<String> scalaVersions = System.getProperty("scalaVersions").split(",").findAll { !it.empty }
+String scalaVersion = scalaVersions[0]
 
 project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 

--- a/flink/v1.18/build.gradle
+++ b/flink/v1.18/build.gradle
@@ -18,7 +18,8 @@
  */
 
 String flinkMajorVersion = '1.18'
-String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
+List<String> scalaVersions = System.getProperty("scalaVersions").split(",").findAll { !it.empty }
+String scalaVersion = scalaVersions[0]
 
 project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 

--- a/flink/v1.19/build.gradle
+++ b/flink/v1.19/build.gradle
@@ -18,7 +18,8 @@
  */
 
 String flinkMajorVersion = '1.19'
-String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
+List<String> scalaVersions = System.getProperty("scalaVersions").split(",").findAll { !it.empty }
+String scalaVersion = scalaVersions[0]
 
 project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 

--- a/flink/v1.19/flink/src/jmh/java/org/apache/iceberg/flink/sink/shuffle/MapRangePartitionerBenchmark.java
+++ b/flink/v1.19/flink/src/jmh/java/org/apache/iceberg/flink/sink/shuffle/MapRangePartitionerBenchmark.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.sink.shuffle;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -27,6 +28,8 @@ import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortKey;
 import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.SortOrderComparators;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -66,6 +69,8 @@ public class MapRangePartitionerBenchmark {
           Types.NestedField.required(9, "name9", Types.StringType.get()));
 
   private static final SortOrder SORT_ORDER = SortOrder.builderFor(SCHEMA).asc("id").build();
+  private static final Comparator<StructLike> SORT_ORDER_COMPARTOR =
+      SortOrderComparators.forSchema(SCHEMA, SORT_ORDER);
   private static final SortKey SORT_KEY = new SortKey(SCHEMA, SORT_ORDER);
 
   private MapRangePartitioner partitioner;
@@ -82,10 +87,11 @@ public class MapRangePartitionerBenchmark {
           mapStatistics.put(sortKey, weight);
         });
 
-    MapDataStatistics dataStatistics = new MapDataStatistics(mapStatistics);
+    MapAssignment mapAssignment =
+        MapAssignment.fromKeyFrequency(2, mapStatistics, 0.0, SORT_ORDER_COMPARTOR);
     this.partitioner =
         new MapRangePartitioner(
-            SCHEMA, SortOrder.builderFor(SCHEMA).asc("id").build(), dataStatistics, 2);
+            SCHEMA, SortOrder.builderFor(SCHEMA).asc("id").build(), mapAssignment);
 
     List<Integer> keys = Lists.newArrayList(weights.keySet().iterator());
     long[] weightsCDF = new long[keys.size()];

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,14 +16,44 @@
 jmhOutputPath=build/reports/jmh/human-readable-output.txt
 jmhJsonOutputPath=build/reports/jmh/results.json
 jmhIncludeRegex=.*
+
+# The following settings define which versions of Flink, Hive, Spark
+# and Scala are known to Iceberg.
+#
+# The 'allModules' system property instructs the Gradle build to build
+# all Flink, Spark and Hive versions.
+systemProp.allModules=false
+#
+# The 'all*Versions' flag defines whether all known versions should
+# be included in the build, overriding the *Versions system properties.
+#
+
+# Flink
 systemProp.defaultFlinkVersions=1.19
 systemProp.knownFlinkVersions=1.17,1.18,1.19
+systemProp.allFlinkVersions=false
+#
+# Hive
 systemProp.defaultHiveVersions=2
 systemProp.knownHiveVersions=2,3
+systemProp.allHiveVersions=false
+#
+# Spark
 systemProp.defaultSparkVersions=3.5
 systemProp.knownSparkVersions=3.3,3.4,3.5
-systemProp.defaultScalaVersion=2.12
+systemProp.allSparkVersions=false
+systemProp.sparkScalaVersions_3.3=2.12,2.13
+systemProp.sparkScalaVersions_3.4=2.12,2.13
+systemProp.sparkScalaVersions_3.5=2.12,2.13
+#
+# Scala
+systemProp.defaultScalaVersions=2.12
 systemProp.knownScalaVersions=2.12,2.13
+# Within IntelliJ, the 'allScalaVersions' system property has no effect,
+# because IJ cannot use the same set of sources against different Scala versions.
+systemProp.allScalaVersions=false
+#
+
 # enable the Gradle build cache - speeds up builds!
 org.gradle.caching=true
 # enable Gradle parallel builds

--- a/hive-runtime/build.gradle
+++ b/hive-runtime/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-def hiveVersions = (System.getProperty("hiveVersions") != null ? System.getProperty("hiveVersions") : System.getProperty("defaultHiveVersions")).split(",")
+def hiveVersions = (System.getProperty("hiveVersions") != null ? System.getProperty("hiveVersions") : System.getProperty("defaultHiveVersions")).split(",").findAll { !it.empty }
 
 project(':iceberg-hive-runtime') {
   apply plugin: 'io.github.goooler.shadow'

--- a/jmh.gradle
+++ b/jmh.gradle
@@ -21,36 +21,19 @@ if (jdkVersion != '11' && jdkVersion != '17' && jdkVersion != '21') {
   throw new GradleException("The JMH benchmarks must be run with JDK 11 or JDK 17 or JDK 21")
 }
 
-def flinkVersions = (System.getProperty("flinkVersions") != null ? System.getProperty("flinkVersions") : System.getProperty("defaultFlinkVersions")).split(",")
-def sparkVersions = (System.getProperty("sparkVersions") != null ? System.getProperty("sparkVersions") : System.getProperty("defaultSparkVersions")).split(",")
-def scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
+List<String> flinkVersions = System.getProperty("flinkVersions").split(",").toList().findAll { !it.empty }
+List<String> sparkVersions = System.getProperty("sparkVersions").split(",").toList().findAll { !it.empty }
+List<String> scalaVersions = System.getProperty("scalaVersions").split(",").findAll { !it.empty }
+String scalaVersion = scalaVersions[0]
 def jmhProjects = [project(":iceberg-core"), project(":iceberg-data")]
 
-if (flinkVersions.contains("1.16")) {
-  jmhProjects.add(project(":iceberg-flink:iceberg-flink-1.16"))
+for (ver in flinkVersions) {
+  jmhProjects.add(project(":iceberg-flink:iceberg-flink-${ver}"))
 }
 
-if (flinkVersions.contains("1.17")) {
-  jmhProjects.add(project(":iceberg-flink:iceberg-flink-1.17"))
-}
-
-if (flinkVersions.contains("1.18")) {
-  jmhProjects.add(project(":iceberg-flink:iceberg-flink-1.18"))
-}
-
-if (sparkVersions.contains("3.3")) {
-  jmhProjects.add(project(":iceberg-spark:iceberg-spark-3.3_${scalaVersion}"))
-  jmhProjects.add(project(":iceberg-spark:iceberg-spark-extensions-3.3_${scalaVersion}"))
-}
-
-if (sparkVersions.contains("3.4")) {
-  jmhProjects.add(project(":iceberg-spark:iceberg-spark-3.4_${scalaVersion}"))
-  jmhProjects.add(project(":iceberg-spark:iceberg-spark-extensions-3.4_${scalaVersion}"))
-}
-
-if (sparkVersions.contains("3.5")) {
-  jmhProjects.add(project(":iceberg-spark:iceberg-spark-3.5_${scalaVersion}"))
-  jmhProjects.add(project(":iceberg-spark:iceberg-spark-extensions-3.5_${scalaVersion}"))
+for (ver in sparkVersions) {
+  jmhProjects.add(project(":iceberg-spark:iceberg-spark-${ver}_${scalaVersion}"))
+  jmhProjects.add(project(":iceberg-spark:iceberg-spark-extensions-${ver}_${scalaVersion}"))
 }
 
 configure(jmhProjects) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -70,41 +70,85 @@ project(':delta-lake').name = 'iceberg-delta-lake'
 project(':kafka-connect').name = 'iceberg-kafka-connect'
 project(':open-api').name = 'iceberg-open-api'
 
+if (System.getProperty("scalaVersion") != null) {
+  if (System.getProperty("scalaVersions") != null && !System.getProperty("scalaVersions").equals(System.getProperty("scalaVersion"))) {
+    throw new GradleException("Using the old 'scalaVersion' system property _and_ the new 'scalaVersions' with different values. Migrate to the 'scalaVersions' system property")
+  }
+  System.setProperty("scalaVersions", System.getProperty("scalaVersion"))
+  logger.warn("Using the old 'scalaVersion' system property, migrate to the 'scalaVersions' system property")
+}
+if (System.getProperty("defaultScalaVersion") != null) {
+  if (System.getProperty("defaultScalaVersions") != null && !System.getProperty("defaultScalaVersions").equals(System.getProperty("defaultScalaVersion"))) {
+    throw new GradleException("Using the old 'defaultScalaVersion' system property _and_ the new 'defaultScalaVersions' with different values. Migrate to the 'defaultScalaVersions' system property")
+  }
+  System.setProperty("defaultScalaVersions", System.getProperty("defaultScalaVersion"))
+  logger.warn("Using the old 'defaultScalaVersion' system property, migrate to the 'defaultScalaVersions' system property")
+}
+
+boolean ideSyncActive =
+        Boolean.getBoolean("idea.sync.active") || System.getProperty("eclipse.product") != null || gradle.startParameter.taskNames.any { it.startsWith("eclipse") }
+
 if (null != System.getProperty("allModules")) {
+  if (!["true", "false"].contains(System.getProperty("allModules"))) {
+    throw new GradleException("The 'allModules' system property is present, but does not represent a boolean, change to '-DallModules=true'")
+  }
+  if (Boolean.getBoolean("allModules")) {
+    System.setProperty("flinkVersions", System.getProperty("knownFlinkVersions"))
+    System.setProperty("sparkVersions", System.getProperty("knownSparkVersions"))
+    System.setProperty("hiveVersions", System.getProperty("knownHiveVersions"))
+  }
+}
+if (Boolean.getBoolean("allFlinkVersions")) {
   System.setProperty("flinkVersions", System.getProperty("knownFlinkVersions"))
+}
+if (Boolean.getBoolean("allSparkVersions")) {
   System.setProperty("sparkVersions", System.getProperty("knownSparkVersions"))
+}
+if (Boolean.getBoolean("allHiveVersions")) {
   System.setProperty("hiveVersions", System.getProperty("knownHiveVersions"))
 }
 
 List<String> knownFlinkVersions = System.getProperty("knownFlinkVersions").split(",")
-String flinkVersionsString = System.getProperty("flinkVersions") != null ? System.getProperty("flinkVersions") : System.getProperty("defaultFlinkVersions")
-List<String> flinkVersions = flinkVersionsString != null && !flinkVersionsString.isEmpty() ? flinkVersionsString.split(",") : []
-
+List<String> flinkVersions = (System.getProperty("flinkVersions") != null ? System.getProperty("flinkVersions") : System.getProperty("defaultFlinkVersions", "")).split(",").findAll { !it.empty }
+System.setProperty("flinkVersions", flinkVersions.join(","))
 if (!knownFlinkVersions.containsAll(flinkVersions)) {
   throw new GradleException("Found unsupported Flink versions: " + (flinkVersions - knownFlinkVersions))
 }
 
 List<String> knownHiveVersions = System.getProperty("knownHiveVersions").split(",")
-String hiveVersionsString = System.getProperty("hiveVersions") != null ? System.getProperty("hiveVersions") : System.getProperty("defaultHiveVersions")
-List<String> hiveVersions = hiveVersionsString != null && !hiveVersionsString.isEmpty() ? hiveVersionsString.split(",") : []
-
+List<String> hiveVersions = (System.getProperty("hiveVersions") != null ? System.getProperty("hiveVersions") : System.getProperty("defaultHiveVersions", "")).split(",").findAll { !it.empty }
+System.setProperty("hiveVersions", hiveVersions.join(","))
 if (!knownHiveVersions.containsAll(hiveVersions)) {
   throw new GradleException("Found unsupported Hive versions: " + (hiveVersions - knownHiveVersions))
 }
-
 List<String> knownSparkVersions = System.getProperty("knownSparkVersions").split(",")
-String sparkVersionsString = System.getProperty("sparkVersions") != null ? System.getProperty("sparkVersions") : System.getProperty("defaultSparkVersions")
-List<String> sparkVersions = sparkVersionsString != null && !sparkVersionsString.isEmpty() ? sparkVersionsString.split(",") : []
-
+List<String> sparkVersions = (System.getProperty("sparkVersions") != null ? System.getProperty("sparkVersions") : System.getProperty("defaultSparkVersions", "")).split(",").findAll { !it.empty }
+System.setProperty("sparkVersions", sparkVersions.join(","))
 if (!knownSparkVersions.containsAll(sparkVersions)) {
   throw new GradleException("Found unsupported Spark versions: " + (sparkVersions - knownSparkVersions))
 }
 
-List<String> knownScalaVersions = System.getProperty("knownScalaVersions").split(",")
-String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
+List<String> knownScalaVersions = System.getProperty("knownScalaVersions").split(",").toList().findAll { !it.empty}
+List<String> scalaVersions = (System.getProperty("scalaVersions") != null ? System.getProperty("scalaVersions") : System.getProperty("defaultScalaVersions", "")).split(",").findAll { !it.empty }
+System.setProperty("scalaVersions", scalaVersions.join(","))
+boolean allScalaVersions = Boolean.getBoolean("allScalaVersions")
+if (!ideSyncActive && allScalaVersions) {
+  System.setProperty("scalaVersions", System.getProperty("knownScalaVersions"))
+  scalaVersions = knownScalaVersions
+}
 
-if (!knownScalaVersions.contains(scalaVersion)) {
-  throw new GradleException("Found unsupported Scala version: " + scalaVersion)
+Map<String, List<String>> sparkScalaVersions = knownSparkVersions.collectEntries {
+  List<String> scalaVers = [] + scalaVersions
+  scalaVers.retainAll(System.getProperty("sparkScalaVersions_${it}").split(",").toList())
+  if (!knownScalaVersions.containsAll(scalaVers) || scalaVers.empty) {
+    throw new GradleException("Found unsupported Scala versions: " + (scalaVers - knownScalaVersions))
+  }
+  if (!allScalaVersions || ideSyncActive) {
+
+    scalaVers = [scalaVers[0]]
+  }
+  System.setProperty("sparkScalaVersions_${it}", scalaVers.join(","))
+  [it, scalaVers]
 }
 
 if (!flinkVersions.isEmpty()) {
@@ -112,67 +156,31 @@ if (!flinkVersions.isEmpty()) {
   project(':flink').name = 'iceberg-flink'
 }
 
-if (flinkVersions.contains("1.17")) {
-  include ":iceberg-flink:flink-1.17"
-  include ":iceberg-flink:flink-runtime-1.17"
-  project(":iceberg-flink:flink-1.17").projectDir = file('flink/v1.17/flink')
-  project(":iceberg-flink:flink-1.17").name = "iceberg-flink-1.17"
-  project(":iceberg-flink:flink-runtime-1.17").projectDir = file('flink/v1.17/flink-runtime')
-  project(":iceberg-flink:flink-runtime-1.17").name = "iceberg-flink-runtime-1.17"
+def flinkProject(String pattern, String ver) {
+  include ":iceberg-flink:iceberg-${pattern}-${ver}"
+  ProjectDescriptor prj = project(":iceberg-flink:iceberg-${pattern}-${ver}")
+  prj.projectDir = file("flink/v${ver}/${pattern}")
+  prj.name = "iceberg-${pattern}-${ver}".toString()
 }
 
-if (flinkVersions.contains("1.18")) {
-  include ":iceberg-flink:flink-1.18"
-  include ":iceberg-flink:flink-runtime-1.18"
-  project(":iceberg-flink:flink-1.18").projectDir = file('flink/v1.18/flink')
-  project(":iceberg-flink:flink-1.18").name = "iceberg-flink-1.18"
-  project(":iceberg-flink:flink-runtime-1.18").projectDir = file('flink/v1.18/flink-runtime')
-  project(":iceberg-flink:flink-runtime-1.18").name = "iceberg-flink-runtime-1.18"
+for (ver in flinkVersions) {
+  flinkProject("flink", ver)
+  flinkProject("flink-runtime", ver)
 }
 
-if (flinkVersions.contains("1.19")) {
-  include ":iceberg-flink:flink-1.19"
-  include ":iceberg-flink:flink-runtime-1.19"
-  project(":iceberg-flink:flink-1.19").projectDir = file('flink/v1.19/flink')
-  project(":iceberg-flink:flink-1.19").name = "iceberg-flink-1.19"
-  project(":iceberg-flink:flink-runtime-1.19").projectDir = file('flink/v1.19/flink-runtime')
-  project(":iceberg-flink:flink-runtime-1.19").name = "iceberg-flink-runtime-1.19"
+def sparkProject(String pattern, String ver, String scala) {
+  include ":iceberg-spark:iceberg-${pattern}-${ver}_${scala}"
+  ProjectDescriptor prj = project(":iceberg-spark:iceberg-${pattern}-${ver}_${scala}")
+  prj.projectDir = file("spark/v${ver}/${pattern}")
+  prj.name = "iceberg-${pattern}-${ver}_${scala}".toString()
 }
 
-if (sparkVersions.contains("3.3")) {
-  include ":iceberg-spark:spark-3.3_${scalaVersion}"
-  include ":iceberg-spark:spark-extensions-3.3_${scalaVersion}"
-  include ":iceberg-spark:spark-runtime-3.3_${scalaVersion}"
-  project(":iceberg-spark:spark-3.3_${scalaVersion}").projectDir = file('spark/v3.3/spark')
-  project(":iceberg-spark:spark-3.3_${scalaVersion}").name = "iceberg-spark-3.3_${scalaVersion}"
-  project(":iceberg-spark:spark-extensions-3.3_${scalaVersion}").projectDir = file('spark/v3.3/spark-extensions')
-  project(":iceberg-spark:spark-extensions-3.3_${scalaVersion}").name = "iceberg-spark-extensions-3.3_${scalaVersion}"
-  project(":iceberg-spark:spark-runtime-3.3_${scalaVersion}").projectDir = file('spark/v3.3/spark-runtime')
-  project(":iceberg-spark:spark-runtime-3.3_${scalaVersion}").name = "iceberg-spark-runtime-3.3_${scalaVersion}"
-}
-
-if (sparkVersions.contains("3.4")) {
-  include ":iceberg-spark:spark-3.4_${scalaVersion}"
-  include ":iceberg-spark:spark-extensions-3.4_${scalaVersion}"
-  include ":iceberg-spark:spark-runtime-3.4_${scalaVersion}"
-  project(":iceberg-spark:spark-3.4_${scalaVersion}").projectDir = file('spark/v3.4/spark')
-  project(":iceberg-spark:spark-3.4_${scalaVersion}").name = "iceberg-spark-3.4_${scalaVersion}"
-  project(":iceberg-spark:spark-extensions-3.4_${scalaVersion}").projectDir = file('spark/v3.4/spark-extensions')
-  project(":iceberg-spark:spark-extensions-3.4_${scalaVersion}").name = "iceberg-spark-extensions-3.4_${scalaVersion}"
-  project(":iceberg-spark:spark-runtime-3.4_${scalaVersion}").projectDir = file('spark/v3.4/spark-runtime')
-  project(":iceberg-spark:spark-runtime-3.4_${scalaVersion}").name = "iceberg-spark-runtime-3.4_${scalaVersion}"
-}
-
-if (sparkVersions.contains("3.5")) {
-  include ":iceberg-spark:spark-3.5_${scalaVersion}"
-  include ":iceberg-spark:spark-extensions-3.5_${scalaVersion}"
-  include ":iceberg-spark:spark-runtime-3.5_${scalaVersion}"
-  project(":iceberg-spark:spark-3.5_${scalaVersion}").projectDir = file('spark/v3.5/spark')
-  project(":iceberg-spark:spark-3.5_${scalaVersion}").name = "iceberg-spark-3.5_${scalaVersion}"
-  project(":iceberg-spark:spark-extensions-3.5_${scalaVersion}").projectDir = file('spark/v3.5/spark-extensions')
-  project(":iceberg-spark:spark-extensions-3.5_${scalaVersion}").name = "iceberg-spark-extensions-3.5_${scalaVersion}"
-  project(":iceberg-spark:spark-runtime-3.5_${scalaVersion}").projectDir = file('spark/v3.5/spark-runtime')
-  project(":iceberg-spark:spark-runtime-3.5_${scalaVersion}").name = "iceberg-spark-runtime-3.5_${scalaVersion}"
+for (ver in sparkVersions) {
+  for (scala in sparkScalaVersions[ver]) {
+    sparkProject("spark", ver, scala)
+    sparkProject("spark-extensions", ver, scala)
+    sparkProject("spark-runtime", ver, scala)
+  }
 }
 
 // hive 3 depends on hive 2, so always add hive 2 if hive3 is enabled

--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -89,7 +89,9 @@ Iceberg is built using Gradle with Java 11, 17, or 21.
 * To invoke a build and run tests: `./gradlew build`
 * To skip tests: `./gradlew build -x test -x integrationTest`
 * To fix code style: `./gradlew spotlessApply`
-* To build particular Spark/Flink Versions: `./gradlew build -DsparkVersions=3.4,3.5 -DflinkVersions=1.14`
+* To build particular Spark/Flink versions: `./gradlew build -DsparkVersions=3.4,3.5 -DflinkVersions=1.14`
+* To build all Spark/Flink/Hive versions: `./gradlew build -DallModules=true`
+* To build all Spark/Flink/Hive and also all Scala versions: `./gradlew build -DallModules=true -DallScalaVersions=true`
 
 Iceberg table support is organized in library modules:
 

--- a/spark/build.gradle
+++ b/spark/build.gradle
@@ -18,16 +18,8 @@
  */
 
 // add enabled Spark version modules to the build
-def sparkVersions = (System.getProperty("sparkVersions") != null ? System.getProperty("sparkVersions") : System.getProperty("defaultSparkVersions")).split(",")
+List<String> sparkVersions = System.getProperty("sparkVersions", System.getProperty("defaultSparkVersions")).split(",").findAll { !it.empty }
 
-if (sparkVersions.contains("3.3")) {
-  apply from: file("$projectDir/v3.3/build.gradle")
-}
-
-if (sparkVersions.contains("3.4")) {
-  apply from: file("$projectDir/v3.4/build.gradle")
-}
-
-if (sparkVersions.contains("3.5")) {
-  apply from: file("$projectDir/v3.5/build.gradle")
+for (ver in sparkVersions) {
+  apply from: file("$projectDir/v${ver}/build.gradle")
 }

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -18,291 +18,300 @@
  */
 
 String sparkMajorVersion = '3.3'
-String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
+List<String> scalaVersions = System.getProperty("sparkScalaVersions_${sparkMajorVersion}").split(",").toList()
 
-def sparkProjects = [
-    project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}"),
-    project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}"),
-    project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}"),
-]
+for (scalaVersion in scalaVersions) {
 
-configure(sparkProjects) {
-  configurations {
-    all {
-      resolutionStrategy {
-        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson213.get()}"
-        force "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
-        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson213.get()}"
+  def sparkProjects = [
+          project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}"),
+          project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}"),
+          project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}"),
+  ]
+
+  configure(sparkProjects) {
+    configurations {
+      all {
+        resolutionStrategy {
+          force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson213.get()}"
+          force "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
+          force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson213.get()}"
+        }
       }
     }
   }
-}
 
-project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'scala'
-  apply plugin: 'com.github.alisiikh.scalastyle'
+  project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
+    layout.buildDirectory.set(layout.buildDirectory.dir(scalaVersion).get())
 
-  sourceSets {
-    main {
-      scala.srcDirs = ['src/main/scala', 'src/main/java']
-      java.srcDirs = []
+    apply plugin: 'scala'
+    apply plugin: 'com.github.alisiikh.scalastyle'
+
+    sourceSets {
+      main {
+        scala.srcDirs = ['src/main/scala', 'src/main/java']
+        java.srcDirs = []
+      }
+    }
+
+    dependencies {
+      implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+      api project(':iceberg-api')
+      implementation project(':iceberg-common')
+      implementation project(':iceberg-core')
+      implementation project(':iceberg-data')
+      implementation project(':iceberg-orc')
+      implementation project(':iceberg-parquet')
+      implementation project(':iceberg-arrow')
+      implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
+      if (scalaVersion == '2.12') {
+        // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
+        implementation 'org.scala-lang:scala-library:2.12.18'
+      }
+
+      compileOnly libs.errorprone.annotations
+      compileOnly libs.avro.avro
+      compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive33.get()}") {
+        exclude group: 'org.apache.avro', module: 'avro'
+        exclude group: 'org.apache.arrow'
+        exclude group: 'org.apache.parquet'
+        // to make sure netty libs only come from project(':iceberg-arrow')
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+        exclude group: 'org.roaringbitmap'
+      }
+
+      implementation libs.parquet.column
+      implementation libs.parquet.hadoop
+
+      implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
+        exclude group: 'org.apache.hadoop'
+        exclude group: 'commons-lang'
+        // These artifacts are shaded and included in the orc-core fat jar
+        exclude group: 'com.google.protobuf', module: 'protobuf-java'
+        exclude group: 'org.apache.hive', module: 'hive-storage-api'
+      }
+
+      implementation(libs.arrow.vector) {
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+      }
+
+      testImplementation(libs.hadoop2.minicluster) {
+        exclude group: 'org.apache.avro', module: 'avro'
+        // to make sure netty libs only come from
+        // project(':iceberg-arrow')
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+      }
+      testImplementation project(path: ':iceberg-hive-metastore')
+      testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
+      testImplementation libs.sqlite.jdbc
+      testImplementation libs.awaitility
+      testImplementation libs.junit.vintage.engine
+    }
+
+    test {
+      useJUnitPlatform()
+    }
+
+    tasks.withType(Test) {
+      // Vectorized reads need more memory
+      maxHeapSize '2560m'
     }
   }
 
-  dependencies {
-    implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
-    api project(':iceberg-api')
-    implementation project(':iceberg-common')
-    implementation project(':iceberg-core')
-    implementation project(':iceberg-data')
-    implementation project(':iceberg-orc')
-    implementation project(':iceberg-parquet')
-    implementation project(':iceberg-arrow')
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
-    if (scalaVersion == '2.12') {
-      // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
-      implementation 'org.scala-lang:scala-library:2.12.18'
-    }
+  project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}") {
+    layout.buildDirectory.set(layout.buildDirectory.dir(scalaVersion).get())
 
-    compileOnly libs.errorprone.annotations
-    compileOnly libs.avro.avro
-    compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive33.get()}") {
-      exclude group: 'org.apache.avro', module: 'avro'
-      exclude group: 'org.apache.arrow'
-      exclude group: 'org.apache.parquet'
-      // to make sure netty libs only come from project(':iceberg-arrow')
-      exclude group: 'io.netty', module: 'netty-buffer'
-      exclude group: 'io.netty', module: 'netty-common'
-      exclude group: 'org.roaringbitmap'
-    }
+    apply plugin: 'java-library'
+    apply plugin: 'scala'
+    apply plugin: 'com.github.alisiikh.scalastyle'
+    apply plugin: 'antlr'
 
-    implementation libs.parquet.column
-    implementation libs.parquet.hadoop
-
-    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
-      exclude group: 'org.apache.hadoop'
-      exclude group: 'commons-lang'
-      // These artifacts are shaded and included in the orc-core fat jar
-      exclude group: 'com.google.protobuf', module: 'protobuf-java'
-      exclude group: 'org.apache.hive', module: 'hive-storage-api'
-    }
-
-    implementation(libs.arrow.vector) {
-      exclude group: 'io.netty', module: 'netty-buffer'
-      exclude group: 'io.netty', module: 'netty-common'
-      exclude group: 'com.google.code.findbugs', module: 'jsr305'
-    }
-
-    testImplementation(libs.hadoop2.minicluster) {
-      exclude group: 'org.apache.avro', module: 'avro'
-      // to make sure netty libs only come from
-      // project(':iceberg-arrow')
-      exclude group: 'io.netty', module: 'netty-buffer'
-      exclude group: 'io.netty', module: 'netty-common'
-    }
-    testImplementation project(path: ':iceberg-hive-metastore')
-    testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
-    testImplementation libs.sqlite.jdbc
-    testImplementation libs.awaitility
-    testImplementation libs.junit.vintage.engine
-  }
-
-  test {
-    useJUnitPlatform()
-  }
-
-  tasks.withType(Test) {
-    // Vectorized reads need more memory
-    maxHeapSize '2560m'
-  }
-}
-
-project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'java-library'
-  apply plugin: 'scala'
-  apply plugin: 'com.github.alisiikh.scalastyle'
-  apply plugin: 'antlr'
-
-  configurations {
-    /*
+    configurations {
+      /*
      The Gradle Antlr plugin erroneously adds both antlr-build and runtime dependencies to the runtime path. This
      bug https://github.com/gradle/gradle/issues/820 exists because older versions of Antlr do not have separate
      runtime and implementation dependencies and they do not want to break backwards compatibility. So to only end up with
      the runtime dependency on the runtime classpath we remove the dependencies added by the plugin here. Then add
      the runtime dependency back to only the runtime configuration manually.
     */
-    implementation {
-      extendsFrom = extendsFrom.findAll { it != configurations.antlr }
+      implementation {
+        extendsFrom = extendsFrom.findAll { it != configurations.antlr }
+      }
+    }
+
+    dependencies {
+      implementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
+      if (scalaVersion == '2.12') {
+        // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
+        implementation 'org.scala-lang:scala-library:2.12.18'
+      }
+      implementation libs.roaringbitmap
+
+      compileOnly "org.scala-lang:scala-library"
+      compileOnly project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+      compileOnly project(':iceberg-api')
+      compileOnly project(':iceberg-core')
+      compileOnly project(':iceberg-common')
+      compileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
+      compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive33.get()}") {
+        exclude group: 'org.apache.avro', module: 'avro'
+        exclude group: 'org.apache.arrow'
+        exclude group: 'org.apache.parquet'
+        // to make sure netty libs only come from project(':iceberg-arrow')
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+        exclude group: 'org.roaringbitmap'
+      }
+      compileOnly libs.errorprone.annotations
+
+      testImplementation project(path: ':iceberg-data')
+      testImplementation project(path: ':iceberg-parquet')
+      testImplementation project(path: ':iceberg-hive-metastore')
+      testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+      testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+
+      testImplementation libs.avro.avro
+      testImplementation libs.parquet.hadoop
+      testImplementation libs.junit.vintage.engine
+
+      // Required because we remove antlr plugin dependencies from the compile configuration, see note above
+      runtimeOnly libs.antlr.runtime
+      antlr libs.antlr.antlr4
+    }
+
+    generateGrammarSource {
+      maxHeapSize = "64m"
+      arguments += ['-visitor', '-package', 'org.apache.spark.sql.catalyst.parser.extensions']
     }
   }
 
-  dependencies {
-    implementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
-    if (scalaVersion == '2.12') {
-      // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
-      implementation 'org.scala-lang:scala-library:2.12.18'
+  project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
+    layout.buildDirectory.set(layout.buildDirectory.dir(scalaVersion).get())
+
+    apply plugin: 'io.github.goooler.shadow'
+
+    tasks.jar.dependsOn tasks.shadowJar
+
+    sourceSets {
+      integration {
+        java.srcDir "$projectDir/src/integration/java"
+        resources.srcDir "$projectDir/src/integration/resources"
+      }
     }
-    implementation libs.roaringbitmap
 
-    compileOnly "org.scala-lang:scala-library"
-    compileOnly project(path: ':iceberg-bundled-guava', configuration: 'shadow')
-    compileOnly project(':iceberg-api')
-    compileOnly project(':iceberg-core')
-    compileOnly project(':iceberg-common')
-    compileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
-    compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive33.get()}") {
-      exclude group: 'org.apache.avro', module: 'avro'
-      exclude group: 'org.apache.arrow'
-      exclude group: 'org.apache.parquet'
-      // to make sure netty libs only come from project(':iceberg-arrow')
-      exclude group: 'io.netty', module: 'netty-buffer'
-      exclude group: 'io.netty', module: 'netty-common'
-      exclude group: 'org.roaringbitmap'
+    configurations {
+      implementation {
+        exclude group: 'org.apache.spark'
+        // included in Spark
+        exclude group: 'org.slf4j'
+        exclude group: 'org.apache.commons'
+        exclude group: 'commons-pool'
+        exclude group: 'commons-codec'
+        exclude group: 'org.xerial.snappy'
+        exclude group: 'javax.xml.bind'
+        exclude group: 'javax.annotation'
+        exclude group: 'com.github.luben'
+        exclude group: 'com.ibm.icu'
+        exclude group: 'org.glassfish'
+        exclude group: 'org.abego.treelayout'
+        exclude group: 'org.antlr'
+        exclude group: 'org.scala-lang'
+        exclude group: 'org.scala-lang.modules'
+      }
     }
-    compileOnly libs.errorprone.annotations
 
-    testImplementation project(path: ':iceberg-data')
-    testImplementation project(path: ':iceberg-parquet')
-    testImplementation project(path: ':iceberg-hive-metastore')
-    testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+    dependencies {
+      api project(':iceberg-api')
+      implementation project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
+      implementation project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
+      implementation project(':iceberg-aws')
+      implementation project(':iceberg-azure')
+      implementation(project(':iceberg-aliyun')) {
+        exclude group: 'edu.umd.cs.findbugs', module: 'findbugs'
+        exclude group: 'org.apache.httpcomponents', module: 'httpclient'
+        exclude group: 'commons-logging', module: 'commons-logging'
+      }
+      implementation project(':iceberg-gcp')
+      implementation project(':iceberg-hive-metastore')
+      implementation(project(':iceberg-nessie')) {
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+      }
+      implementation(project(':iceberg-snowflake')) {
+        exclude group: 'net.snowflake', module: 'snowflake-jdbc'
+      }
 
-    testImplementation libs.avro.avro
-    testImplementation libs.parquet.hadoop
-    testImplementation libs.junit.vintage.engine
+      integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
+      integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive33.get()}"
+      integrationImplementation libs.junit.vintage.engine
+      integrationImplementation libs.slf4j.simple
+      integrationImplementation libs.assertj.core
+      integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+      integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+      integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+      integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+      // Not allowed on our classpath, only the runtime jar is allowed
+      integrationCompileOnly project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
+      integrationCompileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
+      integrationCompileOnly project(':iceberg-api')
+    }
 
-    // Required because we remove antlr plugin dependencies from the compile configuration, see note above
-    runtimeOnly libs.antlr.runtime
-    antlr libs.antlr.antlr4
+    shadowJar {
+      configurations = [project.configurations.runtimeClasspath]
+
+      zip64 true
+
+      // include the LICENSE and NOTICE files for the shaded Jar
+      from(projectDir) {
+        include 'LICENSE'
+        include 'NOTICE'
+      }
+
+      // Relocate dependencies to avoid conflicts
+      relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
+      relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'
+      relocate 'com.fasterxml', 'org.apache.iceberg.shaded.com.fasterxml'
+      relocate 'com.github.benmanes', 'org.apache.iceberg.shaded.com.github.benmanes'
+      relocate 'org.checkerframework', 'org.apache.iceberg.shaded.org.checkerframework'
+      relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
+      relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'
+      relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
+      relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
+      relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
+      relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
+      relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
+      relocate 'org.apache.hc.client5', 'org.apache.iceberg.shaded.org.apache.hc.client5'
+      relocate 'org.apache.hc.core5', 'org.apache.iceberg.shaded.org.apache.hc.core5'
+      // relocate Arrow and related deps to shade Iceberg specific version
+      relocate 'io.netty', 'org.apache.iceberg.shaded.io.netty'
+      relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
+      relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
+      relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
+      relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
+
+      archiveClassifier.set(null)
+    }
+
+    task integrationTest(type: Test) {
+      description = "Test Spark3 Runtime Jar against Spark ${sparkMajorVersion}"
+      group = "verification"
+      jvmArgs += project.property('extraJvmArgs')
+      testClassesDirs = sourceSets.integration.output.classesDirs
+      classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)
+      inputs.file(shadowJar.archiveFile.get().asFile.path)
+    }
+    integrationTest.dependsOn shadowJar
+    check.dependsOn integrationTest
+
+    jar {
+      enabled = false
+    }
   }
 
-  generateGrammarSource {
-    maxHeapSize = "64m"
-    arguments += ['-visitor', '-package', 'org.apache.spark.sql.catalyst.parser.extensions']
-  }
 }
-
-project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'io.github.goooler.shadow'
-
-  tasks.jar.dependsOn tasks.shadowJar
-
-  sourceSets {
-    integration {
-      java.srcDir "$projectDir/src/integration/java"
-      resources.srcDir "$projectDir/src/integration/resources"
-    }
-  }
-
-  configurations {
-    implementation {
-      exclude group: 'org.apache.spark'
-      // included in Spark
-      exclude group: 'org.slf4j'
-      exclude group: 'org.apache.commons'
-      exclude group: 'commons-pool'
-      exclude group: 'commons-codec'
-      exclude group: 'org.xerial.snappy'
-      exclude group: 'javax.xml.bind'
-      exclude group: 'javax.annotation'
-      exclude group: 'com.github.luben'
-      exclude group: 'com.ibm.icu'
-      exclude group: 'org.glassfish'
-      exclude group: 'org.abego.treelayout'
-      exclude group: 'org.antlr'
-      exclude group: 'org.scala-lang'
-      exclude group: 'org.scala-lang.modules'
-    }
-  }
-
-  dependencies {
-    api project(':iceberg-api')
-    implementation project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
-    implementation project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
-    implementation project(':iceberg-aws')
-    implementation project(':iceberg-azure')
-    implementation(project(':iceberg-aliyun')) {
-      exclude group: 'edu.umd.cs.findbugs', module: 'findbugs'
-      exclude group: 'org.apache.httpcomponents', module: 'httpclient'
-      exclude group: 'commons-logging', module: 'commons-logging'
-    }
-    implementation project(':iceberg-gcp')
-    implementation project(':iceberg-hive-metastore')
-    implementation(project(':iceberg-nessie')) {
-      exclude group: 'com.google.code.findbugs', module: 'jsr305'
-    }
-    implementation (project(':iceberg-snowflake')) {
-      exclude group: 'net.snowflake' , module: 'snowflake-jdbc'
-    }
-
-    integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
-    integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive33.get()}"
-    integrationImplementation libs.junit.vintage.engine
-    integrationImplementation libs.slf4j.simple
-    integrationImplementation libs.assertj.core
-    integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
-    integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
-    integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
-    // Not allowed on our classpath, only the runtime jar is allowed
-    integrationCompileOnly project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
-    integrationCompileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
-    integrationCompileOnly project(':iceberg-api')
-  }
-
-  shadowJar {
-    configurations = [project.configurations.runtimeClasspath]
-
-    zip64 true
-
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // Relocate dependencies to avoid conflicts
-    relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
-    relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'
-    relocate 'com.fasterxml', 'org.apache.iceberg.shaded.com.fasterxml'
-    relocate 'com.github.benmanes', 'org.apache.iceberg.shaded.com.github.benmanes'
-    relocate 'org.checkerframework', 'org.apache.iceberg.shaded.org.checkerframework'
-    relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
-    relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'
-    relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
-    relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
-    relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
-    relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
-    relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
-    relocate 'org.apache.hc.client5', 'org.apache.iceberg.shaded.org.apache.hc.client5'
-    relocate 'org.apache.hc.core5', 'org.apache.iceberg.shaded.org.apache.hc.core5'
-    // relocate Arrow and related deps to shade Iceberg specific version
-    relocate 'io.netty', 'org.apache.iceberg.shaded.io.netty'
-    relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
-    relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
-    relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
-    relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
-
-    archiveClassifier.set(null)
-  }
-
-  task integrationTest(type: Test) {
-    description = "Test Spark3 Runtime Jar against Spark ${sparkMajorVersion}"
-    group = "verification"
-    jvmArgs += project.property('extraJvmArgs')
-    testClassesDirs = sourceSets.integration.output.classesDirs
-    classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)
-    inputs.file(shadowJar.archiveFile.get().asFile.path)
-  }
-  integrationTest.dependsOn shadowJar
-  check.dependsOn integrationTest
-
-  jar {
-    enabled = false
-  }
-}
-

--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -18,294 +18,303 @@
  */
 
 String sparkMajorVersion = '3.4'
-String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
+List<String> scalaVersions = System.getProperty("sparkScalaVersions_${sparkMajorVersion}").split(",").toList()
 
-def sparkProjects = [
-    project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}"),
-    project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}"),
-    project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}"),
-]
+for (scalaVersion in scalaVersions) {
 
-configure(sparkProjects) {
-  configurations {
-    all {
-      resolutionStrategy {
-        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson214.get()}"
-        force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson214.get()}"
-        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson214.get()}"
+  def sparkProjects = [
+          project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}"),
+          project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}"),
+          project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}"),
+  ]
+
+  configure(sparkProjects) {
+    configurations {
+      all {
+        resolutionStrategy {
+          force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson214.get()}"
+          force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson214.get()}"
+          force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson214.get()}"
+        }
       }
     }
   }
-}
 
-project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'scala'
-  apply plugin: 'com.github.alisiikh.scalastyle'
+  project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
+    layout.buildDirectory.set(layout.buildDirectory.dir(scalaVersion).get())
 
-  sourceSets {
-    main {
-      scala.srcDirs = ['src/main/scala', 'src/main/java']
-      java.srcDirs = []
+    apply plugin: 'scala'
+    apply plugin: 'com.github.alisiikh.scalastyle'
+
+    sourceSets {
+      main {
+        scala.srcDirs = ['src/main/scala', 'src/main/java']
+        java.srcDirs = []
+      }
+    }
+
+    dependencies {
+      implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+      api project(':iceberg-api')
+      implementation project(':iceberg-common')
+      implementation project(':iceberg-core')
+      implementation project(':iceberg-data')
+      implementation project(':iceberg-orc')
+      implementation project(':iceberg-parquet')
+      implementation project(':iceberg-arrow')
+      implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
+      if (scalaVersion == '2.12') {
+        // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
+        implementation 'org.scala-lang:scala-library:2.12.18'
+      }
+
+      compileOnly libs.errorprone.annotations
+      compileOnly libs.avro.avro
+      compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive34.get()}") {
+        exclude group: 'org.apache.avro', module: 'avro'
+        exclude group: 'org.apache.arrow'
+        exclude group: 'org.apache.parquet'
+        // to make sure netty libs only come from project(':iceberg-arrow')
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+        exclude group: 'org.roaringbitmap'
+      }
+
+      implementation libs.parquet.column
+      implementation libs.parquet.hadoop
+
+      implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
+        exclude group: 'org.apache.hadoop'
+        exclude group: 'commons-lang'
+        // These artifacts are shaded and included in the orc-core fat jar
+        exclude group: 'com.google.protobuf', module: 'protobuf-java'
+        exclude group: 'org.apache.hive', module: 'hive-storage-api'
+      }
+
+      implementation(libs.arrow.vector) {
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+      }
+
+      implementation libs.caffeine
+
+      testImplementation(libs.hadoop2.minicluster) {
+        exclude group: 'org.apache.avro', module: 'avro'
+        // to make sure netty libs only come from project(':iceberg-arrow')
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+      }
+      testImplementation project(path: ':iceberg-hive-metastore')
+      testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
+      testImplementation libs.sqlite.jdbc
+      testImplementation libs.awaitility
+      testImplementation libs.junit.vintage.engine
+    }
+
+    test {
+      useJUnitPlatform()
+    }
+
+    tasks.withType(Test) {
+      // Vectorized reads need more memory
+      maxHeapSize '2560m'
     }
   }
 
-  dependencies {
-    implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
-    api project(':iceberg-api')
-    implementation project(':iceberg-common')
-    implementation project(':iceberg-core')
-    implementation project(':iceberg-data')
-    implementation project(':iceberg-orc')
-    implementation project(':iceberg-parquet')
-    implementation project(':iceberg-arrow')
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
-    if (scalaVersion == '2.12') {
-      // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
-      implementation 'org.scala-lang:scala-library:2.12.18'
-    }
+  project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}") {
+    layout.buildDirectory.set(layout.buildDirectory.dir(scalaVersion).get())
 
-    compileOnly libs.errorprone.annotations
-    compileOnly libs.avro.avro
-    compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive34.get()}") {
-      exclude group: 'org.apache.avro', module: 'avro'
-      exclude group: 'org.apache.arrow'
-      exclude group: 'org.apache.parquet'
-      // to make sure netty libs only come from project(':iceberg-arrow')
-      exclude group: 'io.netty', module: 'netty-buffer'
-      exclude group: 'io.netty', module: 'netty-common'
-      exclude group: 'org.roaringbitmap'
-    }
+    apply plugin: 'java-library'
+    apply plugin: 'scala'
+    apply plugin: 'com.github.alisiikh.scalastyle'
+    apply plugin: 'antlr'
 
-    implementation libs.parquet.column
-    implementation libs.parquet.hadoop
-
-    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
-      exclude group: 'org.apache.hadoop'
-      exclude group: 'commons-lang'
-      // These artifacts are shaded and included in the orc-core fat jar
-      exclude group: 'com.google.protobuf', module: 'protobuf-java'
-      exclude group: 'org.apache.hive', module: 'hive-storage-api'
-    }
-
-    implementation(libs.arrow.vector) {
-      exclude group: 'io.netty', module: 'netty-buffer'
-      exclude group: 'io.netty', module: 'netty-common'
-      exclude group: 'com.google.code.findbugs', module: 'jsr305'
-    }
-
-    implementation libs.caffeine
-
-    testImplementation(libs.hadoop2.minicluster) {
-      exclude group: 'org.apache.avro', module: 'avro'
-      // to make sure netty libs only come from project(':iceberg-arrow')
-      exclude group: 'io.netty', module: 'netty-buffer'
-      exclude group: 'io.netty', module: 'netty-common'
-    }
-    testImplementation project(path: ':iceberg-hive-metastore')
-    testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
-    testImplementation libs.sqlite.jdbc
-    testImplementation libs.awaitility
-    testImplementation libs.junit.vintage.engine
-  }
-
-  test {
-    useJUnitPlatform()
-  }
-
-  tasks.withType(Test) {
-    // Vectorized reads need more memory
-    maxHeapSize '2560m'
-  }
-}
-
-project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'java-library'
-  apply plugin: 'scala'
-  apply plugin: 'com.github.alisiikh.scalastyle'
-  apply plugin: 'antlr'
-
-  configurations {
-    /*
+    configurations {
+      /*
      The Gradle Antlr plugin erroneously adds both antlr-build and runtime dependencies to the runtime path. This
      bug https://github.com/gradle/gradle/issues/820 exists because older versions of Antlr do not have separate
      runtime and implementation dependencies and they do not want to break backwards compatibility. So to only end up with
      the runtime dependency on the runtime classpath we remove the dependencies added by the plugin here. Then add
      the runtime dependency back to only the runtime configuration manually.
     */
-    implementation {
-      extendsFrom = extendsFrom.findAll { it != configurations.antlr }
+      implementation {
+        extendsFrom = extendsFrom.findAll { it != configurations.antlr }
+      }
+    }
+
+    dependencies {
+      implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
+      if (scalaVersion == '2.12') {
+        // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
+        implementation 'org.scala-lang:scala-library:2.12.18'
+      }
+      implementation libs.roaringbitmap
+
+      compileOnly "org.scala-lang:scala-library"
+      compileOnly project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+      compileOnly project(':iceberg-api')
+      compileOnly project(':iceberg-core')
+      compileOnly project(':iceberg-common')
+      compileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
+      compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive34.get()}") {
+        exclude group: 'org.apache.avro', module: 'avro'
+        exclude group: 'org.apache.arrow'
+        exclude group: 'org.apache.parquet'
+        // to make sure netty libs only come from project(':iceberg-arrow')
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+        exclude group: 'org.roaringbitmap'
+      }
+      compileOnly libs.errorprone.annotations
+
+      testImplementation project(path: ':iceberg-data')
+      testImplementation project(path: ':iceberg-parquet')
+      testImplementation project(path: ':iceberg-hive-metastore')
+      testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+      testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+
+      testImplementation libs.avro.avro
+      testImplementation libs.parquet.hadoop
+      testImplementation libs.junit.vintage.engine
+
+      // Required because we remove antlr plugin dependencies from the compile configuration, see note above
+      runtimeOnly libs.antlr.runtime
+      antlr libs.antlr.antlr4
+    }
+
+    generateGrammarSource {
+      maxHeapSize = "64m"
+      arguments += ['-visitor', '-package', 'org.apache.spark.sql.catalyst.parser.extensions']
     }
   }
 
-  dependencies {
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
-    if (scalaVersion == '2.12') {
-      // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
-      implementation 'org.scala-lang:scala-library:2.12.18'
+  project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
+    layout.buildDirectory.set(layout.buildDirectory.dir(scalaVersion).get())
+
+    apply plugin: 'io.github.goooler.shadow'
+
+    tasks.jar.dependsOn tasks.shadowJar
+
+    sourceSets {
+      integration {
+        java.srcDir "$projectDir/src/integration/java"
+        resources.srcDir "$projectDir/src/integration/resources"
+      }
     }
-    implementation libs.roaringbitmap
 
-    compileOnly "org.scala-lang:scala-library"
-    compileOnly project(path: ':iceberg-bundled-guava', configuration: 'shadow')
-    compileOnly project(':iceberg-api')
-    compileOnly project(':iceberg-core')
-    compileOnly project(':iceberg-common')
-    compileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
-    compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive34.get()}") {
-      exclude group: 'org.apache.avro', module: 'avro'
-      exclude group: 'org.apache.arrow'
-      exclude group: 'org.apache.parquet'
-      // to make sure netty libs only come from project(':iceberg-arrow')
-      exclude group: 'io.netty', module: 'netty-buffer'
-      exclude group: 'io.netty', module: 'netty-common'
-      exclude group: 'org.roaringbitmap'
+    configurations {
+      implementation {
+        exclude group: 'org.apache.spark'
+        // included in Spark
+        exclude group: 'org.slf4j'
+        exclude group: 'org.apache.commons'
+        exclude group: 'commons-pool'
+        exclude group: 'commons-codec'
+        exclude group: 'org.xerial.snappy'
+        exclude group: 'javax.xml.bind'
+        exclude group: 'javax.annotation'
+        exclude group: 'com.github.luben'
+        exclude group: 'com.ibm.icu'
+        exclude group: 'org.glassfish'
+        exclude group: 'org.abego.treelayout'
+        exclude group: 'org.antlr'
+        exclude group: 'org.scala-lang'
+        exclude group: 'org.scala-lang.modules'
+      }
     }
-    compileOnly libs.errorprone.annotations
 
-    testImplementation project(path: ':iceberg-data')
-    testImplementation project(path: ':iceberg-parquet')
-    testImplementation project(path: ':iceberg-hive-metastore')
-    testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+    dependencies {
+      api project(':iceberg-api')
+      implementation project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
+      implementation project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
+      implementation project(':iceberg-aws')
+      implementation project(':iceberg-azure')
+      implementation(project(':iceberg-aliyun')) {
+        exclude group: 'edu.umd.cs.findbugs', module: 'findbugs'
+        exclude group: 'org.apache.httpcomponents', module: 'httpclient'
+        exclude group: 'commons-logging', module: 'commons-logging'
+      }
+      implementation project(':iceberg-gcp')
+      implementation project(':iceberg-hive-metastore')
+      implementation(project(':iceberg-nessie')) {
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+      }
+      implementation(project(':iceberg-snowflake')) {
+        exclude group: 'net.snowflake', module: 'snowflake-jdbc'
+      }
 
-    testImplementation libs.avro.avro
-    testImplementation libs.parquet.hadoop
-    testImplementation libs.junit.vintage.engine
+      integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
+      integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive34.get()}"
+      integrationImplementation libs.junit.vintage.engine
+      integrationImplementation libs.slf4j.simple
+      integrationImplementation libs.assertj.core
+      integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+      integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+      integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+      integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+      // Not allowed on our classpath, only the runtime jar is allowed
+      integrationCompileOnly project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
+      integrationCompileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
+      integrationCompileOnly project(':iceberg-api')
+    }
 
-    // Required because we remove antlr plugin dependencies from the compile configuration, see note above
-    runtimeOnly libs.antlr.runtime
-    antlr libs.antlr.antlr4
+    shadowJar {
+      configurations = [project.configurations.runtimeClasspath]
+
+      zip64 true
+
+      // include the LICENSE and NOTICE files for the shaded Jar
+      from(projectDir) {
+        include 'LICENSE'
+        include 'NOTICE'
+      }
+
+      // Relocate dependencies to avoid conflicts
+      relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
+      relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'
+      relocate 'com.fasterxml', 'org.apache.iceberg.shaded.com.fasterxml'
+      relocate 'com.github.benmanes', 'org.apache.iceberg.shaded.com.github.benmanes'
+      relocate 'org.checkerframework', 'org.apache.iceberg.shaded.org.checkerframework'
+      relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
+      relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'
+      relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
+      relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
+      relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
+      relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
+      relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
+      relocate 'org.apache.hc.client5', 'org.apache.iceberg.shaded.org.apache.hc.client5'
+      relocate 'org.apache.hc.core5', 'org.apache.iceberg.shaded.org.apache.hc.core5'
+      // relocate Arrow and related deps to shade Iceberg specific version
+      relocate 'io.netty', 'org.apache.iceberg.shaded.io.netty'
+      relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
+      relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
+      relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
+      relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
+
+      archiveClassifier.set(null)
+    }
+
+    task integrationTest(type: Test) {
+      description = "Test Spark3 Runtime Jar against Spark ${sparkMajorVersion}"
+      group = "verification"
+      jvmArgs += project.property('extraJvmArgs')
+      testClassesDirs = sourceSets.integration.output.classesDirs
+      classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)
+      inputs.file(shadowJar.archiveFile.get().asFile.path)
+    }
+    integrationTest.dependsOn shadowJar
+    check.dependsOn integrationTest
+
+    jar {
+      enabled = false
+    }
   }
 
-  generateGrammarSource {
-    maxHeapSize = "64m"
-    arguments += ['-visitor', '-package', 'org.apache.spark.sql.catalyst.parser.extensions']
-  }
 }
-
-project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'io.github.goooler.shadow'
-
-  tasks.jar.dependsOn tasks.shadowJar
-
-  sourceSets {
-    integration {
-      java.srcDir "$projectDir/src/integration/java"
-      resources.srcDir "$projectDir/src/integration/resources"
-    }
-  }
-
-  configurations {
-    implementation {
-      exclude group: 'org.apache.spark'
-      // included in Spark
-      exclude group: 'org.slf4j'
-      exclude group: 'org.apache.commons'
-      exclude group: 'commons-pool'
-      exclude group: 'commons-codec'
-      exclude group: 'org.xerial.snappy'
-      exclude group: 'javax.xml.bind'
-      exclude group: 'javax.annotation'
-      exclude group: 'com.github.luben'
-      exclude group: 'com.ibm.icu'
-      exclude group: 'org.glassfish'
-      exclude group: 'org.abego.treelayout'
-      exclude group: 'org.antlr'
-      exclude group: 'org.scala-lang'
-      exclude group: 'org.scala-lang.modules'
-    }
-  }
-
-  dependencies {
-    api project(':iceberg-api')
-    implementation project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
-    implementation project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
-    implementation project(':iceberg-aws')
-    implementation project(':iceberg-azure')
-    implementation(project(':iceberg-aliyun')) {
-      exclude group: 'edu.umd.cs.findbugs', module: 'findbugs'
-      exclude group: 'org.apache.httpcomponents', module: 'httpclient'
-      exclude group: 'commons-logging', module: 'commons-logging'
-    }
-    implementation project(':iceberg-gcp')
-    implementation project(':iceberg-hive-metastore')
-    implementation(project(':iceberg-nessie')) {
-      exclude group: 'com.google.code.findbugs', module: 'jsr305'
-    }
-    implementation (project(':iceberg-snowflake')) {
-      exclude group: 'net.snowflake' , module: 'snowflake-jdbc'
-    }
-
-    integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
-    integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive34.get()}"
-    integrationImplementation libs.junit.vintage.engine
-    integrationImplementation libs.slf4j.simple
-    integrationImplementation libs.assertj.core
-    integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
-    integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
-    integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
-    // Not allowed on our classpath, only the runtime jar is allowed
-    integrationCompileOnly project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
-    integrationCompileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
-    integrationCompileOnly project(':iceberg-api')
-  }
-
-  shadowJar {
-    configurations = [project.configurations.runtimeClasspath]
-
-    zip64 true
-
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // Relocate dependencies to avoid conflicts
-    relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
-    relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'
-    relocate 'com.fasterxml', 'org.apache.iceberg.shaded.com.fasterxml'
-    relocate 'com.github.benmanes', 'org.apache.iceberg.shaded.com.github.benmanes'
-    relocate 'org.checkerframework', 'org.apache.iceberg.shaded.org.checkerframework'
-    relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
-    relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'
-    relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
-    relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
-    relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
-    relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
-    relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
-    relocate 'org.apache.hc.client5', 'org.apache.iceberg.shaded.org.apache.hc.client5'
-    relocate 'org.apache.hc.core5', 'org.apache.iceberg.shaded.org.apache.hc.core5'
-    // relocate Arrow and related deps to shade Iceberg specific version
-    relocate 'io.netty', 'org.apache.iceberg.shaded.io.netty'
-    relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
-    relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
-    relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
-    relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
-
-    archiveClassifier.set(null)
-  }
-
-  task integrationTest(type: Test) {
-    description = "Test Spark3 Runtime Jar against Spark ${sparkMajorVersion}"
-    group = "verification"
-    jvmArgs += project.property('extraJvmArgs')
-    testClassesDirs = sourceSets.integration.output.classesDirs
-    classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)
-    inputs.file(shadowJar.archiveFile.get().asFile.path)
-  }
-  integrationTest.dependsOn shadowJar
-  check.dependsOn integrationTest
-
-  jar {
-    enabled = false
-  }
-}
-

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -18,298 +18,307 @@
  */
 
 String sparkMajorVersion = '3.5'
-String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
+List<String> scalaVersions = System.getProperty("sparkScalaVersions_${sparkMajorVersion}").split(",").toList()
 
-def sparkProjects = [
-    project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}"),
-    project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}"),
-    project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}"),
-]
+for (scalaVersion in scalaVersions) {
 
-configure(sparkProjects) {
-  configurations {
-    all {
-      resolutionStrategy {
-        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson215.get()}"
-        force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson215.get()}"
-        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson215.get()}"
+  def sparkProjects = [
+          project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}"),
+          project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}"),
+          project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}"),
+  ]
+
+  configure(sparkProjects) {
+    configurations {
+      all {
+        resolutionStrategy {
+          force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson215.get()}"
+          force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson215.get()}"
+          force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson215.get()}"
+        }
       }
     }
   }
-}
 
-project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'scala'
-  apply plugin: 'com.github.alisiikh.scalastyle'
+  project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
+    layout.buildDirectory.set(layout.buildDirectory.dir(scalaVersion).get())
 
-  sourceSets {
-    main {
-      scala.srcDirs = ['src/main/scala', 'src/main/java']
-      java.srcDirs = []
+    apply plugin: 'scala'
+    apply plugin: 'com.github.alisiikh.scalastyle'
+
+    sourceSets {
+      main {
+        scala.srcDirs = ['src/main/scala', 'src/main/java']
+        java.srcDirs = []
+      }
+    }
+
+    dependencies {
+      implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+      api project(':iceberg-api')
+      implementation project(':iceberg-common')
+      implementation project(':iceberg-core')
+      implementation project(':iceberg-data')
+      implementation project(':iceberg-orc')
+      implementation project(':iceberg-parquet')
+      implementation project(':iceberg-arrow')
+      implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
+      if (scalaVersion == '2.12') {
+        // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
+        implementation 'org.scala-lang:scala-library:2.12.18'
+      }
+
+      compileOnly libs.errorprone.annotations
+      compileOnly libs.avro.avro
+      compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}") {
+        exclude group: 'org.apache.avro', module: 'avro'
+        exclude group: 'org.apache.arrow'
+        exclude group: 'org.apache.parquet'
+        // to make sure netty libs only come from project(':iceberg-arrow')
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+        exclude group: 'org.roaringbitmap'
+      }
+
+      implementation libs.parquet.column
+      implementation libs.parquet.hadoop
+
+      implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
+        exclude group: 'org.apache.hadoop'
+        exclude group: 'commons-lang'
+        // These artifacts are shaded and included in the orc-core fat jar
+        exclude group: 'com.google.protobuf', module: 'protobuf-java'
+        exclude group: 'org.apache.hive', module: 'hive-storage-api'
+      }
+
+      implementation(libs.arrow.vector) {
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+      }
+
+      implementation libs.caffeine
+
+      testImplementation(libs.hadoop2.minicluster) {
+        exclude group: 'org.apache.avro', module: 'avro'
+        // to make sure netty libs only come from project(':iceberg-arrow')
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+      }
+      testImplementation project(path: ':iceberg-hive-metastore')
+      testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
+      testImplementation libs.sqlite.jdbc
+      testImplementation libs.awaitility
+    }
+
+    test {
+      useJUnitPlatform()
+    }
+
+    tasks.withType(Test) {
+      // Vectorized reads need more memory
+      maxHeapSize '2560m'
     }
   }
 
-  dependencies {
-    implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
-    api project(':iceberg-api')
-    implementation project(':iceberg-common')
-    implementation project(':iceberg-core')
-    implementation project(':iceberg-data')
-    implementation project(':iceberg-orc')
-    implementation project(':iceberg-parquet')
-    implementation project(':iceberg-arrow')
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
-    if (scalaVersion == '2.12') {
-      // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
-      implementation 'org.scala-lang:scala-library:2.12.18'
-    }
+  project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}") {
+    layout.buildDirectory.set(layout.buildDirectory.dir(scalaVersion).get())
 
-    compileOnly libs.errorprone.annotations
-    compileOnly libs.avro.avro
-    compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}") {
-      exclude group: 'org.apache.avro', module: 'avro'
-      exclude group: 'org.apache.arrow'
-      exclude group: 'org.apache.parquet'
-      // to make sure netty libs only come from project(':iceberg-arrow')
-      exclude group: 'io.netty', module: 'netty-buffer'
-      exclude group: 'io.netty', module: 'netty-common'
-      exclude group: 'org.roaringbitmap'
-    }
+    apply plugin: 'java-library'
+    apply plugin: 'scala'
+    apply plugin: 'com.github.alisiikh.scalastyle'
+    apply plugin: 'antlr'
 
-    implementation libs.parquet.column
-    implementation libs.parquet.hadoop
-
-    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
-      exclude group: 'org.apache.hadoop'
-      exclude group: 'commons-lang'
-      // These artifacts are shaded and included in the orc-core fat jar
-      exclude group: 'com.google.protobuf', module: 'protobuf-java'
-      exclude group: 'org.apache.hive', module: 'hive-storage-api'
-    }
-
-    implementation(libs.arrow.vector) {
-      exclude group: 'io.netty', module: 'netty-buffer'
-      exclude group: 'io.netty', module: 'netty-common'
-      exclude group: 'com.google.code.findbugs', module: 'jsr305'
-    }
-
-    implementation libs.caffeine
-
-    testImplementation(libs.hadoop2.minicluster) {
-      exclude group: 'org.apache.avro', module: 'avro'
-      // to make sure netty libs only come from project(':iceberg-arrow')
-      exclude group: 'io.netty', module: 'netty-buffer'
-      exclude group: 'io.netty', module: 'netty-common'
-    }
-    testImplementation project(path: ':iceberg-hive-metastore')
-    testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
-    testImplementation libs.sqlite.jdbc
-    testImplementation libs.awaitility
-  }
-
-  test {
-    useJUnitPlatform()
-  }
-
-  tasks.withType(Test) {
-    // Vectorized reads need more memory
-    maxHeapSize '2560m'
-  }
-}
-
-project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'java-library'
-  apply plugin: 'scala'
-  apply plugin: 'com.github.alisiikh.scalastyle'
-  apply plugin: 'antlr'
-
-  configurations {
-    /*
+    configurations {
+      /*
      The Gradle Antlr plugin erroneously adds both antlr-build and runtime dependencies to the runtime path. This
      bug https://github.com/gradle/gradle/issues/820 exists because older versions of Antlr do not have separate
      runtime and implementation dependencies and they do not want to break backwards compatibility. So to only end up with
      the runtime dependency on the runtime classpath we remove the dependencies added by the plugin here. Then add
      the runtime dependency back to only the runtime configuration manually.
     */
-    implementation {
-      extendsFrom = extendsFrom.findAll { it != configurations.antlr }
+      implementation {
+        extendsFrom = extendsFrom.findAll { it != configurations.antlr }
+      }
+    }
+
+    dependencies {
+      implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
+      if (scalaVersion == '2.12') {
+        // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
+        implementation 'org.scala-lang:scala-library:2.12.18'
+      }
+      implementation libs.roaringbitmap
+
+      compileOnly "org.scala-lang:scala-library"
+      compileOnly project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+      compileOnly project(':iceberg-api')
+      compileOnly project(':iceberg-core')
+      compileOnly project(':iceberg-common')
+      compileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
+      compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}") {
+        exclude group: 'org.apache.avro', module: 'avro'
+        exclude group: 'org.apache.arrow'
+        exclude group: 'org.apache.parquet'
+        // to make sure netty libs only come from project(':iceberg-arrow')
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+        exclude group: 'org.roaringbitmap'
+      }
+      compileOnly libs.errorprone.annotations
+
+      testImplementation project(path: ':iceberg-data')
+      testImplementation project(path: ':iceberg-parquet')
+      testImplementation project(path: ':iceberg-hive-metastore')
+      testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
+      testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+      testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+
+      testImplementation libs.avro.avro
+      testImplementation libs.parquet.hadoop
+      testImplementation libs.awaitility
+
+      // Required because we remove antlr plugin dependencies from the compile configuration, see note above
+      runtimeOnly libs.antlr.runtime
+      antlr libs.antlr.antlr4
+    }
+
+    test {
+      useJUnitPlatform()
+    }
+
+    generateGrammarSource {
+      maxHeapSize = "64m"
+      arguments += ['-visitor', '-package', 'org.apache.spark.sql.catalyst.parser.extensions']
     }
   }
 
-  dependencies {
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
-    if (scalaVersion == '2.12') {
-      // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
-      implementation 'org.scala-lang:scala-library:2.12.18'
+  project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
+    layout.buildDirectory.set(layout.buildDirectory.dir(scalaVersion).get())
+
+    apply plugin: 'io.github.goooler.shadow'
+
+    tasks.jar.dependsOn tasks.shadowJar
+
+    sourceSets {
+      integration {
+        java.srcDir "$projectDir/src/integration/java"
+        resources.srcDir "$projectDir/src/integration/resources"
+      }
     }
-    implementation libs.roaringbitmap
 
-    compileOnly "org.scala-lang:scala-library"
-    compileOnly project(path: ':iceberg-bundled-guava', configuration: 'shadow')
-    compileOnly project(':iceberg-api')
-    compileOnly project(':iceberg-core')
-    compileOnly project(':iceberg-common')
-    compileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
-    compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}") {
-      exclude group: 'org.apache.avro', module: 'avro'
-      exclude group: 'org.apache.arrow'
-      exclude group: 'org.apache.parquet'
-      // to make sure netty libs only come from project(':iceberg-arrow')
-      exclude group: 'io.netty', module: 'netty-buffer'
-      exclude group: 'io.netty', module: 'netty-common'
-      exclude group: 'org.roaringbitmap'
+    configurations {
+      implementation {
+        exclude group: 'org.apache.spark'
+        // included in Spark
+        exclude group: 'org.slf4j'
+        exclude group: 'org.apache.commons'
+        exclude group: 'commons-pool'
+        exclude group: 'commons-codec'
+        exclude group: 'org.xerial.snappy'
+        exclude group: 'javax.xml.bind'
+        exclude group: 'javax.annotation'
+        exclude group: 'com.github.luben'
+        exclude group: 'com.ibm.icu'
+        exclude group: 'org.glassfish'
+        exclude group: 'org.abego.treelayout'
+        exclude group: 'org.antlr'
+        exclude group: 'org.scala-lang'
+        exclude group: 'org.scala-lang.modules'
+      }
     }
-    compileOnly libs.errorprone.annotations
 
-    testImplementation project(path: ':iceberg-data')
-    testImplementation project(path: ':iceberg-parquet')
-    testImplementation project(path: ':iceberg-hive-metastore')
-    testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+    dependencies {
+      api project(':iceberg-api')
+      implementation project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
+      implementation project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
+      implementation project(':iceberg-aws')
+      implementation project(':iceberg-azure')
+      implementation(project(':iceberg-aliyun')) {
+        exclude group: 'edu.umd.cs.findbugs', module: 'findbugs'
+        exclude group: 'org.apache.httpcomponents', module: 'httpclient'
+        exclude group: 'commons-logging', module: 'commons-logging'
+      }
+      implementation project(':iceberg-gcp')
+      implementation project(':iceberg-hive-metastore')
+      implementation(project(':iceberg-nessie')) {
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+      }
+      implementation(project(':iceberg-snowflake')) {
+        exclude group: 'net.snowflake', module: 'snowflake-jdbc'
+      }
 
-    testImplementation libs.avro.avro
-    testImplementation libs.parquet.hadoop
-    testImplementation libs.awaitility
+      integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
+      integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}"
+      integrationImplementation libs.junit.vintage.engine
+      integrationImplementation libs.junit.jupiter
+      integrationImplementation libs.slf4j.simple
+      integrationImplementation libs.assertj.core
+      integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+      integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+      integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+      integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+      // Not allowed on our classpath, only the runtime jar is allowed
+      integrationCompileOnly project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
+      integrationCompileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
+      integrationCompileOnly project(':iceberg-api')
+    }
 
-    // Required because we remove antlr plugin dependencies from the compile configuration, see note above
-    runtimeOnly libs.antlr.runtime
-    antlr libs.antlr.antlr4
+    shadowJar {
+      configurations = [project.configurations.runtimeClasspath]
+
+      zip64 true
+
+      // include the LICENSE and NOTICE files for the shaded Jar
+      from(projectDir) {
+        include 'LICENSE'
+        include 'NOTICE'
+      }
+
+      // Relocate dependencies to avoid conflicts
+      relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
+      relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'
+      relocate 'com.fasterxml', 'org.apache.iceberg.shaded.com.fasterxml'
+      relocate 'com.github.benmanes', 'org.apache.iceberg.shaded.com.github.benmanes'
+      relocate 'org.checkerframework', 'org.apache.iceberg.shaded.org.checkerframework'
+      relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
+      relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'
+      relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
+      relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
+      relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
+      relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
+      relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
+      relocate 'org.apache.hc.client5', 'org.apache.iceberg.shaded.org.apache.hc.client5'
+      relocate 'org.apache.hc.core5', 'org.apache.iceberg.shaded.org.apache.hc.core5'
+      // relocate Arrow and related deps to shade Iceberg specific version
+      relocate 'io.netty', 'org.apache.iceberg.shaded.io.netty'
+      relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
+      relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
+      relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
+      relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
+
+      archiveClassifier.set(null)
+    }
+
+    task integrationTest(type: Test) {
+      useJUnitPlatform()
+      description = "Test Spark3 Runtime Jar against Spark ${sparkMajorVersion}"
+      group = "verification"
+      jvmArgs += project.property('extraJvmArgs')
+      testClassesDirs = sourceSets.integration.output.classesDirs
+      classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)
+      inputs.file(shadowJar.archiveFile.get().asFile.path)
+    }
+    integrationTest.dependsOn shadowJar
+    check.dependsOn integrationTest
+
+    jar {
+      enabled = false
+    }
   }
 
-  test {
-    useJUnitPlatform()
-  }
-
-  generateGrammarSource {
-    maxHeapSize = "64m"
-    arguments += ['-visitor', '-package', 'org.apache.spark.sql.catalyst.parser.extensions']
-  }
 }
-
-project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'io.github.goooler.shadow'
-
-  tasks.jar.dependsOn tasks.shadowJar
-
-  sourceSets {
-    integration {
-      java.srcDir "$projectDir/src/integration/java"
-      resources.srcDir "$projectDir/src/integration/resources"
-    }
-  }
-
-  configurations {
-    implementation {
-      exclude group: 'org.apache.spark'
-      // included in Spark
-      exclude group: 'org.slf4j'
-      exclude group: 'org.apache.commons'
-      exclude group: 'commons-pool'
-      exclude group: 'commons-codec'
-      exclude group: 'org.xerial.snappy'
-      exclude group: 'javax.xml.bind'
-      exclude group: 'javax.annotation'
-      exclude group: 'com.github.luben'
-      exclude group: 'com.ibm.icu'
-      exclude group: 'org.glassfish'
-      exclude group: 'org.abego.treelayout'
-      exclude group: 'org.antlr'
-      exclude group: 'org.scala-lang'
-      exclude group: 'org.scala-lang.modules'
-    }
-  }
-
-  dependencies {
-    api project(':iceberg-api')
-    implementation project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
-    implementation project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
-    implementation project(':iceberg-aws')
-    implementation project(':iceberg-azure')
-    implementation(project(':iceberg-aliyun')) {
-      exclude group: 'edu.umd.cs.findbugs', module: 'findbugs'
-      exclude group: 'org.apache.httpcomponents', module: 'httpclient'
-      exclude group: 'commons-logging', module: 'commons-logging'
-    }
-    implementation project(':iceberg-gcp')
-    implementation project(':iceberg-hive-metastore')
-    implementation(project(':iceberg-nessie')) {
-      exclude group: 'com.google.code.findbugs', module: 'jsr305'
-    }
-    implementation (project(':iceberg-snowflake')) {
-      exclude group: 'net.snowflake' , module: 'snowflake-jdbc'
-    }
-
-    integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
-    integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}"
-    integrationImplementation libs.junit.vintage.engine
-    integrationImplementation libs.junit.jupiter
-    integrationImplementation libs.slf4j.simple
-    integrationImplementation libs.assertj.core
-    integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
-    integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
-    integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
-    // Not allowed on our classpath, only the runtime jar is allowed
-    integrationCompileOnly project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
-    integrationCompileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")
-    integrationCompileOnly project(':iceberg-api')
-  }
-
-  shadowJar {
-    configurations = [project.configurations.runtimeClasspath]
-
-    zip64 true
-
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // Relocate dependencies to avoid conflicts
-    relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
-    relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'
-    relocate 'com.fasterxml', 'org.apache.iceberg.shaded.com.fasterxml'
-    relocate 'com.github.benmanes', 'org.apache.iceberg.shaded.com.github.benmanes'
-    relocate 'org.checkerframework', 'org.apache.iceberg.shaded.org.checkerframework'
-    relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
-    relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'
-    relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
-    relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
-    relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
-    relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
-    relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
-    relocate 'org.apache.hc.client5', 'org.apache.iceberg.shaded.org.apache.hc.client5'
-    relocate 'org.apache.hc.core5', 'org.apache.iceberg.shaded.org.apache.hc.core5'
-    // relocate Arrow and related deps to shade Iceberg specific version
-    relocate 'io.netty', 'org.apache.iceberg.shaded.io.netty'
-    relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
-    relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
-    relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
-    relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
-
-    archiveClassifier.set(null)
-  }
-
-  task integrationTest(type: Test) {
-    useJUnitPlatform()
-    description = "Test Spark3 Runtime Jar against Spark ${sparkMajorVersion}"
-    group = "verification"
-    jvmArgs += project.property('extraJvmArgs')
-    testClassesDirs = sourceSets.integration.output.classesDirs
-    classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)
-    inputs.file(shadowJar.archiveFile.get().asFile.path)
-  }
-  integrationTest.dependsOn shadowJar
-  check.dependsOn integrationTest
-
-  jar {
-    enabled = false
-  }
-}
-


### PR DESCRIPTION
Allows building for all Spark/Scala version combinations. Introduces new system properties to control the behavior:
* `allScalaVersions=true` lets Spark build for all Scala versions
* the previous property `scalaVersion` is now a version list via the `scalaVersions` property, provides backwards compatibility
* the previous property `defaultScalaVersion` is now a version list via the `defaultScalaVersions` property, provides backwards compatibility

The defaults, via `gradle.properties` do not change.

Also...
* Unify processing of the xyzVersions everywhere
* Fix compilation bug in Flink 1.19 jmh code (was not built before)
* Update release jobs/script
* Remove "hack" for `:iceberg-bom`
* Simplify and fix related usages of the build system properties
