### PR TITLE
Build: Update baseline-java 5.69.0

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/BoundReference.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundReference.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.util.Locale;
 import org.apache.iceberg.Accessor;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Type;
@@ -82,6 +83,7 @@ public class BoundReference<T> implements BoundTerm<T>, Reference<T> {
 
   @Override
   public String toString() {
-    return String.format("ref(id=%d, accessor-type=%s)", field.fieldId(), accessor.type());
+    return String.format(
+        Locale.ROOT, "ref(id=%d, accessor-type=%s)", field.fieldId(), accessor.type());
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -23,6 +23,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -500,8 +501,10 @@ public class ExpressionUtil {
         abbreviatedList.addAll(distinctValues);
         abbreviatedList.add(
             String.format(
+                Locale.ROOT,
                 "... (%d values hidden, %d in total)",
-                sanitizedValues.size() - distinctValues.size(), sanitizedValues.size()));
+                sanitizedValues.size() - distinctValues.size(),
+                sanitizedValues.size()));
         return abbreviatedList;
       }
     }
@@ -633,7 +636,7 @@ public class ExpressionUtil {
 
   private static String sanitizeSimpleString(CharSequence value) {
     // hash the value and return the hash as hex
-    return String.format("(hash-%08x)", HASH_FUNC.apply(value));
+    return String.format(Locale.ROOT, "(hash-%08x)", HASH_FUNC.apply(value));
   }
 
   private static PartitionSpec identitySpec(Schema schema, int... ids) {

--- a/api/src/main/java/org/apache/iceberg/io/BulkDeletionFailureException.java
+++ b/api/src/main/java/org/apache/iceberg/io/BulkDeletionFailureException.java
@@ -18,11 +18,13 @@
  */
 package org.apache.iceberg.io;
 
+import java.util.Locale;
+
 public class BulkDeletionFailureException extends RuntimeException {
   private final int numberFailedObjects;
 
   public BulkDeletionFailureException(int numberFailedObjects) {
-    super(String.format("Failed to delete %d files", numberFailedObjects));
+    super(String.format(Locale.ROOT, "Failed to delete %d files", numberFailedObjects));
     this.numberFailedObjects = numberFailedObjects;
   }
 

--- a/api/src/main/java/org/apache/iceberg/transforms/TransformUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/TransformUtil.java
@@ -26,6 +26,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
+import java.util.Locale;
 import org.apache.iceberg.util.DateTimeUtil;
 
 class TransformUtil {
@@ -36,19 +37,25 @@ class TransformUtil {
   private static final int EPOCH_YEAR = EPOCH.getYear();
 
   static String humanYear(int yearOrdinal) {
-    return String.format("%04d", EPOCH_YEAR + yearOrdinal);
+    return String.format(Locale.ROOT, "%04d", EPOCH_YEAR + yearOrdinal);
   }
 
   static String humanMonth(int monthOrdinal) {
     return String.format(
+        Locale.ROOT,
         "%04d-%02d",
-        EPOCH_YEAR + Math.floorDiv(monthOrdinal, 12), 1 + Math.floorMod(monthOrdinal, 12));
+        EPOCH_YEAR + Math.floorDiv(monthOrdinal, 12),
+        1 + Math.floorMod(monthOrdinal, 12));
   }
 
   static String humanDay(int dayOrdinal) {
     OffsetDateTime day = EPOCH.plusDays(dayOrdinal);
     return String.format(
-        "%04d-%02d-%02d", day.getYear(), day.getMonth().getValue(), day.getDayOfMonth());
+        Locale.ROOT,
+        "%04d-%02d-%02d",
+        day.getYear(),
+        day.getMonth().getValue(),
+        day.getDayOfMonth());
   }
 
   static String humanTime(Long microsFromMidnight) {
@@ -74,8 +81,12 @@ class TransformUtil {
   static String humanHour(int hourOrdinal) {
     OffsetDateTime time = EPOCH.plusHours(hourOrdinal);
     return String.format(
+        Locale.ROOT,
         "%04d-%02d-%02d-%02d",
-        time.getYear(), time.getMonth().getValue(), time.getDayOfMonth(), time.getHour());
+        time.getYear(),
+        time.getMonth().getValue(),
+        time.getDayOfMonth(),
+        time.getHour());
   }
 
   static String base64encode(ByteBuffer buffer) {

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -372,7 +372,7 @@ public class Types {
 
     @Override
     public String toString() {
-      return String.format("fixed[%d]", length);
+      return String.format(Locale.ROOT, "fixed[%d]", length);
     }
 
     @Override
@@ -443,7 +443,7 @@ public class Types {
 
     @Override
     public String toString() {
-      return String.format("decimal(%d, %d)", precision, scale);
+      return String.format(Locale.ROOT, "decimal(%d, %d)", precision, scale);
     }
 
     @Override
@@ -552,7 +552,8 @@ public class Types {
 
     @Override
     public String toString() {
-      return String.format("%d: %s: %s %s", id, name, isOptional ? "optional" : "required", type)
+      return String.format(
+              Locale.ROOT, "%d: %s: %s %s", id, name, isOptional ? "optional" : "required", type)
           + (doc != null ? " (" + doc + ")" : "");
     }
 

--- a/api/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
@@ -27,6 +27,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 
 public class DateTimeUtil {
   private DateTimeUtil() {}
@@ -43,7 +44,7 @@ public class DateTimeUtil {
           .parseCaseInsensitive()
           .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
           .appendOffset("+HH:MM:ss", "+00:00")
-          .toFormatter();
+          .toFormatter(Locale.ROOT);
 
   public static LocalDate dateFromDays(int daysFromEpoch) {
     return ChronoUnit.DAYS.addTo(EPOCH_DAY, daysFromEpoch);

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/DecimalVectorUtil.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/DecimalVectorUtil.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.arrow.vectorized.parquet;
 
 import java.util.Arrays;
+import java.util.Locale;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 
@@ -62,7 +63,9 @@ public class DecimalVectorUtil {
     }
     throw new IllegalArgumentException(
         String.format(
+            Locale.ROOT,
             "Buffer size of %d is larger than requested size of %d",
-            bigEndianBytes.length, newLength));
+            bigEndianBytes.length,
+            newLength));
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
   }
   dependencies {
     classpath 'io.github.goooler.shadow:shadow-gradle-plugin:8.1.8'
-    classpath 'com.palantir.baseline:gradle-baseline-java:5.61.0'
+    classpath 'com.palantir.baseline:gradle-baseline-java:5.69.0'
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.25.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'
     classpath 'me.champeau.jmh:jmh-gradle-plugin:0.7.2'

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -327,7 +328,8 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
             TableProperties.METADATA_COMPRESSION, TableProperties.METADATA_COMPRESSION_DEFAULT);
     String fileExtension = TableMetadataParser.getFileExtension(codecName);
     return metadataFileLocation(
-        meta, String.format("%05d-%s%s", newVersion, UUID.randomUUID(), fileExtension));
+        meta,
+        String.format(Locale.ROOT, "%05d-%s%s", newVersion, UUID.randomUUID(), fileExtension));
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/MetricsModes.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsModes.java
@@ -114,7 +114,7 @@ public class MetricsModes {
 
     @Override
     public String toString() {
-      return String.format("truncate(%d)", length);
+      return String.format(Locale.ROOT, "truncate(%d)", length);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/ScanSummary.java
+++ b/core/src/main/java/org/apache/iceberg/ScanSummary.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
@@ -346,7 +347,7 @@ public class ScanSummary {
       while (map.size() > maxSize) {
         if (throwIfLimited) {
           throw new IllegalStateException(
-              String.format("Too many matching keys: more than %d", maxSize));
+              String.format(Locale.ROOT, "Too many matching keys: more than %d", maxSize));
         }
         this.cut = map.lastKey();
         map.remove(cut);

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -505,7 +506,11 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
             ops.metadataFileLocation(
                 FileFormat.AVRO.addExtension(
                     String.format(
-                        "snap-%d-%d-%s", snapshotId(), attempt.incrementAndGet(), commitUUID))));
+                        Locale.ROOT,
+                        "snap-%d-%d-%s",
+                        snapshotId(),
+                        attempt.incrementAndGet(),
+                        commitUUID))));
   }
 
   protected EncryptedOutputFile newManifestOutputFile() {

--- a/core/src/main/java/org/apache/iceberg/data/avro/IcebergDecoder.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/IcebergDecoder.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
@@ -138,7 +139,8 @@ public class IcebergDecoder<D> extends MessageDecoder.BaseDecoder<D> {
 
     if (IcebergEncoder.V1_HEADER[0] != header[0] || IcebergEncoder.V1_HEADER[1] != header[1]) {
       throw new BadHeaderException(
-          String.format("Unrecognized header bytes: 0x%02X 0x%02X", header[0], header[1]));
+          String.format(
+              Locale.ROOT, "Unrecognized header bytes: 0x%02X 0x%02X", header[0], header[1]));
     }
 
     RawDecoder<D> decoder = getDecoder(FP_BUFFER.get().getLong(2));

--- a/core/src/main/java/org/apache/iceberg/io/ContentCache.java
+++ b/core/src/main/java/org/apache/iceberg/io/ContentCache.java
@@ -28,6 +28,7 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
@@ -253,8 +254,10 @@ public class ContentCache {
           // IOException and let the caller fallback to non-caching input file.
           throw new IOException(
               String.format(
+                  Locale.ROOT,
                   "Failed to read %d bytes: %d bytes in stream",
-                  fileLength, fileLength - totalBytesToRead));
+                  fileLength,
+                  fileLength - totalBytesToRead));
         } else {
           buffers.add(ByteBuffer.wrap(buf));
         }

--- a/core/src/main/java/org/apache/iceberg/io/OutputFileFactory.java
+++ b/core/src/main/java/org/apache/iceberg/io/OutputFileFactory.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.io;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -92,6 +93,7 @@ public class OutputFileFactory {
   private String generateFilename() {
     return format.addExtension(
         String.format(
+            Locale.ROOT,
             "%05d-%d-%s-%05d%s",
             partitionId,
             taskId,

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -31,6 +31,7 @@ import java.sql.SQLTransientConnectionException;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -798,7 +799,11 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
     }
 
     throw new IllegalStateException(
-        String.format("Failed to insert: %d of %d succeeded", insertedRecords, properties.size()));
+        String.format(
+            Locale.ROOT,
+            "Failed to insert: %d of %d succeeded",
+            insertedRecords,
+            properties.size()));
   }
 
   private boolean updateProperties(Namespace namespace, Map<String, String> properties) {
@@ -818,7 +823,11 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
     }
 
     throw new IllegalStateException(
-        String.format("Failed to update: %d of %d succeeded", updatedRecords, properties.size()));
+        String.format(
+            Locale.ROOT,
+            "Failed to update: %d of %d succeeded",
+            updatedRecords,
+            properties.size()));
   }
 
   private boolean deleteProperties(Namespace namespace, Set<String> properties) {

--- a/core/src/main/java/org/apache/iceberg/view/BaseViewOperations.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseViewOperations.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.view;
 
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -157,7 +158,8 @@ public abstract class BaseViewOperations extends BaseMetastoreOperations impleme
                 ViewProperties.METADATA_COMPRESSION, ViewProperties.METADATA_COMPRESSION_DEFAULT);
     String fileExtension = TableMetadataParser.getFileExtension(codecName);
     return metadataFileLocation(
-        metadata, String.format("%05d-%s%s", newVersion, UUID.randomUUID(), fileExtension));
+        metadata,
+        String.format(Locale.ROOT, "%05d-%s%s", newVersion, UUID.randomUUID(), fileExtension));
   }
 
   private String metadataFileLocation(ViewMetadata metadata, String filename) {

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.sink;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -59,6 +60,7 @@ class ManifestOutputFileFactory {
   private String generatePath(long checkpointId) {
     return FileFormat.AVRO.addExtension(
         String.format(
+            Locale.ROOT,
             "%s-%s-%05d-%d-%d-%05d",
             flinkJobId,
             operatorUniqueId,

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.sink.shuffle;
 
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -265,8 +266,10 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
           }
         },
         String.format(
+            Locale.ROOT,
             "Failed to send operator %s coordinator global data statistics for checkpoint %d",
-            operatorName, statistics.checkpointId()));
+            operatorName,
+            statistics.checkpointId()));
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
@@ -290,8 +293,11 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
             }
           },
           String.format(
+              Locale.ROOT,
               "Failed to send operator %s coordinator global data statistics to requesting subtask %d for checkpoint %d",
-              operatorName, subtask, globalStatistics.checkpointId()));
+              operatorName,
+              subtask,
+              globalStatistics.checkpointId()));
     } else {
       LOG.info(
           "Ignore global statistics request from subtask {} as statistics not available", subtask);
@@ -318,8 +324,11 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
           }
         },
         String.format(
+            Locale.ROOT,
             "handling operator event %s from subtask %d (#%d)",
-            event.getClass(), subtask, attemptNumber));
+            event.getClass(),
+            subtask,
+            attemptNumber));
   }
 
   @Override
