### PR TITLE
OpenAPI: Add planning-mode to loadTable response

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -473,6 +473,13 @@ class PlanStatus(BaseModel):
     )
 
 
+class PlanningMode(BaseModel):
+    __root__: Literal['unsupported', 'supported', 'required'] = Field(
+        ...,
+        description='Indicates to clients if a service supports server-side planning for a given table.',
+    )
+
+
 class RegisterTableRequest(BaseModel):
     name: str
     metadata_location: str = Field(..., alias='metadata-location')
@@ -1176,6 +1183,17 @@ class LoadTableResult(BaseModel):
     The table metadata JSON is returned in the `metadata` field. The corresponding file location of table metadata should be returned in the `metadata-location` field, unless the metadata is not yet committed. For example, a create transaction may return metadata that is staged but not committed.
     Clients can check whether metadata has changed by comparing metadata locations after the table has been created.
 
+    The `planning-mode` returns a string enum to clients, whether a service supports server-side planning for a given table.
+
+    - When "required" the client must initiate server-side planning
+    by calling the `planTableScan` operation.
+
+    - When "supported" the client can opt to either initiate service-side planning
+    or client-side planning.
+
+    - When "unsupported" the service does not support server-side planning,
+    therefore the client will be expected to do its planning.
+
 
     The `config` map returns table-specific configuration for the table's resources, including its HTTP client and FileIO. For example, config may contain a specific FileIO implementation class for the table depending on its underlying storage.
 
@@ -1203,6 +1221,7 @@ class LoadTableResult(BaseModel):
         description='May be null if the table is staged as part of a transaction',
     )
     metadata: TableMetadata
+    planning_mode: Optional[PlanningMode] = Field(None, alias='planning-mode')
     config: Optional[Dict[str, str]] = None
 
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3110,6 +3110,17 @@ components:
 
         The table metadata JSON is returned in the `metadata` field. The corresponding file location of table metadata should be returned in the `metadata-location` field, unless the metadata is not yet committed. For example, a create transaction may return metadata that is staged but not committed.
         Clients can check whether metadata has changed by comparing metadata locations after the table has been created.
+        
+        The `planning-mode` returns a string enum to clients, whether a service supports server-side planning for a given table.
+        
+        - When "required" the client must initiate server-side planning
+        by calling the `planTableScan` operation.
+
+        - When "supported" the client can opt to either initiate service-side planning
+        or client-side planning.
+
+        - When "unsupported" the service does not support server-side planning,
+        therefore the client will be expected to do its planning.
 
 
         The `config` map returns table-specific configuration for the table's resources, including its HTTP client and FileIO. For example, config may contain a specific FileIO implementation class for the table depending on its underlying storage.
@@ -3138,6 +3149,8 @@ components:
           description: May be null if the table is staged as part of a transaction
         metadata:
           $ref: '#/components/schemas/TableMetadata'
+        planning-mode:
+          $ref: '#/components/schemas/PlanningMode'
         config:
           type: object
           additionalProperties:
@@ -3239,6 +3252,11 @@ components:
       description: Status of a server-side planning operation
       type: string
       enum: ["completed", "submitted", "cancelled", "failed"]
+
+    PlanningMode:
+      description: Indicates to clients if a service supports server-side planning for a given table.
+      type: string
+      enum: ["unsupported", "supported", "required"]
 
     FetchPlanningResult:
       type: object


### PR DESCRIPTION
Recently in the iceberg community we landed a new set of scan planning apis within the rest spec https://github.com/apache/iceberg/pull/9695. 

The following spec change in this pr aims to provide a way for client to know when to call the new scan planning apis. Within a rest catalog, services may choose to support scan planning for all tables or for a subset of tables. In this case we think it would be best to make the change in the `loadTable` response to indicate if scan planning is supported for the table.

cc @rdblue @danielcweeks @jackye1995 @amogh-jahagirdar  @singhpk234 @geruh 

