### PR TITLE
Support create multiple element ns together for nessie

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.nessie;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -290,6 +291,14 @@ public class NessieCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public void createNamespace(Namespace namespace, Map<String, String> metadata) {
+    if (namespace.levels().length > 1) {
+      for (int i = 0; i < namespace.levels().length - 1; i++) {
+        Namespace parents = Namespace.of(Arrays.copyOf(namespace.levels(), i + 1));
+        if (!namespaceExists(parents)) {
+          client.createNamespace(parents, ImmutableMap.of());
+        }
+      }
+    }
     client.createNamespace(namespace, metadata);
   }
 

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.nessie;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -291,14 +290,6 @@ public class NessieCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public void createNamespace(Namespace namespace, Map<String, String> metadata) {
-    if (namespace.levels().length > 1) {
-      for (int i = 0; i < namespace.levels().length - 1; i++) {
-        Namespace parents = Namespace.of(Arrays.copyOf(namespace.levels(), i + 1));
-        if (!namespaceExists(parents)) {
-          client.createNamespace(parents, ImmutableMap.of());
-        }
-      }
-    }
     client.createNamespace(namespace, metadata);
   }
 

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -236,7 +236,8 @@ public class NessieIcebergClient implements AutoCloseable {
         Namespace parent = Namespace.of(Arrays.copyOf(namespace.levels(), i + 1));
         ContentKey parentKey = ContentKey.of(parent.levels());
         keys.add(parentKey);
-        Content parentContent = api.getContent().reference(getReference()).key(parentKey).get().get(parentKey);
+        Content parentContent =
+            api.getContent().reference(getReference()).key(parentKey).get().get(parentKey);
         contentInfo.put(parentKey, parentContent);
       }
 

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -18,11 +18,9 @@
  */
 package org.apache.iceberg.nessie;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -46,6 +44,7 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.relocated.com.google.common.base.Suppliers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.view.ViewMetadata;
@@ -231,17 +230,17 @@ public class NessieIcebergClient implements AutoCloseable {
       }
 
       // check if the parent namespace exists
-      List<ContentKey> keys = new ArrayList<>(namespace.levels().length);
-      Map<ContentKey, Content> contentInfo = new HashMap<>();
+      List<ContentKey> keys = Lists.newArrayList();
+      Map<ContentKey, Content> contentInfo = Maps.newHashMap();
       for (int i = 0; i < namespace.levels().length - 1; i++) {
         Namespace parent = Namespace.of(Arrays.copyOf(namespace.levels(), i + 1));
         ContentKey parentKey = ContentKey.of(parent.levels());
         keys.add(parentKey);
-        Content c = api.getContent().reference(getReference()).key(parentKey).get().get(parentKey);
-        contentInfo.put(parentKey, c);
+        Content parentContent = api.getContent().reference(getReference()).key(parentKey).get().get(parentKey);
+        contentInfo.put(parentKey, parentContent);
       }
 
