### PR TITLE
Core: V3 Metadata Upgrade Validation and Testing

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1025,8 +1025,6 @@ public class TableMetadata implements Serializable {
         changes.add(new MetadataUpdate.UpgradeFormatVersion(++formatVersion));
       } while (formatVersion < newFormatVersion);
 
-      this.formatVersion = newFormatVersion;
-
       return this;
     }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1020,12 +1020,8 @@ public class TableMetadata implements Serializable {
         return this;
       }
 
-      // register incremental version changes separately to ensure all upgrade requirements are met
-      for (int version = formatVersion + 1; version <= newFormatVersion; version++) {
-        changes.add(new MetadataUpdate.UpgradeFormatVersion(version));
-      }
-
       this.formatVersion = newFormatVersion;
+      changes.add(new MetadataUpdate.UpgradeFormatVersion(newFormatVersion));
 
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1004,28 +1004,28 @@ public class TableMetadata implements Serializable {
       return this;
     }
 
-    public Builder upgradeFormatVersion(int targetFormatVersion) {
+    public Builder upgradeFormatVersion(int newFormatVersion) {
       Preconditions.checkArgument(
-          targetFormatVersion <= SUPPORTED_TABLE_FORMAT_VERSION,
+          newFormatVersion <= SUPPORTED_TABLE_FORMAT_VERSION,
           "Cannot upgrade table to unsupported format version: v%s (supported: v%s)",
-          targetFormatVersion,
+          newFormatVersion,
           SUPPORTED_TABLE_FORMAT_VERSION);
       Preconditions.checkArgument(
-          targetFormatVersion >= formatVersion,
+          newFormatVersion >= formatVersion,
           "Cannot downgrade v%s table to v%s",
           formatVersion,
-          targetFormatVersion);
+          newFormatVersion);
 
-      if (targetFormatVersion == formatVersion) {
+      if (newFormatVersion == formatVersion) {
         return this;
       }
 
       // register incremental version changes separately to ensure all upgrade requirements are met
-      for (int version = formatVersion + 1; version <= targetFormatVersion; version++) {
+      for (int version = formatVersion + 1; version <= newFormatVersion; version++) {
         changes.add(new MetadataUpdate.UpgradeFormatVersion(version));
       }
 
-      this.formatVersion = targetFormatVersion;
+      this.formatVersion = newFormatVersion;
 
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1020,7 +1020,8 @@ public class TableMetadata implements Serializable {
         return this;
       }
 
-      // register incremental version changes separately to ensure all upgrade requirements are met
+      // register incremental version changes separately to ensure all upgrade requirements are met.
+      // formatVersion will be equivalent to newFormatVersion after the loop completes
       do {
         changes.add(new MetadataUpdate.UpgradeFormatVersion(++formatVersion));
       } while (formatVersion < newFormatVersion);

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1015,6 +1015,11 @@ public class TableMetadata implements Serializable {
           "Cannot downgrade v%s table to v%s",
           formatVersion,
           newFormatVersion);
+      Preconditions.checkArgument(
+          newFormatVersion <= formatVersion + 1,
+          "Cannot skip format version(s) to upgrade v%s table to v%s",
+          formatVersion,
+          newFormatVersion);
 
       if (newFormatVersion == formatVersion) {
         return this;

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1004,29 +1004,28 @@ public class TableMetadata implements Serializable {
       return this;
     }
 
-    public Builder upgradeFormatVersion(int newFormatVersion) {
+    public Builder upgradeFormatVersion(int targetFormatVersion) {
       Preconditions.checkArgument(
-          newFormatVersion <= SUPPORTED_TABLE_FORMAT_VERSION,
+          targetFormatVersion <= SUPPORTED_TABLE_FORMAT_VERSION,
           "Cannot upgrade table to unsupported format version: v%s (supported: v%s)",
-          newFormatVersion,
+          targetFormatVersion,
           SUPPORTED_TABLE_FORMAT_VERSION);
       Preconditions.checkArgument(
-          newFormatVersion >= formatVersion,
+          targetFormatVersion >= formatVersion,
           "Cannot downgrade v%s table to v%s",
           formatVersion,
-          newFormatVersion);
-      Preconditions.checkArgument(
-          newFormatVersion <= formatVersion + 1,
-          "Cannot skip format version(s) to upgrade v%s table to v%s",
-          formatVersion,
-          newFormatVersion);
+          targetFormatVersion);
 
-      if (newFormatVersion == formatVersion) {
+      if (targetFormatVersion == formatVersion) {
         return this;
       }
 
-      this.formatVersion = newFormatVersion;
-      changes.add(new MetadataUpdate.UpgradeFormatVersion(newFormatVersion));
+      // register incremental version changes separately to ensure all upgrade requirements are met
+      for (int version = formatVersion + 1; version <= targetFormatVersion; version++) {
+        changes.add(new MetadataUpdate.UpgradeFormatVersion(version));
+      }
+
+      this.formatVersion = targetFormatVersion;
 
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1021,9 +1021,9 @@ public class TableMetadata implements Serializable {
       }
 
       // register incremental version changes separately to ensure all upgrade requirements are met
-      for (int version = formatVersion + 1; version <= newFormatVersion; version++) {
-        changes.add(new MetadataUpdate.UpgradeFormatVersion(version));
-      }
+      do {
+        changes.add(new MetadataUpdate.UpgradeFormatVersion(++formatVersion));
+      } while (formatVersion < newFormatVersion);
 
       this.formatVersion = newFormatVersion;
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1020,11 +1020,12 @@ public class TableMetadata implements Serializable {
         return this;
       }
 
-      // register incremental version changes separately to ensure all upgrade requirements are met.
-      // formatVersion will be equivalent to newFormatVersion after the loop completes
-      do {
-        changes.add(new MetadataUpdate.UpgradeFormatVersion(++formatVersion));
-      } while (formatVersion < newFormatVersion);
+      // register incremental version changes separately to ensure all upgrade requirements are met
+      for (int version = formatVersion + 1; version <= newFormatVersion; version++) {
+        changes.add(new MetadataUpdate.UpgradeFormatVersion(version));
+      }
+
+      this.formatVersion = newFormatVersion;
 
       return this;
     }

--- a/core/src/test/java/org/apache/iceberg/TestFormatVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestFormatVersions.java
@@ -65,8 +65,8 @@ public class TestFormatVersions extends TestBase {
     TableMetadata newTableMetadata = ops.current().upgradeToFormatVersion(newFormatVersion);
 
     // check that non-incremental updates are syntactic sugar for serial updates. E.g. upgrading
-    // from V1 to V3 will
-    // register changes in the table metadata for upgrading to V2 and V3 in order (V1->V2->V3)
+    // from V1 to V3 will register changes in the table metadata for upgrading to V2 and V3 in
+    // order (V1->V2->V3)
     assertThat(
             newTableMetadata.changes().stream()
                 .filter(MetadataUpdate.UpgradeFormatVersion.class::isInstance)

--- a/core/src/test/java/org/apache/iceberg/TestFormatVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestFormatVersions.java
@@ -23,8 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.TestTemplate;
 
 public class TestFormatVersions extends TestBase {
@@ -60,26 +58,21 @@ public class TestFormatVersions extends TestBase {
   @TestTemplate
   public void testFormatVersionUpgradeToLatest() {
     TableOperations ops = table.ops();
-    int newFormatVersion = TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION;
 
-    TableMetadata newTableMetadata = ops.current().upgradeToFormatVersion(newFormatVersion);
+    TableMetadata newTableMetadata =
+        ops.current().upgradeToFormatVersion(TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION);
 
-    // check that non-incremental updates are syntactic sugar for serial updates. E.g. upgrading
-    // from V1 to V3 will register changes in the table metadata for upgrading to V2 and V3 in
-    // order (V1->V2->V3)
     assertThat(
             newTableMetadata.changes().stream()
                 .filter(MetadataUpdate.UpgradeFormatVersion.class::isInstance)
                 .map(MetadataUpdate.UpgradeFormatVersion.class::cast)
                 .map(MetadataUpdate.UpgradeFormatVersion::formatVersion))
-        .isEqualTo(
-            IntStream.rangeClosed(formatVersion + 1, newFormatVersion)
-                .boxed()
-                .collect(Collectors.toList()));
+        .isEqualTo(List.of(TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION));
 
     ops.commit(ops.current(), newTableMetadata);
 
-    assertThat(ops.current().formatVersion()).isEqualTo(newFormatVersion);
+    assertThat(ops.current().formatVersion())
+        .isEqualTo(TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION);
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -1457,20 +1457,20 @@ public class TestTableMetadata {
         .doesNotContainKey(TableProperties.FORMAT_VERSION);
   }
 
-  private static Stream<Arguments> upgradeTableVersionProvider() {
+  private static Stream<Arguments> upgradeFormatVersionProvider() {
     // return a stream of all valid upgrade paths
     return IntStream.range(1, TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION)
         .boxed()
         .flatMap(
-            baseTableVersion ->
+            baseFormatVersion ->
                 IntStream.rangeClosed(
-                        baseTableVersion + 1, TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION)
-                    .mapToObj(newTableVersion -> arguments(baseTableVersion, newTableVersion)));
+                        baseFormatVersion + 1, TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION)
+                    .mapToObj(newFormatVersion -> arguments(baseFormatVersion, newFormatVersion)));
   }
 
   @ParameterizedTest
-  @MethodSource("upgradeTableVersionProvider")
-  public void testReplaceMetadataThroughTableProperty(int baseTableVersion, int newTableVersion) {
+  @MethodSource("upgradeFormatVersionProvider")
+  public void testReplaceMetadataThroughTableProperty(int baseFormatVersion, int newFormatVersion) {
     Schema schema = new Schema(Types.NestedField.required(10, "x", Types.StringType.get()));
 
     TableMetadata meta =
@@ -1479,7 +1479,7 @@ public class TestTableMetadata {
             PartitionSpec.unpartitioned(),
             null,
             ImmutableMap.of(
-                TableProperties.FORMAT_VERSION, String.valueOf(baseTableVersion), "key", "val"));
+                TableProperties.FORMAT_VERSION, String.valueOf(baseFormatVersion), "key", "val"));
 
     meta =
         meta.buildReplacement(
@@ -1488,9 +1488,9 @@ public class TestTableMetadata {
             meta.sortOrder(),
             meta.location(),
             ImmutableMap.of(
-                TableProperties.FORMAT_VERSION, String.valueOf(newTableVersion), "key2", "val2"));
+                TableProperties.FORMAT_VERSION, String.valueOf(newFormatVersion), "key2", "val2"));
 
-    assertThat(meta.formatVersion()).isEqualTo(newTableVersion);
+    assertThat(meta.formatVersion()).isEqualTo(newFormatVersion);
     assertThat(meta.properties())
         .containsEntry("key", "val")
         .containsEntry("key2", "val2")
@@ -1498,8 +1498,8 @@ public class TestTableMetadata {
   }
 
   @ParameterizedTest
-  @MethodSource("upgradeTableVersionProvider")
-  public void testUpgradeMetadataThroughTableProperty(int baseTableVersion, int newTableVersion) {
+  @MethodSource("upgradeFormatVersionProvider")
+  public void testUpgradeMetadataThroughTableProperty(int baseFormatVersion, int newFormatVersion) {
     Schema schema = new Schema(Types.NestedField.required(10, "x", Types.StringType.get()));
 
     TableMetadata meta =
@@ -1508,16 +1508,16 @@ public class TestTableMetadata {
             PartitionSpec.unpartitioned(),
             null,
             ImmutableMap.of(
-                TableProperties.FORMAT_VERSION, String.valueOf(baseTableVersion), "key", "val"));
+                TableProperties.FORMAT_VERSION, String.valueOf(baseFormatVersion), "key", "val"));
 
     meta =
         meta.replaceProperties(
             ImmutableMap.of(
-                TableProperties.FORMAT_VERSION, String.valueOf(newTableVersion), "key2", "val2"));
+                TableProperties.FORMAT_VERSION, String.valueOf(newFormatVersion), "key2", "val2"));
 
     assertThat(meta.formatVersion())
         .as("format version should be configured based on the format-version key")
-        .isEqualTo(newTableVersion);
+        .isEqualTo(newFormatVersion);
     assertThat(meta.properties())
         .as("should not contain format-version but should contain new properties")
         .containsExactly(entry("key2", "val2"));

--- a/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
@@ -37,6 +37,8 @@ import org.apache.iceberg.view.ViewMetadata;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestUpdateRequirements {
   private final TableMetadata metadata = mock(TableMetadata.class);
@@ -184,11 +186,12 @@ public class TestUpdateRequirements {
                 updatedViewMetadata.uuid(), viewMetadata.uuid()));
   }
 
-  @Test
-  public void upgradeFormatVersionV2() {
+  @ParameterizedTest
+  @ValueSource(ints = {2, 3})
+  public void upgradeFormatVersion(int formatVersion) {
     List<UpdateRequirement> requirements =
         UpdateRequirements.forUpdateTable(
-            metadata, ImmutableList.of(new MetadataUpdate.UpgradeFormatVersion(2)));
+            metadata, ImmutableList.of(new MetadataUpdate.UpgradeFormatVersion(formatVersion)));
     requirements.forEach(req -> req.validate(metadata));
 
     assertThat(requirements)
@@ -198,25 +201,12 @@ public class TestUpdateRequirements {
     assertTableUUID(requirements);
   }
 
-  @Test
-  public void upgradeFormatVersionV3() {
-    List<UpdateRequirement> requirements =
-        UpdateRequirements.forUpdateTable(
-            metadata, ImmutableList.of(new MetadataUpdate.UpgradeFormatVersion(3)));
-    requirements.forEach(req -> req.validate(metadata));
-
-    assertThat(requirements)
-        .hasSize(1)
-        .hasOnlyElementsOfType(UpdateRequirement.AssertTableUUID.class);
-
-    assertTableUUID(requirements);
-  }
-
-  @Test
-  public void upgradeFormatVersionForViewV2() {
+  @ParameterizedTest
+  @ValueSource(ints = {2, 3})
+  public void upgradeFormatVersionForView(int formatVersion) {
     List<UpdateRequirement> requirements =
         UpdateRequirements.forReplaceView(
-            viewMetadata, ImmutableList.of(new MetadataUpdate.UpgradeFormatVersion(2)));
+            viewMetadata, ImmutableList.of(new MetadataUpdate.UpgradeFormatVersion(formatVersion)));
     requirements.forEach(req -> req.validate(viewMetadata));
 
     assertThat(requirements)

--- a/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
@@ -201,26 +201,11 @@ public class TestUpdateRequirements {
     assertTableUUID(requirements);
   }
 
-  @ParameterizedTest
-  @ValueSource(ints = {2, 3})
-  public void upgradeFormatVersionForView(int formatVersion) {
-    List<UpdateRequirement> requirements =
-        UpdateRequirements.forReplaceView(
-            viewMetadata, ImmutableList.of(new MetadataUpdate.UpgradeFormatVersion(formatVersion)));
-    requirements.forEach(req -> req.validate(viewMetadata));
-
-    assertThat(requirements)
-        .hasSize(1)
-        .hasOnlyElementsOfType(UpdateRequirement.AssertViewUUID.class);
-
-    assertViewUUID(requirements);
-  }
-
   @Test
-  public void upgradeFormatVersionForViewV3() {
+  public void upgradeFormatVersionForView() {
     List<UpdateRequirement> requirements =
         UpdateRequirements.forReplaceView(
-            viewMetadata, ImmutableList.of(new MetadataUpdate.UpgradeFormatVersion(3)));
+            viewMetadata, ImmutableList.of(new MetadataUpdate.UpgradeFormatVersion(2)));
     requirements.forEach(req -> req.validate(viewMetadata));
 
     assertThat(requirements)

--- a/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
@@ -185,7 +185,7 @@ public class TestUpdateRequirements {
   }
 
   @Test
-  public void upgradeFormatVersion() {
+  public void upgradeFormatVersionV2() {
     List<UpdateRequirement> requirements =
         UpdateRequirements.forUpdateTable(
             metadata, ImmutableList.of(new MetadataUpdate.UpgradeFormatVersion(2)));
@@ -199,10 +199,38 @@ public class TestUpdateRequirements {
   }
 
   @Test
-  public void upgradeFormatVersionForView() {
+  public void upgradeFormatVersionV3() {
+    List<UpdateRequirement> requirements =
+        UpdateRequirements.forUpdateTable(
+            metadata, ImmutableList.of(new MetadataUpdate.UpgradeFormatVersion(3)));
+    requirements.forEach(req -> req.validate(metadata));
+
+    assertThat(requirements)
+        .hasSize(1)
+        .hasOnlyElementsOfType(UpdateRequirement.AssertTableUUID.class);
+
+    assertTableUUID(requirements);
+  }
+
+  @Test
+  public void upgradeFormatVersionForViewV2() {
     List<UpdateRequirement> requirements =
         UpdateRequirements.forReplaceView(
             viewMetadata, ImmutableList.of(new MetadataUpdate.UpgradeFormatVersion(2)));
+    requirements.forEach(req -> req.validate(viewMetadata));
+
+    assertThat(requirements)
+        .hasSize(1)
+        .hasOnlyElementsOfType(UpdateRequirement.AssertViewUUID.class);
+
+    assertViewUUID(requirements);
+  }
+
+  @Test
+  public void upgradeFormatVersionForViewV3() {
+    List<UpdateRequirement> requirements =
+        UpdateRequirements.forReplaceView(
+            viewMetadata, ImmutableList.of(new MetadataUpdate.UpgradeFormatVersion(3)));
     requirements.forEach(req -> req.validate(viewMetadata));
 
     assertThat(requirements)


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/10763.

Validates metadata format upgrade paths:
- (OK) V1 -> V2
- (OK) V2 -> V3
- (OK) V1 -> V3
  - internally represented as V1->V2->V3

Adds logic for multi-version upgrades to internally execute as a stepwise upgrade so that non-incremental upgrade paths do not need to be explicitly maintained