### PR TITLE
Core: Remove unused code for streaming position deletes

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1092,6 +1092,20 @@ acceptedBreaks:
       old: "enum org.apache.iceberg.BaseMetastoreTableOperations.CommitStatus"
       justification: "Removing deprecated code"
     - code: "java.method.removed"
+      old: "method <T> org.apache.iceberg.io.CloseableIterable<T> org.apache.iceberg.deletes.Deletes::streamingFilter(org.apache.iceberg.io.CloseableIterable<T>,\
+        \ java.util.function.Function<T, java.lang.Long>, org.apache.iceberg.io.CloseableIterable<java.lang.Long>)"
+      justification: "Remove unused method"
+    - code: "java.method.removed"
+      old: "method <T> org.apache.iceberg.io.CloseableIterable<T> org.apache.iceberg.deletes.Deletes::streamingFilter(org.apache.iceberg.io.CloseableIterable<T>,\
+        \ java.util.function.Function<T, java.lang.Long>, org.apache.iceberg.io.CloseableIterable<java.lang.Long>,\
+        \ org.apache.iceberg.deletes.DeleteCounter)"
+      justification: "Remove unused method"
+    - code: "java.method.removed"
+      old: "method <T> org.apache.iceberg.io.CloseableIterable<T> org.apache.iceberg.deletes.Deletes::streamingMarker(org.apache.iceberg.io.CloseableIterable<T>,\
+        \ java.util.function.Function<T, java.lang.Long>, org.apache.iceberg.io.CloseableIterable<java.lang.Long>,\
+        \ java.util.function.Consumer<T>)"
+      justification: "Remove unused method"
+    - code: "java.method.removed"
       old: "method java.lang.String org.apache.iceberg.FileScanTaskParser::toJson(org.apache.iceberg.FileScanTask)"
       justification: "Removing deprecated code"
     - code: "java.method.removed"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1092,20 +1092,6 @@ acceptedBreaks:
       old: "enum org.apache.iceberg.BaseMetastoreTableOperations.CommitStatus"
       justification: "Removing deprecated code"
     - code: "java.method.removed"
-      old: "method <T> org.apache.iceberg.io.CloseableIterable<T> org.apache.iceberg.deletes.Deletes::streamingFilter(org.apache.iceberg.io.CloseableIterable<T>,\
-        \ java.util.function.Function<T, java.lang.Long>, org.apache.iceberg.io.CloseableIterable<java.lang.Long>)"
-      justification: "Remove unused method"
-    - code: "java.method.removed"
-      old: "method <T> org.apache.iceberg.io.CloseableIterable<T> org.apache.iceberg.deletes.Deletes::streamingFilter(org.apache.iceberg.io.CloseableIterable<T>,\
-        \ java.util.function.Function<T, java.lang.Long>, org.apache.iceberg.io.CloseableIterable<java.lang.Long>,\
-        \ org.apache.iceberg.deletes.DeleteCounter)"
-      justification: "Remove unused method"
-    - code: "java.method.removed"
-      old: "method <T> org.apache.iceberg.io.CloseableIterable<T> org.apache.iceberg.deletes.Deletes::streamingMarker(org.apache.iceberg.io.CloseableIterable<T>,\
-        \ java.util.function.Function<T, java.lang.Long>, org.apache.iceberg.io.CloseableIterable<java.lang.Long>,\
-        \ java.util.function.Consumer<T>)"
-      justification: "Remove unused method"
-    - code: "java.method.removed"
       old: "method java.lang.String org.apache.iceberg.FileScanTaskParser::toJson(org.apache.iceberg.FileScanTask)"
       justification: "Removing deprecated code"
     - code: "java.method.removed"

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -185,6 +185,45 @@ public class Deletes {
     }
   }
 
