### PR TITLE
Update the version in deprecation messages

### DIFF
--- a/common/src/main/java/org/apache/iceberg/common/DynFields.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynFields.java
@@ -394,7 +394,7 @@ public class DynFields {
      * @return a {@link StaticField} with a valid implementation
      * @throws IllegalStateException if the method is not static
      * @throws NoSuchFieldException if no implementation was found
-     * @deprecated since 1.7.0, will be removed in 2.0.0
+     * @deprecated since 1.6.0, will be removed in 1.7.0
      */
     @Deprecated
     public <T> StaticField<T> buildStaticChecked() throws NoSuchFieldException {

--- a/common/src/main/java/org/apache/iceberg/common/DynMethods.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynMethods.java
@@ -51,7 +51,7 @@ public class DynMethods {
           (method == null || method.isVarArgs()) ? -1 : method.getParameterTypes().length;
     }
 
-    /** @deprecated since 1.7.0, will be removed in 2.0.0 */
+    /** @deprecated since 1.6.0, will be removed in 1.7.0 */
     @Deprecated // will become private
     @SuppressWarnings("unchecked")
     public <R> R invokeChecked(Object target, Object... args) throws Exception {
@@ -315,7 +315,7 @@ public class DynMethods {
       return this;
     }
 
-    /** @deprecated since 1.7.0, will be removed in 2.0.0 */
+    /** @deprecated since 1.6.0, will be removed in 1.7.0 */
     @Deprecated
     public Builder ctorImpl(Class<?> targetClass, Class<?>... argClasses) {
       // don't do any work if an implementation has been found
@@ -331,7 +331,7 @@ public class DynMethods {
       return this;
     }
 
-    /** @deprecated since 1.7.0, will be removed in 2.0.0 */
+    /** @deprecated since 1.6.0, will be removed in 1.7.0 */
     @Deprecated
     public Builder ctorImpl(String className, Class<?>... argClasses) {
       // don't do any work if an implementation has been found


### PR DESCRIPTION
The release 1.6.0 RC0 won't be promoted and in the meantime the deprecation was merged. The RC1 will be made of the main branch, so will include the deprecations, so the version in the deprecation message should be updated.