### PR TITLE
Core: Limit memory used by ParallelIterable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
+++ b/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
@@ -235,12 +235,16 @@ public class ParallelIterable<T> extends CloseableGroup implements CloseableIter
         if (iterator == null) {
           iterator = input.iterator();
         }
-        while (!closed.get() && iterator.hasNext()) {
+        while (iterator.hasNext()) {
           if (queue.size() >= approximateMaxQueueSize) {
             // yield
             return Optional.of(this);
           }
-          queue.add(iterator.next());
+          T next = iterator.next();
+          if (closed.get()) {
+            break;
+          }
+          queue.add(next);
         }
       } catch (Throwable e) {
         try {

--- a/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
+++ b/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
@@ -45,6 +45,8 @@ public class ParallelIterable<T> extends CloseableGroup implements CloseableIter
 
   private static final Logger LOG = LoggerFactory.getLogger(ParallelIterable.class);
 
+  // Logic behind default value: ParallelIterable is often used for file planning.
+  // Assuming that a DataFile or DeleteFile is about 500 bytes, a 30k limit uses 14.3 MB of memory.
   private static final int DEFAULT_MAX_QUEUE_SIZE = 30_000;
 
   private final Iterable<? extends Iterable<T>> iterables;

--- a/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
+++ b/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
@@ -218,7 +218,7 @@ public class ParallelIterable<T> extends CloseableGroup implements CloseableIter
     private final AtomicBoolean closed;
     private final int approximateMaxQueueSize;
 
-    private Iterator<T> iterator;
+    private Iterator<T> iterator = null;
 
     Task(
         Iterable<T> input,
@@ -262,8 +262,10 @@ public class ParallelIterable<T> extends CloseableGroup implements CloseableIter
             e.addSuppressed(closeException);
           }
         }
+
         throw e;
       }
+
       close();
       // The task is complete. Returning empty means there is no continuation that should be
       // executed.

--- a/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
+++ b/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
@@ -98,8 +98,6 @@ public class ParallelIterable<T> extends CloseableGroup implements CloseableIter
         yieldedTasks.forEach(closer::register);
         yieldedTasks.clear();
 
-        // TODO close input iterables that were not started yet
-
         // cancel background tasks
         for (Future<?> taskFuture : taskFutures) {
           if (taskFuture != null && !taskFuture.isDone()) {

--- a/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
+++ b/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
@@ -158,9 +158,7 @@ public class ParallelIterable<T> extends CloseableGroup implements CloseableIter
       if (!closed.get()) {
         if (!yieldedTasks.isEmpty()) {
           return workerPool.submit(yieldedTasks.removeFirst());
-        }
-
-        if (tasks.hasNext()) {
+        } else if (tasks.hasNext()) {
           return workerPool.submit(tasks.next());
         }
       }

--- a/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
+++ b/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
@@ -259,7 +259,8 @@ public class ParallelIterable<T> extends CloseableGroup implements CloseableIter
 
         while (iterator.hasNext()) {
           if (queue.size() >= approximateMaxQueueSize) {
-            // Yield when queue is over the size limit. Task will be resubmitted later and continue the work.
+            // Yield when queue is over the size limit. Task will be resubmitted later and continue
+            // the work.
             return Optional.of(this);
           }
 

--- a/core/src/test/java/org/apache/iceberg/util/TestParallelIterable.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestParallelIterable.java
@@ -24,15 +24,22 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.collect.HashMultiset;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMultiset;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Multiset;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
@@ -131,6 +138,47 @@ public class TestParallelIterable {
     Awaitility.await("Queue is cleared")
         .atMost(5, TimeUnit.SECONDS)
         .untilAsserted(() -> assertThat(queue).as("Queue is not empty after cleaning").isEmpty());
+  }
+
+  @Test
+  public void limitQueueSize() throws IOException, IllegalAccessException, NoSuchFieldException {
+
+    List<Iterable<Integer>> iterables =
+        ImmutableList.of(
+            () -> IntStream.range(0, 100).iterator(),
+            () -> IntStream.range(0, 100).iterator(),
+            () -> IntStream.range(0, 100).iterator());
+
+    Multiset<Integer> expectedValues =
+        IntStream.range(0, 100)
+            .boxed()
+            .flatMap(i -> Stream.of(i, i, i))
+            .collect(ImmutableMultiset.toImmutableMultiset());
+
+    int maxQueueSize = 20;
+    ExecutorService executor = Executors.newCachedThreadPool();
+    ParallelIterable<Integer> parallelIterable =
+        new ParallelIterable<>(iterables, executor, maxQueueSize);
+    CloseableIterator<Integer> iterator = parallelIterable.iterator();
+    Field queueField = iterator.getClass().getDeclaredField("queue");
+    queueField.setAccessible(true);
+    ConcurrentLinkedQueue<?> queue = (ConcurrentLinkedQueue<?>) queueField.get(iterator);
+
+    Multiset<Integer> actualValues = HashMultiset.create();
+
+    while (iterator.hasNext()) {
+      assertThat(queue)
+          .as("iterator internal queue")
+          .hasSizeLessThanOrEqualTo(maxQueueSize + iterables.size());
+      actualValues.add(iterator.next());
+    }
+
+    assertThat(actualValues)
+        .as("multiset of values returned by the iterator")
+        .isEqualTo(expectedValues);
+
+    iterator.close();
+    executor.shutdownNow();
   }
 
   private void queueHasElements(CloseableIterator<Integer> iterator, Queue queue) {


### PR DESCRIPTION
ParallelIterable schedules 2 * WORKER_THREAD_POOL_SIZE tasks for processing input iterables. This defaults to 2 * # CPU cores.  When one or some of the input iterables are considerable in size and the ParallelIterable consumer is not quick enough, this could result in unbounded allocation inside `ParallelIterator.queue`. This commit bounds the queue. When queue is full, the tasks yield and get removed from the executor. They are resumed when consumer catches up.

Follows https://github.com/apache/iceberg/pull/9402
Alternative to https://github.com/apache/iceberg/pull/7844