### PR TITLE
Core, API: Add addNonDefaultSpec to UpdatePartitionSpec to not set the new partition spec as default

### DIFF
--- a/api/src/main/java/org/apache/iceberg/UpdatePartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/UpdatePartitionSpec.java
@@ -122,4 +122,15 @@ public interface UpdatePartitionSpec extends PendingUpdate<PartitionSpec> {
    *     change conflicts with other additions, removals, or renames.
    */
   UpdatePartitionSpec renameField(String name, String newName);
+
+  /**
+   * Sets that the new partition spec will be NOT set as the default partition spec for the table,
+   * the default behavior is to do so.
+   *
+   * @return this for method chaining
+   */
+  default UpdatePartitionSpec addNonDefaultSpec() {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " doesn't implement addNonDefaultSpec()");
+  };
 }

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -59,11 +59,13 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
   private final Map<String, String> renames = Maps.newHashMap();
 
   private boolean caseSensitive;
+  private boolean setAsDefault;
   private int lastAssignedPartitionId;
 
   BaseUpdatePartitionSpec(TableOperations ops) {
     this.ops = ops;
     this.caseSensitive = true;
+    this.setAsDefault = true;
     this.base = ops.current();
     this.formatVersion = base.formatVersion();
     this.spec = base.spec();
@@ -95,6 +97,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     this.base = null;
     this.formatVersion = formatVersion;
     this.caseSensitive = true;
+    this.setAsDefault = true;
     this.spec = spec;
     this.schema = spec.schema();
     this.nameToField = indexSpecByName(spec);
@@ -143,6 +146,12 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
   @Override
   public UpdatePartitionSpec caseSensitive(boolean isCaseSensitive) {
     this.caseSensitive = isCaseSensitive;
+    return this;
+  }
+
+  @Override
+  public UpdatePartitionSpec addNonDefaultSpec() {
+    this.setAsDefault = false;
     return this;
   }
 
@@ -327,7 +336,12 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
 
   @Override
   public void commit() {
-    TableMetadata update = base.updatePartitionSpec(apply());
+    TableMetadata update;
+    if (setAsDefault) {
+      update = base.updatePartitionSpec(apply());
+    } else {
+      update = base.addPartitionSpec(apply());
+    }
     ops.commit(base, update);
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -564,6 +564,10 @@ public class TableMetadata implements Serializable {
     return new Builder(this).setDefaultPartitionSpec(newPartitionSpec).build();
   }
 
+  public TableMetadata addPartitionSpec(PartitionSpec newPartitionSpec) {
+    return new Builder(this).addPartitionSpec(newPartitionSpec).build();
+  }
+
   public TableMetadata replaceSortOrder(SortOrder newOrder) {
     return new Builder(this).setDefaultSortOrder(newOrder).build();
   }

--- a/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
@@ -287,4 +287,23 @@ public class TestTableUpdatePartitionSpec extends TestBase {
     assertThat(table.spec().lastAssignedFieldId()).isEqualTo(1001);
     assertThat(table.ops().current().lastAssignedPartitionId()).isEqualTo(1001);
   }
+
+  @TestTemplate
+  public void testCommitUpdatedSpecWithoutSettingNewDefault() {
+    PartitionSpec originalSpec = table.spec();
+    table.updateSpec().addField("id").addNonDefaultSpec().commit();
+
+    assertThat(table.spec())
+        .as("Should not set the default spec for the table")
+        .isSameAs(originalSpec);
+
+    assertThat(table.specs().get(1))
+        .as("The new spec created for the table")
+        .isEqualTo(
+            PartitionSpec.builderFor(table.schema())
+                .withSpecId(1)
+                .bucket("data", 16)
+                .identity("id")
+                .build());
+  }
 }


### PR DESCRIPTION
This may be used in cases where we want to add a partition spec but not set the new partition spec as default.

For example, if I want to make sure that there's an unpartitioned spec since I might want to commit specific data to it in some cases, I would first validate that there's an unpartition spec in the table, and if there isn't, I would try to add the unpartitioned spec but not set it as the new default partition spec