### PR TITLE
Core: Support merging in PositionDeleteIndex

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -43,6 +43,15 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
   }
 
   @Override
+  public void merge(PositionDeleteIndex that) {
+    if (that instanceof BitmapPositionDeleteIndex) {
+      merge((BitmapPositionDeleteIndex) that);
+    } else {
+      that.forEach(this::delete);
+    }
+  }
+
+  @Override
   public boolean isDeleted(long position) {
     return roaring64Bitmap.contains(position);
   }

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
@@ -37,6 +37,15 @@ public interface PositionDeleteIndex {
   void delete(long posStart, long posEnd);
 
   /**
+   * Adds positions from the other index, modifying this index in place.
+   *
+   * @param that the other index to merge
+   */
+  default void merge(PositionDeleteIndex that) {
+    that.forEach(this::delete);
+  }
+
+  /**
    * Checks whether a row at the position is deleted.
    *
    * @param position deleted row position

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndexUtil.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndexUtil.java
@@ -18,25 +18,13 @@
  */
 package org.apache.iceberg.deletes;
 
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-
 public class PositionDeleteIndexUtil {
 
   private PositionDeleteIndexUtil() {}
 
   public static PositionDeleteIndex merge(Iterable<? extends PositionDeleteIndex> indexes) {
     BitmapPositionDeleteIndex result = new BitmapPositionDeleteIndex();
-
-    for (PositionDeleteIndex index : indexes) {
-      if (index.isNotEmpty()) {
-        Preconditions.checkArgument(
-            index instanceof BitmapPositionDeleteIndex,
-            "Can merge only bitmap-based indexes, got %s",
-            index.getClass().getName());
-        result.merge((BitmapPositionDeleteIndex) index);
-      }
-    }
-
+    indexes.forEach(result::merge);
     return result;
   }
 }


### PR DESCRIPTION
This PR adds support for merging `PositionDeleteIndex` objects in place without extra objects.