### PR TITLE
Kafka Connect: Include third party licenses and notices in distribution

### DIFF
--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -198,7 +198,8 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
           from configurations.runtimeClasspath
         }
         into('doc/') {
-          from "$rootDir/LICENSE"
+          from "$projectDir/LICENSE"
+          from "$projectDir/NOTICE"
         }
         into('assets/') {
           from "${processResources.destinationDir}/iceberg.png"
@@ -212,7 +213,8 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
           from configurations.hive
         }
         into('doc/') {
-          from "$rootDir/LICENSE"
+          from "$projectDir/LICENSE"
+          from "$projectDir/NOTICE"
         }
         into('assets/') {
           from "${processResources.destinationDir}/iceberg.png"

--- a/kafka-connect/kafka-connect-runtime/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/LICENSE
@@ -1,0 +1,1448 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains code from the following projects:
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-core  Version: 1.49.1
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-core-http-netty  Version: 1.15.1
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-identity  Version: 1.13.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-json  Version: 1.1.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-storage-blob  Version: 12.26.1
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-storage-common  Version: 12.25.1
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-storage-file-datalake  Version: 12.19.1
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-storage-internal-avro  Version: 12.11.1
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-xml  Version: 1.0.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.17.1
+Project URL (from manifest): https://github.com/FasterXML/jackson
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.17.1
+Project URL (from manifest): https://github.com/FasterXML/jackson-core
+Project URL (from POM): https://github.com/FasterXML/jackson-core
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.17.1
+Project URL (from manifest): https://github.com/FasterXML/jackson
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.17.1
+Project URL (from manifest): https://github.com/FasterXML/jackson-dataformat-xml
+Project URL (from POM): https://github.com/FasterXML/jackson-dataformat-xml
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.17.1
+Project URL (from manifest): https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.woodstox  Name: woodstox-core  Version: 6.6.2
+Project URL (from manifest): https://github.com/FasterXML/woodstox
+Project URL (from POM): https://github.com/FasterXML/woodstox
+License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.github.ben-manes.caffeine  Name: caffeine  Version: 2.9.3
+Project URL (from POM): https://github.com/ben-manes/caffeine
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.github.luben  Name: zstd-jni  Version: 1.5.0-1
+License URL (from manifest): https://opensource.org/licenses/BSD-2-Clause
+Project URL (from POM): https://github.com/luben/zstd-jni
+License (from POM): BSD 2-Clause License - https://opensource.org/licenses/BSD-2-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.github.pjfanning  Name: jersey-json  Version: 1.20
+Project URL (from POM): https://github.com/pjfanning/jersey-1.x
+License (from POM): CDDL 1.1 - http://glassfish.java.net/public/CDDL+GPL_1_1.html
+License (from POM): GPL2 w/ CPE - http://glassfish.java.net/public/CDDL+GPL_1_1.html
+
+--------------------------------------------------------------------------------
+
+Group: com.github.stephenc.jcip  Name: jcip-annotations  Version: 1.0-1
+Project URL (from POM): http://stephenc.github.com/jcip-annotations
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.android  Name: annotations  Version: 4.1.1.4
+Project URL (from POM): http://source.android.com/
+License (from POM): Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api  Name: api-common  Version: 2.33.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): BSD-3-Clause - https://github.com/googleapis/api-common-java/blob/main/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api  Name: gax  Version: 2.50.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api  Name: gax-grpc  Version: 2.50.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api  Name: gax-httpjson  Version: 2.50.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api-client  Name: google-api-client  Version: 2.6.0
+Project URL (from manifest): https://developers.google.com/api-client-library/java/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc  Name: gapic-google-cloud-storage-v2  Version: 2.40.1-alpha
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc  Name: grpc-google-cloud-storage-v2  Version: 2.40.1-alpha
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc  Name: proto-google-cloud-storage-v2  Version: 2.40.1-alpha
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc  Name: proto-google-common-protos  Version: 2.41.0
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc  Name: proto-google-iam-v1  Version: 1.36.0
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.apis  Name: google-api-services-storage  Version: v1-rev20240621-2.0.0
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.auth  Name: google-auth-library-credentials  Version: 1.23.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): BSD New license - http://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.auth  Name: google-auth-library-oauth2-http  Version: 1.23.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): BSD New license - http://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.auto.value  Name: auto-value-annotations  Version: 1.10.4
+Project URL (from POM): https://github.com/google/auto/tree/main/value
+License (from POM): Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud  Name: google-cloud-core  Version: 2.40.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud  Name: google-cloud-core-grpc  Version: 2.40.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud  Name: google-cloud-core-http  Version: 2.40.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud  Name: google-cloud-storage  Version: 2.40.1
+Project URL (from POM): https://github.com/googleapis/java-storage
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.code.findbugs  Name: jsr305  Version: 3.0.2
+Project URL (from POM): http://findbugs.sourceforge.net/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.code.gson  Name: gson  Version: 2.11.0
+Project URL (from manifest): https://github.com/google/gson
+Manifest License: "Apache-2.0";link="https://www.apache.org/licenses/LICENSE-2.0.txt" (Not packaged)
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.errorprone  Name: error_prone_annotations  Version: 2.28.0
+Project URL (from manifest): https://errorprone.info/error_prone_annotations
+Manifest License: "Apache 2.0";link="http://www.apache.org/licenses/LICENSE-2.0.txt" (Not packaged)
+License (from POM): Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.guava  Name: failureaccess  Version: 1.0.2
+Project URL (from manifest): https://github.com/google/guava/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.guava  Name: guava  Version: 33.1.0-jre
+Project URL (from manifest): https://github.com/google/guava/
+Project URL (from POM): https://github.com/google/guava
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.guava  Name: listenablefuture  Version: 9999.0-empty-to-avoid-conflict-with-guava
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client  Name: google-http-client  Version: 1.44.2
+Project URL (from manifest): https://www.google.com/
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client  Name: google-http-client-apache-v2  Version: 1.44.2
+Project URL (from manifest): https://www.google.com/
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client  Name: google-http-client-appengine  Version: 1.44.2
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client  Name: google-http-client-gson  Version: 1.44.2
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client  Name: google-http-client-jackson2  Version: 1.44.2
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.j2objc  Name: j2objc-annotations  Version: 3.0.0
+Project URL (from POM): https://github.com/google/j2objc/
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.oauth-client  Name: google-oauth-client  Version: 1.36.0
+Project URL (from manifest): https://www.google.com/
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.protobuf  Name: protobuf-java  Version: 3.25.3
+Project URL (from manifest): https://developers.google.com/protocol-buffers/
+License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.protobuf  Name: protobuf-java-util  Version: 3.25.3
+Project URL (from manifest): https://developers.google.com/protocol-buffers/
+License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.re2j  Name: re2j  Version: 1.7
+Project URL (from POM): http://github.com/google/re2j
+License (from POM): Go License - https://golang.org/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.jcraft  Name: jsch  Version: 0.1.55
+Project URL (from POM): http://www.jcraft.com/jsch/
+License (from POM): Revised BSD - http://www.jcraft.com/jsch/LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.microsoft.azure  Name: msal4j  Version: 1.15.1
+Project URL (from manifest): https://github.com/AzureAD/microsoft-authentication-library-for-java
+Manifest License: "MIT License" (Not packaged)
+Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
+License (from POM): MIT License
+--------------------------------------------------------------------------------
+
+Group: com.microsoft.azure  Name: msal4j-persistence-extension  Version: 1.3.0
+Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
+License (from POM): MIT License
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds  Name: content-type  Version: 2.3
+Project URL (from manifest): https://connect2id.com
+Project URL (from POM): https://bitbucket.org/connect2id/nimbus-content-type
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds  Name: lang-tag  Version: 1.7
+Project URL (from manifest): https://connect2id.com/
+Project URL (from POM): https://bitbucket.org/connect2id/nimbus-language-tags
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds  Name: nimbus-jose-jwt  Version: 9.37.3
+Project URL (from manifest): https://connect2id.com
+Project URL (from POM): https://bitbucket.org/connect2id/nimbus-jose-jwt
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds  Name: oauth2-oidc-sdk  Version: 11.9.1
+Project URL (from manifest): https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
+Manifest License: "Apache License, version 2.0";link="https://www.apache.org/licenses/LICENSE-2.0.html" (Not packaged)
+Project URL (from POM): https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
+License (from POM): Apache License, version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: com.sun.xml.bind  Name: jaxb-impl  Version: 2.2.3-1
+Project URL (from POM): http://jaxb.java.net/
+License (from POM): CDDL 1.1 - https://glassfish.java.net/public/CDDL+GPL_1_1.html
+License (from POM): GPL2 w/ CPE - https://glassfish.java.net/public/CDDL+GPL_1_1.html
+
+--------------------------------------------------------------------------------
+
+Group: commons-beanutils  Name: commons-beanutils  Version: 1.9.4
+Project URL (from manifest): https://commons.apache.org/proper/commons-beanutils/
+Project URL (from POM): https://commons.apache.org/proper/commons-beanutils/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-cli  Name: commons-cli  Version: 1.2
+Project URL (from manifest): http://commons.apache.org/cli/
+Project URL (from POM): http://commons.apache.org/cli/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-codec  Name: commons-codec  Version: 1.17.1
+Project URL (from manifest): https://commons.apache.org/proper/commons-codec/
+Project URL (from POM): https://commons.apache.org/proper/commons-codec/
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-collections  Name: commons-collections  Version: 3.2.2
+Project URL (from manifest): http://commons.apache.org/collections/
+Project URL (from POM): http://commons.apache.org/collections/
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-io  Name: commons-io  Version: 2.15.1
+Project URL (from manifest): https://commons.apache.org/proper/commons-io/
+Project URL (from POM): https://commons.apache.org/proper/commons-io/
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-logging  Name: commons-logging  Version: 1.2
+Project URL (from manifest): http://commons.apache.org/proper/commons-logging/
+Project URL (from POM): http://commons.apache.org/proper/commons-logging/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-net  Name: commons-net  Version: 3.9.0
+Project URL (from manifest): https://commons.apache.org/proper/commons-net/
+Project URL (from POM): https://commons.apache.org/proper/commons-net/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-pool  Name: commons-pool  Version: 1.6
+Project URL (from manifest): http://commons.apache.org/pool/
+Project URL (from POM): http://commons.apache.org/pool/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: dnsjava  Name: dnsjava  Version: 2.1.7
+Project URL (from POM): http://www.dnsjava.org
+License (from POM): BSD 2-Clause license - http://opensource.org/licenses/BSD-2-Clause
+
+--------------------------------------------------------------------------------
+
+Group: io.airlift  Name: aircompressor  Version: 0.27
+Project URL (from POM): https://github.com/airlift/aircompressor
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: io.dropwizard.metrics  Name: metrics-core  Version: 3.2.4
+License (from POM): Apache License 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-alts  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-api  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-auth  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-context  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-core  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-googleapis  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-grpclb  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-inprocess  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-netty-shaded  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-protobuf  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-protobuf-lite  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-rls  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-services  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-stub  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-util  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-xds  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-buffer  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-codec  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-codec-dns  Version: 4.1.109.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-codec-http  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-codec-http2  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-codec-socks  Version: 4.1.110.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-common  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-handler  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-handler-proxy  Version: 4.1.110.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-resolver  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-resolver-dns  Version: 4.1.109.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-resolver-dns-classes-macos  Version: 4.1.109.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-resolver-dns-native-macos  Version: 4.1.109.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-tcnative-boringssl-static  Version: 2.0.65.Final
+Project URL (from manifest): https://netty.io/
+Project URL (from POM): https://github.com/netty/netty-tcnative/netty-tcnative-boringssl-static/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-tcnative-classes  Version: 2.0.65.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-transport  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-transport-classes-kqueue  Version: 4.1.110.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-transport-native-epoll  Version: 4.1.110.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-transport-native-kqueue  Version: 4.1.110.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.opencensus  Name: opencensus-api  Version: 0.31.1
+Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
+License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opencensus  Name: opencensus-contrib-http-util  Version: 0.31.1
+Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
+License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opencensus  Name: opencensus-proto  Version: 0.2.0
+Project URL (from POM): https://github.com/census-instrumentation/opencensus-proto
+License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.perfmark  Name: perfmark-api  Version: 0.27.0
+Project URL (from POM): https://github.com/perfmark/perfmark
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.projectreactor  Name: reactor-core  Version: 3.4.38
+Project URL (from POM): https://github.com/reactor/reactor-core
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.projectreactor.netty  Name: reactor-netty-core  Version: 1.0.45
+Project URL (from POM): https://github.com/reactor/reactor-netty
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.projectreactor.netty  Name: reactor-netty-http  Version: 1.0.45
+Project URL (from POM): https://github.com/reactor/reactor-netty
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.activation  Name: jakarta.activation-api  Version: 1.2.1
+Project URL (from manifest): https://www.eclipse.org
+License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+License (from POM): Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
+License (from POM): GNU General Public License, version 2 with the GNU Classpath Exception - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: javax.annotation  Name: javax.annotation-api  Version: 1.3.2
+Project URL (from manifest): https://javaee.github.io/glassfish
+Project URL (from POM): http://jcp.org/en/jsr/detail?id=250
+License (from POM): CDDL + GPLv2 with classpath exception - https://github.com/javaee/javax.annotation/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: javax.servlet  Name: javax.servlet-api  Version: 3.1.0
+Project URL (from manifest): https://glassfish.dev.java.net
+Project URL (from POM): http://servlet-spec.java.net
+License (from POM): CDDL + GPLv2 with classpath exception - https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+
+--------------------------------------------------------------------------------
+
+Group: javax.servlet.jsp  Name: jsp-api  Version: 2.1
+
+--------------------------------------------------------------------------------
+
+Group: javax.xml.bind  Name: jaxb-api  Version: 2.2.2
+Project URL (from POM): https://jaxb.dev.java.net/
+License (from POM): CDDL 1.1 - https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+License (from POM): GPL2 w/ CPE - https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+
+--------------------------------------------------------------------------------
+
+Group: javax.xml.stream  Name: stax-api  Version: 1.0-2
+License (from POM): COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0 - http://www.sun.com/cddl/cddl.html
+License (from POM): GNU General Public Library - http://www.gnu.org/licenses/gpl.txt
+
+--------------------------------------------------------------------------------
+
+Group: net.java.dev.jna  Name: jna  Version: 5.13.0
+Project URL (from POM): https://github.com/java-native-access/jna
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): LGPL-2.1-or-later - https://www.gnu.org/licenses/old-licenses/lgpl-2.1
+
+--------------------------------------------------------------------------------
+
+Group: net.java.dev.jna  Name: jna-platform  Version: 5.13.0
+Project URL (from POM): https://github.com/java-native-access/jna
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): LGPL-2.1-or-later - https://www.gnu.org/licenses/old-licenses/lgpl-2.1
+
+--------------------------------------------------------------------------------
+
+Group: net.minidev  Name: accessors-smart  Version: 2.5.0
+Project URL (from manifest): https://urielch.github.io/
+Project URL (from POM): https://urielch.github.io/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: net.minidev  Name: json-smart  Version: 2.5.0
+Project URL (from manifest): https://urielch.github.io/
+Project URL (from POM): https://urielch.github.io/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.avro  Name: avro  Version: 1.11.3
+Project URL (from manifest): https://www.apache.org/
+Project URL (from POM): https://avro.apache.org
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-compress  Version: 1.26.0
+Project URL (from manifest): https://commons.apache.org/proper/commons-compress/
+Project URL (from POM): https://commons.apache.org/proper/commons-compress/
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-lang3  Version: 3.14.0
+Project URL (from manifest): https://commons.apache.org/proper/commons-lang/
+Project URL (from POM): https://commons.apache.org/proper/commons-lang/
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-math3  Version: 3.1.1
+Project URL (from manifest): http://commons.apache.org/math/
+Project URL (from POM): http://commons.apache.org/math/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-text  Version: 1.10.0
+Project URL (from manifest): https://commons.apache.org/proper/commons-text
+Project URL (from POM): https://commons.apache.org/proper/commons-text
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-annotations  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-common  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-guava  Version: 1.2.0
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents  Name: httpclient  Version: 4.5.13
+Project URL (from POM): http://hc.apache.org/httpcomponents-client
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents  Name: httpcore  Version: 4.4.16
+Project URL (from POM): http://hc.apache.org/httpcomponents-core-ga
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.client5  Name: httpclient5  Version: 5.3.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.core5  Name: httpcore5  Version: 5.2.4
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.core5  Name: httpcore5-h2  Version: 5.2.4
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.orc  Name: orc-core  Version: 1.9.4
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.orc  Name: orc-shims  Version: 1.9.4
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-avro  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-column  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-common  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-encoding  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-format-structures  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-hadoop  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-jackson  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.yetus  Name: audience-annotations  Version: 0.13.0
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.checkerframework  Name: checker-qual  Version: 3.44.0
+Manifest License: MIT (Not packaged)
+Project URL (from POM): https://checkerframework.org/
+License (from POM): The MIT License - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: org.codehaus.jettison  Name: jettison  Version: 1.5.4
+Project URL (from POM): https://github.com/jettison-json/jettison
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: org.codehaus.mojo  Name: animal-sniffer-annotations  Version: 1.23
+License (from POM): MIT license - https://spdx.org/licenses/MIT.txt
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.codehaus.woodstox  Name: stax2-api  Version: 4.2.2
+Project URL (from manifest): http://github.com/FasterXML/stax2-api
+Project URL (from POM): http://github.com/FasterXML/stax2-api
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The BSD 2-Clause License - http://www.opensource.org/licenses/bsd-license.php
+
+--------------------------------------------------------------------------------
+
+Group: org.conscrypt  Name: conscrypt-openjdk-uber  Version: 2.5.2
+Project URL (from POM): https://conscrypt.org/
+License (from POM): Apache 2 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: org.jetbrains  Name: annotations  Version: 17.0.0
+Project URL (from POM): https://github.com/JetBrains/java-annotations
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.ow2.asm  Name: asm  Version: 9.3
+Project URL (from manifest): http://asm.ow2.org
+Manifest License: BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
+Project URL (from POM): http://asm.ow2.io/
+License (from POM): BSD-3-Clause - https://asm.ow2.io/license.html
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.reactivestreams  Name: reactive-streams  Version: 1.0.4
+Project URL (from manifest): http://reactive-streams.org
+Project URL (from POM): http://www.reactive-streams.org/
+License (from POM): MIT-0 - https://spdx.org/licenses/MIT-0.html
+
+--------------------------------------------------------------------------------
+
+Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.2.1
+Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
+License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.slf4j  Name: slf4j-api  Version: 2.0.7
+Project URL (from manifest): http://www.slf4j.org
+Project URL (from POM): http://www.slf4j.org
+License (from POM): MIT License - http://www.opensource.org/licenses/mit-license.php
+
+--------------------------------------------------------------------------------
+
+Group: org.threeten  Name: threeten-extra  Version: 1.7.1
+Project URL (from manifest): https://www.threeten.org
+Project URL (from POM): https://www.threeten.org/threeten-extra
+License (from POM): BSD 3-clause - https://raw.githubusercontent.com/ThreeTen/threeten-extra/master/LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.threeten  Name: threetenbp  Version: 1.6.9
+Project URL (from manifest): https://www.threeten.org
+Project URL (from POM): https://www.threeten.org/threetenbp
+License (from POM): BSD-3-Clause - https://raw.githubusercontent.com/ThreeTen/threetenbp/main/LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.xerial.snappy  Name: snappy-java  Version: 1.1.10.5
+Project URL (from manifest): http://www.xerial.org/
+Project URL (from POM): https://github.com/xerial/snappy-java
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: annotations  Version: 2.26.25
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: apache-client  Version: 2.26.25
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: arns  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: auth  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: aws-core  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: checksums  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: crt-core  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: dynamodb  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.26.25
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: glue  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: http-auth  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.26.25
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: iam  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: identity-spi  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: json-utils  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: kms  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: lakeformation  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.26.25
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.26.25
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: profiles  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: protocol-core  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: regions  Version: 2.26.25
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: retries  Version: 2.26.25
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: retries-spi  Version: 2.26.25
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: s3  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: sdk-core  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: sso  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: sts  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.26.25
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: utils  Version: 2.26.25
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.eventstream  Name: eventstream  Version: 1.0.1
+Project URL (from POM): https://github.com/awslabs/aws-eventstream-java
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------

--- a/kafka-connect/kafka-connect-runtime/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/LICENSE
@@ -207,6 +207,18 @@ This binary artifact contains code from the following projects:
 
 --------------------------------------------------------------------------------
 
+Group: aopalliance  Name: aopalliance  Version: 1.0
+Project URL (from POM): http://aopalliance.sourceforge.net
+License (from POM): Public Domain
+--------------------------------------------------------------------------------
+
+Group: ch.qos.reload4j  Name: reload4j  Version: 1.2.22
+Project URL (from manifest): https://reload4j.qos.ch/
+Project URL (from POM): https://reload4j.qos.ch
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 Group: com.azure  Name: azure-core  Version: 1.49.1
 Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
 License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
@@ -261,14 +273,14 @@ License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.17.1
+Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.17.2
 Project URL (from manifest): https://github.com/FasterXML/jackson
 Project URL (from POM): https://github.com/FasterXML/jackson
 License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.17.1
+Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.17.2
 Project URL (from manifest): https://github.com/FasterXML/jackson-core
 Project URL (from POM): https://github.com/FasterXML/jackson-core
 License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
@@ -276,7 +288,7 @@ License (from POM): The Apache Software License, Version 2.0 - https://www.apach
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.17.1
+Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.17.2
 Project URL (from manifest): https://github.com/FasterXML/jackson
 Project URL (from POM): https://github.com/FasterXML/jackson
 License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
@@ -284,7 +296,7 @@ License (from POM): The Apache Software License, Version 2.0 - https://www.apach
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.17.1
+Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.17.2
 Project URL (from manifest): https://github.com/FasterXML/jackson-dataformat-xml
 Project URL (from POM): https://github.com/FasterXML/jackson-dataformat-xml
 License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
@@ -292,14 +304,36 @@ License (from POM): The Apache Software License, Version 2.0 - http://www.apache
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.17.1
+Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.17.2
 Project URL (from manifest): https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310
 License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.woodstox  Name: woodstox-core  Version: 6.6.2
+Group: com.fasterxml.jackson.jaxrs  Name: jackson-jaxrs-base  Version: 2.17.2
+Project URL (from manifest): https://github.com/FasterXML/jackson-jaxrs-providers/jackson-jaxrs-base
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.jaxrs  Name: jackson-jaxrs-json-provider  Version: 2.17.2
+Project URL (from manifest): https://github.com/FasterXML/jackson-jaxrs-providers/jackson-jaxrs-json-provider
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.module  Name: jackson-module-jaxb-annotations  Version: 2.17.2
+Project URL (from manifest): https://github.com/FasterXML/jackson-modules-base
+Project URL (from POM): https://github.com/FasterXML/jackson-modules-base
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.woodstox  Name: woodstox-core  Version: 6.7.0
 Project URL (from manifest): https://github.com/FasterXML/woodstox
 Project URL (from POM): https://github.com/FasterXML/woodstox
 License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
@@ -510,6 +544,12 @@ License (from POM): The Apache Software License, Version 2.0 - http://www.apache
 
 --------------------------------------------------------------------------------
 
+Group: com.google.inject  Name: guice  Version: 4.0
+Project URL (from manifest): https://github.com/google/guice
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 Group: com.google.j2objc  Name: j2objc-annotations  Version: 3.0.0
 Project URL (from POM): https://github.com/google/j2objc/
 License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
@@ -543,6 +583,12 @@ License (from POM): Go License - https://golang.org/LICENSE
 Group: com.jcraft  Name: jsch  Version: 0.1.55
 Project URL (from POM): http://www.jcraft.com/jsch/
 License (from POM): Revised BSD - http://www.jcraft.com/jsch/LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.jolbox  Name: bonecp  Version: 0.8.0.RELEASE
+Project URL (from manifest): http://jolbox.com
+License (from POM): Apache v2 - http://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------
 
@@ -587,6 +633,18 @@ License (from POM): Apache License, version 2.0 - https://www.apache.org/license
 
 --------------------------------------------------------------------------------
 
+Group: com.squareup.okhttp3  Name: okhttp  Version: 4.9.3
+Project URL (from POM): https://square.github.io/okhttp/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.squareup.okio  Name: okio  Version: 2.8.0
+Project URL (from POM): https://github.com/square/okio/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 Group: com.sun.xml.bind  Name: jaxb-impl  Version: 2.2.3-1
 Project URL (from POM): http://jaxb.java.net/
 License (from POM): CDDL 1.1 - https://glassfish.java.net/public/CDDL+GPL_1_1.html
@@ -622,10 +680,24 @@ License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses
 
 --------------------------------------------------------------------------------
 
-Group: commons-io  Name: commons-io  Version: 2.15.1
+Group: commons-dbcp  Name: commons-dbcp  Version: 1.4
+Project URL (from manifest): http://commons.apache.org/dbcp/
+Project URL (from POM): http://commons.apache.org/dbcp/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-io  Name: commons-io  Version: 2.16.1
 Project URL (from manifest): https://commons.apache.org/proper/commons-io/
 Project URL (from POM): https://commons.apache.org/proper/commons-io/
 License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-lang  Name: commons-lang  Version: 2.6
+Project URL (from manifest): http://commons.apache.org/lang/
+Project URL (from POM): http://commons.apache.org/lang/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -663,6 +735,16 @@ License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE
 --------------------------------------------------------------------------------
 
 Group: io.dropwizard.metrics  Name: metrics-core  Version: 3.2.4
+License (from POM): Apache License 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: io.dropwizard.metrics  Name: metrics-json  Version: 3.1.0
+License (from POM): Apache License 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: io.dropwizard.metrics  Name: metrics-jvm  Version: 3.1.0
 License (from POM): Apache License 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------
@@ -940,10 +1022,38 @@ License (from POM): GNU General Public License, version 2 with the GNU Classpath
 
 --------------------------------------------------------------------------------
 
+Group: jakarta.activation  Name: jakarta.activation-api  Version: 1.2.2
+Project URL (from manifest): https://www.eclipse.org
+License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+License (from POM): Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
+License (from POM): GNU General Public License, version 2 with the GNU Classpath Exception - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.xml.bind  Name: jakarta.xml.bind-api  Version: 2.3.3
+Project URL (from manifest): https://www.eclipse.org
+License (from POM): Eclipse Distribution License - v 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+License (from POM): Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
+License (from POM): GNU General Public License, version 2 with the GNU Classpath Exception - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
 Group: javax.annotation  Name: javax.annotation-api  Version: 1.3.2
 Project URL (from manifest): https://javaee.github.io/glassfish
 Project URL (from POM): http://jcp.org/en/jsr/detail?id=250
 License (from POM): CDDL + GPLv2 with classpath exception - https://github.com/javaee/javax.annotation/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: javax.inject  Name: javax.inject  Version: 1
+Project URL (from POM): http://code.google.com/p/atinject/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: javax.jdo  Name: jdo-api  Version: 3.0.1
+Project URL (from POM): http://db.apache.org/jdo
+License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -958,6 +1068,19 @@ Group: javax.servlet.jsp  Name: jsp-api  Version: 2.1
 
 --------------------------------------------------------------------------------
 
