### PR TITLE
Core: use bulk delete when removing old metadata.json files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -395,9 +395,6 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
                 Iterables.transform(
                     removedPreviousMetadataFiles, TableMetadata.MetadataLogEntry::file));
       } else {
-        LOG.warn(
-            "IO {} does not support bulk operations. Using non-bulk deletes.",
-            io().getClass().getName());
         Tasks.foreach(removedPreviousMetadataFiles)
             .noRetry()
             .suppressFailureWhenFinished()


### PR DESCRIPTION
`write.metadata.previous-versions-max` is used to control previous version of metadata.json files on commit, default to 100. I believe we can tried to batch the deletion together if io supports it

For testing, it's already covered by testMetadataFileLocationsRemovalAfterCommit in CatalogTests.java