### PR TITLE
open-api: Fix compile warnings for testFixtures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -981,6 +981,8 @@ project(':iceberg-open-api') {
     testFixturesImplementation libs.jetty.servlet
     testFixturesImplementation libs.jetty.server
     testFixturesImplementation libs.sqlite.jdbc
+
+    testFixturesCompileOnly libs.apiguardian
   }
 
   test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ activation = "1.1.1"
 aliyun-sdk-oss = "3.10.2"
 antlr = "4.9.3"
 aircompressor = "0.27"
+apiguardian = "1.1.2"
 arrow = "15.0.2"
 avro = "1.12.0"
 assertj-core = "3.26.3"
@@ -177,6 +178,7 @@ slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 snowflake-jdbc = { module = "net.snowflake:snowflake-jdbc", version.ref = "snowflake-jdbc" }
 
 # test libraries
+apiguardian = { module = "org.apiguardian:apiguardian-api", version.ref = "apiguardian" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj-core" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 delta-spark = { module = "io.delta:delta-spark_2.12", version.ref = "delta-spark" }


### PR DESCRIPTION
`./gradlew clean build -x test -x integrationTest --no-build-cache` results in compile warnings for open-api module. 

<img width="1507" alt="Screenshot 2024-09-02 at 7 49 23 PM" src="https://github.com/user-attachments/assets/27a8f97e-8a48-45f9-812a-b7604de4eee7">


The reason is that new dependencies that are added in https://github.com/apache/iceberg/pull/10908 requires `apigurdian` during `testFixtureCompilation`.

```
+--- org.junit.jupiter:junit-jupiter:5.10.1 -> 5.10.3
|    +--- org.junit:junit-bom:5.10.3
|    |    +--- org.junit.jupiter:junit-jupiter:5.10.3 (c)
|    |    +--- org.junit.jupiter:junit-jupiter-engine:5.10.3 (c)
|    |    +--- org.junit.platform:junit-platform-commons:1.10.3 (c)
|    |    +--- org.junit.platform:junit-platform-engine:1.10.3 (c)
|    |    +--- org.junit.platform:junit-platform-suite-api:1.10.3 (c)
|    |    +--- org.junit.platform:junit-platform-suite-engine:1.10.3 (c)
|    |    +--- org.junit.jupiter:junit-jupiter-api:5.10.3 (c)
|    |    \--- org.junit.jupiter:junit-jupiter-params:5.10.3 (c)
|    +--- org.junit.jupiter:junit-jupiter-api:5.10.3
|    |    +--- org.junit:junit-bom:5.10.3 (*)
|    |    +--- org.opentest4j:opentest4j:1.3.0
|    |    +--- org.junit.platform:junit-platform-commons:1.10.3
|    |    |    +--- org.junit:junit-bom:5.10.3 (*)
|    |    |    \--- org.apiguardian:apiguardian-api:1.1.2
|    |    \--- org.apiguardian:apiguardian-api:1.1.2
|    \--- org.junit.jupiter:junit-jupiter-params:5.10.3
|         +--- org.junit:junit-bom:5.10.3 (*)
|         +--- org.junit.jupiter:junit-jupiter-api:5.10.3 (*)
|         \--- org.apiguardian:apiguardian-api:1.1.2
+--- org.junit.jupiter:junit-jupiter-engine:5.10.1 -> 5.10.3
|    +--- org.junit:junit-bom:5.10.3 (*)
|    +--- org.junit.platform:junit-platform-engine:1.10.3
|    |    +--- org.junit:junit-bom:5.10.3 (*)
|    |    +--- org.opentest4j:opentest4j:1.3.0
|    |    +--- org.junit.platform:junit-platform-commons:1.10.3 (*)
|    |    \--- org.apiguardian:apiguardian-api:1.1.2
|    +--- org.junit.jupiter:junit-jupiter-api:5.10.3 (*)
|    \--- org.apiguardian:apiguardian-api:1.1.2
```