-      ArrayList<Operation.Put> putOperations = new ArrayList<>(keys.size());
+      List<Operation.Put> putOperations = Lists.newArrayList();
       for (Map.Entry<ContentKey, Content> contentKeyContentEntry : contentInfo.entrySet()) {
         if (contentKeyContentEntry.getValue() == null) {
           org.projectnessie.model.Namespace parentContent =

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -241,7 +241,6 @@ public class NessieIcebergClient implements AutoCloseable {
         contentInfo.put(parentKey, c);
       }
 
-
       ArrayList<Operation.Put> putOperations = new ArrayList<>(keys.size());
       for (Map.Entry<ContentKey, Content> contentKeyContentEntry : contentInfo.entrySet()) {
         if (contentKeyContentEntry.getValue() == null) {

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestMultipleClients.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestMultipleClients.java
@@ -72,6 +72,18 @@ public class TestMultipleClients extends BaseTestIceberg {
   }
 
   @Test
+  public void testCreateNamespacesWithLevels() {
+    catalog.createNamespace(Namespace.of("l1", "l2", "l3", "l4"));
+    assertThat(catalog.listNamespaces()).containsExactlyInAnyOrder(Namespace.of("l1"));
+    assertThat(catalog.listNamespaces(Namespace.of("l1")))
+        .containsExactlyInAnyOrder(Namespace.of("l1", "l2"));
+    assertThat(catalog.listNamespaces(Namespace.of("l1", "l2")))
+        .containsExactlyInAnyOrder(Namespace.of("l1", "l2", "l3"));
+    assertThat(catalog.listNamespaces(Namespace.of("l1", "l2", "l3")))
+        .containsExactlyInAnyOrder(Namespace.of("l1", "l2", "l3", "l4"));
+  }
+
+  @Test
   public void testListNamespaces() throws NessieConflictException, NessieNotFoundException {
     assertThat(catalog.listNamespaces()).isEmpty();
     assertThat(anotherCatalog.listNamespaces()).isEmpty();

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
@@ -140,6 +140,25 @@ public class TestNessieIcebergClient extends BaseTestIceberg {
   }
 
   @Test
+  public void testCreateNamespaceWithMultipleLevels() throws NessieConflictException, NessieNotFoundException {
+    String branch = "createNamespaceWithMultipleLevelsBranch";
+    createBranch(branch);
+    Map<String, String> catalogOptions =
+            Map.of(
+                    CatalogProperties.USER, "iceberg-user",
+                    CatalogProperties.APP_ID, "iceberg-nessie");
+    NessieIcebergClient client = new NessieIcebergClient(api, branch, null, catalogOptions);
+
+    client.createNamespace(Namespace.of("a", "b", "c"), Map.of());
+    assertThat(client.listNamespaces(Namespace.of("a"))).isNotNull();
+    assertThat(client.listNamespaces(Namespace.of("a", "b"))).isNotNull();
+    assertThat(client.listNamespaces(Namespace.of("a", "b", "c"))).isNotNull();
+
+    client.createNamespace(Namespace.of("a", "b", "d"), Map.of());
+    assertThat(client.listNamespaces(Namespace.of("a", "b", "d"))).isNotNull();
+  }
+
+  @Test
   public void testCreateNamespaceInvalid() throws NessieConflictException, NessieNotFoundException {
     String branch = "createNamespaceInvalidBranch";
     createBranch(branch);

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
@@ -140,13 +140,14 @@ public class TestNessieIcebergClient extends BaseTestIceberg {
   }
 
   @Test
-  public void testCreateNamespaceWithMultipleLevels() throws NessieConflictException, NessieNotFoundException {
+  public void testCreateNamespaceWithMultipleLevels()
+      throws NessieConflictException, NessieNotFoundException {
     String branch = "createNamespaceWithMultipleLevelsBranch";
     createBranch(branch);
     Map<String, String> catalogOptions =
-            Map.of(
-                    CatalogProperties.USER, "iceberg-user",
-                    CatalogProperties.APP_ID, "iceberg-nessie");
+        Map.of(
+            CatalogProperties.USER, "iceberg-user",
+            CatalogProperties.APP_ID, "iceberg-nessie");
     NessieIcebergClient client = new NessieIcebergClient(api, branch, null, catalogOptions);
 
     client.createNamespace(Namespace.of("a", "b", "c"), Map.of());

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
@@ -132,7 +132,7 @@ public class TestNessieIcebergClient extends BaseTestIceberg {
         .extracting(LogResponse.LogEntry::getCommitMeta)
         .extracting(CommitMeta::getMessage, CommitMeta::getAuthor, CommitMeta::getProperties)
         .containsExactly(
-            "create namespace a",
+            "create namespace [a]",
             "iceberg-user",
             ImmutableMap.of(
                 "application-type", "iceberg",
@@ -168,10 +168,6 @@ public class TestNessieIcebergClient extends BaseTestIceberg {
     assertThatThrownBy(() -> client.createNamespace(Namespace.empty(), Map.of()))
         .isInstanceOf(NoSuchNamespaceException.class)
         .hasMessageContaining("Invalid namespace: ");
-
-    assertThatThrownBy(() -> client.createNamespace(Namespace.of("a", "b"), Map.of()))
-        .isInstanceOf(NoSuchNamespaceException.class)
-        .hasMessageContaining("Cannot create namespace 'a.b': parent namespace 'a' does not exist");
   }
 
   @Test


### PR DESCRIPTION
---

### Motivation
Create multiple level namespace together when creating namespace. For more time, the namespace level is one. But sometimes when we have multiple levels to construct the namespace, the Nessie will throw the parent namespace is not found.
For other catalogs, they may merge the multiple levels to one level so they don’t have such an issue.

We use pulsar build on the iceberg, so map the pulsar tenant/namespace to the namespace name. There are two levels then failed to create the table.