### PR TITLE
Migrate source package in Flink

### DIFF
--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/assigner/SplitAssignerTestBase.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/assigner/SplitAssignerTestBase.java
@@ -113,7 +113,7 @@ public abstract class SplitAssignerTestBase {
         assertThat(result.split()).isNull();
         break;
       default:
-        fail(String.format("Unknown status: %s", expectedStatus));
+        fail("Unknown status: %s", expectedStatus);
     }
   }
 

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestDefaultSplitAssigner.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestDefaultSplitAssigner.java
@@ -19,7 +19,7 @@
 package org.apache.iceberg.flink.source.assigner;
 
 import org.apache.iceberg.flink.source.SplitHelpers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestDefaultSplitAssigner extends SplitAssignerTestBase {
   @Override
@@ -32,7 +32,7 @@ public class TestDefaultSplitAssigner extends SplitAssignerTestBase {
   public void testMultipleFilesInASplit() throws Exception {
     SplitAssigner assigner = splitAssigner();
     assigner.onDiscoveredSplits(
-        SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 4, 2));
+        SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 4, 2));
 
     assertGetNext(assigner, GetSplitResult.Status.AVAILABLE);
     assertSnapshot(assigner, 1);

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.source.assigner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
@@ -26,8 +27,7 @@ import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.flink.source.split.SerializableComparator;
 import org.apache.iceberg.flink.source.split.SplitComparators;
 import org.apache.iceberg.util.SerializationUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestFileSequenceNumberBasedSplitAssigner extends SplitAssignerTestBase {
   @Override
@@ -70,12 +70,12 @@ public class TestFileSequenceNumberBasedSplitAssigner extends SplitAssignerTestB
     byte[] bytes = SerializationUtil.serializeToBytes(SplitComparators.fileSequenceNumber());
     SerializableComparator<IcebergSourceSplit> comparator =
         SerializationUtil.deserializeFromBytes(bytes);
-    Assert.assertNotNull(comparator);
+    assertThat(comparator).isNotNull();
   }
 
   private void assertGetNext(SplitAssigner assigner, Long expectedSequenceNumber) {
     GetSplitResult result = assigner.getNext(null);
     ContentFile file = result.split().task().files().iterator().next().file();
-    Assert.assertEquals(expectedSequenceNumber, file.fileSequenceNumber());
+    assertThat(file.fileSequenceNumber()).isEqualTo(expectedSequenceNumber);
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestWatermarkBasedSplitAssigner.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestWatermarkBasedSplitAssigner.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.source.assigner;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -44,8 +45,7 @@ import org.apache.iceberg.flink.source.split.SplitComparators;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SerializationUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestWatermarkBasedSplitAssigner extends SplitAssignerTestBase {
   public static final Schema SCHEMA =
@@ -104,12 +104,12 @@ public class TestWatermarkBasedSplitAssigner extends SplitAssignerTestBase {
                     TestFixtures.SCHEMA, "id", TimeUnit.MILLISECONDS)));
     SerializableComparator<IcebergSourceSplit> comparator =
         SerializationUtil.deserializeFromBytes(bytes);
-    Assert.assertNotNull(comparator);
+    assertThat(comparator).isNotNull();
   }
 
   private void assertGetNext(SplitAssigner assigner, IcebergSourceSplit split) {
     GetSplitResult result = assigner.getNext(null);
-    Assert.assertEquals(result.split(), split);
+    assertThat(split).isEqualTo(result.split());
   }
 
   @Override
@@ -138,7 +138,7 @@ public class TestWatermarkBasedSplitAssigner extends SplitAssignerTestBase {
     try {
       return IcebergSourceSplit.fromCombinedScanTask(
           ReaderUtil.createCombinedScanTask(
-              records, TEMPORARY_FOLDER, FileFormat.PARQUET, APPENDER_FACTORY));
+              records, temporaryFolder, FileFormat.PARQUET, APPENDER_FACTORY));
     } catch (IOException e) {
       throw new RuntimeException("Split creation exception", e);
     }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.source.enumerator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -36,13 +37,11 @@ import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitStatus;
 import org.apache.iceberg.flink.source.split.SplitRequestEvent;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestContinuousIcebergEnumerator {
-  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+  @TempDir protected Path temporaryFolder;
 
   @Test
   public void testDiscoverSplitWhenNoReaderRegistered() throws Exception {
@@ -59,19 +58,19 @@ public class TestContinuousIcebergEnumerator {
 
     Collection<IcebergSourceSplitState> pendingSplitsEmpty =
         enumerator.snapshotState(1).pendingSplits();
-    Assert.assertEquals(0, pendingSplitsEmpty.size());
+    assertThat(pendingSplitsEmpty).isEmpty();
 
     // make one split available and trigger the periodic discovery
     List<IcebergSourceSplit> splits =
-        SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 1, 1);
+        SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 1, 1);
     splitPlanner.addSplits(splits);
     enumeratorContext.triggerAllActions();
 
     Collection<IcebergSourceSplitState> pendingSplits = enumerator.snapshotState(2).pendingSplits();
-    Assert.assertEquals(1, pendingSplits.size());
+    assertThat(pendingSplits).hasSize(1);
     IcebergSourceSplitState pendingSplit = pendingSplits.iterator().next();
-    Assert.assertEquals(splits.get(0).splitId(), pendingSplit.split().splitId());
-    Assert.assertEquals(IcebergSourceSplitStatus.UNASSIGNED, pendingSplit.status());
+    assertThat(pendingSplit.split().splitId()).isEqualTo(splits.get(0).splitId());
+    assertThat(pendingSplit.status()).isEqualTo(IcebergSourceSplitStatus.UNASSIGNED);
   }
 
   @Test
@@ -94,11 +93,11 @@ public class TestContinuousIcebergEnumerator {
 
     // make one split available and trigger the periodic discovery
     List<IcebergSourceSplit> splits =
-        SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 1, 1);
+        SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 1, 1);
     splitPlanner.addSplits(splits);
     enumeratorContext.triggerAllActions();
 
-    Assert.assertTrue(enumerator.snapshotState(1).pendingSplits().isEmpty());
+    assertThat(enumerator.snapshotState(1).pendingSplits()).isEmpty();
     assertThat(enumeratorContext.getSplitAssignments().get(2).getAssignedSplits())
         .contains(splits.get(0));
   }
@@ -126,26 +125,26 @@ public class TestContinuousIcebergEnumerator {
 
     // make one split available and trigger the periodic discovery
     List<IcebergSourceSplit> splits =
-        SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 1, 1);
-    Assert.assertEquals(1, splits.size());
+        SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 1, 1);
+    assertThat(splits).hasSize(1);
     splitPlanner.addSplits(splits);
     enumeratorContext.triggerAllActions();
 
-    Assert.assertFalse(enumeratorContext.getSplitAssignments().containsKey(2));
+    assertThat(enumeratorContext.getSplitAssignments()).doesNotContainKey(2);
     List<String> pendingSplitIds =
         enumerator.snapshotState(1).pendingSplits().stream()
             .map(IcebergSourceSplitState::split)
             .map(IcebergSourceSplit::splitId)
             .collect(Collectors.toList());
-    Assert.assertEquals(splits.size(), pendingSplitIds.size());
-    Assert.assertEquals(splits.get(0).splitId(), pendingSplitIds.get(0));
+    assertThat(pendingSplitIds).hasSameSizeAs(splits);
+    assertThat(pendingSplitIds).first().isEqualTo(splits.get(0).splitId());
 
     // register the reader again, and let it request a split
     enumeratorContext.registerReader(2, "localhost");
     enumerator.addReader(2);
     enumerator.handleSourceEvent(2, new SplitRequestEvent());
 
-    Assert.assertTrue(enumerator.snapshotState(2).pendingSplits().isEmpty());
+    assertThat(enumerator.snapshotState(2).pendingSplits()).isEmpty();
     assertThat(enumeratorContext.getSplitAssignments().get(2).getAssignedSplits())
         .contains(splits.get(0));
   }
@@ -154,7 +153,7 @@ public class TestContinuousIcebergEnumerator {
   public void testThrottlingDiscovery() throws Exception {
     // create 10 splits
     List<IcebergSourceSplit> splits =
-        SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 10, 1);
+        SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 10, 1);
 
     TestingSplitEnumeratorContext<IcebergSourceSplit> enumeratorContext =
         new TestingSplitEnumeratorContext<>(4);
@@ -179,10 +178,10 @@ public class TestContinuousIcebergEnumerator {
     enumeratorContext.triggerAllActions();
 
     // because discovered split was assigned to reader, pending splits should be empty
-    Assert.assertEquals(0, enumerator.snapshotState(1).pendingSplits().size());
+    assertThat(enumerator.snapshotState(1).pendingSplits()).isEmpty();
     // split assignment to reader-2 should contain splits[0, 1)
-    Assert.assertEquals(
-        splits.subList(0, 1), enumeratorContext.getSplitAssignments().get(2).getAssignedSplits());
+    assertThat(enumeratorContext.getSplitAssignments().get(2).getAssignedSplits())
+        .containsExactlyElementsOf(splits.subList(0, 1));
 
     // add the remaining 9 splits (one for every snapshot)
     // run discovery cycles while reader-2 still processing the splits[0]
@@ -192,20 +191,20 @@ public class TestContinuousIcebergEnumerator {
     }
 
     // can only discover up to 3 snapshots/splits
-    Assert.assertEquals(3, enumerator.snapshotState(2).pendingSplits().size());
+    assertThat(enumerator.snapshotState(2).pendingSplits()).hasSize(3);
     // split assignment to reader-2 should be splits[0, 1)
-    Assert.assertEquals(
-        splits.subList(0, 1), enumeratorContext.getSplitAssignments().get(2).getAssignedSplits());
+    assertThat(enumeratorContext.getSplitAssignments().get(2).getAssignedSplits())
+        .containsExactlyElementsOf(splits.subList(0, 1));
 
     // now reader-2 finished splits[0]
     enumerator.handleSourceEvent(2, new SplitRequestEvent(Arrays.asList(splits.get(0).splitId())));
     enumeratorContext.triggerAllActions();
     // still have 3 pending splits. After assigned splits[1] to reader-2, one more split was
     // discovered and added.
-    Assert.assertEquals(3, enumerator.snapshotState(3).pendingSplits().size());
+    assertThat(enumerator.snapshotState(3).pendingSplits()).hasSize(3);
     // split assignment to reader-2 should be splits[0, 2)
-    Assert.assertEquals(
-        splits.subList(0, 2), enumeratorContext.getSplitAssignments().get(2).getAssignedSplits());
+    assertThat(enumeratorContext.getSplitAssignments().get(2).getAssignedSplits())
+        .containsExactlyElementsOf(splits.subList(0, 2));
 
     // run 3 more split discovery cycles
     for (int i = 0; i < 3; ++i) {
@@ -213,20 +212,20 @@ public class TestContinuousIcebergEnumerator {
     }
 
     // no more splits are discovered due to throttling
-    Assert.assertEquals(3, enumerator.snapshotState(4).pendingSplits().size());
+    assertThat(enumerator.snapshotState(4).pendingSplits()).hasSize(3);
     // split assignment to reader-2 should still be splits[0, 2)
-    Assert.assertEquals(
-        splits.subList(0, 2), enumeratorContext.getSplitAssignments().get(2).getAssignedSplits());
+    assertThat(enumeratorContext.getSplitAssignments().get(2).getAssignedSplits())
+        .containsExactlyElementsOf(splits.subList(0, 2));
 
     // now reader-2 finished splits[1]
     enumerator.handleSourceEvent(2, new SplitRequestEvent(Arrays.asList(splits.get(1).splitId())));
     enumeratorContext.triggerAllActions();
     // still have 3 pending splits. After assigned new splits[2] to reader-2, one more split was
     // discovered and added.
-    Assert.assertEquals(3, enumerator.snapshotState(5).pendingSplits().size());
+    assertThat(enumerator.snapshotState(5).pendingSplits()).hasSize(3);
     // split assignment to reader-2 should be splits[0, 3)
-    Assert.assertEquals(
-        splits.subList(0, 3), enumeratorContext.getSplitAssignments().get(2).getAssignedSplits());
+    assertThat(enumeratorContext.getSplitAssignments().get(2).getAssignedSplits())
+        .containsExactlyElementsOf(splits.subList(0, 3));
   }
 
   @Test
@@ -246,20 +245,20 @@ public class TestContinuousIcebergEnumerator {
 
     // Make one split available and trigger the periodic discovery
     List<IcebergSourceSplit> splits =
-        SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 1, 1);
+        SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 1, 1);
     splitPlanner.addSplits(splits);
 
     // Trigger a planning and check that no splits returned due to the planning error
     enumeratorContext.triggerAllActions();
