### PR TITLE
Api, Core: Set upper boundary for the type parameter of `Scan`

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1024,15 +1024,181 @@ acceptedBreaks:
       old: "class org.apache.iceberg.types.Types.NestedField"
       new: "class org.apache.iceberg.types.Types.NestedField"
       justification: "new Constructor added"
+    - code: "java.class.noLongerImplementsInterface"
+      old: "interface org.apache.iceberg.IncrementalScan<ThisT extends java.lang.Object,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      new: "interface org.apache.iceberg.IncrementalScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.class.nowImplementsInterface"
+      old: "interface org.apache.iceberg.IncrementalScan<ThisT extends java.lang.Object,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      new: "interface org.apache.iceberg.IncrementalScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.class.superTypeTypeParametersChanged"
+      old: "interface org.apache.iceberg.IncrementalScan<ThisT extends java.lang.Object,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      new: "interface org.apache.iceberg.IncrementalScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "interface org.apache.iceberg.IncrementalScan<ThisT extends java.lang.Object,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      new: "interface org.apache.iceberg.IncrementalScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "interface org.apache.iceberg.Scan<ThisT extends java.lang.Object, T extends\
+        \ org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      new: "interface org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.IncrementalScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::fromSnapshotExclusive(java.lang.String)"
+      new: "method ThisT org.apache.iceberg.IncrementalScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::fromSnapshotExclusive(java.lang.String)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.IncrementalScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::fromSnapshotExclusive(long)"
+      new: "method ThisT org.apache.iceberg.IncrementalScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::fromSnapshotExclusive(long)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.IncrementalScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::fromSnapshotInclusive(java.lang.String)"
+      new: "method ThisT org.apache.iceberg.IncrementalScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::fromSnapshotInclusive(java.lang.String)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.IncrementalScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::fromSnapshotInclusive(long)"
+      new: "method ThisT org.apache.iceberg.IncrementalScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::fromSnapshotInclusive(long)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.IncrementalScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::toSnapshot(java.lang.String)"
+      new: "method ThisT org.apache.iceberg.IncrementalScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::toSnapshot(java.lang.String)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.IncrementalScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::toSnapshot(long)"
+      new: "method ThisT org.apache.iceberg.IncrementalScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::toSnapshot(long)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.IncrementalScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::useBranch(java.lang.String)"
+      new: "method ThisT org.apache.iceberg.IncrementalScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::useBranch(java.lang.String)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::caseSensitive(boolean)"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::caseSensitive(boolean)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::filter(org.apache.iceberg.expressions.Expression)"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::filter(org.apache.iceberg.expressions.Expression)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::ignoreResiduals()"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::ignoreResiduals()"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::includeColumnStats()"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::includeColumnStats()"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::includeColumnStats(java.util.Collection<java.lang.String>)"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::includeColumnStats(java.util.Collection<java.lang.String>)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::metricsReporter(org.apache.iceberg.metrics.MetricsReporter)"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::metricsReporter(org.apache.iceberg.metrics.MetricsReporter)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::option(java.lang.String,\
+        \ java.lang.String)"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::option(java.lang.String, java.lang.String)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::planWith(java.util.concurrent.ExecutorService)"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::planWith(java.util.concurrent.ExecutorService)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::project(org.apache.iceberg.Schema)"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::project(org.apache.iceberg.Schema)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::select(java.lang.String[])"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::select(java.lang.String[])"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::select(java.util.Collection<java.lang.String>)"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::select(java.util.Collection<java.lang.String>)"
+      justification: "{Set the upper boundary of the type parameter}"
     org.apache.iceberg:iceberg-core:
-    - code: "java.method.visibilityReduced"
-      old: "method void org.apache.iceberg.encryption.PlaintextEncryptionManager::<init>()"
-      new: "method void org.apache.iceberg.encryption.PlaintextEncryptionManager::<init>()"
-      justification: "Deprecations for 1.6.0 release"
+    - code: "java.class.noLongerImplementsInterface"
+      old: "class org.apache.iceberg.SnapshotScan<ThisT extends java.lang.Object,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      new: "class org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.class.superTypeTypeParametersChanged"
+      old: "class org.apache.iceberg.SnapshotScan<ThisT extends java.lang.Object,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      new: "class org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      justification: "{Set the upper boundary of the type parameter}"
     - code: "java.element.noLongerDeprecated"
       old: "method void org.apache.iceberg.encryption.PlaintextEncryptionManager::<init>()"
       new: "method void org.apache.iceberg.encryption.PlaintextEncryptionManager::<init>()"
