### PR TITLE
Spec: Fix rendering of partition stats file spec

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -782,12 +782,14 @@ Note that partition data tuple's schema is based on the partition spec output us
 The unified partition type is a struct containing all fields that have ever been a part of any spec in the table 
 and sorted by the field ids in ascending order.  
 In other words, the struct fields represent a union of all known partition fields sorted in ascending order by the field ids.
+
 For example,
-1) `spec#0` has two fields `{field#1, field#2}`
+
+1. `spec#0` has two fields `{field#1, field#2}`
 and then the table has evolved into `spec#1` which has three fields `{field#1, field#2, field#3}`.
 The unified partition type looks like `Struct<field#1, field#2, field#3>`.
 
-2) `spec#0` has two fields `{field#1, field#2}`
+2. `spec#0` has two fields `{field#1, field#2}`
 and then the table has evolved into `spec#1` which has just one field `{field#2}`.
 The unified partition type looks like `Struct<field#1, field#2>`.
 


### PR DESCRIPTION
Even though the indentation in `.md` file was correct,
for website (mkdocs), need to use required syntax for rendering. 

Hence, adjusted it accordingly. 

before:
<img width="790" alt="image" src="https://github.com/user-attachments/assets/a1e3c8ab-100c-4207-883a-15d614c51c7b">

After:
<img width="790" alt="image" src="https://github.com/user-attachments/assets/56f6f23c-3942-4451-8945-f27831ca1c5e">
