### PR TITLE
Core: Generalize Util::blockLocations

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1100,12 +1100,6 @@ acceptedBreaks:
     - code: "java.class.removed"
       old: "enum org.apache.iceberg.BaseMetastoreTableOperations.CommitStatus"
       justification: "Removing deprecated code"
-    - code: "java.method.parameterTypeChanged"
-      old: "parameter java.lang.String[] org.apache.iceberg.hadoop.Util::blockLocations(===org.apache.iceberg.CombinedScanTask===,\
-        \ org.apache.hadoop.conf.Configuration)"
-      new: "parameter java.lang.String[] org.apache.iceberg.hadoop.Util::blockLocations(===org.apache.iceberg.ScanTaskGroup<org.apache.iceberg.FileScanTask>===,\
-        \ org.apache.hadoop.conf.Configuration)"
-      justification: "False positive - CombinedScanTask is a subclass of ScanTaskGroup<FileScanTask>"
     - code: "java.method.removed"
       old: "method java.lang.String org.apache.iceberg.FileScanTaskParser::toJson(org.apache.iceberg.FileScanTask)"
       justification: "Removing deprecated code"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1100,6 +1100,12 @@ acceptedBreaks:
     - code: "java.class.removed"
       old: "enum org.apache.iceberg.BaseMetastoreTableOperations.CommitStatus"
       justification: "Removing deprecated code"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter java.lang.String[] org.apache.iceberg.hadoop.Util::blockLocations(===org.apache.iceberg.CombinedScanTask===,\
+        \ org.apache.hadoop.conf.Configuration)"
+      new: "parameter java.lang.String[] org.apache.iceberg.hadoop.Util::blockLocations(===org.apache.iceberg.ScanTaskGroup<org.apache.iceberg.FileScanTask>===,\
+        \ org.apache.hadoop.conf.Configuration)"
+      justification: "False positive - CombinedScanTask is a subclass of ScanTaskGroup<FileScanTask>"
     - code: "java.method.removed"
       old: "method java.lang.String org.apache.iceberg.FileScanTaskParser::toJson(org.apache.iceberg.FileScanTask)"
       justification: "Removing deprecated code"

--- a/core/src/main/java/org/apache/iceberg/hadoop/Util.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Util.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.ContentScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ScanTask;
@@ -58,10 +59,18 @@ public class Util {
     }
   }
 
+  /**
+   * @deprecated since 1.7.0, will be removed in 2.0.0.
+   */
+  @Deprecated
+  public static String[] blockLocations(CombinedScanTask task, Configuration conf) {
+    return blockLocations((ScanTaskGroup<FileScanTask>) task, conf);
+  }
+
   public static String[] blockLocations(ScanTaskGroup<FileScanTask> taskGroup, Configuration conf) {
     Set<String> locationSets = Sets.newHashSet();
     for (FileScanTask f : taskGroup.tasks()) {
-      Path path = new Path(f.file().path().toString());
+      Path path = new Path(f.file().location());
       try {
         FileSystem fs = path.getFileSystem(conf);
         for (BlockLocation b : fs.getFileBlockLocations(path, f.start(), f.length())) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/Util.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Util.java
@@ -60,7 +60,8 @@ public class Util {
   }
 
   /**
-   * @deprecated since 1.7.0, will be removed in 2.0.0.
+   * @deprecated since 1.8.0, will be removed in 1.9.0; use {@link
+   *     Util#blockLocations(ScanTaskGroup, Configuration)} instead.
    */
   @Deprecated
   public static String[] blockLocations(CombinedScanTask task, Configuration conf) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/Util.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Util.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.ContentScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ScanTask;
@@ -59,10 +58,10 @@ public class Util {
     }
   }
 
-  public static String[] blockLocations(CombinedScanTask task, Configuration conf) {
+  public static String[] blockLocations(ScanTaskGroup<FileScanTask> taskGroup, Configuration conf) {
     Set<String> locationSets = Sets.newHashSet();
-    for (FileScanTask f : task.files()) {
-      Path path = new Path(f.file().location());
+    for (FileScanTask f : taskGroup.tasks()) {
+      Path path = new Path(f.file().path().toString());
       try {
         FileSystem fs = path.getFileSystem(conf);
         for (BlockLocation b : fs.getFileBlockLocations(path, f.start(), f.length())) {


### PR DESCRIPTION
The Apache Hive community is trying to implement optimizations, such as Bucket Map Join, using partition transform specs. We presume `Util::blockLocations` should accept not `CombinedScanTask` but `ScanTaskGroup<FileScanTask>`, which is a more general expression.

See also https://github.com/apache/hive/pull/5409