### PR TITLE
Api, Spark: Make StrictMetricsEvaluator not fail on nested column predicates

### DIFF
--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -640,45 +640,48 @@ public class TestStrictMetricsEvaluator {
   }
 
   @Test
-  public void testEvaluateOnNestedColumns() {
+  public void testEvaluateOnNestedColumnWithoutStats() {
     boolean shouldRead =
         new StrictMetricsEvaluator(
                 SCHEMA, greaterThanOrEqual("struct.nested_col_no_stats", INT_MIN_VALUE))
             .eval(FILE);
-    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+    assertThat(shouldRead).as("greaterThanOrEqual nested column should not match").isFalse();
 
     shouldRead =
         new StrictMetricsEvaluator(
                 SCHEMA, lessThanOrEqual("struct.nested_col_no_stats", INT_MAX_VALUE))
             .eval(FILE);
-    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+    assertThat(shouldRead).as("lessThanOrEqual nested column should not match").isFalse();
 
     shouldRead =
         new StrictMetricsEvaluator(SCHEMA, isNull("struct.nested_col_no_stats")).eval(FILE);
-    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+    assertThat(shouldRead).as("isNull nested column should not match").isFalse();
 
     shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notNull("struct.nested_col_no_stats")).eval(FILE);
-    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+    assertThat(shouldRead).as("notNull nested column should not match").isFalse();
+  }
 
-    shouldRead =
+  @Test
+  public void testEvaluateOnNestedColumnWithStats() {
+    boolean shouldRead =
         new StrictMetricsEvaluator(
                 SCHEMA, greaterThanOrEqual("struct.nested_col_with_stats", INT_MIN_VALUE))
             .eval(FILE);
-    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+    assertThat(shouldRead).as("greaterThanOrEqual nested column should not match").isFalse();
 
     shouldRead =
         new StrictMetricsEvaluator(
                 SCHEMA, lessThanOrEqual("struct.nested_col_with_stats", INT_MAX_VALUE))
             .eval(FILE);
-    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+    assertThat(shouldRead).as("lessThanOrEqual nested column should not match").isFalse();
 
     shouldRead =
         new StrictMetricsEvaluator(SCHEMA, isNull("struct.nested_col_with_stats")).eval(FILE);
-    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+    assertThat(shouldRead).as("isNull nested column should not match").isFalse();
 
     shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notNull("struct.nested_col_with_stats")).eval(FILE);
-    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+    assertThat(shouldRead).as("notNull nested column should not match").isFalse();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -66,7 +66,14 @@ public class TestStrictMetricsEvaluator {
           optional(11, "all_nulls_double", Types.DoubleType.get()),
           optional(12, "all_nans_v1_stats", Types.FloatType.get()),
           optional(13, "nan_and_null_only", Types.DoubleType.get()),
-          optional(14, "no_nan_stats", Types.DoubleType.get()));
+          optional(14, "no_nan_stats", Types.DoubleType.get()),
+          optional(
+              15,
+              "struct",
+              Types.StructType.of(
+                  Types.NestedField.optional(16, "nested_col_no_stats", Types.IntegerType.get()),
+                  Types.NestedField.optional(
+                      17, "nested_col_with_stats", Types.IntegerType.get()))));
 
   private static final int INT_MIN_VALUE = 30;
   private static final int INT_MAX_VALUE = 79;
