### PR TITLE
mr：Fix issues 10639

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -153,8 +153,8 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
             conf.getInt(
                 SystemConfigs.WORKER_THREAD_POOL_SIZE.propertyKey(),
                 ThreadPools.WORKER_THREAD_POOL_SIZE));
-    scan = scan.planWith(workerPool);
     try {
+      scan = scan.planWith(workerPool);
       try (CloseableIterable<CombinedScanTask> tasksIterable = scan.planTasks()) {
         Table serializableTable = SerializableTable.copyOf(table);
         tasksIterable.forEach(

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -160,8 +160,8 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
         tasksIterable.forEach(
             task -> {
               if (applyResidual
-                       && (model == InputFormatConfig.InMemoryDataModel.HIVE
-                       || model == InputFormatConfig.InMemoryDataModel.PIG)) {
+                  && (model == InputFormatConfig.InMemoryDataModel.HIVE
+                      || model == InputFormatConfig.InMemoryDataModel.PIG)) {
                 // TODO: We do not support residual evaluation for HIVE and PIG in memory data model
                 // yet
                 checkResiduals(task);

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.SystemConfigs;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
@@ -75,7 +76,6 @@ import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.SystemConfigs;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PartitionUtil;
@@ -148,10 +148,13 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
         conf.getEnum(
             InputFormatConfig.IN_MEMORY_DATA_MODEL, InputFormatConfig.InMemoryDataModel.GENERIC);
     final ExecutorService workerPool =
-        ThreadPools.newWorkerPool("iceberg-plan-worker-pool",
-                conf.getInt(SystemConfigs.WORKER_THREAD_POOL_SIZE.propertyKey(), ThreadPools.WORKER_THREAD_POOL_SIZE));
+            ThreadPools.newWorkerPool(
+                    "iceberg-plan-worker-pool",
+                    conf.getInt(
+                            SystemConfigs.WORKER_THREAD_POOL_SIZE.propertyKey(),
+                            ThreadPools.WORKER_THREAD_POOL_SIZE));
     scan = scan.planWith(workerPool);
-    try{
+    try {
       try (CloseableIterable<CombinedScanTask> tasksIterable = scan.planTasks()) {
         Table serializableTable = SerializableTable.copyOf(table);
         tasksIterable.forEach(
@@ -168,7 +171,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
       } catch (IOException e) {
         throw new UncheckedIOException(String.format("Failed to close table scan: %s", scan), e);
       }
-    } finally{
+    } finally {
       workerPool.shutdown();
     }
 

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -148,26 +148,26 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
         conf.getEnum(
             InputFormatConfig.IN_MEMORY_DATA_MODEL, InputFormatConfig.InMemoryDataModel.GENERIC);
     final ExecutorService workerPool =
-            ThreadPools.newWorkerPool(
-                    "iceberg-plan-worker-pool",
-                    conf.getInt(
-                            SystemConfigs.WORKER_THREAD_POOL_SIZE.propertyKey(),
-                            ThreadPools.WORKER_THREAD_POOL_SIZE));
+        ThreadPools.newWorkerPool(
+            "iceberg-plan-worker-pool",
+            conf.getInt(
+                SystemConfigs.WORKER_THREAD_POOL_SIZE.propertyKey(),
+                ThreadPools.WORKER_THREAD_POOL_SIZE));
     scan = scan.planWith(workerPool);
     try {
       try (CloseableIterable<CombinedScanTask> tasksIterable = scan.planTasks()) {
         Table serializableTable = SerializableTable.copyOf(table);
         tasksIterable.forEach(
-                task -> {
-                  if (applyResidual
-                          && (model == InputFormatConfig.InMemoryDataModel.HIVE
-                          || model == InputFormatConfig.InMemoryDataModel.PIG)) {
-                    // TODO: We do not support residual evaluation for HIVE and PIG in memory data model
-                    // yet
-                    checkResiduals(task);
-                  }
-                  splits.add(new IcebergSplit(serializableTable, conf, task));
-                });
+            task -> {
+              if (applyResidual
+                       && (model == InputFormatConfig.InMemoryDataModel.HIVE
+                       || model == InputFormatConfig.InMemoryDataModel.PIG)) {
+                // TODO: We do not support residual evaluation for HIVE and PIG in memory data model
+                // yet
+                checkResiduals(task);
+              }
+              splits.add(new IcebergSplit(serializableTable, conf, task));
+            });
       } catch (IOException e) {
         throw new UncheckedIOException(String.format("Failed to close table scan: %s", scan), e);
       }

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -417,7 +417,7 @@ public class TestIcebergInputFormats {
               try {
                 method.invoke(new IcebergInputFormat<>(), table, conf, workerpool);
                 return workerpool
-                    .submit(() -> return UserGroupInformation.getCurrentUser().getUserName());
+                    .submit(() -> UserGroupInformation.getCurrentUser().getUserName())
                     .get();
               } catch (Exception e) {
                 throw new RuntimeException("Failed to get user from worker pool", e);

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -417,7 +417,7 @@ public class TestIcebergInputFormats {
               try {
                 method.invoke(new IcebergInputFormat<>(), table, conf, workerpool);
                 return workerpool
-                    .submit(() -> return UserGroupInformation.getCurrentUser().getUserName())
+                    .submit(() -> return UserGroupInformation.getCurrentUser().getUserName());
                     .get();
               } catch (Exception e) {
                 throw new RuntimeException("Failed to get user from worker pool", e);

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -77,7 +77,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestIcebergInputFormats {
@@ -422,7 +421,7 @@ public class TestIcebergInputFormats {
         (PrivilegedAction<String>)
             () -> {
               try {
-                method.invoke(Mockito.mock(IcebergInputFormat.class), table, conf, workerpool);
+                method.invoke(new IcebergInputFormat<>(), table, conf, workerpool);
                 Future<String> submit =
                     workerpool.submit(
                         () -> {

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -433,7 +433,7 @@ public class TestIcebergInputFormats {
                 }
                 return submit.get();
               } catch (Exception e) {
-                throw new RuntimeException("Failed to getUserFromWorkerPool", e);
+                throw new RuntimeException("Failed to get user from worker pool", e);
               }
             });
   }

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.function.Function;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
@@ -425,15 +424,12 @@ public class TestIcebergInputFormats {
             () -> {
               try {
                 method.invoke(new IcebergInputFormat<>(), table, conf, workerpool);
-                Future<String> submit =
-                    workerpool.submit(
+                return workerpool
+                    .submit(
                         () -> {
                           return UserGroupInformation.getCurrentUser().getUserName();
-                        });
-                while (!submit.isDone()) {
-                  Thread.sleep(10);
-                }
-                return submit.get();
+                        })
+                    .get();
               } catch (Exception e) {
                 throw new RuntimeException("Failed to get user from worker pool", e);
               }

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -394,13 +394,14 @@ public class TestIcebergInputFormats {
         UserGroupInformation.createUserForTesting("user1", new String[] {});
     UserGroupInformation user2 =
         UserGroupInformation.createUserForTesting("user2", new String[] {});
-
     assertThat(setAndGetUgi(user1, workerPool1)).isEqualTo("user1");
     assertThat(setAndGetUgi(user2, workerPool1)).isEqualTo("user1");
+    workerPool1.shutdown();
 
     // 2.The ugi in different threads will be different
     final ExecutorService workerPool2 = ThreadPools.newWorkerPool("iceberg-plan-worker-pool", 1);
     assertThat(setAndGetUgi(user2, workerPool2)).isEqualTo("user2");
+    workerPool2.shutdown();
   }
 
   private String setAndGetUgi(UserGroupInformation ugi, ExecutorService workpool)

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -394,17 +394,20 @@ public class TestIcebergInputFormats {
     helper.appendToTable(null, records);
     UserGroupInformation user1 =
         UserGroupInformation.createUserForTesting("user1", new String[] {});
+    UserGroupInformation user2 =
+        UserGroupInformation.createUserForTesting("user2", new String[] {});
     final ExecutorService workerPool1 = ThreadPools.newWorkerPool("iceberg-plan-worker-pool", 1);
     try {
+      // different users still use the first ugi for execution
       assertThat(getUserFromWorkerPool(user1, table, workerPool1)).isEqualTo("user1");
+      assertThat(getUserFromWorkerPool(user2, table, workerPool1)).isEqualTo("user1");
     } finally {
       workerPool1.shutdown();
     }
 
-    UserGroupInformation user2 =
-        UserGroupInformation.createUserForTesting("user2", new String[] {});
     final ExecutorService workerPool2 = ThreadPools.newWorkerPool("iceberg-plan-worker-pool", 1);
     try {
+      // using different ugi in different workerpool
       assertThat(getUserFromWorkerPool(user2, table, workerPool2)).isEqualTo("user2");
     } finally {
       workerPool2.shutdown();


### PR DESCRIPTION
Fix [10639](https://github.com/apache/iceberg/issues/10639)

All users use the same static thread pool in hiveserver2, the ugi in the thread is always the first user to use the thread.
I think each fetch task will new its own thread pool like [HIVE-28276](https://github.com/apache/hive/commit/45867be6cb5308566e4cf16c7b4cf8081085b58c)