### PR TITLE
Support Spark Column Stats

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -351,8 +351,8 @@ public class SparkReadConf {
   public boolean enableColumnStats() {
     return confParser
         .booleanConf()
-        .sessionConf(SparkSQLProperties.ENABLE_COLUMN_STATS)
-        .defaultValue(SparkSQLProperties.ENABLE_COLUMN_STATS_DEFAULT)
+        .sessionConf(SparkSQLProperties.REPORT_COLUMN_STATS)
+        .defaultValue(SparkSQLProperties.REPORT_COLUMN_STATS_DEFAULT)
         .parse();
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -347,4 +347,12 @@ public class SparkReadConf {
         .defaultValue(SparkSQLProperties.EXECUTOR_CACHE_LOCALITY_ENABLED_DEFAULT)
         .parse();
   }
+
+  public boolean enableColumnStats() {
+    return confParser
+        .booleanConf()
+        .sessionConf(SparkSQLProperties.ENABLE_COLUMN_STATS)
+        .defaultValue(SparkSQLProperties.ENABLE_COLUMN_STATS_DEFAULT)
+        .parse();
+  }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -348,7 +348,7 @@ public class SparkReadConf {
         .parse();
   }
 
-  public boolean enableColumnStats() {
+  public boolean reportColumnStats() {
     return confParser
         .booleanConf()
         .sessionConf(SparkSQLProperties.REPORT_COLUMN_STATS)

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -91,7 +91,7 @@ public class SparkSQLProperties {
       "spark.sql.iceberg.executor-cache.locality.enabled";
   public static final boolean EXECUTOR_CACHE_LOCALITY_ENABLED_DEFAULT = false;
 
-  // Controls whether column statistics are enabled when estimating statistics
+  // Controls whether to calculate column statistics and report them to Spark
   public static final String ENABLE_COLUMN_STATS = "spark.sql.iceberg.enable-column-stats";
   public static final boolean ENABLE_COLUMN_STATS_DEFAULT = false;
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -90,4 +90,8 @@ public class SparkSQLProperties {
   public static final String EXECUTOR_CACHE_LOCALITY_ENABLED =
       "spark.sql.iceberg.executor-cache.locality.enabled";
   public static final boolean EXECUTOR_CACHE_LOCALITY_ENABLED_DEFAULT = false;
+
+  // Controls whether column statistics are enabled when estimating statistics
+  public static final String ENABLE_COLUMN_STATS = "spark.sql.iceberg.enable-column-stats";
+  public static final boolean ENABLE_COLUMN_STATS_DEFAULT = false;
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -91,7 +91,7 @@ public class SparkSQLProperties {
       "spark.sql.iceberg.executor-cache.locality.enabled";
   public static final boolean EXECUTOR_CACHE_LOCALITY_ENABLED_DEFAULT = false;
 
-  // Controls whether to calculate column statistics and report them to Spark
-  public static final String ENABLE_COLUMN_STATS = "spark.sql.iceberg.enable-column-stats";
-  public static final boolean ENABLE_COLUMN_STATS_DEFAULT = false;
+  // Controls whether to report available column statistics to Spark for query optimization.
+  public static final String REPORT_COLUMN_STATS = "spark.sql.iceberg.report-column-stats";
+  public static final boolean REPORT_COLUMN_STATS_DEFAULT = true;
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/ColStats.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/ColStats.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
+import org.apache.spark.sql.connector.read.colstats.Histogram;
+
+class ColStats implements ColumnStatistics {
+
+  private final OptionalLong distinctCount;
+  private final Optional<Object> min;
+  private final Optional<Object> max;
+  private final OptionalLong nullCount;
+  private final OptionalLong avgLen;
+  private final OptionalLong maxLen;
+  private final Optional<Histogram> histogram;
+
+  ColStats(
+      long distinctCount,
+      Object min,
+      Object max,
+      long nullCount,
+      long avgLen,
+      long maxLen,
+      Histogram histogram) {
+    this.distinctCount = OptionalLong.of(distinctCount);
+    this.min = min != null ? Optional.of(min) : Optional.empty();
+    this.max = max != null ? Optional.of(max) : Optional.empty();
+    this.nullCount = OptionalLong.of(nullCount);
+    this.avgLen = OptionalLong.of(avgLen);
+    this.maxLen = OptionalLong.of(maxLen);
+    this.histogram = histogram != null ? Optional.of(histogram) : Optional.empty();
+  }
+
+  @Override
+  public OptionalLong distinctCount() {
+    return distinctCount;
+  }
+
+  @Override
+  public Optional<Object> min() {
+    return min;
+  }
+
+  @Override
+  public Optional<Object> max() {
+    return max;
+  }
+
+  @Override
+  public OptionalLong nullCount() {
+    return nullCount;
+  }
+
+  @Override
+  public OptionalLong avgLen() {
+    return avgLen;
+  }
+
+  @Override
+  public OptionalLong maxLen() {
+    return maxLen;
+  }
+
+  @Override
+  public Optional<Histogram> histogram() {
+    return histogram;
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkSchemaUtil;
@@ -88,7 +89,7 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
   public Statistics estimateStatistics() {
     long rowsCount = taskGroups().stream().mapToLong(ScanTaskGroup::estimatedRowsCount).sum();
     long sizeInBytes = SparkSchemaUtil.estimateSize(readSchema(), rowsCount);
-    return new Stats(sizeInBytes, rowsCount);
+    return new Stats(sizeInBytes, rowsCount, Maps.newHashMap());
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -31,7 +31,6 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkSchemaUtil;
@@ -89,7 +88,7 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
   public Statistics estimateStatistics() {
     long rowsCount = taskGroups().stream().mapToLong(ScanTaskGroup::estimatedRowsCount).sum();
     long sizeInBytes = SparkSchemaUtil.estimateSize(readSchema(), rowsCount);
-    return new Stats(sizeInBytes, rowsCount, Maps.newHashMap());
+    return new Stats(sizeInBytes, rowsCount, Collections.emptyMap());
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkColumnStatistics.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkColumnStatistics.java
@@ -34,19 +34,20 @@ class SparkColumnStatistics implements ColumnStatistics {
   private final Optional<Histogram> histogram;
 
   SparkColumnStatistics(
-      long distinctCount,
+      Long distinctCount,
       Object min,
       Object max,
-      long nullCount,
-      long avgLen,
-      long maxLen,
+      Long nullCount,
+      Long avgLen,
+      Long maxLen,
       Histogram histogram) {
-    this.distinctCount = OptionalLong.of(distinctCount);
+    this.distinctCount =
+        (distinctCount == null) ? OptionalLong.empty() : OptionalLong.of(distinctCount);
     this.min = Optional.ofNullable(min);
     this.max = Optional.ofNullable(max);
-    this.nullCount = OptionalLong.of(nullCount);
-    this.avgLen = OptionalLong.of(avgLen);
-    this.maxLen = OptionalLong.of(maxLen);
+    this.nullCount = (nullCount == null) ? OptionalLong.empty() : OptionalLong.of(nullCount);
+    this.avgLen = (avgLen == null) ? OptionalLong.empty() : OptionalLong.of(avgLen);
+    this.maxLen = (maxLen == null) ? OptionalLong.empty() : OptionalLong.of(maxLen);
     this.histogram = Optional.ofNullable(histogram);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkColumnStatistics.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkColumnStatistics.java
@@ -23,7 +23,7 @@ import java.util.OptionalLong;
 import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
 import org.apache.spark.sql.connector.read.colstats.Histogram;
 
-class ColStats implements ColumnStatistics {
+class SparkColumnStatistics implements ColumnStatistics {
 
   private final OptionalLong distinctCount;
   private final Optional<Object> min;
@@ -33,7 +33,7 @@ class ColStats implements ColumnStatistics {
   private final OptionalLong maxLen;
   private final Optional<Histogram> histogram;
 
-  ColStats(
+  SparkColumnStatistics(
       long distinctCount,
       Object min,
       Object max,
@@ -42,12 +42,12 @@ class ColStats implements ColumnStatistics {
       long maxLen,
       Histogram histogram) {
     this.distinctCount = OptionalLong.of(distinctCount);
-    this.min = min != null ? Optional.of(min) : Optional.empty();
-    this.max = max != null ? Optional.of(max) : Optional.empty();
+    this.min = Optional.ofNullable(min);
+    this.max = Optional.ofNullable(max);
     this.nullCount = OptionalLong.of(nullCount);
     this.avgLen = OptionalLong.of(avgLen);
     this.maxLen = OptionalLong.of(maxLen);
-    this.histogram = histogram != null ? Optional.of(histogram) : Optional.empty();
+    this.histogram = Optional.ofNullable(histogram);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -187,7 +187,8 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
       return new Stats(0L, 0L, Collections.emptyMap());
     }
 
-    boolean cboEnabled = Boolean.parseBoolean(spark.conf().get(SQLConf.CBO_ENABLED().key(), "false"));
+    boolean cboEnabled =
+        Boolean.parseBoolean(spark.conf().get(SQLConf.CBO_ENABLED().key(), "false"));
     Map<NamedReference, ColumnStatistics> colStatsMap = null;
     if (readConf.enableColumnStats() && cboEnabled) {
       colStatsMap = Maps.newHashMap();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg.spark.source;
 
-import static org.apache.iceberg.puffin.StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -204,7 +202,9 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
           NamedReference ref = FieldReference.column(colName);
 
           Long ndv = null;
-          if (blobMetadata.type().equals(APACHE_DATASKETCHES_THETA_V1)) {
+          if (blobMetadata
+              .type()
+              .equals(org.apache.iceberg.puffin.StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1)) {
             String ndvStr = blobMetadata.properties().get(NDV_KEY);
             if (ndvStr != null && !ndvStr.isEmpty()) {
               ndv = Long.parseLong(ndvStr);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -216,7 +216,6 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
             LOG.debug("DataSketch blob is not available for column {}", colName);
           }
 
-          // TODO: Fill min, max and null from the manifest file
           ColumnStatistics colStats =
               new SparkColumnStatistics(ndv, null, null, null, null, null, null);
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -191,7 +191,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     boolean cboEnabled =
         Boolean.parseBoolean(spark.conf().get(SQLConf.CBO_ENABLED().key(), "false"));
     Map<NamedReference, ColumnStatistics> colStatsMap = Maps.newHashMap();
-    if (readConf.enableColumnStats() && cboEnabled) {
+    if (readConf.reportColumnStats() && cboEnabled) {
       List<StatisticsFile> files = table.statisticsFiles();
       if (!files.isEmpty()) {
         List<BlobMetadata> metadataList = (files.get(0)).blobMetadata();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -190,8 +190,9 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
 
     boolean cboEnabled =
         Boolean.parseBoolean(spark.conf().get(SQLConf.CBO_ENABLED().key(), "false"));
-    Map<NamedReference, ColumnStatistics> colStatsMap = Maps.newHashMap();
+    Map<NamedReference, ColumnStatistics> colStatsMap = null;
     if (readConf.reportColumnStats() && cboEnabled) {
+      colStatsMap = Maps.newHashMap();
       List<StatisticsFile> files = table.statisticsFiles();
       if (!files.isEmpty()) {
         List<BlobMetadata> metadataList = (files.get(0)).blobMetadata();
@@ -216,11 +217,14 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
           }
 
           // TODO: Fill min, max and null from the manifest file
-          ColumnStatistics colStats = new SparkColumnStatistics(ndv, null, null, 0L, 0L, 0L, null);
+          ColumnStatistics colStats =
+              new SparkColumnStatistics(ndv, null, null, null, null, null, null);
 
           colStatsMap.put(ref, colStats);
         }
       }
+    } else {
+      colStatsMap = Collections.emptyMap();
     }
 
     // estimate stats using snapshot summary only for partitioned tables

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/Stats.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/Stats.java
@@ -18,16 +18,21 @@
  */
 package org.apache.iceberg.spark.source;
 
+import java.util.Map;
 import java.util.OptionalLong;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.read.Statistics;
+import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
 
 class Stats implements Statistics {
   private final OptionalLong sizeInBytes;
   private final OptionalLong numRows;
+  private final Map<NamedReference, ColumnStatistics> colstats;
 
-  Stats(long sizeInBytes, long numRows) {
+  Stats(long sizeInBytes, long numRows, Map<NamedReference, ColumnStatistics> colstats) {
     this.sizeInBytes = OptionalLong.of(sizeInBytes);
     this.numRows = OptionalLong.of(numRows);
+    this.colstats = colstats;
   }
 
   @Override
@@ -38,5 +43,10 @@ class Stats implements Statistics {
   @Override
   public OptionalLong numRows() {
     return numRows;
+  }
+
+  @Override
+  public Map<NamedReference, ColumnStatistics> columnStats() {
+    return colstats;
   }
 }


### PR DESCRIPTION
Co-authored-by: Huaxin Gao
Co-authored-by: Karuppayya Rajendran

This PR adds the column stats support, so Iceberg can report column stats to Spark engine for CBO.