### PR TITLE
Core: Pass namespace separator via query param

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -381,6 +381,17 @@ public class HTTPClient implements RESTClient {
   }
 
   @Override
+  public <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Map<String, String> queryParams,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return execute(Method.POST, path, queryParams, body, responseType, headers, errorHandler);
+  }
+
+  @Override
   public <T extends RESTResponse> T delete(
       String path,
       Class<T> responseType,

--- a/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
@@ -143,6 +143,30 @@ public interface RESTClient extends Closeable {
       Map<String, String> headers,
       Consumer<ErrorResponse> errorHandler);
 
+  default <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Map<String, String> queryParams,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    if (null != queryParams && !queryParams.isEmpty()) {
+      throw new UnsupportedOperationException("Query params are not supported");
+    }
+
+    return post(path, body, responseType, headers, errorHandler);
+  }
+
+  default <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Map<String, String> queryParams,
+      Class<T> responseType,
+      Supplier<Map<String, String>> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return post(path, body, queryParams, responseType, headers.get(), errorHandler);
+  }
+
   default <T extends RESTResponse> T postForm(
       String path,
       Map<String, String> formData,

--- a/core/src/main/java/org/apache/iceberg/rest/RESTMetricsReporter.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTMetricsReporter.java
@@ -36,12 +36,17 @@ class RESTMetricsReporter implements MetricsReporter {
   private final RESTClient client;
   private final String metricsEndpoint;
   private final Supplier<Map<String, String>> headers;
+  private final Map<String, String> queryParams;
 
   RESTMetricsReporter(
-      RESTClient client, String metricsEndpoint, Supplier<Map<String, String>> headers) {
+      RESTClient client,
+      String metricsEndpoint,
+      Supplier<Map<String, String>> headers,
+      Map<String, String> queryParams) {
     this.client = client;
     this.metricsEndpoint = metricsEndpoint;
     this.headers = headers;
+    this.queryParams = queryParams;
   }
 
   @Override
@@ -55,6 +60,7 @@ class RESTMetricsReporter implements MetricsReporter {
       client.post(
           metricsEndpoint,
           ReportMetricsRequest.of(report),
+          queryParams,
           null,
           headers,
           ErrorHandlers.defaultErrorHandler());

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -116,6 +116,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private static final String DEFAULT_FILE_IO_IMPL = "org.apache.iceberg.io.ResolvingFileIO";
   private static final String REST_METRICS_REPORTING_ENABLED = "rest-metrics-reporting-enabled";
   private static final String REST_SNAPSHOT_LOADING_MODE = "snapshot-loading-mode";
+  static final String NAMESPACE_SEPARATOR = "namespace-separator";
   public static final String REST_PAGE_SIZE = "rest-page-size";
   private static final List<String> TOKEN_PREFERENCE_ORDER =
       ImmutableList.of(
@@ -148,6 +149,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private boolean reportingViaRestEnabled;
   private Integer pageSize = null;
   private CloseableGroup closeables = null;
+  private String namespaceSeparator = null;
 
   // a lazy thread pool for token refresh
   private volatile ScheduledExecutorService refreshExecutor = null;
@@ -284,6 +286,9 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
     this.reportingViaRestEnabled =
         PropertyUtil.propertyAsBoolean(mergedProps, REST_METRICS_REPORTING_ENABLED, true);
+    this.namespaceSeparator =
+        PropertyUtil.propertyAsString(
+            mergedProps, NAMESPACE_SEPARATOR, RESTUtil.NAMESPACE_ESCAPED_SEPARATOR);
     super.initialize(name, mergedProps);
   }
 
@@ -547,7 +552,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   public List<Namespace> listNamespaces(SessionContext context, Namespace namespace) {
     Map<String, String> queryParams = Maps.newHashMap();
     if (!namespace.isEmpty()) {
-      queryParams.put("parent", RESTUtil.encodeNamespace(namespace));
+      queryParams.put("parent", RESTUtil.encodeNamespace(namespace, namespaceSeparator));
     }
 
     ImmutableList.Builder<Namespace> namespaces = ImmutableList.builder();

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -52,6 +52,7 @@ class RESTTableOperations implements TableOperations {
 
   private final RESTClient client;
   private final String path;
+  private final Map<String, String> queryParams;
   private final Supplier<Map<String, String>> headers;
   private final FileIO io;
   private final List<MetadataUpdate> createChanges;
@@ -62,15 +63,17 @@ class RESTTableOperations implements TableOperations {
   RESTTableOperations(
       RESTClient client,
       String path,
+      Map<String, String> queryParams,
       Supplier<Map<String, String>> headers,
       FileIO io,
       TableMetadata current) {
-    this(client, path, headers, io, UpdateType.SIMPLE, Lists.newArrayList(), current);
+    this(client, path, queryParams, headers, io, UpdateType.SIMPLE, Lists.newArrayList(), current);
   }
 
   RESTTableOperations(
       RESTClient client,
       String path,
+      Map<String, String> queryParams,
       Supplier<Map<String, String>> headers,
       FileIO io,
       UpdateType updateType,
@@ -78,6 +81,7 @@ class RESTTableOperations implements TableOperations {
       TableMetadata current) {
     this.client = client;
     this.path = path;
+    this.queryParams = queryParams;
     this.headers = headers;
     this.io = io;
     this.updateType = updateType;
@@ -149,7 +153,7 @@ class RESTTableOperations implements TableOperations {
     // UnknownCommitStateException
     // TODO: ensure that the HTTP client lib passes HTTP client errors to the error handler
     LoadTableResponse response =
-        client.post(path, request, LoadTableResponse.class, headers, errorHandler);
+        client.post(path, request, queryParams, LoadTableResponse.class, headers, errorHandler);
 
     // all future commits should be simple commits
     this.updateType = UpdateType.SIMPLE;

--- a/core/src/main/java/org/apache/iceberg/rest/RESTViewOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTViewOperations.java
@@ -31,14 +31,20 @@ import org.apache.iceberg.view.ViewOperations;
 class RESTViewOperations implements ViewOperations {
   private final RESTClient client;
   private final String path;
+  private final Map<String, String> queryParams;
   private final Supplier<Map<String, String>> headers;
   private ViewMetadata current;
 
   RESTViewOperations(
-      RESTClient client, String path, Supplier<Map<String, String>> headers, ViewMetadata current) {
+      RESTClient client,
+      String path,
+      Map<String, String> queryParams,
+      Supplier<Map<String, String>> headers,
+      ViewMetadata current) {
     Preconditions.checkArgument(null != current, "Invalid view metadata: null");
     this.client = client;
     this.path = path;
+    this.queryParams = queryParams;
     this.headers = headers;
     this.current = current;
   }
@@ -65,7 +71,12 @@ class RESTViewOperations implements ViewOperations {
 
     LoadViewResponse response =
         client.post(
-            path, request, LoadViewResponse.class, headers, ErrorHandlers.viewCommitHandler());
+            path,
+            request,
+            queryParams,
+            LoadViewResponse.class,
+            headers,
+            ErrorHandlers.viewCommitHandler());
 
     updateCurrentMetadata(response);
   }

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -73,6 +73,7 @@ import org.apache.iceberg.util.PropertyUtil;
 /** Adaptor class to translate REST requests into {@link Catalog} API calls. */
 public class RESTCatalogAdapter implements RESTClient {
   private static final Splitter SLASH = Splitter.on('/');
+  private static final String NAMESPACE_SEPARATOR = "%2E";
 
   private static final Map<Class<? extends Exception>, Integer> EXCEPTION_ERROR_CODES =
       ImmutableMap.<Class<? extends Exception>, Integer>builder()
@@ -282,7 +283,11 @@ public class RESTCatalogAdapter implements RESTClient {
         return castResponse(responseType, handleOAuthRequest(body));
 
       case CONFIG:
-        return castResponse(responseType, ConfigResponse.builder().build());
+        return castResponse(
+            responseType,
+            ConfigResponse.builder()
+                .withOverride(RESTSessionCatalog.NAMESPACE_SEPARATOR, NAMESPACE_SEPARATOR)
+                .build());
 
       case LIST_NAMESPACES:
         if (asNamespaceCatalog != null) {
@@ -665,7 +670,7 @@ public class RESTCatalogAdapter implements RESTClient {
   }
 
   private static Namespace namespaceFromPathVars(Map<String, String> pathVars) {
-    return RESTUtil.decodeNamespace(pathVars.get("namespace"));
+    return RESTUtil.decodeNamespace(pathVars.get("namespace"), NAMESPACE_SEPARATOR);
   }
 
   private static TableIdentifier identFromPathVars(Map<String, String> pathVars) {

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -286,7 +286,7 @@ public class RESTCatalogAdapter implements RESTClient {
         return castResponse(
             responseType,
             ConfigResponse.builder()
-                .withOverride(RESTSessionCatalog.NAMESPACE_SEPARATOR, NAMESPACE_SEPARATOR)
+                .withDefault(RESTSessionCatalog.NAMESPACE_SEPARATOR, NAMESPACE_SEPARATOR)
                 .build());
 
       case LIST_NAMESPACES:
@@ -600,6 +600,17 @@ public class RESTCatalogAdapter implements RESTClient {
   }
 
   @Override
+  public <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Map<String, String> queryParams,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return execute(HTTPMethod.POST, path, queryParams, body, responseType, headers, errorHandler);
+  }
+
+  @Override
   public <T extends RESTResponse> T get(
       String path,
       Map<String, String> queryParams,
@@ -670,7 +681,9 @@ public class RESTCatalogAdapter implements RESTClient {
   }
 
   private static Namespace namespaceFromPathVars(Map<String, String> pathVars) {
-    return RESTUtil.decodeNamespace(pathVars.get("namespace"), NAMESPACE_SEPARATOR);
+    String namespaceSeparator =
+        PropertyUtil.propertyAsString(pathVars, "separator", NAMESPACE_SEPARATOR);
+    return RESTUtil.decodeNamespace(pathVars.get("namespace"), namespaceSeparator);
   }
 
   private static TableIdentifier identFromPathVars(Map<String, String> pathVars) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
@@ -208,7 +208,16 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
     Mockito.verify(adapter)
         .handleRequest(
             eq(RESTCatalogAdapter.Route.LIST_VIEWS),
-            eq(ImmutableMap.of("pageToken", "", "pageSize", "10", "namespace", namespaceName)),
+            eq(
+                ImmutableMap.of(
+                    "pageToken",
+                    "",
+                    "pageSize",
+                    "10",
+                    "namespace",
+                    namespaceName,
+                    "separator",
+                    "%2E")),
             any(),
             eq(ListTablesResponse.class));
 
@@ -216,7 +225,16 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
     Mockito.verify(adapter)
         .handleRequest(
             eq(RESTCatalogAdapter.Route.LIST_VIEWS),
-            eq(ImmutableMap.of("pageToken", "10", "pageSize", "10", "namespace", namespaceName)),
+            eq(
+                ImmutableMap.of(
+                    "pageToken",
+                    "10",
+                    "pageSize",
+                    "10",
+                    "namespace",
+                    namespaceName,
+                    "separator",
+                    "%2E")),
             any(),
             eq(ListTablesResponse.class));
 
@@ -224,7 +242,16 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
     Mockito.verify(adapter)
         .handleRequest(
             eq(RESTCatalogAdapter.Route.LIST_VIEWS),
-            eq(ImmutableMap.of("pageToken", "20", "pageSize", "10", "namespace", namespaceName)),
+            eq(
+                ImmutableMap.of(
+                    "pageToken",
+                    "20",
+                    "pageSize",
+                    "10",
+                    "namespace",
+                    namespaceName,
+                    "separator",
+                    "%2E")),
             any(),
             eq(ListTablesResponse.class));
   }

--- a/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
@@ -24,6 +24,8 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestResourcePaths {
   private final String prefix = "ws/catalog";
@@ -62,6 +64,50 @@ public class TestResourcePaths {
     Namespace ns = Namespace.of("n", "s");
     assertThat(withPrefix.namespace(ns)).isEqualTo("v1/ws/catalog/namespaces/n%1Fs");
     assertThat(withoutPrefix.namespace(ns)).isEqualTo("v1/namespaces/n%1Fs");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"%1F", "%2D", "%2E"})
+  public void testNamespaceWithMultipartNamespace(String namespaceSeparator) {
+    Namespace ns = Namespace.of("n", "s");
+    String namespace = String.format("n%ss", namespaceSeparator);
+    assertThat(
+            ResourcePaths.forCatalogProperties(
+                    ImmutableMap.of(
+                        "prefix",
+                        prefix,
+                        RESTSessionCatalog.NAMESPACE_SEPARATOR,
+                        namespaceSeparator))
+                .namespace(ns))
+        .isEqualTo("v1/ws/catalog/namespaces/" + namespace);
+
+    assertThat(
+            ResourcePaths.forCatalogProperties(
+                    ImmutableMap.of(RESTSessionCatalog.NAMESPACE_SEPARATOR, namespaceSeparator))
+                .namespace(ns))
+        .isEqualTo("v1/namespaces/" + namespace);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"%1F", "%2D", "%2E"})
+  public void testNamespaceWithDot(String namespaceSeparator) {
+    Namespace ns = Namespace.of("n.s", "a.b");
+    String namespace = String.format("n.s%sa.b", namespaceSeparator);
+    assertThat(
+            ResourcePaths.forCatalogProperties(
+                    ImmutableMap.of(
+                        "prefix",
+                        prefix,
+                        RESTSessionCatalog.NAMESPACE_SEPARATOR,
+                        namespaceSeparator))
+                .namespace(ns))
+        .isEqualTo("v1/ws/catalog/namespaces/" + namespace);
+
+    assertThat(
+            ResourcePaths.forCatalogProperties(
+                    ImmutableMap.of(RESTSessionCatalog.NAMESPACE_SEPARATOR, namespaceSeparator))
+                .namespace(ns))
+        .isEqualTo("v1/namespaces/" + namespace);
   }
 
   @Test

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -222,7 +222,9 @@ paths:
           description:
             An optional namespace, underneath which to list namespaces.
             If not provided or empty, all top-level namespaces should be listed.
-            If parent is a multipart namespace, the parts must be separated by the unit separator (`0x1F`) byte.
+            If parent is a multipart namespace, the parts should be separated by the namespace separator as
+            indicated via the /config override `namespace-separator`, which defaults to the unit separator (`0x1F`) byte.
+            To be compatible with older clients, servers should use both the advertised separator and `0x1F` as valid separators when decoding namespaces.
           required: false
           allowEmptyValue: true
           schema:
@@ -1450,7 +1452,9 @@ components:
       required: true
       description:
         A namespace identifier as a single string.
-        Multipart namespace parts should be separated by the unit separator (`0x1F`) byte.
+        Multipart namespace parts should be separated by the namespace separator as
+        indicated via the /config override `namespace-separator`, which defaults to the unit separator (`0x1F`) byte.
+        To be compatible with older clients, servers should use both the advertised separator and `0x1F` as valid separators when decoding namespaces.
       schema:
         type: string
       examples:


### PR DESCRIPTION
This currently depends on https://github.com/apache/iceberg/pull/10877.

This PR makes the namespace separator configurable from the client and sends it to the server via the `separator` query param. The server then respects this `separator` if it has been set by the client