### PR TITLE
Core: Propagate catalog-level properties to iceberg-views.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -44,6 +44,7 @@ public class ExpressionUtil {
       Transforms.bucket(Integer.MAX_VALUE).bind(Types.StringType.get());
   private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
   private static final long FIVE_MINUTES_IN_MICROS = TimeUnit.MINUTES.toMicros(5);
+  private static final long FIVE_MINUTES_IN_NANOS = TimeUnit.MINUTES.toNanos(5);
   private static final long THREE_DAYS_IN_HOURS = TimeUnit.DAYS.toHours(3);
   private static final long NINETY_DAYS_IN_HOURS = TimeUnit.DAYS.toHours(90);
   private static final Pattern DATE = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");

--- a/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
@@ -67,9 +67,7 @@ public class Transforms {
     return new UnknownTransform<>(transform);
   }
 
-  /**
-   * @deprecated use {@link #identity()} instead; will be removed in 2.0.0
-   */
+  /** @deprecated use {@link #identity()} instead; will be removed in 2.0.0 */
   @Deprecated
   public static Transform<?, ?> fromString(Type type, String transform) {
     Matcher widthMatcher = HAS_WIDTH.matcher(transform);

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -254,34 +254,34 @@ public abstract class BaseMetastoreCatalog implements Catalog, Closeable {
         return Transactions.replaceTableTransaction(identifier.toString(), ops, metadata);
       }
     }
-  }
 
-  /**
-   * Get default table properties set at Catalog level through catalog properties.
-   *
-   * @return default table properties specified in catalog properties
-   */
-  protected Map<String, String> tableDefaultProperties() {
-    Map<String, String> tableDefaultProperties =
-        PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.TABLE_DEFAULT_PREFIX);
-    LOG.info(
-        "Table properties set at catalog level through catalog properties: {}",
-        tableDefaultProperties);
-    return tableDefaultProperties;
-  }
+    /**
+     * Get default table properties set at Catalog level through catalog properties.
+     *
+     * @return default table properties specified in catalog properties
+     */
+    private Map<String, String> tableDefaultProperties() {
+      Map<String, String> tableDefaultProperties =
+          PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.TABLE_DEFAULT_PREFIX);
+      LOG.info(
+          "Table properties set at catalog level through catalog properties: {}",
+          tableDefaultProperties);
+      return tableDefaultProperties;
+    }
 
-  /**
-   * Get table properties that are enforced at Catalog level through catalog properties.
-   *
-   * @return default table properties enforced through catalog properties
-   */
-  protected Map<String, String> tableOverrideProperties() {
-    Map<String, String> tableOverrideProperties =
-        PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.TABLE_OVERRIDE_PREFIX);
-    LOG.info(
-        "Table properties enforced at catalog level through catalog properties: {}",
-        tableOverrideProperties);
-    return tableOverrideProperties;
+    /**
+     * Get table properties that are enforced at Catalog level through catalog properties.
+     *
+     * @return default table properties enforced through catalog properties
+     */
+    private Map<String, String> tableOverrideProperties() {
+      Map<String, String> tableOverrideProperties =
+          PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.TABLE_OVERRIDE_PREFIX);
+      LOG.info(
+          "Table properties enforced at catalog level through catalog properties: {}",
+          tableOverrideProperties);
+      return tableOverrideProperties;
+    }
   }
 
   protected static String fullTableName(String catalogName, TableIdentifier identifier) {

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -254,34 +254,34 @@ public abstract class BaseMetastoreCatalog implements Catalog, Closeable {
         return Transactions.replaceTableTransaction(identifier.toString(), ops, metadata);
       }
     }
+  }
 
-    /**
-     * Get default table properties set at Catalog level through catalog properties.
-     *
-     * @return default table properties specified in catalog properties
-     */
-    private Map<String, String> tableDefaultProperties() {
-      Map<String, String> tableDefaultProperties =
-          PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.TABLE_DEFAULT_PREFIX);
-      LOG.info(
-          "Table properties set at catalog level through catalog properties: {}",
-          tableDefaultProperties);
-      return tableDefaultProperties;
-    }
+  /**
+   * Get default table properties set at Catalog level through catalog properties.
+   *
+   * @return default table properties specified in catalog properties
+   */
+  protected Map<String, String> tableDefaultProperties() {
+    Map<String, String> tableDefaultProperties =
+        PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.TABLE_DEFAULT_PREFIX);
+    LOG.info(
+        "Table properties set at catalog level through catalog properties: {}",
+        tableDefaultProperties);
+    return tableDefaultProperties;
+  }
 
