### PR TITLE
Core: Add estimateRowCount for Files and Entries Metadata Tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -304,6 +304,13 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
               : new Schema();
     }
 
+    @Override
+    public long estimatedRowsCount() {
+      return (long) manifest.addedFilesCount()
+          + (long) manifest.deletedFilesCount()
+          + (long) manifest.existingFilesCount();
+    }
+
     @VisibleForTesting
     ManifestFile manifest() {
       return manifest;

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -169,6 +169,13 @@ abstract class BaseFilesTable extends BaseMetadataTable {
       }
     }
 
+    @Override
+    public long estimatedRowsCount() {
+      return (long) manifest.addedFilesCount()
+          + (long) manifest.deletedFilesCount()
+          + (long) manifest.existingFilesCount();
+    }
+
     private CloseableIterable<? extends ContentFile<?>> files(Schema fileProjection) {
       switch (manifest.content()) {
         case DATA:

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -1758,13 +1758,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testFilesTableEstimateSize() throws Exception {
     preparePartitionedTable(true);
 
-    assertEstimatedSize(new DataFilesTable(table));
-    assertEstimatedSize(new AllDataFilesTable(table));
-    assertEstimatedSize(new AllFilesTable(table));
+    assertEstimatedRowCount(new DataFilesTable(table), 4);
+    assertEstimatedRowCount(new AllDataFilesTable(table), 4);
+    assertEstimatedRowCount(new AllFilesTable(table), 4);
 
     if (formatVersion == 2) {
-      assertEstimatedSize(new DeleteFilesTable(table));
-      assertEstimatedSize(new AllDeleteFilesTable(table));
+      assertEstimatedRowCount(new DeleteFilesTable(table), 4);
+      assertEstimatedRowCount(new AllDeleteFilesTable(table), 4);
     }
   }
 
@@ -1772,17 +1772,17 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testEntriesTableEstimateSize() throws Exception {
     preparePartitionedTable(true);
 
-    assertEstimatedSize(new ManifestEntriesTable(table));
-    assertEstimatedSize(new AllEntriesTable(table));
+    assertEstimatedRowCount(new ManifestEntriesTable(table), 4);
+    assertEstimatedRowCount(new AllEntriesTable(table), 4);
   }
 
-  private void assertEstimatedSize(Table metadataTable) throws Exception {
+  private void assertEstimatedRowCount(Table metadataTable, int size) throws Exception {
     TableScan scan = metadataTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
       List<FileScanTask> taskList = Lists.newArrayList(tasks);
       assertThat(taskList.size()).isGreaterThan(0);
-      taskList.forEach(task -> assertThat(task.estimatedRowsCount()).isEqualTo(4));
+      taskList.forEach(task -> assertThat(task.estimatedRowsCount()).isEqualTo(size));
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -1762,7 +1762,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     assertEstimatedSize(new AllDataFilesTable(table));
     assertEstimatedSize(new AllFilesTable(table));
 
-    if (formatVersion != 2) {
+    if (formatVersion == 2) {
       assertEstimatedSize(new DeleteFilesTable(table));
       assertEstimatedSize(new AllDeleteFilesTable(table));
     }
@@ -1780,8 +1780,9 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scan = metadataTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      StreamSupport.stream(tasks.spliterator(), false)
-          .forEach(task -> assertThat(task.estimatedRowsCount()).isEqualTo(4));
+      List<FileScanTask> taskList = Lists.newArrayList(tasks);
+      assertThat(taskList.size()).isGreaterThan(0);
+      taskList.forEach(task -> assertThat(task.estimatedRowsCount()).isEqualTo(4));
     }
   }
 }


### PR DESCRIPTION
Spark queries of Metadata Tables will often try to check row count estimates repeatedly during planning phase, like picking a join strategy.

By default, this involves an extra call to read the manifest file header, as the default logic on the BaseContentScanTask is as follows:

```
  static long estimateRowsCount(long length, ContentFile<?> file) {
    long[] splitOffsets = splitOffsets(file);
    long splitOffset = splitOffsets != null ? splitOffsets[0] : 0L;
    double scannedFileFraction = ((double) length) / (file.fileSizeInBytes() - splitOffset);
    return (long) (scannedFileFraction * file.recordCount());
  }
```

However, we actually have this information in the metadata and can just return it directly without reading the file header.

This can save many calls on the Spark driver for planning (one call per manifest file, so potentially many thousands, in serial manner).  

This is useful as many Spark maintenance procedures involve querying these tables ( expireSnapshots, removeOrphanFiles)