### PR TITLE
Add scan planning api request and response models

### DIFF
--- a/api/src/main/java/org/apache/iceberg/exceptions/NoSuchPlanIdException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/NoSuchPlanIdException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+
+public class NoSuchPlanIdException extends RuntimeException implements CleanableFailure {
+  @FormatMethod
+  public NoSuchPlanIdException(String message, Object... args) {
+    super(String.format(message, args));
+  }
+
+  @FormatMethod
+  public NoSuchPlanIdException(Throwable cause, String message, Object... args) {
+    super(String.format(message, args), cause);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/exceptions/NoSuchPlanTaskException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/NoSuchPlanTaskException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+
+public class NoSuchPlanTaskException extends RuntimeException implements CleanableFailure {
+  @FormatMethod
+  public NoSuchPlanTaskException(String message, Object... args) {
+    super(String.format(message, args));
+  }
+
+  @FormatMethod
+  public NoSuchPlanTaskException(Throwable cause, String message, Object... args) {
+    super(String.format(message, args), cause);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/PlanStatus.java
+++ b/core/src/main/java/org/apache/iceberg/rest/PlanStatus.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+public enum PlanStatus {
+  COMPLETED("completed"),
+  SUBMITTED("submitted"),
+  CANCELLED("cancelled"),
+  FAILED("failed");
+
+  private final String status;
+
+  PlanStatus(String status) {
+    this.status = status;
+  }
+
+  public String status() {
+    return status;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/FetchScanTasksRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/FetchScanTasksRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.RESTRequest;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface FetchScanTasksRequest extends RESTRequest {
+
+  String planTask();
+
+  @Override
+  default void validate() {
+    Preconditions.checkArgument(
+        planTask() != null, "invalid request, requires planTask to be provided");
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/PlanTableScanRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/PlanTableScanRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.RESTRequest;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface PlanTableScanRequest extends RESTRequest {
+
+  @Nullable
+  Long snapshotId();
+
+  @Nullable
+  List<String> select();
+
+  @Nullable
+  Expression filter();
+
+  @Nullable
+  @Value.Default
+  default Boolean caseSensitive() {
+    return true;
+  }
+
+  @Nullable
+  @Value.Default
+  default Boolean useSnapShotSchema() {
+    return false;
+  }
+
+  @Nullable
+  Long startSnapShotId();
+
+  @Nullable
+  Long endSnapShotId();
+
+  @Nullable
+  List<String> statsFields();
+
+  @Override
+  default void validate() {
+    Preconditions.checkArgument(
+        snapshotId() != null ^ (startSnapShotId() != null && endSnapShotId() != null),
+        "Either snapshotId must be provided or both startSnapshotId and endSnapshotId must be provided");
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.PlanStatus;
+import org.apache.iceberg.rest.RESTResponse;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface FetchPlanningResultResponse extends RESTResponse {
+  PlanStatus planStatus();
+
+  @Nullable
+  List<String> planTasks();
+
+  @Nullable
+  List<FileScanTask> fileScanTasks();
+
+  @Nullable
+  List<DeleteFile> deleteFiles();
+
+  @Override
+  default void validate() {
+    Preconditions.checkArgument(
+        planStatus() != null, "invalid, status can not be null: ", planStatus());
+    Preconditions.checkArgument(
+        planStatus() != PlanStatus.COMPLETED && (planTasks() != null || fileScanTasks() != null),
+        "invalid response, tasks can only be returned in a 'completed' status");
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/FetchScanTasksResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/FetchScanTasksResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.rest.RESTResponse;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface FetchScanTasksResponse extends RESTResponse {
+
+  @Nullable
+  List<String> planTasks();
+
+  @Nullable
+  List<FileScanTask> fileScanTasks();
+
+  @Nullable
+  List<DeleteFile> deleteFiles();
+
+  @Override
+  default void validate() {}
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.PlanStatus;
+import org.apache.iceberg.rest.RESTResponse;
+
+public interface PlanTableScanResponse extends RESTResponse {
+  PlanStatus planStatus();
+
+  @Nullable
+  String planId();
+
+  @Nullable
+  List<String> planTasks();
+
+  @Nullable
+  List<FileScanTask> fileScanTasks();
+
+  @Nullable
+  List<DeleteFile> deleteFiles();
+
+  @Override
+  default void validate() {
+    Preconditions.checkArgument(planStatus() != null, "invalid response, status can not be null");
+    Preconditions.checkArgument(
+        planStatus() != PlanStatus.CANCELLED,
+        "invalid response, 'cancelled' is not a valid status for this endpoint");
+    Preconditions.checkArgument(
+        planStatus() != PlanStatus.COMPLETED && (planTasks() != null || fileScanTasks() != null),
+        "invalid response, tasks can only be returned in a 'completed' status");
+  }
+}


### PR DESCRIPTION
This pr adds the models for new request, responses, and exceptions based on the recent REST spec changes made in the following [pr](https://github.com/apache/iceberg/commit/8d97d54756a1b8ba1986858b2461013864b9e37f)

cc @amogh-jahagirdar 