### PR TITLE
Use Snapshot's statistics file in SparkScan 

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
@@ -372,5 +373,15 @@ public interface Table {
     }
 
     return null;
+  }
+
+  /**
+   * Returns the statistics file for the given snapshot id, if available.
+   *
+   * @return the {@link StatisticsFile} for the given snapshot id, if available.
+   */
+  default Optional<StatisticsFile> statistics(long snapshotId) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " doesn't implement statistics");
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
@@ -278,6 +279,11 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
   @Override
   public String toString() {
     return name();
+  }
+
+  @Override
+  public Optional<StatisticsFile> statistics(long snapshotId) {
+    return statisticsFiles().stream().filter(file -> file.snapshotId() == snapshotId).findFirst();
   }
 
   Object writeReplace() {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -195,7 +195,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     Map<NamedReference, ColumnStatistics> colStatsMap = Collections.emptyMap();
     if (readConf.reportColumnStats() && cboEnabled) {
       colStatsMap = Maps.newHashMap();
-      Optional<StatisticsFile> statisticsFile = statisticsFile(snapshot);
+      Optional<StatisticsFile> statisticsFile = table.statistics(snapshot.snapshotId());
       if (statisticsFile.isPresent()) {
         List<BlobMetadata> metadataList = statisticsFile.get().blobMetadata();
 
@@ -244,13 +244,6 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     long rowsCount = taskGroups().stream().mapToLong(ScanTaskGroup::estimatedRowsCount).sum();
     long sizeInBytes = SparkSchemaUtil.estimateSize(readSchema(), rowsCount);
     return new Stats(sizeInBytes, rowsCount, colStatsMap);
-  }
-
-  private Optional<StatisticsFile> statisticsFile(Snapshot snapshot) {
-    long snapshotId = snapshot.snapshotId();
-    return table.statisticsFiles().stream()
-        .filter(statisticsFile -> statisticsFile.snapshotId() == snapshotId)
-        .findFirst();
   }
 
   private long totalRecords(Snapshot snapshot) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
@@ -344,9 +344,7 @@ public class TestSparkScan extends TestBaseWithCatalog {
         () -> {
           checkColStatisticsReported(scan1, 4, Map.of("id", 4L));
           checkColStatisticsReported(scan2, 5, Map.of("id", 5L));
-
-          Statistics statistics = scan3.estimateStatistics();
-          assertThat(statistics.columnStats()).isEmpty();
+          checkColStatisticsNotReported(scan3, 6L);
         });
   }
 


### PR DESCRIPTION
Use the statistics of the snapshot being scanned, instead of the first statistics file.

 @huaxingao @RussellSpitzer @aokolnychyi Please help review