### PR TITLE
Core: Make new TableMetadata.Builder constructor private

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -910,7 +910,7 @@ public class TableMetadata implements Serializable {
       this(DEFAULT_TABLE_FORMAT_VERSION);
     }
 
-    public Builder(int formatVersion) {
+    private Builder(int formatVersion) {
       this.base = null;
       this.formatVersion = formatVersion;
       this.lastSequenceNumber = INITIAL_SEQUENCE_NUMBER;


### PR DESCRIPTION
This constructor should be made private. Note: If 1.6.0 release passes as is, this will have to go through a deprecation cycle rather than just making it private directly. 

Accidentally added a new public construcotr here https://github.com/apache/iceberg/commit/f236722f41a7fb35cffb80629f0516bb7b6c90b7#diff-c540a31e66b157a8f080433c82a29a070096d0e08c6578a0099153f1229bdb7aR913 when it should've been private.
