### PR TITLE
Build: Ignore benchmark output folders across all modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ spark/v3.4/spark/benchmark/*
 spark/v3.4/spark-extensions/benchmark/*
 spark/v3.5/spark/benchmark/*
 spark/v3.5/spark-extensions/benchmark/*
-data/benchmark/*
+*/benchmark/*
 
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
This PR modifies `.gitignore` to include benchmark output folders across all modules, not just `data`. We already have benchmarks in other modules like `core` and it is easy to accidentally commit benchmark output files.