### PR TITLE
Core: Project data file stats only if there are equality deletes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -71,6 +71,8 @@ class DeleteFileIndex {
   private final PartitionMap<EqualityDeletes> eqDeletesByPartition;
   private final PartitionMap<PositionDeletes> posDeletesByPartition;
   private final CharSequenceMap<PositionDeletes> posDeletesByPath;
+  private final boolean hasEqDeletes;
+  private final boolean hasPosDeletes;
   private final boolean isEmpty;
 
   private DeleteFileIndex(
@@ -82,13 +84,21 @@ class DeleteFileIndex {
     this.eqDeletesByPartition = eqDeletesByPartition;
     this.posDeletesByPartition = posDeletesByPartition;
     this.posDeletesByPath = posDeletesByPath;
-    boolean noEqDeletes = globalDeletes == null && eqDeletesByPartition == null;
-    boolean noPosDeletes = posDeletesByPartition == null && posDeletesByPath == null;
-    this.isEmpty = noEqDeletes && noPosDeletes;
+    this.hasEqDeletes = globalDeletes != null || eqDeletesByPartition != null;
+    this.hasPosDeletes = posDeletesByPartition != null || posDeletesByPath != null;
+    this.isEmpty = !hasEqDeletes && !hasPosDeletes;
   }
 
   public boolean isEmpty() {
     return isEmpty;
+  }
+
+  public boolean hasEqualityDeletes() {
+    return hasEqDeletes;
+  }
+
+  public boolean hasPositionDeletes() {
+    return hasPosDeletes;
   }
 
   public Iterable<DeleteFile> referencedDeleteFiles() {

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -184,7 +184,7 @@ class ManifestGroup {
     DeleteFileIndex deleteFiles = deleteIndexBuilder.scanMetrics(scanMetrics).build();
 
     boolean dropStats = ManifestReader.dropStats(columns);
-    if (!deleteFiles.isEmpty()) {
+    if (deleteFiles.hasEqualityDeletes()) {
       select(ManifestReader.withStatsColumns(columns));
     }
 

--- a/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
@@ -139,6 +139,8 @@ public abstract class DeleteFileIndexTestBase<
 
     DataFile file = unpartitionedFile(partSpec);
 
+    assertThat(index.hasEqualityDeletes()).isTrue();
+    assertThat(index.hasPositionDeletes()).isFalse();
     assertThat(index.forDataFile(0, file)).as("Only one delete file should apply").hasSize(1);
   }
 
@@ -157,6 +159,9 @@ public abstract class DeleteFileIndexTestBase<
         DeleteFileIndex.builderFor(Arrays.asList(deleteFiles))
             .specsById(ImmutableMap.of(partSpec.specId(), partSpec, 1, SPEC))
             .build();
+
+    assertThat(index.hasEqualityDeletes()).isTrue();
+    assertThat(index.hasPositionDeletes()).isTrue();
 
     DataFile unpartitionedFile = unpartitionedFile(partSpec);
     assertThat(index.forDataFile(0, unpartitionedFile))
@@ -212,6 +217,9 @@ public abstract class DeleteFileIndexTestBase<
         DeleteFileIndex.builderFor(Arrays.asList(deleteFiles))
             .specsById(ImmutableMap.of(SPEC.specId(), SPEC, 1, PartitionSpec.unpartitioned()))
             .build();
+
+    assertThat(index.hasEqualityDeletes()).isTrue();
+    assertThat(index.hasPositionDeletes()).isTrue();
 
     assertThat(index.forDataFile(0, FILE_A))
         .as("All deletes should apply to seq 0")


### PR DESCRIPTION
This PR optimizes `ManifestGroup` to only project data file stats if equality deletes are present. Such stats are useless for position deletes as position deletes are either assigned via path lookup or by partition. This is similar to an optimization we performed in distributed planning.