### PR TITLE
[Docs] Add examples for DataFrame branch writes

### DIFF
--- a/docs/docs/branching.md
+++ b/docs/docs/branching.md
@@ -110,8 +110,7 @@ Creating, querying and writing to branches and tags are supported in the Iceberg
 - [Iceberg Java Library](java-api-quickstart.md#branching-and-tagging)
 - [Spark DDLs](spark-ddl.md#branching-and-tagging-ddl)
 - [Spark Reads](spark-queries.md#time-travel)
-- [Spark Branch Writes using SQL](spark-writes.md#writing-to-branches)
-- [Spark Branch Writes using Dataframes](spark-writes.md#writing-to-branches-1)
+- [Spark Branch Writes](spark-writes.md#writing-to-branches)
 - [Flink Reads](flink-queries.md#reading-branches-and-tags-with-SQL)
 - [Flink Branch Writes](flink-writes.md#branch-writes)
 

--- a/docs/docs/branching.md
+++ b/docs/docs/branching.md
@@ -110,7 +110,8 @@ Creating, querying and writing to branches and tags are supported in the Iceberg
 - [Iceberg Java Library](java-api-quickstart.md#branching-and-tagging)
 - [Spark DDLs](spark-ddl.md#branching-and-tagging-ddl)
 - [Spark Reads](spark-queries.md#time-travel)
-- [Spark Branch Writes](spark-writes.md#writing-to-branches)
+- [Spark Branch Writes using SQL](spark-writes.md#writing-to-branches)
+- [Spark Branch Writes using Dataframes](spark-writes.md#writing-to-branches-1)
 - [Flink Reads](flink-queries.md#reading-branches-and-tags-with-SQL)
 - [Flink Branch Writes](flink-writes.md#branch-writes)
 

--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -194,7 +194,7 @@ WHERE EXISTS (SELECT oid FROM prod.db.returned_orders WHERE t1.oid = oid)
 
 For more complex row-level updates based on incoming data, see the section on `MERGE INTO`.
 
-## Writing to Branches
+### Writing to Branches
 Branch writes can be performed via SQL by providing a branch identifier, `branch_yourBranch` in the operation.
 Branch writes can also be performed as part of a write-audit-publish (WAP) workflow by specifying the `spark.wap.branch` config.
 Note WAP branch and branch identifier cannot both be specified.
@@ -332,6 +332,30 @@ The writer must enable the `mergeSchema` option.
 ```scala
 data.writeTo("prod.db.sample").option("mergeSchema","true").append()
 ```
+
+### Writing to Branches
+The branch must exist before performing write. The operation does **not** create the branch if it does not exist.
+For more information on branches please refer to [branches](branching.md). 
+A branch can be created using [Spark DDL](spark-ddl.md#branching-and-tagging-ddl). Branch writes can be performed via  
+by providing a branch identifier, `branch_yourBranch` in the operation.
+
+!!! info
+    Note: When writing to a branch, the current schema of the table will be used for validation.
+
+To insert into `audit` branch
+
+```scala
+val data: DataFrame = ...
+data.writeTo("prod.db.table.branch_audit").append()
+```
+
+To overwrite `audit` branch
+
+```scala
+val data: DataFrame = ...
+data.writeTo("prod.db.table.branch_audit").overwritePartitions()
+```
+
 ## Writing Distribution Modes
 
 Iceberg's default Spark writers require that the data in each spark task is clustered by partition values. This 

--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -195,16 +195,20 @@ WHERE EXISTS (SELECT oid FROM prod.db.returned_orders WHERE t1.oid = oid)
 For more complex row-level updates based on incoming data, see the section on `MERGE INTO`.
 
 ### Writing to Branches
-Branch writes can be performed via SQL by providing a branch identifier, `branch_yourBranch` in the operation.
-Branch writes can also be performed as part of a write-audit-publish (WAP) workflow by specifying the `spark.wap.branch` config.
-Note WAP branch and branch identifier cannot both be specified.
-Also, the branch must exist before performing the write. 
-The operation does **not** create the branch if it does not exist. 
-For more information on branches please refer to [branches](branching.md).
+
+The branch must exist before performing write. The operations do **not** create the branch if it does not exist.
+A branch can be created using [Spark DDL](spark-ddl.md#branching-and-tagging-ddl).
 
 !!! info
-    Note: When writing to a branch, the current schema of the table will be used for validation.
+Note: When writing to a branch, the current schema of the table will be used for validation.
 
+#### Via SQL
+
+Branch writes can be performed by providing a branch identifier, `branch_yourBranch` in the operation.
+
+Branch writes can also be performed as part of a write-audit-publish (WAP) workflow by specifying the `spark.wap.branch` config.
+Note WAP branch and branch identifier cannot both be specified.
+Also, the branch must exist before performing the write.
  
 ```sql
 -- INSERT (1,' a') (2, 'b') into the audit branch.
@@ -226,6 +230,24 @@ DELETE FROM prod.dbl.table.branch_audit WHERE id = 2;
 -- WAP Branch write
 SET spark.wap.branch = audit-branch
 INSERT INTO prod.db.table VALUES (3, 'c');
+```
+
+### Via DataFrames
+
+Branch writes via DataFrames can be performed by providing a branch identifier, `branch_yourBranch` in the operation.
+
+To insert into `audit` branch
+
+```scala
+val data: DataFrame = ...
+data.writeTo("prod.db.table.branch_audit").append()
+```
+
+To overwrite `audit` branch
+
+```scala
+val data: DataFrame = ...
+data.writeTo("prod.db.table.branch_audit").overwritePartitions()
 ```
 
 ## Writing with DataFrames

--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -200,7 +200,7 @@ The branch must exist before performing write. The operations do **not** create 
 A branch can be created using [Spark DDL](spark-ddl.md#branching-and-tagging-ddl).
 
 !!! info
-Note: When writing to a branch, the current schema of the table will be used for validation.
+    Note: When writing to a branch, the current schema of the table will be used for validation.
 
 #### Via SQL
 
@@ -232,7 +232,7 @@ SET spark.wap.branch = audit-branch
 INSERT INTO prod.db.table VALUES (3, 'c');
 ```
 
-### Via DataFrames
+#### Via DataFrames
 
 Branch writes via DataFrames can be performed by providing a branch identifier, `branch_yourBranch` in the operation.
 
@@ -353,29 +353,6 @@ The writer must enable the `mergeSchema` option.
 
 ```scala
 data.writeTo("prod.db.sample").option("mergeSchema","true").append()
-```
-
-### Writing to Branches
-The branch must exist before performing write. The operation does **not** create the branch if it does not exist.
-For more information on branches please refer to [branches](branching.md). 
-A branch can be created using [Spark DDL](spark-ddl.md#branching-and-tagging-ddl). Branch writes can be performed via  
-by providing a branch identifier, `branch_yourBranch` in the operation.
-
-!!! info
-    Note: When writing to a branch, the current schema of the table will be used for validation.
-
-To insert into `audit` branch
-
-```scala
-val data: DataFrame = ...
-data.writeTo("prod.db.table.branch_audit").append()
-```
-
-To overwrite `audit` branch
-
-```scala
-val data: DataFrame = ...
-data.writeTo("prod.db.table.branch_audit").overwritePartitions()
 ```
 
 ## Writing Distribution Modes

--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -236,16 +236,14 @@ INSERT INTO prod.db.table VALUES (3, 'c');
 
 Branch writes via DataFrames can be performed by providing a branch identifier, `branch_yourBranch` in the operation.
 
-To insert into `audit` branch
-
 ```scala
+// To insert into `audit` branch
 val data: DataFrame = ...
 data.writeTo("prod.db.table.branch_audit").append()
 ```
 
-To overwrite `audit` branch
-
 ```scala
+// To overwrite `audit` branch
 val data: DataFrame = ...
 data.writeTo("prod.db.table.branch_audit").overwritePartitions()
 ```

--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -196,7 +196,7 @@ For more complex row-level updates based on incoming data, see the section on `M
 
 ### Writing to Branches
 
-The branch must exist before performing write. The operations do **not** create the branch if it does not exist.
+The branch must exist before performing write. Operations do **not** create the branch if it does not exist.
 A branch can be created using [Spark DDL](spark-ddl.md#branching-and-tagging-ddl).
 
 !!! info
@@ -352,7 +352,6 @@ The writer must enable the `mergeSchema` option.
 ```scala
 data.writeTo("prod.db.sample").option("mergeSchema","true").append()
 ```
-
 ## Writing Distribution Modes
 
 Iceberg's default Spark writers require that the data in each spark task is clustered by partition values. This 

--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -194,7 +194,7 @@ WHERE EXISTS (SELECT oid FROM prod.db.returned_orders WHERE t1.oid = oid)
 
 For more complex row-level updates based on incoming data, see the section on `MERGE INTO`.
 
-### Writing to Branches
+## Writing to Branches
 
 The branch must exist before performing write. Operations do **not** create the branch if it does not exist.
 A branch can be created using [Spark DDL](spark-ddl.md#branching-and-tagging-ddl).
@@ -202,7 +202,7 @@ A branch can be created using [Spark DDL](spark-ddl.md#branching-and-tagging-ddl
 !!! info
     Note: When writing to a branch, the current schema of the table will be used for validation.
 
-#### Via SQL
+### Via SQL
 
 Branch writes can be performed by providing a branch identifier, `branch_yourBranch` in the operation.
 
@@ -232,7 +232,7 @@ SET spark.wap.branch = audit-branch
 INSERT INTO prod.db.table VALUES (3, 'c');
 ```
 
-#### Via DataFrames
+### Via DataFrames
 
 Branch writes via DataFrames can be performed by providing a branch identifier, `branch_yourBranch` in the operation.
 

--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -208,7 +208,6 @@ Branch writes can be performed by providing a branch identifier, `branch_yourBra
 
 Branch writes can also be performed as part of a write-audit-publish (WAP) workflow by specifying the `spark.wap.branch` config.
 Note WAP branch and branch identifier cannot both be specified.
-Also, the branch must exist before performing the write.
  
 ```sql
 -- INSERT (1,' a') (2, 'b') into the audit branch.


### PR DESCRIPTION
Moved `Writing to branches` into SQL and data frame writes section and added examples of writing to branches with dataframes.

<img width="727" alt="Screenshot 2024-07-12 at 3 33 24 PM" src="https://github.com/user-attachments/assets/0c80234e-6ced-4c43-88e2-351828279b33">
