### PR TITLE
Build: Define JUnit4 dependency only where necessary

### DIFF
--- a/api/src/test/java/org/apache/iceberg/Parameter.java
+++ b/api/src/test/java/org/apache/iceberg/Parameter.java
@@ -22,11 +22,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.junit.runners.Parameterized;
 
 /**
- * The annotation is used to replace {@link Parameterized.Parameter} for Junit 5 parameterized
- * tests.
+ * The annotation is used to replace {@link org.junit.runners.Parameterized.Parameter} for Junit 5
+ * parameterized tests.
  *
  * <p>This implementation has been taken from Flink repository. The only difference is the "index"
  * field, renamed to be more intuitive

--- a/build.gradle
+++ b/build.gradle
@@ -212,7 +212,6 @@ subprojects {
   dependencies {
     implementation libs.slf4j.api
 
-    testImplementation libs.junit.vintage.engine
     testImplementation libs.junit.jupiter
     testImplementation libs.junit.jupiter.engine
     testImplementation libs.slf4j.simple
@@ -413,6 +412,7 @@ project(':iceberg-data') {
 
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
+    testImplementation libs.junit.vintage.engine
   }
 
   test {

--- a/flink/v1.17/build.gradle
+++ b/flink/v1.17/build.gradle
@@ -117,6 +117,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
     testImplementation libs.awaitility
     testImplementation libs.assertj.core
+    testImplementation libs.junit.vintage.engine
   }
 
   test {

--- a/flink/v1.18/build.gradle
+++ b/flink/v1.18/build.gradle
@@ -117,6 +117,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
     testImplementation libs.awaitility
     testImplementation libs.assertj.core
+    testImplementation libs.junit.vintage.engine
   }
 
   test {

--- a/flink/v1.19/build.gradle
+++ b/flink/v1.19/build.gradle
@@ -119,6 +119,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
     testImplementation libs.awaitility
     testImplementation libs.assertj.core
+    testImplementation libs.junit.vintage.engine
   }
 
   test {

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -103,6 +103,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
     testImplementation libs.sqlite.jdbc
     testImplementation libs.awaitility
+    testImplementation libs.junit.vintage.engine
   }
 
   test {
@@ -164,6 +165,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
 
     testImplementation libs.avro.avro
     testImplementation libs.parquet.hadoop
+    testImplementation libs.junit.vintage.engine
 
     // Required because we remove antlr plugin dependencies from the compile configuration, see note above
     runtimeOnly libs.antlr.runtime

--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -104,6 +104,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
     testImplementation libs.sqlite.jdbc
     testImplementation libs.awaitility
+    testImplementation libs.junit.vintage.engine
   }
 
   test {
@@ -167,6 +168,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
 
     testImplementation libs.avro.avro
     testImplementation libs.parquet.hadoop
+    testImplementation libs.junit.vintage.engine
 
     // Required because we remove antlr plugin dependencies from the compile configuration, see note above
     runtimeOnly libs.antlr.runtime


### PR DESCRIPTION
Most modules have already been converted to JUnit5, except for Flink and Spark.
Defining the JUnit4 dependency only where necessary reduces the risk that new JUnit4-style tests are being added in the already converted modules.