### PR TITLE
Docs: Rename Clickhouse to ClickHouse

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -53,7 +53,7 @@ nav:
   - hive.md
   - Trino: https://trino.io/docs/current/connector/iceberg.html
   - Daft: daft.md
-  - Clickhouse: https://clickhouse.com/docs/en/engines/table-engines/integrations/iceberg
+  - ClickHouse: https://clickhouse.com/docs/en/engines/table-engines/integrations/iceberg
   - Presto: https://prestodb.io/docs/current/connector/iceberg.html
   - Dremio: https://docs.dremio.com/data-formats/apache-iceberg/
   - Starrocks: https://docs.starrocks.io/en-us/latest/data_source/catalog/iceberg_catalog


### PR DESCRIPTION
ClickHouse is the right name (H should be uppercase): https://clickhouse.com/