### PR TITLE
API: Add SupportsRecoveryOperations mixin for FileIO

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/SupportsRecoveryOperations.java
+++ b/api/src/main/java/org/apache/iceberg/io/SupportsRecoveryOperations.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+/**
+ * This interface is intended as an extension for FileIO implementations to provide additional
+ * best-effort recovery operations that can be useful for repairing corrupted tables where there are
+ * reachable files missing from disk. (e.g. a live manifest points to data file entry which no
+ * longer exists on disk)
+ */
+public interface SupportsRecoveryOperations {
+
+  /**
+   * Perform a best-effort recovery of a file at a given path
+   *
+   * @param path Absolute path of file to attempt recovery for
+   * @return true if recovery was successful, false otherwise
+   */
+  boolean recoverFile(String path);
+}


### PR DESCRIPTION
This change adds a SupportsRecoveryOperations mixin for FileIO which offers a `boolean recoverFile(String path)` API. The purpose of this interface is to enable FileIO implementations to attempt a best effort recovery of a given file in case of corruption cases. This could be used as a primitive in repair functions such as https://github.com/apache/iceberg/pull/10445.

This change also implements this mixin for S3FileIO which will get object versions for the specific object and take the latest non-deleted version. If one is not found, the recoverFile API returns false since this mixin is meant for FileIO to perform a best effort recovery, not neccessarily guarantee recovery since that depends on a lot of factors of the underlying storage configuration.