### PR TITLE
AWS: Don't complete multipart upload on finalize for S3OutputStream

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -253,6 +253,10 @@ class S3OutputStream extends PositionOutputStream {
 
   @Override
   public void close() throws IOException {
+    close(true);
+  }
+
+  private void close(boolean completeUploads) throws IOException {
     if (closed) {
       return;
     }
@@ -262,7 +266,9 @@ class S3OutputStream extends PositionOutputStream {
 
     try {
       stream.close();
-      completeUploads();
+      if (completeUploads) {
+        completeUploads();
+      }
     } finally {
       cleanUpStagingFiles();
     }
@@ -480,7 +486,7 @@ class S3OutputStream extends PositionOutputStream {
   protected void finalize() throws Throwable {
     super.finalize();
     if (!closed) {
-      close(); // releasing resources is more important than printing the warning
+      close(false); // releasing resources is more important than printing the warning
       String trace = Joiner.on("\n\t").join(Arrays.copyOfRange(createStack, 1, createStack.length));
       LOG.warn("Unclosed output stream created by:\n\t{}", trace);
     }


### PR DESCRIPTION
If a user didn't call close on the stream the file shouldn't be uploaded.

This means that if the user forgets to call `close()` on a completed file it will no longer be uploaded. However, this is preferred to having files which were intentionally not closed being uploaded and creating garbage.