### PR TITLE
Puffin: Document stats `ndv` value representation

### DIFF
--- a/format/puffin-spec.md
+++ b/format/puffin-spec.md
@@ -121,7 +121,9 @@ distinct values converted to bytes using Iceberg's single-value serialization.
 
 The blob metadata for this blob may include following properties:
 
-- `ndv`: estimate of number of distinct values, derived from the sketch.
+- `ndv`: estimate of number of distinct values, derived from the sketch,
+  stored as non-negative integer value represented using decimal digits
+  with no leading or trailing spaces.
 
 ### Compression codecs
 


### PR DESCRIPTION
Follows discussion https://github.com/apache/iceberg/pull/10288#discussion_r1691077522