### PR TITLE
Docs: Update Project links to include contributing and REST spec

### DIFF
--- a/site/nav.yml
+++ b/site/nav.yml
@@ -39,7 +39,9 @@ nav:
   - Vendors: vendors.md
   - Project: 
     - Community: community.md
-    - Spec: spec.md
+    - Contributing: contribute.md
+    - REST Catalog Spec: https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/iceberg/main/open-api/rest-catalog-open-api.yaml
+    - Table Spec: spec.md
     - View spec: view-spec.md
     - Puffin spec: puffin-spec.md
     - AES GCM Stream spec: gcm-stream-spec.md


### PR DESCRIPTION
Add the `Contributing` page to the top level project nav (this was previously hidden under community and difficult to find).

Add a link to the REST Spec, which links the swagger editor using the current baselined REST spec url from github.