### PR TITLE
Core: Fix UnicodeUtil#truncateStringMax returns malformed string.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Comparators.java
+++ b/api/src/main/java/org/apache/iceberg/types/Comparators.java
@@ -321,9 +321,9 @@ public class Comparators {
      * represented using two Java characters (using UTF-16 surrogate pairs). Character by character
      * comparison may yield incorrect results while comparing a 4 byte UTF-8 character to a java
      * char. Character by character comparison works as expected if both characters are <= 3 byte
-     * UTF-8 character or both characters are 4 byte UTF-8 characters.
-     * isCharInUTF16HighSurrogateRange method detects a 4-byte character and considers that
-     * character to be lexicographically greater than any 3 byte or lower UTF-8 character.
+     * UTF-8 character or both characters are 4 byte UTF-8 characters. isCharHighSurrogate method
+     * detects a high surrogate (4-byte character) and considers that character to be
+     * lexicographically greater than any 3 byte or lower UTF-8 character.
      */
     @Override
     public int compare(CharSequence s1, CharSequence s2) {

--- a/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
@@ -18,6 +18,10 @@
  */
 package org.apache.iceberg.util;
 
+import static java.lang.Character.MAX_CODE_POINT;
+import static java.lang.Character.MAX_SURROGATE;
+import static java.lang.Character.MIN_SURROGATE;
+
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
@@ -82,9 +86,9 @@ public class UnicodeUtil {
     for (int i = length - 1; i >= 0; i--) {
       // Get the offset in the truncated string buffer where the number of unicode characters = i
       int offsetByCodePoint = truncatedStringBuilder.offsetByCodePoints(0, i);
-      int nextCodePoint = truncatedStringBuilder.codePointAt(offsetByCodePoint) + 1;
+      int nextCodePoint = incrementCodePoint(truncatedStringBuilder.codePointAt(offsetByCodePoint));
       // No overflow
-      if (nextCodePoint != 0 && Character.isValidCodePoint(nextCodePoint)) {
+      if (nextCodePoint != 0) {
         truncatedStringBuilder.setLength(offsetByCodePoint);
         // Append next code point to the truncated substring
         truncatedStringBuilder.appendCodePoint(nextCodePoint);
@@ -92,5 +96,25 @@ public class UnicodeUtil {
       }
     }
     return null; // Cannot find a valid upper bound
+  }
+
+  private static int incrementCodePoint(int codePoint) {
+    // surrogate code points are not Unicode scalar values,
+    // any UTF-8 byte sequence that would otherwise map to code points U+D800..U+DFFF is ill-formed.
+    // see https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-3/#G27288
+    Preconditions.checkArgument(
+        codePoint < MIN_SURROGATE || codePoint > MAX_SURROGATE,
+        "invalid code point: %s",
+        codePoint);
+
+    if (codePoint == Character.MIN_SURROGATE - 1) {
+      // increment to the next Unicode scalar value
+      return MAX_SURROGATE + 1;
+    } else if (codePoint == MAX_CODE_POINT) {
+      // overflow
+      return 0;
+    } else {
+      return codePoint + 1;
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
@@ -18,10 +18,6 @@
  */
 package org.apache.iceberg.util;
 
-import static java.lang.Character.MAX_CODE_POINT;
-import static java.lang.Character.MAX_SURROGATE;
-import static java.lang.Character.MIN_SURROGATE;
-
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
@@ -103,14 +99,14 @@ public class UnicodeUtil {
     // any UTF-8 byte sequence that would otherwise map to code points U+D800..U+DFFF is ill-formed.
     // see https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-3/#G27288
     Preconditions.checkArgument(
-        codePoint < MIN_SURROGATE || codePoint > MAX_SURROGATE,
+        codePoint < Character.MIN_SURROGATE || codePoint > Character.MAX_SURROGATE,
         "invalid code point: %s",
         codePoint);
 
     if (codePoint == Character.MIN_SURROGATE - 1) {
       // increment to the next Unicode scalar value
-      return MAX_SURROGATE + 1;
-    } else if (codePoint == MAX_CODE_POINT) {
+      return Character.MAX_SURROGATE + 1;
+    } else if (codePoint == Character.MAX_CODE_POINT) {
       // overflow
       return 0;
     } else {

--- a/core/src/test/java/org/apache/iceberg/TestMetricsTruncation.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsTruncation.java
@@ -274,4 +274,17 @@ public class TestMetricsTruncation {
             "Test input with multiple 4 byte UTF-8 character where the first unicode character should be incremented")
         .isEqualTo(0);
   }
+
+  @Test
+  public void testTruncateStringMaxUpperBound() {
+    String max = "abcdefghigklmno" + (char) (Character.MIN_SURROGATE - 1) + "p";
+    String expectedUpper = "abcdefghigklmno" + (char) (Character.MAX_SURROGATE + 1);
+    Comparator<CharSequence> cmp = Literal.of(max).comparator();
+    CharSequence truncatedUpper = truncateStringMax(Literal.of(max), 16).value();
+    assertThat(cmp.compare(truncatedUpper, max))
+        .as("Truncated upper bound should be greater than the input max")
+        .isGreaterThan(1);
+
+    assertThat(truncatedUpper).usingComparator(cmp).isEqualTo(expectedUpper);
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetricsTruncation.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsTruncation.java
@@ -202,10 +202,19 @@ public class TestMetricsTruncation {
     String test5 = "\uDBFF\uDFFF\uDBFF\uDFFF";
     String test6 = "\uD800\uDFFF\uD800\uDFFF";
     // Increment the previous character
-    String test6_2_expected = "\uD801\uDC00";
+    String test6_1_expected = "\uD801\uDC00";
     String test7 = "\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02";
     String test7_2_expected = "\uD83D\uDE02\uD83D\uDE03";
     String test7_1_expected = "\uD83D\uDE03";
+
+    // Increment the max UTF-8 character will overflow
+    String test8 = "a\uDBFF\uDFFFc";
+    String test8_2_expected = "b";
+
+    // Increment skip invalid Unicode scalar values [Character.MIN_SURROGATE,
+    // Character.MAX_SURROGATE]
+    String test9 = "a" + (char) (Character.MIN_SURROGATE - 1) + "b";
+    String test9_2_expected = "a" + (char) (Character.MAX_SURROGATE + 1);
 
     Comparator<CharSequence> cmp = Literal.of(test1).comparator();
     assertThat(cmp.compare(truncateStringMax(Literal.of(test1), 4).value(), test1))
@@ -254,10 +263,10 @@ public class TestMetricsTruncation {
     assertThat(truncateStringMax(Literal.of(test5), 1))
         .as("An upper bound doesn't exist since the first two characters are max UTF-8 characters")
         .isNull();
-    assertThat(cmp.compare(truncateStringMax(Literal.of(test6), 2).value(), test6))
+    assertThat(cmp.compare(truncateStringMax(Literal.of(test6), 1).value(), test6))
         .as("Truncated upper bound should be greater than or equal to the actual upper bound")
         .isGreaterThanOrEqualTo(0);
-    assertThat(cmp.compare(truncateStringMax(Literal.of(test6), 1).value(), test6_2_expected))
+    assertThat(cmp.compare(truncateStringMax(Literal.of(test6), 1).value(), test6_1_expected))
         .as(
             "Test 4 byte UTF-8 character increment. Output must have one character with "
                 + "the first character incremented")
@@ -273,18 +282,23 @@ public class TestMetricsTruncation {
         .as(
             "Test input with multiple 4 byte UTF-8 character where the first unicode character should be incremented")
         .isEqualTo(0);
-  }
 
-  @Test
-  public void testTruncateStringMaxUpperBound() {
-    String max = "abcdefghigklmno" + (char) (Character.MIN_SURROGATE - 1) + "p";
-    String expectedUpper = "abcdefghigklmno" + (char) (Character.MAX_SURROGATE + 1);
-    Comparator<CharSequence> cmp = Literal.of(max).comparator();
-    CharSequence truncatedUpper = truncateStringMax(Literal.of(max), 16).value();
-    assertThat(cmp.compare(truncatedUpper, max))
-        .as("Truncated upper bound should be greater than the input max")
-        .isGreaterThan(1);
+    assertThat(cmp.compare(truncateStringMax(Literal.of(test8), 2).value(), test8))
+        .as("Truncated upper bound should be greater than or equal to the actual upper bound")
+        .isGreaterThanOrEqualTo(0);
+    assertThat(cmp.compare(truncateStringMax(Literal.of(test8), 2).value(), test8_2_expected))
+        .as(
+            "Test the last character is the 4-byte max UTF-8 character after truncated where the second-to-last "
+                + "character should be incremented")
+        .isEqualTo(0);
 
-    assertThat(truncatedUpper).usingComparator(cmp).isEqualTo(expectedUpper);
+    assertThat(cmp.compare(truncateStringMax(Literal.of(test9), 2).value(), test9))
+        .as("Truncated upper bound should be greater than or equal to the actual upper bound")
+        .isGreaterThanOrEqualTo(0);
+
+    assertThat(cmp.compare(truncateStringMax(Literal.of(test9), 2).value(), test9_2_expected))
+        .as(
+            "Test the last character is `Character.MIN_SURROGATE - 1` after truncated, it should be incremented to "
+                + "next valid Unicode scalar value `Character.MAX_SURROGATE + 1`");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetricsTruncation.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsTruncation.java
@@ -299,6 +299,7 @@ public class TestMetricsTruncation {
     assertThat(cmp.compare(truncateStringMax(Literal.of(test9), 2).value(), test9_2_expected))
         .as(
             "Test the last character is `Character.MIN_SURROGATE - 1` after truncated, it should be incremented to "
-                + "next valid Unicode scalar value `Character.MAX_SURROGATE + 1`");
+                + "next valid Unicode scalar value `Character.MAX_SURROGATE + 1`")
+        .isEqualTo(0);
   }
 }


### PR DESCRIPTION
We encountered an exception while writing data, and the stack trace is as follows. It occurred during the collection of Parquet column metrics:
#### Exception stack:
``` 
Suppressed: org.apache.iceberg.exceptions.RuntimeIOException: Failed to encode value as UTF-8: Ҋ�Qڞ<֔~�MECڮV?
at org.apache.iceberg.types.Conversions.toByteBuffer(Conversions.java:110)
at org.apache.iceberg.types.Conversions.toByteBuffer(Conversions.java:83)
at org.apache.iceberg.parquet.ParquetUtil.toBufferMap(ParquetUtil.java:343)
at org.apache.iceberg.parquet.ParquetUtil.footerMetrics(ParquetUtil.java:174)
at org.apache.iceberg.parquet.ParquetUtil.footerMetrics(ParquetUtil.java:86)
at org.apache.iceberg.parquet.ParquetWriter.metrics(ParquetWriter.java:166)
at org.apache.iceberg.io.DataWriter.close(DataWriter.java:100)
at org.apache.iceberg.io.RollingFileWriter.closeCurrentWriter(RollingFileWriter.java:122)
at org.apache.iceberg.io.RollingFileWriter.close(RollingFileWriter.java:147)
at org.apache.iceberg.io.RollingDataWriter.close(RollingDataWriter.java:32)
at org.apache.iceberg.io.FanoutWriter.closeWriters(FanoutWriter.java:82)
at org.apache.iceberg.io.FanoutWriter.close(FanoutWriter.java:74)
at org.apache.iceberg.io.FanoutDataWriter.close(FanoutDataWriter.java:31)
at org.apache.iceberg.spark.source.SparkWrite$PartitionedDataWriter.close(SparkWrite.java:1162)
at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.$anonfun$run$9(WriteToDataSourceV2Exec.scala:423)
at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1496)
... 10 more
Caused by: java.nio.charset.MalformedInputException: Input length = 1
at java.nio.charset.CoderResult.throwException(CoderResult.java:281)
at java.nio.charset.CharsetEncoder.encode(CharsetEncoder.java:816)
at org.apache.iceberg.types.Conversions.toByteBuffer(Conversions.java:108)
... 25 more
Caused by: java.nio.charset.MalformedInputException: Input length = 1
at java.nio.charset.CoderResult.throwException(CoderResult.java:281)
at java.nio.charset.CharsetEncoder.encode(CharsetEncoder.java:816)
at org.apache.iceberg.types.Conversions.toByteBuffer(Conversions.java:108)
```

#### Investigation
After some investigation, I found that when collecting Parquet column metrics, string metrics are truncated by default to a length of 16 characters. When truncating the max metric, if the truncated length is less than the length of the original max value, the last character will be incremented by 1 to ensure that the truncated value is greater than the max value. However, this increment operation does not consider skipping illegal UTF-8 Unicode code points, which may lead to the following exception.

In the scenario where we encountered this issue, there is a Parquet file with a column's max metric length exceeding 16, and the code point of its 16th character is '\uD7FF', which is `Character.MIN_SURROGATE - 1`. Adding 1 to this resulted in `Character.MIN_SURROGATE`, which is not a [valid Unicode scalar value](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-3/#G27288). Therefore, when `Conversions.toByteBuffer` attempted to encode it in UTF-8 format, a `MalformedInputException` was thrown.

This fix specifically skips illegal code points when incrementing the last character to avoid this issue.

#### To reproduce
```sql
CREATE TABLE my_table (data string) using iceberg;
INSERT INTO my_table VALUES('abcdefghigklmno\uD7FFp');
```
