### PR TITLE
Spark: Merge new position deletes with old deletes during writing

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/SortingPositionOnlyDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/SortingPositionOnlyDeleteWriter.java
@@ -167,12 +167,8 @@ public class SortingPositionOnlyDeleteWriter<T>
 
   private void validatePreviousDeletes(PositionDeleteIndex index) {
     Preconditions.checkArgument(
-        index.deleteFiles().stream().allMatch(this::isFileScoped),
+        index.deleteFiles().stream().allMatch(ContentFileUtil::isFileScoped),
         "Previous deletes must be file-scoped");
-  }
-
-  private boolean isFileScoped(DeleteFile deleteFile) {
-    return ContentFileUtil.referencedDataFile(deleteFile) != null;
   }
 
   private Collection<CharSequence> sort(Collection<CharSequence> paths) {

--- a/core/src/main/java/org/apache/iceberg/util/ContentFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ContentFileUtil.java
@@ -86,6 +86,10 @@ public class ContentFileUtil {
     return location != null ? location.toString() : null;
   }
 
+  public static boolean isFileScoped(DeleteFile deleteFile) {
+    return referencedDataFile(deleteFile) != null;
+  }
+
   public static boolean isDV(DeleteFile deleteFile) {
     return deleteFile.format() == FileFormat.PUFFIN;
   }

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadUpdate.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadUpdate.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.Map;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -55,19 +56,82 @@ public class TestMergeOnReadUpdate extends TestUpdate {
     checkUpdateFileGranularity(DeleteGranularity.PARTITION);
   }
 
+  @TestTemplate
+  public void testUpdateFileGranularityMergesDeleteFiles() {
+    // Range distribution will produce partition scoped deletes which will not be cleaned up
+    assumeThat(distributionMode).isNotEqualToIgnoringCase("range");
+
+    checkUpdateFileGranularity(DeleteGranularity.FILE);
+    sql("UPDATE %s SET id = id + 1 WHERE id = 4", commitTarget());
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    String expectedDeleteFilesCount = "2";
+    validateMergeOnRead(currentSnapshot, "2", expectedDeleteFilesCount, "2");
+
+    assertThat(currentSnapshot.removedDeleteFiles(table.io())).hasSize(2);
+    assertEquals(
+        "Should have expected rows",
+        ImmutableList.of(
+            row(0, "hr"),
+            row(2, "hr"),
+            row(2, "hr"),
+            row(5, "hr"),
+            row(0, "it"),
+            row(2, "it"),
+            row(2, "it"),
+            row(5, "it")),
+        sql("SELECT * FROM %s ORDER BY dep ASC, id ASC", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testUpdateUnpartitionedFileGranularityMergesDeleteFiles() {
+    // Range distribution will produce partition scoped deletes which will not be cleaned up
+    assumeThat(distributionMode).isNotEqualToIgnoringCase("range");
+    initTable("", DeleteGranularity.FILE);
+
+    sql("UPDATE %s SET id = id - 1 WHERE id = 1 OR id = 3", commitTarget());
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).hasSize(5);
+    Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    String expectedDeleteFilesCount = "4";
+    validateMergeOnRead(currentSnapshot, "1", expectedDeleteFilesCount, "1");
+    assertEquals(
+        "Should have expected rows",
+        ImmutableList.of(
+            row(0, "hr"),
+            row(2, "hr"),
+            row(2, "hr"),
+            row(4, "hr"),
+            row(0, "it"),
+            row(2, "it"),
+            row(2, "it"),
+            row(4, "it")),
+        sql("SELECT * FROM %s ORDER BY dep ASC, id ASC", selectTarget()));
+
+    sql("UPDATE %s SET id = id + 1 WHERE id = 4", commitTarget());
+    table.refresh();
+    currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    expectedDeleteFilesCount = "2";
+
+    validateMergeOnRead(currentSnapshot, "1", expectedDeleteFilesCount, "1");
+    assertThat(currentSnapshot.removedDeleteFiles(table.io())).hasSize(2);
+    assertEquals(
+        "Should have expected rows",
+        ImmutableList.of(
+            row(0, "hr"),
+            row(2, "hr"),
+            row(2, "hr"),
+            row(5, "hr"),
+            row(0, "it"),
+            row(2, "it"),
+            row(2, "it"),
+            row(5, "it")),
+        sql("SELECT * FROM %s ORDER BY dep ASC, id ASC", selectTarget()));
+  }
+
   private void checkUpdateFileGranularity(DeleteGranularity deleteGranularity) {
-    createAndInitTable("id INT, dep STRING", "PARTITIONED BY (dep)", null /* empty */);
-
-    sql(
-        "ALTER TABLE %s SET TBLPROPERTIES ('%s' '%s')",
-        tableName, TableProperties.DELETE_GRANULARITY, deleteGranularity);
-
-    append(tableName, "{ \"id\": 1, \"dep\": \"hr\" }\n" + "{ \"id\": 2, \"dep\": \"hr\" }");
-    append(tableName, "{ \"id\": 3, \"dep\": \"hr\" }\n" + "{ \"id\": 4, \"dep\": \"hr\" }");
-    append(tableName, "{ \"id\": 1, \"dep\": \"it\" }\n" + "{ \"id\": 2, \"dep\": \"it\" }");
-    append(tableName, "{ \"id\": 3, \"dep\": \"it\" }\n" + "{ \"id\": 4, \"dep\": \"it\" }");
-
-    createBranchIfNeeded();
+    initTable("PARTITIONED BY (dep)", deleteGranularity);
 
     sql("UPDATE %s SET id = id - 1 WHERE id = 1 OR id = 3", commitTarget());
 
@@ -90,5 +154,20 @@ public class TestMergeOnReadUpdate extends TestUpdate {
             row(2, "it"),
             row(4, "it")),
         sql("SELECT * FROM %s ORDER BY dep ASC, id ASC", selectTarget()));
+  }
+
+  private void initTable(String partitionedBy, DeleteGranularity deleteGranularity) {
+    createAndInitTable("id INT, dep STRING", partitionedBy, null /* empty */);
+
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s' '%s')",
+        tableName, TableProperties.DELETE_GRANULARITY, deleteGranularity);
+
+    append(tableName, "{ \"id\": 1, \"dep\": \"hr\" }\n" + "{ \"id\": 2, \"dep\": \"hr\" }");
+    append(tableName, "{ \"id\": 3, \"dep\": \"hr\" }\n" + "{ \"id\": 4, \"dep\": \"hr\" }");
+    append(tableName, "{ \"id\": 1, \"dep\": \"it\" }\n" + "{ \"id\": 2, \"dep\": \"it\" }");
+    append(tableName, "{ \"id\": 3, \"dep\": \"it\" }\n" + "{ \"id\": 4, \"dep\": \"it\" }");
+
+    createBranchIfNeeded();
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -28,6 +28,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -42,8 +43,12 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.data.BaseDeleteLoader;
+import org.apache.iceberg.data.DeleteLoader;
 import org.apache.iceberg.deletes.DeleteGranularity;
 import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -67,6 +72,7 @@ import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.SparkWriteRequirements;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
+import org.apache.iceberg.util.DeleteFileSet;
 import org.apache.iceberg.util.StructProjection;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
@@ -166,10 +172,23 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     @Override
     public DeltaWriterFactory createBatchWriterFactory(PhysicalWriteInfo info) {
-      // broadcast the table metadata as the writer factory will be sent to executors
-      Broadcast<Table> tableBroadcast =
-          sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
-      return new PositionDeltaWriteFactory(tableBroadcast, command, context, writeProperties);
+      // broadcast large objects since the writer factory will be sent to executors
+      return new PositionDeltaWriteFactory(
+          sparkContext.broadcast(SerializableTableWithSize.copyOf(table)),
+          broadcastRewritableDeletes(),
+          command,
+          context,
+          writeProperties);
+    }
+
+    private Broadcast<Map<String, DeleteFileSet>> broadcastRewritableDeletes() {
+      if (context.deleteGranularity() == DeleteGranularity.FILE && scan != null) {
+        Map<String, DeleteFileSet> rewritableDeletes = scan.rewritableDeletes();
+        if (rewritableDeletes != null && !rewritableDeletes.isEmpty()) {
+          return sparkContext.broadcast(rewritableDeletes);
+        }
+      }
+      return null;
     }
 
     @Override
@@ -185,6 +204,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
       int addedDataFilesCount = 0;
       int addedDeleteFilesCount = 0;
+      int removedDeleteFilesCount = 0;
 
       for (WriterCommitMessage message : messages) {
         DeltaTaskCommit taskCommit = (DeltaTaskCommit) message;
@@ -197,6 +217,11 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
         for (DeleteFile deleteFile : taskCommit.deleteFiles()) {
           rowDelta.addDeletes(deleteFile);
           addedDeleteFilesCount += 1;
+        }
+
+        for (DeleteFile deleteFile : taskCommit.rewrittenDeleteFiles()) {
+          rowDelta.removeDeletes(deleteFile);
+          removedDeleteFilesCount += 1;
         }
 
         referencedDataFiles.addAll(Arrays.asList(taskCommit.referencedDataFiles()));
@@ -227,10 +252,11 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
         String commitMsg =
             String.format(
-                "position delta with %d data files and %d delete files "
+                "position delta with %d data files, %d delete files and %d rewritten delete files"
                     + "(scanSnapshotId: %d, conflictDetectionFilter: %s, isolationLevel: %s)",
                 addedDataFilesCount,
                 addedDeleteFilesCount,
+                removedDeleteFilesCount,
                 scan.snapshotId(),
                 conflictDetectionFilter,
                 isolationLevel);
@@ -314,18 +340,21 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
   public static class DeltaTaskCommit implements WriterCommitMessage {
     private final DataFile[] dataFiles;
     private final DeleteFile[] deleteFiles;
+    private final DeleteFile[] rewrittenDeleteFiles;
     private final CharSequence[] referencedDataFiles;
 
     DeltaTaskCommit(WriteResult result) {
       this.dataFiles = result.dataFiles();
       this.deleteFiles = result.deleteFiles();
       this.referencedDataFiles = result.referencedDataFiles();
+      this.rewrittenDeleteFiles = result.rewrittenDeleteFiles();
     }
 
     DeltaTaskCommit(DeleteWriteResult result) {
       this.dataFiles = new DataFile[0];
       this.deleteFiles = result.deleteFiles().toArray(new DeleteFile[0]);
       this.referencedDataFiles = result.referencedDataFiles().toArray(new CharSequence[0]);
+      this.rewrittenDeleteFiles = result.rewrittenDeleteFiles().toArray(new DeleteFile[0]);
     }
 
     DataFile[] dataFiles() {
@@ -336,6 +365,10 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       return deleteFiles;
     }
 
+    DeleteFile[] rewrittenDeleteFiles() {
+      return rewrittenDeleteFiles;
+    }
+
     CharSequence[] referencedDataFiles() {
       return referencedDataFiles;
     }
@@ -343,16 +376,19 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
   private static class PositionDeltaWriteFactory implements DeltaWriterFactory {
     private final Broadcast<Table> tableBroadcast;
+    private final Broadcast<Map<String, DeleteFileSet>> rewritableDeletesBroadcast;
     private final Command command;
     private final Context context;
     private final Map<String, String> writeProperties;
 
     PositionDeltaWriteFactory(
         Broadcast<Table> tableBroadcast,
+        Broadcast<Map<String, DeleteFileSet>> rewritableDeletesBroadcast,
         Command command,
         Context context,
         Map<String, String> writeProperties) {
       this.tableBroadcast = tableBroadcast;
+      this.rewritableDeletesBroadcast = rewritableDeletesBroadcast;
       this.command = command;
       this.context = context;
       this.writeProperties = writeProperties;
@@ -385,16 +421,21 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
               .build();
 
       if (command == DELETE) {
-        return new DeleteOnlyDeltaWriter(table, writerFactory, deleteFileFactory, context);
+        return new DeleteOnlyDeltaWriter(
+            table, rewritableDeletes(), writerFactory, deleteFileFactory, context);
 
       } else if (table.spec().isUnpartitioned()) {
         return new UnpartitionedDeltaWriter(
-            table, writerFactory, dataFileFactory, deleteFileFactory, context);
+            table, rewritableDeletes(), writerFactory, dataFileFactory, deleteFileFactory, context);
 
       } else {
         return new PartitionedDeltaWriter(
-            table, writerFactory, dataFileFactory, deleteFileFactory, context);
+            table, rewritableDeletes(), writerFactory, dataFileFactory, deleteFileFactory, context);
       }
+    }
+
+    private Map<String, DeleteFileSet> rewritableDeletes() {
+      return rewritableDeletesBroadcast != null ? rewritableDeletesBroadcast.getValue() : null;
     }
   }
 
@@ -437,20 +478,55 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     // use a fanout writer if the input is unordered no matter whether fanout writers are enabled
     // clustered writers assume that the position deletes are already ordered by file and position
     protected PartitioningWriter<PositionDelete<InternalRow>, DeleteWriteResult> newDeleteWriter(
-        Table table, SparkFileWriterFactory writers, OutputFileFactory files, Context context) {
+        Table table,
+        Map<String, DeleteFileSet> rewritableDeletes,
+        SparkFileWriterFactory writers,
+        OutputFileFactory files,
+        Context context) {
 
       FileIO io = table.io();
       boolean inputOrdered = context.inputOrdered();
       long targetFileSize = context.targetDeleteFileSize();
       DeleteGranularity deleteGranularity = context.deleteGranularity();
 
-      if (inputOrdered) {
+      if (inputOrdered && rewritableDeletes == null) {
         return new ClusteredPositionDeleteWriter<>(
             writers, files, io, targetFileSize, deleteGranularity);
       } else {
         return new FanoutPositionOnlyDeleteWriter<>(
-            writers, files, io, targetFileSize, deleteGranularity);
+            writers,
+            files,
+            io,
+            targetFileSize,
+            deleteGranularity,
+            rewritableDeletes != null
+                ? new PreviousDeleteLoader(table, rewritableDeletes)
+                : path -> null /* no previous file scoped deletes */);
       }
+    }
+  }
+
+  private static class PreviousDeleteLoader implements Function<CharSequence, PositionDeleteIndex> {
+    private final Map<String, DeleteFileSet> deleteFiles;
+    private final DeleteLoader deleteLoader;
+
+    PreviousDeleteLoader(Table table, Map<String, DeleteFileSet> deleteFiles) {
+      this.deleteFiles = deleteFiles;
+      this.deleteLoader =
+          new BaseDeleteLoader(
+              deleteFile ->
+                  EncryptingFileIO.combine(table.io(), table.encryption())
+                      .newInputFile(deleteFile));
+    }
+
+    @Override
+    public PositionDeleteIndex apply(CharSequence path) {
+      DeleteFileSet deleteFileSet = deleteFiles.get(path.toString());
+      if (deleteFileSet == null) {
+        return null;
+      }
+
+      return deleteLoader.loadPositionDeletes(deleteFileSet, path);
     }
   }
 
@@ -470,11 +546,13 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     DeleteOnlyDeltaWriter(
         Table table,
+        Map<String, DeleteFileSet> rewritableDeletes,
         SparkFileWriterFactory writerFactory,
         OutputFileFactory deleteFileFactory,
         Context context) {
 
-      this.delegate = newDeleteWriter(table, writerFactory, deleteFileFactory, context);
+      this.delegate =
+          newDeleteWriter(table, rewritableDeletes, writerFactory, deleteFileFactory, context);
       this.positionDelete = PositionDelete.create();
       this.io = table.io();
       this.specs = table.specs();
@@ -557,6 +635,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     DeleteAndDataDeltaWriter(
         Table table,
+        Map<String, DeleteFileSet> rewritableDeletes,
         SparkFileWriterFactory writerFactory,
         OutputFileFactory dataFileFactory,
         OutputFileFactory deleteFileFactory,
@@ -564,7 +643,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       this.delegate =
           new BasePositionDeltaWriter<>(
               newDataWriter(table, writerFactory, dataFileFactory, context),
-              newDeleteWriter(table, writerFactory, deleteFileFactory, context));
+              newDeleteWriter(table, rewritableDeletes, writerFactory, deleteFileFactory, context));
       this.io = table.io();
       this.specs = table.specs();
 
@@ -629,11 +708,12 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     UnpartitionedDeltaWriter(
         Table table,
+        Map<String, DeleteFileSet> rewritableDeletes,
         SparkFileWriterFactory writerFactory,
         OutputFileFactory dataFileFactory,
         OutputFileFactory deleteFileFactory,
         Context context) {
-      super(table, writerFactory, dataFileFactory, deleteFileFactory, context);
+      super(table, rewritableDeletes, writerFactory, dataFileFactory, deleteFileFactory, context);
       this.dataSpec = table.spec();
     }
 
@@ -655,11 +735,12 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     PartitionedDeltaWriter(
         Table table,
+        Map<String, DeleteFileSet> rewritableDeletes,
         SparkFileWriterFactory writerFactory,
         OutputFileFactory dataFileFactory,
         OutputFileFactory deleteFileFactory,
         Context context) {
-      super(table, writerFactory, dataFileFactory, deleteFileFactory, context);
+      super(table, rewritableDeletes, writerFactory, dataFileFactory, deleteFileFactory, context);
 
       this.dataSpec = table.spec();
       this.dataPartitionKey = new PartitionKey(dataSpec, context.dataSchema());


### PR DESCRIPTION
This change consumes the updated fanout position delete writers in https://github.com/apache/iceberg/pull/11222 to maintain position deletes during writes (_minor compaction_). The mapping of data files to file scoped deletes is broadcasted to executors, where delete file writers merge the historical position deletes with new position deletes. This behavior is behind a Spark conf `maintain-position-deletes` and can also be controlled via the `write.delete.maintain-during-write` table property.
By default this maintenance during write is enabled.

ToDo: UpdateProjectionBenchmark may need to include some changes to use file granularity for MoR cases, so that we can look at the impact of this change before/after. The benchmark should probably be run after https://github.com/apache/iceberg/pull/11131 gets in 