### PR TITLE
Always update metadata when Table.refresh() is called

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -170,14 +170,7 @@ class RESTTableOperations implements TableOperations {
   }
 
   private TableMetadata updateCurrentMetadata(LoadTableResponse response) {
-    // LoadTableResponse is used to deserialize the response, but config is not allowed by the REST
-    // spec so it can be
-    // safely ignored. there is no requirement to update config on refresh or commit.
-    if (current == null
-        || !Objects.equals(current.metadataFileLocation(), response.metadataLocation())) {
-      this.current = response.tableMetadata();
-    }
-
+    this.current = response.tableMetadata();
     return current;
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.rest;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -169,6 +169,9 @@ class RESTTableOperations implements TableOperations {
   }
 
   private TableMetadata updateCurrentMetadata(LoadTableResponse response) {
+    // LoadTableResponse is used to deserialize the response, but config is not allowed by the REST
+    // spec so it can be
+    // safely ignored. there is no requirement to update config on refresh or commit.
     this.current = response.tableMetadata();
     return current;
   }


### PR DESCRIPTION
In the PyIceberg API, calling `refresh` [always](https://github.com/apache/iceberg-python/blob/620ad9f64307193ec0d26846b48f4e063b5da904/pyiceberg/table/__init__.py#L803) updates table metadata. This PR changes the Java API to have the same semantics.

`refresh` not updating the metadata can cause issues when the metadata includes time-sensitive credentials that the user expects `refresh` to refresh.