### PR TITLE
Docs: bump latest version to 1.6.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
@@ -28,7 +28,8 @@ body:
       description: What Apache Iceberg version are you using?
       multiple: false
       options:
-        - "1.6.0 (latest release)"
+        - "1.6.1 (latest release)"
+        - "1.6.0"
         - "1.5.2"
         - "1.5.1"
         - "1.5.0"

--- a/doap.rdf
+++ b/doap.rdf
@@ -41,9 +41,9 @@
     <category rdf:resource="https://projects.apache.org/category/data-engineering" />
     <release>
       <Version>
-        <name>1.6.0</name>
-        <created>2024-07-23</created>
-        <revision>1.6.0</revision>
+        <name>1.6.1</name>
+        <created>2024-08-27</created>
+        <revision>1.6.1</revision>
       </Version>
     </release>
     <repository>

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -78,7 +78,7 @@ markdown_extensions:
       permalink: 🔗
 
 extra:
-  icebergVersion: '1.6.0'
+  icebergVersion: '1.6.1'
   nessieVersion: '0.92.1'
   flinkVersion: '1.19.0'
   flinkVersionMajor: '1.19'

--- a/site/nav.yml
+++ b/site/nav.yml
@@ -23,6 +23,7 @@ nav:
   - Docs: 
     - nightly: '!include docs/docs/nightly/mkdocs.yml'
     - latest: '!include docs/docs/latest/mkdocs.yml'
+    - 1.6.1: '!include docs/docs/1.6.1/mkdocs.yml'
     - 1.6.0: '!include docs/docs/1.6.0/mkdocs.yml'
     - 1.5.2: '!include docs/docs/1.5.2/mkdocs.yml'
     - 1.5.1: '!include docs/docs/1.5.1/mkdocs.yml'   


### PR DESCRIPTION
Update latest release version to 1.6.1 in the doap and iceberg_bug_report.yml.