### PR TITLE
Core: Add internal Avro reader

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroIterable;
+import org.apache.iceberg.avro.InternalReader;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
@@ -65,16 +66,16 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
           "record_count");
 
   protected enum FileType {
-    DATA_FILES(GenericDataFile.class.getName()),
-    DELETE_FILES(GenericDeleteFile.class.getName());
+    DATA_FILES(GenericDataFile.class),
+    DELETE_FILES(GenericDeleteFile.class);
 
-    private final String fileClass;
+    private final Class<? extends StructLike> fileClass;
 
-    FileType(String fileClass) {
+    FileType(Class<? extends StructLike> fileClass) {
       this.fileClass = fileClass;
     }
 
-    private String fileClass() {
+    private Class<? extends StructLike> fileClass() {
       return fileClass;
     }
   }
@@ -261,12 +262,12 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
         AvroIterable<ManifestEntry<F>> reader =
             Avro.read(file)
                 .project(ManifestEntry.wrapFileSchema(Types.StructType.of(fields)))
-                .rename("manifest_entry", GenericManifestEntry.class.getName())
-                .rename("partition", PartitionData.class.getName())
-                .rename("r102", PartitionData.class.getName())
-                .rename("data_file", content.fileClass())
-                .rename("r2", content.fileClass())
-                .classLoader(GenericManifestEntry.class.getClassLoader())
+                .createResolvingReader(
+                    schema ->
+                        InternalReader.create(schema)
+                            .setRootType(GenericManifestEntry.class)
+                            .setCustomType(ManifestEntry.DATA_FILE_ID, content.fileClass())
+                            .setCustomType(DataFile.PARTITION_ID, PartitionData.class))
                 .reuseContainers()
                 .build();
 

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.util.Pair;
  * @param <T> Java type returned by the reader
  */
 public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition {
+  private static final int ROOT_ID = -1;
 
   private final Types.StructType expectedType;
   private final Map<Integer, Class<? extends StructLike>> typeMap = Maps.newHashMap();
@@ -63,7 +64,7 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition {
     this.reader =
         (ValueReader<T>)
             AvroWithPartnerVisitor.visit(
-                Pair.of(-1, expectedType),
+                Pair.of(ROOT_ID, expectedType),
                 fileSchema,
                 new ResolvingReadBuilder(),
                 AccessByID.instance());
@@ -76,7 +77,7 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition {
   }
 
   public InternalReader<T> setRootType(Class<? extends StructLike> rootClass) {
-    typeMap.put(-1, rootClass);
+    typeMap.put(ROOT_ID, rootClass);
     return this;
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -25,39 +25,37 @@ import java.util.function.Supplier;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
-import org.apache.iceberg.common.DynClasses;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 
-public class GenericAvroReader<T>
-    implements DatumReader<T>, SupportsRowPosition, SupportsCustomRecords {
+/**
+ * A reader that produces Iceberg's internal in-memory object model.
+ *
+ * <p>Iceberg's internal in-memory object model produces the types defined in {@link
+ * Type.TypeID#javaClass()}.
+ *
+ * @param <T> Java type returned by the reader
+ */
+public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition {
 
   private final Types.StructType expectedType;
-  private ClassLoader loader = Thread.currentThread().getContextClassLoader();
-  private Map<String, String> renames = ImmutableMap.of();
+  private final Map<Integer, Class<? extends StructLike>> typeMap = Maps.newHashMap();
   private final Map<Integer, Object> idToConstant = ImmutableMap.of();
   private Schema fileSchema = null;
   private ValueReader<T> reader = null;
 
-  public static <D> GenericAvroReader<D> create(org.apache.iceberg.Schema expectedSchema) {
-    return new GenericAvroReader<>(expectedSchema);
+  public static <D> InternalReader<D> create(org.apache.iceberg.Schema schema) {
+    return new InternalReader<>(schema);
   }
 
-  public static <D> GenericAvroReader<D> create(Schema readSchema) {
-    return new GenericAvroReader<>(readSchema);
-  }
-
-  GenericAvroReader(org.apache.iceberg.Schema expectedSchema) {
-    this.expectedType = expectedSchema.asStruct();
-  }
-
-  GenericAvroReader(Schema readSchema) {
-    this.expectedType = AvroSchemaUtil.convert(readSchema).asStructType();
+  InternalReader(org.apache.iceberg.Schema readSchema) {
+    this.expectedType = readSchema.asStruct();
   }
 
   @SuppressWarnings("unchecked")
@@ -65,10 +63,10 @@ public class GenericAvroReader<T>
     this.reader =
         (ValueReader<T>)
             AvroWithPartnerVisitor.visit(
-                expectedType,
+                Pair.of(-1, expectedType),
                 fileSchema,
-                new ResolvingReadBuilder(expectedType, fileSchema.getFullName()),
-                AvroWithPartnerVisitor.FieldIDAccessors.get());
+                new ResolvingReadBuilder(),
+                AccessByID.instance());
   }
 
   @Override
@@ -77,14 +75,14 @@ public class GenericAvroReader<T>
     initReader();
   }
 
-  @Override
-  public void setClassLoader(ClassLoader newClassLoader) {
-    this.loader = newClassLoader;
+  public InternalReader<T> setRootType(Class<? extends StructLike> rootClass) {
+    typeMap.put(-1, rootClass);
+    return this;
   }
 
-  @Override
-  public void setRenames(Map<String, String> renames) {
-    this.renames = renames;
+  public InternalReader<T> setCustomType(int fieldId, Class<? extends StructLike> structClass) {
+    typeMap.put(fieldId, structClass);
+    return this;
   }
 
   @Override
@@ -99,77 +97,65 @@ public class GenericAvroReader<T>
     return reader.read(decoder, reuse);
   }
 
-  private class ResolvingReadBuilder extends AvroWithPartnerVisitor<Type, ValueReader<?>> {
-    private final Map<Type, Schema> avroSchemas;
-
-    private ResolvingReadBuilder(Types.StructType expectedType, String rootName) {
-      this.avroSchemas = AvroSchemaUtil.convertTypes(expectedType, rootName);
-    }
-
+  private class ResolvingReadBuilder
+      extends AvroWithPartnerVisitor<Pair<Integer, Type>, ValueReader<?>> {
     @Override
-    public ValueReader<?> record(Type partner, Schema record, List<ValueReader<?>> fieldResults) {
+    public ValueReader<?> record(
+        Pair<Integer, Type> partner, Schema record, List<ValueReader<?>> fieldResults) {
       if (partner == null) {
         return ValueReaders.skipStruct(fieldResults);
       }
 
-      Types.StructType expected = partner.asStructType();
+      Types.StructType expected = partner.second().asStructType();
       List<Pair<Integer, ValueReader<?>>> readPlan =
           ValueReaders.buildReadPlan(expected, record, fieldResults, idToConstant);
 
-      return recordReader(readPlan, avroSchemas.get(partner), record.getFullName());
+      return structReader(readPlan, partner.first(), expected);
     }
 
-    @SuppressWarnings("unchecked")
-    private ValueReader<?> recordReader(
-        List<Pair<Integer, ValueReader<?>>> readPlan, Schema avroSchema, String recordName) {
-      String className = renames.getOrDefault(recordName, recordName);
-      if (className != null) {
-        try {
-          Class<?> recordClass = DynClasses.builder().loader(loader).impl(className).buildChecked();
-          if (IndexedRecord.class.isAssignableFrom(recordClass)) {
-            return ValueReaders.record(
-                avroSchema, (Class<? extends IndexedRecord>) recordClass, readPlan);
-          }
-        } catch (ClassNotFoundException e) {
-          // use a generic record reader below
-        }
-      }
+    private ValueReader<?> structReader(
+        List<Pair<Integer, ValueReader<?>>> readPlan, int fieldId, Types.StructType struct) {
 
-      return ValueReaders.record(avroSchema, readPlan);
+      Class<? extends StructLike> structClass = typeMap.get(fieldId);
+      if (structClass != null) {
+        return InternalReaders.struct(struct, structClass, readPlan);
+      } else {
+        return InternalReaders.struct(struct, readPlan);
+      }
     }
 
     @Override
-    public ValueReader<?> union(Type partner, Schema union, List<ValueReader<?>> options) {
+    public ValueReader<?> union(
+        Pair<Integer, Type> partner, Schema union, List<ValueReader<?>> options) {
       return ValueReaders.union(options);
     }
 
     @Override
     public ValueReader<?> arrayMap(
-        Type partner, Schema map, ValueReader<?> keyReader, ValueReader<?> valueReader) {
-      if (keyReader == ValueReaders.utf8s()) {
-        return ValueReaders.arrayMap(ValueReaders.strings(), valueReader);
-      }
-
+        Pair<Integer, Type> partner,
+        Schema map,
+        ValueReader<?> keyReader,
+        ValueReader<?> valueReader) {
       return ValueReaders.arrayMap(keyReader, valueReader);
     }
 
     @Override
-    public ValueReader<?> array(Type partner, Schema array, ValueReader<?> elementReader) {
+    public ValueReader<?> array(
+        Pair<Integer, Type> partner, Schema array, ValueReader<?> elementReader) {
       return ValueReaders.array(elementReader);
     }
 
     @Override
-    public ValueReader<?> map(Type partner, Schema map, ValueReader<?> valueReader) {
+    public ValueReader<?> map(Pair<Integer, Type> partner, Schema map, ValueReader<?> valueReader) {
       return ValueReaders.map(ValueReaders.strings(), valueReader);
     }
 
     @Override
-    public ValueReader<?> primitive(Type partner, Schema primitive) {
+    public ValueReader<?> primitive(Pair<Integer, Type> partner, Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
           case "date":
-            // Spark uses the same representation
             return ValueReaders.ints();
 
           case "time-micros":
@@ -181,7 +167,6 @@ public class GenericAvroReader<T>
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
 
           case "timestamp-micros":
-            // Spark uses the same representation
             return ValueReaders.longs();
 
           case "decimal":
@@ -203,21 +188,21 @@ public class GenericAvroReader<T>
         case BOOLEAN:
           return ValueReaders.booleans();
         case INT:
-          if (partner != null && partner.typeId() == Type.TypeID.LONG) {
+          if (partner != null && partner.second().typeId() == Type.TypeID.LONG) {
             return ValueReaders.intsAsLongs();
           }
           return ValueReaders.ints();
         case LONG:
           return ValueReaders.longs();
         case FLOAT:
-          if (partner != null && partner.typeId() == Type.TypeID.DOUBLE) {
+          if (partner != null && partner.second().typeId() == Type.TypeID.DOUBLE) {
             return ValueReaders.floatsAsDoubles();
           }
           return ValueReaders.floats();
         case DOUBLE:
           return ValueReaders.doubles();
         case STRING:
-          return ValueReaders.utf8s();
+          return ValueReaders.strings();
         case FIXED:
           return ValueReaders.fixed(primitive);
         case BYTES:
@@ -227,6 +212,40 @@ public class GenericAvroReader<T>
         default:
           throw new IllegalArgumentException("Unsupported type: " + primitive);
       }
+    }
+  }
+
+  private static class AccessByID
+      implements AvroWithPartnerVisitor.PartnerAccessors<Pair<Integer, Type>> {
+    private static final AccessByID INSTANCE = new AccessByID();
+
+    public static AccessByID instance() {
+      return INSTANCE;
+    }
+
+    @Override
+    public Pair<Integer, Type> fieldPartner(
+        Pair<Integer, Type> partner, Integer fieldId, String name) {
+      Types.NestedField field = partner.second().asStructType().field(fieldId);
+      return field != null ? Pair.of(field.fieldId(), field.type()) : null;
+    }
+
+    @Override
+    public Pair<Integer, Type> mapKeyPartner(Pair<Integer, Type> partner) {
+      Types.MapType map = partner.second().asMapType();
+      return Pair.of(map.keyId(), map.keyType());
+    }
+
+    @Override
+    public Pair<Integer, Type> mapValuePartner(Pair<Integer, Type> partner) {
+      Types.MapType map = partner.second().asMapType();
+      return Pair.of(map.valueId(), map.valueType());
+    }
+
+    @Override
+    public Pair<Integer, Type> listElementPartner(Pair<Integer, Type> partner) {
+      Types.ListType list = partner.second().asListType();
+      return Pair.of(list.elementId(), list.elementType());
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReaders.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.avro;
+
+import java.util.List;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
+
+class InternalReaders {
+  private InternalReaders() {}
+
+  static ValueReader<? extends Record> struct(
+      Types.StructType struct, List<Pair<Integer, ValueReader<?>>> readPlan) {
+    return new RecordReader(readPlan, struct);
+  }
+
+  static <S extends StructLike> ValueReader<S> struct(
+      Types.StructType struct, Class<S> structClass, List<Pair<Integer, ValueReader<?>>> readPlan) {
+    return new PlannedStructLikeReader<>(readPlan, struct, structClass);
+  }
+
+  private static class PlannedStructLikeReader<S extends StructLike>
+      extends ValueReaders.PlannedStructReader<S> {
+    private final Types.StructType structType;
+    private final Class<S> structClass;
+    private final DynConstructors.Ctor<S> ctor;
+
+    private PlannedStructLikeReader(
+        List<Pair<Integer, ValueReader<?>>> readPlan,
+        Types.StructType structType,
+        Class<S> structClass) {
+      super(readPlan);
+      this.structType = structType;
+      this.structClass = structClass;
+      this.ctor =
+          DynConstructors.builder(StructLike.class)
+              .hiddenImpl(structClass, Types.StructType.class)
+              .hiddenImpl(structClass)
+              .build();
+    }
+
+    @Override
+    protected S reuseOrCreate(Object reuse) {
+      if (structClass.isInstance(reuse)) {
+        return structClass.cast(reuse);
+      } else {
+        return ctor.newInstance(structType);
+      }
+    }
+
+    @Override
+    protected Object get(S struct, int pos) {
+      return struct.get(pos, Object.class);
+    }
+
+    @Override
+    protected void set(S struct, int pos, Object value) {
+      struct.set(pos, value);
+    }
+  }
+
+  private static class RecordReader extends ValueReaders.PlannedStructReader<GenericRecord> {
+    private final Types.StructType structType;
+
+    private RecordReader(List<Pair<Integer, ValueReader<?>>> readPlan, Types.StructType structType) {
+      super(readPlan);
+      this.structType = structType;
+    }
+
+    @Override
+    protected GenericRecord reuseOrCreate(Object reuse) {
+      if (reuse instanceof GenericRecord) {
+        return (GenericRecord) reuse;
+      } else {
+        return GenericRecord.create(structType);
+      }
+    }
+
+    @Override
+    protected Object get(GenericRecord struct, int pos) {
+      return struct.get(pos);
+    }
+
+    @Override
+    protected void set(GenericRecord struct, int pos, Object value) {
+      struct.set(pos, value);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReaders.java
@@ -82,7 +82,8 @@ class InternalReaders {
   private static class RecordReader extends ValueReaders.PlannedStructReader<GenericRecord> {
     private final Types.StructType structType;
 
-    private RecordReader(List<Pair<Integer, ValueReader<?>>> readPlan, Types.StructType structType) {
+    private RecordReader(
+        List<Pair<Integer, ValueReader<?>>> readPlan, Types.StructType structType) {
       super(readPlan);
       this.structType = structType;
     }

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -181,6 +181,83 @@ public class ValueReaders {
     return new PlannedIndexedReader<>(recordSchema, recordClass, readPlan);
   }
 
+  public static ValueReader<Void> skipStruct(List<ValueReader<?>> readers) {
+    return new SkipStructReader(readers);
+  }
+
+  /**
+   * Builds a read plan for record classes that use planned reads instead of a ResolvingDecoder.
+   *
+   * @param expected expected StructType
+   * @param record Avro record schema
+   * @param fieldReaders list of readers for each field in the Avro record schema
+   * @param idToConstant a map of field ID to constants values
+   * @return a read plan that is a list of (position, reader) pairs
+   */
+  static List<Pair<Integer, ValueReader<?>>> buildReadPlan(
+      Types.StructType expected,
+      Schema record,
+      List<ValueReader<?>> fieldReaders,
+      Map<Integer, Object> idToConstant) {
+    Map<Integer, Integer> idToPos = idToPos(expected);
+
+    List<Pair<Integer, ValueReader<?>>> readPlan = Lists.newArrayList();
+    List<Schema.Field> fileFields = record.getFields();
+    for (int pos = 0; pos < fileFields.size(); pos += 1) {
+      Schema.Field field = fileFields.get(pos);
+      ValueReader<?> fieldReader = fieldReaders.get(pos);
+      Integer fieldId = AvroSchemaUtil.fieldId(field);
+      Integer projectionPos = idToPos.remove(fieldId);
+
+      Object constant = idToConstant.get(fieldId);
+      if (projectionPos != null && constant != null) {
+        readPlan.add(
+            Pair.of(projectionPos, ValueReaders.replaceWithConstant(fieldReader, constant)));
+      } else {
+        readPlan.add(Pair.of(projectionPos, fieldReader));
+      }
+    }
+
+    // handle any expected columns that are not in the data file
+    for (Map.Entry<Integer, Integer> idAndPos : idToPos.entrySet()) {
+      int fieldId = idAndPos.getKey();
+      int pos = idAndPos.getValue();
+
+      Object constant = idToConstant.get(fieldId);
+      Types.NestedField field = expected.field(fieldId);
+      if (constant != null) {
+        readPlan.add(Pair.of(pos, ValueReaders.constant(constant)));
+      } else if (field.initialDefault() != null) {
+        readPlan.add(Pair.of(pos, ValueReaders.constant(field.initialDefault())));
+      } else if (fieldId == MetadataColumns.IS_DELETED.fieldId()) {
+        readPlan.add(Pair.of(pos, ValueReaders.constant(false)));
+      } else if (fieldId == MetadataColumns.ROW_POSITION.fieldId()) {
+        readPlan.add(Pair.of(pos, ValueReaders.positions()));
+      } else if (field.isOptional()) {
+        readPlan.add(Pair.of(pos, ValueReaders.constant(null)));
+      } else {
+        throw new IllegalArgumentException(
+            String.format("Missing required field: %s", field.name()));
+      }
+    }
+
+    return readPlan;
+  }
+
+  private static Map<Integer, Integer> idToPos(Types.StructType struct) {
+    Map<Integer, Integer> idToPos = Maps.newHashMap();
+
+    if (struct != null) {
+      List<Types.NestedField> fields = struct.fields();
+      for (int pos = 0; pos < fields.size(); pos += 1) {
+        Types.NestedField field = fields.get(pos);
+        idToPos.put(field.fieldId(), pos);
+      }
+    }
+
+    return idToPos;
+  }
+
   private static class NullReader implements ValueReader<Object> {
     private static final NullReader INSTANCE = new NullReader();
 
@@ -773,6 +850,27 @@ public class ValueReaders {
           keyReader.skip(decoder);
           valueReader.skip(decoder);
         }
+      }
+    }
+  }
+
+  private static class SkipStructReader implements ValueReader<Void> {
+    private final ValueReader<?>[] readers;
+
+    private SkipStructReader(List<ValueReader<?>> readers) {
+      this.readers = readers.toArray(ValueReader[]::new);
+    }
+
+    @Override
+    public Void read(Decoder decoder, Object reuse) throws IOException {
+      skip(decoder);
+      return null;
+    }
+
+    @Override
+    public void skip(Decoder decoder) throws IOException {
+      for (ValueReader<?> reader : readers) {
+        reader.skip(decoder);
       }
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -44,7 +44,8 @@ public class TestManifestReader extends TestBase {
               "fileOrdinal",
               "fileSequenceNumber",
               "fromProjectionPos",
-              "manifestLocation")
+              "manifestLocation",
+              "partitionData.partitionType.fieldsById")
           .build();
 
   @TestTemplate


### PR DESCRIPTION
This adds an Avro reader that produces Iceberg's internal object model and uses `StructLike` rather than Avro's `IndexedRecord`.