@@ -339,7 +348,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
                     completedStatistics, completedStatisticsSerializer));
           }
         },
-        String.format("taking checkpoint %d", checkpointId));
+        String.format(Locale.ROOT, "taking checkpoint %d", checkpointId));
   }
 
   @Override
@@ -381,7 +390,8 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
               this.coordinatorThreadFactory.isCurrentThreadCoordinatorThread());
           subtaskGateways.reset(subtask);
         },
-        String.format("handling subtask %d recovery to checkpoint %d", subtask, checkpointId));
+        String.format(
+            Locale.ROOT, "handling subtask %d recovery to checkpoint %d", subtask, checkpointId));
   }
 
   @Override
@@ -397,7 +407,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
               this.coordinatorThreadFactory.isCurrentThreadCoordinatorThread());
           subtaskGateways.unregisterSubtaskGateway(subtask, attemptNumber);
         },
-        String.format("handling subtask %d (#%d) failure", subtask, attemptNumber));
+        String.format(Locale.ROOT, "handling subtask %d (#%d) failure", subtask, attemptNumber));
   }
 
   @Override
@@ -411,7 +421,10 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
           subtaskGateways.registerSubtaskGateway(gateway);
         },
         String.format(
-            "making event gateway to subtask %d (#%d) available", subtask, attemptNumber));
+            Locale.ROOT,
+            "making event gateway to subtask %d (#%d) available",
+            subtask,
+            attemptNumber));
   }
 
   @VisibleForTesting

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeySerializer.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeySerializer.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -170,7 +171,8 @@ class SortKeySerializer extends TypeSerializer<SortKey> {
         default:
           // SortKey transformation is a flattened struct without list and map
           throw new UnsupportedOperationException(
-              String.format("Field %d has unsupported field type: %s", fieldId, typeId));
+              String.format(
+                  Locale.ROOT, "Field %d has unsupported field type: %s", fieldId, typeId));
       }
     }
   }
