### PR TITLE
Added support for evolving the partition of the table

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/TableSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/TableSinkConfig.java
@@ -26,6 +26,8 @@ public class TableSinkConfig {
   private final Pattern routeRegex;
   private final List<String> idColumns;
   private final List<String> partitionBy;
+  private final List<String> removePartitionBy;
+  private final List<String> addPartitionBy;
   private final String commitBranch;
 
   public TableSinkConfig(
@@ -34,6 +36,18 @@ public class TableSinkConfig {
     this.idColumns = idColumns;
     this.partitionBy = partitionBy;
     this.commitBranch = commitBranch;
+    removePartitionBy = List.of();
+    addPartitionBy = List.of();
+  }
+
+  public TableSinkConfig(
+          Pattern routeRegex, List<String> idColumns, List<String> partitionBy, List<String> removePartitionBy, List<String> addPartitionBy, String commitBranch) {
+    this.routeRegex = routeRegex;
+    this.idColumns = idColumns;
+    this.partitionBy = partitionBy;
+    this.commitBranch = commitBranch;
+    this.removePartitionBy = removePartitionBy;
+    this.addPartitionBy = addPartitionBy;
   }
 
   public Pattern routeRegex() {
@@ -50,5 +64,13 @@ public class TableSinkConfig {
 
   public String commitBranch() {
     return commitBranch;
+  }
+
+  public List<String> removePartitionBy() {
+    return removePartitionBy;
+  }
+
+  public List<String> addPartitionBy() {
+    return addPartitionBy;
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/PartitionEvolutionUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/PartitionEvolutionUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.connect.data;
+
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.UpdatePartitionSpec;
+import org.apache.iceberg.connect.IcebergSinkConfig;
+import org.apache.iceberg.connect.data.evolution.AddPartitionUpdater;
+import org.apache.iceberg.connect.data.evolution.PartitionUpdater;
+import org.apache.iceberg.connect.data.evolution.RemovePartitionUpdater;
+import org.apache.iceberg.transforms.Transform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class PartitionEvolutionUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PartitionEvolutionUtils.class);
+
+    public static void checkAndEvolvePartition(Table table, IcebergSinkConfig config) {
+        List<String> removePartitionFields = config.tableConfig(table.name()).removePartitionBy();
+        List<String> addPartitionFields = config.tableConfig(table.name()).addPartitionBy();
+
+        removeCommonElements(removePartitionFields, addPartitionFields);
+
+        if (addPartitionFields.isEmpty() && removePartitionFields.isEmpty()) {
+            LOG.info("Nothing to add or remove for job = {}", config.connectorName());
+            return;
+        }
+
+        UpdatePartitionSpec updateSpec = table.updateSpec();
+        boolean hasUpdates = false;
+
+        if (!removePartitionFields.isEmpty()) {
+            hasUpdates |= processPartitionUpdate(new RemovePartitionUpdater(table, updateSpec), removePartitionFields, table);
+        }
+
+        if (!addPartitionFields.isEmpty()) {
+            hasUpdates |= processPartitionUpdate(new AddPartitionUpdater(table, updateSpec), addPartitionFields, table);
+        }
+
+        if (hasUpdates) {
+            commitPartitionUpdate(updateSpec, config);
+        }
+    }
+
+    private static boolean processPartitionUpdate(PartitionUpdater updater, List<String> partitionFields, Table table) {
+        try {
+            PartitionSpec spec = SchemaUtils.createPartitionSpec(table.schema(), partitionFields);
+            return updater.update(spec);
+        } catch (Exception ex) {
+            LOG.warn("Failed to build partition spec for fields: {}", partitionFields, ex);
+            return false;
+        }
+    }
+
+    private static void commitPartitionUpdate(UpdatePartitionSpec updateSpec, IcebergSinkConfig config) {
+        try {
+            updateSpec.commit();
+        } catch (Exception ex) {
+            LOG.warn("Exception while committing partition update for job = {}. Continuing...", config.connectorName(), ex);
+        }
+    }
+
+    private static <T> void removeCommonElements(List<T> list1, List<T> list2) {
+        Set<T> commonElements = new HashSet<>(list1);
+        commonElements.retainAll(list2);
+        list1.removeAll(commonElements);
+        list2.removeAll(commonElements);
+    }
+
+    public static boolean isIdentityTransform(Transform<?, ?> transform) {
+        return transform.isIdentity();
+    }
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/evolution/AddPartitionUpdater.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/evolution/AddPartitionUpdater.java
@@ -1,0 +1,75 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.connect.data.evolution;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.UpdatePartitionSpec;
+import org.apache.iceberg.connect.data.PartitionEvolutionUtils;
+import org.apache.iceberg.expressions.Expressions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AddPartitionUpdater implements PartitionUpdater {
+    private static final Logger LOG = LoggerFactory.getLogger(AddPartitionUpdater.class);
+
+    private final Table table;
+    private final UpdatePartitionSpec updateSpec;
+
+    public AddPartitionUpdater(Table table, UpdatePartitionSpec updateSpec) {
+        this.table = table;
+        this.updateSpec = updateSpec;
+    }
+
+    @Override
+    public boolean update(PartitionSpec spec) {
+        boolean hasUpdates = false;
+        Set<String> currentPartitionColumns = getCurrentPartitionColumns(table);
+        LOG.info("currentPartitionColumns while adding = {}", currentPartitionColumns);
+        for (PartitionField field : spec.fields()) {
+            if (!currentPartitionColumns.contains(field.name())) {
+                LOG.info("field.name = {} not found in current partition fields = {}, hence will try to add", field.name(), currentPartitionColumns);
+                hasUpdates = true;
+                applyTransformation(field, Arrays.stream(field.name().split("_")).findFirst().get());
+            }
+        }
+        return hasUpdates;
+    }
+
+    private void applyTransformation(PartitionField field, String columnName) {
+        if (PartitionEvolutionUtils.isIdentityTransform(field.transform())) {
+            updateSpec.addField(columnName);
+        } else {
+            updateSpec.addField(Expressions.transform(columnName, field.transform()));
+        }
+    }
+
+    private Set<String> getCurrentPartitionColumns(Table table) {
+        return table.spec().fields().stream()
+                .map(PartitionField::name)
+                .collect(Collectors.toSet());
+    }
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/evolution/PartitionUpdater.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/evolution/PartitionUpdater.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.connect.data.evolution;
+
+import org.apache.iceberg.PartitionSpec;
+
+public interface PartitionUpdater {
+    boolean update(PartitionSpec spec);
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/evolution/RemovePartitionUpdater.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/evolution/RemovePartitionUpdater.java
@@ -1,0 +1,65 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.connect.data.evolution;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.UpdatePartitionSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RemovePartitionUpdater implements PartitionUpdater {
+    private static final Logger LOG = LoggerFactory.getLogger(RemovePartitionUpdater.class);
+
+    private final Table table;
+    private final UpdatePartitionSpec updateSpec;
+
+    public RemovePartitionUpdater(Table table, UpdatePartitionSpec updateSpec) {
+        this.table = table;
+        this.updateSpec = updateSpec;
+    }
+
+    @Override
+    public boolean update(PartitionSpec spec) {
+        boolean hasUpdates = false;
+        Set<String> currentPartitionColumns = getCurrentPartitionColumns(table);
+        LOG.info("currentPartitionColumns while removing = {}", currentPartitionColumns);
+        for (PartitionField field : spec.fields()) {
+            if (currentPartitionColumns.contains(field.name())) {
+                LOG.info("field.name = {} found in current partition fields = {}, hence will try to remove", field.name(), currentPartitionColumns);
+                currentPartitionColumns.remove(field.name());
+                hasUpdates = true;
+                updateSpec.removeField(field.name());
+            }
+        }
+        return hasUpdates;
+    }
+
+    private Set<String> getCurrentPartitionColumns(Table table) {
+        return table.spec().fields().stream()
+                .map(PartitionField::name)
+                .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
**Proposed Change**

This proposal aims to improve on the Partition Evolution of the Iceberg Table through the Kafka Connect itself. Currently if we need to do the Partition Evolution, there is no way other than providing at the time of posting the Kafka Connect Job itself. Other than this the only way is manually modifying the partitions of the Iceberg Table which is kind of hectic and cumbersome and not familiar to everyone.

**Short Comings of the current approach:**

1. Partitions in the table can only be specified at the time of posting the job and there is not other way to modify that via the Kafka-Connect Job.
2. Any modification in the partition is only possible through manual intervention in which the user has to go or ask to manually change the partition of the iceberg table.

**Improvement Proposal Quip:**
https://docs.google.com/document/d/1459siWnxA0I4J-sJgBltyg_NFYOvBV0bXd0EpluVlr0/edit?usp=sharing