### PR TITLE
API: Fix typo in RewriteManifestFiles java doc

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteManifests.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteManifests.java
@@ -54,7 +54,7 @@ public interface RewriteManifests extends SnapshotUpdate<RewriteManifests> {
    * then all manifests will be rewritten.
    *
    * @param predicate Predicate used to determine which manifests to rewrite. If true then the
-   *     manifest file will be included for rewrite. If false then then manifest is kept as-is.
+   *     manifest file will be included for rewrite. If false then the manifest is kept as-is.
    * @return this for method chaining
    */
   RewriteManifests rewriteIf(Predicate<ManifestFile> predicate);


### PR DESCRIPTION
Fixes a small typo I noticed when reading the rewrite manifests API