### PR TITLE
AWS: Implement SupportsRecoveryOperations for S3FileIO

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -53,14 +53,17 @@ import software.amazon.awssdk.services.kms.model.ListAliasesRequest;
 import software.amazon.awssdk.services.kms.model.ListAliasesResponse;
 import software.amazon.awssdk.services.kms.model.ScheduleKeyDeletionRequest;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.BucketVersioningStatus;
 import software.amazon.awssdk.services.s3.model.GetObjectAclRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectAclResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Permission;
+import software.amazon.awssdk.services.s3.model.PutBucketVersioningRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+import software.amazon.awssdk.services.s3.model.VersioningConfiguration;
 import software.amazon.awssdk.services.s3control.S3ControlClient;
 import software.amazon.awssdk.utils.ImmutableMap;
 import software.amazon.awssdk.utils.IoUtils;
@@ -106,6 +109,12 @@ public class TestS3FileIOIntegration {
     AwsIntegTestUtil.createAccessPoint(s3Control, accessPointName, bucketName);
     AwsIntegTestUtil.createAccessPoint(
         crossRegionS3Control, crossRegionAccessPointName, crossRegionBucketName);
+    s3.putBucketVersioning(
+        PutBucketVersioningRequest.builder()
+            .bucket(bucketName)
+            .versioningConfiguration(
+                VersioningConfiguration.builder().status(BucketVersioningStatus.ENABLED).build())
+            .build());
   }
 
   @AfterAll
@@ -443,6 +452,35 @@ public class TestS3FileIOIntegration {
               s3FileIO.deletePrefix(scalePrefix);
               assertThat(s3FileIO.listPrefix(scalePrefix)).isEmpty();
             });
+  }
+
+  @Test
+  public void testFileRecoveryHappyPath() throws Exception {
+    S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, new S3FileIOProperties());
+    String filePath = String.format("s3://%s/%s/%s", bucketName, prefix, "someFile.parquet");
+    write(s3FileIO, filePath);
+    s3FileIO.deleteFile(filePath);
+    assertThat(s3FileIO.newInputFile(filePath).exists()).isFalse();
+
+    assertThat(s3FileIO.recoverFile(filePath)).isTrue();
+    assertThat(s3FileIO.newInputFile(filePath).exists()).isTrue();
+  }
+
+  @Test
+  public void testFileRecoveryFailsToRecover() throws Exception {
+    S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, new S3FileIOProperties());
+    s3.putBucketVersioning(
+        PutBucketVersioningRequest.builder()
+            .bucket(bucketName)
+            .versioningConfiguration(
+                VersioningConfiguration.builder().status(BucketVersioningStatus.SUSPENDED).build())
+            .build());
+    String filePath = String.format("s3://%s/%s/%s", bucketName, prefix, "unversionedFile.parquet");
+    write(s3FileIO, filePath);
+    s3FileIO.deleteFile(filePath);
+    assertThat(s3FileIO.newInputFile(filePath).exists()).isFalse();
+
+    assertThat(s3FileIO.recoverFile(filePath)).isFalse();
   }
 
   private S3FileIOProperties getDeletionTestProperties() {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -20,8 +20,10 @@ package org.apache.iceberg.aws.s3;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -37,6 +39,7 @@ import org.apache.iceberg.io.DelegateFileIO;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SupportsRecoveryOperations;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -52,6 +55,7 @@ import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.Delete;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -61,10 +65,12 @@ import software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectTaggingResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.ObjectVersion;
 import software.amazon.awssdk.services.s3.model.PutObjectTaggingRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
+import software.amazon.awssdk.services.s3.paginators.ListObjectVersionsIterable;
 
 /**
  * FileIO implementation backed by S3.
@@ -73,7 +79,7 @@ import software.amazon.awssdk.services.s3.model.Tagging;
  * schemes s3a, s3n, https are also treated as s3 file paths. Using this FileIO with other schemes
  * will result in {@link org.apache.iceberg.exceptions.ValidationException}.
  */
-public class S3FileIO implements CredentialSupplier, DelegateFileIO {
+public class S3FileIO implements CredentialSupplier, DelegateFileIO, SupportsRecoveryOperations {
   private static final Logger LOG = LoggerFactory.getLogger(S3FileIO.class);
   private static final String DEFAULT_METRICS_IMPL =
       "org.apache.iceberg.hadoop.HadoopMetricsContext";
@@ -419,5 +425,47 @@ public class S3FileIO implements CredentialSupplier, DelegateFileIO {
         LOG.warn("Unclosed S3FileIO instance created by:\n\t{}", trace);
       }
     }
+  }
+
+  @Override
+  public boolean recoverFile(String path) {
+    S3URI location = new S3URI(path, s3FileIOProperties.bucketToAccessPointMapping());
+    ListObjectVersionsIterable response =
+        client()
+            .listObjectVersionsPaginator(
+                builder -> builder.bucket(location.bucket()).prefix(location.key()));
+
+    // Recover to the last modified version, not isLatest,
+    // since isLatest is true for deletion markers.
+    Optional<ObjectVersion> recoverVersion =
+        response.versions().stream().max(Comparator.comparing(ObjectVersion::lastModified));
+
+    return recoverVersion.map(version -> recoverObject(version, location.bucket())).orElse(false);
+  }
+
+  private boolean recoverObject(ObjectVersion version, String bucket) {
+    if (version.isLatest()) {
+      return true;
+    }
+
+    LOG.info("Attempting to recover object {}", version.key());
+    try {
+      // Perform a copy instead of deleting the delete marker
+      // so that recovery does not rely on delete permissions
+      client()
+          .copyObject(
+              builder ->
+                  builder
+                      .sourceBucket(bucket)
+                      .sourceKey(version.key())
+                      .sourceVersionId(version.versionId())
+                      .destinationBucket(bucket)
+                      .destinationKey(version.key()));
+    } catch (SdkException e) {
+      LOG.warn("Failed to recover object {}", version.key(), e);
+      return false;
+    }
+
+    return true;
   }
 }


### PR DESCRIPTION
This change implements the SupportsRecoveryOperations mixin for S3FileIO. The implementation is a best effort recovery which first determines the latest object version, and if that is found, then performs the actual recovery by performing an s3#copy operation.

This can be used as a primitive in repair procedures that the community is working on or even simply work standalone in someone's own logic if they want to correct their table state by recovering files which may have accidentally removed (assuming their bucket has versioning enabled)