### PR TITLE
Core: fix NPE with HadoopFileIO because FileIOParser doesn't serialize Hadoop configuration

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -74,7 +74,7 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
   }
 
   public Configuration conf() {
-    return hadoopConf.get();
+    return getConf();
   }
 
   @Override
@@ -120,6 +120,12 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
 
   @Override
   public Configuration getConf() {
+    // Create a default hadoopConf as it is required for the object to be valid.
+    // E.g. newInputFile would throw NPE with hadoopConf.get() otherwise.
+    if (hadoopConf == null) {
+      this.hadoopConf = new SerializableConfiguration(new Configuration())::get;
+    }
+
     return hadoopConf.get();
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -123,7 +123,11 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
     // Create a default hadoopConf as it is required for the object to be valid.
     // E.g. newInputFile would throw NPE with getConf() otherwise.
     if (hadoopConf == null) {
-      this.hadoopConf = new SerializableConfiguration(new Configuration())::get;
+      synchronized (this) {
+        if (hadoopConf == null) {
+          this.hadoopConf = new SerializableConfiguration(new Configuration())::get;
+        }
+      }
     }
 
     return hadoopConf.get();

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -84,23 +84,23 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
 
   @Override
   public InputFile newInputFile(String path) {
-    return HadoopInputFile.fromLocation(path, hadoopConf.get());
+    return HadoopInputFile.fromLocation(path, getConf());
   }
 
   @Override
   public InputFile newInputFile(String path, long length) {
-    return HadoopInputFile.fromLocation(path, length, hadoopConf.get());
+    return HadoopInputFile.fromLocation(path, length, getConf());
   }
 
   @Override
   public OutputFile newOutputFile(String path) {
-    return HadoopOutputFile.fromPath(new Path(path), hadoopConf.get());
+    return HadoopOutputFile.fromPath(new Path(path), getConf());
   }
 
   @Override
   public void deleteFile(String path) {
     Path toDelete = new Path(path);
-    FileSystem fs = Util.getFs(toDelete, hadoopConf.get());
+    FileSystem fs = Util.getFs(toDelete, getConf());
     try {
       fs.delete(toDelete, false /* not recursive */);
     } catch (IOException e) {
@@ -121,7 +121,7 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
   @Override
   public Configuration getConf() {
     // Create a default hadoopConf as it is required for the object to be valid.
-    // E.g. newInputFile would throw NPE with hadoopConf.get() otherwise.
+    // E.g. newInputFile would throw NPE with getConf() otherwise.
     if (hadoopConf == null) {
       this.hadoopConf = new SerializableConfiguration(new Configuration())::get;
     }
@@ -138,7 +138,7 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
   @Override
   public Iterable<FileInfo> listPrefix(String prefix) {
     Path prefixToList = new Path(prefix);
-    FileSystem fs = Util.getFs(prefixToList, hadoopConf.get());
+    FileSystem fs = Util.getFs(prefixToList, getConf());
 
     return () -> {
       try {
@@ -160,7 +160,7 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
   @Override
   public void deletePrefix(String prefix) {
     Path prefixToDelete = new Path(prefix);
-    FileSystem fs = Util.getFs(prefixToDelete, hadoopConf.get());
+    FileSystem fs = Util.getFs(prefixToDelete, getConf());
 
     try {
       fs.delete(prefixToDelete, true /* recursive */);

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
@@ -220,7 +220,8 @@ public class HadoopFileIOTest {
       String inputFilePath =
           Files.createTempDirectory(tempDir.toPath(), "junit").toFile().getAbsolutePath()
               + "/test.parquet";
-      deserializedHadoopFileIO.newInputFile(File.createTempFile("test", "parquet", tempDir).toString());
+      deserializedHadoopFileIO.newInputFile(
+          File.createTempFile("test", "parquet", tempDir).toString());
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
@@ -220,7 +220,7 @@ public class HadoopFileIOTest {
       String inputFilePath =
           Files.createTempDirectory(tempDir.toPath(), "junit").toFile().getAbsolutePath()
               + "/test.parquet";
-      deserializedHadoopFileIO.newInputFile(inputFilePath);
+      deserializedHadoopFileIO.newInputFile(File.createTempFile("test", "parquet", tempDir).toString());
     }
   }
 


### PR DESCRIPTION
This can happen in the FileIOParser serialization and deserialization scenario. FileIOParser doesn't serialize and deserialize the Hadoop configuration. the deserialized io object is not valid because hadoopConf is null. NPE would be throw if newInputFile is called on deserialized object.

This is a blocker for Flink to switch to JSON parser for scan tasks of metadata tables (like manifest etc.)