### PR TITLE
Docs: Change to Flink directory for instructions

### DIFF
--- a/docs/docs/flink.md
+++ b/docs/docs/flink.md
@@ -66,6 +66,7 @@ HADOOP_HOME=`pwd`/hadoop-${HADOOP_VERSION}
 export HADOOP_CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath`
 
 # Start the flink standalone cluster
+cd flink-${FLINK_VERSION}/
 ./bin/start-cluster.sh
 ```
 


### PR DESCRIPTION
All following commands assumes the directory is in flink-${FLINK_VERSION}. Let's update the instructions to make that clear.