### PR TITLE
Core: Add DataFiles builder API to enable users to specify their own custom conversion logic for string partition values

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -178,7 +178,12 @@ public class FileMetadata {
           isPartitioned || newPartitionPath.isEmpty(),
           "Cannot add partition data for an unpartitioned table");
       if (!newPartitionPath.isEmpty()) {
-        this.partitionData = DataFiles.fillFromPath(spec, newPartitionPath, partitionData);
+        this.partitionData =
+            DataFiles.fillFromPath(
+                spec,
+                newPartitionPath,
+                partitionData,
+                DataFiles.DEFAULT_PARTITION_STRING_CONVERSION);
       }
       return this;
     }


### PR DESCRIPTION
This change adds the following API to DataFile builder:

```
withPartitionPath(String newPartitionPath, BiFunction<String, Type, Object> partitionPathConverter)
```

This is done to enable users that want to use the DataFiles builder API with their own custom partition string conversion logic, that way the burden isn't in iceberg itself to handle all various interpretations of string partition values.

Currently, for the `withPartitionPath` API there is default conversion logic from String partition values to objects to be used for Iceberg partition values in [Conversions](https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/types/Conversions.java#L42) for use cases like Hive table migrations. One use case that I had was for Delta Uniform Iceberg metadata conversion. Currently, timestamp types are not supported for partition columns and Iceberg's Conversion utility https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/types/Conversions.java#L69 does not handle timestamps.


We probably shouldn't be adding to that Conversions class to support new types (like Timestamp for instance) because Iceberg does not outline how Hive identity string partition values should convert into Iceberg partition values. IMO this is rightfully so, since the string conversion is subject to a lot of interpretation and there can be all sorts of partition strings out there.