### PR TITLE
Test: Add rowDelete test in TestChangeLogReader

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
@@ -21,15 +21,19 @@ package org.apache.iceberg.spark.source;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iceberg.ChangelogOperation;
 import org.apache.iceberg.ChangelogScanTask;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.IncrementalChangelogScan;
 import org.apache.iceberg.PartitionSpec;
@@ -41,8 +45,8 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.types.Types;
@@ -58,6 +62,10 @@ public class TestChangelogReader extends TestBase {
           required(1, "id", Types.IntegerType.get()), optional(2, "data", Types.StringType.get()));
   private static final PartitionSpec SPEC =
       PartitionSpec.builderFor(SCHEMA).bucket("data", 16).build();
+
+  private static final String SUFFIX =
+      String.format(".%s", FileFormat.PARQUET.name().toLowerCase());
+
   private final List<Record> records1 = Lists.newArrayList();
   private final List<Record> records2 = Lists.newArrayList();
 
@@ -65,6 +73,7 @@ public class TestChangelogReader extends TestBase {
   private DataFile dataFile1;
   private DataFile dataFile2;
 
+  private DeleteFile positionDelete;
   @TempDir private Path temp;
 
   @BeforeEach
@@ -84,6 +93,14 @@ public class TestChangelogReader extends TestBase {
     // write data to files
     dataFile1 = writeDataFile(records1);
     dataFile2 = writeDataFile(records2);
+
+    // create some position delete
+    PositionDelete<GenericRecord> posDelete = PositionDelete.create();
+    GenericRecord nested = GenericRecord.create(table.schema());
+    nested.set(0, 29);
+    posDelete.set(dataFile1.path(), 0L, nested);
+    List<PositionDelete<?>> deletes = Lists.newArrayList(posDelete);
+    positionDelete = writePositionDeleteFile(deletes);
   }
 
   @AfterEach
@@ -99,20 +116,8 @@ public class TestChangelogReader extends TestBase {
     table.newAppend().appendFile(dataFile2).commit();
     long snapshotId2 = table.currentSnapshot().snapshotId();
 
-    CloseableIterable<ScanTaskGroup<ChangelogScanTask>> taskGroups = newScan().planTasks();
-
-    List<InternalRow> rows = Lists.newArrayList();
-
-    for (ScanTaskGroup<ChangelogScanTask> taskGroup : taskGroups) {
-      ChangelogRowReader reader =
-          new ChangelogRowReader(table, taskGroup, table.schema(), table.schema(), false);
-      while (reader.next()) {
-        rows.add(reader.get().copy());
-      }
-      reader.close();
-    }
-
-    rows.sort((r1, r2) -> r1.getInt(0) - r2.getInt(0));
+    List<InternalRow> rows = rowFromScan(newScan());
+    rows.sort(Comparator.comparingInt(r -> r.getInt(0)));
 
     List<Object[]> expectedRows = Lists.newArrayList();
     addExpectedRows(expectedRows, ChangelogOperation.INSERT, snapshotId1, 0, records1);
@@ -129,21 +134,8 @@ public class TestChangelogReader extends TestBase {
     table.newDelete().deleteFile(dataFile1).commit();
     long snapshotId2 = table.currentSnapshot().snapshotId();
 
-    CloseableIterable<ScanTaskGroup<ChangelogScanTask>> taskGroups =
-        newScan().fromSnapshotExclusive(snapshotId1).planTasks();
-
-    List<InternalRow> rows = Lists.newArrayList();
-
-    for (ScanTaskGroup<ChangelogScanTask> taskGroup : taskGroups) {
-      ChangelogRowReader reader =
-          new ChangelogRowReader(table, taskGroup, table.schema(), table.schema(), false);
-      while (reader.next()) {
-        rows.add(reader.get().copy());
-      }
-      reader.close();
-    }
-
-    rows.sort((r1, r2) -> r1.getInt(0) - r2.getInt(0));
+    List<InternalRow> rows = rowFromScan(newScan().fromSnapshotExclusive(snapshotId1));
+    rows.sort(Comparator.comparingInt(r -> r.getInt(0)));
 
     List<Object[]> expectedRows = Lists.newArrayList();
     addExpectedRows(expectedRows, ChangelogOperation.DELETE, snapshotId2, 0, records1);
@@ -152,30 +144,25 @@ public class TestChangelogReader extends TestBase {
   }
 
   @Test
+  public void testRowDelete() {
+    table.newAppend().appendFile(dataFile1).commit();
+    table.newRowDelta().addDeletes(positionDelete).commit();
+
+    assertThatThrownBy(() -> newScan().planTasks())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Delete files are currently not supported in changelog scans");
+  }
+
+  @Test
   public void testDataFileRewrite() throws IOException {
     table.newAppend().appendFile(dataFile1).commit();
     table.newAppend().appendFile(dataFile2).commit();
     long snapshotId2 = table.currentSnapshot().snapshotId();
 
-    table
-        .newRewrite()
-        .rewriteFiles(ImmutableSet.of(dataFile1), ImmutableSet.of(dataFile2))
-        .commit();
+    table.newRewrite().deleteFile(dataFile1).addFile(dataFile2).commit();
 
     // the rewrite operation should generate no Changelog rows
-    CloseableIterable<ScanTaskGroup<ChangelogScanTask>> taskGroups =
-        newScan().fromSnapshotExclusive(snapshotId2).planTasks();
-
-    List<InternalRow> rows = Lists.newArrayList();
-
-    for (ScanTaskGroup<ChangelogScanTask> taskGroup : taskGroups) {
-      ChangelogRowReader reader =
-          new ChangelogRowReader(table, taskGroup, table.schema(), table.schema(), false);
-      while (reader.next()) {
-        rows.add(reader.get().copy());
-      }
-      reader.close();
-    }
+    List<InternalRow> rows = rowFromScan(newScan().fromSnapshotExclusive(snapshotId2));
 
     assertThat(rows).as("Should have no rows").hasSize(0);
   }
@@ -191,7 +178,21 @@ public class TestChangelogReader extends TestBase {
     table.newAppend().appendFile(dataFile2).commit();
     long snapshotId3 = table.currentSnapshot().snapshotId();
 
-    CloseableIterable<ScanTaskGroup<ChangelogScanTask>> taskGroups = newScan().planTasks();
+    List<InternalRow> rows = rowFromScan(newScan());
+    // order by the change ordinal first and id to break tie
+    rows.sort(
+        Comparator.comparingInt((InternalRow r) -> r.getInt(3)).thenComparingInt(r -> r.getInt(0)));
+
+    List<Object[]> expectedRows = Lists.newArrayList();
+    addExpectedRows(expectedRows, ChangelogOperation.INSERT, snapshotId1, 0, records1);
+    addExpectedRows(expectedRows, ChangelogOperation.DELETE, snapshotId2, 1, records1);
+    addExpectedRows(expectedRows, ChangelogOperation.INSERT, snapshotId3, 2, records2);
+
+    assertEquals("Should have expected rows", expectedRows, internalRowsToJava(rows));
+  }
+
+  private List<InternalRow> rowFromScan(IncrementalChangelogScan scan) throws IOException {
+    CloseableIterable<ScanTaskGroup<ChangelogScanTask>> taskGroups = scan.planTasks();
 
     List<InternalRow> rows = Lists.newArrayList();
 
@@ -203,30 +204,14 @@ public class TestChangelogReader extends TestBase {
       }
       reader.close();
     }
-
-    // order by the change ordinal
-    rows.sort(
-        (r1, r2) -> {
-          if (r1.getInt(3) != r2.getInt(3)) {
-            return r1.getInt(3) - r2.getInt(3);
-          } else {
-            return r1.getInt(0) - r2.getInt(0);
-          }
-        });
-
-    List<Object[]> expectedRows = Lists.newArrayList();
-    addExpectedRows(expectedRows, ChangelogOperation.INSERT, snapshotId1, 0, records1);
-    addExpectedRows(expectedRows, ChangelogOperation.DELETE, snapshotId2, 1, records1);
-    addExpectedRows(expectedRows, ChangelogOperation.INSERT, snapshotId3, 2, records2);
-
-    assertEquals("Should have expected rows", expectedRows, internalRowsToJava(rows));
+    return rows;
   }
 
   private IncrementalChangelogScan newScan() {
     return table.newIncrementalChangelogScan();
   }
 
-  private List<Object[]> addExpectedRows(
+  private void addExpectedRows(
       List<Object[]> expectedRows,
       ChangelogOperation operation,
       long snapshotId,
@@ -235,7 +220,6 @@ public class TestChangelogReader extends TestBase {
     records.forEach(
         r ->
             expectedRows.add(row(r.get(0), r.get(1), operation.name(), changeOrdinal, snapshotId)));
-    return expectedRows;
   }
 
   protected List<Object[]> internalRowsToJava(List<InternalRow> rows) {
@@ -256,8 +240,17 @@ public class TestChangelogReader extends TestBase {
     // records all use IDs that are in bucket id_bucket=0
     return FileHelpers.writeDataFile(
         table,
-        Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
+        Files.localOutput(File.createTempFile("junit", SUFFIX, temp.toFile())),
         TestHelpers.Row.of(0),
         records);
+  }
+
+  private DeleteFile writePositionDeleteFile(List<PositionDelete<?>> deletes) throws IOException {
+    // records all use IDs that are in bucket id_bucket=0
+    return FileHelpers.writePosDeleteFile(
+        table,
+        Files.localOutput(File.createTempFile("junit", SUFFIX, temp.toFile())),
+        TestHelpers.Row.of(0),
+        deletes);
   }
 }


### PR DESCRIPTION
Refactor and improve test for TestChangeLogReader
- added test case for use CDC for reading MOR table
- moved away from deprecated method in https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/RewriteFiles.java#L141-L144
- simplified row sorting with Comparator
- extracted common logic into rowFromScan

Can you help take a look? @flyrain @szehon-ho 

