### PR TITLE
[Docs] Update AWS docs to add more AWS engines that supports iceberg

### DIFF
--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -685,3 +685,9 @@ Search the [Iceberg blogs](../../blogs.md) page for tutorials around running Ice
 
 [Amazon Kinesis Data Analytics](https://aws.amazon.com/about-aws/whats-new/2019/11/you-can-now-run-fully-managed-apache-flink-applications-with-apache-kafka/) provides a platform 
 to run fully managed Apache Flink applications. You can include Iceberg in your application Jar and run it in the platform.
+
+### AWS Redshift
+[AWS Redshift Spectrum or Redshift Serverless](https://docs.aws.amazon.com/redshift/latest/dg/querying-iceberg.html) supports querying Apache Iceberg tables cataloged in the AWS Glue Data Catalog.
+
+### Amazon Data Firehose
+You can use [Firehose](https://docs.aws.amazon.com/firehose/latest/dev/apache-iceberg-destination.html) to directly deliver streaming data to Apache Iceberg Tables in Amazon S3. With this feature, you can route records from a single stream into different Apache Iceberg Tables, and automatically apply insert, update, and delete operations to records in the Apache Iceberg Tables. This feature requires using the AWS Glue Data Catalog.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -59,6 +59,8 @@ nav:
   - Starrocks: https://docs.starrocks.io/en-us/latest/data_source/catalog/iceberg_catalog
   - Amazon Athena: https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html
   - Amazon EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
+  - Amazon Data Firehose: https://docs.aws.amazon.com/firehose/latest/dev/apache-iceberg-destination.html
+  - Amazon Redshift: https://docs.aws.amazon.com/redshift/latest/dg/querying-iceberg.html
   - Google BigQuery: https://cloud.google.com/bigquery/docs/iceberg-tables
   - Snowflake: https://docs.snowflake.com/en/user-guide/tables-iceberg
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html


### PR DESCRIPTION
### About the change

AWS have added the support of Iceberg across more engine, Having this in our docs with existing lists, would certainly help in navigation and support.


cc @jackye1995 @amogh-jahagirdar 


