### PR TITLE
[DRAFT] Support changelog scan for table with delete files

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
@@ -21,8 +21,6 @@ package org.apache.iceberg;
 import static org.apache.iceberg.TableProperties.MANIFEST_MERGE_ENABLED;
 import static org.apache.iceberg.TableProperties.MANIFEST_MIN_MERGE_COUNT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
 import java.util.Comparator;
@@ -245,19 +243,6 @@ public class TestBaseIncrementalChangelogScan
     assertThat(t2.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
     assertThat(t2.file().path()).as("Data file must match").isEqualTo(FILE_B.path());
     assertThat(t2.deletes()).as("Must be no deletes").isEmpty();
-  }
-
-  @TestTemplate
-  public void testDeleteFilesAreNotSupported() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    table.newFastAppend().appendFile(FILE_A2).appendFile(FILE_B).commit();
-
-    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
-
-    assertThatThrownBy(() -> plan(newScan()))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Delete files are currently not supported in changelog scans");
   }
 
   // plans tasks and reorders them to have deterministic order

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -197,16 +197,11 @@ public abstract class DeleteFilter<T> {
   }
 
   public CloseableIterable<T> findEqualityDeleteRows(CloseableIterable<T> records) {
-    // Predicate to test whether a row has been deleted by equality deletions.
-    Predicate<T> deletedRows = applyEqDeletes().stream().reduce(Predicate::or).orElse(t -> false);
-
-    return CloseableIterable.filter(records, deletedRows);
+    return CloseableIterable.filter(records, isEqDeleted());
   }
 
   private CloseableIterable<T> applyEqDeletes(CloseableIterable<T> records) {
-    Predicate<T> isEqDeleted = applyEqDeletes().stream().reduce(Predicate::or).orElse(t -> false);
-
-    return createDeleteIterable(records, isEqDeleted);
+    return createDeleteIterable(records, isEqDeleted());
   }
 
   protected void markRowDeleted(T item) {
@@ -214,12 +209,17 @@ public abstract class DeleteFilter<T> {
         this.getClass().getName() + " does not implement markRowDeleted");
   }
 
-  public Predicate<T> eqDeletedRowFilter() {
+  // Predicate to test whether a row has been deleted by equality deletes
+  public Predicate<T> isEqDeleted() {
     if (eqDeleteRows == null) {
-      eqDeleteRows =
-          applyEqDeletes().stream().map(Predicate::negate).reduce(Predicate::and).orElse(t -> true);
+      eqDeleteRows = applyEqDeletes().stream().reduce(Predicate::or).orElse(t -> false);
     }
     return eqDeleteRows;
+  }
+
+  // Predicate to test whether a row has not been deleted by equality deletes
+  public Predicate<T> eqDeletedRowFilter() {
+    return isEqDeleted().negate();
   }
 
   public PositionDeleteIndex deletedRowPositions() {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -46,7 +46,9 @@ import org.apache.iceberg.data.BaseDeleteLoader;
 import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.data.DeleteLoader;
 import org.apache.iceberg.deletes.DeleteCounter;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.encryption.EncryptingFileIO;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.NameMapping;
@@ -57,6 +59,7 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.ByteBuffers;
+import org.apache.iceberg.util.Filter;
 import org.apache.iceberg.util.PartitionUtil;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -272,6 +275,27 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
         row.setBoolean(columnIsDeletedPosition(), true);
         counter().increment();
       }
+    }
+
+    /**
+     * Returns the rows that are deleted.
+     *
+     * @param rows the rows of the data file
+     * @return the deleted rows
+     */
+    public CloseableIterable<InternalRow> filterDeleted(CloseableIterable<InternalRow> rows) {
+      PositionDeleteIndex deletedRowPositions = deletedRowPositions();
+      Filter<InternalRow> deletedFilter =
+          new Filter<InternalRow>() {
+            @Override
+            protected boolean shouldKeep(InternalRow row) {
+              boolean isPosDeleted = deletedRowPositions.isDeleted(pos(row));
+              boolean isEqDeleted = isEqDeleted().test(row);
+              return isPosDeleted || isEqDeleted;
+            }
+          };
+
+      return deletedFilter.filter(rows);
     }
 
     @Override


### PR DESCRIPTION
Currently changelog scan is only supported for a table with no delete files. We implement support for the case when delete files are present in the snapshots to be scanned.