### PR TITLE
Flink: Fix compile warning

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableChange.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableChange.java
@@ -192,6 +192,8 @@ class TableChange {
     private long eqDeleteRecordCount = 0L;
     private int commitCount = 0;
 
+    private Builder() {}
+
     public Builder dataFileCount(int newDataFileCount) {
       this.dataFileCount = newDataFileCount;
       return this;

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableChange.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableChange.java
@@ -192,6 +192,8 @@ class TableChange {
     private long eqDeleteRecordCount = 0L;
     private int commitCount = 0;
 
+    private Builder() {}
+
     public Builder dataFileCount(int newDataFileCount) {
       this.dataFileCount = newDataFileCount;
       return this;


### PR DESCRIPTION
`./gradlew clean build -x test -x integrationTest --no-build-cache` results in compile warnings on the newly added code.

`iceberg/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableChange.java:186: warning: [ImplicitPublicBuilderConstructor] A Builder with a static factory method on the encapsulating class must have a private constructor. Minimizing unnecessary public API prevents future API breaks from impacting consumers. `

<img width="1507" alt="Screenshot 2024-09-03 at 7 35 58 AM" src="https://github.com/user-attachments/assets/724a87cc-563c-4794-8ee2-237cbec3fd2b">

