### PR TITLE
Build: don't include slf4j-api in bundled JARs

### DIFF
--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -47,6 +47,10 @@ project(":iceberg-aws-bundle") {
       include 'NOTICE'
     }
 
+    dependencies {
+      exclude(dependency('org.slf4j:slf4j-api'))
+    }
+
     // relocate AWS-specific versions
     relocate 'org.apache.http', 'org.apache.iceberg.aws.shaded.org.apache.http'
     relocate 'io.netty', 'org.apache.iceberg.aws.shaded.io.netty'

--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -39,6 +39,10 @@ project(":iceberg-azure-bundle") {
       include 'NOTICE'
     }
 
+    dependencies {
+      exclude(dependency('org.slf4j:slf4j-api'))
+    }
+
     // relocate Azure-specific versions
     relocate 'io.netty', 'org.apache.iceberg.azure.shaded.io.netty'
     relocate 'com.fasterxml.jackson', 'org.apache.iceberg.azure.shaded.com.fasterxml.jackson'

--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -38,6 +38,10 @@ project(":iceberg-gcp-bundle") {
       include 'NOTICE'
     }
 
+    dependencies {
+      exclude(dependency('org.slf4j:slf4j-api'))
+    }
+
     // relocate GCP-specific versions
     relocate 'com.fasterxml.jackson', 'org.apache.iceberg.gcp.shaded.com.fasterxml.jackson'
     relocate 'com.google.common', 'org.apache.iceberg.gcp.shaded.com.google.common'

--- a/hive3-orc-bundle/build.gradle
+++ b/hive3-orc-bundle/build.gradle
@@ -50,6 +50,10 @@ project(':iceberg-hive3-orc-bundle') {
       include 'NOTICE'
     }
 
+    dependencies {
+      exclude(dependency('org.slf4j:slf4j-api'))
+    }
+
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.orc.storage', 'org.apache.hadoop.hive'
 


### PR DESCRIPTION
This excludes `slf4j-api` from being shadowed into `iceberg-aws-bundle`, `iceberg-azure-bundle`, `iceberg-gcp-bundle`, and `iceberg-hive3-orc-bundle`. This uses the same exclude pattern established by `iceberg-bundled-guava`. 

Fixes #10534