### PR TITLE
Build: Add .java-version to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ metastore_db/
 # Spark/metastore files
 spark-warehouse/
 derby.log
+
+# jenv
+.java-version


### PR DESCRIPTION
Add the .java-version file to .gitignore, so users can customize their preferred JDK version locally without affecting the project. This can help users who manage multiple JDK versions using Jenv avoid manually switching JDK versions.

@findepi @szehon-ho can you please help review this?I found your commits #3651 and #8300 related to this in the git history. Thanks.