### PR TITLE
Build for Java 11

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -44,7 +44,6 @@ subprojects {
   apply plugin: 'com.palantir.baseline-class-uniqueness'
   apply plugin: 'com.palantir.baseline-reproducibility'
   apply plugin: 'com.palantir.baseline-exact-dependencies'
-  apply plugin: 'com.palantir.baseline-release-compatibility'
   // We need to update Google Java Format to 1.17.0+ to run spotless on JDK 8, but that requires dropping support for JDK 8.
   if (JavaVersion.current() == JavaVersion.VERSION_21) {
     task spotlessApply {

--- a/baseline.gradle
+++ b/baseline.gradle
@@ -42,7 +42,13 @@ subprojects {
     apply plugin: 'com.palantir.baseline-error-prone'
   }
   apply plugin: 'com.palantir.baseline-class-uniqueness'
-  apply plugin: 'com.palantir.baseline-reproducibility'
+  // What 'com.palantir.baseline-reproducibility' used to do, except the check for the
+  // `sourceCompatibility` Java compile option, which conflicts with the `release` compile option.
+  tasks.withType(AbstractArchiveTask.class).configureEach(t -> {
+    t.setPreserveFileTimestamps(false);
+    t.setReproducibleFileOrder(true);
+    t.setDuplicatesStrategy(DuplicatesStrategy.WARN);
+  });
   apply plugin: 'com.palantir.baseline-exact-dependencies'
   // We need to update Google Java Format to 1.17.0+ to run spotless on JDK 8, but that requires dropping support for JDK 8.
   if (JavaVersion.current() == JavaVersion.VERSION_21) {

--- a/build.gradle
+++ b/build.gradle
@@ -191,20 +191,14 @@ subprojects {
     testArtifacts
   }
 
-  compileJava {
+  tasks.withType(JavaCompile.class).configureEach {
     options.encoding = "UTF-8"
-  }
-
-  compileTestJava {
-    options.encoding = "UTF-8"
+    options.release = 11
   }
 
   javadoc {
     options.encoding = 'UTF-8'
   }
-
-  sourceCompatibility = '1.8'
-  targetCompatibility = '1.8'
 
   dependencies {
     implementation libs.slf4j.api
@@ -886,10 +880,6 @@ project(':iceberg-pig') {
 project(':iceberg-nessie') {
   test {
     useJUnitPlatform()
-  }
-  compileTestJava {
-    sourceCompatibility = "11"
-    targetCompatibility = "11"
   }
 
   dependencies {


### PR DESCRIPTION
Configures the `JavaCompile` tasks to use `options.release = 11` and remove the [no longer necessary](https://github.com/palantir/gradle-baseline?tab=readme-ov-file#compalantirbaseline-release-compatibility) `com.palantir.baseline-release-compatibility` plugin