### PR TITLE
Spark 3.5: Mandate identifier fields when create_changelog_view for table contain unsortable columns

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java
@@ -447,6 +447,7 @@ public class TestCreateChangelogViewProcedure extends ExtensionsTestBase {
             () ->
                 sql("CALL %s.system.create_changelog_view(table => '%s')", catalogName, tableName))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Identifier field is required if table contains unorderable columns");
+        .hasMessageContaining(
+            "Identifier field is required as table contains unorderable columns: [data]");
   }
 }

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java
@@ -436,4 +436,17 @@ public class TestCreateChangelogViewProcedure extends ExtensionsTestBase {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Not support net changes with update images");
   }
+
+  @TestTemplate
+  public void testUpdateWithInComparableType() {
+    sql(
+        "CREATE TABLE %s (id INT NOT NULL, data MAP<STRING,STRING>, age INT) USING iceberg",
+        tableName);
+
+    assertThatThrownBy(
+            () ->
+                sql("CALL %s.system.create_changelog_view(table => '%s')", catalogName, tableName))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Identifier field is required if table contains unorderable columns");
+  }
 }


### PR DESCRIPTION
Throw validation exception in create_changelog_view procedure when table contains unsortable columns and identifier columns are not provided

```
org.apache.spark.sql.AnalysisException: [DATATYPE_MISMATCH.INVALID_ORDERING_TYPE] Cannot resolve "tokens ASC NULLS FIRST" due to data type mismatch: The `sortorder` does not support ordering on type "MAP<STRING, STRING>"
org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt.dataTypeMismatch(package.scala:73)
  org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis0$5(CheckAnalysis.scala:269)
  org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis0$5$adapted(CheckAnalysis.scala:256)
  org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(TreeNode.scala:295)
  org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis0$4(CheckAnalysis.scala:256)
  org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis0$4$adapted(CheckAnalysis.scala:256)
  scala.collection.immutable.Stream.foreach(Stream.scala:533)
  org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis0$1(CheckAnalysis.scala:256)
  org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis0$1$adapted(CheckAnalysis.scala:163)
  org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(TreeNode.scala:295)
  org.apache.spark.sql.catalyst.analysis.CheckAnalysis.checkAnalysis0(CheckAnalysis.scala:163)
  org.apache.spark.sql.catalyst.analysis.CheckAnalysis.checkAnalysis0$(CheckAnalysis.scala:160)
  org.apache.spark.sql.catalyst.analysis.Analyzer.checkAnalysis0(Analyzer.scala:188)
  org.apache.spark.sql.catalyst.analysis.CheckAnalysis.checkAnalysis(CheckAnalysis.scala:156)
  org.apache.spark.sql.catalyst.analysis.CheckAnalysis.checkAnalysis$(CheckAnalysis.scala:146)
  org.apache.spark.sql.catalyst.analysis.Analyzer.checkAnalysis(Analyzer.scala:188)
  org.apache.spark.sql.catalyst.analysis.Analyzer.$anonfun$executeAndCheck$1(Analyzer.scala:211)
  org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.markInAnalyzer(AnalysisHelper.scala:330)
  org.apache.spark.sql.catalyst.analysis.Analyzer.executeAndCheck(Analyzer.scala:208)
  org.apache.spark.sql.execution.QueryExecution.$anonfun$analyzed$1(QueryExecution.scala:78)
  org.apache.spark.sql.catalyst.QueryPlanningTracker.measurePhase(QueryPlanningTracker.scala:111)
  org.apache.spark.sql.execution.QueryExecution.$anonfun$executePhase$2(QueryExecution.scala:204)
  org.apache.spark.sql.execution.QueryExecution$.withInternalError(QueryExecution.scala:547)
  org.apache.spark.sql.execution.QueryExecution.$anonfun$executePhase$1(QueryExecution.scala:204)
  org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:827)
  org.apache.spark.sql.execution.QueryExecution.executePhase(QueryExecution.scala:203)
  org.apache.spark.sql.execution.QueryExecution.analyzed$lzycompute(QueryExecution.scala:78)
  org.apache.spark.sql.execution.QueryExecution.analyzed(QueryExecution.scala:76)
  org.apache.spark.sql.execution.QueryExecution.assertAnalyzed(QueryExecution.scala:68)
  org.apache.spark.sql.Dataset.<init>(Dataset.scala:204)
  org.apache.spark.sql.Dataset.<init>(Dataset.scala:210)
  org.apache.spark.sql.Dataset$.apply(Dataset.scala:74)
  org.apache.spark.sql.Dataset.withTypedPlan(Dataset.scala:4242)
  org.apache.spark.sql.Dataset.sortInternal(Dataset.scala:4230)
  org.apache.spark.sql.Dataset.sortWithinPartitions(Dataset.scala:1381)
  org.apache.spark.sql.Dataset.sortWithinPartitions(Dataset.scala:1380)
  org.apache.iceberg.spark.procedures.CreateChangelogViewProcedure.applyCarryoverRemoveIterator(CreateChangelogViewProcedure.java:267)
  org.apache.iceberg.spark.procedures.CreateChangelogViewProcedure.removeCarryoverRows(CreateChangelogViewProcedure.java:218)
  org.apache.iceberg.spark.procedures.CreateChangelogViewProcedure.call(CreateChangelogViewProcedure.java:167)
```


This is due to we passed incomparable columns to spark using sortWithinPartitions in [here](https://github.com/apache/iceberg/blob/main/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/CreateChangelogViewProcedure.java#L236). 

Find some old spark PR where it consider both maps and binary data type are not comparable/sortable in [SPARK-9415 ](https://issues.apache.org/jira/browse/SPARK-9415) and [code](https://github.com/apache/spark/blob/515dfc166a95ecc8decce0f0cd99e06fe395f94f/sql/api/src/main/scala/org/apache/spark/sql/catalyst/expressions/OrderUtils.scala#L25-L32)