### PR TITLE
REST: Handle Requests with Page Sizes Exceeding Available Number of  Namespaces /Tables/Views

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BaseTransaction;
@@ -73,6 +72,7 @@ import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
+import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.view.BaseView;
 import org.apache.iceberg.view.SQLViewRepresentation;
@@ -148,8 +148,8 @@ public class CatalogHandlers {
     Pair<List<Namespace>, String> page = paginate(results, pageToken, Integer.parseInt(pageSize));
 
     return ListNamespacesResponse.builder()
-        .addAll(page.getLeft())
-        .nextPageToken(page.getRight())
+        .addAll(page.first())
+        .nextPageToken(page.second())
         .build();
   }
 
@@ -217,10 +217,7 @@ public class CatalogHandlers {
     Pair<List<TableIdentifier>, String> page =
         paginate(results, pageToken, Integer.parseInt(pageSize));
 
-    return ListTablesResponse.builder()
-        .addAll(page.getLeft())
-        .nextPageToken(page.getRight())
-        .build();
+    return ListTablesResponse.builder().addAll(page.first()).nextPageToken(page.second()).build();
   }
 
   public static LoadTableResponse stageTableCreate(
@@ -458,10 +455,7 @@ public class CatalogHandlers {
     Pair<List<TableIdentifier>, String> page =
         paginate(results, pageToken, Integer.parseInt(pageSize));
 
-    return ListTablesResponse.builder()
-        .addAll(page.getLeft())
-        .nextPageToken(page.getRight())
-        .build();
+    return ListTablesResponse.builder().addAll(page.first()).nextPageToken(page.second()).build();
   }
 
   public static LoadViewResponse createView(

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -135,14 +135,6 @@ public class CatalogHandlers {
     List<Namespace> subResults;
     String nextToken = null;
 
-
-    if (parent.isEmpty()) {
-      results = catalog.listNamespaces();
-    } else {
-      results = catalog.listNamespaces(parent);
-    }
-
-
     if (parent.isEmpty()) {
       results = catalog.listNamespaces();
     } else {

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -2341,13 +2341,13 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                 RESTSessionCatalog.REST_PAGE_SIZE));
   }
 
-  @Test
-  public void testPaginationForListNamespaces() {
+  @ParameterizedTest
+  @ValueSource(ints = {21, 25, 29, 30})
+  public void testPaginationForListNamespaces(int numberOfItems) {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog =
         new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
     catalog.initialize("test", ImmutableMap.of(RESTSessionCatalog.REST_PAGE_SIZE, "10"));
-    int numberOfItems = 27;
     String namespaceName = "newdb";
 
     // create several namespaces for listing and verify
@@ -2403,13 +2403,13 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             eq(ListNamespacesResponse.class));
   }
 
-  @Test
-  public void testPaginationForListTables() {
+  @ParameterizedTest
+  @ValueSource(ints = {21, 25, 29, 30})
+  public void testPaginationForListTables(int numberOfItems) {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog =
         new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
     catalog.initialize("test", ImmutableMap.of(RESTSessionCatalog.REST_PAGE_SIZE, "10"));
-    int numberOfItems = 28;
     String namespaceName = "newdb";
     String tableName = "newtable";
     catalog.createNamespace(Namespace.of(namespaceName));

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -2342,7 +2342,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {21, 25, 29, 30})
+  @ValueSource(ints = {21, 30})
   public void testPaginationForListNamespaces(int numberOfItems) {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog =
@@ -2404,7 +2404,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {21, 25, 29, 30})
+  @ValueSource(ints = {21, 30})
   public void testPaginationForListTables(int numberOfItems) {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog =

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -2347,7 +2347,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     RESTCatalog catalog =
         new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
     catalog.initialize("test", ImmutableMap.of(RESTSessionCatalog.REST_PAGE_SIZE, "10"));
-    int numberOfItems = 30;
+    int numberOfItems = 27;
     String namespaceName = "newdb";
 
     // create several namespaces for listing and verify
@@ -2409,7 +2409,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     RESTCatalog catalog =
         new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
     catalog.initialize("test", ImmutableMap.of(RESTSessionCatalog.REST_PAGE_SIZE, "10"));
-    int numberOfItems = 30;
+    int numberOfItems = 28;
     String namespaceName = "newdb";
     String tableName = "newtable";
     catalog.createNamespace(Namespace.of(namespaceName));

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
@@ -156,7 +156,7 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {21, 25, 29, 30})
+  @ValueSource(ints = {21, 30})
   public void testPaginationForListViews(int numberOfItems) {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog =

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
@@ -160,7 +160,7 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
         new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
     catalog.initialize("test", ImmutableMap.of(RESTSessionCatalog.REST_PAGE_SIZE, "10"));
 
-    int numberOfItems = 30;
+    int numberOfItems = 29;
     String namespaceName = "newdb";
     String viewName = "newview";
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
@@ -52,6 +52,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
@@ -153,14 +155,14 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
     }
   }
 
-  @Test
-  public void testPaginationForListViews() {
+  @ParameterizedTest
+  @ValueSource(ints = {21, 25, 29, 30})
+  public void testPaginationForListViews(int numberOfItems) {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog =
         new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
     catalog.initialize("test", ImmutableMap.of(RESTSessionCatalog.REST_PAGE_SIZE, "10"));
 
-    int numberOfItems = 29;
     String namespaceName = "newdb";
     String viewName = "newview";
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
@@ -50,7 +50,6 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;


### PR DESCRIPTION
When requesting a pagesize that exceeds the number of namespaces/views/tables from the REST Catalog, it throws an `IndexOutOfBoundsException`. This is due to using `List.subList` with the end-index being set to the page-size. Java's `sublist` doesn't appreciate an end-index bigger than the size of the list.

See https://github.com/apache/iceberg/issues/11142