### PR TITLE
Add `IcebergAnalysisException` in iceberg-spark module

### DIFF
--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckViews.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckViews.scala
@@ -48,7 +48,8 @@ object CheckViews extends (LogicalPlan => Unit) {
         }
 
       case AlterViewAs(ResolvedV2View(_, _), _, _) =>
-        throw new AnalysisException("ALTER VIEW <viewName> AS is not supported. Use CREATE OR REPLACE VIEW instead")
+        throw new IcebergAnalysisException(
+          "ALTER VIEW <viewName> AS is not supported. Use CREATE OR REPLACE VIEW instead")
 
       case _ => // OK
     }
@@ -105,7 +106,7 @@ object CheckViews extends (LogicalPlan => Unit) {
   ): Unit = {
     val newCyclePath = cyclePath :+ currentViewIdent
     if (currentViewIdent == viewIdent) {
-      throw new AnalysisException(String.format("Recursive cycle in view detected: %s (cycle: %s)",
+      throw new IcebergAnalysisException(String.format("Recursive cycle in view detected: %s (cycle: %s)",
         viewIdent.asIdentifier, newCyclePath.map(p => p.mkString(".")).mkString(" -> ")))
     } else {
       children.foreach { c =>

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ProcedureArgumentCoercion.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ProcedureArgumentCoercion.scala
@@ -36,7 +36,7 @@ object ProcedureArgumentCoercion extends Rule[LogicalPlan] {
         val argType = arg.dataType
 
         if (paramType != argType && !Cast.canUpCast(argType, paramType)) {
-          throw new AnalysisException(
+          throw new IcebergAnalysisException(
             s"Wrong arg type for ${param.name}: cannot cast $argType to $paramType")
         }
 

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveProcedures.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveProcedures.scala
@@ -61,13 +61,13 @@ case class ResolveProcedures(spark: SparkSession) extends Rule[LogicalPlan] with
     }
 
     if (duplicateParamNames.nonEmpty) {
-      throw new AnalysisException(s"Duplicate parameter names: ${duplicateParamNames.mkString("[", ",", "]")}")
+      throw new IcebergAnalysisException(s"Duplicate parameter names: ${duplicateParamNames.mkString("[", ",", "]")}")
     }
 
     // optional params should be at the end
     params.sliding(2).foreach {
       case Seq(previousParam, currentParam) if !previousParam.required && currentParam.required =>
-        throw new AnalysisException(
+        throw new IcebergAnalysisException(
           s"Optional parameters must be after required ones but $currentParam is after $previousParam")
       case _ =>
     }
@@ -89,7 +89,7 @@ case class ResolveProcedures(spark: SparkSession) extends Rule[LogicalPlan] with
     }
 
     if (missingParamNames.nonEmpty) {
-      throw new AnalysisException(s"Missing required parameters: ${missingParamNames.mkString("[", ",", "]")}")
+      throw new IcebergAnalysisException(s"Missing required parameters: ${missingParamNames.mkString("[", ",", "]")}")
     }
 
     val argExprs = new Array[Expression](params.size)
@@ -119,7 +119,7 @@ case class ResolveProcedures(spark: SparkSession) extends Rule[LogicalPlan] with
     val containsPositionalArg = args.exists(_.isInstanceOf[PositionalArgument])
 
     if (containsNamedArg && containsPositionalArg) {
-      throw new AnalysisException("Named and positional arguments cannot be mixed")
+      throw new IcebergAnalysisException("Named and positional arguments cannot be mixed")
     }
 
     if (containsNamedArg) {
@@ -141,7 +141,7 @@ case class ResolveProcedures(spark: SparkSession) extends Rule[LogicalPlan] with
     }
 
     if (validationErrors.nonEmpty) {
-      throw new AnalysisException(s"Could not build name to arg map: ${validationErrors.mkString(", ")}")
+      throw new IcebergAnalysisException(s"Could not build name to arg map: ${validationErrors.mkString(", ")}")
     }
 
     namedArgs.map(arg => arg.name -> arg).toMap
@@ -152,7 +152,7 @@ case class ResolveProcedures(spark: SparkSession) extends Rule[LogicalPlan] with
       params: Seq[ProcedureParameter]): Map[String, CallArgument] = {
 
     if (args.size > params.size) {
-      throw new AnalysisException("Too many arguments for procedure")
+      throw new IcebergAnalysisException("Too many arguments for procedure")
     }
 
     args.zipWithIndex.map { case (arg, position) =>
@@ -184,7 +184,7 @@ case class ResolveProcedures(spark: SparkSession) extends Rule[LogicalPlan] with
       case procedureCatalog: ProcedureCatalog =>
         procedureCatalog
       case _ =>
-        throw new AnalysisException(s"Cannot use catalog ${plugin.name}: not a ProcedureCatalog")
+        throw new IcebergAnalysisException(s"Cannot use catalog ${plugin.name}: not a ProcedureCatalog")
     }
   }
 }

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala
@@ -128,12 +128,13 @@ case class RewriteViewCommands(spark: SparkSession) extends Rule[LogicalPlan] wi
   }
 
   private def invalidRefToTempObject(ident: ResolvedIdentifier, tempObjectNames: String, tempObjectType: String) = {
-    new AnalysisException(String.format("Cannot create view %s.%s that references temporary %s: %s",
+    new IcebergAnalysisException(String.format("Cannot create view %s.%s that references temporary %s: %s",
       ident.catalog.name(), ident.identifier, tempObjectType, tempObjectNames))
   }
 
   /**
    * Collect all temporary views and return the identifiers separately
+
    */
   private def collectTemporaryViews(child: LogicalPlan): Seq[Seq[String]] = {
     def collectTempViews(child: LogicalPlan): Seq[Seq[String]] = {

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -30,7 +30,7 @@ import org.apache.iceberg.NullOrder
 import org.apache.iceberg.SortDirection
 import org.apache.iceberg.expressions.Term
 import org.apache.iceberg.spark.Spark3Util
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.analysis.IcebergAnalysisException
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.parser.ParserInterface
@@ -221,7 +221,7 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
     val (distributionSpec, orderingSpec) = toDistributionAndOrderingSpec(ctx.writeSpec)
 
     if (distributionSpec == null && orderingSpec == null) {
-      throw new AnalysisException(
+      throw new IcebergAnalysisException(
         "ALTER TABLE has no changes: missing both distribution and ordering clauses")
     }
 
@@ -246,11 +246,11 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
       writeSpec: WriteSpecContext): (WriteDistributionSpecContext, WriteOrderingSpecContext) = {
 
     if (writeSpec.writeDistributionSpec.size > 1) {
-      throw new AnalysisException("ALTER TABLE contains multiple distribution clauses")
+      throw new IcebergAnalysisException("ALTER TABLE contains multiple distribution clauses")
     }
 
     if (writeSpec.writeOrderingSpec.size > 1) {
-      throw new AnalysisException("ALTER TABLE contains multiple ordering clauses")
+      throw new IcebergAnalysisException("ALTER TABLE contains multiple ordering clauses")
     }
 
     val distributionSpec = toBuffer(writeSpec.writeDistributionSpec).headOption.orNull

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterV2ViewUnsetPropertiesExec.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterV2ViewUnsetPropertiesExec.scala
@@ -19,8 +19,8 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.IcebergAnalysisException
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.catalog.ViewCatalog
@@ -38,7 +38,7 @@ case class AlterV2ViewUnsetPropertiesExec(
   override protected def run(): Seq[InternalRow] = {
     if (!ifExists) {
       propertyKeys.filterNot(catalog.loadView(ident).properties.containsKey).foreach { property =>
-        throw new AnalysisException(s"Cannot remove property that is not set: '$property'")
+        throw new IcebergAnalysisException(s"Cannot remove property that is not set: '$property'")
       }
     }
 

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -22,10 +22,10 @@ package org.apache.spark.sql.execution.datasources.v2
 import org.apache.iceberg.spark.Spark3Util
 import org.apache.iceberg.spark.SparkCatalog
 import org.apache.iceberg.spark.SparkSessionCatalog
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.Strategy
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.IcebergAnalysisException
 import org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier
 import org.apache.spark.sql.catalyst.analysis.ResolvedNamespace
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -107,7 +107,7 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy wi
     case RenameTable(ResolvedV2View(oldCatalog: ViewCatalog, oldIdent), newName, isView@true) =>
       val newIdent = Spark3Util.catalogAndIdentifier(spark, newName.toList.asJava)
       if (oldCatalog.name != newIdent.catalog().name()) {
-        throw new AnalysisException(
+        throw new IcebergAnalysisException(
           s"Cannot move view between catalogs: from=${oldCatalog.name} and to=${newIdent.catalog().name()}")
       }
       RenameV2ViewExec(oldCatalog, oldIdent, newIdent.identifier()) :: Nil

--- a/spark/v3.5/spark/src/main/java/org/apache/spark/sql/catalyst/analysis/IcebergAnalysisException.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/spark/sql/catalyst/analysis/IcebergAnalysisException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.catalyst.analysis;
+
+import org.apache.spark.QueryContext;
+import org.apache.spark.sql.AnalysisException;
+import scala.Option;
+import scala.collection.immutable.Map$;
+
+public class IcebergAnalysisException extends AnalysisException {
+  public IcebergAnalysisException(String message) {
+    super(
+        message,
+        Option.empty(),
+        Option.empty(),
+        Option.empty(),
+        Option.empty(),
+        Map$.MODULE$.<String, String>empty(),
+        new QueryContext[0]);
+  }
+}

--- a/spark/v3.5/spark/src/main/scala/org/apache/spark/sql/execution/datasources/SparkExpressionConverter.scala
+++ b/spark/v3.5/spark/src/main/scala/org/apache/spark/sql/execution/datasources/SparkExpressionConverter.scala
@@ -20,8 +20,8 @@
 package org.apache.spark.sql.execution.datasources
 
 import org.apache.iceberg.spark.SparkV2Filters
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.IcebergAnalysisException
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.Literal
@@ -49,7 +49,7 @@ object SparkExpressionConverter {
     }
   }
 
-  @throws[AnalysisException]
+  @throws[IcebergAnalysisException]
   def collectResolvedSparkExpression(session: SparkSession, tableName: String, where: String): Expression = {
     val tableAttrs = session.table(tableName).queryExecution.analyzed.output
     val unresolvedExpression = session.sessionState.sqlParser.parseExpression(where)
@@ -59,7 +59,7 @@ object SparkExpressionConverter {
       case filter: Filter => filter.condition
       case dummyRelation: DummyRelation => Literal.TrueLiteral
       case localRelation: LocalRelation => Literal.FalseLiteral
-    }.getOrElse(throw new AnalysisException("Failed to find filter expression"))
+    }.getOrElse(throw new IcebergAnalysisException("Failed to find filter expression"))
   }
 
   case class DummyRelation(output: Seq[Attribute]) extends LeafNode


### PR DESCRIPTION
In Iceberg's `spark-extensions`, if we encounter any invalid SQL statements, we throw Spark's `AnalysisException`. However, it would be better to have Iceberg's own `IcebergAnalysisException` to differentiate it from the `AnalysisException` issued by Spark itself.

Another reason to have Iceberg's own `IcebergAnalysisException` is due to Spark's new error handling scheme. Since Spark 3.2, Spark has introduced an error class system. For the `AnalysisExceptions` that are issued in Iceberg's `spark-extensions`, we don't really have a corresponding Spark error class. Therefore, it seems better to have Iceberg's own `IcebergAnalysisException` to differentiate it from the `AnalysisException` issued by Spark itself.