+Group: javax.transaction  Name: jta  Version: 1.1
+Project URL (from POM): http://java.sun.com/products/jta
+
+--------------------------------------------------------------------------------
+
+Group: javax.xml.bind  Name: jaxb-api  Version: 2.2.11
+Project URL (from manifest): http://www.oracle.com/
+Project URL (from POM): http://jaxb.java.net/
+License (from POM): CDDL 1.1 - https://glassfish.java.net/public/CDDL+GPL_1_1.html
+License (from POM): GPL2 w/ CPE - https://glassfish.java.net/public/CDDL+GPL_1_1.html
+
+--------------------------------------------------------------------------------
+
 Group: javax.xml.bind  Name: jaxb-api  Version: 2.2.2
 Project URL (from POM): https://jaxb.dev.java.net/
 License (from POM): CDDL 1.1 - https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
@@ -968,6 +1091,33 @@ License (from POM): GPL2 w/ CPE - https://glassfish.dev.java.net/public/CDDL+GPL
 Group: javax.xml.stream  Name: stax-api  Version: 1.0-2
 License (from POM): COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0 - http://www.sun.com/cddl/cddl.html
 License (from POM): GNU General Public Library - http://www.gnu.org/licenses/gpl.txt
+
+--------------------------------------------------------------------------------
+
+Group: javolution  Name: javolution  Version: 5.5.1
+Project URL (from manifest): http://javolution.org
+Project URL (from POM): http://javolution.org
+License (from POM): BSD License - http://javolution.org/LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: jline  Name: jline  Version: 2.12
+License (from POM): The BSD License - http://www.opensource.org/licenses/bsd-license.php
+
+--------------------------------------------------------------------------------
+
+Group: joda-time  Name: joda-time  Version: 2.8.1
+Project URL (from manifest): http://www.joda.org/joda-time/
+Manifest License: Apache 2.0 (Not packaged)
+Project URL (from POM): http://www.joda.org/joda-time/
+License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: log4j  Name: log4j  Version: 1.2.17
+Project URL (from manifest): http://logging.apache.org/log4j/1.2
+Project URL (from POM): http://logging.apache.org/log4j/1.2/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -999,17 +1149,48 @@ License (from POM): The Apache Software License, Version 2.0 - http://www.apache
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.avro  Name: avro  Version: 1.11.3
+Group: net.sf.opencsv  Name: opencsv  Version: 2.3
+Project URL (from POM): http://opencsv.sf.net
+License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.antlr  Name: antlr-runtime  Version: 3.5.2
+Project URL (from POM): http://www.antlr.org
+License (from POM): BSD licence - http://antlr.org/license.html
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.ant  Name: ant  Version: 1.9.1
+Project URL (from POM): http://ant.apache.org/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.ant  Name: ant-launcher  Version: 1.9.1
+Project URL (from POM): http://ant.apache.org/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.avro  Name: avro  Version: 1.12.0
 Project URL (from manifest): https://www.apache.org/
 Project URL (from POM): https://avro.apache.org
 License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.commons  Name: commons-compress  Version: 1.26.0
+Group: org.apache.commons  Name: commons-compress  Version: 1.26.2
 Project URL (from manifest): https://commons.apache.org/proper/commons-compress/
 Project URL (from POM): https://commons.apache.org/proper/commons-compress/
 License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-configuration2  Version: 2.8.0
+Project URL (from manifest): https://commons.apache.org/proper/commons-configuration/
+Project URL (from POM): https://commons.apache.org/proper/commons-configuration/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -1034,7 +1215,44 @@ License (from POM): Apache License, Version 2.0 - https://www.apache.org/license
 
 --------------------------------------------------------------------------------
 
+Group: org.apache.curator  Name: curator-client  Version: 5.2.0
+Project URL (from manifest): http://www.apache.org/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator  Name: curator-framework  Version: 5.2.0
+Project URL (from manifest): http://www.apache.org/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator  Name: curator-recipes  Version: 5.2.0
+Project URL (from manifest): http://www.apache.org/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.derby  Name: derby  Version: 10.10.2.0
+License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 Group: org.apache.hadoop  Name: hadoop-annotations  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-auth  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-client  Version: 3.3.6
 License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
@@ -1044,8 +1262,88 @@ License (from POM): Apache License, Version 2.0 - https://www.apache.org/license
 
 --------------------------------------------------------------------------------
 
+Group: org.apache.hadoop  Name: hadoop-hdfs-client  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-mapreduce-client-common  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-mapreduce-client-core  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-mapreduce-client-jobclient  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-yarn-api  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-yarn-client  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-yarn-common  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-guava  Version: 1.2.0
 License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-protobuf_3_7  Version: 1.1.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-common  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-metastore  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-serde  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-shims  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-storage-api  Version: 2.4.0
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive.shims  Name: hive-shims-0.23  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive.shims  Name: hive-shims-common  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive.shims  Name: hive-shims-scheduler  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -1072,6 +1370,81 @@ License (from POM): Apache License, Version 2.0 - https://www.apache.org/license
 --------------------------------------------------------------------------------
 
 Group: org.apache.httpcomponents.core5  Name: httpcore5-h2  Version: 5.2.4
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-admin  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-client  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-common  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-core  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-crypto  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-identity  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-server  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-simplekdc  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-util  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-asn1  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-config  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-pkix  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-util  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-xdr  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: token-provider  Version: 1.0.1
 License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
@@ -1135,7 +1508,29 @@ License (from POM): The Apache Software License, Version 2.0 - http://www.apache
 
 --------------------------------------------------------------------------------
 
+Group: org.apache.thrift  Name: libfb303  Version: 0.9.3
+Project URL (from POM): http://thrift.apache.org
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.thrift  Name: libthrift  Version: 0.9.3
+Project URL (from POM): http://thrift.apache.org
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 Group: org.apache.yetus  Name: audience-annotations  Version: 0.13.0
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.zookeeper  Name: zookeeper  Version: 3.6.3
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.zookeeper  Name: zookeeper-jute  Version: 3.6.3
 License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
@@ -1173,9 +1568,130 @@ License (from POM): Apache 2 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
+Group: org.datanucleus  Name: datanucleus-api-jdo  Version: 4.2.4
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: datanucleus-core  Version: 4.1.17
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: datanucleus-rdbms  Version: 4.1.19
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: javax.jdo  Version: 3.2.0-m3
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-client  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-http  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-io  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-security  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-servlet  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-util  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-util-ajax  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-webapp  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-xml  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty.websocket  Name: websocket-api  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty.websocket  Name: websocket-client  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty.websocket  Name: websocket-common  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
 Group: org.jetbrains  Name: annotations  Version: 17.0.0
 Project URL (from POM): https://github.com/JetBrains/java-annotations
 License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jetbrains.kotlin  Name: kotlin-stdlib  Version: 1.4.10
+Project URL (from POM): https://kotlinlang.org/
+License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jetbrains.kotlin  Name: kotlin-stdlib-common  Version: 1.4.10
+Project URL (from POM): https://kotlinlang.org/
+License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jline  Name: jline  Version: 3.9.0
+License (from POM): The BSD License - http://www.opensource.org/licenses/bsd-license.php
 
 --------------------------------------------------------------------------------
 
@@ -1201,9 +1717,15 @@ License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.slf4j  Name: slf4j-api  Version: 2.0.7
+Group: org.slf4j  Name: slf4j-api  Version: 2.0.13
 Project URL (from manifest): http://www.slf4j.org
 Project URL (from POM): http://www.slf4j.org
+License (from POM): MIT License - http://www.opensource.org/licenses/mit-license.php
+
+--------------------------------------------------------------------------------
+
+Group: org.slf4j  Name: slf4j-reload4j  Version: 1.7.36
+Project URL (from POM): http://reload4j.qos.ch
 License (from POM): MIT License - http://www.opensource.org/licenses/mit-license.php
 
 --------------------------------------------------------------------------------
@@ -1229,214 +1751,214 @@ License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.htm
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: annotations  Version: 2.26.25
+Group: software.amazon.awssdk  Name: annotations  Version: 2.26.29
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: apache-client  Version: 2.26.25
+Group: software.amazon.awssdk  Name: apache-client  Version: 2.26.29
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: arns  Version: 2.26.25
+Group: software.amazon.awssdk  Name: arns  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: auth  Version: 2.26.25
+Group: software.amazon.awssdk  Name: auth  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-core  Version: 2.26.25
+Group: software.amazon.awssdk  Name: aws-core  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.26.25
+Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.26.25
+Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.26.25
+Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: checksums  Version: 2.26.25
+Group: software.amazon.awssdk  Name: checksums  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: crt-core  Version: 2.26.25
+Group: software.amazon.awssdk  Name: crt-core  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: dynamodb  Version: 2.26.25
+Group: software.amazon.awssdk  Name: dynamodb  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.26.29
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: glue  Version: 2.26.25
+Group: software.amazon.awssdk  Name: glue  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth  Version: 2.26.25
+Group: software.amazon.awssdk  Name: http-auth  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.26.25
+Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.26.25
+Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.26.29
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: iam  Version: 2.26.25
+Group: software.amazon.awssdk  Name: iam  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: identity-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: identity-spi  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: json-utils  Version: 2.26.25
+Group: software.amazon.awssdk  Name: json-utils  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: kms  Version: 2.26.25
+Group: software.amazon.awssdk  Name: kms  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: lakeformation  Version: 2.26.25
+Group: software.amazon.awssdk  Name: lakeformation  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.26.29
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.26.25
+Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.26.29
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: profiles  Version: 2.26.25
+Group: software.amazon.awssdk  Name: profiles  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: protocol-core  Version: 2.26.25
+Group: software.amazon.awssdk  Name: protocol-core  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: regions  Version: 2.26.25
+Group: software.amazon.awssdk  Name: regions  Version: 2.26.29
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: retries  Version: 2.26.25
+Group: software.amazon.awssdk  Name: retries  Version: 2.26.29
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: retries-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: retries-spi  Version: 2.26.29
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: s3  Version: 2.26.25
+Group: software.amazon.awssdk  Name: s3  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sdk-core  Version: 2.26.25
+Group: software.amazon.awssdk  Name: sdk-core  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sso  Version: 2.26.25
+Group: software.amazon.awssdk  Name: sso  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sts  Version: 2.26.25
+Group: software.amazon.awssdk  Name: sts  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.26.25
+Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: utils  Version: 2.26.25
+Group: software.amazon.awssdk  Name: utils  Version: 2.26.29
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------

--- a/kafka-connect/kafka-connect-runtime/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/LICENSE
@@ -207,49 +207,7 @@ This binary artifact contains code from the following projects:
 
 --------------------------------------------------------------------------------
 
-Group: aopalliance  Name: aopalliance  Version: 1.0
-Project URL (from POM): http://aopalliance.sourceforge.net
-License (from POM): Public Domain
---------------------------------------------------------------------------------
-
-Group: ch.qos.reload4j  Name: reload4j  Version: 1.2.22
-Project URL (from manifest): https://reload4j.qos.ch/
-Project URL (from POM): https://reload4j.qos.ch
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-core  Version: 1.49.1
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-core-http-netty  Version: 1.15.1
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
 Group: com.azure  Name: azure-identity  Version: 1.13.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-json  Version: 1.1.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-storage-blob  Version: 12.26.1
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-storage-common  Version: 12.25.1
 Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
 License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
 
@@ -261,22 +219,108 @@ License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-storage-internal-avro  Version: 12.11.1
+Group: com.google.cloud  Name: google-cloud-storage  Version: 2.41.0
+Project URL (from POM): https://github.com/googleapis/java-storage
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-client  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-common  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-metastore  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.slf4j  Name: slf4j-api  Version: 2.0.13
+Project URL (from manifest): http://www.slf4j.org
+Project URL (from POM): http://www.slf4j.org
+License (from POM): MIT License - http://www.opensource.org/licenses/mit-license.php
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: apache-client  Version: 2.27.21
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: auth  Version: 2.27.21
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: dynamodb  Version: 2.27.21
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: glue  Version: 2.27.21
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.27.21
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: iam  Version: 2.27.21
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: kms  Version: 2.27.21
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: lakeformation  Version: 2.27.21
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: s3  Version: 2.27.21
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: sso  Version: 2.27.21
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: sts  Version: 2.27.21
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-identity  Version: 1.13.0
 Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
 License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-xml  Version: 1.0.0
+Group: com.azure  Name: azure-storage-file-datalake  Version: 12.19.1
 Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
 License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.17.2
-Project URL (from manifest): https://github.com/FasterXML/jackson
-Project URL (from POM): https://github.com/FasterXML/jackson
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -296,880 +340,15 @@ License (from POM): The Apache Software License, Version 2.0 - https://www.apach
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.17.2
-Project URL (from manifest): https://github.com/FasterXML/jackson-dataformat-xml
-Project URL (from POM): https://github.com/FasterXML/jackson-dataformat-xml
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.17.2
-Project URL (from manifest): https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.jaxrs  Name: jackson-jaxrs-base  Version: 2.17.2
-Project URL (from manifest): https://github.com/FasterXML/jackson-jaxrs-providers/jackson-jaxrs-base
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.jaxrs  Name: jackson-jaxrs-json-provider  Version: 2.17.2
-Project URL (from manifest): https://github.com/FasterXML/jackson-jaxrs-providers/jackson-jaxrs-json-provider
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.module  Name: jackson-module-jaxb-annotations  Version: 2.17.2
-Project URL (from manifest): https://github.com/FasterXML/jackson-modules-base
-Project URL (from POM): https://github.com/FasterXML/jackson-modules-base
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.woodstox  Name: woodstox-core  Version: 6.7.0
-Project URL (from manifest): https://github.com/FasterXML/woodstox
-Project URL (from POM): https://github.com/FasterXML/woodstox
-License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: com.github.ben-manes.caffeine  Name: caffeine  Version: 2.9.3
 Project URL (from POM): https://github.com/ben-manes/caffeine
 License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.github.luben  Name: zstd-jni  Version: 1.5.0-1
-License URL (from manifest): https://opensource.org/licenses/BSD-2-Clause
-Project URL (from POM): https://github.com/luben/zstd-jni
-License (from POM): BSD 2-Clause License - https://opensource.org/licenses/BSD-2-Clause
-
---------------------------------------------------------------------------------
-
-Group: com.github.pjfanning  Name: jersey-json  Version: 1.20
-Project URL (from POM): https://github.com/pjfanning/jersey-1.x
-License (from POM): CDDL 1.1 - http://glassfish.java.net/public/CDDL+GPL_1_1.html
-License (from POM): GPL2 w/ CPE - http://glassfish.java.net/public/CDDL+GPL_1_1.html
-
---------------------------------------------------------------------------------
-
-Group: com.github.stephenc.jcip  Name: jcip-annotations  Version: 1.0-1
-Project URL (from POM): http://stephenc.github.com/jcip-annotations
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.android  Name: annotations  Version: 4.1.1.4
-Project URL (from POM): http://source.android.com/
-License (from POM): Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: com.google.api  Name: api-common  Version: 2.33.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): BSD-3-Clause - https://github.com/googleapis/api-common-java/blob/main/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.google.api  Name: gax  Version: 2.50.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.google.api  Name: gax-grpc  Version: 2.50.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.google.api  Name: gax-httpjson  Version: 2.50.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.google.api-client  Name: google-api-client  Version: 2.6.0
-Project URL (from manifest): https://developers.google.com/api-client-library/java/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: gapic-google-cloud-storage-v2  Version: 2.40.1-alpha
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: grpc-google-cloud-storage-v2  Version: 2.40.1-alpha
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-cloud-storage-v2  Version: 2.40.1-alpha
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-common-protos  Version: 2.41.0
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-iam-v1  Version: 1.36.0
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.apis  Name: google-api-services-storage  Version: v1-rev20240621-2.0.0
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.auth  Name: google-auth-library-credentials  Version: 1.23.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): BSD New license - http://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
-Group: com.google.auth  Name: google-auth-library-oauth2-http  Version: 1.23.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): BSD New license - http://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
-Group: com.google.auto.value  Name: auto-value-annotations  Version: 1.10.4
-Project URL (from POM): https://github.com/google/auto/tree/main/value
-License (from POM): Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-core  Version: 2.40.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-core-grpc  Version: 2.40.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-core-http  Version: 2.40.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-storage  Version: 2.40.1
+Group: com.google.cloud  Name: google-cloud-storage  Version: 2.41.0
 Project URL (from POM): https://github.com/googleapis/java-storage
 License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.code.findbugs  Name: jsr305  Version: 3.0.2
-Project URL (from POM): http://findbugs.sourceforge.net/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.code.gson  Name: gson  Version: 2.11.0
-Project URL (from manifest): https://github.com/google/gson
-Manifest License: "Apache-2.0";link="https://www.apache.org/licenses/LICENSE-2.0.txt" (Not packaged)
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.errorprone  Name: error_prone_annotations  Version: 2.28.0
-Project URL (from manifest): https://errorprone.info/error_prone_annotations
-Manifest License: "Apache 2.0";link="http://www.apache.org/licenses/LICENSE-2.0.txt" (Not packaged)
-License (from POM): Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.guava  Name: failureaccess  Version: 1.0.2
-Project URL (from manifest): https://github.com/google/guava/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.guava  Name: guava  Version: 33.1.0-jre
-Project URL (from manifest): https://github.com/google/guava/
-Project URL (from POM): https://github.com/google/guava
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.guava  Name: listenablefuture  Version: 9999.0-empty-to-avoid-conflict-with-guava
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client  Version: 1.44.2
-Project URL (from manifest): https://www.google.com/
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client-apache-v2  Version: 1.44.2
-Project URL (from manifest): https://www.google.com/
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client-appengine  Version: 1.44.2
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client-gson  Version: 1.44.2
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client-jackson2  Version: 1.44.2
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.inject  Name: guice  Version: 4.0
-Project URL (from manifest): https://github.com/google/guice
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.j2objc  Name: j2objc-annotations  Version: 3.0.0
-Project URL (from POM): https://github.com/google/j2objc/
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.oauth-client  Name: google-oauth-client  Version: 1.36.0
-Project URL (from manifest): https://www.google.com/
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.protobuf  Name: protobuf-java  Version: 3.25.3
-Project URL (from manifest): https://developers.google.com/protocol-buffers/
-License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
-Group: com.google.protobuf  Name: protobuf-java-util  Version: 3.25.3
-Project URL (from manifest): https://developers.google.com/protocol-buffers/
-License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
-Group: com.google.re2j  Name: re2j  Version: 1.7
-Project URL (from POM): http://github.com/google/re2j
-License (from POM): Go License - https://golang.org/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.jcraft  Name: jsch  Version: 0.1.55
-Project URL (from POM): http://www.jcraft.com/jsch/
-License (from POM): Revised BSD - http://www.jcraft.com/jsch/LICENSE.txt
-
---------------------------------------------------------------------------------
-
-Group: com.jolbox  Name: bonecp  Version: 0.8.0.RELEASE
-Project URL (from manifest): http://jolbox.com
-License (from POM): Apache v2 - http://www.apache.org/licenses/LICENSE-2.0.html
-
---------------------------------------------------------------------------------
-
-Group: com.microsoft.azure  Name: msal4j  Version: 1.15.1
-Project URL (from manifest): https://github.com/AzureAD/microsoft-authentication-library-for-java
-Manifest License: "MIT License" (Not packaged)
-Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
-License (from POM): MIT License
---------------------------------------------------------------------------------
-
-Group: com.microsoft.azure  Name: msal4j-persistence-extension  Version: 1.3.0
-Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
-License (from POM): MIT License
---------------------------------------------------------------------------------
-
-Group: com.nimbusds  Name: content-type  Version: 2.3
-Project URL (from manifest): https://connect2id.com
-Project URL (from POM): https://bitbucket.org/connect2id/nimbus-content-type
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.nimbusds  Name: lang-tag  Version: 1.7
-Project URL (from manifest): https://connect2id.com/
-Project URL (from POM): https://bitbucket.org/connect2id/nimbus-language-tags
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.nimbusds  Name: nimbus-jose-jwt  Version: 9.37.3
-Project URL (from manifest): https://connect2id.com
-Project URL (from POM): https://bitbucket.org/connect2id/nimbus-jose-jwt
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.nimbusds  Name: oauth2-oidc-sdk  Version: 11.9.1
-Project URL (from manifest): https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
-Manifest License: "Apache License, version 2.0";link="https://www.apache.org/licenses/LICENSE-2.0.html" (Not packaged)
-Project URL (from POM): https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
-License (from POM): Apache License, version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
-
---------------------------------------------------------------------------------
-
-Group: com.squareup.okhttp3  Name: okhttp  Version: 4.9.3
-Project URL (from POM): https://square.github.io/okhttp/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.squareup.okio  Name: okio  Version: 2.8.0
-Project URL (from POM): https://github.com/square/okio/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.sun.xml.bind  Name: jaxb-impl  Version: 2.2.3-1
-Project URL (from POM): http://jaxb.java.net/
-License (from POM): CDDL 1.1 - https://glassfish.java.net/public/CDDL+GPL_1_1.html
-License (from POM): GPL2 w/ CPE - https://glassfish.java.net/public/CDDL+GPL_1_1.html
-
---------------------------------------------------------------------------------
-
-Group: commons-beanutils  Name: commons-beanutils  Version: 1.9.4
-Project URL (from manifest): https://commons.apache.org/proper/commons-beanutils/
-Project URL (from POM): https://commons.apache.org/proper/commons-beanutils/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: commons-cli  Name: commons-cli  Version: 1.2
-Project URL (from manifest): http://commons.apache.org/cli/
-Project URL (from POM): http://commons.apache.org/cli/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: commons-codec  Name: commons-codec  Version: 1.17.1
-Project URL (from manifest): https://commons.apache.org/proper/commons-codec/
-Project URL (from POM): https://commons.apache.org/proper/commons-codec/
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: commons-collections  Name: commons-collections  Version: 3.2.2
-Project URL (from manifest): http://commons.apache.org/collections/
-Project URL (from POM): http://commons.apache.org/collections/
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: commons-dbcp  Name: commons-dbcp  Version: 1.4
-Project URL (from manifest): http://commons.apache.org/dbcp/
-Project URL (from POM): http://commons.apache.org/dbcp/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: commons-io  Name: commons-io  Version: 2.16.1
-Project URL (from manifest): https://commons.apache.org/proper/commons-io/
-Project URL (from POM): https://commons.apache.org/proper/commons-io/
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: commons-lang  Name: commons-lang  Version: 2.6
-Project URL (from manifest): http://commons.apache.org/lang/
-Project URL (from POM): http://commons.apache.org/lang/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: commons-logging  Name: commons-logging  Version: 1.2
-Project URL (from manifest): http://commons.apache.org/proper/commons-logging/
-Project URL (from POM): http://commons.apache.org/proper/commons-logging/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: commons-net  Name: commons-net  Version: 3.9.0
-Project URL (from manifest): https://commons.apache.org/proper/commons-net/
-Project URL (from POM): https://commons.apache.org/proper/commons-net/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: commons-pool  Name: commons-pool  Version: 1.6
-Project URL (from manifest): http://commons.apache.org/pool/
-Project URL (from POM): http://commons.apache.org/pool/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: dnsjava  Name: dnsjava  Version: 2.1.7
-Project URL (from POM): http://www.dnsjava.org
-License (from POM): BSD 2-Clause license - http://opensource.org/licenses/BSD-2-Clause
-
---------------------------------------------------------------------------------
-
-Group: io.airlift  Name: aircompressor  Version: 0.27
-Project URL (from POM): https://github.com/airlift/aircompressor
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
-
---------------------------------------------------------------------------------
-
-Group: io.dropwizard.metrics  Name: metrics-core  Version: 3.2.4
-License (from POM): Apache License 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
-
---------------------------------------------------------------------------------
-
-Group: io.dropwizard.metrics  Name: metrics-json  Version: 3.1.0
-License (from POM): Apache License 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
-
---------------------------------------------------------------------------------
-
-Group: io.dropwizard.metrics  Name: metrics-jvm  Version: 3.1.0
-License (from POM): Apache License 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-alts  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-api  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-auth  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-context  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-core  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-googleapis  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-grpclb  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-inprocess  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-netty-shaded  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-protobuf  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-protobuf-lite  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-rls  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-services  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-stub  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-util  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-xds  Version: 1.62.2
-Project URL (from POM): https://github.com/grpc/grpc-java
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-buffer  Version: 4.1.111.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec  Version: 4.1.111.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-dns  Version: 4.1.109.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-http  Version: 4.1.111.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-http2  Version: 4.1.111.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-socks  Version: 4.1.110.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-common  Version: 4.1.111.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-handler  Version: 4.1.111.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-handler-proxy  Version: 4.1.110.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver  Version: 4.1.111.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver-dns  Version: 4.1.109.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver-dns-classes-macos  Version: 4.1.109.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver-dns-native-macos  Version: 4.1.109.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-tcnative-boringssl-static  Version: 2.0.65.Final
-Project URL (from manifest): https://netty.io/
-Project URL (from POM): https://github.com/netty/netty-tcnative/netty-tcnative-boringssl-static/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-tcnative-classes  Version: 2.0.65.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport  Version: 4.1.111.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.111.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-classes-kqueue  Version: 4.1.110.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-native-epoll  Version: 4.1.110.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-native-kqueue  Version: 4.1.110.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.111.Final
-Project URL (from manifest): https://netty.io/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.opencensus  Name: opencensus-api  Version: 0.31.1
-Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
-License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.opencensus  Name: opencensus-contrib-http-util  Version: 0.31.1
-Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
-License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.opencensus  Name: opencensus-proto  Version: 0.2.0
-Project URL (from POM): https://github.com/census-instrumentation/opencensus-proto
-License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.perfmark  Name: perfmark-api  Version: 0.27.0
-Project URL (from POM): https://github.com/perfmark/perfmark
-License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.projectreactor  Name: reactor-core  Version: 3.4.38
-Project URL (from POM): https://github.com/reactor/reactor-core
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.projectreactor.netty  Name: reactor-netty-core  Version: 1.0.45
-Project URL (from POM): https://github.com/reactor/reactor-netty
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.projectreactor.netty  Name: reactor-netty-http  Version: 1.0.45
-Project URL (from POM): https://github.com/reactor/reactor-netty
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: jakarta.activation  Name: jakarta.activation-api  Version: 1.2.1
-Project URL (from manifest): https://www.eclipse.org
-License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
-License (from POM): Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
-License (from POM): GNU General Public License, version 2 with the GNU Classpath Exception - https://www.gnu.org/software/classpath/license.html
-
---------------------------------------------------------------------------------
-
-Group: jakarta.activation  Name: jakarta.activation-api  Version: 1.2.2
-Project URL (from manifest): https://www.eclipse.org
-License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
-License (from POM): Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
-License (from POM): GNU General Public License, version 2 with the GNU Classpath Exception - https://www.gnu.org/software/classpath/license.html
-
---------------------------------------------------------------------------------
-
-Group: jakarta.xml.bind  Name: jakarta.xml.bind-api  Version: 2.3.3
-Project URL (from manifest): https://www.eclipse.org
-License (from POM): Eclipse Distribution License - v 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
-License (from POM): Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
-License (from POM): GNU General Public License, version 2 with the GNU Classpath Exception - https://www.gnu.org/software/classpath/license.html
-
---------------------------------------------------------------------------------
-
-Group: javax.annotation  Name: javax.annotation-api  Version: 1.3.2
-Project URL (from manifest): https://javaee.github.io/glassfish
-Project URL (from POM): http://jcp.org/en/jsr/detail?id=250
-License (from POM): CDDL + GPLv2 with classpath exception - https://github.com/javaee/javax.annotation/blob/master/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: javax.inject  Name: javax.inject  Version: 1
-Project URL (from POM): http://code.google.com/p/atinject/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: javax.jdo  Name: jdo-api  Version: 3.0.1
-Project URL (from POM): http://db.apache.org/jdo
-License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: javax.servlet  Name: javax.servlet-api  Version: 3.1.0
-Project URL (from manifest): https://glassfish.dev.java.net
-Project URL (from POM): http://servlet-spec.java.net
-License (from POM): CDDL + GPLv2 with classpath exception - https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
-
---------------------------------------------------------------------------------
-
-Group: javax.servlet.jsp  Name: jsp-api  Version: 2.1
-
---------------------------------------------------------------------------------
-
-Group: javax.transaction  Name: jta  Version: 1.1
-Project URL (from POM): http://java.sun.com/products/jta
-
---------------------------------------------------------------------------------
-
-Group: javax.xml.bind  Name: jaxb-api  Version: 2.2.11
-Project URL (from manifest): http://www.oracle.com/
-Project URL (from POM): http://jaxb.java.net/
-License (from POM): CDDL 1.1 - https://glassfish.java.net/public/CDDL+GPL_1_1.html
-License (from POM): GPL2 w/ CPE - https://glassfish.java.net/public/CDDL+GPL_1_1.html
-
---------------------------------------------------------------------------------
-
-Group: javax.xml.bind  Name: jaxb-api  Version: 2.2.2
-Project URL (from POM): https://jaxb.dev.java.net/
-License (from POM): CDDL 1.1 - https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-License (from POM): GPL2 w/ CPE - https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-
---------------------------------------------------------------------------------
-
-Group: javax.xml.stream  Name: stax-api  Version: 1.0-2
-License (from POM): COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0 - http://www.sun.com/cddl/cddl.html
-License (from POM): GNU General Public Library - http://www.gnu.org/licenses/gpl.txt
-
---------------------------------------------------------------------------------
-
-Group: javolution  Name: javolution  Version: 5.5.1
-Project URL (from manifest): http://javolution.org
-Project URL (from POM): http://javolution.org
-License (from POM): BSD License - http://javolution.org/LICENSE.txt
-
---------------------------------------------------------------------------------
-
-Group: jline  Name: jline  Version: 2.12
-License (from POM): The BSD License - http://www.opensource.org/licenses/bsd-license.php
-
---------------------------------------------------------------------------------
-
-Group: joda-time  Name: joda-time  Version: 2.8.1
-Project URL (from manifest): http://www.joda.org/joda-time/
-Manifest License: Apache 2.0 (Not packaged)
-Project URL (from POM): http://www.joda.org/joda-time/
-License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: log4j  Name: log4j  Version: 1.2.17
-Project URL (from manifest): http://logging.apache.org/log4j/1.2
-Project URL (from POM): http://logging.apache.org/log4j/1.2/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: net.java.dev.jna  Name: jna  Version: 5.13.0
-Project URL (from POM): https://github.com/java-native-access/jna
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): LGPL-2.1-or-later - https://www.gnu.org/licenses/old-licenses/lgpl-2.1
-
---------------------------------------------------------------------------------
-
-Group: net.java.dev.jna  Name: jna-platform  Version: 5.13.0
-Project URL (from POM): https://github.com/java-native-access/jna
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): LGPL-2.1-or-later - https://www.gnu.org/licenses/old-licenses/lgpl-2.1
-
---------------------------------------------------------------------------------
-
-Group: net.minidev  Name: accessors-smart  Version: 2.5.0
-Project URL (from manifest): https://urielch.github.io/
-Project URL (from POM): https://urielch.github.io/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: net.minidev  Name: json-smart  Version: 2.5.0
-Project URL (from manifest): https://urielch.github.io/
-Project URL (from POM): https://urielch.github.io/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: net.sf.opencsv  Name: opencsv  Version: 2.3
-Project URL (from POM): http://opencsv.sf.net
-License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.antlr  Name: antlr-runtime  Version: 3.5.2
-Project URL (from POM): http://www.antlr.org
-License (from POM): BSD licence - http://antlr.org/license.html
-
---------------------------------------------------------------------------------
-
-Group: org.apache.ant  Name: ant  Version: 1.9.1
-Project URL (from POM): http://ant.apache.org/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.ant  Name: ant-launcher  Version: 1.9.1
-Project URL (from POM): http://ant.apache.org/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -1177,78 +356,6 @@ Group: org.apache.avro  Name: avro  Version: 1.12.0
 Project URL (from manifest): https://www.apache.org/
 Project URL (from POM): https://avro.apache.org
 License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.commons  Name: commons-compress  Version: 1.26.2
