### PR TITLE
Docs: Add Databend docs url to sidebar

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -63,7 +63,7 @@ nav:
   - Snowflake: https://docs.snowflake.com/en/user-guide/tables-iceberg
   - Databend: 
     - Apache Iceberg Catalog: https://docs.databend.com/guides/access-data-lake/iceberg/iceberg-catalog
-    - Apache Iceberg Table Engine: https://docs.databend.com/guides/access-data-lake/iceberg/iceberg-catalog
+    - Apache Iceberg Table Engine: https://docs.databend.com/guides/access-data-lake/iceberg/iceberg-engine
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
   - Doris: https://doris.apache.org/docs/dev/lakehouse/datalake-analytics/iceberg
   - Integrations:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -61,6 +61,9 @@ nav:
   - Amazon EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
   - Google BigQuery: https://cloud.google.com/bigquery/docs/iceberg-tables
   - Snowflake: https://docs.snowflake.com/en/user-guide/tables-iceberg
+  - Databend: 
+    - Apache Iceberg Catalog: https://docs.databend.com/guides/access-data-lake/iceberg/iceberg-catalog
+    - Apache Iceberg Table Engine: https://docs.databend.com/guides/access-data-lake/iceberg/iceberg-catalog
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
   - Doris: https://doris.apache.org/docs/dev/lakehouse/datalake-analytics/iceberg
   - Integrations:


### PR DESCRIPTION
Add links to the official Databend Iceberg tables support in the sidebar.