### PR TITLE
Core: Fix NPE during conflict handling of NULL partitions

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
@@ -200,8 +200,7 @@ public class PartitionSet extends AbstractSet<Pair<Integer, StructLike>> {
           StringBuilder partitionStringBuilder = new StringBuilder();
           partitionStringBuilder.append(structType.fields().get(i).name());
           partitionStringBuilder.append("=");
-          Object value = s.get(i, Object.class);
-          partitionStringBuilder.append(value == null ? "null" : value.toString());
+          partitionStringBuilder.append(String.valueOf(s.get(i, Object.class)));
           partitionDataJoiner.add(partitionStringBuilder.toString());
         }
       }

--- a/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
@@ -200,7 +200,7 @@ public class PartitionSet extends AbstractSet<Pair<Integer, StructLike>> {
           StringBuilder partitionStringBuilder = new StringBuilder();
           partitionStringBuilder.append(structType.fields().get(i).name());
           partitionStringBuilder.append("=");
-          partitionStringBuilder.append(String.valueOf(s.get(i, Object.class)));
+          partitionStringBuilder.append(s.get(i, Object.class));
           partitionDataJoiner.add(partitionStringBuilder.toString());
         }
       }

--- a/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
@@ -200,7 +200,8 @@ public class PartitionSet extends AbstractSet<Pair<Integer, StructLike>> {
           StringBuilder partitionStringBuilder = new StringBuilder();
           partitionStringBuilder.append(structType.fields().get(i).name());
           partitionStringBuilder.append("=");
-          partitionStringBuilder.append(s.get(i, Object.class).toString());
+          Object value = s.get(i, Object.class);
+          partitionStringBuilder.append(value == null ? "null" : value.toString());
           partitionDataJoiner.add(partitionStringBuilder.toString());
         }
       }

--- a/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
@@ -76,7 +76,7 @@ public class TestReplacePartitions extends TestBase {
           .build();
 
   // Partition spec with VOID partition transform ("alwaysNull" in Java code.)
- static final PartitionSpec SPEC_VOID =
+  static final PartitionSpec SPEC_VOID =
       PartitionSpec.builderFor(SCHEMA).alwaysNull("id").bucket("data", BUCKETS_NUMBER).build();
 
   static final DataFile FILE_A_VOID_PARTITION =

--- a/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
@@ -67,7 +67,6 @@ public class TestReplacePartitions extends TestBase {
           .withRecordCount(1)
           .build();
 
-
   static final DataFile FILE_NULL_PARTITION =
       DataFiles.builder(SPEC)
           .withPath("/path/to/data-null-partition.parquet")
@@ -79,7 +78,6 @@ public class TestReplacePartitions extends TestBase {
   // Partition spec with VOID partition transform ("alwaysNull" in Java code.)
   public static final PartitionSpec SPEC_VOID =
       PartitionSpec.builderFor(SCHEMA).alwaysNull("id").bucket("data", BUCKETS_NUMBER).build();
-
 
   static final DataFile FILE_A_VOID_PARTITION =
       DataFiles.builder(SPEC_VOID)
@@ -374,8 +372,7 @@ public class TestReplacePartitions extends TestBase {
     File tableDir = Files.createTempDirectory(temp, "junit").toFile();
     assertThat(tableDir.delete()).isTrue();
 
-    Table tableVoid = TestTables.create(
-        tableDir, "tablevoid", SCHEMA, SPEC_VOID, formatVersion);
+    Table tableVoid = TestTables.create(tableDir, "tablevoid", SCHEMA, SPEC_VOID, formatVersion);
     commit(tableVoid, tableVoid.newReplacePartitions().addFile(FILE_A_VOID_PARTITION), branch);
 
     // Concurrent Replace Partitions should fail with ValidationException

--- a/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
@@ -76,7 +76,7 @@ public class TestReplacePartitions extends TestBase {
           .build();
 
   // Partition spec with VOID partition transform ("alwaysNull" in Java code.)
-  public static final PartitionSpec SPEC_VOID =
+ static final PartitionSpec SPEC_VOID =
       PartitionSpec.builderFor(SCHEMA).alwaysNull("id").bucket("data", BUCKETS_NUMBER).build();
 
   static final DataFile FILE_A_VOID_PARTITION =


### PR DESCRIPTION
Partition values can be NULLs, or we can have NULLs because of the VOID transforms. If a conflict is found in such partitions we get a NullPointerException instead of a proper error message.