-      justification: "Constructor became private as part of deprecations cleanup for 1.6.0 release"
+      justification: "Constructor became private as part of deprecations cleanup for\
+        \ 1.6.0 release"
     - code: "java.element.noLongerDeprecated"
       old: "method void org.apache.iceberg.rest.auth.OAuth2Util.AuthSession::<init>(java.util.Map<java.lang.String,\
         \ java.lang.String>, java.lang.String, java.lang.String, java.lang.String,\
@@ -1041,6 +1207,12 @@ acceptedBreaks:
         \ java.lang.String>, org.apache.iceberg.rest.auth.AuthConfig)"
       justification: "This is actually a removal of a deprecated constructor as part\
         \ of deprecations for 1.6.0 release, apparently mis-reported by rev-api"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "class org.apache.iceberg.SnapshotScan<ThisT extends java.lang.Object,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      new: "class org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T>>"
+      justification: "{Set the upper boundary of the type parameter}"
     - code: "java.method.numberOfParametersChanged"
       old: "method void org.apache.iceberg.rest.auth.OAuth2Util.AuthSession::<init>(java.util.Map<java.lang.String,\
         \ java.lang.String>, java.lang.String, java.lang.String, java.lang.String,\
@@ -1055,6 +1227,172 @@ acceptedBreaks:
       justification: "Deprecations for 1.6.0 release"
     - code: "java.method.removed"
       old: "method org.apache.iceberg.DataFiles.Builder org.apache.iceberg.DataFiles.Builder::withEqualityFieldIds(java.util.List<java.lang.Integer>)"
+      justification: "Deprecations for 1.6.0 release"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.BaseScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::caseSensitive(boolean)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      new: "method ThisT org.apache.iceberg.BaseScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::caseSensitive(boolean) @ org.apache.iceberg.SnapshotScan<ThisT\
+        \ extends org.apache.iceberg.Scan, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.BaseScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::filter(org.apache.iceberg.expressions.Expression)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      new: "method ThisT org.apache.iceberg.BaseScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::filter(org.apache.iceberg.expressions.Expression)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.BaseScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::ignoreResiduals()\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      new: "method ThisT org.apache.iceberg.BaseScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::ignoreResiduals() @ org.apache.iceberg.SnapshotScan<ThisT\
+        \ extends org.apache.iceberg.Scan, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.BaseScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::includeColumnStats()\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      new: "method ThisT org.apache.iceberg.BaseScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::includeColumnStats() @ org.apache.iceberg.SnapshotScan<ThisT\
+        \ extends org.apache.iceberg.Scan, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.BaseScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::includeColumnStats(java.util.Collection<java.lang.String>)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      new: "method ThisT org.apache.iceberg.BaseScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::includeColumnStats(java.util.Collection<java.lang.String>)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.BaseScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::metricsReporter(org.apache.iceberg.metrics.MetricsReporter)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      new: "method ThisT org.apache.iceberg.BaseScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::metricsReporter(org.apache.iceberg.metrics.MetricsReporter)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.BaseScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::newRefinedScan(org.apache.iceberg.Table,\
+        \ org.apache.iceberg.Schema, org.apache.iceberg.TableScanContext) @ org.apache.iceberg.SnapshotScan<ThisT,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>"
+      new: "method ThisT org.apache.iceberg.BaseScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::newRefinedScan(org.apache.iceberg.Table,\
+        \ org.apache.iceberg.Schema, org.apache.iceberg.TableScanContext) @ org.apache.iceberg.SnapshotScan<ThisT\
+        \ extends org.apache.iceberg.Scan, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.BaseScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::option(java.lang.String,\
+        \ java.lang.String) @ org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      new: "method ThisT org.apache.iceberg.BaseScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::option(java.lang.String, java.lang.String)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.BaseScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::planWith(java.util.concurrent.ExecutorService)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      new: "method ThisT org.apache.iceberg.BaseScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::planWith(java.util.concurrent.ExecutorService)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.BaseScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::project(org.apache.iceberg.Schema)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      new: "method ThisT org.apache.iceberg.BaseScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::project(org.apache.iceberg.Schema)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.BaseScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::select(java.util.Collection<java.lang.String>)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      new: "method ThisT org.apache.iceberg.BaseScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::select(java.util.Collection<java.lang.String>)\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.Scan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::select(java.lang.String[])\
+        \ @ org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      new: "method ThisT org.apache.iceberg.Scan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::select(java.lang.String[]) @ org.apache.iceberg.SnapshotScan<ThisT\
+        \ extends org.apache.iceberg.Scan, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::asOfTime(long)"
+      new: "method ThisT org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::asOfTime(long)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::useRef(java.lang.String)"
+      new: "method ThisT org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::useRef(java.lang.String)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method ThisT org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
+        \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>::useSnapshot(long)"
+      new: "method ThisT org.apache.iceberg.SnapshotScan<ThisT extends org.apache.iceberg.Scan,\
+        \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
+        \ extends org.apache.iceberg.ScanTask>>::useSnapshot(long)"
+      justification: "{Set the upper boundary of the type parameter}"
+    - code: "java.method.visibilityReduced"
+      old: "method void org.apache.iceberg.encryption.PlaintextEncryptionManager::<init>()"
+      new: "method void org.apache.iceberg.encryption.PlaintextEncryptionManager::<init>()"
       justification: "Deprecations for 1.6.0 release"
   apache-iceberg-0.14.0:
     org.apache.iceberg:iceberg-api:

