### PR TITLE
Core: Move internal struct projection to SupportsIndexProjection

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -30,8 +30,8 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.specific.SpecificData;
 import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -39,7 +39,7 @@ import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.SerializableMap;
 
 /** Base class for both {@link DataFile} and {@link DeleteFile}. */
-abstract class BaseFile<F>
+abstract class BaseFile<F> extends SupportsIndexProjection
     implements ContentFile<F>,
         IndexedRecord,
         StructLike,
@@ -55,7 +55,6 @@ abstract class BaseFile<F>
         }
       };
 
-  private int[] fromProjectionPos;
   private Types.StructType partitionType;
 
   private Long fileOrdinal = null;
@@ -84,38 +83,49 @@ abstract class BaseFile<F>
   // cached schema
   private transient Schema avroSchema = null;
 
+  // struct type that corresponds to the positions used for internalGet and internalSet
+  private static final Types.StructType BASE_TYPE =
+      Types.StructType.of(
+          DataFile.CONTENT,
+          DataFile.FILE_PATH,
+          DataFile.FILE_FORMAT,
+          DataFile.SPEC_ID,
+          Types.NestedField.required(
+              DataFile.PARTITION_ID,
+              DataFile.PARTITION_NAME,
+              EMPTY_STRUCT_TYPE,
+              DataFile.PARTITION_DOC),
+          DataFile.RECORD_COUNT,
+          DataFile.FILE_SIZE,
+          DataFile.COLUMN_SIZES,
+          DataFile.VALUE_COUNTS,
+          DataFile.NULL_VALUE_COUNTS,
+          DataFile.NAN_VALUE_COUNTS,
+          DataFile.LOWER_BOUNDS,
+          DataFile.UPPER_BOUNDS,
+          DataFile.KEY_METADATA,
+          DataFile.SPLIT_OFFSETS,
+          DataFile.EQUALITY_IDS,
+          DataFile.SORT_ORDER_ID,
+          MetadataColumns.ROW_POSITION);
+
   /** Used by Avro reflection to instantiate this class when reading manifest files. */
   BaseFile(Schema avroSchema) {
+    this(AvroSchemaUtil.convert(avroSchema).asStructType());
     this.avroSchema = avroSchema;
+  }
 
-    Types.StructType schema = AvroSchemaUtil.convert(avroSchema).asNestedType().asStructType();
+  /** Used by internal readers to instantiate this class with a projection schema. */
+  BaseFile(Types.StructType projection) {
+    super(BASE_TYPE, projection);
+    this.avroSchema = AvroSchemaUtil.convert(projection, "data_file");
 
     // partition type may be null if the field was not projected
-    Type partType = schema.fieldType("partition");
+    Type partType = projection.fieldType("partition");
     if (partType != null) {
       this.partitionType = partType.asNestedType().asStructType();
     } else {
       this.partitionType = EMPTY_STRUCT_TYPE;
-    }
-
-    List<Types.NestedField> fields = schema.fields();
-    List<Types.NestedField> allFields = Lists.newArrayList();
-    allFields.addAll(DataFile.getType(partitionType).fields());
-    allFields.add(MetadataColumns.ROW_POSITION);
-
-    this.fromProjectionPos = new int[fields.size()];
-    for (int i = 0; i < fromProjectionPos.length; i += 1) {
-      boolean found = false;
-      for (int j = 0; j < allFields.size(); j += 1) {
-        if (fields.get(i).fieldId() == allFields.get(j).fieldId()) {
-          found = true;
-          fromProjectionPos[i] = j;
-        }
-      }
-
-      if (!found) {
-        throw new IllegalArgumentException("Cannot find projected field: " + fields.get(i));
-      }
     }
 
     this.partitionData = new PartitionData(partitionType);
@@ -139,6 +149,7 @@ abstract class BaseFile<F>
       int[] equalityFieldIds,
       Integer sortOrderId,
       ByteBuffer keyMetadata) {
+    super(BASE_TYPE.fields().size());
     this.partitionSpecId = specId;
     this.content = content;
     this.filePath = filePath;
@@ -177,6 +188,7 @@ abstract class BaseFile<F>
    *     column stat is kept.
    */
   BaseFile(BaseFile<F> toCopy, boolean copyStats, Set<Integer> requestedColumnIds) {
+    super(toCopy);
     this.fileOrdinal = toCopy.fileOrdinal;
     this.partitionSpecId = toCopy.partitionSpecId;
     this.content = toCopy.content;
@@ -201,7 +213,6 @@ abstract class BaseFile<F>
       this.lowerBounds = null;
       this.upperBounds = null;
     }
-    this.fromProjectionPos = toCopy.fromProjectionPos;
     this.keyMetadata =
         toCopy.keyMetadata == null
             ? null
@@ -220,7 +231,9 @@ abstract class BaseFile<F>
   }
 
   /** Constructor for Java serialization. */
