### PR TITLE
core:  support support move a column with same name after rename column

### DIFF
--- a/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
+++ b/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
@@ -29,6 +29,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.FluentIterable;
+import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -71,6 +72,7 @@ public class GuavaClasses {
     Splitter.class.getName();
     Throwables.class.getName();
     BiMap.class.getName();
+    HashBiMap.class.getName();
     FluentIterable.class.getName();
     ImmutableBiMap.class.getName();
     ImmutableList.class.getName();

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -60,7 +60,6 @@ class SchemaUpdate implements UpdateSchema {
   private final Multimap<Integer, Types.NestedField> adds =
       Multimaps.newListMultimap(Maps.newHashMap(), Lists::newArrayList);
   private final Map<String, Integer> addedNameToId = Maps.newHashMap();
-  private final Map<String, Integer> renamedNameToId = Maps.newHashMap();
   private final BiMap<String, String> renamedColumnNames = HashBiMap.create();
   private final Multimap<Integer, Move> moves =
       Multimaps.newListMultimap(Maps.newHashMap(), Lists::newArrayList);
@@ -228,7 +227,9 @@ class SchemaUpdate implements UpdateSchema {
           fieldId,
           Types.NestedField.of(fieldId, field.isOptional(), newName, field.type(), field.doc()));
     }
-    renamedColumnNames.put(name, newName);
+    if (!name.equals(newName)) {
+      renamedColumnNames.put(name, newName);
+    }
 
     if (identifierFieldNames.contains(name)) {
       identifierFieldNames.remove(name);
@@ -864,8 +865,8 @@ class SchemaUpdate implements UpdateSchema {
   }
 
   private String findFieldNameBeforeRename(BiMap<String, String> columnsMap, String fieldName) {
-    if (columnsMap.containsKey(fieldName)) {
-      return findFieldNameBeforeRename(columnsMap, columnsMap.get(fieldName));
+    while (columnsMap.containsKey(fieldName)) {
+      fieldName = columnsMap.get(fieldName);
     }
     return fieldName;
   }

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -865,9 +865,10 @@ class SchemaUpdate implements UpdateSchema {
   }
 
   private String findFieldNameBeforeRename(BiMap<String, String> columnsMap, String fieldName) {
-    while (columnsMap.containsKey(fieldName)) {
-      fieldName = columnsMap.get(fieldName);
+    String currentFieldName = fieldName;
+    while (columnsMap.containsKey(currentFieldName)) {
+      currentFieldName = columnsMap.get(currentFieldName);
     }
-    return fieldName;
+    return currentFieldName;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -187,7 +187,7 @@ class SchemaUpdate implements UpdateSchema {
   @Override
   public UpdateSchema deleteColumn(String name) {
     Preconditions.checkArgument(
-        !renamedNameToId.containsKey(name), "Cannot delete renaming column: %s", name);
+        !renamedNameToId.containsKey(name), "Cannot delete renamed column: %s", name);
     Types.NestedField field = findField(name);
     Preconditions.checkArgument(field != null, "Cannot delete missing column: %s", name);
     Preconditions.checkArgument(

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -876,7 +876,7 @@ public class TestSchemaUpdate {
               update.renameColumn("id", "col").deleteColumn("col");
             })
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot delete renaming column: col");
+        .hasMessage("Cannot delete renamed column: col");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -2227,7 +2227,7 @@ public class TestSchemaUpdate {
   }
 
   @Test
-  public void testMultiRename() {
+  public void testMultiRenames() {
     Schema schema =
         new Schema(
             required(1, "b", Types.IntegerType.get()), required(2, "c", Types.IntegerType.get()));
@@ -2242,6 +2242,24 @@ public class TestSchemaUpdate {
     Schema expected =
         new Schema(
             required(1, "b", Types.IntegerType.get()), required(2, "e", Types.IntegerType.get()));
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testRenameWithSameName() {
+    Schema schema =
+        new Schema(
+            required(1, "b", Types.IntegerType.get()), required(2, "c", Types.IntegerType.get()));
+
+    Schema actual =
+        new SchemaUpdate(schema, 4)
+            .renameColumn("c", "c")
+            .updateColumn("c", Types.LongType.get())
+            .apply();
+
+    Schema expected =
+        new Schema(
+            required(1, "b", Types.IntegerType.get()), required(2, "c", Types.LongType.get()));
     assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -876,7 +876,7 @@ public class TestSchemaUpdate {
               update.renameColumn("id", "col").deleteColumn("col");
             })
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot delete missing column: col");
+        .hasMessage("Cannot delete renaming column: col");
   }
 
   @Test
@@ -2191,6 +2191,38 @@ public class TestSchemaUpdate {
             .moveFirst("struct.data")
             .apply();
 
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testMoveAfterRename() {
+    Schema schema =
+        new Schema(
+            required(1, "b", Types.IntegerType.get()), required(2, "c", Types.IntegerType.get()));
+
+    Schema actual = new SchemaUpdate(schema, 4).renameColumn("c", "a").moveBefore("a", "b").apply();
+
+    Schema expected =
+        new Schema(
+            required(2, "a", Types.IntegerType.get()), required(1, "b", Types.IntegerType.get()));
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testUpdateAfterRename() {
+    Schema schema =
+        new Schema(
+            required(1, "b", Types.IntegerType.get()), required(2, "c", Types.IntegerType.get()));
+
+    Schema actual =
+        new SchemaUpdate(schema, 4)
+            .renameColumn("c", "a")
+            .updateColumn("a", Types.LongType.get())
+            .apply();
+
+    Schema expected =
+        new Schema(
+            required(1, "b", Types.IntegerType.get()), required(2, "a", Types.LongType.get()));
     assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
 }


### PR DESCRIPTION
fixes : #10830 

Iceberg failed to move a renamed column for not saving the in-flight state of the rename state.  This PR save the state in `renamedNameToId` to support a move or update operation after rename.  Not supporting delete column after rename for some complex scenarios.