### PR TITLE
ThreadPools introduce newExitingWorkerPool and newFixedThreadPool for clearer semantics

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -342,7 +342,7 @@ public class S3FileIO implements CredentialSupplier, DelegateFileIO, SupportsRec
       synchronized (S3FileIO.class) {
         if (executorService == null) {
           executorService =
-              ThreadPools.newWorkerPool(
+              ThreadPools.newExitingWorkerPool(
                   "iceberg-s3fileio-delete", s3FileIOProperties.deleteThreads());
         }
       }

--- a/core/src/jmh/java/org/apache/iceberg/metrics/CountersBenchmark.java
+++ b/core/src/jmh/java/org/apache/iceberg/metrics/CountersBenchmark.java
@@ -50,7 +50,7 @@ public class CountersBenchmark {
   public void defaultCounterMultipleThreads(Blackhole blackhole) {
     Counter counter = new DefaultCounter(Unit.BYTES);
 
-    ExecutorService workerPool = ThreadPools.newWorkerPool("bench-pool", WORKER_POOL_SIZE);
+    ExecutorService workerPool = ThreadPools.newFixedThreadPool("bench-pool", WORKER_POOL_SIZE);
 
     try {
       Tasks.range(WORKER_POOL_SIZE)

--- a/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
@@ -403,6 +403,6 @@ abstract class BaseDistributedDataScan
 
   // a monitor pool that enables planing data and deletes concurrently if remote planning is used
   private ExecutorService newMonitorPool() {
-    return ThreadPools.newWorkerPool("iceberg-planning-monitor-service", MONITOR_POOL_SIZE);
+    return ThreadPools.newFixedThreadPool("iceberg-planning-monitor-service", MONITOR_POOL_SIZE);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
@@ -401,7 +401,13 @@ abstract class BaseDistributedDataScan
     return count == null || !count.equals("0");
   }
 
-  // a monitor pool that enables planing data and deletes concurrently if remote planning is used
+  /**
+   * Creates a monitor pool that enables planing data and deletes concurrently if remote planning is
+   * used
+   *
+   * <p><b>Important:</b> Callers are responsible for shutting down the returned executor service
+   * when it is no longer needed
+   */
   private ExecutorService newMonitorPool() {
     return ThreadPools.newFixedThreadPool("iceberg-planning-monitor-service", MONITOR_POOL_SIZE);
   }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -192,7 +192,8 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
     if (executorService == null) {
       synchronized (HadoopFileIO.class) {
         if (executorService == null) {
-          executorService = ThreadPools.newWorkerPool(DELETE_FILE_POOL_NAME, deleteThreads());
+          executorService =
+              ThreadPools.newExitingWorkerPool(DELETE_FILE_POOL_NAME, deleteThreads());
         }
       }
     }

--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -251,6 +251,6 @@ public class TableMigrationUtil {
   }
 
   public static ExecutorService migrationService(int parallelism) {
-    return parallelism == 1 ? null : ThreadPools.newWorkerPool("table-migration", parallelism);
+    return parallelism == 1 ? null : ThreadPools.newFixedThreadPool("table-migration", parallelism);
   }
 }

--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -97,7 +97,9 @@ public class TableMigrationUtil {
    * @param conf a Hadoop conf
    * @param metricsSpec a metrics conf
    * @param mapping a name mapping
-   * @param parallelism number of threads to use for file reading
+   * @param parallelism number of threads to use for file reading. If null, file reading will be
+   *     performed on the current thread. If non-null, the provided ExecutorService will be shutdown
+   *     within this method after file reading is complete.
    * @return a List of DataFile
    */
   public static List<DataFile> listPartition(
@@ -137,7 +139,9 @@ public class TableMigrationUtil {
    * @param conf a Hadoop conf
    * @param metricsSpec a metrics conf
    * @param mapping a name mapping
-   * @param service executor service to use for file reading
+   * @param service executor service to use for file reading. If null, file reading will be
+   *     performed on the current thread. If non-null, the provided ExecutorService will be shutdown
+   *     within this method after file reading is complete.
    * @return a List of DataFile
    */
   public static List<DataFile> listPartition(
@@ -250,6 +254,15 @@ public class TableMigrationUtil {
         .build();
   }
 
+  /**
+   * Returns an {@link ExecutorService} for table migration.
+   *
+   * <p>If parallelism is 1, this method returns null, indicating that no executor service is
+   * needed. Otherwise, it returns a fixed-size thread pool with the given parallelism.
+   *
+   * <p><b>Important:</b> Callers are responsible for shutting down the returned executor service
+   * when it is no longer needed to prevent resource leaks.
+   */
   public static ExecutorService migrationService(int parallelism) {
     return parallelism == 1 ? null : ThreadPools.newFixedThreadPool("table-migration", parallelism);
   }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -102,7 +102,7 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
     Preconditions.checkArgument(
         maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
     this.workerPool =
-        ThreadPools.newWorkerPool(
+        ThreadPools.newFixedThreadPool(
             "iceberg-committer-pool-" + table.name() + "-" + sinkId, workerPoolSize);
     this.continuousEmptyCheckpoints = 0;
   }
@@ -307,5 +307,6 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
   @Override
   public void close() throws IOException {
     tableLoader.close();
+    workerPool.shutdown();
   }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -455,7 +455,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
 
     final String operatorID = getRuntimeContext().getOperatorUniqueID();
     this.workerPool =
-        ThreadPools.newWorkerPool("iceberg-worker-pool-" + operatorID, workerPoolSize);
+        ThreadPools.newFixedThreadPool("iceberg-worker-pool-" + operatorID, workerPoolSize);
   }
 
   @Override

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
@@ -93,7 +93,7 @@ public class FlinkInputFormat extends RichInputFormat<RowData, FlinkInputSplit> 
     // Called in Job manager, so it is OK to load table from catalog.
     tableLoader.open();
     final ExecutorService workerPool =
-        ThreadPools.newWorkerPool("iceberg-plan-worker-pool", context.planParallelism());
+        ThreadPools.newFixedThreadPool("iceberg-plan-worker-pool", context.planParallelism());
     try (TableLoader loader = tableLoader) {
       Table table = loader.loadTable();
       return FlinkSplitPlanner.planInputSplits(table, context, workerPool);

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -153,7 +153,7 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
     }
 
     ExecutorService workerPool =
-        ThreadPools.newWorkerPool(threadName, scanContext.planParallelism());
+        ThreadPools.newFixedThreadPool(threadName, scanContext.planParallelism());
     try (TableLoader loader = tableLoader.clone()) {
       loader.open();
       this.batchSplits =

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/StreamingMonitorFunction.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/StreamingMonitorFunction.java
@@ -106,7 +106,7 @@ public class StreamingMonitorFunction extends RichSourceFunction<FlinkInputSplit
         "context should be instance of StreamingRuntimeContext");
     final String operatorID = ((StreamingRuntimeContext) runtimeContext).getOperatorUniqueID();
     this.workerPool =
-        ThreadPools.newWorkerPool(
+        ThreadPools.newFixedThreadPool(
             "iceberg-worker-pool-" + operatorID, scanContext.planParallelism());
   }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
@@ -64,7 +64,7 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
     this.workerPool =
         isSharedPool
             ? ThreadPools.getWorkerPool()
-            : ThreadPools.newWorkerPool(
+            : ThreadPools.newFixedThreadPool(
                 "iceberg-plan-worker-pool-" + threadName, scanContext.planParallelism());
   }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -90,7 +90,7 @@ class Coordinator extends Channel {
     this.snapshotOffsetsProp =
         String.format(
             "kafka.connect.offsets.%s.%s", config.controlTopic(), config.connectGroupId());
-    this.exec = ThreadPools.newWorkerPool("iceberg-committer", config.commitThreads());
+    this.exec = ThreadPools.newFixedThreadPool("iceberg-committer", config.commitThreads());
     this.commitState = new CommitState(config);
   }
 

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -108,7 +108,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
                 HiveIcebergStorageHandler.table(conf, conf.get(InputFormatConfig.TABLE_IDENTIFIER)))
             .orElseGet(() -> Catalogs.loadTable(conf));
     final ExecutorService workerPool =
-        ThreadPools.newWorkerPool(
+        ThreadPools.newFixedThreadPool(
             "iceberg-plan-worker-pool",
             conf.getInt(
                 SystemConfigs.WORKER_THREAD_POOL_SIZE.propertyKey(),

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -393,8 +393,10 @@ public class TestIcebergInputFormats {
         UserGroupInformation.createUserForTesting("user1", new String[] {});
     UserGroupInformation user2 =
         UserGroupInformation.createUserForTesting("user2", new String[] {});
-    final ExecutorService workerPool1 = ThreadPools.newWorkerPool("iceberg-plan-worker-pool", 1);
-    final ExecutorService workerPool2 = ThreadPools.newWorkerPool("iceberg-plan-worker-pool", 1);
+    final ExecutorService workerPool1 =
+        ThreadPools.newFixedThreadPool("iceberg-plan-worker-pool", 1);
+    final ExecutorService workerPool2 =
+        ThreadPools.newFixedThreadPool("iceberg-plan-worker-pool", 1);
     try {
       assertThat(getUserFromWorkerPool(user1, table, workerPool1)).isEqualTo("user1");
       assertThat(getUserFromWorkerPool(user2, table, workerPool1)).isEqualTo("user1");

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -443,7 +443,9 @@ public class SparkTableUtil {
    * @param sourceTableIdent an identifier of the source Spark table
    * @param targetTable an Iceberg table where to import the data
    * @param stagingDir a staging directory to store temporary manifest files
-   * @param service executor service to use for file reading
+   * @param service executor service to use for file reading. If null, file reading will be
+   *     performed on the current thread. * If non-null, the provided ExecutorService will be
+   *     shutdown within this method after file reading is complete.
    */
   public static void importSparkTable(
       SparkSession spark,
@@ -501,7 +503,9 @@ public class SparkTableUtil {
    * @param partitionFilter only import partitions whose values match those in the map, can be
    *     partially defined
    * @param checkDuplicateFiles if true, throw exception if import results in a duplicate data file
-   * @param service executor service to use for file reading
+   * @param service executor service to use for file reading. If null, file reading will be
+   *     performed on the current thread. If non-null, the provided ExecutorService will be shutdown
+   *     within this method after file reading is complete.
    */
   public static void importSparkTable(
       SparkSession spark,
@@ -719,7 +723,9 @@ public class SparkTableUtil {
    * @param spec a partition spec
    * @param stagingDir a staging directory to store temporary manifest files
    * @param checkDuplicateFiles if true, throw exception if import results in a duplicate data file
-   * @param service executor service to use for file reading
+   * @param service executor service to use for file reading. If null, file reading will be
+   *     performed on the current thread. If non-null, the provided ExecutorService will be shutdown
+   *     within this method after file reading is complete.
    */
   public static void importSparkPartitions(
       SparkSession spark,


### PR DESCRIPTION
We are currently using Flink's Local Env mode (executing Flink tasks within the local JVM). We are starting many "Flink query Iceberg tasks" sequentially within the lifecycle of a single JVM (which can be considered a long-running service).

After the JVM runs for a while, we can observe a metaspace memory leak. By examining the leaking ClassLoaders, we found that Iceberg's ExecutorService is registered to the ShutdownHook (GC root).

![image](https://github.com/user-attachments/assets/246c6005-feb5-4e69-8269-8cb50955bd1a)
![image](https://github.com/user-attachments/assets/b970b2d2-0fb5-48e8-9edb-bcf8f406a70a)


I noticed that these ExecutorServices are actively shut down. Theoretically, they don't need to be registered to the ShutdownHook.