### PR TITLE
AddPartitionSpec: A new way to set new partition specs

### DIFF
--- a/api/src/main/java/org/apache/iceberg/UpdatePartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/UpdatePartitionSpec.java
@@ -133,4 +133,16 @@ public interface UpdatePartitionSpec extends PendingUpdate<PartitionSpec> {
     throw new UnsupportedOperationException(
         this.getClass().getName() + " doesn't implement addNonDefaultSpec()");
   };
+
+  /**
+   * Sets this update partition spec to evolve the given partition spec instead of the default
+   * partition spec of the table.
+   *
+   * @param partitionSpec The partition spec to evolve
+   * @return this method for chaining
+   */
+  default UpdatePartitionSpec fromSpec(PartitionSpec partitionSpec) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " doesn't implement fromSpec(PartitionSpec)");
+  }
 }


### PR DESCRIPTION
Most of the query engines use SQL to update a partition specification of a table.

The SQL usually look like: alter table partition by a, b, c, ...

The interface of UpdatePartitionSpec is interrupting a clear flow of setting a new partition spec when the user specifies a full partition definition, because it requires the implementation of the command to remove / rename old fields and add new fields that didn't exist.

Instead of that, we can introduce a new command to Iceberg Tables that adds a new partition spec from scratch.