### PR TITLE
Core: Generate realistic bounds in benchmarks

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
@@ -40,7 +40,7 @@ public class TestFileGenerationUtil {
           required(2, "long_col", Types.LongType.get()),
           required(3, "decimal_col", Types.DecimalType.of(10, 10)),
           required(4, "date_col", Types.DateType.get()),
-          required(5, "timestamp_col", Types.TimestampType.withZone()),
+          required(5, "timestamp_col", Types.TimestampType.withoutZone()),
           required(6, "timestamp_tz_col", Types.TimestampType.withZone()),
           required(7, "str_col", Types.StringType.get()));
 
@@ -66,7 +66,7 @@ public class TestFileGenerationUtil {
     NestedField intField = SCHEMA.findField("int_col");
     PrimitiveType type = intField.type().asPrimitiveType();
     ByteBuffer intLower = Conversions.toByteBuffer(type, 0);
-    ByteBuffer intUpper = Conversions.toByteBuffer(type, 0);
+    ByteBuffer intUpper = Conversions.toByteBuffer(type, Integer.MAX_VALUE);
     Metrics metrics =
         FileGenerationUtil.generateRandomMetrics(
             SCHEMA,

--- a/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.util.Comparator;
+import org.apache.iceberg.MetricsModes.MetricsMode;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type.PrimitiveType;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
+import org.junit.jupiter.api.Test;
+
+public class TestFileGenerationUtil {
+
+  public static final Schema SCHEMA =
+      new Schema(
+          required(1, "int_col", Types.IntegerType.get()),
+          required(2, "long_col", Types.LongType.get()),
+          required(3, "decimal_col", Types.DecimalType.of(10, 10)),
+          required(4, "date_col", Types.DateType.get()),
+          required(5, "timestamp_col", Types.TimestampType.withZone()),
+          required(6, "timestamp_tz_col", Types.TimestampType.withZone()),
+          required(7, "str_col", Types.StringType.get()));
+
+  @Test
+  public void testBoundsWithDefaultMetricsConfig() {
+    MetricsConfig metricsConfig = MetricsConfig.getDefault();
+    Metrics metrics =
+        FileGenerationUtil.generateRandomMetrics(
+            SCHEMA,
+            metricsConfig,
+            ImmutableMap.of() /* no known lower bounds */,
+            ImmutableMap.of() /* no known upper bounds */);
+
+    assertThat(metrics.lowerBounds()).hasSize(SCHEMA.columns().size());
+    assertThat(metrics.upperBounds()).hasSize(SCHEMA.columns().size());
+
+    checkBounds(metrics, metricsConfig);
+  }
+
+  @Test
+  public void testBoundsWithSpecificValues() {
+    MetricsConfig metricsConfig = MetricsConfig.getDefault();
+    NestedField intField = SCHEMA.findField("int_col");
+    PrimitiveType type = intField.type().asPrimitiveType();
+    ByteBuffer intLower = Conversions.toByteBuffer(type, 0);
+    ByteBuffer intUpper = Conversions.toByteBuffer(type, 0);
+    Metrics metrics =
+        FileGenerationUtil.generateRandomMetrics(
+            SCHEMA,
+            metricsConfig,
+            ImmutableMap.of(intField.fieldId(), intLower),
+            ImmutableMap.of(intField.fieldId(), intUpper));
+
+    assertThat(metrics.lowerBounds()).hasSize(SCHEMA.columns().size());
+    assertThat(metrics.upperBounds()).hasSize(SCHEMA.columns().size());
+
+    checkBounds(metrics, metricsConfig);
+
+    ByteBuffer actualIntLower = metrics.lowerBounds().get(intField.fieldId());
+    ByteBuffer actualIntUpper = metrics.upperBounds().get(intField.fieldId());
+    assertThat(actualIntLower).isEqualTo(intLower);
+    assertThat(actualIntUpper).isEqualTo(intUpper);
+  }
+
+  private void checkBounds(Metrics metrics, MetricsConfig metricsConfig) {
+    for (NestedField field : SCHEMA.columns()) {
+      MetricsMode mode = metricsConfig.columnMode(field.name());
+      ByteBuffer lowerBuffer = metrics.lowerBounds().get(field.fieldId());
+      ByteBuffer upperBuffer = metrics.upperBounds().get(field.fieldId());
+      if (mode.equals(MetricsModes.None.get()) || mode.equals(MetricsModes.Counts.get())) {
+        assertThat(lowerBuffer).isNull();
+        assertThat(upperBuffer).isNull();
+      } else {
+        checkBounds(field.type().asPrimitiveType(), lowerBuffer, upperBuffer);
+      }
+    }
+  }
+
+  private void checkBounds(PrimitiveType type, ByteBuffer lowerBuffer, ByteBuffer upperBuffer) {
+    Object lower = Conversions.fromByteBuffer(type, lowerBuffer);
+    Object upper = Conversions.fromByteBuffer(type, upperBuffer);
+    Comparator<Object> cmp = Comparators.forType(type);
+    assertThat(cmp.compare(lower, upper)).isLessThanOrEqualTo(0);
+  }
+}


### PR DESCRIPTION
This PR makes `FileGenerationUtil`, which is used in benchmarks, generate realistic bounds.

Our current logic always generates 16 random bytes, which causes problems:
- The metrics mode is not respected (none, count, full).
- Bounds may be invalid values (int/long).
- Lower bounds may be actually be greater than upper bounds.

```
 byte[] lower = new byte[16];
 random().nextBytes(lower);
 lowerBounds.put(fieldId, ByteBuffer.wrap(lower));
 byte[] upper = new byte[16];
 random().nextBytes(upper);
 upperBounds.put(fieldId, ByteBuffer.wrap(upper));
```

I ran a few benchmarks that depend on `FileGenerationUtil ` after this change and they seem to run fine. I also added tests.