### PR TITLE
core:Refactor the code of HadoopTableOptions

### DIFF
--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -24,8 +24,14 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -35,9 +41,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -50,11 +59,14 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.LockManager;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -465,6 +477,650 @@ public class TestHadoopCommits extends HadoopTableTestBase {
     assertThatThrownBy(() -> tableOperations.commit(tableOperations.current(), meta2))
         .isInstanceOf(CommitFailedException.class)
         .hasMessageStartingWith("Failed to acquire lock on file");
+  }
+
+  @Test
+  public void testCommitFailedBeforeChangeVersionHint() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    BaseTable baseTable = (BaseTable) table;
+    HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+
+    HadoopTableOperations spyOps2 = spy(tableOperations);
+    doReturn(10000).when(spyOps2).findVersionWithOutVersionHint(any());
+    TableMetadata metadataV1 = spyOps2.current();
+    SortOrder dataSort = SortOrder.builderFor(baseTable.schema()).asc("data").build();
+    TableMetadata metadataV2 = metadataV1.replaceSortOrder(dataSort);
+    assertThatThrownBy(() -> spyOps2.commit(metadataV1, metadataV2))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("Are there other clients running in parallel with the current task?");
+
+    HadoopTableOperations spyOps3 = spy(tableOperations);
+    doReturn(false).when(spyOps3).nextVersionIsLatest(anyInt(), anyInt());
+    assertCommitNotChangeVersion(
+        baseTable,
+        spyOps3,
+        CommitFailedException.class,
+        "Are there other clients running in parallel with the current task?");
+
+    HadoopTableOperations spyOps4 = spy(tableOperations);
+    doThrow(new RuntimeException("FileSystem crash!"))
+        .when(spyOps4)
+        .renameMetaDataFileAndCheck(any(), any(), any(), anyBoolean());
+    assertCommitNotChangeVersion(
+        baseTable, spyOps4, CommitFailedException.class, "FileSystem crash!");
+  }
+
+  @Test
+  public void testCommitFailedAndCheckFailed() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    BaseTable baseTable = (BaseTable) table;
+    HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+    HadoopTableOperations spyOps = spy(tableOperations);
+    doThrow(new IOException("FileSystem crash!"))
+        .when(spyOps)
+        .renameMetaDataFile(any(), any(), any());
+    doThrow(new IOException("Can not check new Metadata!"))
+        .when(spyOps)
+        .checkMetaDataFileRenameSuccess(any(), any(), any(), anyBoolean());
+    assertCommitNotChangeVersion(
+        baseTable, spyOps, CommitStateUnknownException.class, "FileSystem crash!");
+
+    HadoopTableOperations spyOps2 = spy(tableOperations);
+    doThrow(new OutOfMemoryError("Java heap space"))
+        .when(spyOps2)
+        .renameMetaDataFile(any(), any(), any());
+    assertCommitFail(baseTable, spyOps2, OutOfMemoryError.class, "Java heap space");
+
+    HadoopTableOperations spyOps3 = spy(tableOperations);
+    doThrow(new RuntimeException("UNKNOWN ERROR"))
+        .when(spyOps3)
+        .renameMetaDataFile(any(), any(), any());
+    assertCommitNotChangeVersion(
+        baseTable, spyOps3, CommitStateUnknownException.class, "UNKNOWN ERROR");
+  }
+
+  @Test
+  public void testCommitFailedAndRenameNotSuccess() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    BaseTable baseTable = (BaseTable) table;
+    HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+    HadoopTableOperations spyOps = spy(tableOperations);
+    doThrow(new IOException("FileSystem crash!"))
+        .when(spyOps)
+        .renameMetaDataFile(any(), any(), any());
+    assertCommitNotChangeVersion(
+        baseTable,
+        spyOps,
+        CommitFailedException.class,
+        "Are there other clients running in parallel with the current task?");
+  }
+
+  @Test
+  public void testCommitFailedButActualSuccess() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    BaseTable baseTable = (BaseTable) table;
+    HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+    HadoopTableOperations spyOps = spy(tableOperations);
+    doThrow(new IOException("FileSystem crash!"))
+        .when(spyOps)
+        .renameMetaDataFile(any(), any(), any());
+    doReturn(true).when(spyOps).checkMetaDataFileRenameSuccess(any(), any(), any(), anyBoolean());
+    int versionBefore = spyOps.findVersion();
+    TableMetadata metadataV1 = spyOps.current();
+    SortOrder dataSort = SortOrder.builderFor(baseTable.schema()).asc("data").build();
+    TableMetadata metadataV2 = metadataV1.replaceSortOrder(dataSort);
+    spyOps.commit(metadataV1, metadataV2);
+    int versionAfter = spyOps.findVersion();
+    assertThat(versionAfter).isEqualTo(versionBefore + 1);
+  }
+
+  private void assertCommitNotChangeVersion(
+      BaseTable baseTable,
+      HadoopTableOperations spyOps,
+      Class<? extends Throwable> exceptionClass,
+      String msg) {
+    int versionBefore = spyOps.findVersion();
+    assertCommitFail(baseTable, spyOps, exceptionClass, msg);
+    int versionAfter = spyOps.findVersion();
+    assertThat(versionBefore).isEqualTo(versionAfter);
+  }
+
+  private void assertCommitFail(
+      BaseTable baseTable,
+      HadoopTableOperations spyOps,
+      Class<? extends Throwable> exceptionClass,
+      String msg) {
+    TableMetadata metadataV1 = spyOps.current();
+    SortOrder dataSort = SortOrder.builderFor(baseTable.schema()).asc("data").build();
+    TableMetadata metadataV2 = metadataV1.replaceSortOrder(dataSort);
+    assertThatThrownBy(() -> spyOps.commit(metadataV1, metadataV2))
+        .isInstanceOf(exceptionClass)
+        .hasMessageContaining(msg);
+  }
+
+  @Test
+  public void testCommitFailedAfterChangeVersionHintRepeatCommit() {
+    // Submit a new file to test the functionality.
+    table.newFastAppend().appendFile(FILE_A).commit();
+    BaseTable baseTable = (BaseTable) table;
+    HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+    HadoopTableOperations spyOps = spy(tableOperations);
+    doThrow(new RuntimeException("FileSystem crash!"))
+        .when(spyOps)
+        .deleteRemovedMetadataFiles(any(), any());
+    int versionBefore = spyOps.findVersion();
+    TableMetadata metadataV1 = spyOps.current();
+
+    // first commit
+    SortOrder dataSort = SortOrder.builderFor(baseTable.schema()).asc("data").build();
+    TableMetadata metadataV2 = metadataV1.replaceSortOrder(dataSort);
+
+    spyOps.commit(metadataV1, metadataV2);
+
+    // The commit should actually success
+    int versionAfterSecond = spyOps.findVersion();
+    assertThat(versionAfterSecond).isEqualTo(versionBefore + 1);
+
+    // second commit
+    SortOrder idSort = SortOrder.builderFor(baseTable.schema()).desc("id").build();
+    TableMetadata currentMeta = spyOps.current();
+    TableMetadata metadataV3 = metadataV2.replaceSortOrder(idSort);
+    spyOps.commit(currentMeta, metadataV3);
+
+    // The commit should actually success
+    int versionAfterThird = spyOps.findVersion();
+    assertThat(versionAfterThird).isEqualTo(versionBefore + 2);
+  }
+
+  @Test
+  public void testTwoClientCommitSameVersion() throws InterruptedException {
+    // In the linux environment, the JDK FileSystem interface implementation class is
+    // java.io.UnixFileSystem.
+    // Its behavior follows the posix protocol, which causes rename operations to overwrite the
+    // target file (because linux is compatible with some of the unix interfaces).
+    // However, linux also supports renaming without overwriting the target file. In addition, some
+    // other file systems such as Windows, HDFS, etc. also support renaming without overwriting the
+    // target file.
+    // We use the `mv -n` command to simulate the behavior of such filesystems.
+    table.newFastAppend().appendFile(FILE_A).commit();
+    ExecutorService executorService = Executors.newFixedThreadPool(8);
+    AtomicReference<Throwable> unexpectedException = new AtomicReference<>(null);
+    AtomicReference<Throwable> expectedException = new AtomicReference<>(null);
+    CountDownLatch countDownLatch = new CountDownLatch(2);
+    BaseTable baseTable = (BaseTable) table;
+    assertThat(((HadoopTableOperations) baseTable.operations()).findVersion()).isEqualTo(2);
+    executorService.execute(
+        () -> {
+          try {
+            HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+            HadoopTableOperations spyOps = spy(tableOperations);
+            doNothing().when(spyOps).tryLock(any(), any());
+            doAnswer(
+                    x -> {
+                      countDownLatch.countDown();
+                      countDownLatch.await();
+                      return x.callRealMethod();
+                    })
+                .when(spyOps)
+                .renameMetaDataFileAndCheck(any(), any(), any(), anyBoolean());
+            doAnswer(
+                    x -> {
+                      Path srcPath = x.getArgument(1);
+                      Path dstPath = x.getArgument(2);
+                      File src = new File(srcPath.toUri());
+                      File dst = new File(dstPath.toUri());
+                      String srcPathStr = src.getAbsolutePath();
+                      String dstPathStr = dst.getAbsolutePath();
+                      String cmd = String.format("mv -n %s  %s", srcPathStr, dstPathStr);
+                      Process process = Runtime.getRuntime().exec(cmd);
+                      assertThat(process.waitFor()).isEqualTo(0);
+                      return dst.exists() && !src.exists();
+                    })
+                .when(spyOps)
+                .renameMetaDataFile(any(), any(), any());
+            TableMetadata metadataV1 = spyOps.current();
+            SortOrder dataSort = SortOrder.builderFor(baseTable.schema()).asc("data").build();
+            TableMetadata metadataV2 = metadataV1.replaceSortOrder(dataSort);
+            spyOps.commit(metadataV1, metadataV2);
+          } catch (CommitFailedException e) {
+            expectedException.set(e);
+          } catch (Throwable e) {
+            unexpectedException.set(e);
+          }
+        });
+
+    executorService.execute(
+        () -> {
+          try {
+            HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+            HadoopTableOperations spyOps = spy(tableOperations);
+            doNothing().when(spyOps).tryLock(any(), any());
+            doAnswer(
+                    x -> {
+                      countDownLatch.countDown();
+                      countDownLatch.await();
+                      return x.callRealMethod();
+                    })
+                .when(spyOps)
+                .renameMetaDataFileAndCheck(any(), any(), any(), anyBoolean());
+            doAnswer(
+                    x -> {
+                      Path srcPath = x.getArgument(1);
+                      Path dstPath = x.getArgument(2);
+                      File src = new File(srcPath.toUri());
+                      File dst = new File(dstPath.toUri());
+                      String srcPathStr = src.getAbsolutePath();
+                      String dstPathStr = dst.getAbsolutePath();
+                      String cmd = String.format("mv -n %s  %s", srcPathStr, dstPathStr);
+                      Process process = Runtime.getRuntime().exec(cmd);
+                      assertThat(process.waitFor()).isEqualTo(0);
+                      return dst.exists() && !src.exists();
+                    })
+                .when(spyOps)
+                .renameMetaDataFile(any(), any(), any());
+            TableMetadata metadataV1 = spyOps.current();
+            SortOrder dataSort = SortOrder.builderFor(baseTable.schema()).asc("data").build();
+            TableMetadata metadataV2 = metadataV1.replaceSortOrder(dataSort);
+            spyOps.commit(metadataV1, metadataV2);
+          } catch (CommitFailedException e) {
+            expectedException.set(e);
+          } catch (Throwable e) {
+            unexpectedException.set(e);
+          }
+        });
+    executorService.shutdown();
+    if (!executorService.awaitTermination(610, TimeUnit.SECONDS)) {
+      executorService.shutdownNow();
+    }
+    assertThat(expectedException.get()).isNotNull();
+    assertThat(unexpectedException.get()).isNull();
+    assertThatThrownBy(
+            () -> {
+              throw expectedException.get();
+            })
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining(
+            "Can not commit newMetaData because version [3] has already been committed.");
+    assertThat(((HadoopTableOperations) baseTable.operations()).findVersion()).isEqualTo(3);
+  }
+
+  @Test
+  public void testConcurrentCommitAndRejectCommitAlreadyExistsVersion()
+      throws InterruptedException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    ExecutorService executorService = Executors.newFixedThreadPool(8);
+    AtomicReference<Throwable> unexpectedException = new AtomicReference<>(null);
+    AtomicInteger commitTimes = new AtomicInteger(0);
+    int maxCommitTimes = 20;
+    CountDownLatch countDownLatch = new CountDownLatch(5);
+    CountDownLatch countDownLatch2 = new CountDownLatch(1);
+    executorService.execute(
+        () -> {
+          try {
+            BaseTable baseTable = (BaseTable) table;
+            HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+            HadoopTableOperations spyOps = spy(tableOperations);
+            doNothing().when(spyOps).tryLock(any(), any());
+            doAnswer(
+                    x -> {
+                      countDownLatch2.countDown();
+                      countDownLatch.await();
+                      return x.callRealMethod();
+                    })
+                .when(spyOps)
+                .commitNewVersion(any(), any(), any(), any(), anyBoolean());
+            assertCommitFail(
+                baseTable, spyOps, CommitFailedException.class, "Version 3 already exists");
+          } catch (Throwable e) {
+            unexpectedException.set(e);
+            throw new RuntimeException(e);
+          }
+        });
+
+    executorService.execute(
+        () -> {
+          try {
+            countDownLatch2.await();
+            for (; commitTimes.get() < maxCommitTimes; commitTimes.incrementAndGet()) {
+              table.newFastAppend().appendFile(FILE_A).commit();
+              TimeUnit.SECONDS.sleep(1);
+              countDownLatch.countDown();
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+    executorService.shutdown();
+    if (!executorService.awaitTermination(30, TimeUnit.SECONDS)) {
+      executorService.shutdownNow();
+    }
+    assertThat(unexpectedException.get()).isNull();
+    assertThat(commitTimes.get()).isEqualTo(maxCommitTimes);
+  }
+
+  @Test
+  public void testRejectCommitAlreadyExistsVersionWithUsingObjectStore()
+      throws InterruptedException {
+    // Since java.io.UnixFileSystem.rename overwrites existing files and we currently share the same
+    // memory locks. So we can use the local file system to simulate the use of object storage.
+    table.updateProperties().set(TableProperties.OBJECT_STORE_ENABLED, "true").commit();
+    table.newFastAppend().appendFile(FILE_A).commit();
+    ExecutorService executorService = Executors.newFixedThreadPool(8);
+    AtomicReference<Throwable> unexpectedException = new AtomicReference<>(null);
+    AtomicInteger commitTimes = new AtomicInteger(0);
+    int maxCommitTimes = 20;
+    CountDownLatch countDownLatch = new CountDownLatch(5);
+    CountDownLatch countDownLatch2 = new CountDownLatch(1);
+    executorService.execute(
+        () -> {
+          try {
+            BaseTable baseTable = (BaseTable) table;
+            HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+            HadoopTableOperations spyOps = spy(tableOperations);
+            doAnswer(
+                    x -> {
+                      countDownLatch2.countDown();
+                      countDownLatch.await();
+                      return x.callRealMethod();
+                    })
+                .when(spyOps)
+                .tryLock(any(), any());
+            assertCommitFail(
+                baseTable, spyOps, CommitFailedException.class, "Version 4 already exists");
+          } catch (Throwable e) {
+            unexpectedException.set(e);
+            throw new RuntimeException(e);
+          }
+        });
+
+    executorService.execute(
+        () -> {
+          try {
+            countDownLatch2.await();
+            for (; commitTimes.get() < maxCommitTimes; commitTimes.incrementAndGet()) {
+              table.newFastAppend().appendFile(FILE_A).commit();
+              TimeUnit.SECONDS.sleep(1);
+              countDownLatch.countDown();
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+    executorService.shutdown();
+    if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+      executorService.shutdownNow();
+    }
+    assertThat(unexpectedException.get()).isNull();
+    assertThat(commitTimes.get()).isEqualTo(maxCommitTimes);
+  }
+
+  @Test
+  public void testConcurrentCommitAndRejectTooOldCommit() throws InterruptedException {
+    // Too-old-commit: commitVersion < currentMaxVersion - METADATA_PREVIOUS_VERSIONS_MAX
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.updateProperties().set(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "2").commit();
+    table
+        .updateProperties()
+        .set(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "true")
+        .commit();
+    ExecutorService executorService = Executors.newFixedThreadPool(8);
+    AtomicReference<Throwable> unexpectedException = new AtomicReference<>(null);
+    AtomicInteger commitTimes = new AtomicInteger(0);
+    int maxCommitTimes = 20;
+    CountDownLatch countDownLatch = new CountDownLatch(5);
+    CountDownLatch countDownLatch2 = new CountDownLatch(1);
+    CountDownLatch countDownLatch3 = new CountDownLatch(1);
+    executorService.execute(
+        () -> {
+          try {
+            BaseTable baseTable = (BaseTable) table;
+            HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+            HadoopTableOperations spyOps = spy(tableOperations);
+            doNothing().when(spyOps).tryLock(any(), any());
+            doAnswer(
+                    x -> {
+                      countDownLatch2.countDown();
+                      countDownLatch.await();
+                      return x.callRealMethod();
+                    })
+                .when(spyOps)
+                .commitNewVersion(any(), any(), any(), any(), anyBoolean());
+            assertCommitFail(
+                baseTable,
+                spyOps,
+                CommitFailedException.class,
+                "Cannot commit version [5] because it is smaller or much larger than the current latest version [9].");
+            countDownLatch3.countDown();
+          } catch (Throwable e) {
+            unexpectedException.set(e);
+            throw new RuntimeException(e);
+          }
+        });
+
+    executorService.execute(
+        () -> {
+          try {
+            countDownLatch2.await();
+            for (; commitTimes.get() < maxCommitTimes; commitTimes.incrementAndGet()) {
+              table.newFastAppend().appendFile(FILE_A).commit();
+              countDownLatch.countDown();
+              if (countDownLatch.getCount() == 0) {
+                countDownLatch3.await();
+              }
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+    executorService.shutdown();
+    if (!executorService.awaitTermination(30, TimeUnit.SECONDS)) {
+      executorService.shutdownNow();
+    }
+    assertThat(unexpectedException.get()).isNull();
+    assertThat(commitTimes.get()).isEqualTo(maxCommitTimes);
+  }
+
+  @Test
+  public void testRejectTooOldCommitWithUsingObjectStore() throws InterruptedException {
+    // Since java.io.UnixFileSystem.rename overwrites existing files and we currently share the same
+    // memory locks. So we can use the local file system to simulate the use of object storage.
+    table.updateProperties().set(TableProperties.OBJECT_STORE_ENABLED, "true").commit();
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.updateProperties().set(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "2").commit();
+    table
+        .updateProperties()
+        .set(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "true")
+        .commit();
+    ExecutorService executorService = Executors.newFixedThreadPool(8);
+    AtomicReference<Throwable> unexpectedException = new AtomicReference<>(null);
+    AtomicInteger commitTimes = new AtomicInteger(0);
+    int maxCommitTimes = 20;
+    CountDownLatch countDownLatch = new CountDownLatch(5);
+    CountDownLatch countDownLatch2 = new CountDownLatch(1);
+    executorService.execute(
+        () -> {
+          try {
+            BaseTable baseTable = (BaseTable) table;
+            HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+            HadoopTableOperations spyOps = spy(tableOperations);
+            doNothing().when(spyOps).tryLock(any(), any());
+            doAnswer(
+                    x -> {
+                      countDownLatch2.countDown();
+                      countDownLatch.await();
+                      return x.callRealMethod();
+                    })
+                .when(spyOps)
+                .tryLock(any(), any());
+            assertCommitFail(
+                baseTable,
+                spyOps,
+                CommitFailedException.class,
+                "Cannot commit version [6] because it is smaller or much larger than the current latest version [10].");
+          } catch (Throwable e) {
+            unexpectedException.set(e);
+            throw new RuntimeException(e);
+          }
+        });
+
+    executorService.execute(
+        () -> {
+          try {
+            countDownLatch2.await();
+            for (; commitTimes.get() < maxCommitTimes; commitTimes.incrementAndGet()) {
+              table.newFastAppend().appendFile(FILE_A).commit();
+              countDownLatch.countDown();
+              TimeUnit.SECONDS.sleep(1);
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+    executorService.shutdown();
+    if (!executorService.awaitTermination(30, TimeUnit.SECONDS)) {
+      executorService.shutdownNow();
+    }
+    assertThat(unexpectedException.get()).isNull();
+    assertThat(commitTimes.get()).isEqualTo(maxCommitTimes);
+  }
+
+  @Test
+  public void testConcurrentCommitAndRejectDirtyCommit() throws InterruptedException {
+    // At the end of the commit, if we realize that it is a dirty commit, we should fail the commit.
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.updateProperties().set(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "2").commit();
+    table
+        .updateProperties()
+        .set(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "true")
+        .commit();
+    ExecutorService executorService = Executors.newFixedThreadPool(8);
+    AtomicReference<Throwable> unexpectedException = new AtomicReference<>(null);
+    AtomicInteger commitTimes = new AtomicInteger(0);
+    CountDownLatch countDownLatch = new CountDownLatch(5);
+    CountDownLatch countDownLatch2 = new CountDownLatch(1);
+    int maxCommitTimes = 20;
+    executorService.execute(
+        () -> {
+          try {
+            BaseTable baseTable = (BaseTable) table;
+            HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+            HadoopTableOperations spyOps = spy(tableOperations);
+            TableMetadata metadataV1 = spyOps.current();
+            SortOrder dataSort = SortOrder.builderFor(baseTable.schema()).asc("data").build();
+            TableMetadata metadataV2 = metadataV1.replaceSortOrder(dataSort);
+            doNothing().when(spyOps).tryLock(any(), any());
+            doAnswer(
+                    invocation -> {
+                      countDownLatch.await();
+                      return invocation.callRealMethod();
+                    })
+                .when(spyOps)
+                .renameMetaDataFileAndCheck(any(), any(), any(), anyBoolean());
+            countDownLatch2.countDown();
+            assertThatThrownBy(() -> spyOps.commit(metadataV1, metadataV2))
+                .isInstanceOf(CommitStateUnknownException.class)
+                .hasMessageContaining(
+                    "Commit rejected by server!The current commit version [5] is much smaller than the latest version [9]");
+          } catch (Throwable e) {
+            unexpectedException.set(e);
+            throw new RuntimeException(e);
+          }
+        });
+
+    executorService.execute(
+        () -> {
+          try {
+            countDownLatch2.await();
+            for (; commitTimes.get() < maxCommitTimes; commitTimes.incrementAndGet()) {
+              table.newFastAppend().appendFile(FILE_A).commit();
+              TimeUnit.SECONDS.sleep(1);
+              countDownLatch.countDown();
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+
+    executorService.shutdown();
+    if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+      executorService.shutdownNow();
+    }
+    assertThat(commitTimes.get()).isEqualTo(maxCommitTimes);
+    assertThat(unexpectedException.get()).isNull();
+  }
+
+  @Test
+  public void testCleanTooOldDirtyCommit() throws InterruptedException {
+    // If there are dirty commits in the metadata for some reason, we need to clean them up.
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.updateProperties().set(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "2").commit();
+    table
+        .updateProperties()
+        .set(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "true")
+        .commit();
+    ExecutorService executorService = Executors.newFixedThreadPool(8);
+    AtomicReference<Exception> unexpectedException = new AtomicReference<>(null);
+    AtomicInteger commitTimes = new AtomicInteger(0);
+    int maxCommitTimes = 20;
+    BaseTable baseTable = (BaseTable) table;
+    HadoopTableOperations tableOperations = (HadoopTableOperations) baseTable.operations();
+    HadoopTableOperations spyOps = spy(tableOperations);
+    CountDownLatch countDownLatch = new CountDownLatch(5);
+    CountDownLatch countDownLatch2 = new CountDownLatch(1);
+    AtomicReference<File> dirtyCommitFile = new AtomicReference<>(null);
+    executorService.execute(
+        () -> {
+          try {
+            TableMetadata metadataV1 = spyOps.current();
+            int currentVersion = spyOps.findVersion();
+            int nextVersion = currentVersion + 1;
+            SortOrder dataSort = SortOrder.builderFor(baseTable.schema()).asc("data").build();
+            TableMetadata metadataV2 = metadataV1.replaceSortOrder(dataSort);
+            doNothing().when(spyOps).tryLock(any(), any());
+            doAnswer(
+                    invocation -> {
+                      countDownLatch2.countDown();
+                      countDownLatch.await();
+                      return invocation.callRealMethod();
+                    })
+                .when(spyOps)
+                .renameMetaDataFileAndCheck(any(), any(), any(), anyBoolean());
+            doNothing().when(spyOps).fastFailIfDirtyCommit(anyInt(), anyInt(), any(), any());
+            spyOps.commit(metadataV1, metadataV2);
+            Path metadataFile = spyOps.getMetadataFile(nextVersion);
+            dirtyCommitFile.set(new File(metadataFile.toUri()));
+          } catch (Exception e) {
+            unexpectedException.set(e);
+            throw new RuntimeException(e);
+          }
+        });
+
+    executorService.execute(
+        () -> {
+          try {
+            countDownLatch2.await();
+            for (; commitTimes.get() < maxCommitTimes; commitTimes.incrementAndGet()) {
+              table.newFastAppend().appendFile(FILE_A).commit();
+              TimeUnit.SECONDS.sleep(1);
+              countDownLatch.countDown();
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+
+    executorService.shutdown();
+    if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+      executorService.shutdownNow();
+    }
+
+    assertThat(unexpectedException.get()).isNull();
+    assertThat(dirtyCommitFile.get()).isNotNull();
+    assertThat(dirtyCommitFile.get().exists()).isEqualTo(true);
+    long ttl = 30L * 3600 * 24 * 1000;
+    assertThat(dirtyCommitFile.get().setLastModified(System.currentTimeMillis() - ttl)).isTrue();
+    table.newFastAppend().appendFile(FILE_A).commit();
+    assertThat(dirtyCommitFile.get().exists()).isEqualTo(false);
   }
 
   // Always returns false when trying to acquire


### PR DESCRIPTION
# Refactor the code of HadoopTableOptions

## 1.Current problems

### 1.1.Enabling `write.metadata.delete-after-commit.enabled` may result in dirty commits.

Since this option is turned on, catalog will clean up the commit history.  
If the client re-commits an older version at this point, the commit will succeed because the old-metadata has been deleted.  
Let's assume that there are currently three versions of v7 v8 v9 in the metadata folder. Submitting v2 will work. This is because the file v2 does not exist at the moment. The end result is that after the commit is complete, there are four files v2 v7 v8 v9 in the metadata folder.  
However, the user will not be able to view this commit.  
From the user's point of view, he will encounter a very strange result: his submission is successful, 
but the content of the submission disappears.  
In addition, dirty commits generated in this case will not be cleaned up.  


### 1.2.Problems with lockManager's locking policy. (Or we could just remove the entire lockManager and forget about it.)
Note: If we deprecate lockManager, then users with object-stored filesystems can be able to proxy access them using a system such as CubeFs/JuiceFs etc. Therefore, removing support for object storage is perfectly acceptable.
#### 1.2.1.Incorrect timing of locking and releasing

Current version of the code ignores the fact that the writeVersionHint process may also need to be locked.  
In current implementations, users rely on versionHintFile to speed up version lookups.  
If the information in the versionHintFile is incorrect, then it will lead to big trouble.  
Example:If more than one client executes the commit method concurrently, 
the version information in the versionHintFile may be written to a very old version.(versionHintFile’s version < currentVersion - write.metadata.previous-versions-max).  
At this point, the user cannot call the `refresh` method to get the latest version.  
Eventually, the user's commit will **fail forever**.

#### 1.2.2.Incorrect behaviour of locking and releasing

Current version of the code is locked only for commits of a certain version, e.g., multiple clients are committing to version 3 at the same time, and the lock is in effect.  
However, when multiple clients submit different versions at the same time, they are not locked to each other.  
For object storage filesystems, such locking may cause the information in the versionHintFile to be incorrect.  
For normal filesystems, such locking is meaningless, since the OS provides the same functionality when calling fs.rename. And it also causes the versionHintFile content to be messed up.  

### 1.3.Incorrect behaviour of handing exception

The current implementation of the commit method is not atomic, assuming that the client calls renameMetadata successfully and then encounters an Unexpected Runtime exception, 
which triggers spark to clean up the data files from this commit. 
But spark doesn't clean up the metadata files generated by this commit, which ultimately leads to the problem described in [here](https://github.com/apache/iceberg/pull/9546#issue-2095166356).

In addition to the three major problems mentioned above, there are actually a large number of minor problems with hadoopTableOptions that make it look like it's almost "full of holes".  

**So.given the large number of problems with hadoopTableOptions, we need to completely refactor hadoopTableOptions.**

## 2.List of features to be supported

### 2.1.If a user uses both the global locking service and any type of file system, we need to support the following features(Maybe we should stop support this case):
 - Supports concurrency control
 - No dirty commits
 - Avoid generating versionHintFile files with misplaced content
 - Guarantees the atomicity of commit operations.
### 2.2.In the case where the user is using a normal file system (which supports rename operations that do not overwrite the target file) and is not using the global locking service, the following features need to be supported:
 - Supports concurrency control
 - Regardless of whether the contents of the versionHintFile are incorrect, the client can submit the correct metadata.
 - Support for cleaning up dirty commits
 - Guarantees the atomicity of commit operations.

Ultimately, users can achieve reliable management of metadata&catalogs while using only file systems.

## 3.Glossary:
 - Dirty-commit: `commitVersion < currentVersion - write.metadata.previous-versions-max` && `commit-success=True` && `fs.exists(version-metadata.json)=True`
 - Normal file system: which supports rename operations that do not overwrite the target file,Example: `mv -n a.txt b.txt`,`HdfsFileSystem.rename(src,dst)`,`WindowsFs.rename(src,dst)`
 - Atomicity of commit: After the new version of the metadata has been renamed successfully, any exceptions will be ignored. Any exceptions thrown before the metadata has been renamed will be treated as a commit failure. If the rename of the new version of the metadata fails, we will throw a `CommitStateUnknown` exception and stop everything. The operation of VersionHintFile will be disregarded.
 - ~~Global locking service: All clients operating on the iceberg table must acquire the same lock. Successful acquisitions are required before subsequent commits can be performed. Example: `Distributed locking based on zk/redis/database`, `constrains all operations to the same in-memory lock`.~~  If we don't consider using lockManager, then there's no point in considering it.
## 4.Flow chart:
```mermaid
graph TB
    START[commit-start] -->TRY-LOCK{try-get-lock ~~maybe we should remove this step~~}
    TRY-LOCK --> |fail| COMMIT-FAIL[commit-fail]
    TRY-LOCK --> |success| CHECK-EXISTS{check-metadata-file-exists}
    CHECK-EXISTS -->|already-exists| COMMIT-FAIL
    CHECK-EXISTS -->|not-exists| GLOBAL-LOCK{useGlobalLockingService? ~~maybe we should remove this step~~}
    GLOBAL-LOCK -->|yes| FIND-LATEST-VERSION(findLatestVersion)
    GLOBAL-LOCK -->|no| FIND-LATEST-VERSION-NO-HINT(findLatestVersionWithOutVersionHint)
    FIND-LATEST-VERSION-NO-HINT --> CHECK-COMMIT-VERSION{checkCurrentVersionIsLatest}
    FIND-LATEST-VERSION --> CHECK-COMMIT-VERSION
    CHECK-COMMIT-VERSION --> |no| COMMIT-FAIL(commit-fail)
    CHECK-COMMIT-VERSION --> |yes| DO-COMMIT{do-commit}
    FAST-FAIL --> COMMIT-STATE-UNKNOWN(commit-state-unknow)
    DO-COMMIT --> |not-success| COMMIT-FAIL(commit-fail)
    DO-COMMIT --> |server-side-exception| TRY-CHECK-COMMIT(try-check)
    DO-COMMIT --> |commit-success| NEED-CLEAN-DIRTY{useGlobalLockingService? ~~maybe we should remove this step~~}
    DO-COMMIT --> |client-side-exception| COMMIT-STATE-UNKNOWN
    TRY-CHECK-COMMIT --> |check-success-and-commit-fail| COMMIT-FAIL
    TRY-CHECK-COMMIT --> |check-success-and-commit-success| COMMIT-SUCCESS
    TRY-CHECK-COMMIT --> |exception| COMMIT-STATE-UNKNOWN
    NEED-CLEAN-DIRTY --> |no| CHECK-DIRTY-COMMIT{this-commit-is-a-dirty-commit?}
    CHECK-DIRTY-COMMIT --> |no| CLEAN-DIRTY(clean-old-dirty-commit)
    CHECK-DIRTY-COMMIT --> |yes| FAST-FAIL(fast-fail)
    CLEAN-DIRTY  --> COMMIT-SUCCESS
    NEED-CLEAN-DIRTY --> |yes| COMMIT-SUCCESS
    COMMIT-SUCCESS --> UNLOCK(UNLOCK ~~maybe we should remove this step~~)
    COMMIT-STATE-UNKNOWN --> UNLOCK
    COMMIT-FAIL --> UNLOCK
    UNLOCK --> END(END)
```



