### PR TITLE
Infra: Increase operation per limit for stale bot workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -55,4 +55,4 @@ jobs:
           days-before-pr-stale: 30
           days-before-pr-close: 7
           ascending: true
-          operations-per-run: 100
+          operations-per-run: 200


### PR DESCRIPTION
Stale PR bot is finally working after #10706
 
https://github.com/apache/iceberg/actions/runs/9965906264/job/27537049317#step:2:1119

<img width="1083" alt="image" src="https://github.com/user-attachments/assets/d848052b-1e89-46d7-9d36-7ef0be02e8ae">

Based on above stats, it has only processed 23 PRs. As each issue/PR requires 3 operation (comment, label, fetch). 
Also, GH Iceberg repo has `14896` operation left during that time. Hence, increasing the operations limit a bit more. (it will just use 100 more operations) 