### PR TITLE
API: Update Conversions.fromPartitionString API to handle timestamps

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -27,8 +27,11 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoField;
 import java.util.Arrays;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.util.UUIDUtil;
@@ -68,6 +71,10 @@ public class Conversions {
         return new BigDecimal(asString);
       case DATE:
         return Literal.of(asString).to(Types.DateType.get()).value();
+      case TIMESTAMP:
+        Instant instant = Instant.parse(asString);
+        return TimeUnit.SECONDS.toMicros(instant.getEpochSecond())
+            + instant.get(ChronoField.MICRO_OF_SECOND);
       default:
         throw new UnsupportedOperationException(
             "Unsupported type for fromPartitionString: " + type);

--- a/api/src/test/java/org/apache/iceberg/types/TestConversions.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestConversions.java
@@ -180,6 +180,16 @@ public class TestConversions {
         .isEqualTo(new byte[] {11});
   }
 
+  @Test
+  public void testFromPartitionStringConversions() {
+    Object timestamp =
+        Conversions.fromPartitionString(TimestampType.withZone(), "2024-06-16T05:00:00.123456Z");
+    assertThat(timestamp).isInstanceOf(Long.class);
+    assertThat((long) timestamp)
+        .as("Timestamp should have expected microseconds since epoch")
+        .isEqualTo(1718514000123456L);
+  }
+
   private <T> void assertConversion(T value, Type type, byte[] expectedBinary) {
     ByteBuffer byteBuffer = Conversions.toByteBuffer(type, value);
     assertThat(byteBuffer.array()).isEqualTo(expectedBinary);


### PR DESCRIPTION
This can be considered as an alternative to https://github.com/apache/iceberg/pull/10724

In #10724, a new API on the DataFile builder was proposed which enabled callers to pass in custom partition string conversion functions. The rationale behind that API was that Iceberg should not be opinionated on how to do the conversion, and `Conversions` utility primarily existed for enabling Hive style table migrations. Callers could pass in whatever they wanted.

The use case that was driving #10724 was to enable Delta uniform to be be able to have timestamp partitions.
Since the `Conversions` utility already doesn't support timestamps, and maybe the proposed API isn't really needed beyond the uniform use-case, this approach just adds the handling the timestamp partitioning.

Specifically, handling expects an ISO8601 UTC adjusted instant. Anything else will fail parsing in the conversion. The conversion logic for timestamp returns a microseconds since epoch long that aligns with what the Iceberg data type representation is. 