### PR TITLE
AWS: Make sure overridden configurations are applied

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -899,9 +899,14 @@ public class S3FileIOProperties implements Serializable {
    * </pre>
    */
   public <T extends S3ClientBuilder> void applyRetryConfigurations(T builder) {
+    ClientOverrideConfiguration.Builder configBuilder =
+        null != builder.overrideConfiguration()
+            ? builder.overrideConfiguration().toBuilder()
+            : ClientOverrideConfiguration.builder();
+
     builder.overrideConfiguration(
-        config ->
-            config.retryPolicy(
+        configBuilder
+            .retryPolicy(
                 // Use a retry strategy which will persistently retry throttled exceptions with
                 // exponential backoff, to give S3 a chance to autoscale.
                 // LEGACY mode works best here, as it will allow throttled exceptions to use all of
@@ -945,7 +950,8 @@ public class S3FileIOProperties implements Serializable {
                                   return 5;
                                 })
                             .build())
-                    .build()));
+                    .build())
+            .build());
   }
 
   /**

--- a/aws/src/test/java/org/apache/iceberg/aws/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestS3FileIOProperties.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
@@ -239,7 +240,7 @@ public class TestS3FileIOProperties {
   }
 
   @Test
-  public void s3RemoteSigningEnabledWithUserAgent() {
+  public void s3RemoteSigningEnabledWithUserAgentAndRetryPolicy() {
     String uri = "http://localhost:12345";
     Map<String, String> properties =
         ImmutableMap.of(
@@ -249,6 +250,7 @@ public class TestS3FileIOProperties {
 
     s3Properties.applySignerConfiguration(builder);
     s3Properties.applyUserAgentConfigurations(builder);
+    s3Properties.applyRetryConfigurations(builder);
 
     Optional<String> userAgent =
         builder.overrideConfiguration().advancedOption(SdkAdvancedClientOption.USER_AGENT_PREFIX);
@@ -260,6 +262,9 @@ public class TestS3FileIOProperties {
     S3V4RestSignerClient signerClient = (S3V4RestSignerClient) signer.get();
     assertThat(signerClient.baseSignerUri()).isEqualTo(uri);
     assertThat(signerClient.properties()).isEqualTo(properties);
+
+    Optional<RetryPolicy> retryPolicy = builder.overrideConfiguration().retryPolicy();
+    assertThat(retryPolicy).isPresent().get().isInstanceOf(RetryPolicy.class);
   }
 
   @Test


### PR DESCRIPTION
### Context
 - In the `iceberg-aws` module, the community has added the following S3 configurations over time:

| S3 configuration | Pull Request |
| ---------------- | ------------- |
| `Signer` configuration | https://github.com/apache/iceberg/pull/7562 |
| `UserAgent` configuration | https://github.com/apache/iceberg/pull/9963 |
| `Retry` configuration | https://github.com/apache/iceberg/pull/11052 |

 - As PR https://github.com/apache/iceberg/pull/10198 suggested, calling `builder.overrideConfiguration()` will return a new `ClientOverrideConfiguration` instance and ignore existing overridden configurations.
 - However, the previous PR didn't take care of the `Retry` configuration b/c it was introduced only a few days ago.

### Proposed changes
 - Make sure we can apply the following configurations without losing conf values.

```java
s3Properties.applySignerConfiguration(builder);
s3Properties.applyUserAgentConfigurations(builder);
s3Properties.applyRetryConfigurations(builder);
```