+  /**
+   * @deprecated since 1.7.0, will be removed in future.
+   */
+  @Deprecated
+  public static <T> CloseableIterable<T> streamingFilter(
+      CloseableIterable<T> rows,
+      Function<T, Long> rowToPosition,
+      CloseableIterable<Long> posDeletes) {
+    return streamingFilter(rows, rowToPosition, posDeletes, new DeleteCounter());
+  }
+
+  /**
+   * @deprecated since 1.7.0, will be removed in future.
+   */
+  @Deprecated
+  public static <T> CloseableIterable<T> streamingFilter(
+      CloseableIterable<T> rows,
+      Function<T, Long> rowToPosition,
+      CloseableIterable<Long> posDeletes,
+      DeleteCounter counter) {
+    PositionDeleteIndex positionIndex = toPositionIndex(posDeletes);
+    Predicate<T> isDeleted = row -> positionIndex.isDeleted(rowToPosition.apply(row));
+    return filterDeleted(rows, isDeleted, counter);
+  }
+
+  /**
+   * @deprecated since 1.7.0, will be removed in future.
+   */
+  @Deprecated
+  public static <T> CloseableIterable<T> streamingMarker(
+      CloseableIterable<T> rows,
+      Function<T, Long> rowToPosition,
+      CloseableIterable<Long> posDeletes,
+      Consumer<T> markRowDeleted) {
+    PositionDeleteIndex positionIndex = toPositionIndex(posDeletes);
+    Predicate<T> isDeleted = row -> positionIndex.isDeleted(rowToPosition.apply(row));
+    return markDeleted(rows, isDeleted, markRowDeleted);
+  }
+
   public static CloseableIterable<Long> deletePositions(
       CharSequence dataLocation, CloseableIterable<StructLike> deleteFile) {
     return deletePositions(dataLocation, ImmutableList.of(deleteFile));

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -29,10 +29,7 @@ import org.apache.iceberg.Accessor;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
-import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.CloseableIterator;
-import org.apache.iceberg.io.FilterIterator;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -44,12 +41,8 @@ import org.apache.iceberg.util.ParallelIterable;
 import org.apache.iceberg.util.SortedMerge;
 import org.apache.iceberg.util.StructLikeSet;
 import org.apache.iceberg.util.ThreadPools;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Deletes {
-
-  private static final Logger LOG = LoggerFactory.getLogger(Deletes.class);
 
   private static final Schema POSITION_DELETE_SCHEMA =
       new Schema(MetadataColumns.DELETE_FILE_PATH, MetadataColumns.DELETE_FILE_POS);
@@ -192,29 +185,6 @@ public class Deletes {
     }
   }
 
-  public static <T> CloseableIterable<T> streamingFilter(
-      CloseableIterable<T> rows,
-      Function<T, Long> rowToPosition,
-      CloseableIterable<Long> posDeletes) {
-    return streamingFilter(rows, rowToPosition, posDeletes, new DeleteCounter());
-  }
-
-  public static <T> CloseableIterable<T> streamingFilter(
-      CloseableIterable<T> rows,
-      Function<T, Long> rowToPosition,
-      CloseableIterable<Long> posDeletes,
-      DeleteCounter counter) {
-    return new PositionStreamDeleteFilter<>(rows, rowToPosition, posDeletes, counter);
-  }
-
-  public static <T> CloseableIterable<T> streamingMarker(
-      CloseableIterable<T> rows,
-      Function<T, Long> rowToPosition,
-      CloseableIterable<Long> posDeletes,
-      Consumer<T> markDeleted) {
-    return new PositionStreamDeleteMarker<>(rows, rowToPosition, posDeletes, markDeleted);
-  }
-
   public static CloseableIterable<Long> deletePositions(
       CharSequence dataLocation, CloseableIterable<StructLike> deleteFile) {
     return deletePositions(dataLocation, ImmutableList.of(deleteFile));
@@ -245,148 +215,6 @@ public class Deletes {
     @Override
     protected boolean shouldKeep(T row) {
       return !deletes.contains(extractEqStruct.apply(row));
-    }
-  }
-
-  private abstract static class PositionStreamDeleteIterable<T> extends CloseableGroup
-      implements CloseableIterable<T> {
-    private final CloseableIterable<T> rows;
-    private final CloseableIterator<Long> deletePosIterator;
-    private final Function<T, Long> rowToPosition;
-    private long nextDeletePos;
-
-    PositionStreamDeleteIterable(
-        CloseableIterable<T> rows,
-        Function<T, Long> rowToPosition,
-        CloseableIterable<Long> deletePositions) {
-      this.rows = rows;
-      this.rowToPosition = rowToPosition;
-      this.deletePosIterator = deletePositions.iterator();
-    }
-
-    @Override
-    public CloseableIterator<T> iterator() {
-      CloseableIterator<T> iter;
-      if (deletePosIterator.hasNext()) {
-        nextDeletePos = deletePosIterator.next();
-        iter = applyDelete(rows.iterator(), deletePosIterator);
-      } else {
-        iter = rows.iterator();
-      }
-
-      addCloseable(iter);
-      addCloseable(deletePosIterator);
-
-      return iter;
-    }
-
-    boolean isDeleted(T row) {
-      long currentPos = rowToPosition.apply(row);
-      if (currentPos < nextDeletePos) {
-        return false;
-      }
-
-      // consume delete positions until the next is past the current position
-      boolean isDeleted = currentPos == nextDeletePos;
-      while (deletePosIterator.hasNext() && nextDeletePos <= currentPos) {
-        this.nextDeletePos = deletePosIterator.next();
-        if (!isDeleted && currentPos == nextDeletePos) {
-          // if any delete position matches the current position
-          isDeleted = true;
-        }
-      }
-
-      return isDeleted;
-    }
-
-    protected abstract CloseableIterator<T> applyDelete(
-        CloseableIterator<T> items, CloseableIterator<Long> deletePositions);
-  }
-
-  private static class PositionStreamDeleteFilter<T> extends PositionStreamDeleteIterable<T> {
-    private final DeleteCounter counter;
-
-    PositionStreamDeleteFilter(
-        CloseableIterable<T> rows,
-        Function<T, Long> rowToPosition,
-        CloseableIterable<Long> deletePositions,
-        DeleteCounter counter) {
-      super(rows, rowToPosition, deletePositions);
-      this.counter = counter;
-    }
-
-    @Override
-    protected CloseableIterator<T> applyDelete(
-        CloseableIterator<T> items, CloseableIterator<Long> deletePositions) {
-      return new FilterIterator<T>(items) {
-        @Override
-        protected boolean shouldKeep(T item) {
-          boolean deleted = isDeleted(item);
-          if (deleted) {
-            counter.increment();
-          }
-
-          return !deleted;
-        }
-
-        @Override
-        public void close() {
-          try {
-            deletePositions.close();
-          } catch (IOException e) {
-            LOG.warn("Error closing delete file", e);
-          }
-          super.close();
-        }
-      };
-    }
-  }
-
-  private static class PositionStreamDeleteMarker<T> extends PositionStreamDeleteIterable<T> {
-    private final Consumer<T> markDeleted;
-
-    PositionStreamDeleteMarker(
-        CloseableIterable<T> rows,
-        Function<T, Long> rowToPosition,
-        CloseableIterable<Long> deletePositions,
-        Consumer<T> markDeleted) {
-      super(rows, rowToPosition, deletePositions);
-      this.markDeleted = markDeleted;
-    }
-
-    @Override
-    protected CloseableIterator<T> applyDelete(
-        CloseableIterator<T> items, CloseableIterator<Long> deletePositions) {
-
-      return new CloseableIterator<T>() {
-        @Override
-        public void close() {
-          try {
-            deletePositions.close();
-          } catch (IOException e) {
-            LOG.warn("Error closing delete file", e);
-          }
-          try {
-            items.close();
-          } catch (IOException e) {
-            LOG.warn("Error closing data file", e);
-          }
-        }
-
-        @Override
-        public boolean hasNext() {
-          return items.hasNext();
-        }
-
-        @Override
-        public T next() {
-          T row = items.next();
-          if (isDeleted(row)) {
-            markDeleted.accept(row);
-          }
-          return row;
-        }
-      };
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -186,7 +186,7 @@ public class Deletes {
   }
 
   /**
-   * @deprecated since 1.7.0, will be removed in future.
+   * @deprecated since 1.7.0, will be removed in 1.8.0.
    */
   @Deprecated
   public static <T> CloseableIterable<T> streamingFilter(
@@ -197,7 +197,7 @@ public class Deletes {
   }
 
   /**
-   * @deprecated since 1.7.0, will be removed in future.
+   * @deprecated since 1.7.0, will be removed in 1.8.0.
    */
   @Deprecated
   public static <T> CloseableIterable<T> streamingFilter(
@@ -211,7 +211,7 @@ public class Deletes {
   }
 
   /**
-   * @deprecated since 1.7.0, will be removed in future.
+   * @deprecated since 1.7.0, will be removed in 1.8.0.
    */
   @Deprecated
   public static <T> CloseableIterable<T> streamingMarker(

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
@@ -20,20 +20,16 @@ package org.apache.iceberg.deletes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -108,155 +104,6 @@ public class TestPositionFilter {
     assertThat(Deletes.deletePositions("file_a.avro", deletes))
         .as("Should merge deletes in order, with duplicates")
         .containsExactly(0L, 3L, 3L, 9L, 16L, 19L, 19L, 22L, 22L, 56L, 63L, 70L, 91L);
-  }
-
-  @Test
-  public void testPositionStreamRowFilter() {
-    CloseableIterable<StructLike> rows =
-        CloseableIterable.withNoopClose(
-            Lists.newArrayList(
-                Row.of(0L, "a"),
-                Row.of(1L, "b"),
-                Row.of(2L, "c"),
-                Row.of(3L, "d"),
-                Row.of(4L, "e"),
-                Row.of(5L, "f"),
-                Row.of(6L, "g"),
-                Row.of(7L, "h"),
-                Row.of(8L, "i"),
-                Row.of(9L, "j")));
-
-    CloseableIterable<Long> deletes =
-        CloseableIterable.withNoopClose(Lists.newArrayList(0L, 3L, 4L, 7L, 9L));
-
-    CloseableIterable<StructLike> actual =
-        Deletes.streamingFilter(rows, row -> row.get(0, Long.class), deletes);
-
-    assertThat(Iterables.transform(actual, row -> row.get(0, Long.class)))
-        .as("Filter should produce expected rows")
-        .containsExactlyElementsOf(Lists.newArrayList(1L, 2L, 5L, 6L, 8L));
-  }
-
-  @Test
-  public void testPositionStreamRowDeleteMarker() {
-    CloseableIterable<StructLike> rows =
-        CloseableIterable.withNoopClose(
-            Lists.newArrayList(
-                Row.of(0L, "a", false),
-                Row.of(1L, "b", false),
-                Row.of(2L, "c", false),
-                Row.of(3L, "d", false),
-                Row.of(4L, "e", false),
-                Row.of(5L, "f", false),
-                Row.of(6L, "g", false),
-                Row.of(7L, "h", false),
-                Row.of(8L, "i", false),
-                Row.of(9L, "j", false)));
-
-    CloseableIterable<Long> deletes =
-        CloseableIterable.withNoopClose(Lists.newArrayList(0L, 3L, 4L, 7L, 9L));
-
-    CloseableIterable<StructLike> actual =
-        Deletes.streamingMarker(
-            rows,
-            row -> row.get(0, Long.class), /* row to position */
-            deletes,
-            row -> row.set(2, true) /* delete marker */);
-
-    assertThat(Iterables.transform(actual, row -> row.get(2, Boolean.class)))
-        .as("Filter should produce expected rows")
-        .containsExactlyElementsOf(
-            Lists.newArrayList(true, false, false, true, true, false, false, true, false, true));
-  }
-
-  @Test
-  public void testPositionStreamRowFilterWithDuplicates() {
-    CloseableIterable<StructLike> rows =
-        CloseableIterable.withNoopClose(
-            Lists.newArrayList(
-                Row.of(0L, "a"),
-                Row.of(1L, "b"),
-                Row.of(2L, "c"),
-                Row.of(3L, "d"),
-                Row.of(4L, "e"),
-                Row.of(5L, "f"),
-                Row.of(6L, "g"),
-                Row.of(7L, "h"),
-                Row.of(8L, "i"),
-                Row.of(9L, "j")));
-
-    CloseableIterable<Long> deletes =
-        CloseableIterable.withNoopClose(Lists.newArrayList(0L, 0L, 0L, 3L, 4L, 7L, 7L, 9L, 9L, 9L));
-
-    CloseableIterable<StructLike> actual =
-        Deletes.streamingFilter(rows, row -> row.get(0, Long.class), deletes);
-
-    assertThat(Iterables.transform(actual, row -> row.get(0, Long.class)))
-        .as("Filter should produce expected rows")
-        .containsExactlyElementsOf(Lists.newArrayList(1L, 2L, 5L, 6L, 8L));
-  }
-
-  @Test
-  public void testPositionStreamRowFilterWithRowGaps() {
-    // test the case where row position is greater than the delete position
-    CloseableIterable<StructLike> rows =
-        CloseableIterable.withNoopClose(
-            Lists.newArrayList(Row.of(2L, "c"), Row.of(3L, "d"), Row.of(5L, "f"), Row.of(6L, "g")));
-
-    CloseableIterable<Long> deletes =
-        CloseableIterable.withNoopClose(Lists.newArrayList(0L, 2L, 3L, 4L, 7L, 9L));
-
-    CloseableIterable<StructLike> actual =
-        Deletes.streamingFilter(rows, row -> row.get(0, Long.class), deletes);
-
-    assertThat(Iterables.transform(actual, row -> row.get(0, Long.class)))
-        .as("Filter should produce expected rows")
-        .containsExactlyElementsOf(Lists.newArrayList(5L, 6L));
-  }
-
-  @Test
-  public void testCombinedPositionStreamRowFilter() {
-    CloseableIterable<StructLike> positionDeletes1 =
-        CloseableIterable.withNoopClose(
-            Lists.newArrayList(
-                Row.of("file_a.avro", 0L),
-                Row.of("file_a.avro", 3L),
-                Row.of("file_a.avro", 9L),
-                Row.of("file_b.avro", 5L),
-                Row.of("file_b.avro", 6L)));
-
-    CloseableIterable<StructLike> positionDeletes2 =
-        CloseableIterable.withNoopClose(
-            Lists.newArrayList(
-                Row.of("file_a.avro", 3L),
-                Row.of("file_a.avro", 4L),
-                Row.of("file_a.avro", 7L),
-                Row.of("file_b.avro", 2L)));
-
-    CloseableIterable<StructLike> rows =
-        CloseableIterable.withNoopClose(
-            Lists.newArrayList(
-                Row.of(0L, "a"),
-                Row.of(1L, "b"),
-                Row.of(2L, "c"),
-                Row.of(3L, "d"),
-                Row.of(4L, "e"),
-                Row.of(5L, "f"),
-                Row.of(6L, "g"),
-                Row.of(7L, "h"),
-                Row.of(8L, "i"),
-                Row.of(9L, "j")));
-
-    CloseableIterable<StructLike> actual =
-        Deletes.streamingFilter(
-            rows,
-            row -> row.get(0, Long.class),
-            Deletes.deletePositions(
-                "file_a.avro", ImmutableList.of(positionDeletes1, positionDeletes2)));
-
-    assertThat(Iterables.transform(actual, row -> row.get(0, Long.class)))
-        .as("Filter should produce expected rows")
-        .containsExactlyElementsOf(Lists.newArrayList(1L, 2L, 5L, 6L, 8L));
   }
 
   @Test
@@ -340,106 +187,5 @@ public class TestPositionFilter {
     assertThat(Iterables.transform(actual, row -> row.get(0, Long.class)))
         .as("Filter should produce expected rows")
         .containsExactlyElementsOf(Lists.newArrayList(1L, 2L, 5L, 6L, 8L));
-  }
-
-  @Test
-  public void testClosePositionStreamRowDeleteMarker() {
-    List<Long> deletes = Lists.newArrayList(1L, 2L);
-
-    List<StructLike> records =
-        Lists.newArrayList(
-            Row.of(29, "a", 1L), Row.of(43, "b", 2L), Row.of(61, "c", 3L), Row.of(89, "d", 4L));
-
-    CheckingClosableIterable<StructLike> data = new CheckingClosableIterable<>(records);
-    CheckingClosableIterable<Long> deletePositions = new CheckingClosableIterable<>(deletes);
-
-    CloseableIterable<StructLike> posDeletesIterable =
-        Deletes.streamingFilter(data, row -> row.get(2, Long.class), deletePositions);
-
-    // end iterator is always wrapped with FilterIterator
-    CloseableIterable<StructLike> eqDeletesIterable =
-        Deletes.filterDeleted(posDeletesIterable, i -> false, new DeleteCounter());
-    List<StructLike> result = Lists.newArrayList(eqDeletesIterable.iterator());
-
-    // as first two records deleted, expect only last two records
-    assertThat(Iterables.transform(result, row -> row.get(2, Long.class)))
-        .as("Filter should produce expected rows")
-        .containsExactlyElementsOf(Lists.newArrayList(3L, 4L));
-
-    assertThat(data.isClosed).isTrue();
-    assertThat(deletePositions.isClosed).isTrue();
-  }
-
-  @Test
-  public void testDeleteMarkerFileClosed() {
-
-    List<Long> deletes = Lists.newArrayList(1L, 2L);
-
-    List<StructLike> records =
-        Lists.newArrayList(
-            Row.of(29, "a", 1L, false),
-            Row.of(43, "b", 2L, false),
-            Row.of(61, "c", 3L, false),
-            Row.of(89, "d", 4L, false));
-
-    CheckingClosableIterable<StructLike> data = new CheckingClosableIterable<>(records);
-    CheckingClosableIterable<Long> deletePositions = new CheckingClosableIterable<>(deletes);
-
-    CloseableIterable<StructLike> resultIterable =
-        Deletes.streamingMarker(
-            data, row -> row.get(2, Long.class), deletePositions, row -> row.set(3, true));
-
-    // end iterator is always wrapped with FilterIterator
-    CloseableIterable<StructLike> eqDeletesIterable =
-        Deletes.filterDeleted(resultIterable, i -> false, new DeleteCounter());
-    List<StructLike> result = Lists.newArrayList(eqDeletesIterable.iterator());
-
-    // as first two records deleted, expect only those two records marked
-    assertThat(Iterables.transform(result, row -> row.get(3, Boolean.class)))
-        .as("Filter should produce expected rows")
-        .containsExactlyElementsOf(Lists.newArrayList(true, true, false, false));
-
-    assertThat(data.isClosed).isTrue();
-    assertThat(deletePositions.isClosed).isTrue();
-  }
-
-  private static class CheckingClosableIterable<E> implements CloseableIterable<E> {
-    AtomicBoolean isClosed = new AtomicBoolean(false);
-    final Iterable<E> iterable;
-
-    CheckingClosableIterable(Iterable<E> iterable) {
-      this.iterable = iterable;
-    }
-
-    public boolean isClosed() {
-      return isClosed.get();
-    }
-
-    @Override
-    public void close() throws IOException {
-      isClosed.set(true);
-    }
-
-    @Override
-    public CloseableIterator<E> iterator() {
-      Iterator<E> it = iterable.iterator();
-      return new CloseableIterator<E>() {
-
-        @Override
-        public boolean hasNext() {
-          return it.hasNext();
-        }
-
-        @Override
-        public E next() {
-          return it.next();
-        }
-
-        @Override
-        public void close() {
-          isClosed.set(true);
-        }
-      };
-    }
   }
 }


### PR DESCRIPTION
Follow up to https://github.com/apache/iceberg/pull/9117.
Prior to that PR, there were two code paths in `DeleteFilter` for applying position deletes: if the number of position deletes were below a certain number, we use the `PositionDeleteIndex` bitmap and otherwise we use a streaming filter. That PR makes it so that we always use the first code path, but did not remove the now unused code for the second code path.
This PR is to remove most of the unused code. It includes removing tests which were only added to test that second code path as well as bugs found in that code path (https://github.com/apache/iceberg/pull/8132). The `streamingFilter` and `streamingMarker` public methods in `Deletes` are not removed but are deprecated; they can be removed in the version after 1.7. However, the implementation of the methods is replaced by the much simpler implementation using the `PositionDeleteIndex` bitmap (first code path mentioned above) and the backing classes for the streaming implementation is removed.
