### PR TITLE
Core:support http lock-manager

### DIFF
--- a/core/src/main/java/org/apache/iceberg/lock/DefaultAuthImpl.java
+++ b/core/src/main/java/org/apache/iceberg/lock/DefaultAuthImpl.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.lock;
+
+import java.util.Map;
+
+public class DefaultAuthImpl implements HttpAuthentication {
+  @Override
+  public Map<String, String> assignRequestHeader(String httpUrl) {
+    return null;
+  }
+
+  @Override
+  public boolean confirmResponse(String respBody) {
+    return true;
+  }
+
+  @Override
+  public void init(Map<String, String> props) {}
+}

--- a/core/src/main/java/org/apache/iceberg/lock/HttpAuthentication.java
+++ b/core/src/main/java/org/apache/iceberg/lock/HttpAuthentication.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.lock;
+
+import java.util.Map;
+
+public interface HttpAuthentication {
+  Map<String, String> assignRequestHeader(String httpUrl);
+
+  boolean confirmResponse(String respBody);
+
+  void init(Map<String, String> props);
+}

--- a/core/src/main/java/org/apache/iceberg/lock/ServerSideHttpLockManager.java
+++ b/core/src/main/java/org/apache/iceberg/lock/ServerSideHttpLockManager.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.lock;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.RequestAcceptEncoding;
+import org.apache.http.client.protocol.ResponseContentEncoding;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.CoreConnectionPNames;
+import org.apache.http.util.EntityUtils;
+import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.LockManagers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The user is required to provide an API interface with distributed locking functionality as
+ * agreed.
+ */
+public class ServerSideHttpLockManager extends LockManagers.BaseLockManager {
+  private static final Logger LOG = LoggerFactory.getLogger(ServerSideHttpLockManager.class);
+  private String httpUrl = null;
+  private static final String OPERATOR = "operator";
+  private static final String LOCK = "lock";
+  private static final String UNLOCK = "unlock";
+  private static final String ENTITY_ID = "entityId";
+  private static final String OWNER_ID = "ownerId";
+  private static final int REQUEST_SUCCESS = 200;
+  public static final String REQUEST_URL = "lock.http.conf.request.url";
+  public static final String REQUEST_AUTH = "lock.http.conf.request.auth.impl";
+  private HttpClient httpClient = null;
+  private HttpAuthentication httpAuthentication = null;
+
+  public ServerSideHttpLockManager() {}
+
+  public ServerSideHttpLockManager(String requestUrl) {
+    initialize(ImmutableMap.of(REQUEST_URL, requestUrl));
+  }
+
+  @Override
+  public boolean acquire(String entityId, String ownerId) {
+    return process(entityId, ownerId, LOCK);
+  }
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    super.initialize(properties);
+    init(properties);
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    if (httpClient != null) {
+      httpClient.getConnectionManager().shutdown();
+    }
+  }
+
+  private synchronized void init(Map<String, String> properties) {
+    String requestUrl = properties.getOrDefault(REQUEST_URL, null);
+    String authImplClass = properties.getOrDefault(REQUEST_AUTH, null);
+    if (requestUrl == null) {
+      String msg = String.format("[%s] must be set.", REQUEST_URL);
+      throw new IllegalArgumentException(msg);
+    }
+    if (this.httpUrl == null) {
+      this.httpUrl = requestUrl;
+    }
+    try {
+      if (this.httpClient == null) {
+        DefaultHttpClient defaultHttpClient = new DefaultHttpClient();
+        defaultHttpClient.addRequestInterceptor(new RequestAcceptEncoding());
+        defaultHttpClient.addResponseInterceptor(new ResponseContentEncoding());
+        defaultHttpClient
+            .getParams()
+            .setParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, acquireTimeoutMs());
+        defaultHttpClient
+            .getParams()
+            .setParameter(CoreConnectionPNames.SO_TIMEOUT, heartbeatTimeoutMs());
+        this.httpClient = new DefaultHttpClient();
+      }
+      if (authImplClass == null) {
+        httpAuthentication = new DefaultAuthImpl();
+      } else {
+        DynConstructors.Ctor<HttpAuthentication> ctor =
+            DynConstructors.builder(HttpAuthentication.class)
+                .hiddenImpl(authImplClass)
+                .buildChecked();
+        httpAuthentication = ctor.newInstance();
+      }
+      httpAuthentication.init(properties);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  private String encode(String entity) {
+    if (entity == null) {
+      return null;
+    }
+    return new String(
+        Base64.getUrlEncoder().encode(entity.getBytes(StandardCharsets.UTF_8)),
+        StandardCharsets.UTF_8);
+  }
+
+  private boolean process(String entityId, String ownerId, String operator) {
+    try {
+      HttpGet lockRequest = new HttpGet();
+      lockRequest.addHeader("Content-Type", "application/json");
+      String requestUrl =
+          new URIBuilder(httpUrl)
+              .setParameter(OWNER_ID, encode(ownerId))
+              .setParameter(ENTITY_ID, encode(entityId))
+              .setParameter(OPERATOR, operator)
+              .build()
+              .toString();
+      Map<String, String> headerMap = httpAuthentication.assignRequestHeader(requestUrl);
+      if (headerMap != null) {
+        headerMap.forEach(lockRequest::addHeader);
+      }
+      lockRequest.setURI(new URI(requestUrl));
+      HttpResponse response = httpClient.execute(lockRequest);
+      StatusLine stateLine = response.getStatusLine();
+      int statsCode = stateLine.getStatusCode();
+      String content = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+      lockRequest.abort();
+      boolean respStatIsOk = REQUEST_SUCCESS == statsCode;
+      if (respStatIsOk) {
+        boolean confirmSuccess = httpAuthentication.confirmResponse(content);
+        if (!confirmSuccess) {
+          LOG.error("Request not success.Resp is [{}]", content);
+        }
+        return confirmSuccess;
+      } else {
+        return false;
+      }
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    } catch (Exception e) {
+      httpClient.getConnectionManager().closeExpiredConnections();
+      LOG.error("An exception occurred during the {} process.", operator, e);
+    }
+    return false;
+  }
+
+  @Override
+  public boolean release(String entityId, String ownerId) {
+    return process(entityId, ownerId, UNLOCK);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/lock/HttpLockManagerTest.java
+++ b/core/src/test/java/org/apache/iceberg/lock/HttpLockManagerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.lock;
+
+import static org.apache.iceberg.lock.ServerSideHttpLockManager.REQUEST_AUTH;
+import static org.apache.iceberg.lock.ServerSideHttpLockManager.REQUEST_URL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.UUID;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class HttpLockManagerTest {
+  private TestHttpServer testHttpServer = null;
+
+  @BeforeEach
+  public void before() throws IOException {
+    testHttpServer = new TestHttpServer();
+  }
+
+  @AfterEach
+  public void after() throws IOException {
+    testHttpServer.close();
+  }
+
+  @Test
+  public void httpLockTest() {
+    ServerSideHttpLockManager httpLockManager =
+        new ServerSideHttpLockManager("http://localhost:28081/test-rest-lock");
+    String ownerId = UUID.randomUUID().toString();
+    String entityId = UUID.randomUUID().toString();
+    assertThat(httpLockManager.acquire(entityId, ownerId)).isTrue();
+    assertThat(httpLockManager.release(entityId, ownerId)).isTrue();
+  }
+
+  @Test
+  public void testWithAuth() {
+    ServerSideHttpLockManager httpLockManager = new ServerSideHttpLockManager();
+
+    httpLockManager.initialize(
+        ImmutableMap.of(
+            REQUEST_AUTH,
+            TestAuthImpl.class.getName(),
+            REQUEST_URL,
+            "http://localhost:28081/test-rest-lock"));
+
+    String ownerId = UUID.randomUUID().toString();
+    String entityId = UUID.randomUUID().toString();
+    assertThat(httpLockManager.acquire(entityId, ownerId)).isTrue();
+    assertThat(httpLockManager.release(entityId, ownerId)).isTrue();
+  }
+
+  @Test
+  public void testWithAuthAndRequestFailed() {
+    ServerSideHttpLockManager httpLockManager = new ServerSideHttpLockManager();
+
+    httpLockManager.initialize(
+        ImmutableMap.of(
+            REQUEST_AUTH,
+            TestAuthImpl.class.getName(),
+            REQUEST_URL,
+            "http://localhost:28081/test-rest-lock",
+            "timeStamp",
+            "123456"));
+
+    String ownerId = UUID.randomUUID().toString();
+    String entityId = UUID.randomUUID().toString();
+    assertThat(httpLockManager.acquire(entityId, ownerId)).isFalse();
+    assertThat(httpLockManager.release(entityId, ownerId)).isFalse();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/lock/TestAuthImpl.java
+++ b/core/src/test/java/org/apache/iceberg/lock/TestAuthImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.lock;
+
+import java.util.Map;
+import org.apache.commons.collections.MapUtils;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+
+public class TestAuthImpl implements HttpAuthentication {
+
+  private long timeStamp = -1L;
+
+  @Override
+  public Map<String, String> assignRequestHeader(String httpUrl) {
+    return ImmutableMap.of("timeStamp", String.valueOf(timeStamp));
+  }
+
+  @Override
+  public boolean confirmResponse(String respBody) {
+    return true;
+  }
+
+  @Override
+  public void init(Map<String, String> props) {
+    timeStamp = MapUtils.getLongValue(props, "timeStamp", System.currentTimeMillis());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/lock/TestHttpServer.java
+++ b/core/src/test/java/org/apache/iceberg/lock/TestHttpServer.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.lock;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringTokenizer;
+import org.apache.commons.collections.MapUtils;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestHttpServer implements Runnable, Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(TestHttpServer.class);
+
+  private static final int PORT = 28081;
+  private ServerSocket server = null;
+  private static final String RESP = "OK!";
+  private static final String PATH_DEF = "/test-rest-lock?";
+  private transient boolean running = true;
+  private static final String OWNER_ID = "ownerId";
+  private static final String ENTITY_ID = "entityId";
+  private static final String OPERATOR = "operator";
+  private static final String LOCK = "lock";
+  private static final String UNLOCK = "unlock";
+  private static final long TTL = 3600 * 1000 * 2;
+  private final Map<String, String> cache = Maps.newConcurrentMap();
+
+  public TestHttpServer() {
+    try {
+      server = new ServerSocket(PORT);
+      new Thread(this).start();
+    } catch (IOException e) {
+      LOG.error(e.getMessage(), e);
+      System.exit(1);
+    }
+  }
+
+  private Map<String, String> extractParams(String paramList) {
+    String[] params = paramList.split("&");
+    Map<String, String> result = Maps.newHashMap();
+    for (String paramKV : params) {
+      String[] paramPair = paramKV.split("=");
+      String key = paramPair[0];
+      String value = paramPair[1];
+      result.putIfAbsent(key, value);
+    }
+    return result;
+  }
+
+  private Map<String, String> parseHeader(BufferedReader reader) throws IOException {
+    String line = null;
+    Map<String, String> headers = Maps.newHashMap();
+    while ((line = reader.readLine()) != null) {
+      if (line.equals("")) {
+        break;
+      }
+      String[] kvPair = line.split(":");
+      headers.put(kvPair[0].trim(), kvPair[1].trim());
+    }
+    return headers;
+  }
+
+  @Override
+  public void run() {
+    while (running) {
+      try (Socket client = server.accept()) {
+        if (client == null) {
+          LOG.info("skip.");
+          continue;
+        }
+        BufferedReader reader = new BufferedReader(new InputStreamReader(client.getInputStream()));
+        // GET /apple /HTTP1.1
+        String line = reader.readLine();
+        String resource = line.substring(line.indexOf('/'), line.lastIndexOf('/') - 5);
+        resource = URLDecoder.decode(resource, "UTF-8");
+        String method = new StringTokenizer(line).nextElement().toString();
+        Map<String, String> headers = parseHeader(reader);
+        long requestTimeStamp =
+            MapUtils.getLongValue(headers, "timeStamp", System.currentTimeMillis());
+        if (System.currentTimeMillis() - TTL > requestTimeStamp) {
+          doResp(client, "HTTP/1.0 500 ERROR", null);
+          continue;
+        }
+        if (!"GET".equalsIgnoreCase(method) || !resource.startsWith(PATH_DEF)) {
+          doResp(client, "HTTP/1.0 404 Not found", null);
+        } else {
+          URI uri = URI.create(resource);
+          String paramList = uri.getQuery();
+          Map<String, String> paramKV = extractParams(paramList);
+          String ownerId = paramKV.get(OWNER_ID);
+          String entityId = paramKV.get(ENTITY_ID);
+          String operator = paramKV.get(OPERATOR);
+          switch (operator) {
+            case LOCK:
+              doLock(client, entityId, ownerId);
+              break;
+            case UNLOCK:
+              cache.remove(entityId);
+              doResp(client, "HTTP/1.0 200 OK", RESP);
+              break;
+            default:
+              doResp(client, "HTTP/1.0 500 ERROR", null);
+          }
+        }
+      } catch (Exception e) {
+        LOG.error(e.getMessage(), e);
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private void doLock(Socket client, String entityId, String ownerId) throws IOException {
+    if (cache.containsKey(entityId)) {
+      doResp(client, "HTTP/1.0 500 ERROR", null);
+      return;
+    }
+    String realOwnerId = cache.putIfAbsent(entityId, ownerId);
+    if (!Objects.equals(ownerId, realOwnerId) && realOwnerId != null) {
+      doResp(client, "HTTP/1.0 500 ERROR", null);
+    } else {
+      doResp(client, "HTTP/1.0 200 OK", RESP);
+    }
+  }
+
+  private void doResp(Socket client, String respLine, String body) throws IOException {
+    PrintStream writer = new PrintStream(client.getOutputStream());
+    writer.println(respLine);
+    if (body != null) {
+      writer.println("Content-Length:" + body.length());
+    }
+    writer.println();
+    if (body != null) {
+      writer.println(body);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    running = false;
+    if (server != null && !server.isClosed()) {
+      server.close();
+    }
+  }
+}


### PR DESCRIPTION
Currently, the only lockManager implementation in iceberg-core is InMemoryLockManager. This PR extends two LockManager implementations, ~~one based on the Redis~~, and another based on the Rest-API.

In general, most users use redisLockManager is sufficient to cope with most of the scenarios, for redis can not meet the user's requirements, we can let the user to provide a RestApi service to achieve this function. I believe that, for a long time, these two lock-manager's will satisfy most of the customer's needs.