@@ -239,7 +241,8 @@ class SortKeySerializer extends TypeSerializer<SortKey> {
         default:
           // SortKey transformation is a flattened struct without list and map
           throw new UnsupportedOperationException(
-              String.format("Field %d has unsupported field type: %s", fieldId, typeId));
+              String.format(
+                  Locale.ROOT, "Field %d has unsupported field type: %s", fieldId, typeId));
       }
     }
 

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.source;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
+import java.util.Locale;
 import org.apache.flink.annotation.Internal;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
@@ -95,8 +96,11 @@ public class DataIterator<T> implements CloseableIterator<T> {
       } else {
         throw new IllegalStateException(
             String.format(
+                Locale.ROOT,
                 "Invalid starting record offset %d for file %d from CombinedScanTask: %s",
-                startingRecordOffset, startingFileOffset, combinedTask));
+                startingRecordOffset,
+                startingFileOffset,
+                combinedTask));
       }
     }
 

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/AbstractIcebergEnumerator.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/AbstractIcebergEnumerator.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -76,6 +77,7 @@ abstract class AbstractIcebergEnumerator
     // Iceberg source uses custom split request event to piggyback finished split ids.
     throw new UnsupportedOperationException(
         String.format(
+            Locale.ROOT,
             "Received invalid default split request event "
                 + "from subtask %d as Iceberg source uses custom split request event",
             subtaskId));
