### PR TITLE
Build: Fix Scala compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -237,6 +237,10 @@ subprojects {
   plugins.withType(ScalaPlugin.class) {
     tasks.withType(ScalaCompile.class) {
       scalaCompileOptions.keepAliveMode.set(KeepAliveMode.DAEMON)
+      // `options.release` doesn't seem to work for ScalaCompile :(
+      sourceCompatibility = "11"
+      targetCompatibility = "11"
+      scalaCompileOptions.additionalParameters.add("-release:11")
     }
   }
 }


### PR DESCRIPTION
`ScalaCompile` does not respect `options.release` and `-release:11` in the aruments is not enough. Re-adding `sourceCompatibility` + `targetCompatibility` for 11.

Otherwise Java code compiled with ScalaCompile will be generated using the "current" Java version running the Gradle build.