### PR TITLE
Config for deciding whether to use Iceberg Time type

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -95,6 +95,9 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String DEFAULT_CONTROL_TOPIC = "control-iceberg";
   public static final String DEFAULT_CONTROL_GROUP_PREFIX = "cg-control-";
 
+  private static final String CONVERT_CONNECT_TIME_TO_ICEBERG_INTEGER_TYPE = "iceberg.convert.connect-time-to.iceberg-time-type";
+  private static final boolean CONVERT_CONNECT_TIME_TO_ICEBERG_INTEGER_TYPE_DEFAULT = false;
+
   public static final int SCHEMA_UPDATE_RETRIES = 2; // 3 total attempts
   public static final int CREATE_TABLE_RETRIES = 2; // 3 total attempts
 
@@ -210,6 +213,13 @@ public class IcebergSinkConfig extends AbstractConfig {
         null,
         Importance.MEDIUM,
         "If specified, Hadoop config files in this directory will be loaded");
+    configDef.define(
+        CONVERT_CONNECT_TIME_TO_ICEBERG_INTEGER_TYPE,
+        ConfigDef.Type.BOOLEAN,
+        CONVERT_CONNECT_TIME_TO_ICEBERG_INTEGER_TYPE_DEFAULT,
+        Importance.HIGH,
+        "specify whether to convert to iceberg time type as spark does not have the support to read"
+                    + "iceberg time type");
     return configDef;
   }
 
@@ -320,6 +330,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public String tablesDefaultPartitionBy() {
     return getString(TABLES_DEFAULT_PARTITION_BY);
+  }
+
+  public boolean shouldConvertConnectTimeToIcebergIntegerType() {
+    return getBoolean(CONVERT_CONNECT_TIME_TO_ICEBERG_INTEGER_TYPE);
   }
 
   public TableSinkConfig tableConfig(String tableName) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -309,6 +309,8 @@ class RecordConverter {
       return ((Number) value).intValue();
     } else if (value instanceof String) {
       return Integer.parseInt((String) value);
+    } else if (!config.shouldConvertConnectTimeToIcebergIntegerType() && value instanceof Date) {
+      return Long.valueOf(((Date) value).getTime()).intValue();
     }
     throw new IllegalArgumentException("Cannot convert to int: " + value.getClass().getName());
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
@@ -243,7 +243,7 @@ class SchemaUtils {
         case INT32:
           if (Date.LOGICAL_NAME.equals(valueSchema.name())) {
             return DateType.get();
-          } else if (Time.LOGICAL_NAME.equals(valueSchema.name())) {
+          } else if (!config.shouldConvertConnectTimeToIcebergIntegerType() && Time.LOGICAL_NAME.equals(valueSchema.name())) {
             return TimeType.get();
           }
           return IntegerType.get();
@@ -307,7 +307,7 @@ class SchemaUtils {
       } else if (value instanceof LocalDate) {
         return DateType.get();
       } else if (value instanceof LocalTime) {
-        return TimeType.get();
+        return config.shouldConvertConnectTimeToIcebergIntegerType() ? IntegerType.get() : TimeType.get();
       } else if (value instanceof java.util.Date || value instanceof OffsetDateTime) {
         return TimestampType.withZone();
       } else if (value instanceof LocalDateTime) {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/RecordConverterTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/RecordConverterTest.java
@@ -208,6 +208,7 @@ public class RecordConverterTest {
   public void before() {
     this.config = mock(IcebergSinkConfig.class);
     when(config.jsonConverter()).thenReturn(JSON_CONVERTER);
+    when(config.shouldConvertConnectTimeToIcebergIntegerType()).thenReturn(false);
   }
 
   @Test
@@ -780,7 +781,7 @@ public class RecordConverterTest {
     assertThat(fn.apply("i")).isInstanceOf(IntegerType.class);
     assertThat(fn.apply("l")).isInstanceOf(LongType.class);
     assertThat(fn.apply("d")).isInstanceOf(DateType.class);
-    assertThat(fn.apply("t")).isInstanceOf(TimeType.class);
+    assertThat(fn.apply("t")).isInstanceOf(config.shouldConvertConnectTimeToIcebergIntegerType() ? IntegerType.class : TimeType.class);
     assertThat(fn.apply("ts")).isInstanceOf(TimestampType.class);
     assertThat(fn.apply("tsz")).isInstanceOf(TimestampType.class);
     assertThat(fn.apply("fl")).isInstanceOf(FloatType.class);

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/SchemaUtilsTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/SchemaUtilsTest.java
@@ -238,7 +238,7 @@ public class SchemaUtilsTest {
     assertThat(SchemaUtils.toIcebergType(Schema.STRING_SCHEMA, config))
         .isInstanceOf(StringType.class);
     assertThat(SchemaUtils.toIcebergType(Date.SCHEMA, config)).isInstanceOf(DateType.class);
-    assertThat(SchemaUtils.toIcebergType(Time.SCHEMA, config)).isInstanceOf(TimeType.class);
+    assertThat(SchemaUtils.toIcebergType(Time.SCHEMA, config)).isInstanceOf(config.shouldConvertConnectTimeToIcebergIntegerType() ? IntegerType.class : TimeType.class);
 
     Type timestampType = SchemaUtils.toIcebergType(Timestamp.SCHEMA, config);
     assertThat(timestampType).isInstanceOf(TimestampType.class);
@@ -281,7 +281,7 @@ public class SchemaUtilsTest {
     assertThat(SchemaUtils.inferIcebergType("foobar", config)).isInstanceOf(StringType.class);
     assertThat(SchemaUtils.inferIcebergType(true, config)).isInstanceOf(BooleanType.class);
     assertThat(SchemaUtils.inferIcebergType(LocalDate.now(), config)).isInstanceOf(DateType.class);
-    assertThat(SchemaUtils.inferIcebergType(LocalTime.now(), config)).isInstanceOf(TimeType.class);
+    assertThat(SchemaUtils.inferIcebergType(LocalTime.now(), config)).isInstanceOf(config.shouldConvertConnectTimeToIcebergIntegerType() ? IntegerType.class : TimeType.class);
 
     Type timestampType = SchemaUtils.inferIcebergType(new java.util.Date(), config);
     assertThat(timestampType).isInstanceOf(TimestampType.class);


### PR DESCRIPTION
As per the current design:
If Connect Schema is int32 with logical type is Time, then iceberg table type is returned as TimeType.
Spark does not support the Iceberg TimeType https://iceberg.apache.org/docs/1.4.3/spark-writes/#iceberg-type-to-spark-type.
In this PR, We have added the config to decide whether to use Iceberg Time Type or IntegerType.
This config gives the flexibility to the users to choose IntegerType over TimeType without loosing any precision with being able to query via spark.