### PR TITLE
Core: Support iterating over positions in PositionDeleteIndex

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.deletes;
 
+import java.util.function.LongConsumer;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 
 class BitmapPositionDeleteIndex implements PositionDeleteIndex {
@@ -49,5 +50,10 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
   @Override
   public boolean isEmpty() {
     return roaring64Bitmap.isEmpty();
+  }
+
+  @Override
+  public void forEach(LongConsumer consumer) {
+    roaring64Bitmap.forEach(consumer::accept);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.deletes;
 
+import java.util.function.LongConsumer;
+
 public interface PositionDeleteIndex {
   /**
    * Set a deleted row position.
@@ -48,6 +50,17 @@ public interface PositionDeleteIndex {
   /** Returns true if this collection contains elements. */
   default boolean isNotEmpty() {
     return !isEmpty();
+  }
+
+  /**
+   * Traverses all positions in the index in ascending order, applying the provided consumer.
+   *
+   * @param consumer a consumer for the positions
+   */
+  default void forEach(LongConsumer consumer) {
+    if (isNotEmpty()) {
+      throw new UnsupportedOperationException(getClass().getName() + " does not support forEach");
+    }
   }
 
   /** Returns an empty immutable position delete index. */

--- a/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.deletes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+public class TestBitmapPositionDeleteIndex {
+
+  @Test
+  public void testForEach() {
+    long pos1 = 10L; // Container 0 (high bits = 0)
+    long pos2 = 1L << 33; // Container 1 (high bits = 1)
+    long pos3 = pos2 + 1; // Container 1 (high bits = 1)
+    long pos4 = 2L << 33; // Container 2 (high bits = 2)
+    long pos5 = pos4 + 1; // Container 2 (high bits = 2)
+    long pos6 = 3L << 33; // Container 3 (high bits = 3)
+
+    PositionDeleteIndex index = new BitmapPositionDeleteIndex();
+
+    // add in any order
+    index.delete(pos1);
+    index.delete(pos6);
+    index.delete(pos2);
+    index.delete(pos3);
+    index.delete(pos5);
+    index.delete(pos4);
+
+    // output must be sorted in ascending order across containers
+    List<Long> positions = collect(index);
+    assertThat(positions).containsExactly(pos1, pos2, pos3, pos4, pos5, pos6);
+  }
+
+  @Test
+  public void testForEachEmptyBitmapIndex() {
+    PositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    List<Long> positions = collect(index);
+    assertThat(positions).isEmpty();
+  }
+
+  @Test
+  public void testForEachEmptyIndex() {
+    PositionDeleteIndex index = PositionDeleteIndex.empty();
+    List<Long> positions = collect(index);
+    assertThat(positions).isEmpty();
+  }
+
+  private List<Long> collect(PositionDeleteIndex index) {
+    List<Long> positions = Lists.newArrayList();
+    index.forEach(positions::add);
+    return positions;
+  }
+}


### PR DESCRIPTION
This PR adds support for iterating over positions in `PositionDeleteIndex`.