### PR TITLE
Spark 3.5: Don't change table distribution when only altering local order

### DIFF
--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -226,11 +226,13 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
     }
 
     val distributionMode = if (distributionSpec != null) {
-      DistributionMode.HASH
-    } else if (orderingSpec.UNORDERED != null || orderingSpec.LOCALLY != null) {
-      DistributionMode.NONE
+      Some(DistributionMode.HASH)
+    } else if (orderingSpec.UNORDERED != null) {
+      Some(DistributionMode.NONE)
+    } else if (orderingSpec.LOCALLY() != null) {
+      None
     } else {
-      DistributionMode.RANGE
+      Some(DistributionMode.RANGE)
     }
 
     val ordering = if (orderingSpec != null && orderingSpec.order != null) {

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/SetWriteDistributionAndOrderingExec.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/SetWriteDistributionAndOrderingExec.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
 case class SetWriteDistributionAndOrderingExec(
     catalog: TableCatalog,
     ident: Identifier,
-    distributionMode: DistributionMode,
+    distributionMode: Option[DistributionMode],
     sortOrder: Seq[(Term, SortDirection, NullOrder)]) extends LeafV2CommandExec {
 
   import CatalogV2Implicits._
@@ -56,9 +56,11 @@ case class SetWriteDistributionAndOrderingExec(
         }
         orderBuilder.commit()
 
-        txn.updateProperties()
-          .set(WRITE_DISTRIBUTION_MODE, distributionMode.modeName())
-          .commit()
+        distributionMode.foreach { mode =>
+          txn.updateProperties()
+            .set(WRITE_DISTRIBUTION_MODE, mode.modeName())
+            .commit()
+        }
 
         txn.commitTransaction()
 

--- a/spark/v3.5/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SetWriteDistributionAndOrdering.scala
+++ b/spark/v3.5/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SetWriteDistributionAndOrdering.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.connector.catalog.CatalogV2Implicits
 
 case class SetWriteDistributionAndOrdering(
     table: Seq[String],
-    distributionMode: DistributionMode,
+    distributionMode: Option[DistributionMode],
     sortOrder: Seq[(Term, SortDirection, NullOrder)]) extends LeafCommand {
 
   import CatalogV2Implicits._


### PR DESCRIPTION
As discussed with @aokolnychyi @szehon-ho and @RussellSpitzer in https://github.com/apache/iceberg/pull/10647#issuecomment-2237793353