### PR TITLE
Kafka Connect: Disable publish tasks in runtime project

### DIFF
--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -221,6 +221,11 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
     }
   }
 
+  // there are no Maven artifacts so disable publishing tasks...
+  project.afterEvaluate {
+    project.tasks.matching { it.group == 'publishing' }.each {it.enabled = false}
+  }
+
   tasks.jar.enabled = false
 
   tasks.distTar.enabled = false


### PR DESCRIPTION
This PR disables the build publishing tasks for the `kafka-connect-runtime` project. This project doesn't have any libraries to publish. This should resolve https://github.com/apache/iceberg/issues/11026.
