### PR TITLE
Core: Fix setting hasNewDataFile flag in MergingSnapshotProducer

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -984,11 +984,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
                 writer.close();
               }
               this.cachedNewDataManifests.addAll(writer.toManifestFiles());
-              this.hasNewDataFiles = false;
             } catch (IOException e) {
               throw new RuntimeIOException(e, "Failed to close manifest writer");
             }
           });
+      this.hasNewDataFiles = false;
     }
 
     return cachedNewDataManifests;


### PR DESCRIPTION
After the support for adding data files that belong to multiple specs in #9860, we have to fix resetting `hasNewDataFile`.