### PR TITLE
[Flink] the precondition judgment is incorrect in the FlinkSink class.

### DIFF
--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -327,11 +327,12 @@ public class FlinkSink {
       Preconditions.checkArgument(
           inputCreator != null,
           "Please use forRowData() or forMapperOutputType() to initialize the input DataStream.");
-      Preconditions.checkNotNull(tableLoader, "Table loader shouldn't be null");
 
       DataStream<RowData> rowDataInput = inputCreator.apply(uidPrefix);
 
       if (table == null) {
+        Preconditions.checkNotNull(tableLoader, "Table is null and Table loader shouldn't be null");
+
         if (!tableLoader.isOpen()) {
           tableLoader.open();
         }

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -332,6 +332,8 @@ public class FlinkSink {
       DataStream<RowData> rowDataInput = inputCreator.apply(uidPrefix);
 
       if (table == null) {
+        Preconditions.checkNotNull(tableLoader, "Table is null and Table loader shouldn't be null");
+
         if (!tableLoader.isOpen()) {
           tableLoader.open();
         }

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -327,11 +327,12 @@ public class FlinkSink {
       Preconditions.checkArgument(
           inputCreator != null,
           "Please use forRowData() or forMapperOutputType() to initialize the input DataStream.");
-      Preconditions.checkNotNull(tableLoader, "Table loader shouldn't be null");
 
       DataStream<RowData> rowDataInput = inputCreator.apply(uidPrefix);
 
       if (table == null) {
+        Preconditions.checkNotNull(tableLoader, "Table is null and Table loader shouldn't be null");
+
         if (!tableLoader.isOpen()) {
           tableLoader.open();
         }


### PR DESCRIPTION
When we create a FlinkSink object using the chainIcebergOperators method, we use the Table field. If the Table is set, it will be used directly; if the Table is not set, a Table is loaded using the tableLoader.This bug causes the table we set to be ineffective; we must use the tableLoader method to create a FlinkSink.