-Project URL (from manifest): https://commons.apache.org/proper/commons-compress/
-Project URL (from POM): https://commons.apache.org/proper/commons-compress/
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.commons  Name: commons-configuration2  Version: 2.8.0
-Project URL (from manifest): https://commons.apache.org/proper/commons-configuration/
-Project URL (from POM): https://commons.apache.org/proper/commons-configuration/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.commons  Name: commons-lang3  Version: 3.14.0
-Project URL (from manifest): https://commons.apache.org/proper/commons-lang/
-Project URL (from POM): https://commons.apache.org/proper/commons-lang/
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.commons  Name: commons-math3  Version: 3.1.1
-Project URL (from manifest): http://commons.apache.org/math/
-Project URL (from POM): http://commons.apache.org/math/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.commons  Name: commons-text  Version: 1.10.0
-Project URL (from manifest): https://commons.apache.org/proper/commons-text
-Project URL (from POM): https://commons.apache.org/proper/commons-text
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.curator  Name: curator-client  Version: 5.2.0
-Project URL (from manifest): http://www.apache.org/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.curator  Name: curator-framework  Version: 5.2.0
-Project URL (from manifest): http://www.apache.org/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.curator  Name: curator-recipes  Version: 5.2.0
-Project URL (from manifest): http://www.apache.org/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.derby  Name: derby  Version: 10.10.2.0
-License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop  Name: hadoop-annotations  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop  Name: hadoop-auth  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -1262,199 +369,12 @@ License (from POM): Apache License, Version 2.0 - https://www.apache.org/license
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.hadoop  Name: hadoop-hdfs-client  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop  Name: hadoop-mapreduce-client-common  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop  Name: hadoop-mapreduce-client-core  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop  Name: hadoop-mapreduce-client-jobclient  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop  Name: hadoop-yarn-api  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop  Name: hadoop-yarn-client  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop  Name: hadoop-yarn-common  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-guava  Version: 1.2.0
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-protobuf_3_7  Version: 1.1.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive  Name: hive-common  Version: 2.3.9
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.hive  Name: hive-metastore  Version: 2.3.9
 License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.hive  Name: hive-serde  Version: 2.3.9
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive  Name: hive-shims  Version: 2.3.9
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive  Name: hive-storage-api  Version: 2.4.0
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive.shims  Name: hive-shims-0.23  Version: 2.3.9
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive.shims  Name: hive-shims-common  Version: 2.3.9
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive.shims  Name: hive-shims-scheduler  Version: 2.3.9
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.httpcomponents  Name: httpclient  Version: 4.5.13
-Project URL (from POM): http://hc.apache.org/httpcomponents-client
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.httpcomponents  Name: httpcore  Version: 4.4.16
-Project URL (from POM): http://hc.apache.org/httpcomponents-core-ga
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.httpcomponents.client5  Name: httpclient5  Version: 5.3.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.httpcomponents.core5  Name: httpcore5  Version: 5.2.4
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.httpcomponents.core5  Name: httpcore5-h2  Version: 5.2.4
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-admin  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-client  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-common  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-core  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-crypto  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-identity  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-server  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-simplekdc  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-util  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerby-asn1  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerby-config  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerby-pkix  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerby-util  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerby-xdr  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: token-provider  Version: 1.0.1
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.apache.orc  Name: orc-core  Version: 1.9.4
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.orc  Name: orc-shims  Version: 1.9.4
 License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
@@ -1466,257 +386,6 @@ License (from POM): The Apache Software License, Version 2.0 - http://www.apache
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.parquet  Name: parquet-column  Version: 1.13.1
-Project URL (from POM): https://parquet.apache.org
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.parquet  Name: parquet-common  Version: 1.13.1
-Project URL (from POM): https://parquet.apache.org
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.parquet  Name: parquet-encoding  Version: 1.13.1
-Project URL (from POM): https://parquet.apache.org
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.parquet  Name: parquet-format-structures  Version: 1.13.1
-Project URL (from POM): https://parquet.apache.org/
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.parquet  Name: parquet-hadoop  Version: 1.13.1
-Project URL (from POM): https://parquet.apache.org
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.parquet  Name: parquet-jackson  Version: 1.13.1
-Project URL (from POM): https://parquet.apache.org
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.thrift  Name: libfb303  Version: 0.9.3
-Project URL (from POM): http://thrift.apache.org
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.thrift  Name: libthrift  Version: 0.9.3
-Project URL (from POM): http://thrift.apache.org
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.yetus  Name: audience-annotations  Version: 0.13.0
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.zookeeper  Name: zookeeper  Version: 3.6.3
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.zookeeper  Name: zookeeper-jute  Version: 3.6.3
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.checkerframework  Name: checker-qual  Version: 3.44.0
-Manifest License: MIT (Not packaged)
-Project URL (from POM): https://checkerframework.org/
-License (from POM): The MIT License - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: org.codehaus.jettison  Name: jettison  Version: 1.5.4
-Project URL (from POM): https://github.com/jettison-json/jettison
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: org.codehaus.mojo  Name: animal-sniffer-annotations  Version: 1.23
-License (from POM): MIT license - https://spdx.org/licenses/MIT.txt
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.codehaus.woodstox  Name: stax2-api  Version: 4.2.2
-Project URL (from manifest): http://github.com/FasterXML/stax2-api
-Project URL (from POM): http://github.com/FasterXML/stax2-api
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): The BSD 2-Clause License - http://www.opensource.org/licenses/bsd-license.php
-
---------------------------------------------------------------------------------
-
-Group: org.conscrypt  Name: conscrypt-openjdk-uber  Version: 2.5.2
-Project URL (from POM): https://conscrypt.org/
-License (from POM): Apache 2 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: org.datanucleus  Name: datanucleus-api-jdo  Version: 4.2.4
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.datanucleus  Name: datanucleus-core  Version: 4.1.17
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.datanucleus  Name: datanucleus-rdbms  Version: 4.1.19
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.datanucleus  Name: javax.jdo  Version: 3.2.0-m3
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty  Name: jetty-client  Version: 9.4.51.v20230217
-Project URL (from manifest): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty  Name: jetty-http  Version: 9.4.51.v20230217
-Project URL (from manifest): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty  Name: jetty-io  Version: 9.4.51.v20230217
-Project URL (from manifest): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty  Name: jetty-security  Version: 9.4.51.v20230217
-Project URL (from manifest): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty  Name: jetty-servlet  Version: 9.4.51.v20230217
-Project URL (from manifest): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty  Name: jetty-util  Version: 9.4.51.v20230217
-Project URL (from manifest): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty  Name: jetty-util-ajax  Version: 9.4.51.v20230217
-Project URL (from manifest): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty  Name: jetty-webapp  Version: 9.4.51.v20230217
-Project URL (from manifest): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty  Name: jetty-xml  Version: 9.4.51.v20230217
-Project URL (from manifest): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty.websocket  Name: websocket-api  Version: 9.4.51.v20230217
-Project URL (from manifest): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty.websocket  Name: websocket-client  Version: 9.4.51.v20230217
-Project URL (from manifest): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty.websocket  Name: websocket-common  Version: 9.4.51.v20230217
-Project URL (from manifest): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.jetbrains  Name: annotations  Version: 17.0.0
-Project URL (from POM): https://github.com/JetBrains/java-annotations
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.jetbrains.kotlin  Name: kotlin-stdlib  Version: 1.4.10
-Project URL (from POM): https://kotlinlang.org/
-License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.jetbrains.kotlin  Name: kotlin-stdlib-common  Version: 1.4.10
-Project URL (from POM): https://kotlinlang.org/
-License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.jline  Name: jline  Version: 3.9.0
-License (from POM): The BSD License - http://www.opensource.org/licenses/bsd-license.php
-
---------------------------------------------------------------------------------
-
-Group: org.ow2.asm  Name: asm  Version: 9.3
-Project URL (from manifest): http://asm.ow2.org
-Manifest License: BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
-Project URL (from POM): http://asm.ow2.io/
-License (from POM): BSD-3-Clause - https://asm.ow2.io/license.html
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.reactivestreams  Name: reactive-streams  Version: 1.0.4
-Project URL (from manifest): http://reactive-streams.org
-Project URL (from POM): http://www.reactive-streams.org/
-License (from POM): MIT-0 - https://spdx.org/licenses/MIT-0.html
-
---------------------------------------------------------------------------------
-
-Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.2.1
-Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
-License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
 Group: org.slf4j  Name: slf4j-api  Version: 2.0.13
 Project URL (from manifest): http://www.slf4j.org
 Project URL (from POM): http://www.slf4j.org
@@ -1724,247 +393,67 @@ License (from POM): MIT License - http://www.opensource.org/licenses/mit-license
 
 --------------------------------------------------------------------------------
 
-Group: org.slf4j  Name: slf4j-reload4j  Version: 1.7.36
-Project URL (from POM): http://reload4j.qos.ch
-License (from POM): MIT License - http://www.opensource.org/licenses/mit-license.php
-
---------------------------------------------------------------------------------
-
-Group: org.threeten  Name: threeten-extra  Version: 1.7.1
-Project URL (from manifest): https://www.threeten.org
-Project URL (from POM): https://www.threeten.org/threeten-extra
-License (from POM): BSD 3-clause - https://raw.githubusercontent.com/ThreeTen/threeten-extra/master/LICENSE.txt
-
---------------------------------------------------------------------------------
-
-Group: org.threeten  Name: threetenbp  Version: 1.6.9
-Project URL (from manifest): https://www.threeten.org
-Project URL (from POM): https://www.threeten.org/threetenbp
-License (from POM): BSD-3-Clause - https://raw.githubusercontent.com/ThreeTen/threetenbp/main/LICENSE.txt
-
---------------------------------------------------------------------------------
-
-Group: org.xerial.snappy  Name: snappy-java  Version: 1.1.10.5
-Project URL (from manifest): http://www.xerial.org/
-Project URL (from POM): https://github.com/xerial/snappy-java
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: annotations  Version: 2.26.29
+Group: software.amazon.awssdk  Name: apache-client  Version: 2.27.21
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: apache-client  Version: 2.26.29
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: arns  Version: 2.26.29
+Group: software.amazon.awssdk  Name: auth  Version: 2.27.21
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: auth  Version: 2.26.29
+Group: software.amazon.awssdk  Name: dynamodb  Version: 2.27.21
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-core  Version: 2.26.29
+Group: software.amazon.awssdk  Name: glue  Version: 2.27.21
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.26.29
+Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.27.21
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.26.29
+Group: software.amazon.awssdk  Name: iam  Version: 2.27.21
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.26.29
+Group: software.amazon.awssdk  Name: kms  Version: 2.27.21
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: checksums  Version: 2.26.29
+Group: software.amazon.awssdk  Name: lakeformation  Version: 2.27.21
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: s3  Version: 2.27.21
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: crt-core  Version: 2.26.29
+Group: software.amazon.awssdk  Name: sso  Version: 2.27.21
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: dynamodb  Version: 2.26.29
+Group: software.amazon.awssdk  Name: sts  Version: 2.27.21
 Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.26.29
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: glue  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: http-auth  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.26.29
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: iam  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: identity-spi  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: json-utils  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: kms  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: lakeformation  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.26.29
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.26.29
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: profiles  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: protocol-core  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: regions  Version: 2.26.29
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: retries  Version: 2.26.29
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: retries-spi  Version: 2.26.29
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: s3  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: sdk-core  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: sso  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: sts  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.26.29
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: utils  Version: 2.26.29
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.eventstream  Name: eventstream  Version: 1.0.1
-Project URL (from POM): https://github.com/awslabs/aws-eventstream-java
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------

--- a/kafka-connect/kafka-connect-runtime/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/LICENSE
@@ -207,108 +207,27 @@ This binary artifact contains code from the following projects:
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-identity  Version: 1.13.0
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
+Group: aopalliance  Name: aopalliance  Version: 1.0
+Project URL (from POM): http://aopalliance.sourceforge.net
+License (from POM): Public Domain
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-storage-file-datalake  Version: 12.19.1
-Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
-License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-storage  Version: 2.41.0
-Project URL (from POM): https://github.com/googleapis/java-storage
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop  Name: hadoop-client  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop  Name: hadoop-common  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive  Name: hive-metastore  Version: 2.3.9
+Group: ch.qos.reload4j  Name: reload4j  Version: 1.2.22
+Project URL (from manifest): https://reload4j.qos.ch/
+Project URL (from POM): https://reload4j.qos.ch
 License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.slf4j  Name: slf4j-api  Version: 2.0.13
-Project URL (from manifest): http://www.slf4j.org
-Project URL (from POM): http://www.slf4j.org
-License (from POM): MIT License - http://www.opensource.org/licenses/mit-license.php
+Group: com.azure  Name: azure-core  Version: 1.49.1
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: apache-client  Version: 2.27.21
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: auth  Version: 2.27.21
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: dynamodb  Version: 2.27.21
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: glue  Version: 2.27.21
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.27.21
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: iam  Version: 2.27.21
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: kms  Version: 2.27.21
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: lakeformation  Version: 2.27.21
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: s3  Version: 2.27.21
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: sso  Version: 2.27.21
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: sts  Version: 2.27.21
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+Group: com.azure  Name: azure-core-http-netty  Version: 1.15.1
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
@@ -318,9 +237,46 @@ License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
+Group: com.azure  Name: azure-json  Version: 1.1.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-storage-blob  Version: 12.26.1
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-storage-common  Version: 12.25.1
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
 Group: com.azure  Name: azure-storage-file-datalake  Version: 12.19.1
 Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
 License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-storage-internal-avro  Version: 12.11.1
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.azure  Name: azure-xml  Version: 1.0.0
+Project URL (from POM): https://github.com/Azure/azure-sdk-for-java
+License (from POM): The MIT License (MIT) - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.17.2
+Project URL (from manifest): https://github.com/FasterXML/jackson
+Project URL (from POM): https://github.com/FasterXML/jackson
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -340,15 +296,880 @@ License (from POM): The Apache Software License, Version 2.0 - https://www.apach
 
 --------------------------------------------------------------------------------
 
+Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.17.2
+Project URL (from manifest): https://github.com/FasterXML/jackson-dataformat-xml
+Project URL (from POM): https://github.com/FasterXML/jackson-dataformat-xml
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.17.2
+Project URL (from manifest): https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.jaxrs  Name: jackson-jaxrs-base  Version: 2.17.2
+Project URL (from manifest): https://github.com/FasterXML/jackson-jaxrs-providers/jackson-jaxrs-base
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.jaxrs  Name: jackson-jaxrs-json-provider  Version: 2.17.2
+Project URL (from manifest): https://github.com/FasterXML/jackson-jaxrs-providers/jackson-jaxrs-json-provider
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.module  Name: jackson-module-jaxb-annotations  Version: 2.17.2
+Project URL (from manifest): https://github.com/FasterXML/jackson-modules-base
+Project URL (from POM): https://github.com/FasterXML/jackson-modules-base
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.woodstox  Name: woodstox-core  Version: 6.7.0
+Project URL (from manifest): https://github.com/FasterXML/woodstox
+Project URL (from POM): https://github.com/FasterXML/woodstox
+License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 Group: com.github.ben-manes.caffeine  Name: caffeine  Version: 2.9.3
 Project URL (from POM): https://github.com/ben-manes/caffeine
 License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.cloud  Name: google-cloud-storage  Version: 2.41.0
+Group: com.github.luben  Name: zstd-jni  Version: 1.5.0-1
+License URL (from manifest): https://opensource.org/licenses/BSD-2-Clause
+Project URL (from POM): https://github.com/luben/zstd-jni
+License (from POM): BSD 2-Clause License - https://opensource.org/licenses/BSD-2-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.github.pjfanning  Name: jersey-json  Version: 1.20
+Project URL (from POM): https://github.com/pjfanning/jersey-1.x
+License (from POM): CDDL 1.1 - http://glassfish.java.net/public/CDDL+GPL_1_1.html
+License (from POM): GPL2 w/ CPE - http://glassfish.java.net/public/CDDL+GPL_1_1.html
+
+--------------------------------------------------------------------------------
+
+Group: com.github.stephenc.jcip  Name: jcip-annotations  Version: 1.0-1
+Project URL (from POM): http://stephenc.github.com/jcip-annotations
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.android  Name: annotations  Version: 4.1.1.4
+Project URL (from POM): http://source.android.com/
+License (from POM): Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api  Name: api-common  Version: 2.33.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): BSD-3-Clause - https://github.com/googleapis/api-common-java/blob/main/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api  Name: gax  Version: 2.50.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api  Name: gax-grpc  Version: 2.50.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api  Name: gax-httpjson  Version: 2.50.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api-client  Name: google-api-client  Version: 2.6.0
+Project URL (from manifest): https://developers.google.com/api-client-library/java/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc  Name: gapic-google-cloud-storage-v2  Version: 2.40.1-alpha
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc  Name: grpc-google-cloud-storage-v2  Version: 2.40.1-alpha
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc  Name: proto-google-cloud-storage-v2  Version: 2.40.1-alpha
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc  Name: proto-google-common-protos  Version: 2.41.0
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.api.grpc  Name: proto-google-iam-v1  Version: 1.36.0
+Project URL (from POM): https://github.com/googleapis/sdk-platform-java
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.apis  Name: google-api-services-storage  Version: v1-rev20240621-2.0.0
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.auth  Name: google-auth-library-credentials  Version: 1.23.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): BSD New license - http://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.auth  Name: google-auth-library-oauth2-http  Version: 1.23.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): BSD New license - http://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.auto.value  Name: auto-value-annotations  Version: 1.10.4
+Project URL (from POM): https://github.com/google/auto/tree/main/value
+License (from POM): Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud  Name: google-cloud-core  Version: 2.40.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud  Name: google-cloud-core-grpc  Version: 2.40.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud  Name: google-cloud-core-http  Version: 2.40.0
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.cloud  Name: google-cloud-storage  Version: 2.40.1
 Project URL (from POM): https://github.com/googleapis/java-storage
 License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.code.findbugs  Name: jsr305  Version: 3.0.2
