### PR TITLE
API: Deprecate ContentFile#path API and add location API which returns String

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -46,12 +46,12 @@ public interface ContentFile<F> {
   /**
    * Returns fully qualified path to the file, suitable for constructing a Hadoop Path.
    *
-   * @deprecated since 1.7.0, will be removed in 2.0.0 Use {@link #location()} instead.
+   * @deprecated since 1.7.0, will be removed in 2.0.0; use {@link #location()} instead.
    */
   @Deprecated
   CharSequence path();
 
-  /** Return the fully qualified path to the file, suitable for constructing a Hadoop Path */
+  /** Return the fully qualified path to the file. */
   default String location() {
     return path().toString();
   }

--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -43,8 +43,18 @@ public interface ContentFile<F> {
    */
   FileContent content();
 
-  /** Returns fully qualified path to the file, suitable for constructing a Hadoop Path. */
+  /**
+   * Returns fully qualified path to the file, suitable for constructing a Hadoop Path.
+   *
+   * @deprecated since 1.7.0, will be removed in 2.0.0 Use {@link #location()} instead.
+   */
+  @Deprecated
   CharSequence path();
+
+  /** Return the fully qualified path to the file, suitable for constructing a Hadoop Path */
+  default String location() {
+    return path().toString();
+  }
 
   /** Returns format of the file. */
   FileFormat format();


### PR DESCRIPTION
ContentFile#path returns CharSequence instead of String. The original intention of this API returning CharSequence was to directly surface Avro UTF8 without any conversion, however for distributed cases the CharSequence needs to be converted into String since CharSequence itself isn't serializable. Furthermore, in terms of naming we tend to use location in other places like manifestListLocation or metadataLocation, also in FileIO. This change performs the following:

1. Deprecate path on ContentFile since callers need to convert the CharSequence to String for the majority of cases. This would be removed from the interface in 2.0
2. Add a String location() API to ContentFile which logically returns the same filePath but it will return String instead. An initial default implementation of location has been provided.

Over time up until 2.0 we can remove references to path and use location. After 2.0 implementations of ContentFile would need to implement location.