-    Assert.assertEquals(0, enumerator.snapshotState(2).pendingSplits().size());
+    assertThat(enumerator.snapshotState(2).pendingSplits()).isEmpty();
 
     // Second scan planning should succeed and discover the expected splits
     enumeratorContext.triggerAllActions();
     Collection<IcebergSourceSplitState> pendingSplits = enumerator.snapshotState(3).pendingSplits();
-    Assert.assertEquals(1, pendingSplits.size());
+    assertThat(pendingSplits).hasSize(1);
     IcebergSourceSplitState pendingSplit = pendingSplits.iterator().next();
-    Assert.assertEquals(splits.get(0).splitId(), pendingSplit.split().splitId());
-    Assert.assertEquals(IcebergSourceSplitStatus.UNASSIGNED, pendingSplit.status());
+    assertThat(pendingSplit.split().splitId()).isEqualTo(splits.get(0).splitId());
+    assertThat(pendingSplit.status()).isEqualTo(IcebergSourceSplitStatus.UNASSIGNED);
   }
 
   @Test
@@ -278,19 +277,19 @@ public class TestContinuousIcebergEnumerator {
 
     // Make one split available and trigger the periodic discovery
     List<IcebergSourceSplit> splits =
-        SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 1, 1);
+        SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 1, 1);
     splitPlanner.addSplits(splits);
 
     // Check that the scheduler response ignores the current error and continues to run until the
     // failure limit is reached
     enumeratorContext.triggerAllActions();
-    Assert.assertFalse(
-        enumeratorContext.getExecutorService().getAllScheduledTasks().get(0).isDone());
+    assertThat(enumeratorContext.getExecutorService().getAllScheduledTasks().get(0).isDone())
+        .isFalse();
 
     // Check that the task has failed with the expected exception after the failure limit is reached
     enumeratorContext.triggerAllActions();
-    Assert.assertTrue(
-        enumeratorContext.getExecutorService().getAllScheduledTasks().get(0).isDone());
+    assertThat(enumeratorContext.getExecutorService().getAllScheduledTasks().get(0).isDone())
+        .isTrue();
     assertThatThrownBy(
             () -> enumeratorContext.getExecutorService().getAllScheduledTasks().get(0).get())
         .hasCauseInstanceOf(RuntimeException.class)
@@ -316,7 +315,7 @@ public class TestContinuousIcebergEnumerator {
 
     // Make one split available and trigger the periodic discovery
     List<IcebergSourceSplit> splits =
-        SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 1, 1);
+        SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 1, 1);
     splitPlanner.addSplits(splits);
 
     Collection<IcebergSourceSplitState> pendingSplits;
