### PR TITLE
Core: (unit test) Replace the duplicated ALL_DATA_FILES with ALL_DELETE_FILES

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
@@ -40,7 +40,7 @@ public class TestMetadataTableFilters extends TestBase {
   private static final Set<MetadataTableType> AGG_FILE_TABLES =
       Sets.newHashSet(
           MetadataTableType.ALL_DATA_FILES,
-          MetadataTableType.ALL_DATA_FILES,
+          MetadataTableType.ALL_DELETE_FILES,
           MetadataTableType.ALL_FILES,
           MetadataTableType.ALL_ENTRIES);
 
@@ -132,9 +132,9 @@ public class TestMetadataTableFilters extends TestBase {
         }
       case DATA_FILES:
       case DELETE_FILES:
-      case ALL_DELETE_FILES:
         return partitions;
       case ALL_DATA_FILES:
+      case ALL_DELETE_FILES:
         return partitions * 2; // ScanTask for Data Manifest in DELETED and ADDED states
       case ALL_FILES:
       case ALL_ENTRIES:


### PR DESCRIPTION
 - Found 2 `MetadataTableType.ALL_DATA_FILES` from the `AGG_FILE_TABLES` set. One of them should be `ALL_DELETE_FILES`.
 - Fix unit test as `ALL_DATA_FILES ` and `ALL_DELETE_FILES` should return data/delete manifests in DELETED and ADDED states.

cc @szehon-ho 