### PR TITLE
Infra: Fix stale PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,6 +25,7 @@ on:
 permissions:
   # All other permissions are set to none
   issues: write
+  pull-requests: write
 
 jobs:
   stale:


### PR DESCRIPTION
Looks like stale PR bot never worked. 

I checked https://github.com/apache/iceberg/pulls?q=is%3Aopen+is%3Apr+label%3Astale and found 0 stale issues. 
After debugging found that it is a permission issue. 
<img width="858" alt="image" src="https://github.com/user-attachments/assets/609e156e-9cbb-41ff-ab95-d1aaa25b6c54">

This PR should fix it. 