### PR TITLE
Flink: Remove JUnit4 dependency

### DIFF
--- a/flink/v1.17/build.gradle
+++ b/flink/v1.17/build.gradle
@@ -117,7 +117,6 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
     testImplementation libs.awaitility
     testImplementation libs.assertj.core
-    testImplementation libs.junit.vintage.engine
   }
 
   test {

--- a/flink/v1.18/build.gradle
+++ b/flink/v1.18/build.gradle
@@ -117,7 +117,6 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
     testImplementation libs.awaitility
     testImplementation libs.assertj.core
-    testImplementation libs.junit.vintage.engine
   }
 
   test {

--- a/flink/v1.19/build.gradle
+++ b/flink/v1.19/build.gradle
@@ -119,7 +119,6 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
     testImplementation libs.awaitility
     testImplementation libs.assertj.core
-    testImplementation libs.junit.vintage.engine
   }
 
   test {


### PR DESCRIPTION
Now that https://github.com/apache/iceberg/issues/9087 is complete we can remove the JUnit4 dependency from Flink