+Project URL (from POM): http://findbugs.sourceforge.net/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.code.gson  Name: gson  Version: 2.11.0
+Project URL (from manifest): https://github.com/google/gson
+Manifest License: "Apache-2.0";link="https://www.apache.org/licenses/LICENSE-2.0.txt" (Not packaged)
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.errorprone  Name: error_prone_annotations  Version: 2.28.0
+Project URL (from manifest): https://errorprone.info/error_prone_annotations
+Manifest License: "Apache 2.0";link="http://www.apache.org/licenses/LICENSE-2.0.txt" (Not packaged)
+License (from POM): Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.guava  Name: failureaccess  Version: 1.0.2
+Project URL (from manifest): https://github.com/google/guava/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.guava  Name: guava  Version: 33.1.0-jre
+Project URL (from manifest): https://github.com/google/guava/
+Project URL (from POM): https://github.com/google/guava
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.guava  Name: listenablefuture  Version: 9999.0-empty-to-avoid-conflict-with-guava
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client  Name: google-http-client  Version: 1.44.2
+Project URL (from manifest): https://www.google.com/
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client  Name: google-http-client-apache-v2  Version: 1.44.2
+Project URL (from manifest): https://www.google.com/
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client  Name: google-http-client-appengine  Version: 1.44.2
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client  Name: google-http-client-gson  Version: 1.44.2
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.http-client  Name: google-http-client-jackson2  Version: 1.44.2
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.inject  Name: guice  Version: 4.0
+Project URL (from manifest): https://github.com/google/guice
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.j2objc  Name: j2objc-annotations  Version: 3.0.0
+Project URL (from POM): https://github.com/google/j2objc/
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.oauth-client  Name: google-oauth-client  Version: 1.36.0
+Project URL (from manifest): https://www.google.com/
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.google.protobuf  Name: protobuf-java  Version: 3.25.3
+Project URL (from manifest): https://developers.google.com/protocol-buffers/
+License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.protobuf  Name: protobuf-java-util  Version: 3.25.3
+Project URL (from manifest): https://developers.google.com/protocol-buffers/
+License (from POM): BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+
+--------------------------------------------------------------------------------
+
+Group: com.google.re2j  Name: re2j  Version: 1.7
+Project URL (from POM): http://github.com/google/re2j
+License (from POM): Go License - https://golang.org/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: com.jcraft  Name: jsch  Version: 0.1.55
+Project URL (from POM): http://www.jcraft.com/jsch/
+License (from POM): Revised BSD - http://www.jcraft.com/jsch/LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.jolbox  Name: bonecp  Version: 0.8.0.RELEASE
+Project URL (from manifest): http://jolbox.com
+License (from POM): Apache v2 - http://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: com.microsoft.azure  Name: msal4j  Version: 1.15.1
+Project URL (from manifest): https://github.com/AzureAD/microsoft-authentication-library-for-java
+Manifest License: "MIT License" (Not packaged)
+Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
+License (from POM): MIT License
+--------------------------------------------------------------------------------
+
+Group: com.microsoft.azure  Name: msal4j-persistence-extension  Version: 1.3.0
+Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
+License (from POM): MIT License
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds  Name: content-type  Version: 2.3
+Project URL (from manifest): https://connect2id.com
+Project URL (from POM): https://bitbucket.org/connect2id/nimbus-content-type
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds  Name: lang-tag  Version: 1.7
+Project URL (from manifest): https://connect2id.com/
+Project URL (from POM): https://bitbucket.org/connect2id/nimbus-language-tags
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds  Name: nimbus-jose-jwt  Version: 9.37.3
+Project URL (from manifest): https://connect2id.com
+Project URL (from POM): https://bitbucket.org/connect2id/nimbus-jose-jwt
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.nimbusds  Name: oauth2-oidc-sdk  Version: 11.9.1
+Project URL (from manifest): https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
+Manifest License: "Apache License, version 2.0";link="https://www.apache.org/licenses/LICENSE-2.0.html" (Not packaged)
+Project URL (from POM): https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
+License (from POM): Apache License, version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: com.squareup.okhttp3  Name: okhttp  Version: 4.9.3
+Project URL (from POM): https://square.github.io/okhttp/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.squareup.okio  Name: okio  Version: 2.8.0
+Project URL (from POM): https://github.com/square/okio/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: com.sun.xml.bind  Name: jaxb-impl  Version: 2.2.3-1
+Project URL (from POM): http://jaxb.java.net/
+License (from POM): CDDL 1.1 - https://glassfish.java.net/public/CDDL+GPL_1_1.html
+License (from POM): GPL2 w/ CPE - https://glassfish.java.net/public/CDDL+GPL_1_1.html
+
+--------------------------------------------------------------------------------
+
+Group: commons-beanutils  Name: commons-beanutils  Version: 1.9.4
+Project URL (from manifest): https://commons.apache.org/proper/commons-beanutils/
+Project URL (from POM): https://commons.apache.org/proper/commons-beanutils/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-cli  Name: commons-cli  Version: 1.2
+Project URL (from manifest): http://commons.apache.org/cli/
+Project URL (from POM): http://commons.apache.org/cli/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-codec  Name: commons-codec  Version: 1.17.1
+Project URL (from manifest): https://commons.apache.org/proper/commons-codec/
+Project URL (from POM): https://commons.apache.org/proper/commons-codec/
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-collections  Name: commons-collections  Version: 3.2.2
+Project URL (from manifest): http://commons.apache.org/collections/
+Project URL (from POM): http://commons.apache.org/collections/
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-dbcp  Name: commons-dbcp  Version: 1.4
+Project URL (from manifest): http://commons.apache.org/dbcp/
+Project URL (from POM): http://commons.apache.org/dbcp/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-io  Name: commons-io  Version: 2.16.1
+Project URL (from manifest): https://commons.apache.org/proper/commons-io/
+Project URL (from POM): https://commons.apache.org/proper/commons-io/
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-lang  Name: commons-lang  Version: 2.6
+Project URL (from manifest): http://commons.apache.org/lang/
+Project URL (from POM): http://commons.apache.org/lang/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-logging  Name: commons-logging  Version: 1.2
+Project URL (from manifest): http://commons.apache.org/proper/commons-logging/
+Project URL (from POM): http://commons.apache.org/proper/commons-logging/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-net  Name: commons-net  Version: 3.9.0
+Project URL (from manifest): https://commons.apache.org/proper/commons-net/
+Project URL (from POM): https://commons.apache.org/proper/commons-net/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: commons-pool  Name: commons-pool  Version: 1.6
+Project URL (from manifest): http://commons.apache.org/pool/
+Project URL (from POM): http://commons.apache.org/pool/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: dnsjava  Name: dnsjava  Version: 2.1.7
+Project URL (from POM): http://www.dnsjava.org
+License (from POM): BSD 2-Clause license - http://opensource.org/licenses/BSD-2-Clause
+
+--------------------------------------------------------------------------------
+
+Group: io.airlift  Name: aircompressor  Version: 0.27
+Project URL (from POM): https://github.com/airlift/aircompressor
+License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: io.dropwizard.metrics  Name: metrics-core  Version: 3.2.4
+License (from POM): Apache License 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: io.dropwizard.metrics  Name: metrics-json  Version: 3.1.0
+License (from POM): Apache License 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: io.dropwizard.metrics  Name: metrics-jvm  Version: 3.1.0
+License (from POM): Apache License 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-alts  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-api  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-auth  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-context  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-core  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-googleapis  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-grpclb  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-inprocess  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-netty-shaded  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-protobuf  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-protobuf-lite  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-rls  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-services  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-stub  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-util  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-xds  Version: 1.62.2
+Project URL (from POM): https://github.com/grpc/grpc-java
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-buffer  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-codec  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-codec-dns  Version: 4.1.109.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-codec-http  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-codec-http2  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-codec-socks  Version: 4.1.110.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-common  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-handler  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-handler-proxy  Version: 4.1.110.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-resolver  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-resolver-dns  Version: 4.1.109.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-resolver-dns-classes-macos  Version: 4.1.109.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-resolver-dns-native-macos  Version: 4.1.109.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-tcnative-boringssl-static  Version: 2.0.65.Final
+Project URL (from manifest): https://netty.io/
+Project URL (from POM): https://github.com/netty/netty-tcnative/netty-tcnative-boringssl-static/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-tcnative-classes  Version: 2.0.65.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-transport  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-transport-classes-kqueue  Version: 4.1.110.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-transport-native-epoll  Version: 4.1.110.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-transport-native-kqueue  Version: 4.1.110.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.111.Final
+Project URL (from manifest): https://netty.io/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.opencensus  Name: opencensus-api  Version: 0.31.1
+Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
+License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opencensus  Name: opencensus-contrib-http-util  Version: 0.31.1
+Project URL (from POM): https://github.com/census-instrumentation/opencensus-java
+License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.opencensus  Name: opencensus-proto  Version: 0.2.0
+Project URL (from POM): https://github.com/census-instrumentation/opencensus-proto
+License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.perfmark  Name: perfmark-api  Version: 0.27.0
+Project URL (from POM): https://github.com/perfmark/perfmark
+License (from POM): Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.projectreactor  Name: reactor-core  Version: 3.4.38
+Project URL (from POM): https://github.com/reactor/reactor-core
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.projectreactor.netty  Name: reactor-netty-core  Version: 1.0.45
+Project URL (from POM): https://github.com/reactor/reactor-netty
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: io.projectreactor.netty  Name: reactor-netty-http  Version: 1.0.45
+Project URL (from POM): https://github.com/reactor/reactor-netty
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.activation  Name: jakarta.activation-api  Version: 1.2.1
+Project URL (from manifest): https://www.eclipse.org
+License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+License (from POM): Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
+License (from POM): GNU General Public License, version 2 with the GNU Classpath Exception - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.activation  Name: jakarta.activation-api  Version: 1.2.2
+Project URL (from manifest): https://www.eclipse.org
+License (from POM): EDL 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+License (from POM): Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
+License (from POM): GNU General Public License, version 2 with the GNU Classpath Exception - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.xml.bind  Name: jakarta.xml.bind-api  Version: 2.3.3
+Project URL (from manifest): https://www.eclipse.org
+License (from POM): Eclipse Distribution License - v 1.0 - http://www.eclipse.org/org/documents/edl-v10.php
+License (from POM): Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
+License (from POM): GNU General Public License, version 2 with the GNU Classpath Exception - https://www.gnu.org/software/classpath/license.html
+
+--------------------------------------------------------------------------------
+
+Group: javax.annotation  Name: javax.annotation-api  Version: 1.3.2
+Project URL (from manifest): https://javaee.github.io/glassfish
+Project URL (from POM): http://jcp.org/en/jsr/detail?id=250
+License (from POM): CDDL + GPLv2 with classpath exception - https://github.com/javaee/javax.annotation/blob/master/LICENSE
+
+--------------------------------------------------------------------------------
+
+Group: javax.inject  Name: javax.inject  Version: 1
+Project URL (from POM): http://code.google.com/p/atinject/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: javax.jdo  Name: jdo-api  Version: 3.0.1
+Project URL (from POM): http://db.apache.org/jdo
+License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: javax.servlet  Name: javax.servlet-api  Version: 3.1.0
+Project URL (from manifest): https://glassfish.dev.java.net
+Project URL (from POM): http://servlet-spec.java.net
+License (from POM): CDDL + GPLv2 with classpath exception - https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+
+--------------------------------------------------------------------------------
+
+Group: javax.servlet.jsp  Name: jsp-api  Version: 2.1
+
+--------------------------------------------------------------------------------
+
+Group: javax.transaction  Name: jta  Version: 1.1
+Project URL (from POM): http://java.sun.com/products/jta
+
+--------------------------------------------------------------------------------
+
+Group: javax.xml.bind  Name: jaxb-api  Version: 2.2.11
+Project URL (from manifest): http://www.oracle.com/
+Project URL (from POM): http://jaxb.java.net/
+License (from POM): CDDL 1.1 - https://glassfish.java.net/public/CDDL+GPL_1_1.html
+License (from POM): GPL2 w/ CPE - https://glassfish.java.net/public/CDDL+GPL_1_1.html
+
+--------------------------------------------------------------------------------
+
+Group: javax.xml.bind  Name: jaxb-api  Version: 2.2.2
+Project URL (from POM): https://jaxb.dev.java.net/
+License (from POM): CDDL 1.1 - https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+License (from POM): GPL2 w/ CPE - https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+
+--------------------------------------------------------------------------------
+
+Group: javax.xml.stream  Name: stax-api  Version: 1.0-2
+License (from POM): COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0 - http://www.sun.com/cddl/cddl.html
+License (from POM): GNU General Public Library - http://www.gnu.org/licenses/gpl.txt
+
+--------------------------------------------------------------------------------
+
+Group: javolution  Name: javolution  Version: 5.5.1
+Project URL (from manifest): http://javolution.org
+Project URL (from POM): http://javolution.org
+License (from POM): BSD License - http://javolution.org/LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: jline  Name: jline  Version: 2.12
+License (from POM): The BSD License - http://www.opensource.org/licenses/bsd-license.php
+
+--------------------------------------------------------------------------------
+
+Group: joda-time  Name: joda-time  Version: 2.8.1
+Project URL (from manifest): http://www.joda.org/joda-time/
+Manifest License: Apache 2.0 (Not packaged)
+Project URL (from POM): http://www.joda.org/joda-time/
+License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: log4j  Name: log4j  Version: 1.2.17
+Project URL (from manifest): http://logging.apache.org/log4j/1.2
+Project URL (from POM): http://logging.apache.org/log4j/1.2/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: net.java.dev.jna  Name: jna  Version: 5.13.0
+Project URL (from POM): https://github.com/java-native-access/jna
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): LGPL-2.1-or-later - https://www.gnu.org/licenses/old-licenses/lgpl-2.1
+
+--------------------------------------------------------------------------------
+
+Group: net.java.dev.jna  Name: jna-platform  Version: 5.13.0
+Project URL (from POM): https://github.com/java-native-access/jna
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): LGPL-2.1-or-later - https://www.gnu.org/licenses/old-licenses/lgpl-2.1
+
+--------------------------------------------------------------------------------
+
+Group: net.minidev  Name: accessors-smart  Version: 2.5.0
+Project URL (from manifest): https://urielch.github.io/
+Project URL (from POM): https://urielch.github.io/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: net.minidev  Name: json-smart  Version: 2.5.0
+Project URL (from manifest): https://urielch.github.io/
+Project URL (from POM): https://urielch.github.io/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: net.sf.opencsv  Name: opencsv  Version: 2.3
+Project URL (from POM): http://opencsv.sf.net
+License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.antlr  Name: antlr-runtime  Version: 3.5.2
+Project URL (from POM): http://www.antlr.org
+License (from POM): BSD licence - http://antlr.org/license.html
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.ant  Name: ant  Version: 1.9.1
+Project URL (from POM): http://ant.apache.org/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.ant  Name: ant-launcher  Version: 1.9.1
+Project URL (from POM): http://ant.apache.org/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -356,6 +1177,78 @@ Group: org.apache.avro  Name: avro  Version: 1.12.0
 Project URL (from manifest): https://www.apache.org/
 Project URL (from POM): https://avro.apache.org
 License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-compress  Version: 1.26.2
+Project URL (from manifest): https://commons.apache.org/proper/commons-compress/
+Project URL (from POM): https://commons.apache.org/proper/commons-compress/
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-configuration2  Version: 2.8.0
+Project URL (from manifest): https://commons.apache.org/proper/commons-configuration/
+Project URL (from POM): https://commons.apache.org/proper/commons-configuration/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-lang3  Version: 3.14.0
+Project URL (from manifest): https://commons.apache.org/proper/commons-lang/
+Project URL (from POM): https://commons.apache.org/proper/commons-lang/
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-math3  Version: 3.1.1
+Project URL (from manifest): http://commons.apache.org/math/
+Project URL (from POM): http://commons.apache.org/math/
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-text  Version: 1.10.0
+Project URL (from manifest): https://commons.apache.org/proper/commons-text
+Project URL (from POM): https://commons.apache.org/proper/commons-text
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator  Name: curator-client  Version: 5.2.0
+Project URL (from manifest): http://www.apache.org/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator  Name: curator-framework  Version: 5.2.0
+Project URL (from manifest): http://www.apache.org/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator  Name: curator-recipes  Version: 5.2.0
+Project URL (from manifest): http://www.apache.org/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.derby  Name: derby  Version: 10.10.2.0
+License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-annotations  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-auth  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
@@ -369,12 +1262,199 @@ License (from POM): Apache License, Version 2.0 - https://www.apache.org/license
 
 --------------------------------------------------------------------------------
 
+Group: org.apache.hadoop  Name: hadoop-hdfs-client  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-mapreduce-client-common  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-mapreduce-client-core  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-mapreduce-client-jobclient  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-yarn-api  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-yarn-client  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-yarn-common  Version: 3.3.6
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-guava  Version: 1.2.0
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-protobuf_3_7  Version: 1.1.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-common  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 Group: org.apache.hive  Name: hive-metastore  Version: 2.3.9
 License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
+Group: org.apache.hive  Name: hive-serde  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-shims  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-storage-api  Version: 2.4.0
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive.shims  Name: hive-shims-0.23  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive.shims  Name: hive-shims-common  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive.shims  Name: hive-shims-scheduler  Version: 2.3.9
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents  Name: httpclient  Version: 4.5.13
+Project URL (from POM): http://hc.apache.org/httpcomponents-client
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents  Name: httpcore  Version: 4.4.16
+Project URL (from POM): http://hc.apache.org/httpcomponents-core-ga
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.client5  Name: httpclient5  Version: 5.3.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.core5  Name: httpcore5  Version: 5.2.4
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.core5  Name: httpcore5-h2  Version: 5.2.4
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-admin  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-client  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-common  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-core  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-crypto  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-identity  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-server  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-simplekdc  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-util  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-asn1  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-config  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-pkix  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-util  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-xdr  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: token-provider  Version: 1.0.1
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 Group: org.apache.orc  Name: orc-core  Version: 1.9.4
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.orc  Name: orc-shims  Version: 1.9.4
 License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
@@ -386,6 +1466,257 @@ License (from POM): The Apache Software License, Version 2.0 - http://www.apache
 
 --------------------------------------------------------------------------------
 
+Group: org.apache.parquet  Name: parquet-column  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-common  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-encoding  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-format-structures  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org/
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-hadoop  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-jackson  Version: 1.13.1
+Project URL (from POM): https://parquet.apache.org
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.thrift  Name: libfb303  Version: 0.9.3
+Project URL (from POM): http://thrift.apache.org
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.thrift  Name: libthrift  Version: 0.9.3
+Project URL (from POM): http://thrift.apache.org
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.yetus  Name: audience-annotations  Version: 0.13.0
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.zookeeper  Name: zookeeper  Version: 3.6.3
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.zookeeper  Name: zookeeper-jute  Version: 3.6.3
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.checkerframework  Name: checker-qual  Version: 3.44.0
+Manifest License: MIT (Not packaged)
+Project URL (from POM): https://checkerframework.org/
+License (from POM): The MIT License - http://opensource.org/licenses/MIT
+
+--------------------------------------------------------------------------------
+
+Group: org.codehaus.jettison  Name: jettison  Version: 1.5.4
+Project URL (from POM): https://github.com/jettison-json/jettison
+License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: org.codehaus.mojo  Name: animal-sniffer-annotations  Version: 1.23
+License (from POM): MIT license - https://spdx.org/licenses/MIT.txt
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.codehaus.woodstox  Name: stax2-api  Version: 4.2.2
+Project URL (from manifest): http://github.com/FasterXML/stax2-api
+Project URL (from POM): http://github.com/FasterXML/stax2-api
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License (from POM): The BSD 2-Clause License - http://www.opensource.org/licenses/bsd-license.php
+
+--------------------------------------------------------------------------------
+
+Group: org.conscrypt  Name: conscrypt-openjdk-uber  Version: 2.5.2
+Project URL (from POM): https://conscrypt.org/
+License (from POM): Apache 2 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: datanucleus-api-jdo  Version: 4.2.4
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: datanucleus-core  Version: 4.1.17
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: datanucleus-rdbms  Version: 4.1.19
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: javax.jdo  Version: 3.2.0-m3
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-client  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-http  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-io  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-security  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-servlet  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-util  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-util-ajax  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-webapp  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-xml  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty.websocket  Name: websocket-api  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty.websocket  Name: websocket-client  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty.websocket  Name: websocket-common  Version: 9.4.51.v20230217
+Project URL (from manifest): https://eclipse.org/jetty
+License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+License (from POM): Eclipse Public License - Version 1.0 - https://www.eclipse.org/org/documents/epl-v10.php
+
+--------------------------------------------------------------------------------
+
+Group: org.jetbrains  Name: annotations  Version: 17.0.0
+Project URL (from POM): https://github.com/JetBrains/java-annotations
+License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jetbrains.kotlin  Name: kotlin-stdlib  Version: 1.4.10
+Project URL (from POM): https://kotlinlang.org/
+License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jetbrains.kotlin  Name: kotlin-stdlib-common  Version: 1.4.10
+Project URL (from POM): https://kotlinlang.org/
+License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.jline  Name: jline  Version: 3.9.0
+License (from POM): The BSD License - http://www.opensource.org/licenses/bsd-license.php
+
+--------------------------------------------------------------------------------
+
+Group: org.ow2.asm  Name: asm  Version: 9.3
+Project URL (from manifest): http://asm.ow2.org
+Manifest License: BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
+Project URL (from POM): http://asm.ow2.io/
+License (from POM): BSD-3-Clause - https://asm.ow2.io/license.html
+License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.reactivestreams  Name: reactive-streams  Version: 1.0.4
+Project URL (from manifest): http://reactive-streams.org
+Project URL (from POM): http://www.reactive-streams.org/
+License (from POM): MIT-0 - https://spdx.org/licenses/MIT-0.html
+
+--------------------------------------------------------------------------------
+
+Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.2.1
+Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
+License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 Group: org.slf4j  Name: slf4j-api  Version: 2.0.13
 Project URL (from manifest): http://www.slf4j.org
 Project URL (from POM): http://www.slf4j.org
@@ -393,67 +1724,247 @@ License (from POM): MIT License - http://www.opensource.org/licenses/mit-license
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: apache-client  Version: 2.27.21
+Group: org.slf4j  Name: slf4j-reload4j  Version: 1.7.36
+Project URL (from POM): http://reload4j.qos.ch
+License (from POM): MIT License - http://www.opensource.org/licenses/mit-license.php
+
+--------------------------------------------------------------------------------
+
+Group: org.threeten  Name: threeten-extra  Version: 1.7.1
+Project URL (from manifest): https://www.threeten.org
+Project URL (from POM): https://www.threeten.org/threeten-extra
+License (from POM): BSD 3-clause - https://raw.githubusercontent.com/ThreeTen/threeten-extra/master/LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.threeten  Name: threetenbp  Version: 1.6.9
+Project URL (from manifest): https://www.threeten.org
+Project URL (from POM): https://www.threeten.org/threetenbp
+License (from POM): BSD-3-Clause - https://raw.githubusercontent.com/ThreeTen/threetenbp/main/LICENSE.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.xerial.snappy  Name: snappy-java  Version: 1.1.10.5
+Project URL (from manifest): http://www.xerial.org/
+Project URL (from POM): https://github.com/xerial/snappy-java
+License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: annotations  Version: 2.26.29
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: auth  Version: 2.27.21
+Group: software.amazon.awssdk  Name: apache-client  Version: 2.26.29
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: arns  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: dynamodb  Version: 2.27.21
+Group: software.amazon.awssdk  Name: auth  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: glue  Version: 2.27.21
+Group: software.amazon.awssdk  Name: aws-core  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.27.21
+Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: iam  Version: 2.27.21
+Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: kms  Version: 2.27.21
+Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: lakeformation  Version: 2.27.21
+Group: software.amazon.awssdk  Name: checksums  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: s3  Version: 2.27.21
+Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sso  Version: 2.27.21
+Group: software.amazon.awssdk  Name: crt-core  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sts  Version: 2.27.21
+Group: software.amazon.awssdk  Name: dynamodb  Version: 2.26.29
 Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.26.29
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: glue  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: http-auth  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.26.29
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: iam  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: identity-spi  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: json-utils  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: kms  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: lakeformation  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.26.29
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.26.29
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: profiles  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: protocol-core  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: regions  Version: 2.26.29
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: retries  Version: 2.26.29
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: retries-spi  Version: 2.26.29
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: s3  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: sdk-core  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: sso  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: sts  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.26.29
+Project URL (from POM): https://aws.amazon.com/sdkforjava
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: utils  Version: 2.26.29
+License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.eventstream  Name: eventstream  Version: 1.0.1
+Project URL (from POM): https://github.com/awslabs/aws-eventstream-java
 License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------

