### PR TITLE
Docs: Add Druid docs url to sidebar

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
   - Snowflake: https://docs.snowflake.com/en/user-guide/tables-iceberg
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
   - Doris: https://doris.apache.org/docs/dev/lakehouse/datalake-analytics/iceberg
+  - Druid: https://druid.apache.org/docs/latest/development/extensions-contrib/iceberg/
   - Integrations:
     - aws.md
     - dell.md


### PR DESCRIPTION
Add entry to the sidebar linking to the official Druid Iceberg tables support.