@@ -88,6 +95,7 @@ public class TestStrictMetricsEvaluator {
               .put(12, 50L)
               .put(13, 50L)
               .put(14, 50L)
+              .put(17, 50L)
               .buildOrThrow(),
           // null value counts
           ImmutableMap.<Integer, Long>builder()
@@ -97,6 +105,7 @@ public class TestStrictMetricsEvaluator {
               .put(11, 50L)
               .put(12, 0L)
               .put(13, 1L)
+              .put(17, 0L)
               .buildOrThrow(),
           // nan value counts
           ImmutableMap.of(
@@ -108,13 +117,15 @@ public class TestStrictMetricsEvaluator {
               1, toByteBuffer(IntegerType.get(), INT_MIN_VALUE),
               7, toByteBuffer(IntegerType.get(), 5),
               12, toByteBuffer(Types.FloatType.get(), Float.NaN),
-              13, toByteBuffer(Types.DoubleType.get(), Double.NaN)),
+              13, toByteBuffer(Types.DoubleType.get(), Double.NaN),
+              17, toByteBuffer(Types.IntegerType.get(), INT_MIN_VALUE)),
           // upper bounds
           ImmutableMap.of(
               1, toByteBuffer(IntegerType.get(), INT_MAX_VALUE),
               7, toByteBuffer(IntegerType.get(), 5),
               12, toByteBuffer(Types.FloatType.get(), Float.NaN),
-              13, toByteBuffer(Types.DoubleType.get(), Double.NaN)));
+              13, toByteBuffer(Types.DoubleType.get(), Double.NaN),
+              17, toByteBuffer(IntegerType.get(), INT_MAX_VALUE)));
 
   private static final DataFile FILE_2 =
       new TestDataFile(
@@ -626,5 +637,48 @@ public class TestStrictMetricsEvaluator {
 
     shouldRead = new StrictMetricsEvaluator(SCHEMA, notIn("no_nulls", "abc", "def")).eval(FILE);
     assertThat(shouldRead).as("Should not match: no_nulls field does not have bounds").isFalse();
+  }
+
+  @Test
+  public void testEvaluateOnNestedColumns() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(
+                SCHEMA, greaterThanOrEqual("struct.nested_col_no_stats", INT_MIN_VALUE))
+            .eval(FILE);
+    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+
+    shouldRead =
+        new StrictMetricsEvaluator(
+                SCHEMA, lessThanOrEqual("struct.nested_col_no_stats", INT_MAX_VALUE))
+            .eval(FILE);
+    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, isNull("struct.nested_col_no_stats")).eval(FILE);
+    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notNull("struct.nested_col_no_stats")).eval(FILE);
+    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+
+    shouldRead =
+        new StrictMetricsEvaluator(
+                SCHEMA, greaterThanOrEqual("struct.nested_col_with_stats", INT_MIN_VALUE))
+            .eval(FILE);
+    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+
+    shouldRead =
+        new StrictMetricsEvaluator(
+                SCHEMA, lessThanOrEqual("struct.nested_col_with_stats", INT_MAX_VALUE))
+            .eval(FILE);
+    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, isNull("struct.nested_col_with_stats")).eval(FILE);
+    assertThat(shouldRead).as("Should not match: nested column").isFalse();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notNull("struct.nested_col_with_stats")).eval(FILE);
+    assertThat(shouldRead).as("Should not match: nested column").isFalse();
   }
 }

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -1408,6 +1408,12 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("INSERT INTO TABLE %s VALUES (1, named_struct(\"c1\", 3, \"c2\", \"v1\"))", tableName);
     sql("INSERT INTO TABLE %s VALUES (2, named_struct(\"c1\", 2, \"c2\", \"v2\"))", tableName);
 
+    sql("DELETE FROM %s WHERE complex.c1 > 3", tableName);
+    assertEquals(
+        "Should have expected rows",
+        ImmutableList.of(row(1), row(2)),
+        sql("SELECT id FROM %s order by id", tableName));
+
     sql("DELETE FROM %s WHERE complex.c1 = 3", tableName);
     assertEquals(
         "Should have expected rows", ImmutableList.of(row(2)), sql("SELECT id FROM %s", tableName));

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -1401,6 +1401,22 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         });
   }
 
+  @TestTemplate
+  public void testDeleteWithFilterOnNestedColumn() {
+    createAndInitNestedColumnsTable();
+
+    sql("INSERT INTO TABLE %s VALUES (1, named_struct(\"c1\", 3, \"c2\", \"v1\"))", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, named_struct(\"c1\", 2, \"c2\", \"v2\"))", tableName);
+
+    sql("DELETE FROM %s WHERE complex.c1 = 3", tableName);
+    assertEquals(
+        "Should have expected rows", ImmutableList.of(row(2)), sql("SELECT id FROM %s", tableName));
+
+    sql("DELETE FROM %s t WHERE t.complex.c1 = 2", tableName);
+    assertEquals(
+        "Should have expected rows", ImmutableList.of(), sql("SELECT id FROM %s", tableName));
+  }
+
   // TODO: multiple stripes for ORC
 
   protected void createAndInitPartitionedTable() {


### PR DESCRIPTION
Currently, the `StrictMetricsEvaluator` fails when evaluating expressions with nested columns, causing Spark's `DELETE FROM` statement to throw an exception if the `WHERE` condition uses nested columns as predicates.

The `StrictMetricsEvaluator` requires null count data for columns during evaluation, but the null count data for nested columns collected in the current metadata might be incorrect (see #8611). Therefore, the `StrictMetricsEvaluator` cannot support the evaluation of filters on nested columns.

However, I think we can at least return `ROWS_MIGHT_NOT_MATCH` when encountering filters with nested columns instead of directly throwing exceptions and causing job failures. We are currently alreadt doing this in the evaluation of `startsWith`:
 https://github.com/apache/iceberg/blob/5922b4bbc431131e9dfd112f751b796c5200a35e/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java#L464-L467

This fixes #7065.

@aokolnychyi @szehon-ho @RussellSpitzer @Fokko can you please take a look when you have time? Thanks.