### PR TITLE
Core: Expose table incremental scan for appends API  in SerializableTable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -278,6 +278,7 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
     return lazyTable().newScan();
   }
 
+  @Override
   public IncrementalAppendScan newIncrementalAppendScan() {
     return lazyTable().newIncrementalAppendScan();
   }

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -284,6 +284,11 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
   }
 
   @Override
+  public IncrementalChangelogScan newIncrementalChangelogScan() {
+    return lazyTable().newIncrementalChangelogScan();
+  }
+
+  @Override
   public BatchScan newBatchScan() {
     return lazyTable().newBatchScan();
   }

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -278,6 +278,10 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
     return lazyTable().newScan();
   }
 
+  public IncrementalAppendScan newIncrementalAppendScan() {
+    return lazyTable().newIncrementalAppendScan();
+  }
+
   @Override
   public BatchScan newBatchScan() {
     return lazyTable().newBatchScan();


### PR DESCRIPTION
required for [HIVE-27101](https://issues.apache.org/jira/browse/HIVE-27101): Support incremental materialized view rebuild when Iceberg source tables have insert operation only