### PR TITLE
Flink: Increase the number of checkpoints from 4 to 6 to fix flakiness.

### DIFF
--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkRangeDistributionBucketing.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkRangeDistributionBucketing.java
@@ -98,7 +98,7 @@ public class TestFlinkIcebergSinkRangeDistributionBucketing {
       new HadoopCatalogExtension(TestFixtures.DATABASE, TestFixtures.TABLE);
 
   private static final int NUM_BUCKETS = 4;
-  private static final int NUM_OF_CHECKPOINTS = 4;
+  private static final int NUM_OF_CHECKPOINTS = 6;
   private static final int ROW_COUNT_PER_CHECKPOINT = 200;
   private static final Schema SCHEMA =
       new Schema(

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkRangeDistributionBucketing.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkRangeDistributionBucketing.java
@@ -98,7 +98,7 @@ public class TestFlinkIcebergSinkRangeDistributionBucketing {
       new HadoopCatalogExtension(TestFixtures.DATABASE, TestFixtures.TABLE);
 
   private static final int NUM_BUCKETS = 4;
-  private static final int NUM_OF_CHECKPOINTS = 4;
+  private static final int NUM_OF_CHECKPOINTS = 6;
   private static final int ROW_COUNT_PER_CHECKPOINT = 200;
   private static final Schema SCHEMA =
       new Schema(


### PR DESCRIPTION
6 checkpoionts cycles seem to be more stable based on the existing TestFlinkIcebergSinkDistributionMode test.