### PR TITLE
Docs: Fix Typos and Markdown Formats in Documentation Files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -13,7 +13,7 @@ the following copyright notice:
 | Copyright 2013 Cloudera Inc.
 |
 | Licensed under the Apache License, Version 2.0 (the "License");
-| you may not use this file except in compliance with the License.
+| You may not use this file except in compliance with the License.
 | You may obtain a copy of the License at
 |
 |   http://www.apache.org/licenses/LICENSE-2.0

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Spark, Flink and<!--
 
 Iceberg is a high-performance format for huge analytic tables. Iceberg brings the reliability and simplicity of SQL tables to big data while making it possible for engines like Spark, Trino, Flink, Presto, Hive, and Impala to safely work with the same tables, at the same time.
 
-Background and documentation is available at <https://iceberg.apache.org>
+Background and documentation are available at <https://iceberg.apache.org>
 
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!--
+Spark, Flink and<!--
   - Licensed to the Apache Software Foundation (ASF) under one
   - or more contributor license agreements.  See the NOTICE file
   - distributed with this work for additional information
@@ -90,7 +90,7 @@ Iceberg also has modules for adding Iceberg support to processing engines:
 
 ### Engine Compatibility
 
-See the [Multi-Engine Support](https://iceberg.apache.org/multi-engine-support/) page to learn about Iceberg compatibility with different Spark, Flink and Hive versions.
+See the [Multi-Engine Support](https://iceberg.apache.org/multi-engine-support/) page to learn about Iceberg compatibility with different Spark, Flink, and Hive versions.
 For other engines such as Presto or Trino, please visit their websites for Iceberg integration details.
 
 ### Implementations

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Iceberg also has modules for adding Iceberg support to processing engines:
 ---
 > [!NOTE]
 >
-> The tests require Docker to execute. On MacOS (with Docker Desktop), you might need to create a symbolic name to the docker socket in order to be detected by the tests:
+> The tests require Docker to execute. On MacOS (with Docker Desktop), you might need to create a symbolic name for the docker socket in order to be detected by the tests:
 >
 > ```
 > sudo ln -s $HOME/.docker/run/docker.sock /var/run/docker.sock

--- a/README.md
+++ b/README.md
@@ -77,13 +77,15 @@ Iceberg also has modules for adding Iceberg support to processing engines:
 * `iceberg-pig` is an implementation of Pig's LoadFunc API for Iceberg
 
 ---
-**NOTE**
-
-The tests require Docker to execute. On MacOS (with Docker Desktop), you might need to create a symbolic name to the docker socket in order to be detected by the tests:
-
-```
-sudo ln -s $HOME/.docker/run/docker.sock /var/run/docker.sock
-```
+---
+> [!NOTE]
+>
+> The tests require Docker to execute. On MacOS (with Docker Desktop), you might need to create a symbolic name to the docker socket in order to be detected by the tests:
+>
+> ```
+> sudo ln -s $HOME/.docker/run/docker.sock /var/run/docker.sock
+> ```
+---
 ---
 
 ### Engine Compatibility

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 [![](https://github.com/apache/iceberg/actions/workflows/java-ci.yml/badge.svg)](https://github.com/apache/iceberg/actions/workflows/java-ci.yml)
 [![Slack](https://img.shields.io/badge/chat-on%20Slack-brightgreen.svg)](https://apache-iceberg.slack.com/)
 
-Iceberg is a high-performance format for huge analytic tables. Iceberg brings the reliability and simplicity of SQL tables to big data, while making it possible for engines like Spark, Trino, Flink, Presto, Hive and Impala to safely work with the same tables, at the same time.
+Iceberg is a high-performance format for huge analytic tables. Iceberg brings the reliability and simplicity of SQL tables to big data while making it possible for engines like Spark, Trino, Flink, Presto, Hive and Impala to safely work with the same tables, at the same time.
 
 Background and documentation is available at <https://iceberg.apache.org>
 
@@ -90,7 +90,7 @@ Iceberg also has modules for adding Iceberg support to processing engines:
 
 ### Engine Compatibility
 
-See the [Multi-Engine Support](https://iceberg.apache.org/multi-engine-support/) page to know about Iceberg compatibility with different Spark, Flink and Hive versions.
+See the [Multi-Engine Support](https://iceberg.apache.org/multi-engine-support/) page to learn about Iceberg compatibility with different Spark, Flink and Hive versions.
 For other engines such as Presto or Trino, please visit their websites for Iceberg integration details.
 
 ### Implementations

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Iceberg table support is organized in library modules:
 
 Iceberg also has modules for adding Iceberg support to processing engines:
 
-* `iceberg-spark` is an implementation of Spark's Datasource V2 API for Iceberg with submodules for each spark versions (use runtime jars for a shaded version)
+* `iceberg-spark` is an implementation of Spark's Datasource V2 API for Iceberg with submodules for each spark version (use runtime jars for a shaded version)
 * `iceberg-flink` contains classes for integrating with Apache Flink (use iceberg-flink-runtime for a shaded version)
 * `iceberg-mr` contains an InputFormat and other classes for integrating with Apache Hive
 * `iceberg-pig` is an implementation of Pig's LoadFunc API for Iceberg

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Spark, Flink and<!--
 [![](https://github.com/apache/iceberg/actions/workflows/java-ci.yml/badge.svg)](https://github.com/apache/iceberg/actions/workflows/java-ci.yml)
 [![Slack](https://img.shields.io/badge/chat-on%20Slack-brightgreen.svg)](https://apache-iceberg.slack.com/)
 
-Iceberg is a high-performance format for huge analytic tables. Iceberg brings the reliability and simplicity of SQL tables to big data while making it possible for engines like Spark, Trino, Flink, Presto, Hive and Impala to safely work with the same tables, at the same time.
+Iceberg is a high-performance format for huge analytic tables. Iceberg brings the reliability and simplicity of SQL tables to big data while making it possible for engines like Spark, Trino, Flink, Presto, Hive, and Impala to safely work with the same tables, at the same time.
 
 Background and documentation is available at <https://iceberg.apache.org>
 

--- a/aws-bundle/NOTICE
+++ b/aws-bundle/NOTICE
@@ -3,20 +3,20 @@ Apache Iceberg
 Copyright 2017-2024 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation <http://www.apache.org/>.
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
 NOTICE for Group: commons-codec  Name: commons-codec  Version: 1.15
 
 src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
-contains test data from <http://aspell.net/test/orig/batch0.tab>.
-Copyright (C) 2002 Kevin Atkinson <kevina@gnu.org>
+contains test data from http://aspell.net/test/orig/batch0.tab.
+Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
 
 ===============================================================================
 
 The content of package org.apache.commons.codec.language.bm has been translated
-from the original php source code available at <http://stevemorse.org/phoneticinfo.htm>
+from the original php source code available at http://stevemorse.org/phoneticinfo.htm
 with permission from the original authors.
 Original source copyright:
 Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
@@ -54,7 +54,7 @@ AWS SDK for Java 2.0
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 This product includes software developed by
-Amazon Technologies, Inc <http://www.amazon.com/>.
+Amazon Technologies, Inc (http://www.amazon.com/).
 
 **********************
 THIRD PARTY COMPONENTS
@@ -62,10 +62,10 @@ THIRD PARTY COMPONENTS
 This software includes third party software subject to the following copyrights:
 - XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
 - PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
-- Apache Commons Lang - <https://github.com/apache/commons-lang>
-- Netty Reactive Streams - <https://github.com/playframework/netty-reactive-streams>
-- Jackson-core - <https://github.com/FasterXML/jackson-core>
-- Jackson-dataformat-cbor - <https://github.com/FasterXML/jackson-dataformats-binary>
+- Apache Commons Lang - https://github.com/apache/commons-lang
+- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
+- Jackson-core - https://github.com/FasterXML/jackson-core
+- Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
 
 The licenses for these third party components are included in LICENSE.txt
 
@@ -76,7 +76,7 @@ NOTICE for Group: software.amazon.awssdk  Name: third-party-jackson-core  Versio
 # Jackson JSON processor
 
 Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta <tatu.saloranta@iki.fi>, and has
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi) and has
 been in development since 2007.
 It is currently developed by a community of developers.
 
@@ -87,7 +87,6 @@ To find the details that apply to this artifact see the accompanying LICENSE fil
 
 ## Credits
 
-A list of contributors may be found from CREDITS(-2.x) file, which is included
+A list of contributors may be found in CREDITS(-2.x) file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
-

--- a/aws-bundle/NOTICE
+++ b/aws-bundle/NOTICE
@@ -76,7 +76,7 @@ NOTICE for Group: software.amazon.awssdk  Name: third-party-jackson-core  Versio
 # Jackson JSON processor
 
 Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi) and has
 been in development since 2007.
 It is currently developed by a community of developers.
 

--- a/aws-bundle/NOTICE
+++ b/aws-bundle/NOTICE
@@ -87,6 +87,6 @@ To find the details that apply to this artifact see the accompanying LICENSE fil
 
 ## Credits
 
-A list of contributors may be found from CREDITS(-2.x) file, which is included
+A list of contributors may be found in CREDITS(-2.x) file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.

--- a/aws-bundle/NOTICE
+++ b/aws-bundle/NOTICE
@@ -3,20 +3,20 @@ Apache Iceberg
 Copyright 2017-2024 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation <http://www.apache.org/>.
 
 --------------------------------------------------------------------------------
 
 NOTICE for Group: commons-codec  Name: commons-codec  Version: 1.15
 
 src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
-contains test data from http://aspell.net/test/orig/batch0.tab.
-Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
+contains test data from <http://aspell.net/test/orig/batch0.tab>.
+Copyright (C) 2002 Kevin Atkinson <kevina@gnu.org>
 
 ===============================================================================
 
 The content of package org.apache.commons.codec.language.bm has been translated
-from the original php source code available at http://stevemorse.org/phoneticinfo.htm
+from the original php source code available at <http://stevemorse.org/phoneticinfo.htm>
 with permission from the original authors.
 Original source copyright:
 Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
@@ -54,7 +54,7 @@ AWS SDK for Java 2.0
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 This product includes software developed by
-Amazon Technologies, Inc (http://www.amazon.com/).
+Amazon Technologies, Inc <http://www.amazon.com/>.
 
 **********************
 THIRD PARTY COMPONENTS
@@ -62,10 +62,10 @@ THIRD PARTY COMPONENTS
 This software includes third party software subject to the following copyrights:
 - XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
 - PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
-- Apache Commons Lang - https://github.com/apache/commons-lang
-- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
-- Jackson-core - https://github.com/FasterXML/jackson-core
-- Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
+- Apache Commons Lang - <https://github.com/apache/commons-lang>
+- Netty Reactive Streams - <https://github.com/playframework/netty-reactive-streams>
+- Jackson-core - <https://github.com/FasterXML/jackson-core>
+- Jackson-dataformat-cbor - <https://github.com/FasterXML/jackson-dataformats-binary>
 
 The licenses for these third party components are included in LICENSE.txt
 
@@ -76,7 +76,7 @@ NOTICE for Group: software.amazon.awssdk  Name: third-party-jackson-core  Versio
 # Jackson JSON processor
 
 Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi) and has
+It was originally written by Tatu Saloranta <tatu.saloranta@iki.fi>, and has
 been in development since 2007.
 It is currently developed by a community of developers.
 
@@ -87,6 +87,7 @@ To find the details that apply to this artifact see the accompanying LICENSE fil
 
 ## Credits
 
-A list of contributors may be found in CREDITS(-2.x) file, which is included
+A list of contributors may be found from CREDITS(-2.x) file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
+

--- a/gcp-bundle/NOTICE
+++ b/gcp-bundle/NOTICE
@@ -12,7 +12,7 @@ NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.14.
 # Jackson JSON processor
 
 Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi) and has
 been in development since 2007.
 It is currently developed by a community of developers.
 
@@ -23,7 +23,7 @@ To find the details that apply to this artifact see the accompanying LICENSE fil
 
 ## Credits
 
-A list of contributors may be found from CREDITS(-2.x) file, which is included
+A list of contributors may be found in CREDITS(-2.x) file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
 
@@ -50,7 +50,7 @@ NOTICE for Group: io.grpc  Name: grpc-netty-shaded  Version: 1.55.1
                           The Netty Project
                             =================
 
-Please visit the Netty web site for more information:
+Please visit the Netty website for more information:
 
   * http://netty.io/
 
@@ -77,14 +77,14 @@ This product contains a forked and modified version of Tomcat Native
     * http://tomcat.apache.org/native-doc/
     * https://svn.apache.org/repos/asf/tomcat/native/
 
-This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+This product contains the Maven wrapper scripts from 'Maven Wrapper', which provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
     * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-This product contains small piece of code to support AIX, taken from netbsd.
+This product contains a small piece of code to support AIX, taken from Netbsd.
 
   * LICENSE:
     * license/LICENSE.aix-netbsd.txt (OpenSSL License)

--- a/hive-runtime/NOTICE
+++ b/hive-runtime/NOTICE
@@ -42,11 +42,11 @@ NOTICE file:
 |     * Redistributions of source code must retain the above copyright
 | notice, this list of conditions and the following disclaimer.
 |     * Redistributions in binary form must reproduce the above
-| copyright notice, this list of conditions and the following disclaimer
-| in the documentation and/or other materials provided with the
+| copyright notice, this list of conditions, and the following disclaimer
+| In the documentation and/or other materials provided with the
 | distribution.
 |     * Neither the name of Google Inc. nor the names of its
-| contributors may be used to endorse or promote products derived from
+| Contributors may be used to endorse or promote products derived from
 | this software without specific prior written permission.
 |
 | THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -56,7 +56,7 @@ NOTICE file:
 | OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 | SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
 | LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER, CAUSED AND ON ANY
 | THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 | (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 | OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -89,4 +89,3 @@ file:
 |
 | This product includes software developed at
 | The Apache Software Foundation (http://www.apache.org/).
-

--- a/open-api/README.md
+++ b/open-api/README.md
@@ -1,21 +1,21 @@
 <!--
-  - Licensed to the Apache Software Foundation (ASF) under one
-  - or more contributor license agreements.  See the NOTICE file
-  - distributed with this work for additional information
-  - regarding copyright ownership.  The ASF licenses this file
-  - to you under the Apache License, Version 2.0 (the
-  - "License"); you may not use this file except in compliance
-  - with the License.  You may obtain a copy of the License at
-  -
-  -   http://www.apache.org/licenses/LICENSE-2.0
-  -
-  - Unless required by applicable law or agreed to in writing,
-  - software distributed under the License is distributed on an
-  - "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  - KIND, either express or implied.  See the License for the
-  - specific language governing permissions and limitations
-  - under the License.
-  -->
+ - Licensed to the Apache Software Foundation (ASF) under one
+ - or more contributor license agreements.  See the NOTICE file
+ - distributed with this work for additional information
+ - regarding copyright ownership.  The ASF licenses this file
+ - to you under the Apache License, Version 2.0 (the
+ - "License"); you may not use this file except in compliance
+ - with the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing,
+ - software distributed under the License is distributed on an
+ - "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ - KIND, either express or implied.  See the License for the
+ - specific language governing permissions and limitations
+ - under the License.
+ -->
 
 # Open API spec
 
@@ -39,4 +39,4 @@ make install
 make generate
 ```
 
-The generated code is not being used in the project, but helps to see what the changes in the open-API definition are in the generated code.
+The generated code is not being used in the project but helps to see what the changes in the open-API definition are in the generated code.


### PR DESCRIPTION
#### Description
I've modified minor grammatical errors and markdown formats across several documentation files. The changes aim to improve readability and ensure consistency with markdown standards.

#### Changes
The following files were updated to fix typos and enhance markdown formatting:

1. **README.md**
    - Corrected grammatical errors
    - Improved sentence structures
    - Ensured proper markdown syntax

2. **aws-bundle/NOTICE**
    - Corrected minor typos
    - Adjusted formatting to align with markdown standards

3. **gcp-bundle/NOTICE**
    - Fixed typos
    - Improved markdown formatting

4. **hive-runtime/NOTICE**
    - Addressed grammatical issues
    - Enhanced markdown structure

5. **spark/README.md**
    - Corrected typographical errors