-  BaseFile() {}
+  BaseFile() {
+    super(BASE_TYPE.fields().size());
+  }
 
   @Override
   public int specId() {
@@ -260,13 +273,12 @@ abstract class BaseFile<F>
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public void put(int i, Object value) {
-    int pos = i;
-    // if the schema was projected, map the incoming ordinal to the expected one
-    if (fromProjectionPos != null) {
-      pos = fromProjectionPos[i];
-    }
+    set(i, value);
+  }
+
+  @Override
+  protected <T> void internalSet(int pos, T value) {
     switch (pos) {
       case 0:
         this.content = value != null ? FILE_CONTENT_VALUES[(Integer) value] : FileContent.DATA;
@@ -329,18 +341,12 @@ abstract class BaseFile<F>
   }
 
   @Override
-  public <T> void set(int pos, T value) {
-    put(pos, value);
+  protected <T> T internalGet(int pos, Class<T> javaClass) {
+    return javaClass.cast(getByPos(pos));
   }
 
-  @Override
-  public Object get(int i) {
-    int pos = i;
-    // if the schema was projected, map the incoming ordinal to the expected one
-    if (fromProjectionPos != null) {
-      pos = fromProjectionPos[i];
-    }
-    switch (pos) {
+  private Object getByPos(int basePos) {
+    switch (basePos) {
       case 0:
         return content.id();
       case 1:
@@ -378,13 +384,13 @@ abstract class BaseFile<F>
       case 17:
         return fileOrdinal;
       default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        throw new UnsupportedOperationException("Unknown field ordinal: " + basePos);
     }
   }
 
   @Override
-  public <T> T get(int pos, Class<T> javaClass) {
-    return javaClass.cast(get(pos));
+  public Object get(int pos) {
+    return get(pos, Object.class);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -32,6 +32,11 @@ class GenericDataFile extends BaseFile<DataFile> implements DataFile {
     super(avroSchema);
   }
 
+  /** Used by internal readers to instantiate this class with a projection schema. */
+  GenericDataFile(Types.StructType projection) {
+    super(projection);
+  }
+
   GenericDataFile(
       int specId,
       String filePath,

--- a/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
@@ -32,6 +32,11 @@ class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
     super(avroSchema);
   }
 
+  /** Used by internal readers to instantiate this class with a projection schema. */
+  GenericDeleteFile(Types.StructType projection) {
+    super(projection);
+  }
+
   GenericDeleteFile(
       int specId,
       FileContent content,

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -38,8 +38,9 @@ class GenericManifestEntry<F extends ContentFile<F>>
     this.schema = schema;
   }
 
-  GenericManifestEntry(Types.StructType partitionType) {
-    this.schema = AvroSchemaUtil.convert(V1Metadata.entrySchema(partitionType), "manifest_entry");
+  /** Used by internal readers to instantiate this class with a projection schema. */
+  GenericManifestEntry(Types.StructType schema) {
+    this.schema = AvroSchemaUtil.convert(schema, "manifest_entry");
   }
 
   private GenericManifestEntry(GenericManifestEntry<F> toCopy, boolean fullCopy) {

--- a/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
@@ -28,21 +28,20 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.specific.SpecificData.SchemaConstructable;
 import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 
-public class GenericManifestFile
+public class GenericManifestFile extends SupportsIndexProjection
     implements ManifestFile, StructLike, IndexedRecord, SchemaConstructable, Serializable {
   private static final Schema AVRO_SCHEMA =
       AvroSchemaUtil.convert(ManifestFile.schema(), "manifest_file");
   private static final ManifestContent[] MANIFEST_CONTENT_VALUES = ManifestContent.values();
 
   private transient Schema avroSchema; // not final for Java serialization
-  private int[] fromProjectionPos;
 
   // data fields
   private InputFile file = null;
@@ -64,28 +63,12 @@ public class GenericManifestFile
 
   /** Used by Avro reflection to instantiate this class when reading manifest files. */
   public GenericManifestFile(Schema avroSchema) {
+    super(ManifestFile.schema().asStruct(), AvroSchemaUtil.convert(avroSchema).asStructType());
     this.avroSchema = avroSchema;
-
-    List<Types.NestedField> fields = AvroSchemaUtil.convert(avroSchema).asStructType().fields();
-    List<Types.NestedField> allFields = ManifestFile.schema().asStruct().fields();
-
-    this.fromProjectionPos = new int[fields.size()];
-    for (int i = 0; i < fromProjectionPos.length; i += 1) {
-      boolean found = false;
-      for (int j = 0; j < allFields.size(); j += 1) {
-        if (fields.get(i).fieldId() == allFields.get(j).fieldId()) {
-          found = true;
-          fromProjectionPos[i] = j;
-        }
-      }
-
-      if (!found) {
-        throw new IllegalArgumentException("Cannot find projected field: " + fields.get(i));
-      }
-    }
   }
 
   GenericManifestFile(InputFile file, int specId) {
+    super(ManifestFile.schema().columns().size());
     this.avroSchema = AVRO_SCHEMA;
     this.file = file;
     this.manifestPath = file.location();
@@ -101,7 +84,6 @@ public class GenericManifestFile
     this.deletedFilesCount = null;
     this.deletedRowsCount = null;
     this.partitions = null;
-    this.fromProjectionPos = null;
     this.keyMetadata = null;
   }
 
@@ -122,6 +104,7 @@ public class GenericManifestFile
       Long existingRowsCount,
       Integer deletedFilesCount,
       Long deletedRowsCount) {
+    super(ManifestFile.schema().columns().size());
     this.avroSchema = AVRO_SCHEMA;
     this.manifestPath = path;
     this.length = length;
@@ -137,7 +120,6 @@ public class GenericManifestFile
     this.deletedFilesCount = deletedFilesCount;
     this.deletedRowsCount = deletedRowsCount;
     this.partitions = partitions == null ? null : partitions.toArray(new PartitionFieldSummary[0]);
-    this.fromProjectionPos = null;
     this.keyMetadata = ByteBuffers.toByteArray(keyMetadata);
   }
 
@@ -157,6 +139,7 @@ public class GenericManifestFile
       long deletedRowsCount,
       List<PartitionFieldSummary> partitions,
       ByteBuffer keyMetadata) {
+    super(ManifestFile.schema().columns().size());
     this.avroSchema = AVRO_SCHEMA;
     this.manifestPath = path;
     this.length = length;
@@ -172,7 +155,6 @@ public class GenericManifestFile
     this.deletedFilesCount = deletedFilesCount;
     this.deletedRowsCount = deletedRowsCount;
     this.partitions = partitions == null ? null : partitions.toArray(new PartitionFieldSummary[0]);
-    this.fromProjectionPos = null;
     this.keyMetadata = ByteBuffers.toByteArray(keyMetadata);
   }
 
@@ -182,6 +164,7 @@ public class GenericManifestFile
    * @param toCopy a generic manifest file to copy.
    */
   private GenericManifestFile(GenericManifestFile toCopy) {
+    super(toCopy);
     this.avroSchema = toCopy.avroSchema;
     this.manifestPath = toCopy.manifestPath;
     this.length = toCopy.length;
@@ -204,7 +187,6 @@ public class GenericManifestFile
     } else {
       this.partitions = null;
     }
-    this.fromProjectionPos = toCopy.fromProjectionPos;
     this.keyMetadata =
         toCopy.keyMetadata == null
             ? null
@@ -212,7 +194,9 @@ public class GenericManifestFile
   }
 
   /** Constructor for Java serialization. */
-  GenericManifestFile() {}
+  GenericManifestFile() {
+    super(ManifestFile.schema().columns().size());
+  }
 
   @Override
   public String path() {
@@ -308,18 +292,17 @@ public class GenericManifestFile
   }
 
   @Override
-  public <T> T get(int pos, Class<T> javaClass) {
-    return javaClass.cast(get(pos));
+  public Object get(int pos) {
+    return internalGet(pos, Object.class);
   }
 
   @Override
-  public Object get(int i) {
-    int pos = i;
-    // if the schema was projected, map the incoming ordinal to the expected one
-    if (fromProjectionPos != null) {
-      pos = fromProjectionPos[i];
-    }
-    switch (pos) {
+  protected <T> T internalGet(int pos, Class<T> javaClass) {
+    return javaClass.cast(getByPos(pos));
+  }
+
+  private Object getByPos(int basePos) {
+    switch (basePos) {
       case 0:
         return manifestPath;
       case 1:
@@ -351,19 +334,13 @@ public class GenericManifestFile
       case 14:
         return keyMetadata();
       default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        throw new UnsupportedOperationException("Unknown field ordinal: " + basePos);
     }
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public <T> void set(int i, T value) {
-    int pos = i;
-    // if the schema was projected, map the incoming ordinal to the expected one
-    if (fromProjectionPos != null) {
-      pos = fromProjectionPos[i];
-    }
-    switch (pos) {
+  protected <T> void internalSet(int basePos, T value) {
+    switch (basePos) {
       case 0:
         // always coerce to String for Serializable
         this.manifestPath = value.toString();

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -60,7 +60,8 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
     this.specId = spec.specId();
     this.writer = newAppender(spec, this.file);
     this.snapshotId = snapshotId;
-    this.reused = new GenericManifestEntry<>(spec.partitionType());
+    this.reused =
+        new GenericManifestEntry<>(V1Metadata.entrySchema(spec.partitionType()).asStruct());
     this.stats = new PartitionSummary(spec);
     this.keyMetadataBuffer = (file.keyMetadata() == null) ? null : file.keyMetadata().buffer();
   }

--- a/core/src/main/java/org/apache/iceberg/avro/SupportsIndexProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SupportsIndexProjection.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.avro;
+
+import java.io.Serializable;
+import java.util.List;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.types.Types;
+
+public abstract class SupportsIndexProjection implements StructLike, Serializable {
+  private final int[] fromProjectionPos;
+
+  /** Noop constructor that does not project fields */
+  protected SupportsIndexProjection(int size) {
+    this.fromProjectionPos = new int[size];
+    for (int i = 0; i < fromProjectionPos.length; i++) {
+      fromProjectionPos[i] = i;
+    }
+  }
+
+  /** Base constructor for building the type mapping */
+  protected SupportsIndexProjection(Types.StructType baseType, Types.StructType projectionType) {
+    List<Types.NestedField> allFields = baseType.fields();
+    List<Types.NestedField> fields = projectionType.fields();
+
+    this.fromProjectionPos = new int[fields.size()];
+    for (int i = 0; i < fromProjectionPos.length; i += 1) {
+      boolean found = false;
+      for (int j = 0; j < allFields.size(); j += 1) {
+        if (fields.get(i).fieldId() == allFields.get(j).fieldId()) {
+          found = true;
+          fromProjectionPos[i] = j;
+        }
+      }
+
+      if (!found) {
+        throw new IllegalArgumentException("Cannot find projected field: " + fields.get(i));
+      }
+    }
+  }
+
+  /** Copy constructor */
+  protected SupportsIndexProjection(SupportsIndexProjection toCopy) {
+    this.fromProjectionPos = toCopy.fromProjectionPos;
+  }
+
+  protected abstract <T> T internalGet(int pos, Class<T> javaClass);
+
+  protected abstract <T> void internalSet(int pos, T value);
+
+  private int pos(int basePos) {
+    return fromProjectionPos[basePos];
+  }
+
+  @Override
+  public int size() {
+    return fromProjectionPos.length;
+  }
+
+  @Override
+  public <T> T get(int basePos, Class<T> javaClass) {
+    return internalGet(pos(basePos), javaClass);
+  }
+
+  @Override
+  public <T> void set(int basePos, T value) {
+    internalSet(pos(basePos), value);
+  }
+}


### PR DESCRIPTION
This makes projection more generic and reusable for internal types.