### PR TITLE
Core, API, Arrow: Type promotion for int/long to string for V3 tables

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.BinaryUtil;
 import org.apache.iceberg.util.NaNUtil;
@@ -207,8 +208,15 @@ public class InclusiveMetricsEvaluator {
         return ROWS_CANNOT_MATCH;
       }
 
-      if (lowerBounds != null && lowerBounds.containsKey(id)) {
-        T lower = Conversions.fromByteBuffer(ref.type(), lowerBounds.get(id));
+      ByteBuffer fieldLowerBounds = lowerBounds != null ? lowerBounds.get(id) : null;
+      ByteBuffer fieldUpperBounds = upperBounds != null ? upperBounds.get(id) : null;
+
+      if (fieldPromotedToString(ref, fieldLowerBounds, fieldUpperBounds)) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      if (fieldLowerBounds != null) {
+        T lower = Conversions.fromByteBuffer(ref.type(), fieldLowerBounds);
 
         if (NaNUtil.isNaN(lower)) {
           // NaN indicates unreliable bounds. See the InclusiveMetricsEvaluator docs for more.
@@ -232,8 +240,15 @@ public class InclusiveMetricsEvaluator {
         return ROWS_CANNOT_MATCH;
       }
 
-      if (lowerBounds != null && lowerBounds.containsKey(id)) {
-        T lower = Conversions.fromByteBuffer(ref.type(), lowerBounds.get(id));
+      ByteBuffer fieldLowerBounds = lowerBounds != null ? lowerBounds.get(id) : null;
+      ByteBuffer fieldUpperBounds = upperBounds != null ? upperBounds.get(id) : null;
+
+      if (fieldPromotedToString(ref, fieldLowerBounds, fieldUpperBounds)) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      if (fieldLowerBounds != null) {
+        T lower = Conversions.fromByteBuffer(ref.type(), fieldLowerBounds);
 
         if (NaNUtil.isNaN(lower)) {
           // NaN indicates unreliable bounds. See the InclusiveMetricsEvaluator docs for more.
@@ -257,8 +272,15 @@ public class InclusiveMetricsEvaluator {
         return ROWS_CANNOT_MATCH;
       }
 
-      if (upperBounds != null && upperBounds.containsKey(id)) {
-        T upper = Conversions.fromByteBuffer(ref.type(), upperBounds.get(id));
+      ByteBuffer fieldLowerBounds = lowerBounds != null ? lowerBounds.get(id) : null;
+      ByteBuffer fieldUpperBounds = upperBounds != null ? upperBounds.get(id) : null;
+
+      if (fieldPromotedToString(ref, fieldLowerBounds, fieldUpperBounds)) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      if (fieldUpperBounds != null) {
+        T upper = Conversions.fromByteBuffer(ref.type(), fieldUpperBounds);
 
         int cmp = lit.comparator().compare(upper, lit.value());
         if (cmp <= 0) {
@@ -277,8 +299,15 @@ public class InclusiveMetricsEvaluator {
         return ROWS_CANNOT_MATCH;
       }
 
-      if (upperBounds != null && upperBounds.containsKey(id)) {
-        T upper = Conversions.fromByteBuffer(ref.type(), upperBounds.get(id));
+      ByteBuffer fieldLowerBounds = lowerBounds != null ? lowerBounds.get(id) : null;
+      ByteBuffer fieldUpperBounds = upperBounds != null ? upperBounds.get(id) : null;
+
+      if (fieldPromotedToString(ref, fieldLowerBounds, fieldUpperBounds)) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      if (fieldUpperBounds != null) {
+        T upper = Conversions.fromByteBuffer(ref.type(), fieldUpperBounds);
 
         int cmp = lit.comparator().compare(upper, lit.value());
         if (cmp < 0) {
@@ -297,8 +326,15 @@ public class InclusiveMetricsEvaluator {
         return ROWS_CANNOT_MATCH;
       }
 
-      if (lowerBounds != null && lowerBounds.containsKey(id)) {
-        T lower = Conversions.fromByteBuffer(ref.type(), lowerBounds.get(id));
+      ByteBuffer fieldLowerBounds = lowerBounds != null ? lowerBounds.get(id) : null;
+      ByteBuffer fieldUpperBounds = upperBounds != null ? upperBounds.get(id) : null;
+
+      if (fieldPromotedToString(ref, fieldLowerBounds, fieldUpperBounds)) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      if (fieldLowerBounds != null) {
+        T lower = Conversions.fromByteBuffer(ref.type(), fieldLowerBounds);
 
         if (NaNUtil.isNaN(lower)) {
           // NaN indicates unreliable bounds. See the InclusiveMetricsEvaluator docs for more.
@@ -311,8 +347,8 @@ public class InclusiveMetricsEvaluator {
         }
       }
 
-      if (upperBounds != null && upperBounds.containsKey(id)) {
-        T upper = Conversions.fromByteBuffer(ref.type(), upperBounds.get(id));
+      if (fieldUpperBounds != null) {
+        T upper = Conversions.fromByteBuffer(ref.type(), fieldUpperBounds);
 
         int cmp = lit.comparator().compare(upper, lit.value());
         if (cmp < 0) {
@@ -338,6 +374,13 @@ public class InclusiveMetricsEvaluator {
         return ROWS_CANNOT_MATCH;
       }
 
+      ByteBuffer fieldLowerBounds = lowerBounds != null ? lowerBounds.get(id) : null;
+      ByteBuffer fieldUpperBounds = upperBounds != null ? upperBounds.get(id) : null;
+
+      if (fieldPromotedToString(ref, fieldLowerBounds, fieldUpperBounds)) {
+        return ROWS_MIGHT_MATCH;
+      }
+
       Collection<T> literals = literalSet;
 
       if (literals.size() > IN_PREDICATE_LIMIT) {
@@ -345,8 +388,8 @@ public class InclusiveMetricsEvaluator {
         return ROWS_MIGHT_MATCH;
       }
 
-      if (lowerBounds != null && lowerBounds.containsKey(id)) {
-        T lower = Conversions.fromByteBuffer(ref.type(), lowerBounds.get(id));
+      if (fieldLowerBounds != null) {
+        T lower = Conversions.fromByteBuffer(ref.type(), fieldLowerBounds);
 
         if (NaNUtil.isNaN(lower)) {
           // NaN indicates unreliable bounds. See the InclusiveMetricsEvaluator docs for more.
@@ -362,8 +405,8 @@ public class InclusiveMetricsEvaluator {
         }
       }
 
-      if (upperBounds != null && upperBounds.containsKey(id)) {
-        T upper = Conversions.fromByteBuffer(ref.type(), upperBounds.get(id));
+      if (fieldUpperBounds != null) {
+        T upper = Conversions.fromByteBuffer(ref.type(), fieldUpperBounds);
         literals =
             literals.stream()
                 .filter(v -> ref.comparator().compare(upper, v) >= 0)
@@ -468,6 +511,15 @@ public class InclusiveMetricsEvaluator {
       }
 
       return ROWS_MIGHT_MATCH;
+    }
+
+    private <T> boolean fieldPromotedToString(
+        BoundReference<T> ref, ByteBuffer fieldLowerBounds, ByteBuffer fieldUpperBounds) {
+      return fieldLowerBounds != null
+          && fieldUpperBounds != null
+          && ref.field().type().typeId() == Type.TypeID.STRING
+          && (fieldLowerBounds.capacity() == 8L || fieldLowerBounds.capacity() == 4L)
+          && fieldLowerBounds.capacity() == fieldUpperBounds.capacity();
     }
 
     private boolean mayContainNull(Integer id) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
+import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.iceberg.arrow.vectorized.GenericArrowVectorAccessorFactory.DecimalFactory;
 import org.apache.iceberg.arrow.vectorized.GenericArrowVectorAccessorFactory.StringFactory;
@@ -63,6 +64,11 @@ final class ArrowVectorAccessors {
     @Override
     public String ofRow(VarCharVector vector, int rowId) {
       return ofBytes(vector.get(rowId));
+    }
+
+    @Override
+    public String ofRow(BigIntVector vector, int rowId) {
+      return String.valueOf(vector.get(rowId));
     }
 
     @Override

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/GenericArrowVectorAccessorFactory.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/GenericArrowVectorAccessorFactory.java
@@ -188,7 +188,7 @@ public class GenericArrowVectorAccessorFactory<
       if (isDecimal(primitive)) {
         return new LongBackedDecimalAccessor<>((BigIntVector) vector, decimalFactorySupplier.get());
       }
-      return new LongAccessor<>((BigIntVector) vector);
+      return new LongAccessor<>((BigIntVector) vector, stringFactorySupplier.get());
     } else if (vector instanceof Float4Vector) {
       return new FloatAccessor<>((Float4Vector) vector);
     } else if (vector instanceof Float8Vector) {
@@ -271,15 +271,22 @@ public class GenericArrowVectorAccessorFactory<
       extends ArrowVectorAccessor<DecimalT, Utf8StringT, ArrayT, ChildVectorT> {
 
     private final BigIntVector vector;
+    private final StringFactory<Utf8StringT> stringFactory;
 
-    LongAccessor(BigIntVector vector) {
+    LongAccessor(BigIntVector vector, StringFactory<Utf8StringT> stringFactory) {
       super(vector);
       this.vector = vector;
+      this.stringFactory = stringFactory;
     }
 
     @Override
     public final long getLong(int rowId) {
       return vector.get(rowId);
+    }
+
+    @Override
+    public final Utf8StringT getUTF8String(int rowId) {
+      return stringFactory.ofRow(vector, rowId);
     }
   }
 
@@ -811,6 +818,12 @@ public class GenericArrowVectorAccessorFactory<
           String.format(
               "Creating %s from a FixedSizeBinaryVector is not supported",
               getGenericClass().getSimpleName()));
+    }
+
+    default Utf8StringT ofRow(BigIntVector vector, int rowId) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Creating %s from BigIntVector is not supported", getGenericClass().getSimpleName()));
     }
 
     /** Create a UTF8 String from the byte array. */

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -33,6 +33,7 @@ import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.TimeMicroVector;
 import org.apache.arrow.vector.TimeStampMicroTZVector;
 import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -414,6 +415,16 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
         break;
       case INT64:
         this.vec = arrowField.createVector(rootAlloc);
+        if (vec instanceof VarCharVector) {
+          Field localIntField =
+              new Field(
+                  icebergField.name(),
+                  new FieldType(
+                      icebergField.isOptional(), new ArrowType.Int(Long.SIZE, true), null, null),
+                  null);
+          this.vec = localIntField.createVector(rootAlloc);
+        }
+
         ((BigIntVector) vec).allocateNew(batchSize);
         this.readType = ReadType.LONG;
         this.typeWidth = (int) BigIntVector.TYPE_WIDTH;

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -285,7 +285,7 @@ class SchemaUpdate implements UpdateSchema {
     }
 
     Preconditions.checkArgument(
-        TypeUtil.isPromotionAllowed(field.type(), newType),
+        TypeUtil.isPromotionAllowed(field, newType, base.specs(), base.formatVersion()),
         "Cannot change column type: %s: %s -> %s",
         name,
         field.type(),

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -39,6 +39,8 @@ import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.BinaryUtil;
+import org.apache.parquet.column.statistics.IntStatistics;
+import org.apache.parquet.column.statistics.LongStatistics;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -217,6 +219,10 @@ public class ParquetMetricsRowGroupFilter {
           return ROWS_CANNOT_MATCH;
         }
 
+        if (fieldPromotedToString(ref, colStats)) {
+          return ROWS_MIGHT_MATCH;
+        }
+
         if (minMaxUndefined(colStats)) {
           return ROWS_MIGHT_MATCH;
         }
@@ -245,6 +251,10 @@ public class ParquetMetricsRowGroupFilter {
       if (colStats != null && !colStats.isEmpty()) {
         if (allNulls(colStats, valueCount)) {
           return ROWS_CANNOT_MATCH;
+        }
+
+        if (fieldPromotedToString(ref, colStats)) {
+          return ROWS_MIGHT_MATCH;
         }
 
         if (minMaxUndefined(colStats)) {
@@ -277,6 +287,10 @@ public class ParquetMetricsRowGroupFilter {
           return ROWS_CANNOT_MATCH;
         }
 
+        if (fieldPromotedToString(ref, colStats)) {
+          return ROWS_MIGHT_MATCH;
+        }
+
         if (minMaxUndefined(colStats)) {
           return ROWS_MIGHT_MATCH;
         }
@@ -305,6 +319,10 @@ public class ParquetMetricsRowGroupFilter {
       if (colStats != null && !colStats.isEmpty()) {
         if (allNulls(colStats, valueCount)) {
           return ROWS_CANNOT_MATCH;
+        }
+
+        if (fieldPromotedToString(ref, colStats)) {
+          return ROWS_MIGHT_MATCH;
         }
 
         if (minMaxUndefined(colStats)) {
@@ -342,6 +360,10 @@ public class ParquetMetricsRowGroupFilter {
       if (colStats != null && !colStats.isEmpty()) {
         if (allNulls(colStats, valueCount)) {
           return ROWS_CANNOT_MATCH;
+        }
+
+        if (fieldPromotedToString(ref, colStats)) {
+          return ROWS_MIGHT_MATCH;
         }
 
         if (minMaxUndefined(colStats)) {
@@ -547,6 +569,11 @@ public class ParquetMetricsRowGroupFilter {
       }
 
       return ROWS_MIGHT_MATCH;
+    }
+
+    private <T> boolean fieldPromotedToString(BoundReference<T> field, Statistics<?> colStats) {
+      return field.type().typeId() == Type.TypeID.STRING
+          && (colStats instanceof LongStatistics || colStats instanceof IntStatistics);
     }
 
     @SuppressWarnings("unchecked")

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.data.vectorized;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarCharVector;
@@ -79,6 +80,11 @@ final class ArrowVectorAccessorFactory
     @Override
     public UTF8String ofRow(FixedSizeBinaryVector vector, int rowId) {
       return UTF8String.fromString(UUIDUtil.convert(vector.get(rowId)).toString());
+    }
+
+    @Override
+    public UTF8String ofRow(BigIntVector vector, int rowId) {
+      return UTF8String.fromString(String.valueOf(vector.get(rowId)));
     }
 
     @Override


### PR DESCRIPTION
Leaving in draft as we discuss as a community, but this change adds support for int/long -> string conversion without any additional metadata changes. InclusiveMetricsEvaluator is updated to do a check where if a type is string and the bounds are equal and the bounds are either 4/8 bytes, that file is assumed to have been type promoted and as a result the file must be read. This change also updates the vectorized read path so that the projection from int to string can happen after type promotion. Note, ParquetRowGroup filter needed to be updated to identify a possible type promotion and ensure the row group is read before comparing stats since that would fail due to casting issues.

Leaving in draft as we discuss as a community on the approach and the code still needs to be cleaned up/more tests/considerations for other file formats like ORC/Avro.