### PR TITLE
Parquet: update PruneColumns to inherit from TypeWithSchemaVisitor to have Iceberg type

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -78,8 +78,9 @@ public class ParquetSchemaUtil {
   public static MessageType pruneColumns(MessageType fileSchema, Schema expectedSchema) {
     // column order must match the incoming type, so it doesn't matter that the ids are unordered
     Set<Integer> selectedIds = TypeUtil.getProjectedIds(expectedSchema);
-    return (MessageType) TypeWithSchemaVisitor.visit(expectedSchema.asStruct(), fileSchema,
-        new PruneColumns(selectedIds));
+    return (MessageType)
+        TypeWithSchemaVisitor.visit(
+            expectedSchema.asStruct(), fileSchema, new PruneColumns(selectedIds));
   }
 
   /**

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -78,7 +78,8 @@ public class ParquetSchemaUtil {
   public static MessageType pruneColumns(MessageType fileSchema, Schema expectedSchema) {
     // column order must match the incoming type, so it doesn't matter that the ids are unordered
     Set<Integer> selectedIds = TypeUtil.getProjectedIds(expectedSchema);
-    return (MessageType) ParquetTypeVisitor.visit(fileSchema, new PruneColumns(selectedIds));
+    return (MessageType) TypeWithSchemaVisitor.visit(expectedSchema.asStruct(), fileSchema,
+        new PruneColumns(selectedIds));
   }
 
   /**

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -24,6 +24,9 @@ import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types.ListType;
+import org.apache.iceberg.types.Types.MapType;
+import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
@@ -31,7 +34,7 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
 
-class PruneColumns extends ParquetTypeVisitor<Type> {
+class PruneColumns extends TypeWithSchemaVisitor<Type> {
   private final Set<Integer> selectedIds;
 
   PruneColumns(Set<Integer> selectedIds) {
@@ -40,7 +43,7 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
   }
 
   @Override
-  public Type message(MessageType message, List<Type> fields) {
+  public Type message(StructType iStruct, MessageType message, List<Type> fields) {
     Types.MessageTypeBuilder builder = Types.buildMessage();
 
     boolean hasChange = false;
@@ -79,7 +82,7 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
   }
 
   @Override
-  public Type struct(GroupType struct, List<Type> fields) {
+  public Type struct(StructType iStruct, GroupType struct, List<Type> fields) {
     boolean hasChange = false;
     List<Type> filteredFields = Lists.newArrayListWithExpectedSize(fields.size());
     for (int i = 0; i < fields.size(); i += 1) {
@@ -106,7 +109,7 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
   }
 
   @Override
-  public Type list(GroupType list, Type element) {
+  public Type list(ListType iList, GroupType list, Type element) {
     Type repeated = list.getType(0);
     Type originalElement = ParquetSchemaUtil.determineListElementType(list);
     Integer elementId = getId(originalElement);
@@ -128,7 +131,7 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
   }
 
   @Override
-  public Type map(GroupType map, Type key, Type value) {
+  public Type map(MapType iMap, GroupType map, Type key, Type value) {
     GroupType repeated = map.getType(0).asGroupType();
     Type originalKey = repeated.getType(0);
     Type originalValue = repeated.getType(1);
@@ -150,7 +153,7 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
   }
 
   @Override
-  public Type primitive(PrimitiveType primitive) {
+  public Type primitive(org.apache.iceberg.types.Type.PrimitiveType iPrimitive, PrimitiveType primitive) {
     return null;
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -43,7 +43,7 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
   }
 
   @Override
-  public Type message(StructType iStruct, MessageType message, List<Type> fields) {
+  public Type message(StructType expected, MessageType message, List<Type> fields) {
     Types.MessageTypeBuilder builder = Types.buildMessage();
 
     boolean hasChange = false;
@@ -82,7 +82,7 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
   }
 
   @Override
-  public Type struct(StructType iStruct, GroupType struct, List<Type> fields) {
+  public Type struct(StructType expected, GroupType struct, List<Type> fields) {
     boolean hasChange = false;
     List<Type> filteredFields = Lists.newArrayListWithExpectedSize(fields.size());
     for (int i = 0; i < fields.size(); i += 1) {
@@ -109,7 +109,7 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
   }
 
   @Override
-  public Type list(ListType iList, GroupType list, Type element) {
+  public Type list(ListType expected, GroupType list, Type element) {
     Type repeated = list.getType(0);
     Type originalElement = ParquetSchemaUtil.determineListElementType(list);
     Integer elementId = getId(originalElement);
@@ -131,7 +131,7 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
   }
 
   @Override
-  public Type map(MapType iMap, GroupType map, Type key, Type value) {
+  public Type map(MapType expected, GroupType map, Type key, Type value) {
     GroupType repeated = map.getType(0).asGroupType();
     Type originalKey = repeated.getType(0);
     Type originalValue = repeated.getType(1);
@@ -153,7 +153,7 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
   }
 
   @Override
-  public Type primitive(org.apache.iceberg.types.Type.PrimitiveType iPrimitive, PrimitiveType primitive) {
+  public Type primitive(org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
     return null;
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -153,7 +153,8 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
   }
 
   @Override
-  public Type primitive(org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
+  public Type primitive(
+      org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
     return null;
   }
 


### PR DESCRIPTION
Currently PruneColumns inherits from ParquetTypeVisitor which will only pass Parquet types. Later when we add the support for Variant type, we need to know the column is a Variant type during column pruning. Before logical Variant type is added to Parquet, we can change to inherit from TypeWithSchemaVisitor to have the Iceberg type. #11178 

Existing tests in TestPruneColumns should provide the test coverage so no tests are added.