### PR TITLE
Core: Update TableMetadataParser to ensure all streams closed

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -130,7 +130,6 @@ public class TableMetadataParser {
           generator.useDefaultPrettyPrinter();
           toJson(metadata, generator);
           generator.flush();
-      }
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to write json to file: %s", outputFile);
     }

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -123,13 +123,12 @@ public class TableMetadataParser {
       TableMetadata metadata, OutputFile outputFile, boolean overwrite) {
     boolean isGzip = Codec.fromFileName(outputFile.location()) == Codec.GZIP;
     try (OutputStream os = overwrite ? outputFile.createOrOverwrite() : outputFile.create();
-         OutputStream gos = isGzip ? new GZIPOutputStream(os) : os;
-         OutputStreamWriter writer = new OutputStreamWriter(gos, StandardCharsets.UTF_8)
-    ) {
-          JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-          generator.useDefaultPrettyPrinter();
-          toJson(metadata, generator);
-          generator.flush();
+        OutputStream gos = isGzip ? new GZIPOutputStream(os) : os;
+        OutputStreamWriter writer = new OutputStreamWriter(gos, StandardCharsets.UTF_8)) {
+      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+      generator.useDefaultPrettyPrinter();
+      toJson(metadata, generator);
+      generator.flush();
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to write json to file: %s", outputFile);
     }
@@ -277,8 +276,7 @@ public class TableMetadataParser {
   public static TableMetadata read(FileIO io, InputFile file) {
     Codec codec = Codec.fromFileName(file.location());
     try (InputStream is = file.newStream();
-         InputStream gis = codec == Codec.GZIP ? new GZIPInputStream(is) : is;
-    ) {
+        InputStream gis = codec == Codec.GZIP ? new GZIPInputStream(is) : is) {
       return fromJson(file, JsonUtil.mapper().readValue(gis, JsonNode.class));
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to read file: %s", file);


### PR DESCRIPTION
Minor try-with-resources tweak to fix an unclosed stream memory leak I encountered.

More specifically, this occurs when the file is Gzipped and file.newStream().read() throws an exception.

The `GZIPInputStream` constructor calls read on it's input to load the header.

see: https://stackoverflow.com/questions/12552863/correct-idiom-for-managing-multiple-chained-resources-in-try-with-resources-bloc