--- a/kafka-connect/kafka-connect-runtime/NOTICE
+++ b/kafka-connect/kafka-connect-runtime/NOTICE
@@ -1,0 +1,1722 @@
+
+Apache Iceberg
+Copyright 2017-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+This project includes code from Kite, developed at Cloudera, Inc. with
+the following copyright notice:
+
+| Copyright 2013 Cloudera Inc.
+|
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+|
+|   http://www.apache.org/licenses/LICENSE-2.0
+|
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains code from the following projects:
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-math3  Version: 3.1.1
+
+Notice: Apache Commons Math
+Copyright 2001-2012 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+===============================================================================
+
+The BracketFinder (package org.apache.commons.math3.optimization.univariate)
+and PowellOptimizer (package org.apache.commons.math3.optimization.general)
+classes are based on the Python code in module "optimize.py" (version 0.5)
+developed by Travis E. Oliphant for the SciPy library (http://www.scipy.org/)
+Copyright © 2003-2009 SciPy Developers.
+===============================================================================
+
+The LinearConstraint, LinearObjectiveFunction, LinearOptimizer,
+RelationShip, SimplexSolver and SimplexTableau classes in package
+org.apache.commons.math3.optimization.linear include software developed by
+Benjamin McCann (http://www.benmccann.com) and distributed with
+the following copyright: Copyright 2009 Google Inc.
+===============================================================================
+
+This product includes software developed by the
+University of Chicago, as Operator of Argonne National
+Laboratory.
+The LevenbergMarquardtOptimizer class in package
+org.apache.commons.math3.optimization.general includes software
+translated from the lmder, lmpar and qrsolv Fortran routines
+from the Minpack package
+Minpack Copyright Notice (1999) University of Chicago.  All rights reserved
+===============================================================================
+
+The GraggBulirschStoerIntegrator class in package
+org.apache.commons.math3.ode.nonstiff includes software translated
+from the odex Fortran routine developed by E. Hairer and G. Wanner.
+Original source copyright:
+Copyright (c) 2004, Ernst Hairer
+===============================================================================
+
+The EigenDecompositionImpl class in package
+org.apache.commons.math3.linear includes software translated
+from some LAPACK Fortran routines.  Original source copyright:
+Copyright (c) 1992-2008 The University of Tennessee.  All rights reserved.
+===============================================================================
+
+The MersenneTwister class in package org.apache.commons.math3.random
+includes software translated from the 2002-01-26 version of
+the Mersenne-Twister generator written in C by Makoto Matsumoto and Takuji
+Nishimura. Original source copyright:
+Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+All rights reserved
+===============================================================================
+
+The LocalizedFormatsTest class in the unit tests is an adapted version of
+the OrekitMessagesTest class from the orekit library distributed under the
+terms of the Apache 2 licence. Original source copyright:
+Copyright 2010 CS Systèmes d'Information
+===============================================================================
+
+The HermiteInterpolator class and its corresponding test have been imported from
+the orekit library distributed under the terms of the Apache 2 licence. Original
+source copyright:
+Copyright 2010-2012 CS Systèmes d'Information
+===============================================================================
+
+The creation of the package "o.a.c.m.analysis.integration.gauss" was inspired
+by an original code donated by Sébastien Brisard.
+===============================================================================
+
+
+The complete text of licenses and disclaimers associated with the the original
+sources enumerated above at the time of code translation are in the LICENSE.txt
+file.
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.core5  Name: httpcore5-h2  Version: 5.2.4
+
+Notice: Apache HttpComponents Core HTTP/2
+Copyright 2005-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-admin  Version: 1.0.1
+
+Notice: Kerby-kerb Admin
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-crypto  Version: 1.0.1
+
+Notice: Kerby-kerb Crypto
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.orc  Name: orc-core  Version: 1.9.4
+
+Notice: ORC Core
+Copyright 2013-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-shims  Version: 2.3.9
+
+Notice: Hive Shims
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-pkix  Version: 1.0.1
+
+Notice: Kerby PKIX Project
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive.shims  Name: hive-shims-scheduler  Version: 2.3.9
+
+Notice: Hive Shims Scheduler
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.ant  Name: ant  Version: 1.9.1
+Group: org.apache.ant  Name: ant-launcher  Version: 1.9.1
+
+Notice: Apache Ant
+   Copyright 1999-2013 The Apache Software Foundation
+
+   The <sync> task is based on code Copyright (c) 2002, Landmark
+   Graphics Corp that has been kindly donated to the Apache Software
+   Foundation.
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-lang  Name: commons-lang  Version: 2.6
+
+Notice: Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-configuration2  Version: 2.8.0
+
+Notice: Apache Commons Configuration
+Copyright 2001-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-config  Version: 1.0.1
+
+Notice: Kerby Config
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-avro  Version: 1.13.1
+
+Notice: Apache Parquet MR (Incubating)
+Copyright 2014-2015 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Avro, which includes the following in
+its NOTICE file:
+
+  Apache Avro
+  Copyright 2010-2015 The Apache Software Foundation
+
+  This product includes software developed at
+  The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-netty-shaded  Version: 1.62.2
+
+Notice: The Netty Project
+                            =================
+
+Please visit the Netty web site for more information:
+
+  * http://netty.io/
+
+Copyright 2016 The Netty Project
+
+The Netty Project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+-------------------------------------------------------------------------------
+This product contains a forked and modified version of Tomcat Native
+
+  * LICENSE:
+    * license/LICENSE.tomcat-native.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * http://tomcat.apache.org/native-doc/
+    * https://svn.apache.org/repos/asf/tomcat/native/
+
+This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+
+  * LICENSE:
+    * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/takari/maven-wrapper
+
+This product contains small piece of code to support AIX, taken from netbsd.
+
+  * LICENSE:
+    * license/LICENSE.aix-netbsd.txt (OpenSSL License)
+  * HOMEPAGE:
+    * https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/crypto/external/bsd/openssl/dist
+
+
+This product contains code from boringssl.
+
+  * LICENSE (Combination ISC and OpenSSL license)
+    * license/LICENSE.boringssl.txt (Combination ISC and OpenSSL license)
+  * HOMEPAGE:
+    * https://boringssl.googlesource.com/boringssl/
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator  Name: curator-recipes  Version: 5.2.0
+
+Notice: Curator Recipes
+Copyright 2011-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-storage-api  Version: 2.4.0
+
+Notice: Hive Storage API
+Copyright 2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-annotations  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-auth  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-client  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-common  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-hdfs-client  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-mapreduce-client-common  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-mapreduce-client-core  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-mapreduce-client-jobclient  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-yarn-api  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-yarn-client  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-yarn-common  Version: 3.3.6
+
+Notice: Apache Hadoop
+Copyright 2006 and onwards The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+Export Control Notice
+---------------------
+
+This distribution includes cryptographic software.  The country in
+which you currently reside may have restrictions on the import,
+possession, use, and/or re-export to another country, of
+encryption software.  BEFORE using any encryption software, please
+check your country's laws, regulations and policies concerning the
+import, possession, or use, and re-export of encryption software, to
+see if this is permitted.  See <http://www.wassenaar.org/> for more
+information.
+
+The U.S. Government Department of Commerce, Bureau of Industry and
+Security (BIS), has classified this software as Export Commodity
+Control Number (ECCN) 5D002.C.1, which includes information security
+software using or performing cryptographic functions with asymmetric
+algorithms.  The form and manner of this Apache Software Foundation
+distribution makes it eligible for export under the License Exception
+ENC Technology Software Unrestricted (TSU) exception (see the BIS
+Export Administration Regulations, Section 740.13) for both object
+code and source code.
+
+The following provides more details on the included cryptographic software:
+
+This software uses the SSL libraries from the Jetty project written
+by mortbay.org.
+Hadoop Yarn Server Web Proxy uses the BouncyCastle Java
+cryptography APIs written by the Legion of the Bouncy Castle Inc.
+
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.17.1
+
+Notice: # Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson components are licensed under Apache (Software) License, version 2.0,
+as per accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-common  Version: 2.3.9
+
+Notice: Hive Common
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-common  Version: 1.0.1
+
+Notice: Kerby-kerb Common
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-xdr  Version: 1.0.1
+
+Notice: Kerby XDR Project
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-jackson  Version: 1.13.1
+
+Notice: # Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.activation  Name: jakarta.activation-api  Version: 1.2.2
+
+Notice: # Notices for Jakarta Activation
+
+This content is produced and maintained by Jakarta Activation project.
+
+* Project home: https://projects.eclipse.org/projects/ee4j.jaf
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Distribution License v. 1.0,
+which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: BSD-3-Clause
+
+## Source Code
+
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse-ee4j/jaf
+
+## Third-party Content
+
+This project leverages the following third party content.
+
+JUnit (4.12)
+
+* License: Eclipse Public License
+
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.xml.bind  Name: jakarta.xml.bind-api  Version: 2.3.3
+
+Notice: [//]: # " Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved. "
+[//]: # "  "
+[//]: # " This program and the accompanying materials are made available under the "
+[//]: # " terms of the Eclipse Distribution License v. 1.0, which is available at "
+[//]: # " http://www.eclipse.org/org/documents/edl-v10.php. "
+[//]: # "  "
+[//]: # " SPDX-License-Identifier: BSD-3-Clause "
+
+# Notices for Jakarta XML Binding
+
+This content is produced and maintained by the Jakarta XML Binding
+project.
+
+* Project home: https://projects.eclipse.org/projects/ee4j.jaxb
+
+## Trademarks
+
+Jakarta XML Binding is a trademark of the Eclipse Foundation.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Distribution License v. 1.0 which is available at
+http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: BSD-3-Clause
+
+## Source Code
+
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse-ee4j/jaxb-api
+* https://github.com/eclipse-ee4j/jaxb-tck
+
+## Third-party Content
+
+This project leverages the following third party content.
+
+Apache River (3.0.0)
+
+* License: Apache-2.0 AND BSD-3-Clause
+
+ASM 7 (n/a)
+
+* License: BSD-3-Clause
+* Project: https://asm.ow2.io/
+* Source:
+   https://repository.ow2.org/nexus/#nexus-search;gav~org.ow2.asm~asm-commons~~~~kw,versionexpand
+
+JTHarness (5.0)
+
+* License: (GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)	
+* Project: https://wiki.openjdk.java.net/display/CodeTools/JT+Harness
+* Source: http://hg.openjdk.java.net/code-tools/jtharness/
+
+normalize.css (3.0.2)
+
+* License: MIT
+
+SigTest (n/a)
+
+* License: GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+## Cryptography
+
+Content may contain encryption software. The country in which you are currently
+may have restrictions on the import, possession, and use, and/or re-export to
+another country, of encryption software. BEFORE using any encryption software,
+please check the country's laws, regulations and policies concerning the import,
+possession, or use, and re-export of encryption software, to see if this is
+permitted.
+
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.module  Name: jackson-module-jaxb-annotations  Version: 2.17.1
+
+Notice: # Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers, as well as supported
+commercially by FasterXML.com.
+
+## Licensing
+
+Jackson core and extension components may licensed under different licenses.
+To find the details that apply to this artifact see the accompanying LICENSE file.
+For more information, including possible other licensing options, contact
+FasterXML.com (http://fasterxml.com).
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-compress  Version: 1.26.0
+
+Notice: Apache Commons Compress
+Copyright 2002-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-client  Version: 1.0.1
+
+Notice: Kerby-kerb Client
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: datanucleus-core  Version: 4.1.17
+
+Notice: =========================================================================
+==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+==  Version 2.0, in this case for the DataNucleus distribution.        ==
+=========================================================================
+
+===================================================================
+This product includes software developed by many individuals,
+including the following:
+===================================================================
+Erik Bengtson
+Andy Jefferson
+
+
+===================================================================
+This product has included contributions from some individuals,
+including the following:
+===================================================================
+Joerg von Frantzius
+Thomas Marti
+Barry Haddow
+Marco Schulze
+Ralph Ullrich
+David Ezzio
+Brendan de Beer
+David Eaves
+Martin Taal
+Tony Lai
+Roland Szabo
+Marcus Mennemeier
+Xuan Baldauf
+Eric Sultan
+
+
+===================================================================
+This product also includes software developed by the TJDO project
+(http://tjdo.sourceforge.net/).
+===================================================================
+
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: annotations  Version: 2.26.25
+Group: software.amazon.awssdk  Name: apache-client  Version: 2.26.25
+Group: software.amazon.awssdk  Name: arns  Version: 2.26.25
+Group: software.amazon.awssdk  Name: auth  Version: 2.26.25
+Group: software.amazon.awssdk  Name: aws-core  Version: 2.26.25
+Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.26.25
+Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.26.25
+Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.26.25
+Group: software.amazon.awssdk  Name: checksums  Version: 2.26.25
+Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: crt-core  Version: 2.26.25
+Group: software.amazon.awssdk  Name: dynamodb  Version: 2.26.25
+Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: glue  Version: 2.26.25
+Group: software.amazon.awssdk  Name: http-auth  Version: 2.26.25
+Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.26.25
+Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.26.25
+Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: iam  Version: 2.26.25
+Group: software.amazon.awssdk  Name: identity-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: json-utils  Version: 2.26.25
+Group: software.amazon.awssdk  Name: kms  Version: 2.26.25
+Group: software.amazon.awssdk  Name: lakeformation  Version: 2.26.25
+Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.26.25
+Group: software.amazon.awssdk  Name: profiles  Version: 2.26.25
+Group: software.amazon.awssdk  Name: protocol-core  Version: 2.26.25
+Group: software.amazon.awssdk  Name: regions  Version: 2.26.25
+Group: software.amazon.awssdk  Name: retries  Version: 2.26.25
+Group: software.amazon.awssdk  Name: retries-spi  Version: 2.26.25
+Group: software.amazon.awssdk  Name: s3  Version: 2.26.25
+Group: software.amazon.awssdk  Name: sdk-core  Version: 2.26.25
+Group: software.amazon.awssdk  Name: sso  Version: 2.26.25
+Group: software.amazon.awssdk  Name: sts  Version: 2.26.25
+Group: software.amazon.awssdk  Name: utils  Version: 2.26.25
+
+Notice: AWS SDK for Java 2.0
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+This product includes software developed by
+Amazon Technologies, Inc (http://www.amazon.com/).
+
+**********************
+THIRD PARTY COMPONENTS
+**********************
+This software includes third party software subject to the following copyrights:
+- XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+- PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+- Apache Commons Lang - https://github.com/apache/commons-lang
+- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
+- Jackson-core - https://github.com/FasterXML/jackson-core
+- Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
+
+The licenses for these third party components are included in LICENSE.txt
+
+- For Apache Commons Lang see also this required NOTICE:
+  Apache Commons Lang
+  Copyright 2001-2020 The Apache Software Foundation
+  
+  This product includes software developed at
+  The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.client5  Name: httpclient5  Version: 5.3.1
+
+Notice: Apache HttpClient
+Copyright 1999-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive.shims  Name: hive-shims-common  Version: 2.3.9
+
+Notice: Hive Shims Common
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-logging  Name: commons-logging  Version: 1.2
+
+Notice: Apache Commons Logging
+Copyright 2003-2014 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-dbcp  Name: commons-dbcp  Version: 1.4
+
+Notice: Apache Commons DBCP
+Copyright 2001-2010 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-net  Name: commons-net  Version: 3.9.0
+
+Notice: Apache Commons Net
+Copyright 2001-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: com.squareup.okhttp3  Name: okhttp  Version: 4.9.3
+
+Notice: Note that publicsuffixes.gz is compiled from The Public Suffix List:
+https://publicsuffix.org/list/public_suffix_list.dat
+
+It is subject to the terms of the Mozilla Public License, v. 2.0:
+https://mozilla.org/MPL/2.0/
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-collections  Name: commons-collections  Version: 3.2.2
+
+Notice: Apache Commons Collections
+Copyright 2001-2015 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.activation  Name: jakarta.activation-api  Version: 1.2.1
+
+Notice: # Notices for Eclipse Project for JAF
+
+This content is produced and maintained by the Eclipse Project for JAF project.
+
+* Project home: https://projects.eclipse.org/projects/ee4j.jaf
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Distribution License v. 1.0,
+which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: BSD-3-Clause
+
+## Source Code
+
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse-ee4j/jaf
+
+## Third-party Content
+
+This project leverages the following third party content.
+
+JUnit (4.12)
+
+* License: Eclipse Public License
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.derby  Name: derby  Version: 10.10.2.0
+
+Notice: =========================================================================
+==  NOTICE file corresponding to section 4(d) of the Apache License,
+==  Version 2.0, in this case for the Apache Derby distribution.
+==
+==  DO NOT EDIT THIS FILE DIRECTLY. IT IS GENERATED
+==  BY THE buildnotice TARGET IN THE TOP LEVEL build.xml FILE.
+==
+=========================================================================
+
+Apache Derby
+Copyright 2004-2014 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+
+=========================================================================
+
+Portions of Derby were originally developed by
+International Business Machines Corporation and are
+licensed to the Apache Software Foundation under the
+"Software Grant and Corporate Contribution License Agreement",
+informally known as the "Derby CLA".
+The following copyright notice(s) were affixed to portions of the code
+with which this file is now or was at one time distributed
+and are placed here unaltered.
+
+(C) Copyright 1997,2004 International Business Machines Corporation.  All rights reserved.
+
+(C) Copyright IBM Corp. 2003. 
+
+
+=========================================================================
+
+
+The portion of the functionTests under 'nist' was originally 
+developed by the National Institute of Standards and Technology (NIST), 
+an agency of the United States Department of Commerce, and adapted by
+International Business Machines Corporation in accordance with the NIST
+Software Acknowledgment and Redistribution document at
+http://www.itl.nist.gov/div897/ctg/sql_form.htm
+
+
+
+=========================================================================
+
+
+The JDBC apis for small devices and JDBC3 (under java/stubs/jsr169 and
+java/stubs/jdbc3) were produced by trimming sources supplied by the
+Apache Harmony project. In addition, the Harmony SerialBlob and
+SerialClob implementations are used. The following notice covers the Harmony sources:
+
+Portions of Harmony were originally developed by
+Intel Corporation and are licensed to the Apache Software
+Foundation under the "Software Grant and Corporate Contribution
+License Agreement", informally known as the "Intel Harmony CLA".
+
+
+=========================================================================
+
+
+The Derby build relies on source files supplied by the Apache Felix
+project. The following notice covers the Felix files:
+
+  Apache Felix Main
+  Copyright 2008 The Apache Software Foundation
+
+
+  I. Included Software
+
+  This product includes software developed at
+  The Apache Software Foundation (http://www.apache.org/).
+  Licensed under the Apache License 2.0.
+
+  This product includes software developed at
+  The OSGi Alliance (http://www.osgi.org/).
+  Copyright (c) OSGi Alliance (2000, 2007).
+  Licensed under the Apache License 2.0.
+
+  This product includes software from http://kxml.sourceforge.net.
+  Copyright (c) 2002,2003, Stefan Haustein, Oberhausen, Rhld., Germany.
+  Licensed under BSD License.
+
+  II. Used Software
+
+  This product uses software developed at
+  The OSGi Alliance (http://www.osgi.org/).
+  Copyright (c) OSGi Alliance (2000, 2007).
+  Licensed under the Apache License 2.0.
+
+
+  III. License Summary
+  - Apache License 2.0
+  - BSD License
+
+
+=========================================================================
+
+
+The Derby build relies on jar files supplied by the Apache Xalan
+project. The following notice covers the Xalan jar files:
+
+   =========================================================================
+   ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+   ==  Version 2.0, in this case for the Apache Xalan Java distribution.  ==
+   =========================================================================
+
+   Apache Xalan (Xalan XSLT processor)
+   Copyright 1999-2006 The Apache Software Foundation
+
+   Apache Xalan (Xalan serializer)
+   Copyright 1999-2006 The Apache Software Foundation
+
+   This product includes software developed at
+   The Apache Software Foundation (http://www.apache.org/).
+
+   =========================================================================
+   Portions of this software was originally based on the following:
+     - software copyright (c) 1999-2002, Lotus Development Corporation.,
+       http://www.lotus.com.
+     - software copyright (c) 2001-2002, Sun Microsystems.,
+       http://www.sun.com.
+     - software copyright (c) 2003, IBM Corporation., 
+       http://www.ibm.com.
+       
+   =========================================================================
+   The binary distribution package (ie. jars, samples and documentation) of
+   this product includes software developed by the following:
+       
+     - The Apache Software Foundation 
+         - Xerces Java - see LICENSE.txt 
+         - JAXP 1.3 APIs - see LICENSE.txt
+         - Bytecode Engineering Library - see LICENSE.txt
+         - Regular Expression - see LICENSE.txt
+       
+     - Scott Hudson, Frank Flannery, C. Scott Ananian 
+         - CUP Parser Generator runtime (javacup\runtime) - see LICENSE.txt 
+ 
+   ========================================================================= 
+   The source distribution package (ie. all source and tools required to build
+   Xalan Java) of this product includes software developed by the following:
+       
+     - The Apache Software Foundation
+         - Xerces Java - see LICENSE.txt 
+         - JAXP 1.3 APIs - see LICENSE.txt
+         - Bytecode Engineering Library - see LICENSE.txt
+         - Regular Expression - see LICENSE.txt
+         - Ant - see LICENSE.txt
+         - Stylebook doc tool - see LICENSE.txt    
+       
+     - Elliot Joel Berk and C. Scott Ananian 
+         - Lexical Analyzer Generator (JLex) - see LICENSE.txt
+
+   =========================================================================       
+   Apache Xerces Java
+   Copyright 1999-2006 The Apache Software Foundation
+
+   This product includes software developed at
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Portions of Apache Xerces Java in xercesImpl.jar and xml-apis.jar
+   were originally based on the following:
+     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
+     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+     - voluntary contributions made by Paul Eng on behalf of the 
+       Apache Software Foundation that were originally developed at iClick, Inc.,
+       software copyright (c) 1999.    
+
+   =========================================================================   
+   Apache xml-commons xml-apis (redistribution of xml-apis.jar)
+
+   Apache XML Commons
+   Copyright 2001-2003,2006 The Apache Software Foundation.
+
+   This product includes software developed at
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Portions of this software were originally based on the following:
+     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
+     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+     - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-io  Name: commons-io  Version: 2.15.1
+
+Notice: Apache Commons IO
+Copyright 2002-2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: com.google.inject  Name: guice  Version: 4.0
+
+Notice: Google Guice - Core Library
+Copyright 2006-2015 Google, Inc.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: ch.qos.reload4j  Name: reload4j  Version: 1.2.22
+Group: log4j  Name: log4j  Version: 1.2.17
+
+Notice: Apache log4j
+Copyright 2007 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-codec  Name: commons-codec  Version: 1.17.1
+
+Notice: Apache Commons Codec
+Copyright 2002-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: joda-time  Name: joda-time  Version: 2.8.1
+
+Notice: =============================================================================
+= NOTICE file corresponding to section 4d of the Apache License Version 2.0 =
+=============================================================================
+This product includes software developed by
+Joda.org (http://www.joda.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-text  Version: 1.10.0
+
+Notice: Apache Commons Text
+Copyright 2014-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-identity  Version: 1.0.1
+
+Notice: Kerby-kerb Identity
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator  Name: curator-client  Version: 5.2.0
+
+Notice: Curator Client
+Copyright 2011-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.thrift  Name: libthrift  Version: 0.9.3
+
+Notice: Apache Thrift
+Copyright 2006-2010 The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.17.1
+Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.26.25
+
+Notice: # Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+and the licenses and copyrights that apply to that code.
+
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.17.1
+
+Notice: # Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Licensing
+
+Jackson components are licensed under Apache (Software) License, version 2.0,
+as per accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator  Name: curator-framework  Version: 5.2.0
+
+Notice: Curator Framework
+Copyright 2011-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents  Name: httpclient  Version: 4.5.13
+
+Notice: Apache HttpClient
+Copyright 1999-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-util  Version: 1.0.1
+
+Notice: Kerby Util
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-serde  Version: 2.3.9
+
+Notice: Hive Serde
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.core5  Name: httpcore5  Version: 5.2.4
+
+Notice: Apache HttpComponents Core HTTP/1.1
+Copyright 2005-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-core  Version: 1.0.1
+
+Notice: Kerby-kerb core
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: datanucleus-api-jdo  Version: 4.2.4
+
+Notice: =========================================================================
+==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+==  Version 2.0, in this case for the DataNucleus distribution.        ==
+=========================================================================
+
+===================================================================
+This product includes software developed by many individuals,
+including the following:
+===================================================================
+Erik Bengtson
+Andy Jefferson
+
+
+===================================================================
+This product has included contributions from some individuals,
+including the following:
+===================================================================
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-util  Version: 1.0.1
+
+Notice: Kerby-kerb Util
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.avro  Name: avro  Version: 1.11.3
+
+Notice: Apache Avro
+Copyright 2009-2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: datanucleus-rdbms  Version: 4.1.19
+
+Notice: =========================================================================
+==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+==  Version 2.0, in this case for the DataNucleus distribution.        ==
+=========================================================================
+
+===================================================================
+This product includes software developed by many individuals,
+including the following:
+===================================================================
+Andy Jefferson
+Erik Bengtson
+Joerg von Frantzius
+Marco Schulze
+
+
+===================================================================
+This product has included contributions from some individuals,
+including the following:
+===================================================================
+Barry Haddow
+Ralph Ullrich
+David Ezzio
+Brendan de Beer
+David Eaves
+Martin Taal
+Tony Lai
+Roland Szabo
+Anton Troshin (Timesten)
+
+
+===================================================================
+This product also includes software developed by the TJDO project
+(http://tjdo.sourceforge.net/).
+===================================================================
+
+===================================================================
+This product also includes software developed by the Apache Commons project
+(http://commons.apache.org/).
+===================================================================
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-metastore  Version: 2.3.9
+
+Notice: Hive Metastore
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-cli  Name: commons-cli  Version: 1.2
+
+Notice: Apache Commons CLI
+Copyright 2001-2009 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-pool  Name: commons-pool  Version: 1.6
+
+Notice: Apache Commons Pool
+Copyright 2001-2012 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: javax.jdo  Name: jdo-api  Version: 3.0.1
+
+Notice: Apache Java Data Objects (JDO)
+Copyright 2005-2006 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.orc  Name: orc-shims  Version: 1.9.4
+
+Notice: ORC Shims
+Copyright 2013-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-guava  Version: 1.2.0
+Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-protobuf_3_7  Version: 1.1.1
+
+Notice: Apache Hadoop Third-party Libs
+Copyright 2020 and onwards The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents  Name: httpcore  Version: 4.4.16
+
+Notice: Apache HttpCore
+Copyright 2005-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-beanutils  Name: commons-beanutils  Version: 1.9.4
+
+Notice: Apache Commons BeanUtils
+Copyright 2000-2019 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.17.1
+Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.17.1
+
+Notice: # Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-simplekdc  Version: 1.0.1
+
+Notice: Kerb Simple Kdc
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-server  Version: 1.0.1
+
+Notice: Kerby-kerb Server
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive.shims  Name: hive-shims-0.23  Version: 2.3.9
+
+Notice: Hive Shims 0.23
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-asn1  Version: 1.0.1
+
+Notice: Kerby ASN1 Project
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: token-provider  Version: 1.0.1
+
+Notice: Token provider
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.jaxrs  Name: jackson-jaxrs-json-provider  Version: 2.17.1
+
+Notice: # Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers, as well as supported
+commercially by FasterXML.com.
+
+## Licensing
+
+Jackson core and extension components may be licensed under different licenses.
+To find the details that apply to this artifact see the accompanying LICENSE file.
+For more information, including possible other licensing options, contact
+FasterXML.com (http://fasterxml.com).
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.yetus  Name: audience-annotations  Version: 0.13.0
+
+Notice: Apache Yetus - Audience Annotations
+Copyright 2015-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-lang3  Version: 3.14.0
+
+Notice: Apache Commons Lang
+Copyright 2001-2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-client  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-http  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-io  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-security  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-servlet  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-util  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-util-ajax  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-webapp  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-xml  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty.websocket  Name: websocket-api  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty.websocket  Name: websocket-client  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty.websocket  Name: websocket-common  Version: 9.4.51.v20230217
+
+Notice: ==============================================================
+ Jetty Web Container
+ Copyright 1995-2018 Mort Bay Consulting Pty Ltd.
+==============================================================
+
+The Jetty Web Container is Copyright Mort Bay Consulting Pty Ltd
+unless otherwise noted.
+
+Jetty is dual licensed under both
+
+  * The Apache 2.0 License
+    http://www.apache.org/licenses/LICENSE-2.0.html
+
+      and
+
+  * The Eclipse Public 1.0 License
+    http://www.eclipse.org/legal/epl-v10.html
+
+Jetty may be distributed under either license.
+
+------
+Eclipse
+
+The following artifacts are EPL.
+ * org.eclipse.jetty.orbit:org.eclipse.jdt.core
+
+The following artifacts are EPL and ASL2.
+ * org.eclipse.jetty.orbit:javax.security.auth.message
+
+
+The following artifacts are EPL and CDDL 1.0.
+ * org.eclipse.jetty.orbit:javax.mail.glassfish
+
+
+------
+Oracle
+
+The following artifacts are CDDL + GPLv2 with classpath exception.
+https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+
+ * javax.servlet:javax.servlet-api
+ * javax.annotation:javax.annotation-api
+ * javax.transaction:javax.transaction-api
+ * javax.websocket:javax.websocket-api
+
+------
+Oracle OpenJDK
+
+If ALPN is used to negotiate HTTP/2 connections, then the following
+artifacts may be included in the distribution or downloaded when ALPN 
+module is selected. 
+
+ * java.sun.security.ssl
+
+These artifacts replace/modify OpenJDK classes.  The modififications
+are hosted at github and both modified and original are under GPL v2 with 
+classpath exceptions.
+http://openjdk.java.net/legal/gplv2+ce.html
+
+
+------
+OW2
+
+The following artifacts are licensed by the OW2 Foundation according to the
+terms of http://asm.ow2.org/license.html
+
+org.ow2.asm:asm-commons
+org.ow2.asm:asm
+
+
+------
+Apache
+
+The following artifacts are ASL2 licensed.
+
+org.apache.taglibs:taglibs-standard-spec
+org.apache.taglibs:taglibs-standard-impl
+
+
+------
+MortBay
+
+The following artifacts are ASL2 licensed.  Based on selected classes from 
+following Apache Tomcat jars, all ASL2 licensed.
+
+org.mortbay.jasper:apache-jsp
+  org.apache.tomcat:tomcat-jasper
+  org.apache.tomcat:tomcat-juli
+  org.apache.tomcat:tomcat-jsp-api
+  org.apache.tomcat:tomcat-el-api
+  org.apache.tomcat:tomcat-jasper-el
+  org.apache.tomcat:tomcat-api
+  org.apache.tomcat:tomcat-util-scan
+  org.apache.tomcat:tomcat-util
+
+org.mortbay.jasper:apache-el
+  org.apache.tomcat:tomcat-jasper-el
+  org.apache.tomcat:tomcat-el-api
+
+
+------
+Mortbay
+
+The following artifacts are CDDL + GPLv2 with classpath exception.
+
+https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+
+org.eclipse.jetty.toolchain:jetty-schemas
+
+------
+Assorted
+
+The UnixCrypt.java code implements the one way cryptography used by
+Unix systems for simple password protection.  Copyright 1996 Aki Yoshida,
+modified April 2001  by Iris Van den Broeke, Daniel Deville.
+Permission to use, copy, modify and distribute UnixCrypt
+for non-commercial or commercial purposes and without fee is
+granted provided that the copyright notice appears in all copies.
+
+
+--------------------------------------------------------------------------------

--- a/kafka-connect/kafka-connect-runtime/NOTICE
+++ b/kafka-connect/kafka-connect-runtime/NOTICE
@@ -7,25 +7,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-This project includes code from Kite, developed at Cloudera, Inc. with
-the following copyright notice:
-
-| Copyright 2013 Cloudera Inc.
-|
-| Licensed under the Apache License, Version 2.0 (the "License");
-| you may not use this file except in compliance with the License.
-| You may obtain a copy of the License at
-|
-|   http://www.apache.org/licenses/LICENSE-2.0
-|
-| Unless required by applicable law or agreed to in writing, software
-| distributed under the License is distributed on an "AS IS" BASIS,
-| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-| See the License for the specific language governing permissions and
-| limitations under the License.
-
---------------------------------------------------------------------------------
-
 This binary artifact contains code from the following projects:
 
 --------------------------------------------------------------------------------

--- a/kafka-connect/kafka-connect-runtime/NOTICE
+++ b/kafka-connect/kafka-connect-runtime/NOTICE
@@ -30,49 +30,320 @@ This binary artifact contains code from the following projects:
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: apache-client  Version: 2.27.21
-Group: software.amazon.awssdk  Name: auth  Version: 2.27.21
-Group: software.amazon.awssdk  Name: dynamodb  Version: 2.27.21
-Group: software.amazon.awssdk  Name: glue  Version: 2.27.21
-Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.27.21
-Group: software.amazon.awssdk  Name: iam  Version: 2.27.21
-Group: software.amazon.awssdk  Name: kms  Version: 2.27.21
-Group: software.amazon.awssdk  Name: lakeformation  Version: 2.27.21
-Group: software.amazon.awssdk  Name: s3  Version: 2.27.21
-Group: software.amazon.awssdk  Name: sso  Version: 2.27.21
-Group: software.amazon.awssdk  Name: sts  Version: 2.27.21
+Group: org.apache.commons  Name: commons-math3  Version: 3.1.1
 
-Notice: AWS SDK for Java 2.0
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Notice: Apache Commons Math
+Copyright 2001-2012 The Apache Software Foundation
 
 This product includes software developed by
-Amazon Technologies, Inc (http://www.amazon.com/).
+The Apache Software Foundation (http://www.apache.org/).
 
-**********************
-THIRD PARTY COMPONENTS
-**********************
-This software includes third party software subject to the following copyrights:
-- XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
-- PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
-- Apache Commons Lang - https://github.com/apache/commons-lang
-- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
-- Jackson-core - https://github.com/FasterXML/jackson-core
-- Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
+===============================================================================
 
-The licenses for these third party components are included in LICENSE.txt
+The BracketFinder (package org.apache.commons.math3.optimization.univariate)
+and PowellOptimizer (package org.apache.commons.math3.optimization.general)
+classes are based on the Python code in module "optimize.py" (version 0.5)
+developed by Travis E. Oliphant for the SciPy library (http://www.scipy.org/)
+Copyright © 2003-2009 SciPy Developers.
+===============================================================================
 
-- For Apache Commons Lang see also this required NOTICE:
-  Apache Commons Lang
-  Copyright 2001-2020 The Apache Software Foundation
+The LinearConstraint, LinearObjectiveFunction, LinearOptimizer,
+RelationShip, SimplexSolver and SimplexTableau classes in package
+org.apache.commons.math3.optimization.linear include software developed by
+Benjamin McCann (http://www.benmccann.com) and distributed with
+the following copyright: Copyright 2009 Google Inc.
+===============================================================================
 
-  This product includes software developed at
-  The Apache Software Foundation (https://www.apache.org/).
+This product includes software developed by the
+University of Chicago, as Operator of Argonne National
+Laboratory.
+The LevenbergMarquardtOptimizer class in package
+org.apache.commons.math3.optimization.general includes software
+translated from the lmder, lmpar and qrsolv Fortran routines
+from the Minpack package
+Minpack Copyright Notice (1999) University of Chicago.  All rights reserved
+===============================================================================
+
+The GraggBulirschStoerIntegrator class in package
+org.apache.commons.math3.ode.nonstiff includes software translated
+from the odex Fortran routine developed by E. Hairer and G. Wanner.
+Original source copyright:
+Copyright (c) 2004, Ernst Hairer
+===============================================================================
+
+The EigenDecompositionImpl class in package
+org.apache.commons.math3.linear includes software translated
+from some LAPACK Fortran routines.  Original source copyright:
+Copyright (c) 1992-2008 The University of Tennessee.  All rights reserved.
+===============================================================================
+
+The MersenneTwister class in package org.apache.commons.math3.random
+includes software translated from the 2002-01-26 version of
+the Mersenne-Twister generator written in C by Makoto Matsumoto and Takuji
+Nishimura. Original source copyright:
+Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+All rights reserved
+===============================================================================
+
+The LocalizedFormatsTest class in the unit tests is an adapted version of
+the OrekitMessagesTest class from the orekit library distributed under the
+terms of the Apache 2 licence. Original source copyright:
+Copyright 2010 CS Systèmes d'Information
+===============================================================================
+
+The HermiteInterpolator class and its corresponding test have been imported from
+the orekit library distributed under the terms of the Apache 2 licence. Original
+source copyright:
+Copyright 2010-2012 CS Systèmes d'Information
+===============================================================================
+
+The creation of the package "o.a.c.m.analysis.integration.gauss" was inspired
+by an original code donated by Sébastien Brisard.
+===============================================================================
+
+
+The complete text of licenses and disclaimers associated with the the original
+sources enumerated above at the time of code translation are in the LICENSE.txt
+file.
 
 
 --------------------------------------------------------------------------------
 
+Group: org.apache.httpcomponents.core5  Name: httpcore5-h2  Version: 5.2.4
+
+Notice: Apache HttpComponents Core HTTP/2
+Copyright 2005-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-admin  Version: 1.0.1
+
+Notice: Kerby-kerb Admin
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-crypto  Version: 1.0.1
+
+Notice: Kerby-kerb Crypto
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.orc  Name: orc-core  Version: 1.9.4
+
+Notice: ORC Core
+Copyright 2013-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-shims  Version: 2.3.9
+
+Notice: Hive Shims
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-pkix  Version: 1.0.1
+
+Notice: Kerby PKIX Project
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive.shims  Name: hive-shims-scheduler  Version: 2.3.9
+
+Notice: Hive Shims Scheduler
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.ant  Name: ant  Version: 1.9.1
+Group: org.apache.ant  Name: ant-launcher  Version: 1.9.1
+
+Notice: Apache Ant
+   Copyright 1999-2013 The Apache Software Foundation
+
+   The <sync> task is based on code Copyright (c) 2002, Landmark
+   Graphics Corp that has been kindly donated to the Apache Software
+   Foundation.
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-lang  Name: commons-lang  Version: 2.6
+
+Notice: Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-configuration2  Version: 2.8.0
+
+Notice: Apache Commons Configuration
+Copyright 2001-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-config  Version: 1.0.1
+
+Notice: Kerby Config
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-avro  Version: 1.13.1
+
+Notice: Apache Parquet MR (Incubating)
+Copyright 2014-2015 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Avro, which includes the following in
+its NOTICE file:
+
+  Apache Avro
+  Copyright 2010-2015 The Apache Software Foundation
+
+  This product includes software developed at
+  The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: io.grpc  Name: grpc-netty-shaded  Version: 1.62.2
+
+Notice: The Netty Project
+                            =================
+
+Please visit the Netty web site for more information:
+
+  * http://netty.io/
+
+Copyright 2016 The Netty Project
+
+The Netty Project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+-------------------------------------------------------------------------------
+This product contains a forked and modified version of Tomcat Native
+
+  * LICENSE:
+    * license/LICENSE.tomcat-native.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * http://tomcat.apache.org/native-doc/
+    * https://svn.apache.org/repos/asf/tomcat/native/
+
+This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+
+  * LICENSE:
+    * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/takari/maven-wrapper
+
+This product contains small piece of code to support AIX, taken from netbsd.
+
+  * LICENSE:
+    * license/LICENSE.aix-netbsd.txt (OpenSSL License)
+  * HOMEPAGE:
+    * https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/crypto/external/bsd/openssl/dist
+
+
+This product contains code from boringssl.
+
+  * LICENSE (Combination ISC and OpenSSL license)
+    * license/LICENSE.boringssl.txt (Combination ISC and OpenSSL license)
+  * HOMEPAGE:
+    * https://boringssl.googlesource.com/boringssl/
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator  Name: curator-recipes  Version: 5.2.0
+
+Notice: Curator Recipes
+Copyright 2011-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-storage-api  Version: 2.4.0
+
+Notice: Hive Storage API
+Copyright 2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-annotations  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-auth  Version: 3.3.6
 Group: org.apache.hadoop  Name: hadoop-client  Version: 3.3.6
 Group: org.apache.hadoop  Name: hadoop-common  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-hdfs-client  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-mapreduce-client-common  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-mapreduce-client-core  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-mapreduce-client-jobclient  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-yarn-api  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-yarn-client  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-yarn-common  Version: 3.3.6
 
 Notice: Apache Hadoop
 Copyright 2006 and onwards The Apache Software Foundation.
@@ -112,9 +383,36 @@ cryptography APIs written by the Legion of the Bouncy Castle Inc.
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.hive  Name: hive-metastore  Version: 2.3.9
+Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.17.2
 
-Notice: Hive Metastore
+Notice: # Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson components are licensed under Apache (Software) License, version 2.0,
+as per accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive  Name: hive-common  Version: 2.3.9
+
+Notice: Hive Common
 Copyright 2021 The Apache Software Foundation
 
 This product includes software developed at
@@ -123,29 +421,735 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.parquet  Name: parquet-avro  Version: 1.13.1
+Group: org.apache.kerby  Name: kerb-common  Version: 1.0.1
 
-Notice: Apache Parquet MR (Incubating)
-Copyright 2014-2015 The Apache Software Foundation
+Notice: Kerby-kerb Common
+Copyright 2014-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+
 --------------------------------------------------------------------------------
 
-This product includes code from Apache Avro, which includes the following in
-its NOTICE file:
+Group: org.apache.kerby  Name: kerby-xdr  Version: 1.0.1
 
-  Apache Avro
-  Copyright 2010-2015 The Apache Software Foundation
+Notice: Kerby XDR Project
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet  Name: parquet-jackson  Version: 1.13.1
+
+Notice: # Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.activation  Name: jakarta.activation-api  Version: 1.2.2
+
+Notice: # Notices for Jakarta Activation
+
+This content is produced and maintained by Jakarta Activation project.
+
+* Project home: https://projects.eclipse.org/projects/ee4j.jaf
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Distribution License v. 1.0,
+which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: BSD-3-Clause
+
+## Source Code
+
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse-ee4j/jaf
+
+## Third-party Content
+
+This project leverages the following third party content.
+
+JUnit (4.12)
+
+* License: Eclipse Public License
+
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.xml.bind  Name: jakarta.xml.bind-api  Version: 2.3.3
+
+Notice: [//]: # " Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved. "
+[//]: # "  "
+[//]: # " This program and the accompanying materials are made available under the "
+[//]: # " terms of the Eclipse Distribution License v. 1.0, which is available at "
+[//]: # " http://www.eclipse.org/org/documents/edl-v10.php. "
+[//]: # "  "
+[//]: # " SPDX-License-Identifier: BSD-3-Clause "
+
+# Notices for Jakarta XML Binding
+
+This content is produced and maintained by the Jakarta XML Binding
+project.
+
+* Project home: https://projects.eclipse.org/projects/ee4j.jaxb
+
+## Trademarks
+
+Jakarta XML Binding is a trademark of the Eclipse Foundation.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Distribution License v. 1.0 which is available at
+http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: BSD-3-Clause
+
+## Source Code
+
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse-ee4j/jaxb-api
+* https://github.com/eclipse-ee4j/jaxb-tck
+
+## Third-party Content
+
+This project leverages the following third party content.
+
+Apache River (3.0.0)
+
+* License: Apache-2.0 AND BSD-3-Clause
+
+ASM 7 (n/a)
+
+* License: BSD-3-Clause
+* Project: https://asm.ow2.io/
+* Source:
+   https://repository.ow2.org/nexus/#nexus-search;gav~org.ow2.asm~asm-commons~~~~kw,versionexpand
+
+JTHarness (5.0)
+
+* License: (GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)  
+* Project: https://wiki.openjdk.java.net/display/CodeTools/JT+Harness
+* Source: http://hg.openjdk.java.net/code-tools/jtharness/
+
+normalize.css (3.0.2)
+
+* License: MIT
+
+SigTest (n/a)
+
+* License: GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+## Cryptography
+
+Content may contain encryption software. The country in which you are currently
+may have restrictions on the import, possession, and use, and/or re-export to
+another country, of encryption software. BEFORE using any encryption software,
+please check the country's laws, regulations and policies concerning the import,
+possession, or use, and re-export of encryption software, to see if this is
+permitted.
+
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.module  Name: jackson-module-jaxb-annotations  Version: 2.17.2
+
+Notice: # Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers, as well as supported
+commercially by FasterXML.com.
+
+## Licensing
+
+Jackson core and extension components may licensed under different licenses.
+To find the details that apply to this artifact see the accompanying LICENSE file.
+For more information, including possible other licensing options, contact
+FasterXML.com (http://fasterxml.com).
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-compress  Version: 1.26.2
+
+Notice: Apache Commons Compress
+Copyright 2002-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-client  Version: 1.0.1
+
+Notice: Kerby-kerb Client
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-io  Name: commons-io  Version: 2.16.1
+
+Notice: Apache Commons IO
+Copyright 2002-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: datanucleus-core  Version: 4.1.17
+
+Notice: =========================================================================
+==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+==  Version 2.0, in this case for the DataNucleus distribution.        ==
+=========================================================================
+
+===================================================================
+This product includes software developed by many individuals,
+including the following:
+===================================================================
+Erik Bengtson
+Andy Jefferson
+
+
+===================================================================
+This product has included contributions from some individuals,
+including the following:
+===================================================================
+Joerg von Frantzius
+Thomas Marti
+Barry Haddow
+Marco Schulze
+Ralph Ullrich
+David Ezzio
+Brendan de Beer
+David Eaves
+Martin Taal
+Tony Lai
+Roland Szabo
+Marcus Mennemeier
+Xuan Baldauf
+Eric Sultan
+
+
+===================================================================
+This product also includes software developed by the TJDO project
+(http://tjdo.sourceforge.net/).
+===================================================================
+
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: annotations  Version: 2.26.29
+Group: software.amazon.awssdk  Name: apache-client  Version: 2.26.29
+Group: software.amazon.awssdk  Name: arns  Version: 2.26.29
+Group: software.amazon.awssdk  Name: auth  Version: 2.26.29
+Group: software.amazon.awssdk  Name: aws-core  Version: 2.26.29
+Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.26.29
+Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.26.29
+Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.26.29
+Group: software.amazon.awssdk  Name: checksums  Version: 2.26.29
+Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: crt-core  Version: 2.26.29
+Group: software.amazon.awssdk  Name: dynamodb  Version: 2.26.29
+Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: glue  Version: 2.26.29
+Group: software.amazon.awssdk  Name: http-auth  Version: 2.26.29
+Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.26.29
+Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.26.29
+Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: iam  Version: 2.26.29
+Group: software.amazon.awssdk  Name: identity-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: json-utils  Version: 2.26.29
+Group: software.amazon.awssdk  Name: kms  Version: 2.26.29
+Group: software.amazon.awssdk  Name: lakeformation  Version: 2.26.29
+Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.26.29
+Group: software.amazon.awssdk  Name: profiles  Version: 2.26.29
+Group: software.amazon.awssdk  Name: protocol-core  Version: 2.26.29
+Group: software.amazon.awssdk  Name: regions  Version: 2.26.29
+Group: software.amazon.awssdk  Name: retries  Version: 2.26.29
+Group: software.amazon.awssdk  Name: retries-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: s3  Version: 2.26.29
+Group: software.amazon.awssdk  Name: sdk-core  Version: 2.26.29
+Group: software.amazon.awssdk  Name: sso  Version: 2.26.29
+Group: software.amazon.awssdk  Name: sts  Version: 2.26.29
+Group: software.amazon.awssdk  Name: utils  Version: 2.26.29
+
+Notice: AWS SDK for Java 2.0
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+This product includes software developed by
+Amazon Technologies, Inc (http://www.amazon.com/).
+
+**********************
+THIRD PARTY COMPONENTS
+**********************
+This software includes third party software subject to the following copyrights:
+- XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+- PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+- Apache Commons Lang - https://github.com/apache/commons-lang
+- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
+- Jackson-core - https://github.com/FasterXML/jackson-core
+- Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
+
+The licenses for these third party components are included in LICENSE.txt
+
+- For Apache Commons Lang see also this required NOTICE:
+  Apache Commons Lang
+  Copyright 2001-2020 The Apache Software Foundation
+  
+  This product includes software developed at
+  The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.client5  Name: httpclient5  Version: 5.3.1
+
+Notice: Apache HttpClient
+Copyright 1999-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive.shims  Name: hive-shims-common  Version: 2.3.9
+
+Notice: Hive Shims Common
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-logging  Name: commons-logging  Version: 1.2
+
+Notice: Apache Commons Logging
+Copyright 2003-2014 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-dbcp  Name: commons-dbcp  Version: 1.4
+
+Notice: Apache Commons DBCP
+Copyright 2001-2010 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-net  Name: commons-net  Version: 3.9.0
+
+Notice: Apache Commons Net
+Copyright 2001-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: com.squareup.okhttp3  Name: okhttp  Version: 4.9.3
+
+Notice: Note that publicsuffixes.gz is compiled from The Public Suffix List:
+https://publicsuffix.org/list/public_suffix_list.dat
+
+It is subject to the terms of the Mozilla Public License, v. 2.0:
+https://mozilla.org/MPL/2.0/
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-collections  Name: commons-collections  Version: 3.2.2
+
+Notice: Apache Commons Collections
+Copyright 2001-2015 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: jakarta.activation  Name: jakarta.activation-api  Version: 1.2.1
+
+Notice: # Notices for Eclipse Project for JAF
+
+This content is produced and maintained by the Eclipse Project for JAF project.
+
+* Project home: https://projects.eclipse.org/projects/ee4j.jaf
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Distribution License v. 1.0,
+which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: BSD-3-Clause
+
+## Source Code
+
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse-ee4j/jaf
+
+## Third-party Content
+
+This project leverages the following third party content.
+
+JUnit (4.12)
+
+* License: Eclipse Public License
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.derby  Name: derby  Version: 10.10.2.0
+
+Notice: =========================================================================
+==  NOTICE file corresponding to section 4(d) of the Apache License,
+==  Version 2.0, in this case for the Apache Derby distribution.
+==
+==  DO NOT EDIT THIS FILE DIRECTLY. IT IS GENERATED
+==  BY THE buildnotice TARGET IN THE TOP LEVEL build.xml FILE.
+==
+=========================================================================
+
+Apache Derby
+Copyright 2004-2014 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+
+=========================================================================
+
+Portions of Derby were originally developed by
+International Business Machines Corporation and are
+licensed to the Apache Software Foundation under the
+"Software Grant and Corporate Contribution License Agreement",
+informally known as the "Derby CLA".
+The following copyright notice(s) were affixed to portions of the code
+with which this file is now or was at one time distributed
+and are placed here unaltered.
+
+(C) Copyright 1997,2004 International Business Machines Corporation.  All rights reserved.
+
+(C) Copyright IBM Corp. 2003. 
+
+
+=========================================================================
+
+
+The portion of the functionTests under 'nist' was originally 
+developed by the National Institute of Standards and Technology (NIST), 
+an agency of the United States Department of Commerce, and adapted by
+International Business Machines Corporation in accordance with the NIST
+Software Acknowledgment and Redistribution document at
+http://www.itl.nist.gov/div897/ctg/sql_form.htm
+
+
+
+=========================================================================
+
+
+The JDBC apis for small devices and JDBC3 (under java/stubs/jsr169 and
+java/stubs/jdbc3) were produced by trimming sources supplied by the
+Apache Harmony project. In addition, the Harmony SerialBlob and
+SerialClob implementations are used. The following notice covers the Harmony sources:
+
+Portions of Harmony were originally developed by
+Intel Corporation and are licensed to the Apache Software
+Foundation under the "Software Grant and Corporate Contribution
+License Agreement", informally known as the "Intel Harmony CLA".
+
+
+=========================================================================
+
+
+The Derby build relies on source files supplied by the Apache Felix
+project. The following notice covers the Felix files:
+
+  Apache Felix Main
+  Copyright 2008 The Apache Software Foundation
+
+
+  I. Included Software
 
   This product includes software developed at
   The Apache Software Foundation (http://www.apache.org/).
+  Licensed under the Apache License 2.0.
+
+  This product includes software developed at
+  The OSGi Alliance (http://www.osgi.org/).
+  Copyright (c) OSGi Alliance (2000, 2007).
+  Licensed under the Apache License 2.0.
+
+  This product includes software from http://kxml.sourceforge.net.
+  Copyright (c) 2002,2003, Stefan Haustein, Oberhausen, Rhld., Germany.
+  Licensed under BSD License.
+
+  II. Used Software
+
+  This product uses software developed at
+  The OSGi Alliance (http://www.osgi.org/).
+  Copyright (c) OSGi Alliance (2000, 2007).
+  Licensed under the Apache License 2.0.
+
+
+  III. License Summary
+  - Apache License 2.0
+  - BSD License
+
+
+=========================================================================
+
+
+The Derby build relies on jar files supplied by the Apache Xalan
+project. The following notice covers the Xalan jar files:
+
+   =========================================================================
+   ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+   ==  Version 2.0, in this case for the Apache Xalan Java distribution.  ==
+   =========================================================================
+
+   Apache Xalan (Xalan XSLT processor)
+   Copyright 1999-2006 The Apache Software Foundation
+
+   Apache Xalan (Xalan serializer)
+   Copyright 1999-2006 The Apache Software Foundation
+
+   This product includes software developed at
+   The Apache Software Foundation (http://www.apache.org/).
+
+   =========================================================================
+   Portions of this software was originally based on the following:
+     - software copyright (c) 1999-2002, Lotus Development Corporation.,
+       http://www.lotus.com.
+     - software copyright (c) 2001-2002, Sun Microsystems.,
+       http://www.sun.com.
+     - software copyright (c) 2003, IBM Corporation., 
+       http://www.ibm.com.
+       
+   =========================================================================
+   The binary distribution package (ie. jars, samples and documentation) of
+   this product includes software developed by the following:
+       
+     - The Apache Software Foundation 
+         - Xerces Java - see LICENSE.txt 
+         - JAXP 1.3 APIs - see LICENSE.txt
+         - Bytecode Engineering Library - see LICENSE.txt
+         - Regular Expression - see LICENSE.txt
+       
+     - Scott Hudson, Frank Flannery, C. Scott Ananian 
+         - CUP Parser Generator runtime (javacup\runtime) - see LICENSE.txt 
+ 
+   ========================================================================= 
+   The source distribution package (ie. all source and tools required to build
+   Xalan Java) of this product includes software developed by the following:
+       
+     - The Apache Software Foundation
+         - Xerces Java - see LICENSE.txt 
+         - JAXP 1.3 APIs - see LICENSE.txt
+         - Bytecode Engineering Library - see LICENSE.txt
+         - Regular Expression - see LICENSE.txt
+         - Ant - see LICENSE.txt
+         - Stylebook doc tool - see LICENSE.txt    
+       
+     - Elliot Joel Berk and C. Scott Ananian 
+         - Lexical Analyzer Generator (JLex) - see LICENSE.txt
+
+   =========================================================================       
+   Apache Xerces Java
+   Copyright 1999-2006 The Apache Software Foundation
+
+   This product includes software developed at
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Portions of Apache Xerces Java in xercesImpl.jar and xml-apis.jar
+   were originally based on the following:
+     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
+     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+     - voluntary contributions made by Paul Eng on behalf of the 
+       Apache Software Foundation that were originally developed at iClick, Inc.,
+       software copyright (c) 1999.    
+
+   =========================================================================   
+   Apache xml-commons xml-apis (redistribution of xml-apis.jar)
+
+   Apache XML Commons
+   Copyright 2001-2003,2006 The Apache Software Foundation.
+
+   This product includes software developed at
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Portions of this software were originally based on the following:
+     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
+     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+     - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
+
+
+--------------------------------------------------------------------------------
+
+Group: com.google.inject  Name: guice  Version: 4.0
+
+Notice: Google Guice - Core Library
+Copyright 2006-2015 Google, Inc.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: ch.qos.reload4j  Name: reload4j  Version: 1.2.22
+Group: log4j  Name: log4j  Version: 1.2.17
+
+Notice: Apache log4j
+Copyright 2007 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-codec  Name: commons-codec  Version: 1.17.1
+
+Notice: Apache Commons Codec
+Copyright 2002-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: joda-time  Name: joda-time  Version: 2.8.1
+
+Notice: =============================================================================
+= NOTICE file corresponding to section 4d of the Apache License Version 2.0 =
+=============================================================================
+This product includes software developed by
+Joda.org (http://www.joda.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-text  Version: 1.10.0
+
+Notice: Apache Commons Text
+Copyright 2014-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-identity  Version: 1.0.1
+
+Notice: Kerby-kerb Identity
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator  Name: curator-client  Version: 5.2.0
+
+Notice: Curator Client
+Copyright 2011-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.thrift  Name: libthrift  Version: 0.9.3
+
+Notice: Apache Thrift
+Copyright 2006-2010 The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 
 --------------------------------------------------------------------------------
 
 Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.17.2
+Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.26.29
 
 Notice: # Jackson JSON processor
 
@@ -183,11 +1187,33 @@ and the licenses and copyrights that apply to that code.
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.avro  Name: avro  Version: 1.12.0
+Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.17.2
 
-Notice: Apache Avro
-Copyright 2009-2024 The Apache Software Foundation
+Notice: # Jackson JSON processor
 
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Licensing
+
+Jackson components are licensed under Apache (Software) License, version 2.0,
+as per accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.curator  Name: curator-framework  Version: 5.2.0
+
+Notice: Curator Framework
+Copyright 2011-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -195,10 +1221,10 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.orc  Name: orc-core  Version: 1.9.4
+Group: org.apache.httpcomponents  Name: httpclient  Version: 4.5.13
 
-Notice: ORC Core
-Copyright 2013-2024 The Apache Software Foundation
+Notice: Apache HttpClient
+Copyright 1999-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -206,84 +1232,125 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: apache-client  Version: 2.27.21
-Group: software.amazon.awssdk  Name: auth  Version: 2.27.21
-Group: software.amazon.awssdk  Name: dynamodb  Version: 2.27.21
-Group: software.amazon.awssdk  Name: glue  Version: 2.27.21
-Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.27.21
-Group: software.amazon.awssdk  Name: iam  Version: 2.27.21
-Group: software.amazon.awssdk  Name: kms  Version: 2.27.21
-Group: software.amazon.awssdk  Name: lakeformation  Version: 2.27.21
-Group: software.amazon.awssdk  Name: s3  Version: 2.27.21
-Group: software.amazon.awssdk  Name: sso  Version: 2.27.21
-Group: software.amazon.awssdk  Name: sts  Version: 2.27.21
+Group: org.apache.kerby  Name: kerby-util  Version: 1.0.1
 
-Notice: AWS SDK for Java 2.0
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-This product includes software developed by
-Amazon Technologies, Inc (http://www.amazon.com/).
-
-**********************
-THIRD PARTY COMPONENTS
-**********************
-This software includes third party software subject to the following copyrights:
-- XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
-- PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
-- Apache Commons Lang - https://github.com/apache/commons-lang
-- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
-- Jackson-core - https://github.com/FasterXML/jackson-core
-- Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
-
-The licenses for these third party components are included in LICENSE.txt
-
-- For Apache Commons Lang see also this required NOTICE:
-  Apache Commons Lang
-  Copyright 2001-2020 The Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (https://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop  Name: hadoop-client  Version: 3.3.6
-Group: org.apache.hadoop  Name: hadoop-common  Version: 3.3.6
-
-Notice: Apache Hadoop
-Copyright 2006 and onwards The Apache Software Foundation.
+Notice: Kerby Util
+Copyright 2014-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
-Export Control Notice
----------------------
 
-This distribution includes cryptographic software.  The country in
-which you currently reside may have restrictions on the import,
-possession, use, and/or re-export to another country, of
-encryption software.  BEFORE using any encryption software, please
-check your country's laws, regulations and policies concerning the
-import, possession, or use, and re-export of encryption software, to
-see if this is permitted.  See <http://www.wassenaar.org/> for more
-information.
+--------------------------------------------------------------------------------
 
-The U.S. Government Department of Commerce, Bureau of Industry and
-Security (BIS), has classified this software as Export Commodity
-Control Number (ECCN) 5D002.C.1, which includes information security
-software using or performing cryptographic functions with asymmetric
-algorithms.  The form and manner of this Apache Software Foundation
-distribution makes it eligible for export under the License Exception
-ENC Technology Software Unrestricted (TSU) exception (see the BIS
-Export Administration Regulations, Section 740.13) for both object
-code and source code.
+Group: org.apache.hive  Name: hive-serde  Version: 2.3.9
 
-The following provides more details on the included cryptographic software:
+Notice: Hive Serde
+Copyright 2021 The Apache Software Foundation
 
-This software uses the SSL libraries from the Jetty project written
-by mortbay.org.
-Hadoop Yarn Server Web Proxy uses the BouncyCastle Java
-cryptography APIs written by the Legion of the Bouncy Castle Inc.
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents.core5  Name: httpcore5  Version: 5.2.4
+
+Notice: Apache HttpComponents Core HTTP/1.1
+Copyright 2005-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-core  Version: 1.0.1
+
+Notice: Kerby-kerb core
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: datanucleus-api-jdo  Version: 4.2.4
+
+Notice: =========================================================================
+==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+==  Version 2.0, in this case for the DataNucleus distribution.        ==
+=========================================================================
+
+===================================================================
+This product includes software developed by many individuals,
+including the following:
+===================================================================
+Erik Bengtson
+Andy Jefferson
+
+
+===================================================================
+This product has included contributions from some individuals,
+including the following:
+===================================================================
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-util  Version: 1.0.1
+
+Notice: Kerby-kerb Util
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.datanucleus  Name: datanucleus-rdbms  Version: 4.1.19
+
+Notice: =========================================================================
+==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+==  Version 2.0, in this case for the DataNucleus distribution.        ==
+=========================================================================
+
+===================================================================
+This product includes software developed by many individuals,
+including the following:
+===================================================================
+Andy Jefferson
+Erik Bengtson
+Joerg von Frantzius
+Marco Schulze
+
+
+===================================================================
+This product has included contributions from some individuals,
+including the following:
+===================================================================
+Barry Haddow
+Ralph Ullrich
+David Ezzio
+Brendan de Beer
+David Eaves
+Martin Taal
+Tony Lai
+Roland Szabo
+Anton Troshin (Timesten)
+
+
+===================================================================
+This product also includes software developed by the TJDO project
+(http://tjdo.sourceforge.net/).
+===================================================================
+
+===================================================================
+This product also includes software developed by the Apache Commons project
+(http://commons.apache.org/).
+===================================================================
 
 
 --------------------------------------------------------------------------------
@@ -299,6 +1366,85 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
+Group: commons-cli  Name: commons-cli  Version: 1.2
+
+Notice: Apache Commons CLI
+Copyright 2001-2009 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-pool  Name: commons-pool  Version: 1.6
+
+Notice: Apache Commons Pool
+Copyright 2001-2012 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: javax.jdo  Name: jdo-api  Version: 3.0.1
+
+Notice: Apache Java Data Objects (JDO)
+Copyright 2005-2006 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.orc  Name: orc-shims  Version: 1.9.4
+
+Notice: ORC Shims
+Copyright 2013-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-guava  Version: 1.2.0
+Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-protobuf_3_7  Version: 1.1.1
+
+Notice: Apache Hadoop Third-party Libs
+Copyright 2020 and onwards The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents  Name: httpcore  Version: 4.4.16
+
+Notice: Apache HttpCore
+Copyright 2005-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-beanutils  Name: commons-beanutils  Version: 1.9.4
+
+Notice: Apache Commons BeanUtils
+Copyright 2000-2019 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.17.2
 Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.17.2
 
 Notice: # Jackson JSON processor
@@ -326,3 +1472,252 @@ from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
 
+Group: org.apache.kerby  Name: kerb-simplekdc  Version: 1.0.1
+
+Notice: Kerb Simple Kdc
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerb-server  Version: 1.0.1
+
+Notice: Kerby-kerb Server
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.avro  Name: avro  Version: 1.12.0
+
+Notice: Apache Avro
+Copyright 2009-2024 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hive.shims  Name: hive-shims-0.23  Version: 2.3.9
+
+Notice: Hive Shims 0.23
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: kerby-asn1  Version: 1.0.1
+
+Notice: Kerby ASN1 Project
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.kerby  Name: token-provider  Version: 1.0.1
+
+Notice: Token provider
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.jaxrs  Name: jackson-jaxrs-json-provider  Version: 2.17.2
+
+Notice: # Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers, as well as supported
+commercially by FasterXML.com.
+
+## Licensing
+
+Jackson core and extension components may be licensed under different licenses.
+To find the details that apply to this artifact see the accompanying LICENSE file.
+For more information, including possible other licensing options, contact
+FasterXML.com (http://fasterxml.com).
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.yetus  Name: audience-annotations  Version: 0.13.0
+
+Notice: Apache Yetus - Audience Annotations
+Copyright 2015-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.commons  Name: commons-lang3  Version: 3.14.0
+
+Notice: Apache Commons Lang
+Copyright 2001-2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.jetty  Name: jetty-client  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-http  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-io  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-security  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-servlet  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-util  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-util-ajax  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-webapp  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty  Name: jetty-xml  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty.websocket  Name: websocket-api  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty.websocket  Name: websocket-client  Version: 9.4.51.v20230217
+Group: org.eclipse.jetty.websocket  Name: websocket-common  Version: 9.4.51.v20230217
+
+Notice: ==============================================================
+ Jetty Web Container
+ Copyright 1995-2018 Mort Bay Consulting Pty Ltd.
+==============================================================
+
+The Jetty Web Container is Copyright Mort Bay Consulting Pty Ltd
+unless otherwise noted.
+
+Jetty is dual licensed under both
+
+  * The Apache 2.0 License
+    http://www.apache.org/licenses/LICENSE-2.0.html
+
+      and
+
+  * The Eclipse Public 1.0 License
+    http://www.eclipse.org/legal/epl-v10.html
+
+Jetty may be distributed under either license.
+
+------
+Eclipse
+
+The following artifacts are EPL.
+ * org.eclipse.jetty.orbit:org.eclipse.jdt.core
+
+The following artifacts are EPL and ASL2.
+ * org.eclipse.jetty.orbit:javax.security.auth.message
+
+
+The following artifacts are EPL and CDDL 1.0.
+ * org.eclipse.jetty.orbit:javax.mail.glassfish
+
+
+------
+Oracle
+
+The following artifacts are CDDL + GPLv2 with classpath exception.
+https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+
+ * javax.servlet:javax.servlet-api
+ * javax.annotation:javax.annotation-api
+ * javax.transaction:javax.transaction-api
+ * javax.websocket:javax.websocket-api
+
+------
+Oracle OpenJDK
+
+If ALPN is used to negotiate HTTP/2 connections, then the following
+artifacts may be included in the distribution or downloaded when ALPN 
+module is selected. 
+
+ * java.sun.security.ssl
+
+These artifacts replace/modify OpenJDK classes.  The modififications
+are hosted at github and both modified and original are under GPL v2 with 
+classpath exceptions.
+http://openjdk.java.net/legal/gplv2+ce.html
+
+
+------
+OW2
+
+The following artifacts are licensed by the OW2 Foundation according to the
+terms of http://asm.ow2.org/license.html
+
+org.ow2.asm:asm-commons
+org.ow2.asm:asm
+
+
+------
+Apache
+
+The following artifacts are ASL2 licensed.
+
+org.apache.taglibs:taglibs-standard-spec
+org.apache.taglibs:taglibs-standard-impl
+
+
+------
+MortBay
+
+The following artifacts are ASL2 licensed.  Based on selected classes from 
+following Apache Tomcat jars, all ASL2 licensed.
+
+org.mortbay.jasper:apache-jsp
+  org.apache.tomcat:tomcat-jasper
+  org.apache.tomcat:tomcat-juli
+  org.apache.tomcat:tomcat-jsp-api
+  org.apache.tomcat:tomcat-el-api
+  org.apache.tomcat:tomcat-jasper-el
+  org.apache.tomcat:tomcat-api
+  org.apache.tomcat:tomcat-util-scan
+  org.apache.tomcat:tomcat-util
+
+org.mortbay.jasper:apache-el
+  org.apache.tomcat:tomcat-jasper-el
+  org.apache.tomcat:tomcat-el-api
+
+
+------
+Mortbay
+
+The following artifacts are CDDL + GPLv2 with classpath exception.
+
+https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+
+org.eclipse.jetty.toolchain:jetty-schemas
+
+------
+Assorted
+
+The UnixCrypt.java code implements the one way cryptography used by
+Unix systems for simple password protection.  Copyright 1996 Aki Yoshida,
+modified April 2001  by Iris Van den Broeke, Daniel Deville.
+Permission to use, copy, modify and distribute UnixCrypt
+for non-commercial or commercial purposes and without fee is
+granted provided that the copyright notice appears in all copies.
+
+
+--------------------------------------------------------------------------------

--- a/kafka-connect/kafka-connect-runtime/NOTICE
+++ b/kafka-connect/kafka-connect-runtime/NOTICE
@@ -383,7 +383,7 @@ cryptography APIs written by the Legion of the Bouncy Castle Inc.
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.17.1
+Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.17.2
 
 Notice: # Jackson JSON processor
 
@@ -564,7 +564,7 @@ ASM 7 (n/a)
 
 JTHarness (5.0)
 
-* License: (GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)	
+* License: (GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)  
 * Project: https://wiki.openjdk.java.net/display/CodeTools/JT+Harness
 * Source: http://hg.openjdk.java.net/code-tools/jtharness/
 
@@ -588,7 +588,7 @@ permitted.
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.module  Name: jackson-module-jaxb-annotations  Version: 2.17.1
+Group: com.fasterxml.jackson.module  Name: jackson-module-jaxb-annotations  Version: 2.17.2
 
 Notice: # Jackson JSON processor
 
@@ -614,7 +614,7 @@ from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.commons  Name: commons-compress  Version: 1.26.0
+Group: org.apache.commons  Name: commons-compress  Version: 1.26.2
 
 Notice: Apache Commons Compress
 Copyright 2002-2024 The Apache Software Foundation
@@ -632,6 +632,17 @@ Copyright 2014-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: commons-io  Name: commons-io  Version: 2.16.1
+
+Notice: Apache Commons IO
+Copyright 2002-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
 
 
 --------------------------------------------------------------------------------
@@ -679,42 +690,42 @@ This product also includes software developed by the TJDO project
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: annotations  Version: 2.26.25
-Group: software.amazon.awssdk  Name: apache-client  Version: 2.26.25
-Group: software.amazon.awssdk  Name: arns  Version: 2.26.25
-Group: software.amazon.awssdk  Name: auth  Version: 2.26.25
-Group: software.amazon.awssdk  Name: aws-core  Version: 2.26.25
-Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.26.25
-Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.26.25
-Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.26.25
-Group: software.amazon.awssdk  Name: checksums  Version: 2.26.25
-Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.26.25
-Group: software.amazon.awssdk  Name: crt-core  Version: 2.26.25
-Group: software.amazon.awssdk  Name: dynamodb  Version: 2.26.25
-Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.26.25
-Group: software.amazon.awssdk  Name: glue  Version: 2.26.25
-Group: software.amazon.awssdk  Name: http-auth  Version: 2.26.25
-Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.26.25
-Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.26.25
-Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.26.25
-Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.26.25
-Group: software.amazon.awssdk  Name: iam  Version: 2.26.25
-Group: software.amazon.awssdk  Name: identity-spi  Version: 2.26.25
-Group: software.amazon.awssdk  Name: json-utils  Version: 2.26.25
-Group: software.amazon.awssdk  Name: kms  Version: 2.26.25
-Group: software.amazon.awssdk  Name: lakeformation  Version: 2.26.25
-Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.26.25
-Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.26.25
-Group: software.amazon.awssdk  Name: profiles  Version: 2.26.25
-Group: software.amazon.awssdk  Name: protocol-core  Version: 2.26.25
-Group: software.amazon.awssdk  Name: regions  Version: 2.26.25
-Group: software.amazon.awssdk  Name: retries  Version: 2.26.25
-Group: software.amazon.awssdk  Name: retries-spi  Version: 2.26.25
-Group: software.amazon.awssdk  Name: s3  Version: 2.26.25
-Group: software.amazon.awssdk  Name: sdk-core  Version: 2.26.25
-Group: software.amazon.awssdk  Name: sso  Version: 2.26.25
-Group: software.amazon.awssdk  Name: sts  Version: 2.26.25
-Group: software.amazon.awssdk  Name: utils  Version: 2.26.25
+Group: software.amazon.awssdk  Name: annotations  Version: 2.26.29
+Group: software.amazon.awssdk  Name: apache-client  Version: 2.26.29
+Group: software.amazon.awssdk  Name: arns  Version: 2.26.29
+Group: software.amazon.awssdk  Name: auth  Version: 2.26.29
+Group: software.amazon.awssdk  Name: aws-core  Version: 2.26.29
+Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.26.29
+Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.26.29
+Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.26.29
+Group: software.amazon.awssdk  Name: checksums  Version: 2.26.29
+Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: crt-core  Version: 2.26.29
+Group: software.amazon.awssdk  Name: dynamodb  Version: 2.26.29
+Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: glue  Version: 2.26.29
+Group: software.amazon.awssdk  Name: http-auth  Version: 2.26.29
+Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.26.29
+Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.26.29
+Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: iam  Version: 2.26.29
+Group: software.amazon.awssdk  Name: identity-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: json-utils  Version: 2.26.29
+Group: software.amazon.awssdk  Name: kms  Version: 2.26.29
+Group: software.amazon.awssdk  Name: lakeformation  Version: 2.26.29
+Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.26.29
+Group: software.amazon.awssdk  Name: profiles  Version: 2.26.29
+Group: software.amazon.awssdk  Name: protocol-core  Version: 2.26.29
+Group: software.amazon.awssdk  Name: regions  Version: 2.26.29
+Group: software.amazon.awssdk  Name: retries  Version: 2.26.29
+Group: software.amazon.awssdk  Name: retries-spi  Version: 2.26.29
+Group: software.amazon.awssdk  Name: s3  Version: 2.26.29
+Group: software.amazon.awssdk  Name: sdk-core  Version: 2.26.29
+Group: software.amazon.awssdk  Name: sso  Version: 2.26.29
+Group: software.amazon.awssdk  Name: sts  Version: 2.26.29
+Group: software.amazon.awssdk  Name: utils  Version: 2.26.29
 
 Notice: AWS SDK for Java 2.0
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -1048,17 +1059,6 @@ project. The following notice covers the Xalan jar files:
 
 --------------------------------------------------------------------------------
 
-Group: commons-io  Name: commons-io  Version: 2.15.1
-
-Notice: Apache Commons IO
-Copyright 2002-2023 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
 Group: com.google.inject  Name: guice  Version: 4.0
 
 Notice: Google Guice - Core Library
@@ -1148,8 +1148,8 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.17.1
-Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.26.25
+Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.17.2
+Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.26.29
 
 Notice: # Jackson JSON processor
 
@@ -1187,7 +1187,7 @@ and the licenses and copyrights that apply to that code.
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.17.1
+Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.17.2
 
 Notice: # Jackson JSON processor
 
@@ -1303,17 +1303,6 @@ Group: org.apache.kerby  Name: kerb-util  Version: 1.0.1
 
 Notice: Kerby-kerb Util
 Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.avro  Name: avro  Version: 1.11.3
-
-Notice: Apache Avro
-Copyright 2009-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1455,8 +1444,8 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.17.1
-Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.17.1
+Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.17.2
+Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.17.2
 
 Notice: # Jackson JSON processor
 
@@ -1505,6 +1494,18 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
+Group: org.apache.avro  Name: avro  Version: 1.12.0
+
+Notice: Apache Avro
+Copyright 2009-2024 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
 Group: org.apache.hive.shims  Name: hive-shims-0.23  Version: 2.3.9
 
 Notice: Hive Shims 0.23
@@ -1538,7 +1539,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.jaxrs  Name: jackson-jaxrs-json-provider  Version: 2.17.1
+Group: com.fasterxml.jackson.jaxrs  Name: jackson-jaxrs-json-provider  Version: 2.17.2
 
 Notice: # Jackson JSON processor
 

--- a/kafka-connect/kafka-connect-runtime/NOTICE
+++ b/kafka-connect/kafka-connect-runtime/NOTICE
@@ -7,6 +7,25 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
+This project includes code from Kite, developed at Cloudera, Inc. with
+the following copyright notice:
+
+| Copyright 2013 Cloudera Inc.
+|
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+|
+|   http://www.apache.org/licenses/LICENSE-2.0
+|
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+
+--------------------------------------------------------------------------------
+
 This binary artifact contains code from the following projects:
 
 --------------------------------------------------------------------------------

--- a/kafka-connect/kafka-connect-runtime/NOTICE
+++ b/kafka-connect/kafka-connect-runtime/NOTICE
@@ -30,320 +30,49 @@ This binary artifact contains code from the following projects:
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.commons  Name: commons-math3  Version: 3.1.1
+Group: software.amazon.awssdk  Name: apache-client  Version: 2.27.21
+Group: software.amazon.awssdk  Name: auth  Version: 2.27.21
+Group: software.amazon.awssdk  Name: dynamodb  Version: 2.27.21
+Group: software.amazon.awssdk  Name: glue  Version: 2.27.21
+Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.27.21
+Group: software.amazon.awssdk  Name: iam  Version: 2.27.21
+Group: software.amazon.awssdk  Name: kms  Version: 2.27.21
+Group: software.amazon.awssdk  Name: lakeformation  Version: 2.27.21
+Group: software.amazon.awssdk  Name: s3  Version: 2.27.21
+Group: software.amazon.awssdk  Name: sso  Version: 2.27.21
+Group: software.amazon.awssdk  Name: sts  Version: 2.27.21
 
-Notice: Apache Commons Math
-Copyright 2001-2012 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
-===============================================================================
-
-The BracketFinder (package org.apache.commons.math3.optimization.univariate)
-and PowellOptimizer (package org.apache.commons.math3.optimization.general)
-classes are based on the Python code in module "optimize.py" (version 0.5)
-developed by Travis E. Oliphant for the SciPy library (http://www.scipy.org/)
-Copyright © 2003-2009 SciPy Developers.
-===============================================================================
-
-The LinearConstraint, LinearObjectiveFunction, LinearOptimizer,
-RelationShip, SimplexSolver and SimplexTableau classes in package
-org.apache.commons.math3.optimization.linear include software developed by
-Benjamin McCann (http://www.benmccann.com) and distributed with
-the following copyright: Copyright 2009 Google Inc.
-===============================================================================
-
-This product includes software developed by the
-University of Chicago, as Operator of Argonne National
-Laboratory.
-The LevenbergMarquardtOptimizer class in package
-org.apache.commons.math3.optimization.general includes software
-translated from the lmder, lmpar and qrsolv Fortran routines
-from the Minpack package
-Minpack Copyright Notice (1999) University of Chicago.  All rights reserved
-===============================================================================
-
-The GraggBulirschStoerIntegrator class in package
-org.apache.commons.math3.ode.nonstiff includes software translated
-from the odex Fortran routine developed by E. Hairer and G. Wanner.
-Original source copyright:
-Copyright (c) 2004, Ernst Hairer
-===============================================================================
-
-The EigenDecompositionImpl class in package
-org.apache.commons.math3.linear includes software translated
-from some LAPACK Fortran routines.  Original source copyright:
-Copyright (c) 1992-2008 The University of Tennessee.  All rights reserved.
-===============================================================================
-
-The MersenneTwister class in package org.apache.commons.math3.random
-includes software translated from the 2002-01-26 version of
-the Mersenne-Twister generator written in C by Makoto Matsumoto and Takuji
-Nishimura. Original source copyright:
-Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
-All rights reserved
-===============================================================================
-
-The LocalizedFormatsTest class in the unit tests is an adapted version of
-the OrekitMessagesTest class from the orekit library distributed under the
-terms of the Apache 2 licence. Original source copyright:
-Copyright 2010 CS Systèmes d'Information
-===============================================================================
-
-The HermiteInterpolator class and its corresponding test have been imported from
-the orekit library distributed under the terms of the Apache 2 licence. Original
-source copyright:
-Copyright 2010-2012 CS Systèmes d'Information
-===============================================================================
-
-The creation of the package "o.a.c.m.analysis.integration.gauss" was inspired
-by an original code donated by Sébastien Brisard.
-===============================================================================
-
-
-The complete text of licenses and disclaimers associated with the the original
-sources enumerated above at the time of code translation are in the LICENSE.txt
-file.
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.httpcomponents.core5  Name: httpcore5-h2  Version: 5.2.4
-
-Notice: Apache HttpComponents Core HTTP/2
-Copyright 2005-2021 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-admin  Version: 1.0.1
-
-Notice: Kerby-kerb Admin
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-crypto  Version: 1.0.1
-
-Notice: Kerby-kerb Crypto
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.orc  Name: orc-core  Version: 1.9.4
-
-Notice: ORC Core
-Copyright 2013-2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive  Name: hive-shims  Version: 2.3.9
-
-Notice: Hive Shims
-Copyright 2021 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerby-pkix  Version: 1.0.1
-
-Notice: Kerby PKIX Project
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive.shims  Name: hive-shims-scheduler  Version: 2.3.9
-
-Notice: Hive Shims Scheduler
-Copyright 2021 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.ant  Name: ant  Version: 1.9.1
-Group: org.apache.ant  Name: ant-launcher  Version: 1.9.1
-
-Notice: Apache Ant
-   Copyright 1999-2013 The Apache Software Foundation
-
-   The <sync> task is based on code Copyright (c) 2002, Landmark
-   Graphics Corp that has been kindly donated to the Apache Software
-   Foundation.
-
-
---------------------------------------------------------------------------------
-
-Group: commons-lang  Name: commons-lang  Version: 2.6
-
-Notice: Apache Commons Lang
-Copyright 2001-2011 The Apache Software Foundation
+Notice: AWS SDK for Java 2.0
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
+Amazon Technologies, Inc (http://www.amazon.com/).
 
+**********************
+THIRD PARTY COMPONENTS
+**********************
+This software includes third party software subject to the following copyrights:
+- XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+- PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+- Apache Commons Lang - https://github.com/apache/commons-lang
+- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
+- Jackson-core - https://github.com/FasterXML/jackson-core
+- Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
 
---------------------------------------------------------------------------------
+The licenses for these third party components are included in LICENSE.txt
 
-Group: org.apache.commons  Name: commons-configuration2  Version: 2.8.0
-
-Notice: Apache Commons Configuration
-Copyright 2001-2022 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerby-config  Version: 1.0.1
-
-Notice: Kerby Config
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.parquet  Name: parquet-avro  Version: 1.13.1
-
-Notice: Apache Parquet MR (Incubating)
-Copyright 2014-2015 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product includes code from Apache Avro, which includes the following in
-its NOTICE file:
-
-  Apache Avro
-  Copyright 2010-2015 The Apache Software Foundation
+- For Apache Commons Lang see also this required NOTICE:
+  Apache Commons Lang
+  Copyright 2001-2020 The Apache Software Foundation
 
   This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
+  The Apache Software Foundation (https://www.apache.org/).
 
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-netty-shaded  Version: 1.62.2
-
-Notice: The Netty Project
-                            =================
-
-Please visit the Netty web site for more information:
-
-  * http://netty.io/
-
-Copyright 2016 The Netty Project
-
-The Netty Project licenses this file to you under the Apache License,
-version 2.0 (the "License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at:
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations
-under the License.
-
--------------------------------------------------------------------------------
-This product contains a forked and modified version of Tomcat Native
-
-  * LICENSE:
-    * license/LICENSE.tomcat-native.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://tomcat.apache.org/native-doc/
-    * https://svn.apache.org/repos/asf/tomcat/native/
-
-This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
-
-  * LICENSE:
-    * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * https://github.com/takari/maven-wrapper
-
-This product contains small piece of code to support AIX, taken from netbsd.
-
-  * LICENSE:
-    * license/LICENSE.aix-netbsd.txt (OpenSSL License)
-  * HOMEPAGE:
-    * https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/crypto/external/bsd/openssl/dist
-
-
-This product contains code from boringssl.
-
-  * LICENSE (Combination ISC and OpenSSL license)
-    * license/LICENSE.boringssl.txt (Combination ISC and OpenSSL license)
-  * HOMEPAGE:
-    * https://boringssl.googlesource.com/boringssl/
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.curator  Name: curator-recipes  Version: 5.2.0
-
-Notice: Curator Recipes
-Copyright 2011-2021 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive  Name: hive-storage-api  Version: 2.4.0
-
-Notice: Hive Storage API
-Copyright 2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop  Name: hadoop-annotations  Version: 3.3.6
-Group: org.apache.hadoop  Name: hadoop-auth  Version: 3.3.6
 Group: org.apache.hadoop  Name: hadoop-client  Version: 3.3.6
 Group: org.apache.hadoop  Name: hadoop-common  Version: 3.3.6
-Group: org.apache.hadoop  Name: hadoop-hdfs-client  Version: 3.3.6
-Group: org.apache.hadoop  Name: hadoop-mapreduce-client-common  Version: 3.3.6
-Group: org.apache.hadoop  Name: hadoop-mapreduce-client-core  Version: 3.3.6
-Group: org.apache.hadoop  Name: hadoop-mapreduce-client-jobclient  Version: 3.3.6
-Group: org.apache.hadoop  Name: hadoop-yarn-api  Version: 3.3.6
-Group: org.apache.hadoop  Name: hadoop-yarn-client  Version: 3.3.6
-Group: org.apache.hadoop  Name: hadoop-yarn-common  Version: 3.3.6
 
 Notice: Apache Hadoop
 Copyright 2006 and onwards The Apache Software Foundation.
@@ -383,36 +112,9 @@ cryptography APIs written by the Legion of the Bouncy Castle Inc.
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.17.2
+Group: org.apache.hive  Name: hive-metastore  Version: 2.3.9
 
-Notice: # Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Copyright
-
-Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-
-## Licensing
-
-Jackson components are licensed under Apache (Software) License, version 2.0,
-as per accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive  Name: hive-common  Version: 2.3.9
-
-Notice: Hive Common
+Notice: Hive Metastore
 Copyright 2021 The Apache Software Foundation
 
 This product includes software developed at
@@ -421,735 +123,29 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.kerby  Name: kerb-common  Version: 1.0.1
+Group: org.apache.parquet  Name: parquet-avro  Version: 1.13.1
 
-Notice: Kerby-kerb Common
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerby-xdr  Version: 1.0.1
-
-Notice: Kerby XDR Project
-Copyright 2014-2017 The Apache Software Foundation
+Notice: Apache Parquet MR (Incubating)
+Copyright 2014-2015 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
-
 --------------------------------------------------------------------------------
 
-Group: org.apache.parquet  Name: parquet-jackson  Version: 1.13.1
-
-Notice: # Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-
---------------------------------------------------------------------------------
-
-Group: jakarta.activation  Name: jakarta.activation-api  Version: 1.2.2
-
-Notice: # Notices for Jakarta Activation
-
-This content is produced and maintained by Jakarta Activation project.
-
-* Project home: https://projects.eclipse.org/projects/ee4j.jaf
-
-## Copyright
-
-All content is the property of the respective authors or their employers. For
-more information regarding authorship of content, please consult the listed
-source code repository logs.
-
-## Declared Project Licenses
-
-This program and the accompanying materials are made available under the terms
-of the Eclipse Distribution License v. 1.0,
-which is available at http://www.eclipse.org/org/documents/edl-v10.php.
-
-SPDX-License-Identifier: BSD-3-Clause
-
-## Source Code
-
-The project maintains the following source code repositories:
-
-* https://github.com/eclipse-ee4j/jaf
-
-## Third-party Content
-
-This project leverages the following third party content.
-
-JUnit (4.12)
-
-* License: Eclipse Public License
-
-
---------------------------------------------------------------------------------
-
-Group: jakarta.xml.bind  Name: jakarta.xml.bind-api  Version: 2.3.3
-
-Notice: [//]: # " Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved. "
-[//]: # "  "
-[//]: # " This program and the accompanying materials are made available under the "
-[//]: # " terms of the Eclipse Distribution License v. 1.0, which is available at "
-[//]: # " http://www.eclipse.org/org/documents/edl-v10.php. "
-[//]: # "  "
-[//]: # " SPDX-License-Identifier: BSD-3-Clause "
-
-# Notices for Jakarta XML Binding
-
-This content is produced and maintained by the Jakarta XML Binding
-project.
-
-* Project home: https://projects.eclipse.org/projects/ee4j.jaxb
-
-## Trademarks
-
-Jakarta XML Binding is a trademark of the Eclipse Foundation.
-
-## Copyright
-
-All content is the property of the respective authors or their employers. For
-more information regarding authorship of content, please consult the listed
-source code repository logs.
-
-## Declared Project Licenses
-
-This program and the accompanying materials are made available under the terms
-of the Eclipse Distribution License v. 1.0 which is available at
-http://www.eclipse.org/org/documents/edl-v10.php.
-
-SPDX-License-Identifier: BSD-3-Clause
-
-## Source Code
-
-The project maintains the following source code repositories:
-
-* https://github.com/eclipse-ee4j/jaxb-api
-* https://github.com/eclipse-ee4j/jaxb-tck
-
-## Third-party Content
-
-This project leverages the following third party content.
-
-Apache River (3.0.0)
-
-* License: Apache-2.0 AND BSD-3-Clause
-
-ASM 7 (n/a)
-
-* License: BSD-3-Clause
-* Project: https://asm.ow2.io/
-* Source:
-   https://repository.ow2.org/nexus/#nexus-search;gav~org.ow2.asm~asm-commons~~~~kw,versionexpand
-
-JTHarness (5.0)
-
-* License: (GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)  
-* Project: https://wiki.openjdk.java.net/display/CodeTools/JT+Harness
-* Source: http://hg.openjdk.java.net/code-tools/jtharness/
-
-normalize.css (3.0.2)
-
-* License: MIT
-
-SigTest (n/a)
-
-* License: GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-
-## Cryptography
-
-Content may contain encryption software. The country in which you are currently
-may have restrictions on the import, possession, and use, and/or re-export to
-another country, of encryption software. BEFORE using any encryption software,
-please check the country's laws, regulations and policies concerning the import,
-possession, or use, and re-export of encryption software, to see if this is
-permitted.
-
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.module  Name: jackson-module-jaxb-annotations  Version: 2.17.2
-
-Notice: # Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers, as well as supported
-commercially by FasterXML.com.
-
-## Licensing
-
-Jackson core and extension components may licensed under different licenses.
-To find the details that apply to this artifact see the accompanying LICENSE file.
-For more information, including possible other licensing options, contact
-FasterXML.com (http://fasterxml.com).
-
-## Credits
-
-A list of contributors may be found from CREDITS file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.commons  Name: commons-compress  Version: 1.26.2
-
-Notice: Apache Commons Compress
-Copyright 2002-2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-client  Version: 1.0.1
-
-Notice: Kerby-kerb Client
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: commons-io  Name: commons-io  Version: 2.16.1
-
-Notice: Apache Commons IO
-Copyright 2002-2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.datanucleus  Name: datanucleus-core  Version: 4.1.17
-
-Notice: =========================================================================
-==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
-==  Version 2.0, in this case for the DataNucleus distribution.        ==
-=========================================================================
-
-===================================================================
-This product includes software developed by many individuals,
-including the following:
-===================================================================
-Erik Bengtson
-Andy Jefferson
-
-
-===================================================================
-This product has included contributions from some individuals,
-including the following:
-===================================================================
-Joerg von Frantzius
-Thomas Marti
-Barry Haddow
-Marco Schulze
-Ralph Ullrich
-David Ezzio
-Brendan de Beer
-David Eaves
-Martin Taal
-Tony Lai
-Roland Szabo
-Marcus Mennemeier
-Xuan Baldauf
-Eric Sultan
-
-
-===================================================================
-This product also includes software developed by the TJDO project
-(http://tjdo.sourceforge.net/).
-===================================================================
-
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: annotations  Version: 2.26.29
-Group: software.amazon.awssdk  Name: apache-client  Version: 2.26.29
-Group: software.amazon.awssdk  Name: arns  Version: 2.26.29
-Group: software.amazon.awssdk  Name: auth  Version: 2.26.29
-Group: software.amazon.awssdk  Name: aws-core  Version: 2.26.29
-Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.26.29
-Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.26.29
-Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.26.29
-Group: software.amazon.awssdk  Name: checksums  Version: 2.26.29
-Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.26.29
-Group: software.amazon.awssdk  Name: crt-core  Version: 2.26.29
-Group: software.amazon.awssdk  Name: dynamodb  Version: 2.26.29
-Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.26.29
-Group: software.amazon.awssdk  Name: glue  Version: 2.26.29
-Group: software.amazon.awssdk  Name: http-auth  Version: 2.26.29
-Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.26.29
-Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.26.29
-Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.26.29
-Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.26.29
-Group: software.amazon.awssdk  Name: iam  Version: 2.26.29
-Group: software.amazon.awssdk  Name: identity-spi  Version: 2.26.29
-Group: software.amazon.awssdk  Name: json-utils  Version: 2.26.29
-Group: software.amazon.awssdk  Name: kms  Version: 2.26.29
-Group: software.amazon.awssdk  Name: lakeformation  Version: 2.26.29
-Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.26.29
-Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.26.29
-Group: software.amazon.awssdk  Name: profiles  Version: 2.26.29
-Group: software.amazon.awssdk  Name: protocol-core  Version: 2.26.29
-Group: software.amazon.awssdk  Name: regions  Version: 2.26.29
-Group: software.amazon.awssdk  Name: retries  Version: 2.26.29
-Group: software.amazon.awssdk  Name: retries-spi  Version: 2.26.29
-Group: software.amazon.awssdk  Name: s3  Version: 2.26.29
-Group: software.amazon.awssdk  Name: sdk-core  Version: 2.26.29
-Group: software.amazon.awssdk  Name: sso  Version: 2.26.29
-Group: software.amazon.awssdk  Name: sts  Version: 2.26.29
-Group: software.amazon.awssdk  Name: utils  Version: 2.26.29
-
-Notice: AWS SDK for Java 2.0
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-This product includes software developed by
-Amazon Technologies, Inc (http://www.amazon.com/).
-
-**********************
-THIRD PARTY COMPONENTS
-**********************
-This software includes third party software subject to the following copyrights:
-- XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
-- PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
-- Apache Commons Lang - https://github.com/apache/commons-lang
-- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
-- Jackson-core - https://github.com/FasterXML/jackson-core
-- Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
-
-The licenses for these third party components are included in LICENSE.txt
-
-- For Apache Commons Lang see also this required NOTICE:
-  Apache Commons Lang
-  Copyright 2001-2020 The Apache Software Foundation
-  
-  This product includes software developed at
-  The Apache Software Foundation (https://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.httpcomponents.client5  Name: httpclient5  Version: 5.3.1
-
-Notice: Apache HttpClient
-Copyright 1999-2021 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive.shims  Name: hive-shims-common  Version: 2.3.9
-
-Notice: Hive Shims Common
-Copyright 2021 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: commons-logging  Name: commons-logging  Version: 1.2
-
-Notice: Apache Commons Logging
-Copyright 2003-2014 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: commons-dbcp  Name: commons-dbcp  Version: 1.4
-
-Notice: Apache Commons DBCP
-Copyright 2001-2010 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: commons-net  Name: commons-net  Version: 3.9.0
-
-Notice: Apache Commons Net
-Copyright 2001-2022 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: com.squareup.okhttp3  Name: okhttp  Version: 4.9.3
-
-Notice: Note that publicsuffixes.gz is compiled from The Public Suffix List:
-https://publicsuffix.org/list/public_suffix_list.dat
-
-It is subject to the terms of the Mozilla Public License, v. 2.0:
-https://mozilla.org/MPL/2.0/
-
-
---------------------------------------------------------------------------------
-
-Group: commons-collections  Name: commons-collections  Version: 3.2.2
-
-Notice: Apache Commons Collections
-Copyright 2001-2015 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: jakarta.activation  Name: jakarta.activation-api  Version: 1.2.1
-
-Notice: # Notices for Eclipse Project for JAF
-
-This content is produced and maintained by the Eclipse Project for JAF project.
-
-* Project home: https://projects.eclipse.org/projects/ee4j.jaf
-
-## Copyright
-
-All content is the property of the respective authors or their employers. For
-more information regarding authorship of content, please consult the listed
-source code repository logs.
-
-## Declared Project Licenses
-
-This program and the accompanying materials are made available under the terms
-of the Eclipse Distribution License v. 1.0,
-which is available at http://www.eclipse.org/org/documents/edl-v10.php.
-
-SPDX-License-Identifier: BSD-3-Clause
-
-## Source Code
-
-The project maintains the following source code repositories:
-
-* https://github.com/eclipse-ee4j/jaf
-
-## Third-party Content
-
-This project leverages the following third party content.
-
-JUnit (4.12)
-
-* License: Eclipse Public License
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.derby  Name: derby  Version: 10.10.2.0
-
-Notice: =========================================================================
-==  NOTICE file corresponding to section 4(d) of the Apache License,
-==  Version 2.0, in this case for the Apache Derby distribution.
-==
-==  DO NOT EDIT THIS FILE DIRECTLY. IT IS GENERATED
-==  BY THE buildnotice TARGET IN THE TOP LEVEL build.xml FILE.
-==
-=========================================================================
-
-Apache Derby
-Copyright 2004-2014 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
-
-=========================================================================
-
-Portions of Derby were originally developed by
-International Business Machines Corporation and are
-licensed to the Apache Software Foundation under the
-"Software Grant and Corporate Contribution License Agreement",
-informally known as the "Derby CLA".
-The following copyright notice(s) were affixed to portions of the code
-with which this file is now or was at one time distributed
-and are placed here unaltered.
-
-(C) Copyright 1997,2004 International Business Machines Corporation.  All rights reserved.
-
-(C) Copyright IBM Corp. 2003. 
-
-
-=========================================================================
-
-
-The portion of the functionTests under 'nist' was originally 
-developed by the National Institute of Standards and Technology (NIST), 
-an agency of the United States Department of Commerce, and adapted by
-International Business Machines Corporation in accordance with the NIST
-Software Acknowledgment and Redistribution document at
-http://www.itl.nist.gov/div897/ctg/sql_form.htm
-
-
-
-=========================================================================
-
-
-The JDBC apis for small devices and JDBC3 (under java/stubs/jsr169 and
-java/stubs/jdbc3) were produced by trimming sources supplied by the
-Apache Harmony project. In addition, the Harmony SerialBlob and
-SerialClob implementations are used. The following notice covers the Harmony sources:
-
-Portions of Harmony were originally developed by
-Intel Corporation and are licensed to the Apache Software
-Foundation under the "Software Grant and Corporate Contribution
-License Agreement", informally known as the "Intel Harmony CLA".
-
-
-=========================================================================
-
-
-The Derby build relies on source files supplied by the Apache Felix
-project. The following notice covers the Felix files:
-
-  Apache Felix Main
-  Copyright 2008 The Apache Software Foundation
-
-
-  I. Included Software
+This product includes code from Apache Avro, which includes the following in
+its NOTICE file:
+
+  Apache Avro
+  Copyright 2010-2015 The Apache Software Foundation
 
   This product includes software developed at
   The Apache Software Foundation (http://www.apache.org/).
-  Licensed under the Apache License 2.0.
-
-  This product includes software developed at
-  The OSGi Alliance (http://www.osgi.org/).
-  Copyright (c) OSGi Alliance (2000, 2007).
-  Licensed under the Apache License 2.0.
-
-  This product includes software from http://kxml.sourceforge.net.
-  Copyright (c) 2002,2003, Stefan Haustein, Oberhausen, Rhld., Germany.
-  Licensed under BSD License.
-
-  II. Used Software
-
-  This product uses software developed at
-  The OSGi Alliance (http://www.osgi.org/).
-  Copyright (c) OSGi Alliance (2000, 2007).
-  Licensed under the Apache License 2.0.
-
-
-  III. License Summary
-  - Apache License 2.0
-  - BSD License
-
-
-=========================================================================
-
-
-The Derby build relies on jar files supplied by the Apache Xalan
-project. The following notice covers the Xalan jar files:
-
-   =========================================================================
-   ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
-   ==  Version 2.0, in this case for the Apache Xalan Java distribution.  ==
-   =========================================================================
-
-   Apache Xalan (Xalan XSLT processor)
-   Copyright 1999-2006 The Apache Software Foundation
-
-   Apache Xalan (Xalan serializer)
-   Copyright 1999-2006 The Apache Software Foundation
-
-   This product includes software developed at
-   The Apache Software Foundation (http://www.apache.org/).
-
-   =========================================================================
-   Portions of this software was originally based on the following:
-     - software copyright (c) 1999-2002, Lotus Development Corporation.,
-       http://www.lotus.com.
-     - software copyright (c) 2001-2002, Sun Microsystems.,
-       http://www.sun.com.
-     - software copyright (c) 2003, IBM Corporation., 
-       http://www.ibm.com.
-       
-   =========================================================================
-   The binary distribution package (ie. jars, samples and documentation) of
-   this product includes software developed by the following:
-       
-     - The Apache Software Foundation 
-         - Xerces Java - see LICENSE.txt 
-         - JAXP 1.3 APIs - see LICENSE.txt
-         - Bytecode Engineering Library - see LICENSE.txt
-         - Regular Expression - see LICENSE.txt
-       
-     - Scott Hudson, Frank Flannery, C. Scott Ananian 
-         - CUP Parser Generator runtime (javacup\runtime) - see LICENSE.txt 
- 
-   ========================================================================= 
-   The source distribution package (ie. all source and tools required to build
-   Xalan Java) of this product includes software developed by the following:
-       
-     - The Apache Software Foundation
-         - Xerces Java - see LICENSE.txt 
-         - JAXP 1.3 APIs - see LICENSE.txt
-         - Bytecode Engineering Library - see LICENSE.txt
-         - Regular Expression - see LICENSE.txt
-         - Ant - see LICENSE.txt
-         - Stylebook doc tool - see LICENSE.txt    
-       
-     - Elliot Joel Berk and C. Scott Ananian 
-         - Lexical Analyzer Generator (JLex) - see LICENSE.txt
-
-   =========================================================================       
-   Apache Xerces Java
-   Copyright 1999-2006 The Apache Software Foundation
-
-   This product includes software developed at
-   The Apache Software Foundation (http://www.apache.org/).
-
-   Portions of Apache Xerces Java in xercesImpl.jar and xml-apis.jar
-   were originally based on the following:
-     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
-     - voluntary contributions made by Paul Eng on behalf of the 
-       Apache Software Foundation that were originally developed at iClick, Inc.,
-       software copyright (c) 1999.    
-
-   =========================================================================   
-   Apache xml-commons xml-apis (redistribution of xml-apis.jar)
-
-   Apache XML Commons
-   Copyright 2001-2003,2006 The Apache Software Foundation.
-
-   This product includes software developed at
-   The Apache Software Foundation (http://www.apache.org/).
-
-   Portions of this software were originally based on the following:
-     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
-     - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
-
-
---------------------------------------------------------------------------------
-
-Group: com.google.inject  Name: guice  Version: 4.0
-
-Notice: Google Guice - Core Library
-Copyright 2006-2015 Google, Inc.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: ch.qos.reload4j  Name: reload4j  Version: 1.2.22
-Group: log4j  Name: log4j  Version: 1.2.17
-
-Notice: Apache log4j
-Copyright 2007 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: commons-codec  Name: commons-codec  Version: 1.17.1
-
-Notice: Apache Commons Codec
-Copyright 2002-2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: joda-time  Name: joda-time  Version: 2.8.1
-
-Notice: =============================================================================
-= NOTICE file corresponding to section 4d of the Apache License Version 2.0 =
-=============================================================================
-This product includes software developed by
-Joda.org (http://www.joda.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.commons  Name: commons-text  Version: 1.10.0
-
-Notice: Apache Commons Text
-Copyright 2014-2022 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-identity  Version: 1.0.1
-
-Notice: Kerby-kerb Identity
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.curator  Name: curator-client  Version: 5.2.0
-
-Notice: Curator Client
-Copyright 2011-2021 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.thrift  Name: libthrift  Version: 0.9.3
-
-Notice: Apache Thrift
-Copyright 2006-2010 The Apache Software Foundation.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
 
 
 --------------------------------------------------------------------------------
 
 Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.17.2
-Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.26.29
 
 Notice: # Jackson JSON processor
 
@@ -1187,33 +183,11 @@ and the licenses and copyrights that apply to that code.
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.17.2
+Group: org.apache.avro  Name: avro  Version: 1.12.0
 
-Notice: # Jackson JSON processor
+Notice: Apache Avro
+Copyright 2009-2024 The Apache Software Foundation
 
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Licensing
-
-Jackson components are licensed under Apache (Software) License, version 2.0,
-as per accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.curator  Name: curator-framework  Version: 5.2.0
-
-Notice: Curator Framework
-Copyright 2011-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1221,21 +195,10 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.httpcomponents  Name: httpclient  Version: 4.5.13
+Group: org.apache.orc  Name: orc-core  Version: 1.9.4
 
-Notice: Apache HttpClient
-Copyright 1999-2020 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerby-util  Version: 1.0.1
-
-Notice: Kerby Util
-Copyright 2014-2017 The Apache Software Foundation
+Notice: ORC Core
+Copyright 2013-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1243,114 +206,84 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.hive  Name: hive-serde  Version: 2.3.9
+Group: software.amazon.awssdk  Name: apache-client  Version: 2.27.21
+Group: software.amazon.awssdk  Name: auth  Version: 2.27.21
+Group: software.amazon.awssdk  Name: dynamodb  Version: 2.27.21
+Group: software.amazon.awssdk  Name: glue  Version: 2.27.21
+Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.27.21
+Group: software.amazon.awssdk  Name: iam  Version: 2.27.21
+Group: software.amazon.awssdk  Name: kms  Version: 2.27.21
+Group: software.amazon.awssdk  Name: lakeformation  Version: 2.27.21
+Group: software.amazon.awssdk  Name: s3  Version: 2.27.21
+Group: software.amazon.awssdk  Name: sso  Version: 2.27.21
+Group: software.amazon.awssdk  Name: sts  Version: 2.27.21
 
-Notice: Hive Serde
-Copyright 2021 The Apache Software Foundation
+Notice: AWS SDK for Java 2.0
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+This product includes software developed by
+Amazon Technologies, Inc (http://www.amazon.com/).
+
+**********************
+THIRD PARTY COMPONENTS
+**********************
+This software includes third party software subject to the following copyrights:
+- XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+- PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+- Apache Commons Lang - https://github.com/apache/commons-lang
+- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
+- Jackson-core - https://github.com/FasterXML/jackson-core
+- Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
+
+The licenses for these third party components are included in LICENSE.txt
+
+- For Apache Commons Lang see also this required NOTICE:
+  Apache Commons Lang
+  Copyright 2001-2020 The Apache Software Foundation
+
+  This product includes software developed at
+  The Apache Software Foundation (https://www.apache.org/).
+
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.hadoop  Name: hadoop-client  Version: 3.3.6
+Group: org.apache.hadoop  Name: hadoop-common  Version: 3.3.6
+
+Notice: Apache Hadoop
+Copyright 2006 and onwards The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+Export Control Notice
+---------------------
 
---------------------------------------------------------------------------------
+This distribution includes cryptographic software.  The country in
+which you currently reside may have restrictions on the import,
+possession, use, and/or re-export to another country, of
+encryption software.  BEFORE using any encryption software, please
+check your country's laws, regulations and policies concerning the
+import, possession, or use, and re-export of encryption software, to
+see if this is permitted.  See <http://www.wassenaar.org/> for more
+information.
 
-Group: org.apache.httpcomponents.core5  Name: httpcore5  Version: 5.2.4
+The U.S. Government Department of Commerce, Bureau of Industry and
+Security (BIS), has classified this software as Export Commodity
+Control Number (ECCN) 5D002.C.1, which includes information security
+software using or performing cryptographic functions with asymmetric
+algorithms.  The form and manner of this Apache Software Foundation
+distribution makes it eligible for export under the License Exception
+ENC Technology Software Unrestricted (TSU) exception (see the BIS
+Export Administration Regulations, Section 740.13) for both object
+code and source code.
 
-Notice: Apache HttpComponents Core HTTP/1.1
-Copyright 2005-2021 The Apache Software Foundation
+The following provides more details on the included cryptographic software:
 
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-core  Version: 1.0.1
-
-Notice: Kerby-kerb core
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.datanucleus  Name: datanucleus-api-jdo  Version: 4.2.4
-
-Notice: =========================================================================
-==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
-==  Version 2.0, in this case for the DataNucleus distribution.        ==
-=========================================================================
-
-===================================================================
-This product includes software developed by many individuals,
-including the following:
-===================================================================
-Erik Bengtson
-Andy Jefferson
-
-
-===================================================================
-This product has included contributions from some individuals,
-including the following:
-===================================================================
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-util  Version: 1.0.1
-
-Notice: Kerby-kerb Util
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.datanucleus  Name: datanucleus-rdbms  Version: 4.1.19
-
-Notice: =========================================================================
-==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
-==  Version 2.0, in this case for the DataNucleus distribution.        ==
-=========================================================================
-
-===================================================================
-This product includes software developed by many individuals,
-including the following:
-===================================================================
-Andy Jefferson
-Erik Bengtson
-Joerg von Frantzius
-Marco Schulze
-
-
-===================================================================
-This product has included contributions from some individuals,
-including the following:
-===================================================================
-Barry Haddow
-Ralph Ullrich
-David Ezzio
-Brendan de Beer
-David Eaves
-Martin Taal
-Tony Lai
-Roland Szabo
-Anton Troshin (Timesten)
-
-
-===================================================================
-This product also includes software developed by the TJDO project
-(http://tjdo.sourceforge.net/).
-===================================================================
-
-===================================================================
-This product also includes software developed by the Apache Commons project
-(http://commons.apache.org/).
-===================================================================
+This software uses the SSL libraries from the Jetty project written
+by mortbay.org.
+Hadoop Yarn Server Web Proxy uses the BouncyCastle Java
+cryptography APIs written by the Legion of the Bouncy Castle Inc.
 
 
 --------------------------------------------------------------------------------
@@ -1366,85 +299,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-Group: commons-cli  Name: commons-cli  Version: 1.2
-
-Notice: Apache Commons CLI
-Copyright 2001-2009 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: commons-pool  Name: commons-pool  Version: 1.6
-
-Notice: Apache Commons Pool
-Copyright 2001-2012 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: javax.jdo  Name: jdo-api  Version: 3.0.1
-
-Notice: Apache Java Data Objects (JDO)
-Copyright 2005-2006 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.orc  Name: orc-shims  Version: 1.9.4
-
-Notice: ORC Shims
-Copyright 2013-2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-guava  Version: 1.2.0
-Group: org.apache.hadoop.thirdparty  Name: hadoop-shaded-protobuf_3_7  Version: 1.1.1
-
-Notice: Apache Hadoop Third-party Libs
-Copyright 2020 and onwards The Apache Software Foundation.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.httpcomponents  Name: httpcore  Version: 4.4.16
-
-Notice: Apache HttpCore
-Copyright 2005-2022 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: commons-beanutils  Name: commons-beanutils  Version: 1.9.4
-
-Notice: Apache Commons BeanUtils
-Copyright 2000-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.17.2
 Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.17.2
 
 Notice: # Jackson JSON processor
@@ -1472,252 +326,3 @@ from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.kerby  Name: kerb-simplekdc  Version: 1.0.1
-
-Notice: Kerb Simple Kdc
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerb-server  Version: 1.0.1
-
-Notice: Kerby-kerb Server
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.avro  Name: avro  Version: 1.12.0
-
-Notice: Apache Avro
-Copyright 2009-2024 The Apache Software Foundation
-
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.hive.shims  Name: hive-shims-0.23  Version: 2.3.9
-
-Notice: Hive Shims 0.23
-Copyright 2021 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: kerby-asn1  Version: 1.0.1
-
-Notice: Kerby ASN1 Project
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.kerby  Name: token-provider  Version: 1.0.1
-
-Notice: Token provider
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.jaxrs  Name: jackson-jaxrs-json-provider  Version: 2.17.2
-
-Notice: # Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers, as well as supported
-commercially by FasterXML.com.
-
-## Licensing
-
-Jackson core and extension components may be licensed under different licenses.
-To find the details that apply to this artifact see the accompanying LICENSE file.
-For more information, including possible other licensing options, contact
-FasterXML.com (http://fasterxml.com).
-
-## Credits
-
-A list of contributors may be found from CREDITS file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.yetus  Name: audience-annotations  Version: 0.13.0
-
-Notice: Apache Yetus - Audience Annotations
-Copyright 2015-2020 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.apache.commons  Name: commons-lang3  Version: 3.14.0
-
-Notice: Apache Commons Lang
-Copyright 2001-2023 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty  Name: jetty-client  Version: 9.4.51.v20230217
-Group: org.eclipse.jetty  Name: jetty-http  Version: 9.4.51.v20230217
-Group: org.eclipse.jetty  Name: jetty-io  Version: 9.4.51.v20230217
-Group: org.eclipse.jetty  Name: jetty-security  Version: 9.4.51.v20230217
-Group: org.eclipse.jetty  Name: jetty-servlet  Version: 9.4.51.v20230217
-Group: org.eclipse.jetty  Name: jetty-util  Version: 9.4.51.v20230217
-Group: org.eclipse.jetty  Name: jetty-util-ajax  Version: 9.4.51.v20230217
-Group: org.eclipse.jetty  Name: jetty-webapp  Version: 9.4.51.v20230217
-Group: org.eclipse.jetty  Name: jetty-xml  Version: 9.4.51.v20230217
-Group: org.eclipse.jetty.websocket  Name: websocket-api  Version: 9.4.51.v20230217
-Group: org.eclipse.jetty.websocket  Name: websocket-client  Version: 9.4.51.v20230217
-Group: org.eclipse.jetty.websocket  Name: websocket-common  Version: 9.4.51.v20230217
-
-Notice: ==============================================================
- Jetty Web Container
- Copyright 1995-2018 Mort Bay Consulting Pty Ltd.
-==============================================================
-
-The Jetty Web Container is Copyright Mort Bay Consulting Pty Ltd
-unless otherwise noted.
-
-Jetty is dual licensed under both
-
-  * The Apache 2.0 License
-    http://www.apache.org/licenses/LICENSE-2.0.html
-
-      and
-
-  * The Eclipse Public 1.0 License
-    http://www.eclipse.org/legal/epl-v10.html
-
-Jetty may be distributed under either license.
-
-------
-Eclipse
-
-The following artifacts are EPL.
- * org.eclipse.jetty.orbit:org.eclipse.jdt.core
-
-The following artifacts are EPL and ASL2.
- * org.eclipse.jetty.orbit:javax.security.auth.message
-
-
-The following artifacts are EPL and CDDL 1.0.
- * org.eclipse.jetty.orbit:javax.mail.glassfish
-
-
-------
-Oracle
-
-The following artifacts are CDDL + GPLv2 with classpath exception.
-https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
-
- * javax.servlet:javax.servlet-api
- * javax.annotation:javax.annotation-api
- * javax.transaction:javax.transaction-api
- * javax.websocket:javax.websocket-api
-
-------
-Oracle OpenJDK
-
-If ALPN is used to negotiate HTTP/2 connections, then the following
-artifacts may be included in the distribution or downloaded when ALPN 
-module is selected. 
-
- * java.sun.security.ssl
-
-These artifacts replace/modify OpenJDK classes.  The modififications
-are hosted at github and both modified and original are under GPL v2 with 
-classpath exceptions.
-http://openjdk.java.net/legal/gplv2+ce.html
-
-
-------
-OW2
-
-The following artifacts are licensed by the OW2 Foundation according to the
-terms of http://asm.ow2.org/license.html
-
-org.ow2.asm:asm-commons
-org.ow2.asm:asm
-
-
-------
-Apache
-
-The following artifacts are ASL2 licensed.
-
-org.apache.taglibs:taglibs-standard-spec
-org.apache.taglibs:taglibs-standard-impl
-
-
-------
-MortBay
-
-The following artifacts are ASL2 licensed.  Based on selected classes from 
-following Apache Tomcat jars, all ASL2 licensed.
-
-org.mortbay.jasper:apache-jsp
-  org.apache.tomcat:tomcat-jasper
-  org.apache.tomcat:tomcat-juli
-  org.apache.tomcat:tomcat-jsp-api
-  org.apache.tomcat:tomcat-el-api
-  org.apache.tomcat:tomcat-jasper-el
-  org.apache.tomcat:tomcat-api
-  org.apache.tomcat:tomcat-util-scan
-  org.apache.tomcat:tomcat-util
-
-org.mortbay.jasper:apache-el
-  org.apache.tomcat:tomcat-jasper-el
-  org.apache.tomcat:tomcat-el-api
-
-
-------
-Mortbay
-
-The following artifacts are CDDL + GPLv2 with classpath exception.
-
-https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
-
-org.eclipse.jetty.toolchain:jetty-schemas
-
-------
-Assorted
-
-The UnixCrypt.java code implements the one way cryptography used by
-Unix systems for simple password protection.  Copyright 1996 Aki Yoshida,
-modified April 2001  by Iris Van den Broeke, Daniel Deville.
-Permission to use, copy, modify and distribute UnixCrypt
-for non-commercial or commercial purposes and without fee is
-granted provided that the copyright notice appears in all copies.
-
-
---------------------------------------------------------------------------------


### PR DESCRIPTION
This PR includes third party licenses and notices in the Kafka Connect sink distribution archives.

The third party licenses and notices were generated using the Gradle License Report [plugin](https://github.com/jk1/Gradle-License-Report), along with a custom report renderer. This is the same plugin used to generate the license and notice files for the AWS, GCP, and Azure bundles. The plugin scans jar and pom file dependencies for license and notice information.

(We might want to consider adding this plugin to the build so we can regenerate the license and notice files more easily.)