-    /**
-     * Get table properties that are enforced at Catalog level through catalog properties.
-     *
-     * @return default table properties enforced through catalog properties
-     */
-    private Map<String, String> tableOverrideProperties() {
-      Map<String, String> tableOverrideProperties =
-          PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.TABLE_OVERRIDE_PREFIX);
-      LOG.info(
-          "Table properties enforced at catalog level through catalog properties: {}",
-          tableOverrideProperties);
-      return tableOverrideProperties;
-    }
+  /**
+   * Get table properties that are enforced at Catalog level through catalog properties.
+   *
+   * @return default table properties enforced through catalog properties
+   */
+  protected Map<String, String> tableOverrideProperties() {
+    Map<String, String> tableOverrideProperties =
+        PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.TABLE_OVERRIDE_PREFIX);
+    LOG.info(
+        "Table properties enforced at catalog level through catalog properties: {}",
+        tableOverrideProperties);
+    return tableOverrideProperties;
   }
 
   protected static String fullTableName(String catalogName, TableIdentifier identifier) {

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -29,6 +29,8 @@ public class CatalogProperties {
   public static final String WAREHOUSE_LOCATION = "warehouse";
   public static final String TABLE_DEFAULT_PREFIX = "table-default.";
   public static final String TABLE_OVERRIDE_PREFIX = "table-override.";
+  public static final String VIEW_DEFAULT_PREFIX = "view-default.";
+  public static final String VIEW_OVERRIDE_PREFIX = "view-override.";
   public static final String METRICS_REPORTER_IMPL = "metrics-reporter-impl";
 
   /**

--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
@@ -68,6 +68,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
   private final ConcurrentMap<TableIdentifier, String> views;
   private FileIO io;
   private String catalogName;
+  private Map<String, String> catalogProperties;
   private String warehouseLocation;
   private CloseableGroup closeableGroup;
 
@@ -85,6 +86,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
   @Override
   public void initialize(String name, Map<String, String> properties) {
     this.catalogName = name != null ? name : InMemoryCatalog.class.getSimpleName();
+    this.catalogProperties = ImmutableMap.copyOf(properties);
 
     String warehouse = properties.getOrDefault(CatalogProperties.WAREHOUSE_LOCATION, "");
     this.warehouseLocation = warehouse.replaceAll("/*$", "");
@@ -92,6 +94,11 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(metricsReporter());
     closeableGroup.setSuppressCloseFailure(true);
+  }
+
+  @Override
+  protected Map<String, String> properties() {
+    return catalogProperties == null ? ImmutableMap.of() : catalogProperties;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/view/BaseMetastoreViewCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseMetastoreViewCatalog.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.view;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.BaseMetastoreCatalog;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Transaction;
@@ -33,6 +34,7 @@ import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.PropertyUtil;
 
 public abstract class BaseMetastoreViewCatalog extends BaseMetastoreCatalog implements ViewCatalog {
   protected abstract ViewOperations newViewOps(TableIdentifier identifier);
@@ -79,7 +81,8 @@ public abstract class BaseMetastoreViewCatalog extends BaseMetastoreCatalog impl
       Preconditions.checkArgument(
           isValidIdentifier(identifier), "Invalid view identifier: %s", identifier);
       this.identifier = identifier;
-      this.properties.putAll(tableDefaultProperties());
+      this.properties.putAll(
+          PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.VIEW_DEFAULT_PREFIX));
     }
 
     @Override
@@ -156,7 +159,8 @@ public abstract class BaseMetastoreViewCatalog extends BaseMetastoreCatalog impl
       Preconditions.checkState(
           null != defaultNamespace, "Cannot create view without specifying a default namespace");
 
-      properties.putAll(tableOverrideProperties());
+      properties.putAll(
+          PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.VIEW_OVERRIDE_PREFIX));
       ViewVersion viewVersion =
           ImmutableViewVersion.builder()
               .versionId(1)
@@ -192,7 +196,8 @@ public abstract class BaseMetastoreViewCatalog extends BaseMetastoreCatalog impl
       if (null == ops.current()) {
         throw new NoSuchViewException("View does not exist: %s", identifier);
       }
-      properties.putAll(tableOverrideProperties());
+      properties.putAll(
+          PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.VIEW_OVERRIDE_PREFIX));
 
       Preconditions.checkState(
           !representations.isEmpty(), "Cannot replace view without specifying a query");

--- a/core/src/main/java/org/apache/iceberg/view/BaseMetastoreViewCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseMetastoreViewCatalog.java
@@ -79,6 +79,7 @@ public abstract class BaseMetastoreViewCatalog extends BaseMetastoreCatalog impl
       Preconditions.checkArgument(
           isValidIdentifier(identifier), "Invalid view identifier: %s", identifier);
       this.identifier = identifier;
+      this.properties.putAll(tableDefaultProperties());
     }
 
     @Override
@@ -155,6 +156,7 @@ public abstract class BaseMetastoreViewCatalog extends BaseMetastoreCatalog impl
       Preconditions.checkState(
           null != defaultNamespace, "Cannot create view without specifying a default namespace");
 
+      properties.putAll(tableOverrideProperties());
       ViewVersion viewVersion =
           ImmutableViewVersion.builder()
               .versionId(1)
@@ -190,6 +192,7 @@ public abstract class BaseMetastoreViewCatalog extends BaseMetastoreCatalog impl
       if (null == ops.current()) {
         throw new NoSuchViewException("View does not exist: %s", identifier);
       }
+      properties.putAll(tableOverrideProperties());
 
       Preconditions.checkState(
           !representations.isEmpty(), "Cannot replace view without specifying a query");

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -64,6 +64,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1661,19 +1662,19 @@ public class TestTableMetadata {
                         6, "ts_nanos", Types.TimestampNanoType.withZone()))));
 
     for (int unsupportedFormatVersion : ImmutableList.of(1, 2)) {
-      assertThatThrownBy(
-              () ->
-                  TableMetadata.newTableMetadata(
-                      v3Schema,
-                      PartitionSpec.unpartitioned(),
-                      SortOrder.unsorted(),
-                      TEST_LOCATION,
-                      ImmutableMap.of(),
-                      unsupportedFormatVersion))
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessage(
+      Assertions.assertThrows(
+          IllegalStateException.class,
+          () ->
+              TableMetadata.newTableMetadata(
+                  v3Schema,
+                  PartitionSpec.unpartitioned(),
+                  SortOrder.unsorted(),
+                  TEST_LOCATION,
+                  ImmutableMap.of(),
+                  unsupportedFormatVersion),
+          String.format(
               "Invalid type in v%s schema: struct.ts_nanos timestamptz_ns is not supported until v3",
-              unsupportedFormatVersion);
+              unsupportedFormatVersion));
     }
 
     // should be allowed in v3

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -79,6 +79,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.View;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -1127,6 +1128,116 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
           .isInstanceOf(AlreadyExistsException.class)
           .hasMessageStartingWith("Table already exists: " + tableIdent);
     }
+  }
+
+  @Test
+  public void testTablePropsDefinedAtCatalogLevel() throws IOException {
+    TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    ImmutableMap<String, String> catalogProps =
+        ImmutableMap.of(
+            CatalogProperties.WAREHOUSE_LOCATION,
+            this.tableDir.toAbsolutePath().toString(),
+            CatalogProperties.URI,
+            "jdbc:sqlite:file::memory:?icebergDBV0",
+            JdbcUtil.SCHEMA_VERSION_PROPERTY,
+            JdbcUtil.SchemaVersion.V0.name(),
+            "table-default.key1",
+            "catalog-default-key1",
+            "table-default.key2",
+            "catalog-default-key2",
+            "table-default.key3",
+            "catalog-default-key3",
+            "table-override.key3",
+            "catalog-override-key3",
+            "table-override.key4",
+            "catalog-override-key4");
+    JdbcCatalog jdbcCatalog = new JdbcCatalog();
+    jdbcCatalog.setConf(conf);
+    jdbcCatalog.initialize("v0catalog", catalogProps);
+    Table table =
+        jdbcCatalog
+            .buildTable(tableIdent, SCHEMA)
+            .withProperties(null)
+            .withProperty("key2", "table-key2")
+            .withProperty("key3", "table-key3")
+            .withProperty("key5", "table-key5")
+            .create();
+
+    assertThat(table.properties().get("key1"))
+        .as("Table defaults set for the catalog must be added to the table properties.")
+        .isEqualTo("catalog-default-key1");
+    assertThat(table.properties().get("key2"))
+        .as("Table property must override table default properties set at catalog level.")
+        .isEqualTo("table-key2");
+    assertThat(table.properties().get("key3"))
+        .as(
+            "Table property override set at catalog level must override table default"
+                + " properties set at catalog level and table property specified.")
+        .isEqualTo("catalog-override-key3");
+    assertThat(table.properties().get("key4"))
+        .as("Table override not in table props or defaults should be added to table properties")
+        .isEqualTo("catalog-override-key4");
+    assertThat(table.properties().get("key5"))
+        .as(
+            "Table properties without any catalog level default or override should be added to table"
+                + " properties.")
+        .isEqualTo("table-key5");
+  }
+
+  @Test
+  public void testViewPropsDefinedAtCatalogLevel() throws IOException {
+    TableIdentifier viewIdent = TableIdentifier.of("db", "ns1");
+    ImmutableMap<String, String> catalogProps =
+        ImmutableMap.of(
+            CatalogProperties.WAREHOUSE_LOCATION,
+            this.tableDir.toAbsolutePath().toString(),
+            CatalogProperties.URI,
+            "jdbc:sqlite:file::memory:?icebergDBV0",
+            JdbcUtil.SCHEMA_VERSION_PROPERTY,
+            JdbcUtil.SchemaVersion.V1.name(),
+            "table-default.key1",
+            "catalog-default-key1",
+            "table-default.key2",
+            "catalog-default-key2",
+            "table-default.key3",
+            "catalog-default-key3",
+            "table-override.key3",
+            "catalog-override-key3",
+            "table-override.key4",
+            "catalog-override-key4");
+    JdbcCatalog jdbcCatalog = new JdbcCatalog();
+    jdbcCatalog.setConf(conf);
+    jdbcCatalog.initialize("v0catalog", catalogProps);
+    View view =
+        jdbcCatalog
+            .buildView(viewIdent)
+            .withQuery("spark", "SELECT * FROM t1")
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(Namespace.of("db"))
+            .withProperty("key2", "view-key2")
+            .withProperty("key3", "view-key3")
+            .withProperty("key5", "view-key5")
+            .create();
+
+    assertThat(view.properties().get("key1"))
+        .as("Table defaults set for the catalog must be added to the view properties.")
+        .isEqualTo("catalog-default-key1");
+    assertThat(view.properties().get("key2"))
+        .as("View property must override table default properties set at catalog level.")
+        .isEqualTo("view-key2");
+    assertThat(view.properties().get("key3"))
+        .as(
+            "View property override set at catalog level must override table default"
+                + " properties set at catalog level and table property specified.")
+        .isEqualTo("catalog-override-key3");
+    assertThat(view.properties().get("key4"))
+        .as("Table override not in table props or defaults should be added to view properties")
+        .isEqualTo("catalog-override-key4");
+    assertThat(view.properties().get("key5"))
+        .as(
+            "Table properties without any catalog level default or override should be added to view"
+                + " properties.")
+        .isEqualTo("view-key5");
   }
 
   public static class CustomMetricsReporter implements MetricsReporter {

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -1186,7 +1186,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
 
   @Test
   public void testViewPropsDefinedAtCatalogLevel() throws IOException {
-    TableIdentifier viewIdent = TableIdentifier.of("db", "ns1");
+    TableIdentifier identifier = TableIdentifier.of("db", "ns1");
     ImmutableMap<String, String> catalogProps =
         ImmutableMap.of(
             CatalogProperties.WAREHOUSE_LOCATION,
@@ -1195,22 +1195,22 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
             "jdbc:sqlite:file::memory:?icebergDBV0",
             JdbcUtil.SCHEMA_VERSION_PROPERTY,
             JdbcUtil.SchemaVersion.V1.name(),
-            "table-default.key1",
+            "view-default.key1",
             "catalog-default-key1",
-            "table-default.key2",
+            "view-default.key2",
             "catalog-default-key2",
-            "table-default.key3",
+            "view-default.key3",
             "catalog-default-key3",
-            "table-override.key3",
+            "view-override.key3",
             "catalog-override-key3",
-            "table-override.key4",
+            "view-override.key4",
             "catalog-override-key4");
     JdbcCatalog jdbcCatalog = new JdbcCatalog();
     jdbcCatalog.setConf(conf);
     jdbcCatalog.initialize("v0catalog", catalogProps);
     View view =
         jdbcCatalog
-            .buildView(viewIdent)
+            .buildView(identifier)
             .withQuery("spark", "SELECT * FROM t1")
             .withSchema(SCHEMA)
             .withDefaultNamespace(Namespace.of("db"))
@@ -1220,22 +1220,22 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
             .create();
 
     assertThat(view.properties().get("key1"))
-        .as("Table defaults set for the catalog must be added to the view properties.")
+        .as("View defaults set for the catalog must be added to the view properties.")
         .isEqualTo("catalog-default-key1");
     assertThat(view.properties().get("key2"))
-        .as("View property must override table default properties set at catalog level.")
+        .as("View property must override view default properties set at catalog level.")
         .isEqualTo("view-key2");
     assertThat(view.properties().get("key3"))
         .as(
-            "View property override set at catalog level must override table default"
-                + " properties set at catalog level and table property specified.")
+            "View property override set at catalog level must override view default"
+                + " properties set at catalog level and view property specified.")
         .isEqualTo("catalog-override-key3");
     assertThat(view.properties().get("key4"))
-        .as("Table override not in table props or defaults should be added to view properties")
+        .as("Table override not in view props or defaults should be added to view properties")
         .isEqualTo("catalog-override-key4");
     assertThat(view.properties().get("key5"))
         .as(
-            "Table properties without any catalog level default or override should be added to view"
+            "View properties without any catalog level default or override should be added to view"
                 + " properties.")
         .isEqualTo("view-key5");
   }


### PR DESCRIPTION
Similar like Iceberg-Table, allow view properties defaults to be configured at catalog level. 