### PR TITLE
Api, Build: Fix typo in comments in `Table` and `gradlew`

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -270,7 +270,7 @@ public interface Table {
   ReplacePartitions newReplacePartitions();
 
   /**
-   * Create a new {@link DeleteFiles delete API} to replace files in this table and commit.
+   * Create a new {@link DeleteFiles delete API} to delete files in this table and commit.
    *
    * @return a new {@link DeleteFiles}
    */
@@ -299,7 +299,7 @@ public interface Table {
   }
 
   /**
-   * Create a new {@link ExpireSnapshots expire API} to manage snapshots in this table and commit.
+   * Create a new {@link ExpireSnapshots expire API} to expire snapshots in this table and commit.
    *
    * @return a new {@link ExpireSnapshots}
    */

--- a/gradlew
+++ b/gradlew
@@ -207,7 +207,7 @@ fi
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Collect all arguments for the java command:
-#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
 #     and any embedded shellness will be escaped.
 #   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.


### PR DESCRIPTION
This PR fix typos in the comment of interface methods in `Table`, and remove duplicate messages in the comment in `gradlew`