### PR TITLE
Flink: Add table.exec.iceberg.use-v2-sink option

### DIFF
--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -374,15 +374,14 @@ orphan files that are old enough.
 
 # Flink Writes (SinkV2 based implementation)
 
-The [SinkV2 interface](https://cwiki.apache.org/confluence/display/FLINK/FLIP-191%3A+Extend+unified+Sink+interface+to+support+small+file+compaction)
-was introduced in Flink 1.15.
-The previous [SinkV1 interface](https://cwiki.apache.org/confluence/display/FLINK/FLIP-143%3A+Unified+Sink+API)
-had some limitations - for example it created a lot of small files when writing to it. This problem is called
-the `small-file-compaction` problem in
-the [FLIP-191 document](https://cwiki.apache.org/confluence/display/FLINK/FLIP-191%3A+Extend+unified+Sink+interface+to+support+small+file+compaction).
-The default `FlinkSink` implementation available in `iceberg-flink` module builds its own chain of `StreamOperator`s  terminated by `DiscardingSink`.
-However, in the same module, there is also `IcebergSink` which is based on the SinkV2 API.
-The SinkV2 based `IcebergSink` is currently an experimental feature.
+At the time when the current default, `FlinkSink` implementation was created, Flink Sink's interface had some
+limitations that were not acceptable for the Iceberg tables purpose. Due to these limitations, `FlinkSink` is based 
+on a custom chain of `StreamOperator`s  terminated by `DiscardingSink`.
+
+In the Flink 1.15 version, [SinkV2 interface](https://cwiki.apache.org/confluence/display/FLINK/FLIP-191%3A+Extend+unified+Sink+interface+to+support+small+file+compaction) 
+was introduced. This interface is used in the new, `IcebergSink` implementation that is also available in the `iceberg-flink` module. 
+The new implementation will be a base for further work on features such as [table maintenance](maintenance.md).
+The SinkV2 based implementation is currently an experimental feature so please use it with caution.
 
 ## Writing with SQL
 

--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -371,3 +371,28 @@ and [deleting orphan files](maintenance.md#delete-orphan-files) could possibly c
 the state of the Flink job. To avoid that, make sure to keep the last snapshot created by the Flink
 job (which can be identified by the `flink.job-id` property in the summary), and only delete
 orphan files that are old enough.
+
+# Flink Writes (SinkV2 based implementation)
+
+The [SinkV2 interface](https://cwiki.apache.org/confluence/display/FLINK/FLIP-191%3A+Extend+unified+Sink+interface+to+support+small+file+compaction)
+was introduced in Flink 1.15.
+The previous [SinkV1 interface](https://cwiki.apache.org/confluence/display/FLINK/FLIP-143%3A+Unified+Sink+API)
+had some limitations - for example it created a lot of small files when writing to it. This problem is called
+the `small-file-compaction` problem in
+the [FLIP-191 document](https://cwiki.apache.org/confluence/display/FLINK/FLIP-191%3A+Extend+unified+Sink+interface+to+support+small+file+compaction).
+The default `FlinkSink` implementation available in `iceberg-flink` module builds its own `StreamOperator`s chain ends with `DiscardingSink`.
+However, in the same module, there is also `IcebergSink` which is based on the SinkV2 API.
+The SinkV2 based `IcebergSink` is currently an experimental feature.
+
+## Writing with SQL
+
+To turn on SinkV2 based implementation in SQL, set this configuration option:
+```sql
+SET table.exec.iceberg.use-v2-sink = true;
+```
+
+## Writing with DataStream
+
+To use SinkV2 based implementation, replace `FlinkSink` with `IcebergSink` in the provided snippets.
+Warning: some settings are not available in this class (e.g. `rangeDistributionStatisticsType`),
+some others are slightly different (e.g. there is a `uidSuffix` method instead of `uidPrefix`).

--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -394,5 +394,6 @@ SET table.exec.iceberg.use-v2-sink = true;
 ## Writing with DataStream
 
 To use SinkV2 based implementation, replace `FlinkSink` with `IcebergSink` in the provided snippets.
-Warning: some settings are not available in this class (e.g. `rangeDistributionStatisticsType`),
-some others are slightly different (e.g. there is a `uidSuffix` method instead of `uidPrefix`).
+Warning: There are some slight differences between these implementations:
+- The `RANGE` distribution mode is not yet available for the `IcebergSink`
+- When using `IcebergSink` use `uidSuffix` instead of the `uidPrefix`

--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -380,7 +380,7 @@ The previous [SinkV1 interface](https://cwiki.apache.org/confluence/display/FLIN
 had some limitations - for example it created a lot of small files when writing to it. This problem is called
 the `small-file-compaction` problem in
 the [FLIP-191 document](https://cwiki.apache.org/confluence/display/FLINK/FLIP-191%3A+Extend+unified+Sink+interface+to+support+small+file+compaction).
-The default `FlinkSink` implementation available in `iceberg-flink` module builds its own `StreamOperator`s chain ends with `DiscardingSink`.
+The default `FlinkSink` implementation available in `iceberg-flink` module builds its own chain of `StreamOperator`s  terminated by `DiscardingSink`.
 However, in the same module, there is also `IcebergSink` which is based on the SinkV2 API.
 The SinkV2 based `IcebergSink` is currently an experimental feature.
 

--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -378,10 +378,10 @@ At the time when the current default, `FlinkSink` implementation was created, Fl
 limitations that were not acceptable for the Iceberg tables purpose. Due to these limitations, `FlinkSink` is based 
 on a custom chain of `StreamOperator`s  terminated by `DiscardingSink`.
 
-In the Flink 1.15 version, [SinkV2 interface](https://cwiki.apache.org/confluence/display/FLINK/FLIP-191%3A+Extend+unified+Sink+interface+to+support+small+file+compaction) 
-was introduced. This interface is used in the new, `IcebergSink` implementation that is also available in the `iceberg-flink` module. 
-The new implementation will be a base for further work on features such as [table maintenance](maintenance.md).
-The SinkV2 based implementation is currently an experimental feature so please use it with caution.
+In the 1.15 version of Flink [SinkV2 interface](https://cwiki.apache.org/confluence/display/FLINK/FLIP-191%3A+Extend+unified+Sink+interface+to+support+small+file+compaction)
+was introduced. This interface is used in the new `IcebergSink` implementation which is available in the `iceberg-flink` module.
+The new implementation is a base for further work on features such as [table maintenance](maintenance.md).
+The SinkV2 based implementation is currently an experimental feature so use it with caution.
 
 ## Writing with SQL
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
@@ -91,6 +91,12 @@ public class FlinkConfigOptions {
           .defaultValue(true)
           .withDescription("Use the FLIP-27 based Iceberg source implementation.");
 
+  public static final ConfigOption<Boolean> TABLE_EXEC_ICEBERG_USE_V2_SINK =
+      ConfigOptions.key("table.exec.iceberg.use-v2-sink")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Use the SinkV2 API based Iceberg sink implementation.");
+
   public static final ConfigOption<SplitAssignerType> TABLE_EXEC_SPLIT_ASSIGNER_TYPE =
       ConfigOptions.key("table.exec.iceberg.split-assigner-type")
           .enumType(SplitAssignerType.class)

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.flink.sink.FlinkSink;
+import org.apache.iceberg.flink.sink.IcebergSink;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning, SupportsOverwrite {
@@ -77,14 +78,25 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
       @Override
       public DataStreamSink<?> consumeDataStream(
           ProviderContext providerContext, DataStream<RowData> dataStream) {
-        return FlinkSink.forRowData(dataStream)
-            .tableLoader(tableLoader)
-            .tableSchema(tableSchema)
-            .equalityFieldColumns(equalityColumns)
-            .overwrite(overwrite)
-            .setAll(writeProps)
-            .flinkConf(readableConfig)
-            .append();
+        if (readableConfig.get(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_V2_SINK)) {
+          return IcebergSink.forRowData(dataStream)
+              .tableLoader(tableLoader)
+              .tableSchema(tableSchema)
+              .equalityFieldColumns(equalityColumns)
+              .overwrite(overwrite)
+              .setAll(writeProps)
+              .flinkConf(readableConfig)
+              .append();
+        } else {
+          return FlinkSink.forRowData(dataStream)
+              .tableLoader(tableLoader)
+              .tableSchema(tableSchema)
+              .equalityFieldColumns(equalityColumns)
+              .overwrite(overwrite)
+              .setAll(writeProps)
+              .flinkConf(readableConfig)
+              .append();
+        }
       }
     };
   }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -41,7 +41,7 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
-import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
@@ -392,7 +392,7 @@ public class FlinkSink {
       return this;
     }
 
-    private <T> DataStreamSink<T> chainIcebergOperators() {
+    private DataStreamSink<Void> chainIcebergOperators() {
       Preconditions.checkArgument(
           inputCreator != null,
           "Please use forRowData() or forMapperOutputType() to initialize the input DataStream.");
@@ -484,12 +484,10 @@ public class FlinkSink {
       return equalityFieldIds;
     }
 
-    @SuppressWarnings("unchecked")
-    private <T> DataStreamSink<T> appendDummySink(
-        SingleOutputStreamOperator<Void> committerStream) {
-      DataStreamSink<T> resultStream =
+    private DataStreamSink<Void> appendDummySink(SingleOutputStreamOperator<Void> committerStream) {
+      DataStreamSink<Void> resultStream =
           committerStream
-              .addSink(new DiscardingSink())
+              .sinkTo(new DiscardingSink<>())
               .name(operatorName(String.format("IcebergSink %s", this.table.name())))
               .setParallelism(1);
       if (uidPrefix != null) {

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -69,6 +69,7 @@ public class TestFlinkTableSink extends CatalogTestBase {
         }
       }
     }
+
     for (FileFormat format :
         new FileFormat[] {FileFormat.ORC, FileFormat.AVRO, FileFormat.PARQUET}) {
       for (Boolean isStreaming : new Boolean[] {true, false}) {
@@ -78,6 +79,7 @@ public class TestFlinkTableSink extends CatalogTestBase {
         parameters.add(new Object[] {catalogName, baseNamespace, format, isStreaming, useV2Sink});
       }
     }
+
     return parameters;
   }
 
@@ -101,9 +103,11 @@ public class TestFlinkTableSink extends CatalogTestBase {
         }
       }
     }
+
     tEnv.getConfig()
         .getConfiguration()
         .set(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_V2_SINK, useV2Sink);
+
     return tEnv;
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -51,7 +51,11 @@ public class TestFlinkTableSink extends CatalogTestBase {
   @Parameter(index = 3)
   private boolean isStreamingJob;
 
-  @Parameters(name = "catalogName={0}, baseNamespace={1}, format={2}, isStreaming={3}")
+  @Parameter(index = 4)
+  private boolean useV2Sink;
+
+  @Parameters(
+      name = "catalogName={0}, baseNamespace={1}, format={2}, isStreaming={3}, useV2Sink={4}")
   public static List<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
     for (FileFormat format :
@@ -60,8 +64,19 @@ public class TestFlinkTableSink extends CatalogTestBase {
         for (Object[] catalogParams : CatalogTestBase.parameters()) {
           String catalogName = (String) catalogParams[0];
           Namespace baseNamespace = (Namespace) catalogParams[1];
-          parameters.add(new Object[] {catalogName, baseNamespace, format, isStreaming});
+          boolean doNotUseV2Sink = false;
+          parameters.add(
+              new Object[] {catalogName, baseNamespace, format, isStreaming, doNotUseV2Sink});
         }
+      }
+    }
+    for (FileFormat format :
+        new FileFormat[] {FileFormat.ORC, FileFormat.AVRO, FileFormat.PARQUET}) {
+      for (Boolean isStreaming : new Boolean[] {true, false}) {
+        String catalogName = "testhadoop_basenamespace";
+        Namespace baseNamespace = Namespace.of("l0", "l1");
+        boolean useV2Sink = true;
+        parameters.add(new Object[] {catalogName, baseNamespace, format, isStreaming, useV2Sink});
       }
     }
     return parameters;
@@ -87,6 +102,9 @@ public class TestFlinkTableSink extends CatalogTestBase {
         }
       }
     }
+    tEnv.getConfig()
+        .getConfiguration()
+        .set(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_V2_SINK, useV2Sink);
     return tEnv;
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.TestTemplate;
 
 public class TestFlinkTableSink extends CatalogTestBase {
 
-  private static final String SOURCE_TABLE = "default_catalog.default_database.bounded_source";
   private static final String TABLE_NAME = "test_table";
   private TableEnvironment tEnv;
   private Table icebergTable;

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -63,9 +63,10 @@ public class TestFlinkTableSink extends CatalogTestBase {
         for (Object[] catalogParams : CatalogTestBase.parameters()) {
           String catalogName = (String) catalogParams[0];
           Namespace baseNamespace = (Namespace) catalogParams[1];
-          boolean doNotUseV2Sink = false;
           parameters.add(
-              new Object[] {catalogName, baseNamespace, format, isStreaming, doNotUseV2Sink});
+              new Object[] {
+                catalogName, baseNamespace, format, isStreaming, false /* don't use v2 sink */
+              });
         }
       }
     }
@@ -75,8 +76,8 @@ public class TestFlinkTableSink extends CatalogTestBase {
       for (Boolean isStreaming : new Boolean[] {true, false}) {
         String catalogName = "testhadoop_basenamespace";
         Namespace baseNamespace = Namespace.of("l0", "l1");
-        boolean useV2Sink = true;
-        parameters.add(new Object[] {catalogName, baseNamespace, format, isStreaming, useV2Sink});
+        parameters.add(
+            new Object[] {catalogName, baseNamespace, format, isStreaming, true /* use v2 sink */});
       }
     }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSinkExtended.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSinkExtended.java
@@ -91,11 +91,19 @@ public class TestFlinkTableSinkExtended extends SqlBase {
 
   private TableEnvironment tEnv;
 
-  @Parameter protected boolean isStreamingJob;
+  @Parameter(index = 0)
+  protected boolean isStreamingJob;
 
-  @Parameters(name = "isStreamingJob={0}")
+  @Parameter(index = 1)
+  protected boolean useV2Sink;
+
+  @Parameters(name = "isStreamingJob={0}, useV2Sink={1}")
   protected static List<Object[]> parameters() {
-    return Arrays.asList(new Boolean[] {true}, new Boolean[] {false});
+    return Arrays.asList(
+        new Boolean[] {true, false},
+        new Boolean[] {false, false},
+        new Boolean[] {true, true},
+        new Boolean[] {false, true});
   }
 
   protected synchronized TableEnvironment getTableEnv() {
@@ -115,6 +123,9 @@ public class TestFlinkTableSinkExtended extends SqlBase {
         tEnv = TableEnvironment.create(settingsBuilder.build());
       }
     }
+    tEnv.getConfig()
+        .getConfiguration()
+        .set(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_V2_SINK, useV2Sink);
     return tEnv;
   }
 


### PR DESCRIPTION
This PR adds a `table.exec.iceberg.use-v2-sink` configuration option allowing to use Flink's Sink v2 API described in the [FLIP-143](https://cwiki.apache.org/confluence/display/FLINK/FLIP-143%3A+Unified+Sink+API) document.

The configuration option is by default set to `false`.

This PR is the follow-up of discussion in #10179 and in #11219