### PR TITLE
Nit: fix/suppress false-positivie errorprone warning

### DIFF
--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
@@ -51,6 +51,7 @@ public class IcebergTimestampObjectInspectorHive3 extends AbstractPrimitiveJavaO
   }
 
   @Override
+  @SuppressWarnings("JavaLocalDateTimeGetNano")
   public Timestamp getPrimitiveJavaObject(Object o) {
     if (o == null) {
       return null;


### PR DESCRIPTION
```
.../hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java:60: warning: [JavaLocalDateTimeGetNano] localDateTime.getNano() only accesss the nanos-of-second field. It's rare to only use getNano() without a nearby getSecond() call.
    timestamp.setNanos(time.getNano());
                                   ^
    (see https://errorprone.info/bugpattern/JavaLocalDateTimeGetNano)
```