### PR TITLE
Add interfaces for Action CheckSnapshotIntegrity

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -70,4 +70,9 @@ public interface ActionsProvider {
     throw new UnsupportedOperationException(
         this.getClass().getName() + " does not implement rewritePositionDeletes");
   }
+  /** Instantiates an action to check snapshot integrity. */
+  default CheckSnapshotIntegrity checkSnapshotIntegrity(Table table) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement checkSnapshotIntegrity");
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -70,6 +70,7 @@ public interface ActionsProvider {
     throw new UnsupportedOperationException(
         this.getClass().getName() + " does not implement rewritePositionDeletes");
   }
+
   /** Instantiates an action to check snapshot integrity. */
   default CheckSnapshotIntegrity checkSnapshotIntegrity(Table table) {
     throw new UnsupportedOperationException(

--- a/api/src/main/java/org/apache/iceberg/actions/CheckSnapshotIntegrity.java
+++ b/api/src/main/java/org/apache/iceberg/actions/CheckSnapshotIntegrity.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import java.util.concurrent.ExecutorService;
+
+public interface CheckSnapshotIntegrity
+    extends Action<CheckSnapshotIntegrity, CheckSnapshotIntegrity.Result> {
+
+  /**
+   * Passes an alternative executor service that will be used for snapshot integrity checking. If
+   * this method is not called, snapshot integrity checker will still be running by a single
+   * threaded executor service.
+   *
+   * @param executorService an executor service to parallelize tasks to check snapshot integrity
+   * @return this for method chaining
+   */
+  CheckSnapshotIntegrity executeWith(ExecutorService executorService);
+
+  /**
+   * Pass the target version to check. The action checks the snapshots in the target version, not in
+   * the current version of the table.
+   *
+   * @param targetVersion the target version file to be checked. Either a file name or a file path
+   *     is acceptable. For example, it could be either
+   *     "00001-8893aa9e-f92e-4443-80e7-cfa42238a654.metadata.json" or
+   *     "/path/to/00001-8893aa9e-f92e-4443-80e7-cfa42238a654.metadata.json".
+   * @return this for method chaining
+   */
+  CheckSnapshotIntegrity targetVersion(String targetVersion);
+
+  /** The action result that contains a summary of the execution. */
+  interface Result {
+    /** Returns locations of missing metadata/data files. */
+    Iterable<String> missingFileLocations();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/actions/BaseCheckSnapshotIntegrityResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseCheckSnapshotIntegrityResult.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+public class BaseCheckSnapshotIntegrityResult implements CheckSnapshotIntegrity.Result {
+  private final Iterable<String> missingFileLocations;
+
+  public BaseCheckSnapshotIntegrityResult(Iterable<String> missingFileLocations) {
+    this.missingFileLocations = missingFileLocations;
+  }
+
+  @Override
+  public Iterable<String> missingFileLocations() {
+    return missingFileLocations;
+  }
+}


### PR DESCRIPTION
Co-authored-by: Yufei Gu [yufei@apache.org](yufei@apache.org)
Co-authored-by: Huaxin Gao [huaxin_gao@apple.com](mailto:huaxin_gao@apple.com)

This PR adds  interfaces for Action CheckSnapshotIntegrity. We will have another PR to implement the interfaces in Spark 3.4 and Spark 3.5.