### PR TITLE
Core,AWS: Fix NPE in ResolvingFileIO when HadoopConf is not set

### DIFF
--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -385,6 +385,18 @@ public class TestS3FileIO {
   }
 
   @Test
+  public void testResolvingFileIOLoadWithoutConf() {
+    ResolvingFileIO resolvingFileIO = new ResolvingFileIO();
+    resolvingFileIO.initialize(ImmutableMap.of());
+    FileIO result =
+        DynMethods.builder("io")
+            .hiddenImpl(ResolvingFileIO.class, String.class)
+            .build(resolvingFileIO)
+            .invoke("s3://foo/bar");
+    assertThat(result).isInstanceOf(S3FileIO.class);
+  }
+
+  @Test
   public void testInputFileWithDataFile() throws IOException {
     String location = "s3://bucket/path/to/data-file.parquet";
     DataFile dataFile =

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -153,7 +153,7 @@ public class ResolvingFileIO implements HadoopConfigurable, DelegateFileIO {
 
   @Override
   public Configuration getConf() {
-    return Optional.ofNullable(hadoopConf).map(Supplier::get).orElse(null);
+    return hadoopConf.get();
   }
 
   @VisibleForTesting
@@ -176,7 +176,7 @@ public class ResolvingFileIO implements HadoopConfigurable, DelegateFileIO {
     return ioInstances.computeIfAbsent(
         impl,
         key -> {
-          Configuration conf = getConf();
+          Configuration conf = Optional.ofNullable(hadoopConf).map(Supplier::get).orElse(null);
           FileIO fileIO;
 
           try {

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -153,7 +153,7 @@ public class ResolvingFileIO implements HadoopConfigurable, DelegateFileIO {
 
   @Override
   public Configuration getConf() {
-    return hadoopConf.get();
+    return Optional.ofNullable(hadoopConf).map(Supplier::get).orElse(null);
   }
 
   @VisibleForTesting
@@ -176,7 +176,7 @@ public class ResolvingFileIO implements HadoopConfigurable, DelegateFileIO {
     return ioInstances.computeIfAbsent(
         impl,
         key -> {
-          Configuration conf = Optional.ofNullable(hadoopConf).map(Supplier::get).orElse(null);
+          Configuration conf = getConf();
           FileIO fileIO;
 
           try {


### PR DESCRIPTION
When `ResolvingFileIo` is invoked without conf set (which can happen when catalog or fileIo is explicitly created), it throws NPE. 

```
java.lang.NullPointerException
	at org.apache.iceberg.io.ResolvingFileIO.lambda$io$1(ResolvingFileIO.java:179)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
	at org.apache.iceberg.io.ResolvingFileIO.io(ResolvingFileIO.java:176)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.iceberg.common.DynMethods$UnboundMethod.invokeChecked(DynMethods.java:62)
	at org.apache.iceberg.common.DynMethods$UnboundMethod.invoke(DynMethods.java:74)
	at org.apache.iceberg.common.DynMethods$BoundMethod.invoke(DynMethods.java:171)
```


The workaround is set to `Configuration` always.
For example, while creating the RESTCatalog like below but the order need to be maintained
```java
RESTCatalog catalog = new RESTCatalog();
catalog.setConf(new Configuration());
catalog.initialize("rest", Map.of());
```

Exception HadoopFileIO, conf is not required or unused for other FileIo impl hence, handling with soft check, other option was to have strict check and fail if it is not set [here](https://github.com/apache/iceberg/blob/b17d1c9abdb8fbd668ac02194cadd6003c3e37f7/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java#L177)
