### PR TITLE
Spec: Fix rendering of unified partition struct

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -759,13 +759,13 @@ The unified partition type is a struct containing all fields that have ever been
 and sorted by the field ids in ascending order.  
 In other words, the struct fields represent a union of all known partition fields sorted in ascending order by the field ids.
 For example,
-1) spec#0 has two fields {field#1, field#2}
-and then the table has evolved into spec#1 which has three fields {field#1, field#2, field#3}.
-The unified partition type looks like Struct<field#1, field#2, field#3>.
+1) `spec#0` has two fields `{field#1, field#2}`
+and then the table has evolved into `spec#1` which has three fields `{field#1, field#2, field#3}`.
+The unified partition type looks like `Struct<field#1, field#2, field#3>`.
 
-2) spec#0 has two fields {field#1, field#2}
-and then the table has evolved into spec#1 which has just one field {field#2}.
-The unified partition type looks like Struct<field#1, field#2>.
+2) `spec#0` has two fields `{field#1, field#2}`
+and then the table has evolved into `spec#1` which has just one field `{field#2}`.
+The unified partition type looks like `Struct<field#1, field#2>`.
 
 #### Commit Conflict Resolution and Retry
 


### PR DESCRIPTION
The angle brackets were without any escapes so docs renderer treated them as HTML. The resulting text on the website looked like an unfinished sentence:

    The unified partition type looks like Struct.

Putting the angle brackets in backticks prevent them from being interpreted as HTML. Surrounding names like spec#0, field#1 are also put inside backticks for consistence.



### Before

<img width="854" alt="image" src="https://github.com/user-attachments/assets/bfd4e890-7344-45f7-a4a2-e00aa594b97e">

### After

<img width="846" alt="image" src="https://github.com/user-attachments/assets/43df7dbe-d8aa-478f-953b-09f2f4cd4285">
