### PR TITLE
Kafka Connect: Wait for coordinator shutdown

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -303,10 +304,10 @@ class Coordinator extends Channel {
     // ensure coordinator tasks are shut down, else cause the sink worker to fail
     try {
       if (!exec.awaitTermination(1, TimeUnit.MINUTES)) {
-        throw new RuntimeException("Timed out waiting for coordinator shutdown");
+        throw new ConnectException("Timed out waiting for coordinator shutdown");
       }
     } catch (InterruptedException e) {
-      throw new RuntimeException("Interrupted while waiting for coordinator shutdown", e);
+      throw new ConnectException("Interrupted while waiting for coordinator shutdown", e);
     }
 
     super.stop();

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
@@ -68,9 +68,9 @@ class CoordinatorThread extends Thread {
     terminated = true;
 
     try {
-      join();
+      join(60_000);
     } catch (InterruptedException e) {
-      throw new ConnectException(e);
+      throw new ConnectException("Timed out waiting for coordinator thread to terminate", e);
     }
 
     if (coordinator != null) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -61,6 +61,7 @@ import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 
 class RecordConverter {
 
@@ -421,7 +422,7 @@ class RecordConverter {
       int days = (int) (((Date) value).getTime() / 1000 / 60 / 60 / 24);
       return DateTimeUtil.dateFromDays(days);
     }
-    throw new RuntimeException("Cannot convert date: " + value);
+    throw new ConnectException("Cannot convert date: " + value);
   }
 
   @SuppressWarnings("JavaUtilDate")
@@ -437,7 +438,7 @@ class RecordConverter {
       long millis = ((Date) value).getTime();
       return DateTimeUtil.timeFromMicros(millis * 1000);
     }
-    throw new RuntimeException("Cannot convert time: " + value);
+    throw new ConnectException("Cannot convert time: " + value);
   }
 
   protected Temporal convertTimestampValue(Object value, TimestampType type) {
@@ -461,7 +462,7 @@ class RecordConverter {
     } else if (value instanceof Date) {
       return DateTimeUtil.timestamptzFromMicros(((Date) value).getTime() * 1000);
     }
-    throw new RuntimeException(
+    throw new ConnectException(
         "Cannot convert timestamptz: " + value + ", type: " + value.getClass());
   }
 
@@ -489,7 +490,7 @@ class RecordConverter {
     } else if (value instanceof Date) {
       return DateTimeUtil.timestampFromMicros(((Date) value).getTime() * 1000);
     }
-    throw new RuntimeException(
+    throw new ConnectException(
         "Cannot convert timestamp: " + value + ", type: " + value.getClass());
   }
 


### PR DESCRIPTION
This PR waits for the coordinator thread to complete when stopping the sink, to ensure there are no coordinator tasks pending before starting a new coordinator. The sink was designed with the assumption that only one coordinator and its tasks are active at a given time.

This also changes throwing `RuntimeException` to `ConnectException` to be a little bit more specific.