### PR TITLE
Core: Remove one comment from FastAppend

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.events.CreateSnapshotEvent;
-import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -32,12 +31,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.CharSequenceSet;
 
-/**
- * {@link AppendFiles Append} implementation that adds a new manifest file for the write.
- *
- * <p>This implementation will attempt to commit 5 times before throwing {@link
- * CommitFailedException}.
- */
+/** {@link AppendFiles Append} implementation that adds a new manifest file for the write. */
 class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
   private final String tableName;
   private final TableOperations ops;

--- a/core/src/main/java/org/apache/iceberg/MergeAppend.java
+++ b/core/src/main/java/org/apache/iceberg/MergeAppend.java
@@ -18,15 +18,9 @@
  */
 package org.apache.iceberg;
 
-import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-/**
- * Append implementation that produces a minimal number of manifest files.
- *
- * <p>This implementation will attempt to commit 5 times before throwing {@link
- * CommitFailedException}.
- */
+/** {@link AppendFiles Append} implementation that produces a minimal number of manifest files. */
 class MergeAppend extends MergingSnapshotProducer<AppendFiles> implements AppendFiles {
   MergeAppend(String tableName, TableOperations ops) {
     super(tableName, ops);

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -70,6 +70,12 @@ import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Keeps common functionality to create a new snapshot.
+ *
+ * <p>The number of attempted commits is controlled by {@link TableProperties#COMMIT_NUM_RETRIES}
+ * and {@link TableProperties#COMMIT_NUM_RETRIES_DEFAULT} properties.
+ */
 @SuppressWarnings("UnnecessaryAnonymousClass")
 abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   private static final Logger LOG = LoggerFactory.getLogger(SnapshotProducer.class);

--- a/core/src/main/java/org/apache/iceberg/StreamingDelete.java
+++ b/core/src/main/java/org/apache/iceberg/StreamingDelete.java
@@ -18,15 +18,9 @@
  */
 package org.apache.iceberg;
 
-import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.expressions.Expression;
 
-/**
- * {@link DeleteFiles Delete} implementation that avoids loading full manifests in memory.
- *
- * <p>This implementation will attempt to commit 5 times before throwing {@link
- * CommitFailedException}.
- */
+/** {@link DeleteFiles Delete} implementation that avoids loading full manifests in memory. */
 public class StreamingDelete extends MergingSnapshotProducer<DeleteFiles> implements DeleteFiles {
   private boolean validateFilesToDeleteExist = false;
 


### PR DESCRIPTION
There is a comment for FastAppend that mentions the number of commit retries done by the class. I removed it for 2 reasons:
  1) Not the FastAppend class does the commit so the commit retries shouldn't be commented there.
  2) The number of commit retries is configurable via a table property so mentioning a hard-coded
     value in the comment is incorrect.

Added a new test that adjusts the COMMIT_NUM_RETRIES table property. Adjusted existing tests to exercise the boundaries of the number of commit retries.