@@ -92,8 +94,10 @@ abstract class AbstractIcebergEnumerator
     } else {
       throw new IllegalArgumentException(
           String.format(
+              Locale.ROOT,
               "Received unknown event from subtask %d: %s",
-              subtaskId, sourceEvent.getClass().getCanonicalName()));
+              subtaskId,
+              sourceEvent.getClass().getCanonicalName()));
     }
   }
 

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/reader/RecordAndPosition.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/reader/RecordAndPosition.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.source.reader;
 
+import java.util.Locale;
 import org.apache.flink.annotation.Internal;
 
 /**
@@ -73,6 +74,6 @@ public class RecordAndPosition<T> {
 
   @Override
   public String toString() {
-    return String.format("%s @ %d + %d", record, fileOffset, recordOffset);
+    return String.format(Locale.ROOT, "%s @ %d + %d", record, fileOffset, recordOffset);
   }
 }

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.source.split;
 
 import java.io.IOException;
+import java.util.Locale;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
@@ -54,6 +55,7 @@ public class IcebergSourceSplitSerializer implements SimpleVersionedSerializer<I
       default:
         throw new IOException(
             String.format(
+                Locale.ROOT,
                 "Failed to deserialize IcebergSourceSplit. "
                     + "Encountered unsupported version: %d. Supported version are [1]",
                 version));

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.sink;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -59,6 +60,7 @@ class ManifestOutputFileFactory {
   private String generatePath(long checkpointId) {
     return FileFormat.AVRO.addExtension(
         String.format(
+            Locale.ROOT,
             "%s-%s-%05d-%d-%d-%05d",
             flinkJobId,
             operatorUniqueId,

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.sink.shuffle;
 
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -265,8 +266,10 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
           }
         },
         String.format(
+            Locale.ROOT,
             "Failed to send operator %s coordinator global data statistics for checkpoint %d",
-            operatorName, statistics.checkpointId()));
+            operatorName,
+            statistics.checkpointId()));
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
@@ -290,8 +293,11 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
             }
           },
           String.format(
+              Locale.ROOT,
               "Failed to send operator %s coordinator global data statistics to requesting subtask %d for checkpoint %d",
-              operatorName, subtask, globalStatistics.checkpointId()));
+              operatorName,
+              subtask,
+              globalStatistics.checkpointId()));
     } else {
       LOG.info(
           "Ignore global statistics request from subtask {} as statistics not available", subtask);
@@ -318,8 +324,11 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
           }
         },
         String.format(
+            Locale.ROOT,
             "handling operator event %s from subtask %d (#%d)",
-            event.getClass(), subtask, attemptNumber));
+            event.getClass(),
+            subtask,
+            attemptNumber));
   }
 
   @Override
@@ -339,7 +348,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
                     completedStatistics, completedStatisticsSerializer));
           }
         },
-        String.format("taking checkpoint %d", checkpointId));
+        String.format(Locale.ROOT, "taking checkpoint %d", checkpointId));
   }
 
   @Override
@@ -381,7 +390,8 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
               this.coordinatorThreadFactory.isCurrentThreadCoordinatorThread());
           subtaskGateways.reset(subtask);
         },
-        String.format("handling subtask %d recovery to checkpoint %d", subtask, checkpointId));
+        String.format(
+            Locale.ROOT, "handling subtask %d recovery to checkpoint %d", subtask, checkpointId));
   }
 
   @Override
@@ -397,7 +407,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
               this.coordinatorThreadFactory.isCurrentThreadCoordinatorThread());
           subtaskGateways.unregisterSubtaskGateway(subtask, attemptNumber);
         },
-        String.format("handling subtask %d (#%d) failure", subtask, attemptNumber));
+        String.format(Locale.ROOT, "handling subtask %d (#%d) failure", subtask, attemptNumber));
   }
 
   @Override
@@ -411,7 +421,10 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
           subtaskGateways.registerSubtaskGateway(gateway);
         },
         String.format(
-            "making event gateway to subtask %d (#%d) available", subtask, attemptNumber));
+            Locale.ROOT,
+            "making event gateway to subtask %d (#%d) available",
+            subtask,
+            attemptNumber));
   }
 
   @VisibleForTesting

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeySerializer.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeySerializer.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -169,7 +170,8 @@ class SortKeySerializer extends TypeSerializer<SortKey> {
         default:
           // SortKey transformation is a flattened struct without list and map
           throw new UnsupportedOperationException(
-              String.format("Field %d has unsupported field type: %s", fieldId, typeId));
+              String.format(
+                  Locale.ROOT, "Field %d has unsupported field type: %s", fieldId, typeId));
       }
     }
   }
@@ -238,7 +240,8 @@ class SortKeySerializer extends TypeSerializer<SortKey> {
         default:
           // SortKey transformation is a flattened struct without list and map
           throw new UnsupportedOperationException(
-              String.format("Field %d has unsupported field type: %s", fieldId, typeId));
+              String.format(
+                  Locale.ROOT, "Field %d has unsupported field type: %s", fieldId, typeId));
       }
     }
 

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.source;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
+import java.util.Locale;
 import org.apache.flink.annotation.Internal;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
@@ -95,8 +96,11 @@ public class DataIterator<T> implements CloseableIterator<T> {
       } else {
         throw new IllegalStateException(
             String.format(
+                Locale.ROOT,
                 "Invalid starting record offset %d for file %d from CombinedScanTask: %s",
-                startingRecordOffset, startingFileOffset, combinedTask));
+                startingRecordOffset,
+                startingFileOffset,
+                combinedTask));
       }
     }
 

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/AbstractIcebergEnumerator.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/AbstractIcebergEnumerator.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -76,6 +77,7 @@ abstract class AbstractIcebergEnumerator
     // Iceberg source uses custom split request event to piggyback finished split ids.
     throw new UnsupportedOperationException(
         String.format(
+            Locale.ROOT,
             "Received invalid default split request event "
                 + "from subtask %d as Iceberg source uses custom split request event",
             subtaskId));
@@ -92,8 +94,10 @@ abstract class AbstractIcebergEnumerator
     } else {
       throw new IllegalArgumentException(
           String.format(
+              Locale.ROOT,
               "Received unknown event from subtask %d: %s",
-              subtaskId, sourceEvent.getClass().getCanonicalName()));
+              subtaskId,
+              sourceEvent.getClass().getCanonicalName()));
     }
   }
 

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/reader/RecordAndPosition.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/reader/RecordAndPosition.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.source.reader;
 
+import java.util.Locale;
 import org.apache.flink.annotation.Internal;
 
 /**
@@ -73,6 +74,6 @@ public class RecordAndPosition<T> {
 
   @Override
   public String toString() {
-    return String.format("%s @ %d + %d", record, fileOffset, recordOffset);
+    return String.format(Locale.ROOT, "%s @ %d + %d", record, fileOffset, recordOffset);
   }
 }

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.source.split;
 
 import java.io.IOException;
+import java.util.Locale;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
@@ -54,6 +55,7 @@ public class IcebergSourceSplitSerializer implements SimpleVersionedSerializer<I
       default:
         throw new IOException(
             String.format(
+                Locale.ROOT,
                 "Failed to deserialize IcebergSourceSplit. "
                     + "Encountered unsupported version: %d. Supported version are [1]",
                 version));

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.sink;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -59,6 +60,7 @@ class ManifestOutputFileFactory {
   private String generatePath(long checkpointId) {
     return FileFormat.AVRO.addExtension(
         String.format(
+            Locale.ROOT,
             "%s-%s-%05d-%d-%d-%05d",
             flinkJobId,
             operatorUniqueId,

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.sink.shuffle;
 
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -265,8 +266,10 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
           }
         },
         String.format(
+            Locale.ROOT,
             "Failed to send operator %s coordinator global data statistics for checkpoint %d",
-            operatorName, statistics.checkpointId()));
+            operatorName,
+            statistics.checkpointId()));
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
@@ -290,8 +293,11 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
             }
           },
           String.format(
+              Locale.ROOT,
               "Failed to send operator %s coordinator global data statistics to requesting subtask %d for checkpoint %d",
-              operatorName, subtask, globalStatistics.checkpointId()));
+              operatorName,
+              subtask,
+              globalStatistics.checkpointId()));
     } else {
       LOG.info(
           "Ignore global statistics request from subtask {} as statistics not available", subtask);
@@ -318,8 +324,11 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
           }
         },
         String.format(
+            Locale.ROOT,
             "handling operator event %s from subtask %d (#%d)",
-            event.getClass(), subtask, attemptNumber));
+            event.getClass(),
+            subtask,
+            attemptNumber));
   }
 
   @Override
@@ -339,7 +348,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
                     completedStatistics, completedStatisticsSerializer));
           }
         },
-        String.format("taking checkpoint %d", checkpointId));
+        String.format(Locale.ROOT, "taking checkpoint %d", checkpointId));
   }
 
   @Override
@@ -381,7 +390,8 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
               this.coordinatorThreadFactory.isCurrentThreadCoordinatorThread());
           subtaskGateways.reset(subtask);
         },
-        String.format("handling subtask %d recovery to checkpoint %d", subtask, checkpointId));
+        String.format(
+            Locale.ROOT, "handling subtask %d recovery to checkpoint %d", subtask, checkpointId));
   }
 
   @Override
@@ -397,7 +407,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
               this.coordinatorThreadFactory.isCurrentThreadCoordinatorThread());
           subtaskGateways.unregisterSubtaskGateway(subtask, attemptNumber);
         },
-        String.format("handling subtask %d (#%d) failure", subtask, attemptNumber));
+        String.format(Locale.ROOT, "handling subtask %d (#%d) failure", subtask, attemptNumber));
   }
 
   @Override
@@ -411,7 +421,10 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
           subtaskGateways.registerSubtaskGateway(gateway);
         },
         String.format(
-            "making event gateway to subtask %d (#%d) available", subtask, attemptNumber));
+            Locale.ROOT,
+            "making event gateway to subtask %d (#%d) available",
+            subtask,
+            attemptNumber));
   }
 
   @VisibleForTesting

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeySerializer.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeySerializer.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -169,7 +170,8 @@ class SortKeySerializer extends TypeSerializer<SortKey> {
         default:
           // SortKey transformation is a flattened struct without list and map
           throw new UnsupportedOperationException(
-              String.format("Field %d has unsupported field type: %s", fieldId, typeId));
+              String.format(
+                  Locale.ROOT, "Field %d has unsupported field type: %s", fieldId, typeId));
       }
     }
   }
@@ -238,7 +240,8 @@ class SortKeySerializer extends TypeSerializer<SortKey> {
         default:
           // SortKey transformation is a flattened struct without list and map
           throw new UnsupportedOperationException(
-              String.format("Field %d has unsupported field type: %s", fieldId, typeId));
+              String.format(
+                  Locale.ROOT, "Field %d has unsupported field type: %s", fieldId, typeId));
       }
     }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.source;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
+import java.util.Locale;
 import org.apache.flink.annotation.Internal;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
@@ -95,8 +96,11 @@ public class DataIterator<T> implements CloseableIterator<T> {
       } else {
         throw new IllegalStateException(
             String.format(
+                Locale.ROOT,
                 "Invalid starting record offset %d for file %d from CombinedScanTask: %s",
-                startingRecordOffset, startingFileOffset, combinedTask));
+                startingRecordOffset,
+                startingFileOffset,
+                combinedTask));
       }
     }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/AbstractIcebergEnumerator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/AbstractIcebergEnumerator.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -76,6 +77,7 @@ abstract class AbstractIcebergEnumerator
     // Iceberg source uses custom split request event to piggyback finished split ids.
     throw new UnsupportedOperationException(
         String.format(
+            Locale.ROOT,
             "Received invalid default split request event "
                 + "from subtask %d as Iceberg source uses custom split request event",
             subtaskId));
@@ -92,8 +94,10 @@ abstract class AbstractIcebergEnumerator
     } else {
       throw new IllegalArgumentException(
           String.format(
+              Locale.ROOT,
               "Received unknown event from subtask %d: %s",
-              subtaskId, sourceEvent.getClass().getCanonicalName()));
+              subtaskId,
+              sourceEvent.getClass().getCanonicalName()));
     }
   }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/RecordAndPosition.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/RecordAndPosition.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.source.reader;
 
+import java.util.Locale;
 import org.apache.flink.annotation.Internal;
 
 /**
@@ -73,6 +74,6 @@ public class RecordAndPosition<T> {
 
   @Override
   public String toString() {
-    return String.format("%s @ %d + %d", record, fileOffset, recordOffset);
+    return String.format(Locale.ROOT, "%s @ %d + %d", record, fileOffset, recordOffset);
   }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.source.split;
 
 import java.io.IOException;
+import java.util.Locale;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
@@ -54,6 +55,7 @@ public class IcebergSourceSplitSerializer implements SimpleVersionedSerializer<I
       default:
         throw new IOException(
             String.format(
+                Locale.ROOT,
                 "Failed to deserialize IcebergSourceSplit. "
                     + "Encountered unsupported version: %d. Supported version are [1]",
                 version));

--- a/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/KafkaConnectUtils.java
+++ b/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/KafkaConnectUtils.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.classic.HttpClient;
@@ -66,7 +67,9 @@ public class KafkaConnectUtils {
   public static void startConnector(Config config) {
     try {
       HttpPost request =
-          new HttpPost(String.format("http://localhost:%d/connectors", TestContext.CONNECT_PORT));
+          new HttpPost(
+              String.format(
+                  Locale.ROOT, "http://localhost:%d/connectors", TestContext.CONNECT_PORT));
       String body = TestContext.MAPPER.writeValueAsString(config);
       request.setHeader("Content-Type", "application/json");
       request.setEntity(new StringEntity(body));
@@ -80,7 +83,10 @@ public class KafkaConnectUtils {
     HttpGet request =
         new HttpGet(
             String.format(
-                "http://localhost:%d/connectors/%s/status", TestContext.CONNECT_PORT, name));
+                Locale.ROOT,
+                "http://localhost:%d/connectors/%s/status",
+                TestContext.CONNECT_PORT,
+                name));
     Awaitility.await()
         .atMost(60, TimeUnit.SECONDS)
         .until(
@@ -106,7 +112,11 @@ public class KafkaConnectUtils {
     try {
       HttpDelete request =
           new HttpDelete(
-              String.format("http://localhost:%d/connectors/%s", TestContext.CONNECT_PORT, name));
+              String.format(
+                  Locale.ROOT,
+                  "http://localhost:%d/connectors/%s",
+                  TestContext.CONNECT_PORT,
+                  name));
       HTTP.execute(request, response -> null);
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriter.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.IcebergSinkConfig;
@@ -65,8 +66,11 @@ class IcebergWriter implements RecordWriter {
     } catch (Exception e) {
       throw new DataException(
           String.format(
+              Locale.ROOT,
               "An error occurred converting record, topic: %s, partition, %d, offset: %d",
-              record.topic(), record.kafkaPartition(), record.kafkaOffset()),
+              record.topic(),
+              record.kafkaPartition(),
+              record.kafkaOffset()),
           e);
     }
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -37,6 +37,7 @@ import java.time.temporal.Temporal;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -71,7 +72,7 @@ class RecordConverter {
       new DateTimeFormatterBuilder()
           .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
           .appendOffset("+HHmm", "Z")
-          .toFormatter();
+          .toFormatter(Locale.ROOT);
 
   private final Schema tableSchema;
   private final NameMapping nameMapping;

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -272,8 +272,10 @@ public class NessieIcebergClient implements AutoCloseable {
             org.projectnessie.model.Namespace.of(namespace.levels());
         filter +=
             String.format(
+                Locale.ROOT,
                 "size(entry.keyElements) == %d && entry.encodedKey.startsWith('%s.')",
-                root.getElementCount() + 1, root.name());
+                root.getElementCount() + 1,
+                root.name());
       }
       List<ContentKey> entries =
           withReference(api.getEntries()).filter(filter).stream()

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.orc;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -327,7 +328,11 @@ public final class ORCSchemaUtil {
         } else {
           if (isRequired) {
             throw new IllegalArgumentException(
-                String.format("Field %d of type %s is required and was not found.", fieldId, type));
+                String.format(
+                    Locale.ROOT,
+                    "Field %d of type %s is required and was not found.",
+                    fieldId,
+                    type));
           }
 
           orcType = convert(fieldId, type, false);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PageIterator.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PageIterator.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.parquet;
 
 import java.io.IOException;
+import java.util.Locale;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.parquet.CorruptDeltaByteArrays;
 import org.apache.parquet.bytes.ByteBufferInputStream;
@@ -211,16 +212,26 @@ abstract class PageIterator<T> extends BasePageIterator implements TripleIterato
           "Read failure possibly due to " + "PARQUET-246: try setting parquet.split.files to false",
           new ParquetDecodingException(
               String.format(
+                  Locale.ROOT,
                   "Can't read value in column %s at value %d out of %d in current page. "
                       + "repetition level: %d, definition level: %d",
-                  desc, triplesRead, triplesCount, currentRL, currentDL),
+                  desc,
+                  triplesRead,
+                  triplesCount,
+                  currentRL,
+                  currentDL),
               exception));
     }
     throw new ParquetDecodingException(
         String.format(
+            Locale.ROOT,
             "Can't read value in column %s at value %d out of %d in current page. "
                 + "repetition level: %d, definition level: %d",
-            desc, triplesRead, triplesCount, currentRL, currentDL),
+            desc,
+            triplesRead,
+            triplesCount,
+            currentRL,
+            currentDL),
         exception);
   }
 

--- a/pig/src/main/java/org/apache/iceberg/pig/PigParquetReader.java
+++ b/pig/src/main/java/org/apache/iceberg/pig/PigParquetReader.java
@@ -24,6 +24,7 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.parquet.ParquetSchemaUtil;
@@ -304,7 +305,11 @@ public class PigParquetReader {
     public String read(String reuse) {
       OffsetDateTime day = EPOCH.plusDays(column.nextInteger());
       return String.format(
-          "%04d-%02d-%02d", day.getYear(), day.getMonth().getValue(), day.getDayOfMonth());
+          Locale.ROOT,
+          "%04d-%02d-%02d",
+          day.getYear(),
+          day.getMonth().getValue(),
+          day.getDayOfMonth());
     }
   }
 
@@ -437,7 +442,9 @@ public class PigParquetReader {
         tuple.set(pos, value);
       } catch (ExecException e) {
         throw new RuntimeException(
-            String.format("Error setting tuple value for pos: %d, value: %s", pos, value), e);
+            String.format(
+                Locale.ROOT, "Error setting tuple value for pos: %d, value: %s", pos, value),
+            e);
       }
     }
   }

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/NamespaceHelpers.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/NamespaceHelpers.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.snowflake;
 
+import java.util.Locale;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -47,8 +48,10 @@ class NamespaceHelpers {
       default:
         throw new IllegalArgumentException(
             String.format(
+                Locale.ROOT,
                 "Snowflake max namespace level is %d, got namespace '%s'",
-                MAX_NAMESPACE_DEPTH, namespace));
+                MAX_NAMESPACE_DEPTH,
+                namespace));
     }
   }
 

--- a/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+++ b/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
@@ -22,6 +22,7 @@ import static org.apache.spark.sql.functions.lit;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.AppendFiles;
@@ -124,7 +125,7 @@ public class DeleteOrphanFilesBenchmark {
     for (int i = 0; i < NUM_SNAPSHOTS; i++) {
       AppendFiles appendFiles = table().newFastAppend();
       for (int j = 0; j < NUM_FILES; j++) {
-        String path = String.format("%s/path/to/data-%d-%d.parquet", location, i, j);
+        String path = String.format(Locale.ROOT, "%s/path/to/data-%d-%d.parquet", location, i, j);
         validAndOrphanPaths.add(path);
         DataFile dataFile =
             DataFiles.builder(partitionSpec)

--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
@@ -22,6 +22,7 @@ import static org.apache.spark.sql.functions.lit;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.AppendFiles;
@@ -124,7 +125,7 @@ public class DeleteOrphanFilesBenchmark {
     for (int i = 0; i < NUM_SNAPSHOTS; i++) {
       AppendFiles appendFiles = table().newFastAppend();
       for (int j = 0; j < NUM_FILES; j++) {
-        String path = String.format("%s/path/to/data-%d-%d.parquet", location, i, j);
+        String path = String.format(Locale.ROOT, "%s/path/to/data-%d-%d.parquet", location, i, j);
         validAndOrphanPaths.add(path);
         DataFile dataFile =
             DataFiles.builder(partitionSpec)

--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
@@ -22,6 +22,7 @@ import static org.apache.spark.sql.functions.lit;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.AppendFiles;
@@ -124,7 +125,7 @@ public class DeleteOrphanFilesBenchmark {
     for (int i = 0; i < NUM_SNAPSHOTS; i++) {
       AppendFiles appendFiles = table().newFastAppend();
       for (int j = 0; j < NUM_FILES; j++) {
-        String path = String.format("%s/path/to/data-%d-%d.parquet", location, i, j);
+        String path = String.format(Locale.ROOT, "%s/path/to/data-%d-%d.parquet", location, i, j);
         validAndOrphanPaths.add(path);
         DataFile dataFile =
             DataFiles.builder(partitionSpec)


### PR DESCRIPTION
- Update [com.palantir.baseline:gradle-baseline-java](https://github.com/palantir/gradle-baseline) from 5.61.0 to 5.69.0.
- Fix code to comply with `DefaultLocale` error-prone check (https://github.com/google/error-prone/issues/632 / https://github.com/google/error-prone/pull/4487 / https://github.com/google/error-prone/pull/4496)
   - we had it enabled, but it was previously ineffective, apparently we were using error-prone version prior to this check. Now we have to update the code.

replaces https://github.com/apache/iceberg/pull/11232