### PR TITLE
Core: (unit test) Set partition to the right PartitionKey

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
@@ -465,7 +465,7 @@ public class TestMetadataTableFilters extends TestBase {
             .withPartition(data10Key)
             .build();
     PartitionKey data11Key = new PartitionKey(newSpec, table.schema());
-    data11Key.set(0, 1); // data=0
+    data11Key.set(0, 1); // data=1
     data11Key.set(1, 11); // id=11
     DataFile data11 =
         DataFiles.builder(newSpec)

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
@@ -317,7 +317,7 @@ public class TestMetadataTableFilters extends TestBase {
             .withPartition(data10Key)
             .build();
     PartitionKey data11Key = new PartitionKey(newSpec, table.schema());
-    data10Key.set(1, 11);
+    data11Key.set(1, 11);
     DataFile data11 =
         DataFiles.builder(newSpec)
             .withPath("/path/to/data-11.parquet")
@@ -466,7 +466,7 @@ public class TestMetadataTableFilters extends TestBase {
             .build();
     PartitionKey data11Key = new PartitionKey(newSpec, table.schema());
     data11Key.set(0, 1); // data=0
-    data10Key.set(1, 11); // id=11
+    data11Key.set(1, 11); // id=11
     DataFile data11 =
         DataFiles.builder(newSpec)
             .withPath("/path/to/data-11.parquet")

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -939,7 +939,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             .withPartition(data10Key)
             .build();
     PartitionKey data11Key = new PartitionKey(newSpec, table.schema());
-    data11Key.set(0, 1); // data=0
+    data11Key.set(0, 1); // data=1
     data11Key.set(1, 11); // id=11
     DataFile data11 =
         DataFiles.builder(newSpec)

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -940,7 +940,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             .build();
     PartitionKey data11Key = new PartitionKey(newSpec, table.schema());
     data11Key.set(0, 1); // data=0
-    data10Key.set(1, 11); // id=11
+    data11Key.set(1, 11); // id=11
     DataFile data11 =
         DataFiles.builder(newSpec)
             .withPath("/path/to/data-11.parquet")


### PR DESCRIPTION
 - Found a few minor typos where the right partition key is not set. Coincidentally, they don't break unit tests so it is a bit tricky to detect.
 - Fix comments on partition values

cc @szehon-ho @RussellSpitzer Please take a look for me, thanks!