### PR TITLE
Build warning fix.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Metrics.java
+++ b/api/src/main/java/org/apache/iceberg/Metrics.java
@@ -190,6 +190,7 @@ public class Metrics implements Serializable {
     upperBounds = readByteBufferMap(in);
   }
 
+  @SuppressWarnings("DangerousJavaDeserialization")
   private static Map<Integer, ByteBuffer> readByteBufferMap(ObjectInputStream in)
       throws IOException, ClassNotFoundException {
     int size = in.readInt();

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -412,7 +412,7 @@ public class S3FileIO implements CredentialSupplier, DelegateFileIO, SupportsRec
     }
   }
 
-  @SuppressWarnings("checkstyle:NoFinalizer")
+  @SuppressWarnings({"checkstyle:NoFinalizer", "Finalize"})
   @Override
   protected void finalize() throws Throwable {
     super.finalize();

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -227,7 +227,7 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
     this.skipSize = skipSize;
   }
 
-  @SuppressWarnings("checkstyle:NoFinalizer")
+  @SuppressWarnings({"checkstyle:NoFinalizer", "Finalize"})
   @Override
   protected void finalize() throws Throwable {
     super.finalize();

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -475,7 +475,7 @@ class S3OutputStream extends PositionOutputStream {
     }
   }
 
-  @SuppressWarnings("checkstyle:NoFinalizer")
+  @SuppressWarnings({"checkstyle:NoFinalizer", "Finalize"})
   @Override
   protected void finalize() throws Throwable {
     super.finalize();

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
@@ -122,7 +122,7 @@ public class HadoopStreams {
       return stream.read(b, off, len);
     }
 
-    @SuppressWarnings("checkstyle:NoFinalizer")
+    @SuppressWarnings({"checkstyle:NoFinalizer", "Finalize"})
     @Override
     protected void finalize() throws Throwable {
       super.finalize();
@@ -195,7 +195,7 @@ public class HadoopStreams {
       }
     }
 
-    @SuppressWarnings("checkstyle:NoFinalizer")
+    @SuppressWarnings({"checkstyle:NoFinalizer", "Finalize"})
     @Override
     protected void finalize() throws Throwable {
       super.finalize();

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -240,7 +240,7 @@ public class ResolvingFileIO implements HadoopConfigurable, DelegateFileIO {
     return null;
   }
 
-  @SuppressWarnings("checkstyle:NoFinalizer")
+  @SuppressWarnings({"checkstyle:NoFinalizer", "Finalize"})
   @Override
   protected void finalize() throws Throwable {
     super.finalize();

--- a/core/src/main/java/org/apache/iceberg/util/SerializationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SerializationUtil.java
@@ -69,7 +69,7 @@ public class SerializationUtil {
     }
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"DangerousJavaDeserialization", "unchecked"})
   public static <T> T deserializeFromBytes(byte[] bytes) {
     if (bytes == null) {
       return null;

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
@@ -186,7 +186,7 @@ class GCSInputStream extends SeekableInputStream implements RangeReadable {
     }
   }
 
-  @SuppressWarnings("checkstyle:NoFinalizer")
+  @SuppressWarnings({"checkstyle:NoFinalizer", "Finalize"})
   @Override
   protected void finalize() throws Throwable {
     super.finalize();

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSOutputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSOutputStream.java
@@ -130,7 +130,7 @@ class GCSOutputStream extends PositionOutputStream {
     stream.close();
   }
 
-  @SuppressWarnings("checkstyle:NoFinalizer")
+  @SuppressWarnings({"checkstyle:NoFinalizer", "Finalize"})
   @Override
   protected void finalize() throws Throwable {
     super.finalize();


### PR DESCRIPTION
After upgrading to Java 21, the build is showing new warnings. One of the warnings is related to the deprecated `finalize` method and should be fixed rather than suppressed. 
I have created an [issue](https://github.com/apache/iceberg/issues/10901) for that. 