### PR TITLE
[Minor][Test] Fix TestFastAppend.testAddManyFiles()

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestFastAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestFastAppend.java
@@ -54,7 +54,7 @@ public class TestFastAppend extends TestBase {
       dataFiles.add(dataFile);
     }
 
-    AppendFiles append = table.newAppend();
+    AppendFiles append = table.newFastAppend();
     dataFiles.forEach(append::appendFile);
     append.commit();
 


### PR DESCRIPTION
This test was added in https://github.com/apache/iceberg/pull/11086/. It should use `FastAppend` instead of `MergeAppend`. 