--- a/api/src/main/java/org/apache/iceberg/IncrementalScan.java
+++ b/api/src/main/java/org/apache/iceberg/IncrementalScan.java
@@ -19,7 +19,7 @@
 package org.apache.iceberg;
 
 /** API for configuring an incremental scan. */
-public interface IncrementalScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
+public interface IncrementalScan<ThisT extends Scan, T extends ScanTask, G extends ScanTaskGroup<T>>
     extends Scan<ThisT, T, G> {
   /**
    * Instructs this scan to look for changes starting from a particular snapshot (inclusive).

--- a/api/src/main/java/org/apache/iceberg/Scan.java
+++ b/api/src/main/java/org/apache/iceberg/Scan.java
@@ -27,13 +27,13 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 /**
  * Scan objects are immutable and can be shared between threads. Refinement methods, like {@link
- * #select(Collection)} and {@link #filter(Expression)}, create new TableScan instances.
+ * #select(Collection)} and {@link #filter(Expression)}, create new Scan instances.
  *
  * @param <ThisT> the child Java API class, returned by method chaining
  * @param <T> the Java type of tasks produces by this scan
  * @param <G> the Java type of task groups produces by this scan
  */
-public interface Scan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>> {
+public interface Scan<ThisT extends Scan, T extends ScanTask, G extends ScanTaskGroup<T>> {
   /**
    * Create a new scan from this scan's configuration that will override the {@link Table}'s
    * behavior based on the incoming pair. Unknown properties will be ignored.

--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalScan.java
@@ -24,7 +24,8 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.SnapshotUtil;
 
-abstract class BaseIncrementalScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
+abstract class BaseIncrementalScan<
+        ThisT extends Scan, T extends ScanTask, G extends ScanTaskGroup<T>>
     extends BaseScan<ThisT, T, G> implements IncrementalScan<ThisT, T, G> {
 
   protected BaseIncrementalScan(Table table, Schema schema, TableScanContext context) {

--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -35,7 +35,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 
-abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
+abstract class BaseScan<ThisT extends Scan, T extends ScanTask, G extends ScanTaskGroup<T>>
     implements Scan<ThisT, T, G> {
 
   protected static final List<String> SCAN_COLUMNS =

--- a/core/src/main/java/org/apache/iceberg/DataScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataScan.java
@@ -21,7 +21,7 @@ package org.apache.iceberg;
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
-abstract class DataScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
+abstract class DataScan<ThisT extends Scan, T extends ScanTask, G extends ScanTaskGroup<T>>
     extends SnapshotScan<ThisT, T, G> {
 
   protected DataScan(Table table, Schema schema, TableScanContext context) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -49,7 +49,8 @@ import org.slf4j.LoggerFactory;
  * @param <T> type of ScanTask returned
  * @param <G> type of ScanTaskGroup returned
  */
-public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
+public abstract class SnapshotScan<
+        ThisT extends Scan, T extends ScanTask, G extends ScanTaskGroup<T>>
     extends BaseScan<ThisT, T, G> {
 
   private static final Logger LOG = LoggerFactory.getLogger(SnapshotScan.class);


### PR DESCRIPTION
The comment of interface `Scan` instructs that it's refined methods, like `select(Collection)` and `filter(Expression)` will return new `Scan` instances. That is, they should always return `Scan` or child classes of `Scan`, and support the method chaining usage as follows:

```
    Scan oldScan = ...;
    Scan newScan = oldScan.select("col1", "col2")
            .filter(expression)
            .project(schema);
```

However, at the level of declaration, we do not enforce the above restricts. So that someone can declare a new incremental scan class in his own project as follows:

```
public class NewDefinedIncrementalScan
        implements IncrementalScan<Object, FileScanTask, CombinedScanTask>
{
      ......
}
```

It would violate the instructions in the comment of `Scan` and break the method chain, but is legal during the compilation phase. That may lead in some confusions, as its a little difficult to distinguish whether it's intentionally to allow this.

This PR set the upper boundary of type parameter for `Scan` and it's child classes. It will explicitly disallow the issues described above and report the problem during compilation phase.