@@ -324,16 +323,16 @@ public class TestContinuousIcebergEnumerator {
     for (int i = 0; i < expectedFailures; ++i) {
       enumeratorContext.triggerAllActions();
       pendingSplits = enumerator.snapshotState(i).pendingSplits();
-      Assert.assertEquals(0, pendingSplits.size());
+      assertThat(pendingSplits).isEmpty();
     }
 
     // Discovered the new split after a successful scan planning
     enumeratorContext.triggerAllActions();
     pendingSplits = enumerator.snapshotState(expectedFailures + 1).pendingSplits();
-    Assert.assertEquals(1, pendingSplits.size());
+    assertThat(pendingSplits).hasSize(1);
     IcebergSourceSplitState pendingSplit = pendingSplits.iterator().next();
-    Assert.assertEquals(splits.get(0).splitId(), pendingSplit.split().splitId());
-    Assert.assertEquals(IcebergSourceSplitStatus.UNASSIGNED, pendingSplit.status());
+    assertThat(pendingSplit.split().splitId()).isEqualTo(splits.get(0).splitId());
+    assertThat(pendingSplit.status()).isEqualTo(IcebergSourceSplitStatus.UNASSIGNED);
   }
 
   private static ContinuousIcebergEnumerator createEnumerator(

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -18,9 +18,11 @@
  */
 package org.apache.iceberg.flink.source.enumerator;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -31,33 +33,27 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.flink.HadoopTableResource;
+import org.apache.iceberg.flink.HadoopTableExtension;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestContinuousSplitPlannerImpl {
-  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+  @TempDir protected Path temporaryFolder;
 
   private static final FileFormat fileFormat = FileFormat.PARQUET;
   private static final AtomicLong randomSeed = new AtomicLong();
 
-  @Rule
-  public final HadoopTableResource tableResource =
-      new HadoopTableResource(
-          TEMPORARY_FOLDER, TestFixtures.DATABASE, TestFixtures.TABLE, TestFixtures.SCHEMA);
-
-  @Rule public TestName testName = new TestName();
+  @RegisterExtension
+  private static final HadoopTableExtension tableResource =
+      new HadoopTableExtension(TestFixtures.DATABASE, TestFixtures.TABLE, TestFixtures.SCHEMA);
 
   private GenericAppenderHelper dataAppender;
   private DataFile dataFile1;
@@ -65,9 +61,9 @@ public class TestContinuousSplitPlannerImpl {
   private DataFile dataFile2;
   private Snapshot snapshot2;
 
-  @Before
+  @BeforeEach
   public void before() throws IOException {
-    dataAppender = new GenericAppenderHelper(tableResource.table(), fileFormat, TEMPORARY_FOLDER);
+    dataAppender = new GenericAppenderHelper(tableResource.table(), fileFormat, temporaryFolder);
   }
 
   private void appendTwoSnapshots() throws IOException {
@@ -95,18 +91,19 @@ public class TestContinuousSplitPlannerImpl {
     Snapshot snapshot = tableResource.table().currentSnapshot();
 
     ContinuousEnumerationResult result = splitPlanner.planSplits(lastPosition);
-    Assert.assertEquals(lastPosition.snapshotId(), result.fromPosition().snapshotId());
-    Assert.assertEquals(
-        lastPosition.snapshotTimestampMs(), result.fromPosition().snapshotTimestampMs());
-    Assert.assertEquals(snapshot.snapshotId(), result.toPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        snapshot.timestampMillis(), result.toPosition().snapshotTimestampMs().longValue());
-    Assert.assertEquals(1, result.splits().size());
+    assertThat(result.fromPosition().snapshotId()).isEqualTo(lastPosition.snapshotId());
+    assertThat(result.fromPosition().snapshotTimestampMs())
+        .isEqualTo(lastPosition.snapshotTimestampMs());
+    assertThat(result.toPosition().snapshotId().longValue()).isEqualTo(snapshot.snapshotId());
+    assertThat(result.toPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(snapshot.timestampMillis());
+    assertThat(result.splits()).hasSize(1);
     IcebergSourceSplit split = Iterables.getOnlyElement(result.splits());
-    Assert.assertEquals(1, split.task().files().size());
-    Assert.assertEquals(
-        dataFile.path().toString(),
-        Iterables.getOnlyElement(split.task().files()).file().path().toString());
+    assertThat(split.task().files())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            fileScanTask -> assertThat(fileScanTask.file().path()).isEqualTo(dataFile.path()));
     return new CycleResult(result.toPosition(), split);
   }
 
@@ -120,18 +117,18 @@ public class TestContinuousSplitPlannerImpl {
         new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult emptyTableInitialDiscoveryResult = splitPlanner.planSplits(null);
-    Assert.assertTrue(emptyTableInitialDiscoveryResult.splits().isEmpty());
-    Assert.assertNull(emptyTableInitialDiscoveryResult.fromPosition());
-    Assert.assertTrue(emptyTableInitialDiscoveryResult.toPosition().isEmpty());
-    Assert.assertNull(emptyTableInitialDiscoveryResult.toPosition().snapshotTimestampMs());
+    assertThat(emptyTableInitialDiscoveryResult.splits()).isEmpty();
+    assertThat(emptyTableInitialDiscoveryResult.fromPosition()).isNull();
+    assertThat(emptyTableInitialDiscoveryResult.toPosition().isEmpty()).isTrue();
+    assertThat(emptyTableInitialDiscoveryResult.toPosition().snapshotTimestampMs()).isNull();
 
     ContinuousEnumerationResult emptyTableSecondDiscoveryResult =
         splitPlanner.planSplits(emptyTableInitialDiscoveryResult.toPosition());
-    Assert.assertTrue(emptyTableSecondDiscoveryResult.splits().isEmpty());
-    Assert.assertTrue(emptyTableSecondDiscoveryResult.fromPosition().isEmpty());
-    Assert.assertNull(emptyTableSecondDiscoveryResult.fromPosition().snapshotTimestampMs());
-    Assert.assertTrue(emptyTableSecondDiscoveryResult.toPosition().isEmpty());
-    Assert.assertNull(emptyTableSecondDiscoveryResult.toPosition().snapshotTimestampMs());
+    assertThat(emptyTableSecondDiscoveryResult.splits()).isEmpty();
+    assertThat(emptyTableSecondDiscoveryResult.fromPosition().isEmpty()).isTrue();
+    assertThat(emptyTableSecondDiscoveryResult.fromPosition().snapshotTimestampMs()).isNull();
+    assertThat(emptyTableSecondDiscoveryResult.toPosition().isEmpty()).isTrue();
+    assertThat(emptyTableSecondDiscoveryResult.toPosition().snapshotTimestampMs()).isNull();
 
     // next 3 snapshots
     IcebergEnumeratorPosition lastPosition = emptyTableSecondDiscoveryResult.toPosition();
@@ -152,21 +149,21 @@ public class TestContinuousSplitPlannerImpl {
         new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
-    Assert.assertNull(initialResult.fromPosition());
-    Assert.assertEquals(
-        snapshot2.snapshotId(), initialResult.toPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        snapshot2.timestampMillis(), initialResult.toPosition().snapshotTimestampMs().longValue());
-    Assert.assertEquals(1, initialResult.splits().size());
+    assertThat(initialResult.fromPosition()).isNull();
+    assertThat(initialResult.toPosition().snapshotId().longValue())
+        .isEqualTo(snapshot2.snapshotId());
+    assertThat(initialResult.toPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(snapshot2.timestampMillis());
+    assertThat(initialResult.splits()).hasSize(1);
     IcebergSourceSplit split = Iterables.getOnlyElement(initialResult.splits());
-    Assert.assertEquals(2, split.task().files().size());
+    assertThat(split.task().files()).hasSize(2);
     Set<String> discoveredFiles =
         split.task().files().stream()
             .map(fileScanTask -> fileScanTask.file().path().toString())
             .collect(Collectors.toSet());
     Set<String> expectedFiles =
         ImmutableSet.of(dataFile1.path().toString(), dataFile2.path().toString());
-    Assert.assertEquals(expectedFiles, discoveredFiles);
+    assertThat(discoveredFiles).containsExactlyInAnyOrderElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = initialResult.toPosition();
     for (int i = 0; i < 3; ++i) {
@@ -185,24 +182,24 @@ public class TestContinuousSplitPlannerImpl {
         new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult emptyTableInitialDiscoveryResult = splitPlanner.planSplits(null);
-    Assert.assertTrue(emptyTableInitialDiscoveryResult.splits().isEmpty());
-    Assert.assertNull(emptyTableInitialDiscoveryResult.fromPosition());
-    Assert.assertTrue(emptyTableInitialDiscoveryResult.toPosition().isEmpty());
-    Assert.assertNull(emptyTableInitialDiscoveryResult.toPosition().snapshotTimestampMs());
+    assertThat(emptyTableInitialDiscoveryResult.splits()).isEmpty();
+    assertThat(emptyTableInitialDiscoveryResult.fromPosition()).isNull();
+    assertThat(emptyTableInitialDiscoveryResult.toPosition().isEmpty()).isTrue();
+    assertThat(emptyTableInitialDiscoveryResult.toPosition().snapshotTimestampMs()).isNull();
 
     ContinuousEnumerationResult emptyTableSecondDiscoveryResult =
         splitPlanner.planSplits(emptyTableInitialDiscoveryResult.toPosition());
-    Assert.assertTrue(emptyTableSecondDiscoveryResult.splits().isEmpty());
-    Assert.assertTrue(emptyTableSecondDiscoveryResult.fromPosition().isEmpty());
-    Assert.assertNull(emptyTableSecondDiscoveryResult.fromPosition().snapshotTimestampMs());
-    Assert.assertTrue(emptyTableSecondDiscoveryResult.toPosition().isEmpty());
-    Assert.assertNull(emptyTableSecondDiscoveryResult.toPosition().snapshotTimestampMs());
+    assertThat(emptyTableSecondDiscoveryResult.splits()).isEmpty();
+    assertThat(emptyTableSecondDiscoveryResult.fromPosition().isEmpty()).isTrue();
+    assertThat(emptyTableSecondDiscoveryResult.fromPosition().snapshotTimestampMs()).isNull();
+    assertThat(emptyTableSecondDiscoveryResult.toPosition().isEmpty()).isTrue();
+    assertThat(emptyTableSecondDiscoveryResult.toPosition().snapshotTimestampMs()).isNull();
 
     // latest mode should discover both snapshots, as latest position is marked by when job starts
     appendTwoSnapshots();
     ContinuousEnumerationResult afterTwoSnapshotsAppended =
         splitPlanner.planSplits(emptyTableSecondDiscoveryResult.toPosition());
-    Assert.assertEquals(2, afterTwoSnapshotsAppended.splits().size());
+    assertThat(afterTwoSnapshotsAppended.splits()).hasSize(2);
 
     // next 3 snapshots
     IcebergEnumeratorPosition lastPosition = afterTwoSnapshotsAppended.toPosition();
@@ -223,32 +220,33 @@ public class TestContinuousSplitPlannerImpl {
         new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
-    Assert.assertNull(initialResult.fromPosition());
+    assertThat(initialResult.fromPosition()).isNull();
     // For inclusive behavior, the initial result should point to snapshot1
     // Then the next incremental scan shall discover files from latest snapshot2 (inclusive)
-    Assert.assertEquals(
-        snapshot1.snapshotId(), initialResult.toPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        snapshot1.timestampMillis(), initialResult.toPosition().snapshotTimestampMs().longValue());
-    Assert.assertEquals(0, initialResult.splits().size());
+    assertThat(initialResult.toPosition().snapshotId().longValue())
+        .isEqualTo(snapshot1.snapshotId());
+    assertThat(initialResult.toPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(snapshot1.timestampMillis());
+    assertThat(initialResult.splits()).isEmpty();
 
     ContinuousEnumerationResult secondResult = splitPlanner.planSplits(initialResult.toPosition());
-    Assert.assertEquals(
-        snapshot1.snapshotId(), secondResult.fromPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        snapshot1.timestampMillis(), secondResult.fromPosition().snapshotTimestampMs().longValue());
-    Assert.assertEquals(snapshot2.snapshotId(), secondResult.toPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        snapshot2.timestampMillis(), secondResult.toPosition().snapshotTimestampMs().longValue());
+    assertThat(secondResult.fromPosition().snapshotId().longValue())
+        .isEqualTo(snapshot1.snapshotId());
+    assertThat(secondResult.fromPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(snapshot1.timestampMillis());
+    assertThat(secondResult.toPosition().snapshotId().longValue())
+        .isEqualTo(snapshot2.snapshotId());
+    assertThat(secondResult.toPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(snapshot2.timestampMillis());
     IcebergSourceSplit split = Iterables.getOnlyElement(secondResult.splits());
-    Assert.assertEquals(1, split.task().files().size());
+    assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
             .map(fileScanTask -> fileScanTask.file().path().toString())
             .collect(Collectors.toSet());
     // should discover dataFile2 appended in snapshot2
     Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
-    Assert.assertEquals(expectedFiles, discoveredFiles);
+    assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
     for (int i = 0; i < 3; ++i) {
@@ -266,18 +264,18 @@ public class TestContinuousSplitPlannerImpl {
         new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult emptyTableInitialDiscoveryResult = splitPlanner.planSplits(null);
-    Assert.assertTrue(emptyTableInitialDiscoveryResult.splits().isEmpty());
-    Assert.assertNull(emptyTableInitialDiscoveryResult.fromPosition());
-    Assert.assertNull(emptyTableInitialDiscoveryResult.toPosition().snapshotId());
-    Assert.assertNull(emptyTableInitialDiscoveryResult.toPosition().snapshotTimestampMs());
+    assertThat(emptyTableInitialDiscoveryResult.splits()).isEmpty();
+    assertThat(emptyTableInitialDiscoveryResult.fromPosition()).isNull();
+    assertThat(emptyTableInitialDiscoveryResult.toPosition().snapshotId()).isNull();
+    assertThat(emptyTableInitialDiscoveryResult.toPosition().snapshotTimestampMs()).isNull();
 
     ContinuousEnumerationResult emptyTableSecondDiscoveryResult =
         splitPlanner.planSplits(emptyTableInitialDiscoveryResult.toPosition());
-    Assert.assertTrue(emptyTableSecondDiscoveryResult.splits().isEmpty());
-    Assert.assertNull(emptyTableSecondDiscoveryResult.fromPosition().snapshotId());
-    Assert.assertNull(emptyTableSecondDiscoveryResult.fromPosition().snapshotTimestampMs());
-    Assert.assertNull(emptyTableSecondDiscoveryResult.toPosition().snapshotId());
-    Assert.assertNull(emptyTableSecondDiscoveryResult.toPosition().snapshotTimestampMs());
+    assertThat(emptyTableSecondDiscoveryResult.splits()).isEmpty();
+    assertThat(emptyTableSecondDiscoveryResult.fromPosition().snapshotId()).isNull();
+    assertThat(emptyTableSecondDiscoveryResult.fromPosition().snapshotTimestampMs()).isNull();
+    assertThat(emptyTableSecondDiscoveryResult.toPosition().snapshotId()).isNull();
+    assertThat(emptyTableSecondDiscoveryResult.toPosition().snapshotTimestampMs()).isNull();
 
     // next 3 snapshots
     IcebergEnumeratorPosition lastPosition = emptyTableSecondDiscoveryResult.toPosition();
@@ -298,21 +296,22 @@ public class TestContinuousSplitPlannerImpl {
         new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
-    Assert.assertNull(initialResult.fromPosition());
+    assertThat(initialResult.fromPosition()).isNull();
     // For inclusive behavior, the initial result should point to snapshot1's parent,
     // which leads to null snapshotId and snapshotTimestampMs.
-    Assert.assertNull(initialResult.toPosition().snapshotId());
-    Assert.assertNull(initialResult.toPosition().snapshotTimestampMs());
-    Assert.assertEquals(0, initialResult.splits().size());
+    assertThat(initialResult.toPosition().snapshotId()).isNull();
+    assertThat(initialResult.toPosition().snapshotTimestampMs()).isNull();
+    assertThat(initialResult.splits()).isEmpty();
 
     ContinuousEnumerationResult secondResult = splitPlanner.planSplits(initialResult.toPosition());
-    Assert.assertNull(secondResult.fromPosition().snapshotId());
-    Assert.assertNull(secondResult.fromPosition().snapshotTimestampMs());
-    Assert.assertEquals(snapshot2.snapshotId(), secondResult.toPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        snapshot2.timestampMillis(), secondResult.toPosition().snapshotTimestampMs().longValue());
+    assertThat(secondResult.fromPosition().snapshotId()).isNull();
+    assertThat(secondResult.fromPosition().snapshotTimestampMs()).isNull();
+    assertThat(secondResult.toPosition().snapshotId().longValue())
+        .isEqualTo(snapshot2.snapshotId());
+    assertThat(secondResult.toPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(snapshot2.timestampMillis());
     IcebergSourceSplit split = Iterables.getOnlyElement(secondResult.splits());
-    Assert.assertEquals(2, split.task().files().size());
+    assertThat(split.task().files()).hasSize(2);
     Set<String> discoveredFiles =
         split.task().files().stream()
             .map(fileScanTask -> fileScanTask.file().path().toString())
@@ -320,7 +319,7 @@ public class TestContinuousSplitPlannerImpl {
     // should discover files appended in both snapshot1 and snapshot2
     Set<String> expectedFiles =
         ImmutableSet.of(dataFile1.path().toString(), dataFile2.path().toString());
-    Assert.assertEquals(expectedFiles, discoveredFiles);
+    assertThat(discoveredFiles).containsExactlyInAnyOrderElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
     for (int i = 0; i < 3; ++i) {
@@ -383,32 +382,33 @@ public class TestContinuousSplitPlannerImpl {
         new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
-    Assert.assertNull(initialResult.fromPosition());
+    assertThat(initialResult.fromPosition()).isNull();
     // For inclusive behavior of snapshot2, the initial result should point to snapshot1 (as
     // snapshot2's parent)
-    Assert.assertEquals(
-        snapshot1.snapshotId(), initialResult.toPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        snapshot1.timestampMillis(), initialResult.toPosition().snapshotTimestampMs().longValue());
-    Assert.assertEquals(0, initialResult.splits().size());
+    assertThat(initialResult.toPosition().snapshotId().longValue())
+        .isEqualTo(snapshot1.snapshotId());
+    assertThat(initialResult.toPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(snapshot1.timestampMillis());
+    assertThat(initialResult.splits()).isEmpty();
 
     ContinuousEnumerationResult secondResult = splitPlanner.planSplits(initialResult.toPosition());
-    Assert.assertEquals(
-        snapshot1.snapshotId(), secondResult.fromPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        snapshot1.timestampMillis(), secondResult.fromPosition().snapshotTimestampMs().longValue());
-    Assert.assertEquals(snapshot2.snapshotId(), secondResult.toPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        snapshot2.timestampMillis(), secondResult.toPosition().snapshotTimestampMs().longValue());
+    assertThat(secondResult.fromPosition().snapshotId().longValue())
+        .isEqualTo(snapshot1.snapshotId());
+    assertThat(secondResult.fromPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(snapshot1.timestampMillis());
+    assertThat(secondResult.toPosition().snapshotId().longValue())
+        .isEqualTo(snapshot2.snapshotId());
+    assertThat(secondResult.toPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(snapshot2.timestampMillis());
     IcebergSourceSplit split = Iterables.getOnlyElement(secondResult.splits());
-    Assert.assertEquals(1, split.task().files().size());
+    assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
             .map(fileScanTask -> fileScanTask.file().path().toString())
             .collect(Collectors.toSet());
     // should  discover dataFile2 appended in snapshot2
     Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
-    Assert.assertEquals(expectedFiles, discoveredFiles);
+    assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
     for (int i = 0; i < 3; ++i) {
@@ -466,31 +466,32 @@ public class TestContinuousSplitPlannerImpl {
         new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
-    Assert.assertNull(initialResult.fromPosition());
+    assertThat(initialResult.fromPosition()).isNull();
     // For inclusive behavior, the initial result should point to snapshot1 (as snapshot2's parent).
-    Assert.assertEquals(
-        snapshot1.snapshotId(), initialResult.toPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        snapshot1.timestampMillis(), initialResult.toPosition().snapshotTimestampMs().longValue());
-    Assert.assertEquals(0, initialResult.splits().size());
+    assertThat(initialResult.toPosition().snapshotId().longValue())
+        .isEqualTo(snapshot1.snapshotId());
+    assertThat(initialResult.toPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(snapshot1.timestampMillis());
+    assertThat(initialResult.splits()).isEmpty();
 
     ContinuousEnumerationResult secondResult = splitPlanner.planSplits(initialResult.toPosition());
-    Assert.assertEquals(
-        snapshot1.snapshotId(), secondResult.fromPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        snapshot1.timestampMillis(), secondResult.fromPosition().snapshotTimestampMs().longValue());
-    Assert.assertEquals(snapshot2.snapshotId(), secondResult.toPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        snapshot2.timestampMillis(), secondResult.toPosition().snapshotTimestampMs().longValue());
+    assertThat(secondResult.fromPosition().snapshotId().longValue())
+        .isEqualTo(snapshot1.snapshotId());
+    assertThat(secondResult.fromPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(snapshot1.timestampMillis());
+    assertThat(secondResult.toPosition().snapshotId().longValue())
+        .isEqualTo(snapshot2.snapshotId());
+    assertThat(secondResult.toPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(snapshot2.timestampMillis());
     IcebergSourceSplit split = Iterables.getOnlyElement(secondResult.splits());
-    Assert.assertEquals(1, split.task().files().size());
+    assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
             .map(fileScanTask -> fileScanTask.file().path().toString())
             .collect(Collectors.toSet());
     // should discover dataFile2 appended in snapshot2
     Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
-    Assert.assertEquals(expectedFiles, discoveredFiles);
+    assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
     for (int i = 0; i < 3; ++i) {
@@ -516,12 +517,12 @@ public class TestContinuousSplitPlannerImpl {
         new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
-    Assert.assertNull(initialResult.fromPosition());
+    assertThat(initialResult.fromPosition()).isNull();
     // For inclusive behavior, the initial result should point to snapshot1's parent,
     // which leads to null snapshotId and snapshotTimestampMs.
-    Assert.assertNull(initialResult.toPosition().snapshotId());
-    Assert.assertNull(initialResult.toPosition().snapshotTimestampMs());
-    Assert.assertEquals(0, initialResult.splits().size());
+    assertThat(initialResult.toPosition().snapshotId()).isNull();
+    assertThat(initialResult.toPosition().snapshotTimestampMs()).isNull();
+    assertThat(initialResult.splits()).isEmpty();
 
     ContinuousEnumerationResult secondResult = splitPlanner.planSplits(initialResult.toPosition());
     // should discover dataFile1 appended in snapshot1
@@ -547,9 +548,9 @@ public class TestContinuousSplitPlannerImpl {
         new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
-    Assert.assertEquals(1, initialResult.splits().size());
+    assertThat(initialResult.splits()).hasSize(1);
     IcebergSourceSplit split = Iterables.getOnlyElement(initialResult.splits());
-    Assert.assertEquals(2, split.task().files().size());
+    assertThat(split.task().files()).hasSize(2);
     verifyStatCount(split, 0);
 
     IcebergEnumeratorPosition lastPosition = initialResult.toPosition();
@@ -573,9 +574,9 @@ public class TestContinuousSplitPlannerImpl {
         new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
-    Assert.assertEquals(1, initialResult.splits().size());
+    assertThat(initialResult.splits()).hasSize(1);
     IcebergSourceSplit split = Iterables.getOnlyElement(initialResult.splits());
-    Assert.assertEquals(2, split.task().files().size());
+    assertThat(split.task().files()).hasSize(2);
     verifyStatCount(split, 3);
 
     IcebergEnumeratorPosition lastPosition = initialResult.toPosition();
@@ -599,9 +600,9 @@ public class TestContinuousSplitPlannerImpl {
         new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
-    Assert.assertEquals(1, initialResult.splits().size());
+    assertThat(initialResult.splits()).hasSize(1);
     IcebergSourceSplit split = Iterables.getOnlyElement(initialResult.splits());
-    Assert.assertEquals(2, split.task().files().size());
+    assertThat(split.task().files()).hasSize(2);
     verifyStatCount(split, 1);
 
     IcebergEnumeratorPosition lastPosition = initialResult.toPosition();
@@ -619,12 +620,12 @@ public class TestContinuousSplitPlannerImpl {
           .files()
           .forEach(
               f -> {
-                Assert.assertNull(f.file().valueCounts());
-                Assert.assertNull(f.file().columnSizes());
-                Assert.assertNull(f.file().lowerBounds());
-                Assert.assertNull(f.file().upperBounds());
-                Assert.assertNull(f.file().nanValueCounts());
-                Assert.assertNull(f.file().nullValueCounts());
+                assertThat(f.file().valueCounts()).isNull();
+                assertThat(f.file().columnSizes()).isNull();
+                assertThat(f.file().lowerBounds()).isNull();
+                assertThat(f.file().upperBounds()).isNull();
+                assertThat(f.file().nanValueCounts()).isNull();
+                assertThat(f.file().nullValueCounts()).isNull();
               });
     } else {
       split
@@ -632,13 +633,13 @@ public class TestContinuousSplitPlannerImpl {
           .files()
           .forEach(
               f -> {
-                Assert.assertEquals(expected, f.file().valueCounts().size());
-                Assert.assertEquals(expected, f.file().columnSizes().size());
-                Assert.assertEquals(expected, f.file().lowerBounds().size());
-                Assert.assertEquals(expected, f.file().upperBounds().size());
-                Assert.assertEquals(expected, f.file().nullValueCounts().size());
+                assertThat(f.file().valueCounts()).hasSize(expected);
+                assertThat(f.file().columnSizes()).hasSize(expected);
+                assertThat(f.file().lowerBounds()).hasSize(expected);
+                assertThat(f.file().upperBounds()).hasSize(expected);
+                assertThat(f.file().nullValueCounts()).hasSize(expected);
                 // The nanValue is not counted for long and string fields
-                Assert.assertEquals(0, f.file().nanValueCounts().size());
+                assertThat(f.file().nanValueCounts()).isEmpty();
               });
     }
   }
@@ -649,29 +650,27 @@ public class TestContinuousSplitPlannerImpl {
       Snapshot toSnapshotInclusive,
       Set<String> expectedFiles) {
     if (fromSnapshotExclusive == null) {
-      Assert.assertNull(result.fromPosition().snapshotId());
-      Assert.assertNull(result.fromPosition().snapshotTimestampMs());
+      assertThat(result.fromPosition().snapshotId()).isNull();
+      assertThat(result.fromPosition().snapshotTimestampMs()).isNull();
     } else {
-      Assert.assertEquals(
-          fromSnapshotExclusive.snapshotId(), result.fromPosition().snapshotId().longValue());
-      Assert.assertEquals(
-          fromSnapshotExclusive.timestampMillis(),
-          result.fromPosition().snapshotTimestampMs().longValue());
+      assertThat(result.fromPosition().snapshotId().longValue())
+          .isEqualTo(fromSnapshotExclusive.snapshotId());
+      assertThat(result.fromPosition().snapshotTimestampMs().longValue())
+          .isEqualTo(fromSnapshotExclusive.timestampMillis());
     }
-    Assert.assertEquals(
-        toSnapshotInclusive.snapshotId(), result.toPosition().snapshotId().longValue());
-    Assert.assertEquals(
-        toSnapshotInclusive.timestampMillis(),
-        result.toPosition().snapshotTimestampMs().longValue());
+    assertThat(result.toPosition().snapshotId().longValue())
+        .isEqualTo(toSnapshotInclusive.snapshotId());
+    assertThat(result.toPosition().snapshotTimestampMs().longValue())
+        .isEqualTo(toSnapshotInclusive.timestampMillis());
     // should only have one split with one data file, because split discover is limited to
     // one snapshot and each snapshot has only one data file appended.
     IcebergSourceSplit split = Iterables.getOnlyElement(result.splits());
-    Assert.assertEquals(1, split.task().files().size());
+    assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
             .map(fileScanTask -> fileScanTask.file().path().toString())
             .collect(Collectors.toSet());
-    Assert.assertEquals(expectedFiles, discoveredFiles);
+    assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
   }
 
   private Snapshot appendSnapshot(long seed, int numRecords) throws Exception {

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -52,7 +52,7 @@ public class TestContinuousSplitPlannerImpl {
   private static final AtomicLong randomSeed = new AtomicLong();
 
   @RegisterExtension
-  private static final HadoopTableExtension tableResource =
+  private static final HadoopTableExtension TABLE_RESOURCE =
       new HadoopTableExtension(TestFixtures.DATABASE, TestFixtures.TABLE, TestFixtures.SCHEMA);
 
   private GenericAppenderHelper dataAppender;
@@ -63,7 +63,7 @@ public class TestContinuousSplitPlannerImpl {
 
   @BeforeEach
   public void before() throws IOException {
-    dataAppender = new GenericAppenderHelper(tableResource.table(), fileFormat, temporaryFolder);
+    dataAppender = new GenericAppenderHelper(TABLE_RESOURCE.table(), fileFormat, temporaryFolder);
   }
 
   private void appendTwoSnapshots() throws IOException {
@@ -71,13 +71,13 @@ public class TestContinuousSplitPlannerImpl {
     List<Record> batch1 = RandomGenericData.generate(TestFixtures.SCHEMA, 2, 0L);
     dataFile1 = dataAppender.writeFile(null, batch1);
     dataAppender.appendToTable(dataFile1);
-    snapshot1 = tableResource.table().currentSnapshot();
+    snapshot1 = TABLE_RESOURCE.table().currentSnapshot();
 
     // snapshot2
     List<Record> batch2 = RandomGenericData.generate(TestFixtures.SCHEMA, 2, 1L);
     dataFile2 = dataAppender.writeFile(null, batch2);
     dataAppender.appendToTable(dataFile2);
-    snapshot2 = tableResource.table().currentSnapshot();
+    snapshot2 = TABLE_RESOURCE.table().currentSnapshot();
   }
 
   /** @return the last enumerated snapshot id */
@@ -88,7 +88,7 @@ public class TestContinuousSplitPlannerImpl {
         RandomGenericData.generate(TestFixtures.SCHEMA, 2, randomSeed.incrementAndGet());
     DataFile dataFile = dataAppender.writeFile(null, batch);
     dataAppender.appendToTable(dataFile);
-    Snapshot snapshot = tableResource.table().currentSnapshot();
+    Snapshot snapshot = TABLE_RESOURCE.table().currentSnapshot();
 
     ContinuousEnumerationResult result = splitPlanner.planSplits(lastPosition);
     assertThat(result.fromPosition().snapshotId()).isEqualTo(lastPosition.snapshotId());
@@ -114,7 +114,7 @@ public class TestContinuousSplitPlannerImpl {
             .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
-        new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult emptyTableInitialDiscoveryResult = splitPlanner.planSplits(null);
     assertThat(emptyTableInitialDiscoveryResult.splits()).isEmpty();
@@ -146,7 +146,7 @@ public class TestContinuousSplitPlannerImpl {
             .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
-        new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
     assertThat(initialResult.fromPosition()).isNull();
@@ -179,7 +179,7 @@ public class TestContinuousSplitPlannerImpl {
             .splitSize(1L)
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
-        new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult emptyTableInitialDiscoveryResult = splitPlanner.planSplits(null);
     assertThat(emptyTableInitialDiscoveryResult.splits()).isEmpty();
@@ -217,7 +217,7 @@ public class TestContinuousSplitPlannerImpl {
             .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_LATEST_SNAPSHOT)
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
-        new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
     assertThat(initialResult.fromPosition()).isNull();
@@ -261,7 +261,7 @@ public class TestContinuousSplitPlannerImpl {
             .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_EARLIEST_SNAPSHOT)
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
-        new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult emptyTableInitialDiscoveryResult = splitPlanner.planSplits(null);
     assertThat(emptyTableInitialDiscoveryResult.splits()).isEmpty();
@@ -293,7 +293,7 @@ public class TestContinuousSplitPlannerImpl {
             .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_EARLIEST_SNAPSHOT)
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
-        new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
     assertThat(initialResult.fromPosition()).isNull();
@@ -336,7 +336,7 @@ public class TestContinuousSplitPlannerImpl {
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
         new ContinuousSplitPlannerImpl(
-            tableResource.tableLoader().clone(), scanContextWithInvalidSnapshotId, null);
+            TABLE_RESOURCE.tableLoader().clone(), scanContextWithInvalidSnapshotId, null);
 
     assertThatThrownBy(() -> splitPlanner.planSplits(null))
         .isInstanceOf(IllegalArgumentException.class)
@@ -362,7 +362,7 @@ public class TestContinuousSplitPlannerImpl {
 
     ContinuousSplitPlannerImpl splitPlanner =
         new ContinuousSplitPlannerImpl(
-            tableResource.tableLoader().clone(), scanContextWithInvalidSnapshotId, null);
+            TABLE_RESOURCE.tableLoader().clone(), scanContextWithInvalidSnapshotId, null);
 
     assertThatThrownBy(() -> splitPlanner.planSplits(null))
         .isInstanceOf(IllegalArgumentException.class)
@@ -379,7 +379,7 @@ public class TestContinuousSplitPlannerImpl {
             .startSnapshotId(snapshot2.snapshotId())
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
-        new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
     assertThat(initialResult.fromPosition()).isNull();
@@ -425,7 +425,7 @@ public class TestContinuousSplitPlannerImpl {
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
         new ContinuousSplitPlannerImpl(
-            tableResource.tableLoader().clone(), scanContextWithInvalidSnapshotId, null);
+            TABLE_RESOURCE.tableLoader().clone(), scanContextWithInvalidSnapshotId, null);
 
     assertThatThrownBy(() -> splitPlanner.planSplits(null))
         .isInstanceOf(IllegalArgumentException.class)
@@ -446,7 +446,7 @@ public class TestContinuousSplitPlannerImpl {
 
     ContinuousSplitPlannerImpl splitPlanner =
         new ContinuousSplitPlannerImpl(
-            tableResource.tableLoader().clone(), scanContextWithInvalidSnapshotId, null);
+            TABLE_RESOURCE.tableLoader().clone(), scanContextWithInvalidSnapshotId, null);
 
     assertThatThrownBy(() -> splitPlanner.planSplits(null))
         .isInstanceOf(IllegalArgumentException.class)
@@ -463,7 +463,7 @@ public class TestContinuousSplitPlannerImpl {
             .startSnapshotTimestamp(snapshot2.timestampMillis())
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
-        new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
     assertThat(initialResult.fromPosition()).isNull();
@@ -514,7 +514,7 @@ public class TestContinuousSplitPlannerImpl {
             .maxPlanningSnapshotCount(1)
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
-        new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
     assertThat(initialResult.fromPosition()).isNull();
@@ -545,7 +545,7 @@ public class TestContinuousSplitPlannerImpl {
             .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
-        new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
     assertThat(initialResult.splits()).hasSize(1);
@@ -571,7 +571,7 @@ public class TestContinuousSplitPlannerImpl {
             .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
-        new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
     assertThat(initialResult.splits()).hasSize(1);
@@ -597,7 +597,7 @@ public class TestContinuousSplitPlannerImpl {
             .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
             .build();
     ContinuousSplitPlannerImpl splitPlanner =
-        new ContinuousSplitPlannerImpl(tableResource.tableLoader().clone(), scanContext, null);
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
 
     ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
     assertThat(initialResult.splits()).hasSize(1);
@@ -677,7 +677,7 @@ public class TestContinuousSplitPlannerImpl {
     List<Record> batch = RandomGenericData.generate(TestFixtures.SCHEMA, numRecords, seed);
     DataFile dataFile = dataAppender.writeFile(null, batch);
     dataAppender.appendToTable(dataFile);
-    return tableResource.table().currentSnapshot();
+    return TABLE_RESOURCE.table().currentSnapshot();
   }
 
   private static class CycleResult {

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImplStartStrategy.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImplStartStrategy.java
@@ -44,7 +44,7 @@ public class TestContinuousSplitPlannerImplStartStrategy {
   @TempDir protected Path temporaryFolder;
 
   @RegisterExtension
-  private static final HadoopTableExtension tableResource =
+  private static final HadoopTableExtension TABLE_RESOURCE =
       new HadoopTableExtension(TestFixtures.DATABASE, TestFixtures.TABLE, TestFixtures.SCHEMA);
 
   private GenericAppenderHelper dataAppender;
@@ -54,21 +54,21 @@ public class TestContinuousSplitPlannerImplStartStrategy {
 
   @BeforeEach
   public void before() throws IOException {
-    dataAppender = new GenericAppenderHelper(tableResource.table(), FILE_FORMAT, temporaryFolder);
+    dataAppender = new GenericAppenderHelper(TABLE_RESOURCE.table(), FILE_FORMAT, temporaryFolder);
   }
 
   private void appendThreeSnapshots() throws IOException {
     List<Record> batch1 = RandomGenericData.generate(TestFixtures.SCHEMA, 2, 0L);
     dataAppender.appendToTable(batch1);
-    snapshot1 = tableResource.table().currentSnapshot();
+    snapshot1 = TABLE_RESOURCE.table().currentSnapshot();
 
     List<Record> batch2 = RandomGenericData.generate(TestFixtures.SCHEMA, 2, 1L);
     dataAppender.appendToTable(batch2);
-    snapshot2 = tableResource.table().currentSnapshot();
+    snapshot2 = TABLE_RESOURCE.table().currentSnapshot();
 
     List<Record> batch3 = RandomGenericData.generate(TestFixtures.SCHEMA, 2, 2L);
     dataAppender.appendToTable(batch3);
-    snapshot3 = tableResource.table().currentSnapshot();
+    snapshot3 = TABLE_RESOURCE.table().currentSnapshot();
   }
 
   @Test
@@ -80,12 +80,12 @@ public class TestContinuousSplitPlannerImplStartStrategy {
             .build();
 
     // empty table
-    assertThat(ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext))
+    assertThat(ContinuousSplitPlannerImpl.startSnapshot(TABLE_RESOURCE.table(), scanContext))
         .isNotPresent();
 
     appendThreeSnapshots();
     Snapshot startSnapshot =
-        ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
+        ContinuousSplitPlannerImpl.startSnapshot(TABLE_RESOURCE.table(), scanContext).get();
     assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot3.snapshotId());
   }
 
@@ -98,12 +98,12 @@ public class TestContinuousSplitPlannerImplStartStrategy {
             .build();
 
     // empty table
-    assertThat(ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext))
+    assertThat(ContinuousSplitPlannerImpl.startSnapshot(TABLE_RESOURCE.table(), scanContext))
         .isNotPresent();
 
     appendThreeSnapshots();
     Snapshot startSnapshot =
-        ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
+        ContinuousSplitPlannerImpl.startSnapshot(TABLE_RESOURCE.table(), scanContext).get();
     assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot3.snapshotId());
   }
 
@@ -116,12 +116,12 @@ public class TestContinuousSplitPlannerImplStartStrategy {
             .build();
 
     // empty table
-    assertThat(ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext))
+    assertThat(ContinuousSplitPlannerImpl.startSnapshot(TABLE_RESOURCE.table(), scanContext))
         .isNotPresent();
 
     appendThreeSnapshots();
     Snapshot startSnapshot =
-        ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
+        ContinuousSplitPlannerImpl.startSnapshot(TABLE_RESOURCE.table(), scanContext).get();
     assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot1.snapshotId());
   }
 
@@ -138,7 +138,7 @@ public class TestContinuousSplitPlannerImplStartStrategy {
     assertThatThrownBy(
             () ->
                 ContinuousSplitPlannerImpl.startSnapshot(
-                    tableResource.table(), scanContextInvalidSnapshotId))
+                    TABLE_RESOURCE.table(), scanContextInvalidSnapshotId))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Start snapshot id not found in history: 1");
 
@@ -152,7 +152,7 @@ public class TestContinuousSplitPlannerImplStartStrategy {
             .build();
 
     Snapshot startSnapshot =
-        ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
+        ContinuousSplitPlannerImpl.startSnapshot(TABLE_RESOURCE.table(), scanContext).get();
     assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot2.snapshotId());
   }
 
@@ -169,7 +169,7 @@ public class TestContinuousSplitPlannerImplStartStrategy {
     assertThatThrownBy(
             () ->
                 ContinuousSplitPlannerImpl.startSnapshot(
-                    tableResource.table(), scanContextInvalidSnapshotTimestamp))
+                    TABLE_RESOURCE.table(), scanContextInvalidSnapshotTimestamp))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot find a snapshot after: ");
 
@@ -183,7 +183,7 @@ public class TestContinuousSplitPlannerImplStartStrategy {
             .build();
 
     Snapshot startSnapshot =
-        ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
+        ContinuousSplitPlannerImpl.startSnapshot(TABLE_RESOURCE.table(), scanContext).get();
     assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot2.snapshotId());
   }
 
@@ -199,7 +199,7 @@ public class TestContinuousSplitPlannerImplStartStrategy {
             .build();
 
     Snapshot startSnapshot =
-        ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), config).get();
+        ContinuousSplitPlannerImpl.startSnapshot(TABLE_RESOURCE.table(), config).get();
     assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot2.snapshotId());
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImplStartStrategy.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImplStartStrategy.java
@@ -18,42 +18,41 @@
  */
 package org.apache.iceberg.flink.source.enumerator;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.flink.HadoopTableResource;
+import org.apache.iceberg.flink.HadoopTableExtension;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestContinuousSplitPlannerImplStartStrategy {
   private static final FileFormat FILE_FORMAT = FileFormat.PARQUET;
 
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-  public final HadoopTableResource tableResource =
-      new HadoopTableResource(
-          temporaryFolder, TestFixtures.DATABASE, TestFixtures.TABLE, TestFixtures.SCHEMA);
-  @Rule public final TestRule chain = RuleChain.outerRule(temporaryFolder).around(tableResource);
+  @TempDir protected Path temporaryFolder;
+
+  @RegisterExtension
+  private static final HadoopTableExtension tableResource =
+      new HadoopTableExtension(TestFixtures.DATABASE, TestFixtures.TABLE, TestFixtures.SCHEMA);
 
   private GenericAppenderHelper dataAppender;
   private Snapshot snapshot1;
   private Snapshot snapshot2;
   private Snapshot snapshot3;
 
-  @Before
+  @BeforeEach
   public void before() throws IOException {
     dataAppender = new GenericAppenderHelper(tableResource.table(), FILE_FORMAT, temporaryFolder);
   }
@@ -81,13 +80,13 @@ public class TestContinuousSplitPlannerImplStartStrategy {
             .build();
 
     // empty table
-    Assert.assertFalse(
-        ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).isPresent());
+    assertThat(ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext))
+        .isNotPresent();
 
     appendThreeSnapshots();
     Snapshot startSnapshot =
         ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
-    Assert.assertEquals(snapshot3.snapshotId(), startSnapshot.snapshotId());
+    assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot3.snapshotId());
   }
 
   @Test
@@ -99,13 +98,13 @@ public class TestContinuousSplitPlannerImplStartStrategy {
             .build();
 
     // empty table
-    Assert.assertFalse(
-        ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).isPresent());
+    assertThat(ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext))
+        .isNotPresent();
 
     appendThreeSnapshots();
     Snapshot startSnapshot =
         ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
-    Assert.assertEquals(snapshot3.snapshotId(), startSnapshot.snapshotId());
+    assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot3.snapshotId());
   }
 
   @Test
@@ -117,13 +116,13 @@ public class TestContinuousSplitPlannerImplStartStrategy {
             .build();
 
     // empty table
-    Assert.assertFalse(
-        ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).isPresent());
+    assertThat(ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext))
+        .isNotPresent();
 
     appendThreeSnapshots();
     Snapshot startSnapshot =
         ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
-    Assert.assertEquals(snapshot1.snapshotId(), startSnapshot.snapshotId());
+    assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot1.snapshotId());
   }
 
   @Test
@@ -154,7 +153,7 @@ public class TestContinuousSplitPlannerImplStartStrategy {
 
     Snapshot startSnapshot =
         ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
-    Assert.assertEquals(snapshot2.snapshotId(), startSnapshot.snapshotId());
+    assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot2.snapshotId());
   }
 
   @Test
@@ -185,7 +184,7 @@ public class TestContinuousSplitPlannerImplStartStrategy {
 
     Snapshot startSnapshot =
         ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
-    Assert.assertEquals(snapshot2.snapshotId(), startSnapshot.snapshotId());
+    assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot2.snapshotId());
   }
 
   @Test
@@ -201,6 +200,6 @@ public class TestContinuousSplitPlannerImplStartStrategy {
 
     Snapshot startSnapshot =
         ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), config).get();
-    Assert.assertEquals(snapshot2.snapshotId(), startSnapshot.snapshotId());
+    assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot2.snapshotId());
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestEnumerationHistory.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestEnumerationHistory.java
@@ -18,8 +18,9 @@
  */
 package org.apache.iceberg.flink.source.enumerator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 public class TestEnumerationHistory {
   private static final int MAX_HISTORY_SIZE = 3;
@@ -89,28 +90,28 @@ public class TestEnumerationHistory {
   }
 
   private void testHistory(EnumerationHistory history, int[] expectedHistorySnapshot) {
-    Assert.assertFalse(history.shouldPauseSplitDiscovery(FEW_PENDING_SPLITS));
+    assertThat(history.shouldPauseSplitDiscovery(FEW_PENDING_SPLITS)).isFalse();
     if (history.hasFullHistory()) {
       // throttle because pending split count is more than the sum of enumeration history
-      Assert.assertTrue(history.shouldPauseSplitDiscovery(TOO_MANY_PENDING_SPLITS));
+      assertThat(history.shouldPauseSplitDiscovery(TOO_MANY_PENDING_SPLITS)).isTrue();
     } else {
       // skipped throttling check because there is not enough history
-      Assert.assertFalse(history.shouldPauseSplitDiscovery(TOO_MANY_PENDING_SPLITS));
+      assertThat(history.shouldPauseSplitDiscovery(TOO_MANY_PENDING_SPLITS)).isFalse();
     }
 
     int[] historySnapshot = history.snapshot();
-    Assert.assertArrayEquals(expectedHistorySnapshot, historySnapshot);
+    assertThat(historySnapshot).containsExactly(expectedHistorySnapshot);
 
     EnumerationHistory restoredHistory = new EnumerationHistory(MAX_HISTORY_SIZE);
     restoredHistory.restore(historySnapshot);
 
-    Assert.assertFalse(history.shouldPauseSplitDiscovery(FEW_PENDING_SPLITS));
+    assertThat(history.shouldPauseSplitDiscovery(FEW_PENDING_SPLITS)).isFalse();
     if (history.hasFullHistory()) {
       // throttle because pending split count is more than the sum of enumeration history
-      Assert.assertTrue(history.shouldPauseSplitDiscovery(TOO_MANY_PENDING_SPLITS));
+      assertThat(history.shouldPauseSplitDiscovery(TOO_MANY_PENDING_SPLITS)).isTrue();
     } else {
       // skipped throttling check because there is not enough history
-      Assert.assertFalse(history.shouldPauseSplitDiscovery(30));
+      assertThat(history.shouldPauseSplitDiscovery(30)).isFalse();
     }
   }
 
@@ -125,10 +126,10 @@ public class TestEnumerationHistory {
     EnumerationHistory smallerHistory = new EnumerationHistory(2);
     smallerHistory.restore(historySnapshot);
     int[] expectedRestoredHistorySnapshot = {2, 3};
-    Assert.assertArrayEquals(expectedRestoredHistorySnapshot, smallerHistory.snapshot());
+    assertThat(smallerHistory.snapshot()).containsExactly(expectedRestoredHistorySnapshot);
 
     EnumerationHistory largerHisotry = new EnumerationHistory(4);
     largerHisotry.restore(historySnapshot);
-    Assert.assertArrayEquals(historySnapshot, largerHisotry.snapshot());
+    assertThat(largerHisotry.snapshot()).containsExactly(historySnapshot);
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestIcebergEnumeratorStateSerializer.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestIcebergEnumeratorStateSerializer.java
@@ -18,48 +18,48 @@
  */
 package org.apache.iceberg.flink.source.enumerator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.flink.source.SplitHelpers;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitStatus;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestIcebergEnumeratorStateSerializer {
-  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+  @TempDir protected Path temporaryFolder;
 
   private final IcebergEnumeratorStateSerializer serializer =
       new IcebergEnumeratorStateSerializer(true);
 
-  protected final int version;
+  @Parameter(index = 0)
+  protected int version;
 
-  @Parameterized.Parameters(name = "version={0}")
-  public static Object[] parameters() {
-    return new Object[] {1, 2};
+  @Parameters(name = "version={0}")
+  public static Object[][] parameters() {
+    return new Object[][] {new Object[] {1}, new Object[] {2}};
   }
 
-  public TestIcebergEnumeratorStateSerializer(int version) {
-    this.version = version;
-  }
-
-  @Test
+  @TestTemplate
   public void testEmptySnapshotIdAndPendingSplits() throws Exception {
     IcebergEnumeratorState enumeratorState = new IcebergEnumeratorState(Collections.emptyList());
     testSerializer(enumeratorState);
   }
 
-  @Test
+  @TestTemplate
   public void testSomeSnapshotIdAndEmptyPendingSplits() throws Exception {
     IcebergEnumeratorPosition position =
         IcebergEnumeratorPosition.of(1L, System.currentTimeMillis());
@@ -69,12 +69,12 @@ public class TestIcebergEnumeratorStateSerializer {
     testSerializer(enumeratorState);
   }
 
-  @Test
+  @TestTemplate
   public void testSomeSnapshotIdAndPendingSplits() throws Exception {
     IcebergEnumeratorPosition position =
         IcebergEnumeratorPosition.of(2L, System.currentTimeMillis());
     List<IcebergSourceSplit> splits =
-        SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 3, 1);
+        SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 3, 1);
     Collection<IcebergSourceSplitState> pendingSplits = Lists.newArrayList();
     pendingSplits.add(
         new IcebergSourceSplitState(splits.get(0), IcebergSourceSplitStatus.UNASSIGNED));
@@ -87,13 +87,13 @@ public class TestIcebergEnumeratorStateSerializer {
     testSerializer(enumeratorState);
   }
 
-  @Test
+  @TestTemplate
   public void testEnumerationSplitCountHistory() throws Exception {
     if (version == 2) {
       IcebergEnumeratorPosition position =
           IcebergEnumeratorPosition.of(2L, System.currentTimeMillis());
       List<IcebergSourceSplit> splits =
-          SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 3, 1);
+          SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 3, 1);
       Collection<IcebergSourceSplitState> pendingSplits = Lists.newArrayList();
       pendingSplits.add(
           new IcebergSourceSplitState(splits.get(0), IcebergSourceSplitStatus.UNASSIGNED));
@@ -123,23 +123,24 @@ public class TestIcebergEnumeratorStateSerializer {
 
   private void assertEnumeratorStateEquals(
       IcebergEnumeratorState expected, IcebergEnumeratorState actual) {
-    Assert.assertEquals(expected.lastEnumeratedPosition(), actual.lastEnumeratedPosition());
+    assertThat(actual.lastEnumeratedPosition()).isEqualTo(expected.lastEnumeratedPosition());
 
-    Assert.assertEquals(expected.pendingSplits().size(), actual.pendingSplits().size());
+    assertThat(actual.pendingSplits()).hasSameSizeAs(expected.pendingSplits());
     Iterator<IcebergSourceSplitState> expectedIterator = expected.pendingSplits().iterator();
     Iterator<IcebergSourceSplitState> actualIterator = actual.pendingSplits().iterator();
     for (int i = 0; i < expected.pendingSplits().size(); ++i) {
       IcebergSourceSplitState expectedSplitState = expectedIterator.next();
       IcebergSourceSplitState actualSplitState = actualIterator.next();
-      Assert.assertEquals(expectedSplitState.split().splitId(), actualSplitState.split().splitId());
-      Assert.assertEquals(
-          expectedSplitState.split().fileOffset(), actualSplitState.split().fileOffset());
-      Assert.assertEquals(
-          expectedSplitState.split().recordOffset(), actualSplitState.split().recordOffset());
-      Assert.assertEquals(expectedSplitState.status(), actualSplitState.status());
+      assertThat(actualSplitState.split().splitId())
+          .isEqualTo(expectedSplitState.split().splitId());
+      assertThat(actualSplitState.split().fileOffset())
+          .isEqualTo(expectedSplitState.split().fileOffset());
+      assertThat(actualSplitState.split().recordOffset())
+          .isEqualTo(expectedSplitState.split().recordOffset());
+      assertThat(actualSplitState.status()).isEqualTo(expectedSplitState.status());
     }
 
-    Assert.assertArrayEquals(
-        expected.enumerationSplitCountHistory(), actual.enumerationSplitCountHistory());
+    assertThat(actual.enumerationSplitCountHistory())
+        .containsExactly(expected.enumerationSplitCountHistory());
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
@@ -49,7 +49,6 @@ import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.FileAppenderFactory;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.junit.rules.TemporaryFolder;
 
 public class ReaderUtil {
 
@@ -105,24 +104,6 @@ public class ReaderUtil {
       long seed, Schema schema, int listSize, int batchCount) {
     List<Record> records = RandomGenericData.generate(schema, listSize * batchCount, seed);
     return Lists.partition(records, batchCount);
-  }
-
-  // Only for JUnit4 tests. Keep this method for test migration from JUnit4 to JUnit5
-  public static CombinedScanTask createCombinedScanTask(
-      List<List<Record>> recordBatchList,
-      TemporaryFolder temporaryFolder,
-      FileFormat fileFormat,
-      GenericAppenderFactory appenderFactory)
-      throws IOException {
-    List<FileScanTask> fileTasks = Lists.newArrayListWithCapacity(recordBatchList.size());
-    for (List<Record> recordBatch : recordBatchList) {
-      FileScanTask fileTask =
-          ReaderUtil.createFileTask(
-              recordBatch, temporaryFolder.newFile(), fileFormat, appenderFactory);
-      fileTasks.add(fileTask);
-    }
-
-    return new BaseCombinedScanTask(fileTasks);
   }
 
   public static CombinedScanTask createCombinedScanTask(

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayBatchRecords.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayBatchRecords.java
@@ -18,9 +18,10 @@
  */
 package org.apache.iceberg.flink.source.reader;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestArrayBatchRecords {
 
@@ -50,19 +51,19 @@ public class TestArrayBatchRecords {
             fileOffset,
             startingRecordOffset);
 
-    Assert.assertEquals(splitId, recordsWithSplitIds.nextSplit());
+    assertThat(recordsWithSplitIds.nextSplit()).isEqualTo(splitId);
 
     for (int i = 0; i < numberOfRecords; i++) {
       RecordAndPosition<String> recAndPos = recordsWithSplitIds.nextRecordFromSplit();
-      Assert.assertEquals(elements[i], recAndPos.record());
-      Assert.assertEquals(fileOffset, recAndPos.fileOffset());
+      assertThat(recAndPos.record()).isEqualTo(elements[i]);
+      assertThat(recAndPos.fileOffset()).isEqualTo(fileOffset);
       // recordOffset points to the position after this one
-      Assert.assertEquals(startingRecordOffset + i + 1, recAndPos.recordOffset());
+      assertThat(recAndPos.recordOffset()).isEqualTo(startingRecordOffset + i + 1);
     }
 
-    Assert.assertNull(recordsWithSplitIds.nextRecordFromSplit());
-    Assert.assertNull(recordsWithSplitIds.nextSplit());
+    assertThat(recordsWithSplitIds.nextRecordFromSplit()).isNull();
+    assertThat(recordsWithSplitIds.nextSplit()).isNull();
     recordsWithSplitIds.recycle();
-    Assert.assertTrue(recycled.get());
+    assertThat(recycled.get()).isTrue();
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class TestArrayPoolDataIteratorBatcherRowData {
 
   @TempDir protected Path temporaryFolder;
-  private static final FileFormat fileFormat = FileFormat.PARQUET;
+  private static final FileFormat FILE_FORMAT = FileFormat.PARQUET;
   private static final Configuration config = new Configuration();
 
   private final GenericAppenderFactory appenderFactory =
@@ -71,7 +71,7 @@ public class TestArrayPoolDataIteratorBatcherRowData {
         ReaderUtil.createFileTask(
             records,
             File.createTempFile("junit", null, temporaryFolder.toFile()),
-            fileFormat,
+            FILE_FORMAT,
             appenderFactory);
     CombinedScanTask combinedTask = new BaseCombinedScanTask(fileTask);
     DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
@@ -117,7 +117,7 @@ public class TestArrayPoolDataIteratorBatcherRowData {
         ReaderUtil.createFileTask(
             records,
             File.createTempFile("junit", null, temporaryFolder.toFile()),
-            fileFormat,
+            FILE_FORMAT,
             appenderFactory);
     CombinedScanTask combinedTask = new BaseCombinedScanTask(fileTask);
     DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
@@ -227,21 +227,21 @@ public class TestArrayPoolDataIteratorBatcherRowData {
         ReaderUtil.createFileTask(
             records0,
             File.createTempFile("junit", null, temporaryFolder.toFile()),
-            fileFormat,
+            FILE_FORMAT,
             appenderFactory);
     List<Record> records1 = RandomGenericData.generate(TestFixtures.SCHEMA, 4, 2);
     FileScanTask fileTask1 =
         ReaderUtil.createFileTask(
             records1,
             File.createTempFile("junit", null, temporaryFolder.toFile()),
-            fileFormat,
+            FILE_FORMAT,
             appenderFactory);
     List<Record> records2 = RandomGenericData.generate(TestFixtures.SCHEMA, 3, 3);
     FileScanTask fileTask2 =
         ReaderUtil.createFileTask(
             records2,
             File.createTempFile("junit", null, temporaryFolder.toFile()),
-            fileFormat,
+            FILE_FORMAT,
             appenderFactory);
     CombinedScanTask combinedTask =
         new BaseCombinedScanTask(Arrays.asList(fileTask0, fileTask1, fileTask2));
@@ -307,7 +307,7 @@ public class TestArrayPoolDataIteratorBatcherRowData {
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records1.get(3), recordAndPosition.record());
 
     assertThat(batch11.nextRecordFromSplit()).isNull();
-    assertThat(batch11.nextSplit());
+    assertThat(batch11.nextSplit()).isNull();
     batch11.recycle();
 
     ///////////////////////////////

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
@@ -18,6 +18,10 @@
  */
 package org.apache.iceberg.flink.source.reader;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.flink.configuration.Configuration;
@@ -36,28 +40,27 @@ import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.flink.source.DataIterator;
 import org.apache.iceberg.io.CloseableIterator;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestArrayPoolDataIteratorBatcherRowData {
 
-  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+  @TempDir protected Path temporaryFolder;
   private static final FileFormat fileFormat = FileFormat.PARQUET;
+  private static final Configuration config = new Configuration();
 
-  private final GenericAppenderFactory appenderFactory;
-  private final DataIteratorBatcher<RowData> batcher;
+  private final GenericAppenderFactory appenderFactory =
+      new GenericAppenderFactory(TestFixtures.SCHEMA);;
+  private final DataIteratorBatcher<RowData> batcher =
+      new ArrayPoolDataIteratorBatcher<>(config, new RowDataRecordFactory(TestFixtures.ROW_TYPE));
 
-  public TestArrayPoolDataIteratorBatcherRowData() {
-    Configuration config = new Configuration();
+  @BeforeAll
+  public static void setConfig() {
     // set array pool size to 1
     config.set(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 1);
     // set batch array size to 2
     config.set(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 2);
-    this.batcher =
-        new ArrayPoolDataIteratorBatcher<>(config, new RowDataRecordFactory(TestFixtures.ROW_TYPE));
-    this.appenderFactory = new GenericAppenderFactory(TestFixtures.SCHEMA);
   }
 
   /** Read a CombinedScanTask that contains a single file with less than a full batch of records */
@@ -65,7 +68,11 @@ public class TestArrayPoolDataIteratorBatcherRowData {
   public void testSingleFileLessThanOneFullBatch() throws Exception {
     List<Record> records = RandomGenericData.generate(TestFixtures.SCHEMA, 1, 1);
     FileScanTask fileTask =
-        ReaderUtil.createFileTask(records, TEMPORARY_FOLDER.newFile(), fileFormat, appenderFactory);
+        ReaderUtil.createFileTask(
+            records,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            fileFormat,
+            appenderFactory);
     CombinedScanTask combinedTask = new BaseCombinedScanTask(fileTask);
     DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
     String splitId = "someSplitId";
@@ -73,29 +80,29 @@ public class TestArrayPoolDataIteratorBatcherRowData {
         batcher.batch(splitId, dataIterator);
 
     ArrayBatchRecords<RowData> batch = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
-    Assert.assertTrue(batch.finishedSplits().isEmpty());
-    Assert.assertEquals(splitId, batch.nextSplit());
+    assertThat(batch.finishedSplits()).isEmpty();
+    assertThat(batch.nextSplit()).isEqualTo(splitId);
     // reusable array size should be the configured value of 2
-    Assert.assertEquals(2, batch.records().length);
+    assertThat(batch.records()).hasSize(2);
     // assert actual number of records in the array
-    Assert.assertEquals(1, batch.numberOfRecords());
+    assertThat(batch.numberOfRecords()).isEqualTo(1);
 
     RecordAndPosition<RowData> recordAndPosition = batch.nextRecordFromSplit();
 
     ///////////////////////////////
     // assert first record
 
-    Assert.assertEquals(0, recordAndPosition.fileOffset());
+    assertThat(recordAndPosition.fileOffset()).isEqualTo(0);
     // The position points to where the reader should resume after this record is processed.
-    Assert.assertEquals(1, recordAndPosition.recordOffset());
+    assertThat(recordAndPosition.recordOffset()).isEqualTo(1);
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records.get(0), recordAndPosition.record());
 
-    Assert.assertNull(batch.nextRecordFromSplit());
-    Assert.assertNull(batch.nextSplit());
+    assertThat(batch.nextRecordFromSplit()).isNull();
+    assertThat(batch.nextSplit()).isNull();
     batch.recycle();
 
     // assert end of input
-    Assert.assertFalse(recordBatchIterator.hasNext());
+    assertThat(recordBatchIterator).isExhausted();
   }
 
   /**
@@ -107,7 +114,11 @@ public class TestArrayPoolDataIteratorBatcherRowData {
   public void testSingleFileWithMultipleBatches() throws Exception {
     List<Record> records = RandomGenericData.generate(TestFixtures.SCHEMA, 5, 1);
     FileScanTask fileTask =
-        ReaderUtil.createFileTask(records, TEMPORARY_FOLDER.newFile(), fileFormat, appenderFactory);
+        ReaderUtil.createFileTask(
+            records,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            fileFormat,
+            appenderFactory);
     CombinedScanTask combinedTask = new BaseCombinedScanTask(fileTask);
     DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
     String splitId = "someSplitId";
@@ -118,31 +129,31 @@ public class TestArrayPoolDataIteratorBatcherRowData {
     // assert first batch with full batch of 2 records
 
     ArrayBatchRecords<RowData> batch0 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
-    Assert.assertTrue(batch0.finishedSplits().isEmpty());
-    Assert.assertEquals(splitId, batch0.nextSplit());
+    assertThat(batch0.finishedSplits()).isEmpty();
+    assertThat(batch0.nextSplit()).isEqualTo(splitId);
     // reusable array size should be the configured value of 2
-    Assert.assertEquals(2, batch0.records().length);
+    assertThat(batch0.records()).hasSize(2);
     // assert actual number of records in the array
-    Assert.assertEquals(2, batch0.numberOfRecords());
+    assertThat(batch0.numberOfRecords()).isEqualTo(2);
 
     RecordAndPosition<RowData> recordAndPosition;
 
     // assert first record
     recordAndPosition = batch0.nextRecordFromSplit();
-    Assert.assertEquals(0, recordAndPosition.fileOffset());
+    assertThat(recordAndPosition.fileOffset()).isEqualTo(0);
     // The position points to where the reader should resume after this record is processed.
-    Assert.assertEquals(1, recordAndPosition.recordOffset());
+    assertThat(recordAndPosition.recordOffset()).isEqualTo(1);
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records.get(0), recordAndPosition.record());
 
     // assert second record
     recordAndPosition = batch0.nextRecordFromSplit();
-    Assert.assertEquals(0, recordAndPosition.fileOffset());
+    assertThat(recordAndPosition.fileOffset()).isEqualTo(0);
     // The position points to where the reader should resume after this record is processed.
-    Assert.assertEquals(2, recordAndPosition.recordOffset());
+    assertThat(recordAndPosition.recordOffset()).isEqualTo(2);
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records.get(1), recordAndPosition.record());
 
-    Assert.assertNull(batch0.nextRecordFromSplit());
-    Assert.assertNull(batch0.nextSplit());
+    assertThat(batch0.nextRecordFromSplit()).isNull();
+    assertThat(batch0.nextSplit()).isNull();
     batch0.recycle();
 
     ///////////////////////////////
@@ -150,30 +161,30 @@ public class TestArrayPoolDataIteratorBatcherRowData {
 
     ArrayBatchRecords<RowData> batch1 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
     // assert array is reused
-    Assert.assertSame(batch0.records(), batch1.records());
-    Assert.assertTrue(batch1.finishedSplits().isEmpty());
-    Assert.assertEquals(splitId, batch1.nextSplit());
+    assertThat(batch1.records()).containsExactlyInAnyOrder(batch0.records());
+    assertThat(batch1.finishedSplits()).isEmpty();
+    assertThat(batch1.nextSplit()).isEqualTo(splitId);
     // reusable array size should be the configured value of 2
-    Assert.assertEquals(2, batch1.records().length);
+    assertThat(batch1.records()).hasSize(2);
     // assert actual number of records in the array
-    Assert.assertEquals(2, batch1.numberOfRecords());
+    assertThat(batch1.numberOfRecords()).isEqualTo(2);
 
     // assert third record
     recordAndPosition = batch1.nextRecordFromSplit();
-    Assert.assertEquals(0, recordAndPosition.fileOffset());
+    assertThat(recordAndPosition.fileOffset()).isEqualTo(0);
     // The position points to where the reader should resume after this record is processed.
-    Assert.assertEquals(3, recordAndPosition.recordOffset());
+    assertThat(recordAndPosition.recordOffset()).isEqualTo(3);
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records.get(2), recordAndPosition.record());
 
     // assert fourth record
     recordAndPosition = batch1.nextRecordFromSplit();
-    Assert.assertEquals(0, recordAndPosition.fileOffset());
+    assertThat(recordAndPosition.fileOffset()).isEqualTo(0);
     // The position points to where the reader should resume after this record is processed.
-    Assert.assertEquals(4, recordAndPosition.recordOffset());
+    assertThat(recordAndPosition.recordOffset()).isEqualTo(4);
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records.get(3), recordAndPosition.record());
 
-    Assert.assertNull(batch1.nextRecordFromSplit());
-    Assert.assertNull(batch1.nextSplit());
+    assertThat(batch1.nextRecordFromSplit()).isNull();
+    assertThat(batch1.nextSplit()).isNull();
     batch1.recycle();
 
     ///////////////////////////////
@@ -181,27 +192,27 @@ public class TestArrayPoolDataIteratorBatcherRowData {
 
     ArrayBatchRecords<RowData> batch2 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
     // assert array is reused
-    Assert.assertSame(batch0.records(), batch2.records());
-    Assert.assertTrue(batch2.finishedSplits().isEmpty());
-    Assert.assertEquals(splitId, batch2.nextSplit());
+    assertThat(batch2.records()).containsExactlyInAnyOrder(batch0.records());
+    assertThat(batch2.finishedSplits()).isEmpty();
+    assertThat(batch2.nextSplit()).isEqualTo(splitId);
     // reusable array size should be the configured value of 2
-    Assert.assertEquals(2, batch2.records().length);
+    assertThat(batch2.records()).hasSize(2);
     // assert actual number of records in the array
-    Assert.assertEquals(1, batch2.numberOfRecords());
+    assertThat(batch2.numberOfRecords()).isEqualTo(1);
 
     // assert fifth record
     recordAndPosition = batch2.nextRecordFromSplit();
-    Assert.assertEquals(0, recordAndPosition.fileOffset());
+    assertThat(recordAndPosition.fileOffset()).isEqualTo(0);
     // The position points to where the reader should resume after this record is processed.
-    Assert.assertEquals(5, recordAndPosition.recordOffset());
+    assertThat(recordAndPosition.recordOffset()).isEqualTo(5);
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records.get(4), recordAndPosition.record());
 
-    Assert.assertNull(batch2.nextRecordFromSplit());
-    Assert.assertNull(batch2.nextSplit());
+    assertThat(batch2.nextRecordFromSplit()).isNull();
+    assertThat(batch2.nextSplit()).isNull();
     batch2.recycle();
 
     // assert end of input
-    Assert.assertFalse(recordBatchIterator.hasNext());
+    assertThat(recordBatchIterator).isExhausted();
   }
 
   /**
@@ -214,20 +225,28 @@ public class TestArrayPoolDataIteratorBatcherRowData {
     List<Record> records0 = RandomGenericData.generate(TestFixtures.SCHEMA, 1, 1);
     FileScanTask fileTask0 =
         ReaderUtil.createFileTask(
-            records0, TEMPORARY_FOLDER.newFile(), fileFormat, appenderFactory);
+            records0,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            fileFormat,
+            appenderFactory);
     List<Record> records1 = RandomGenericData.generate(TestFixtures.SCHEMA, 4, 2);
     FileScanTask fileTask1 =
         ReaderUtil.createFileTask(
-            records1, TEMPORARY_FOLDER.newFile(), fileFormat, appenderFactory);
+            records1,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            fileFormat,
+            appenderFactory);
     List<Record> records2 = RandomGenericData.generate(TestFixtures.SCHEMA, 3, 3);
     FileScanTask fileTask2 =
         ReaderUtil.createFileTask(
-            records2, TEMPORARY_FOLDER.newFile(), fileFormat, appenderFactory);
+            records2,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            fileFormat,
+            appenderFactory);
     CombinedScanTask combinedTask =
         new BaseCombinedScanTask(Arrays.asList(fileTask0, fileTask1, fileTask2));
 
     DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
-    // seek to file1 and after record 1
     dataIterator.seek(1, 1);
 
     String splitId = "someSplitId";
@@ -246,52 +265,49 @@ public class TestArrayPoolDataIteratorBatcherRowData {
 
     // variable naming convention: batch<fileOffset><batchId>
     ArrayBatchRecords<RowData> batch10 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
-    Assert.assertTrue(batch10.finishedSplits().isEmpty());
-    Assert.assertEquals(splitId, batch10.nextSplit());
-    // reusable array size should be the configured value of 2
-    Assert.assertEquals(2, batch10.records().length);
-    // assert actual number of records in the array
-    Assert.assertEquals(2, batch10.numberOfRecords());
+    assertThat(batch10.finishedSplits()).isEmpty();
+    assertThat(batch10.nextSplit()).isEqualTo(splitId);
+    assertThat(batch10.records()).hasSize(2);
+    assertThat(batch10.numberOfRecords()).isEqualTo(2);
 
     RecordAndPosition<RowData> recordAndPosition;
 
     recordAndPosition = batch10.nextRecordFromSplit();
-    Assert.assertEquals(1, recordAndPosition.fileOffset());
+    assertThat(recordAndPosition.fileOffset()).isEqualTo(1);
     // seek should skip the first record in file1. starting from the second record
-    Assert.assertEquals(2, recordAndPosition.recordOffset());
+    assertThat(recordAndPosition.recordOffset()).isEqualTo(2);
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records1.get(1), recordAndPosition.record());
 
     recordAndPosition = batch10.nextRecordFromSplit();
-    Assert.assertEquals(1, recordAndPosition.fileOffset());
-    // The position points to where the reader should resume after this record is processed.
-    Assert.assertEquals(3, recordAndPosition.recordOffset());
+    assertThat(recordAndPosition.fileOffset()).isEqualTo(1);
+    assertThat(recordAndPosition.recordOffset())
+        .as("The position points to where the reader should resume after this record is processed.")
+        .isEqualTo(3);
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records1.get(2), recordAndPosition.record());
 
-    Assert.assertNull(batch10.nextRecordFromSplit());
-    Assert.assertNull(batch10.nextSplit());
+    assertThat(batch10.nextRecordFromSplit()).isNull();
+    assertThat(batch10.nextSplit()).isNull();
     batch10.recycle();
 
     // assert second batch from file1 with partial batch of 1 record
 
     // variable naming convention: batch_<fileOffset>_<batchId>
     ArrayBatchRecords<RowData> batch11 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
-    // assert array is reused
-    Assert.assertSame(batch10.records(), batch11.records());
-    Assert.assertTrue(batch11.finishedSplits().isEmpty());
-    Assert.assertEquals(splitId, batch11.nextSplit());
-    // reusable array size should be the configured value of 2
-    Assert.assertEquals(2, batch11.records().length);
-    // assert actual number of records in the array
-    Assert.assertEquals(1, batch11.numberOfRecords());
+    assertThat(batch11.records()).containsExactlyInAnyOrder(batch10.records());
+    assertThat(batch11.finishedSplits()).isEmpty();
+    assertThat(batch11.nextSplit()).isEqualTo(splitId);
+    assertThat(batch11.records()).hasSize(2);
+    assertThat(batch11.numberOfRecords()).isEqualTo(1);
 
     recordAndPosition = batch11.nextRecordFromSplit();
-    Assert.assertEquals(1, recordAndPosition.fileOffset());
-    // The position points to where the reader should resume after this record is processed.
-    Assert.assertEquals(4, recordAndPosition.recordOffset());
+    assertThat(recordAndPosition.fileOffset()).isEqualTo(1);
+    assertThat(recordAndPosition.recordOffset())
+        .as("The position points to where the reader should resume after this record is processed.")
+        .isEqualTo(4);
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records1.get(3), recordAndPosition.record());
 
-    Assert.assertNull(batch11.nextRecordFromSplit());
-    Assert.assertNull(batch11.nextSplit());
+    assertThat(batch11.nextRecordFromSplit()).isNull();
+    assertThat(batch11.nextSplit());
     batch11.recycle();
 
     ///////////////////////////////
@@ -303,29 +319,27 @@ public class TestArrayPoolDataIteratorBatcherRowData {
 
     // variable naming convention: batch_<fileOffset>_<batchId>
     ArrayBatchRecords<RowData> batch20 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
-    // assert array is reused
-    Assert.assertSame(batch10.records(), batch20.records());
-    Assert.assertTrue(batch20.finishedSplits().isEmpty());
-    Assert.assertEquals(splitId, batch20.nextSplit());
-    // reusable array size should be the configured value of 2
-    Assert.assertEquals(2, batch20.records().length);
-    // assert actual number of records in the array
-    Assert.assertEquals(2, batch20.numberOfRecords());
+    assertThat(batch20.records()).containsExactlyInAnyOrder(batch10.records());
+    assertThat(batch20.finishedSplits()).isEmpty();
+    assertThat(batch20.nextSplit()).isEqualTo(splitId);
+    assertThat(batch20.records()).hasSize(2);
+    assertThat(batch20.numberOfRecords()).isEqualTo(2);
 
     recordAndPosition = batch20.nextRecordFromSplit();
-    Assert.assertEquals(2, recordAndPosition.fileOffset());
+    assertThat(recordAndPosition.fileOffset()).isEqualTo(2);
     // The position points to where the reader should resume after this record is processed.
-    Assert.assertEquals(1, recordAndPosition.recordOffset());
+    assertThat(recordAndPosition.recordOffset()).isEqualTo(1);
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records2.get(0), recordAndPosition.record());
 
     recordAndPosition = batch20.nextRecordFromSplit();
-    Assert.assertEquals(2, recordAndPosition.fileOffset());
-    // The position points to where the reader should resume after this record is processed.
-    Assert.assertEquals(2, recordAndPosition.recordOffset());
+    assertThat(recordAndPosition.fileOffset()).isEqualTo(2);
+    assertThat(recordAndPosition.recordOffset())
+        .as("The position points to where the reader should resume after this record is processed.")
+        .isEqualTo(2);
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records2.get(1), recordAndPosition.record());
 
-    Assert.assertNull(batch20.nextRecordFromSplit());
-    Assert.assertNull(batch20.nextSplit());
+    assertThat(batch20.nextRecordFromSplit()).isNull();
+    assertThat(batch20.nextSplit()).isNull();
     batch20.recycle();
 
     ///////////////////////////////
@@ -333,26 +347,24 @@ public class TestArrayPoolDataIteratorBatcherRowData {
 
     // variable naming convention: batch_<fileOffset>_<batchId>
     ArrayBatchRecords<RowData> batch21 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
-    // assert array is reused
-    Assert.assertSame(batch10.records(), batch21.records());
-    Assert.assertTrue(batch21.finishedSplits().isEmpty());
-    Assert.assertEquals(splitId, batch21.nextSplit());
-    // reusable array size should be the configured value of 2
-    Assert.assertEquals(2, batch21.records().length);
-    // assert actual number of records in the array
-    Assert.assertEquals(1, batch21.numberOfRecords());
+    assertThat(batch21.records()).containsExactlyInAnyOrder(batch10.records());
+    assertThat(batch21.finishedSplits()).isEmpty();
+    assertThat(batch21.nextSplit()).isEqualTo(splitId);
+    assertThat(batch21.records()).hasSize(2);
+    assertThat(batch21.numberOfRecords()).isEqualTo(1);
 
     recordAndPosition = batch21.nextRecordFromSplit();
-    Assert.assertEquals(2, recordAndPosition.fileOffset());
-    // The position points to where the reader should resume after this record is processed.
-    Assert.assertEquals(3, recordAndPosition.recordOffset());
+    assertThat(recordAndPosition.fileOffset()).isEqualTo(2);
+
+    assertThat(recordAndPosition.recordOffset())
+        .as("The position points to where the reader should resume after this record is processed.")
+        .isEqualTo(3);
     TestHelpers.assertRowData(TestFixtures.SCHEMA, records2.get(2), recordAndPosition.record());
 
-    Assert.assertNull(batch21.nextRecordFromSplit());
-    Assert.assertNull(batch21.nextSplit());
+    assertThat(batch21.nextRecordFromSplit()).isNull();
+    assertThat(batch21.nextSplit()).isNull();
     batch21.recycle();
 
-    // assert end of input
-    Assert.assertFalse(recordBatchIterator.hasNext());
+    assertThat(recordBatchIterator).isExhausted();
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.flink.source.reader;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -37,19 +40,14 @@ import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.flink.source.split.SerializableComparator;
 import org.apache.iceberg.hadoop.HadoopFileIO;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestIcebergSourceReader {
-  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+  @TempDir protected Path temporaryFolder;
 
-  private final GenericAppenderFactory appenderFactory;
-
-  public TestIcebergSourceReader() {
-    this.appenderFactory = new GenericAppenderFactory(TestFixtures.SCHEMA);
-  }
+  private final GenericAppenderFactory appenderFactory =
+      new GenericAppenderFactory(TestFixtures.SCHEMA);
 
   @Test
   public void testReaderMetrics() throws Exception {
@@ -70,13 +68,13 @@ public class TestIcebergSourceReader {
         ReaderUtil.createRecordBatchList(0L, TestFixtures.SCHEMA, 1, 1);
     CombinedScanTask task1 =
         ReaderUtil.createCombinedScanTask(
-            recordBatchList1, TEMPORARY_FOLDER, FileFormat.PARQUET, appenderFactory);
+            recordBatchList1, temporaryFolder, FileFormat.PARQUET, appenderFactory);
 
     List<List<Record>> recordBatchList2 =
         ReaderUtil.createRecordBatchList(1L, TestFixtures.SCHEMA, 1, 1);
     CombinedScanTask task2 =
         ReaderUtil.createCombinedScanTask(
-            recordBatchList2, TEMPORARY_FOLDER, FileFormat.PARQUET, appenderFactory);
+            recordBatchList2, temporaryFolder, FileFormat.PARQUET, appenderFactory);
 
     // Sort the splits in one way
     List<RowData> rowDataList1 =
@@ -95,8 +93,7 @@ public class TestIcebergSourceReader {
             2);
 
     // Check that the order of the elements is not changed
-    Assert.assertEquals(rowDataList1.get(0), rowDataList2.get(0));
-    Assert.assertEquals(rowDataList1.get(1), rowDataList2.get(1));
+    assertThat(rowDataList1).containsExactlyElementsOf(rowDataList2);
   }
 
   private List<RowData> read(List<IcebergSourceSplit> splits, long expected) throws Exception {
@@ -114,7 +111,7 @@ public class TestIcebergSourceReader {
 
     reader.pollNext(readerOutput);
 
-    Assert.assertEquals(expected, readerOutput.getEmittedRecords().size());
+    assertThat(readerOutput.getEmittedRecords()).hasSize((int) expected);
     return readerOutput.getEmittedRecords();
   }
 
@@ -130,7 +127,7 @@ public class TestIcebergSourceReader {
         ReaderUtil.createRecordBatchList(seed, TestFixtures.SCHEMA, 1, 1);
     CombinedScanTask task =
         ReaderUtil.createCombinedScanTask(
-            recordBatchList, TEMPORARY_FOLDER, FileFormat.PARQUET, appenderFactory);
+            recordBatchList, temporaryFolder, FileFormat.PARQUET, appenderFactory);
     IcebergSourceSplit split = IcebergSourceSplit.fromCombinedScanTask(task);
     reader.addSplits(Collections.singletonList(split));
 
@@ -138,12 +135,12 @@ public class TestIcebergSourceReader {
       reader.pollNext(readerOutput);
     }
 
-    Assert.assertEquals(expectedCount, readerOutput.getEmittedRecords().size());
+    assertThat(readerOutput.getEmittedRecords()).hasSize(expectedCount);
     TestHelpers.assertRowData(
         TestFixtures.SCHEMA,
         recordBatchList.get(0).get(0),
         readerOutput.getEmittedRecords().get(expectedCount - 1));
-    Assert.assertEquals(expectedCount, metricGroup.counters().get("assignedSplits").getCount());
+    assertThat(metricGroup.counters().get("assignedSplits").getCount()).isEqualTo(expectedCount);
 
     // One more poll will get null record batch.
     // That will finish the split and cause split fetcher to be closed due to idleness.

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestRowDataReaderFunction.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestRowDataReaderFunction.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.data.conversion.DataStructureConverters;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.types.Row;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
@@ -42,10 +41,6 @@ public class TestRowDataReaderFunction extends ReaderFunctionTestBase<RowData> {
   protected static final RowType rowType = FlinkSchemaUtil.convert(TestFixtures.SCHEMA);
   private static final DataStructureConverter<Object, Object> rowDataConverter =
       DataStructureConverters.getConverter(TypeConversions.fromLogicalToDataType(rowType));
-
-  public TestRowDataReaderFunction(FileFormat fileFormat) {
-    super(fileFormat);
-  }
 
   @Override
   protected ReaderFunction<RowData> readerFunction() {

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestRowDataReaderFunction.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestRowDataReaderFunction.java
@@ -38,9 +38,9 @@ import org.apache.iceberg.hadoop.HadoopFileIO;
 
 public class TestRowDataReaderFunction extends ReaderFunctionTestBase<RowData> {
 
-  protected static final RowType rowType = FlinkSchemaUtil.convert(TestFixtures.SCHEMA);
-  private static final DataStructureConverter<Object, Object> rowDataConverter =
-      DataStructureConverters.getConverter(TypeConversions.fromLogicalToDataType(rowType));
+  protected static final RowType ROW_TYPE = FlinkSchemaUtil.convert(TestFixtures.SCHEMA);
+  private static final DataStructureConverter<Object, Object> ROW_DATA_CONVERTER =
+      DataStructureConverters.getConverter(TypeConversions.fromLogicalToDataType(ROW_TYPE));
 
   @Override
   protected ReaderFunction<RowData> readerFunction() {
@@ -63,7 +63,7 @@ public class TestRowDataReaderFunction extends ReaderFunctionTestBase<RowData> {
 
   private List<Row> toRows(List<RowData> actual) {
     return actual.stream()
-        .map(rowData -> (Row) rowDataConverter.toExternal(rowData))
+        .map(rowData -> (Row) ROW_DATA_CONVERTER.toExternal(rowData))
         .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
Migrate the following classes in `iceberg-flink`  to JUnit 5 for https://github.com/apache/iceberg/issues/9087

Curretly only including Flink 1.19. 
  - [x] assigner
    - [x] `SplitAssignerTestBase`
    - [x] `TestDefaultSplitAssigner` 
    - [x] `TestFileSequenceNumberBasedSplitAssigner` 
    - [x] `TestWatermarkBasedSplitAssigner`
  - [x] enumerator
    - [x] `TestContinuousIcebergEnumerator`  
    - [x] `TestContinuousSplitPlannerImpl`
    - [x] `TestContinuousSplitPlannerImplStartStrategy`
    - [x] `TestEnumerationHistory`
    - [x] `TestIcebergEnumeratorStateSerializer`
  - [x] reader
    - [x] `ReaderFunctionTestBase`
    - [x] `ReaderUtil`
    - [x] `TestArrayBatchRecords`
    - [x] `TestArrayPoolDataIteratorBatcherRowData`
    - [x] `TestIcebergSourceReader`
    - [x] `TestRowDataReaderFunction`
  - [x] split
     - [x] `TestIcebergSourceSplitSerializer`
  - [x] `SplitHelpers`