### PR TITLE
Hive: Pre-check namespace presence for listTables

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -138,6 +138,10 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
         isValidateNamespace(namespace), "Missing database in namespace: %s", namespace);
     String database = namespace.level(0);
 
+    if (!namespaceExists(namespace)) {
+      throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
+    }
+
     try {
       List<String> tableNames = clients.run(client -> client.getAllTables(database));
       List<TableIdentifier> tableIdentifiers;

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -69,6 +69,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.hadoop.ConfigProperties;
@@ -351,6 +352,11 @@ public class HiveTableTest extends HiveTableBaseTest {
 
     assertThat(catalog.tableExists(TABLE_IDENTIFIER)).isTrue();
     HIVE_METASTORE_EXTENSION.metastoreClient().dropTable(DB_NAME, hiveTableName);
+
+    // test listing tables in a db that doesn't exist
+    assertThatThrownBy(() -> catalog.listTables(Namespace.of("db_does_not_exist")))
+            .isInstanceOf(NoSuchNamespaceException.class)
+            .hasMessage("Namespace does not exist: db_does_not_exist");
   }
 
   @ParameterizedTest

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -355,8 +355,8 @@ public class HiveTableTest extends HiveTableBaseTest {
 
     // test listing tables in a db that doesn't exist
     assertThatThrownBy(() -> catalog.listTables(Namespace.of("db_does_not_exist")))
-            .isInstanceOf(NoSuchNamespaceException.class)
-            .hasMessage("Namespace does not exist: db_does_not_exist");
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessage("Namespace does not exist: db_does_not_exist");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Change
Add a Pre-check of namespace presence for listTables in HiveCatalog

## Intention
When invoking listTables on the current HiveCatalog for a database that does not exist, it will return an empty list; however, it seems the intention is to throw an `NoSuchNamespaceException` on such cases.

Currently, there is a catch-block intended to capture `UnknownDBException` thrown by Hive Metastore:
https://github.com/apache/iceberg/blob/7e2920a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java#L163

However, the problem with that is Hive Metastore in many cases won't throw an `UnknownDBException` when listing tables in a database that does not exist: internally to Hive Metastore, databases and tables are tracked by separate RDBMS tables - a query against the "tables" table for an absent DB yields empty list, but it won't be aware of the absence of the DB.
