### PR TITLE
Core: Use %2E as namespace separator instead of %1F

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -547,7 +547,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   public List<Namespace> listNamespaces(SessionContext context, Namespace namespace) {
     Map<String, String> queryParams = Maps.newHashMap();
     if (!namespace.isEmpty()) {
-      queryParams.put("parent", RESTUtil.NAMESPACE_JOINER.join(namespace.levels()));
+      queryParams.put("parent", RESTUtil.encodeNamespace(namespace));
     }
 
     ImmutableList.Builder<Namespace> namespaces = ImmutableList.builder();

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -288,11 +288,7 @@ public class RESTCatalogAdapter implements RESTClient {
         if (asNamespaceCatalog != null) {
           Namespace ns;
           if (vars.containsKey("parent")) {
-            ns =
-                Namespace.of(
-                    RESTUtil.NAMESPACE_SPLITTER
-                        .splitToStream(vars.get("parent"))
-                        .toArray(String[]::new));
+            ns = RESTUtil.decodeNamespace(vars.get("parent"));
           } else {
             ns = Namespace.empty();
           }

--- a/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
@@ -60,8 +60,8 @@ public class TestResourcePaths {
   @Test
   public void testNamespaceWithMultipartNamespace() {
     Namespace ns = Namespace.of("n", "s");
-    assertThat(withPrefix.namespace(ns)).isEqualTo("v1/ws/catalog/namespaces/n%1Fs");
-    assertThat(withoutPrefix.namespace(ns)).isEqualTo("v1/namespaces/n%1Fs");
+    assertThat(withPrefix.namespace(ns)).isEqualTo("v1/ws/catalog/namespaces/n%2Es");
+    assertThat(withoutPrefix.namespace(ns)).isEqualTo("v1/namespaces/n%2Es");
   }
 
   @Test
@@ -84,8 +84,8 @@ public class TestResourcePaths {
   public void testNamespacePropertiesWithMultipartNamespace() {
     Namespace ns = Namespace.of("n", "s");
     assertThat(withPrefix.namespaceProperties(ns))
-        .isEqualTo("v1/ws/catalog/namespaces/n%1Fs/properties");
-    assertThat(withoutPrefix.namespaceProperties(ns)).isEqualTo("v1/namespaces/n%1Fs/properties");
+        .isEqualTo("v1/ws/catalog/namespaces/n%2Es/properties");
+    assertThat(withoutPrefix.namespaceProperties(ns)).isEqualTo("v1/namespaces/n%2Es/properties");
   }
 
   @Test
@@ -105,8 +105,8 @@ public class TestResourcePaths {
   @Test
   public void testTablesWithMultipartNamespace() {
     Namespace ns = Namespace.of("n", "s");
-    assertThat(withPrefix.tables(ns)).isEqualTo("v1/ws/catalog/namespaces/n%1Fs/tables");
-    assertThat(withoutPrefix.tables(ns)).isEqualTo("v1/namespaces/n%1Fs/tables");
+    assertThat(withPrefix.tables(ns)).isEqualTo("v1/ws/catalog/namespaces/n%2Es/tables");
+    assertThat(withoutPrefix.tables(ns)).isEqualTo("v1/namespaces/n%2Es/tables");
   }
 
   @Test
@@ -126,8 +126,8 @@ public class TestResourcePaths {
   @Test
   public void testTableWithMultipartNamespace() {
     TableIdentifier ident = TableIdentifier.of("n", "s", "table");
-    assertThat(withPrefix.table(ident)).isEqualTo("v1/ws/catalog/namespaces/n%1Fs/tables/table");
-    assertThat(withoutPrefix.table(ident)).isEqualTo("v1/namespaces/n%1Fs/tables/table");
+    assertThat(withPrefix.table(ident)).isEqualTo("v1/ws/catalog/namespaces/n%2Es/tables/table");
+    assertThat(withoutPrefix.table(ident)).isEqualTo("v1/namespaces/n%2Es/tables/table");
   }
 
   @Test
@@ -154,8 +154,8 @@ public class TestResourcePaths {
   @Test
   public void viewsWithMultipartNamespace() {
     Namespace ns = Namespace.of("n", "s");
-    assertThat(withPrefix.views(ns)).isEqualTo("v1/ws/catalog/namespaces/n%1Fs/views");
-    assertThat(withoutPrefix.views(ns)).isEqualTo("v1/namespaces/n%1Fs/views");
+    assertThat(withPrefix.views(ns)).isEqualTo("v1/ws/catalog/namespaces/n%2Es/views");
+    assertThat(withoutPrefix.views(ns)).isEqualTo("v1/namespaces/n%2Es/views");
   }
 
   @Test
@@ -176,7 +176,7 @@ public class TestResourcePaths {
   @Test
   public void viewWithMultipartNamespace() {
     TableIdentifier ident = TableIdentifier.of("n", "s", "view-name");
-    assertThat(withPrefix.view(ident)).isEqualTo("v1/ws/catalog/namespaces/n%1Fs/views/view-name");
-    assertThat(withoutPrefix.view(ident)).isEqualTo("v1/namespaces/n%1Fs/views/view-name");
+    assertThat(withPrefix.view(ident)).isEqualTo("v1/ws/catalog/namespaces/n%2Es/views/view-name");
+    assertThat(withoutPrefix.view(ident)).isEqualTo("v1/namespaces/n%2Es/views/view-name");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
@@ -77,7 +77,7 @@ public class TestCreateNamespaceRequest extends RequestResponseTestBase<CreateNa
   @Test
   public void testDeserializeInvalidRequest() {
     String jsonIncorrectTypeForNamespace =
-        "{\"namespace\":\"accounting%1Ftax\",\"properties\":null}";
+        "{\"namespace\":\"accounting%2Etax\",\"properties\":null}";
     assertThatThrownBy(() -> deserialize(jsonIncorrectTypeForNamespace))
         .isInstanceOf(JsonProcessingException.class)
         .hasMessageStartingWith("Cannot parse string array from non-array");

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestCreateNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestCreateNamespaceResponse.java
@@ -85,7 +85,7 @@ public class TestCreateNamespaceResponse extends RequestResponseTestBase<CreateN
   @Test
   public void testDeserializeInvalidResponse() {
     String jsonResponseMalformedNamespaceValue =
-        "{\"namespace\":\"accounting%1Ftax\",\"properties\":null}";
+        "{\"namespace\":\"accounting%2Etax\",\"properties\":null}";
     assertThatThrownBy(() -> deserialize(jsonResponseMalformedNamespaceValue))
         .isInstanceOf(JsonProcessingException.class)
         .hasMessageContaining("Cannot parse string array from non-array");

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestGetNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestGetNamespaceResponse.java
@@ -67,7 +67,7 @@ public class TestGetNamespaceResponse extends RequestResponseTestBase<GetNamespa
 
   @Test
   public void testDeserializeInvalidResponse() {
-    String jsonNamespaceHasWrongType = "{\"namespace\":\"accounting%1Ftax\",\"properties\":null}";
+    String jsonNamespaceHasWrongType = "{\"namespace\":\"accounting%2Etax\",\"properties\":null}";
     assertThatThrownBy(() -> deserialize(jsonNamespaceHasWrongType))
         .as("A JSON response with the wrong type for a field should fail to deserialize")
         .isInstanceOf(JsonProcessingException.class)

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestListTablesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestListTablesResponse.java
@@ -48,7 +48,7 @@ public class TestListTablesResponse extends RequestResponseTestBase<ListTablesRe
 
   @Test
   public void testDeserializeInvalidResponsesThrows() {
-    String identifiersHasWrongType = "{\"identifiers\":\"accounting%1Ftax\"}";
+    String identifiersHasWrongType = "{\"identifiers\":\"accounting%2Etax\"}";
     assertThatThrownBy(() -> deserialize(identifiersHasWrongType))
         .isInstanceOf(JsonProcessingException.class)
         .hasMessageContaining(


### PR DESCRIPTION
This fixes the issue described in #10338 