### PR TITLE
OpenAPI, Build: Apply spotless to testFixtures source code

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -73,7 +73,7 @@ subprojects {
   pluginManager.withPlugin('com.diffplug.spotless') {
     spotless {
       java {
-        target 'src/main/java/**/*.java', 'src/test/java/**/*.java', 'src/jmh/java/**/*.java', 'src/integration/java/**/*.java'
+        target 'src/main/java/**/*.java', 'src/test/java/**/*.java', 'src/testFixtures/java/**/*.java', 'src/jmh/java/**/*.java', 'src/integration/java/**/*.java'
         // we use an older version of google-java-format that is compatible with JDK 8
         googleJavaFormat("1.7")
         removeUnusedImports()

--- a/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTCatalogServer.java
+++ b/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTCatalogServer.java
@@ -106,7 +106,7 @@ public class RESTCatalogServer {
     httpServer.setHandler(context);
     httpServer.start();
 
-    if(join) {
+    if (join) {
       httpServer.join();
     }
   }

--- a/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTServerExtension.java
+++ b/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTServerExtension.java
@@ -28,9 +28,7 @@ public class RESTServerExtension implements BeforeAllCallback, AfterAllCallback 
   @Override
   public void beforeAll(ExtensionContext extensionContext) throws Exception {
     if (Boolean.parseBoolean(
-        extensionContext
-            .getConfigurationParameter(RCKUtils.RCK_LOCAL)
-            .orElse("true"))) {
+        extensionContext.getConfigurationParameter(RCKUtils.RCK_LOCAL).orElse("true"))) {
       this.localServer = new RESTCatalogServer();
       this.localServer.start(false);
     }


### PR DESCRIPTION
The `testFixtures` directories were not included in spotless, this PR adds them to the source targets.