### PR TITLE
Spark 3.5: fix drop table & purge table have to check iceberg catalog

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -278,7 +278,11 @@ public class SparkSessionCatalog<T extends TableCatalog & FunctionCatalog & Supp
     // no need to check table existence to determine which catalog to use. if a table doesn't exist
     // then both are
     // required to return false.
-    return icebergCatalog.dropTable(ident) || getSessionCatalog().dropTable(ident);
+    if (icebergCatalog.tableExists(ident)) {
+      return icebergCatalog.dropTable(ident);
+    } else {
+      return getSessionCatalog().dropTable(ident);
+    }
   }
 
   @Override
@@ -286,7 +290,11 @@ public class SparkSessionCatalog<T extends TableCatalog & FunctionCatalog & Supp
     // no need to check table existence to determine which catalog to use. if a table doesn't exist
     // then both are
     // required to return false.
-    return icebergCatalog.purgeTable(ident) || getSessionCatalog().purgeTable(ident);
+    if (icebergCatalog.tableExists(ident)) {
+      return icebergCatalog.purgeTable(ident);
+    } else {
+      return getSessionCatalog().purgeTable(ident);
+    }
   }
 
   @Override


### PR DESCRIPTION
In the current version of spark 3.5, regardless of whether the table is iceberg or not, it will be droped and purged as iceberg. We must verify whether the table is an iceberg catalog before performing the operation.