### PR TITLE
Iceberg Kafka Connect :: Writer Per Topic Partition Design

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/Committer.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/Committer.java
@@ -19,14 +19,19 @@
 package org.apache.iceberg.connect;
 
 import java.util.Collection;
-import org.apache.iceberg.catalog.Catalog;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.connect.sink.SinkTaskContext;
 
 public interface Committer {
-  void start(Catalog catalog, IcebergSinkConfig config, SinkTaskContext context);
+  void start(ResourceType resourceType);
 
-  void stop();
+  void open(TopicPartition topicPartition);
+
+  void stop(ResourceType resourceType);
+
+  void close(TopicPartition topicPartition);
 
   void save(Collection<SinkRecord> sinkRecords);
+
+  boolean leader(Collection<TopicPartition> currentAssignedPartitions);
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/CommitterFactory.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/CommitterFactory.java
@@ -18,11 +18,14 @@
  */
 package org.apache.iceberg.connect;
 
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.connect.channel.CommitterImpl;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 
 class CommitterFactory {
-  static Committer createCommitter(IcebergSinkConfig config) {
-    return new CommitterImpl();
+
+  static Committer createCommitter(Catalog catalog, IcebergSinkConfig config, SinkTaskContext context) {
+    return new CommitterImpl(catalog, config, context);
   }
 
   private CommitterFactory() {}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/ResourceType.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/ResourceType.java
@@ -1,0 +1,27 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.connect;
+
+public enum ResourceType {
+    WORKER,
+    COORDINATOR
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/WriterFactory.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/WriterFactory.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.connect;
+
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.connect.data.SinkWriter;
+
+public class WriterFactory {
+
+    public static SinkWriter getSinkWriter(Catalog catalog, IcebergSinkConfig config) {
+        return new SinkWriter(catalog, config);
+    }
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -19,11 +19,17 @@
 package org.apache.iceberg.connect.channel;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.connect.IcebergSinkConfig;
+import org.apache.iceberg.connect.WriterFactory;
+import org.apache.iceberg.connect.data.IcebergWriterResult;
 import org.apache.iceberg.connect.data.Offset;
 import org.apache.iceberg.connect.data.SinkWriter;
 import org.apache.iceberg.connect.data.SinkWriterResult;
@@ -34,31 +40,43 @@ import org.apache.iceberg.connect.events.PayloadType;
 import org.apache.iceberg.connect.events.StartCommit;
 import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.connect.events.TopicPartitionOffset;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 class Worker extends Channel {
 
   private final IcebergSinkConfig config;
   private final SinkTaskContext context;
-  private final SinkWriter sinkWriter;
+  private final Map<TopicPartition, SinkWriter> writers;
+  private final Catalog catalog;
 
   Worker(
-      IcebergSinkConfig config,
-      KafkaClientFactory clientFactory,
-      SinkWriter sinkWriter,
-      SinkTaskContext context) {
+          Catalog catalog,
+          IcebergSinkConfig config,
+          KafkaClientFactory clientFactory,
+          SinkTaskContext context) {
     // pass transient consumer group ID to which we never commit offsets
     super(
-        "worker",
-        IcebergSinkConfig.DEFAULT_CONTROL_GROUP_PREFIX + UUID.randomUUID(),
-        config,
-        clientFactory,
-        context);
+            "worker",
+            IcebergSinkConfig.DEFAULT_CONTROL_GROUP_PREFIX + UUID.randomUUID(),
+            config,
+            clientFactory,
+            context);
 
     this.config = config;
     this.context = context;
-    this.sinkWriter = sinkWriter;
+    this.writers = Maps.newHashMap();
+    this.catalog = catalog;
+  }
+
+  public void open(TopicPartition topicPartition) {
+    writers.put(topicPartition, WriterFactory.getSinkWriter(catalog, config));
+  }
+
+  public void close(TopicPartition topicPartition) {
+    writers.remove(topicPartition).close();
   }
 
   void process() {
@@ -72,55 +90,69 @@ class Worker extends Channel {
       return false;
     }
 
-    SinkWriterResult results = sinkWriter.completeWrite();
+    List<IcebergWriterResult> writerResults = new ArrayList<>();
+    Map<TopicPartition, Offset> offsets = new HashMap<>();
+
+    for(Map.Entry<TopicPartition, SinkWriter> topicPartitionWriter : writers.entrySet()) {
+      SinkWriterResult topicPartitionWriterResult = topicPartitionWriter.getValue().completeWrite();
+      if(validateSourceOffset(topicPartitionWriterResult.sourceOffset())) {
+        writerResults.addAll(topicPartitionWriterResult.writerResults());
+        offsets.put(topicPartitionWriter.getKey(), topicPartitionWriterResult.sourceOffset());
+      }
+    }
 
     // include all assigned topic partitions even if no messages were read
     // from a partition, as the coordinator will use that to determine
     // when all data for a commit has been received
     List<TopicPartitionOffset> assignments =
-        context.assignment().stream()
-            .map(
-                tp -> {
-                  Offset offset = results.sourceOffsets().get(tp);
-                  if (offset == null) {
-                    offset = Offset.NULL_OFFSET;
-                  }
-                  return new TopicPartitionOffset(
-                      tp.topic(), tp.partition(), offset.offset(), offset.timestamp());
-                })
-            .collect(Collectors.toList());
+            context.assignment().stream()
+                    .map(
+                            tp -> {
+                              Offset offset = offsets.get(tp);
+                              if (offset == null) {
+                                offset = Offset.NULL_OFFSET;
+                              }
+                              return new TopicPartitionOffset(
+                                      tp.topic(), tp.partition(), offset.offset(), offset.timestamp());
+                            })
+                    .collect(Collectors.toList());
 
     UUID commitId = ((StartCommit) event.payload()).commitId();
 
     List<Event> events =
-        results.writerResults().stream()
-            .map(
-                writeResult ->
-                    new Event(
-                        config.connectGroupId(),
-                        new DataWritten(
-                            writeResult.partitionStruct(),
-                            commitId,
-                            TableReference.of(config.catalogName(), writeResult.tableIdentifier()),
-                            writeResult.dataFiles(),
-                            writeResult.deleteFiles())))
-            .collect(Collectors.toList());
+            writerResults.stream()
+                    .map(
+                            writeResult ->
+                                    new Event(
+                                            config.connectGroupId(),
+                                            new DataWritten(
+                                                    writeResult.partitionStruct(),
+                                                    commitId,
+                                                    TableReference.of(config.catalogName(), writeResult.tableIdentifier()),
+                                                    writeResult.dataFiles(),
+                                                    writeResult.deleteFiles())))
+                    .collect(Collectors.toList());
 
     Event readyEvent = new Event(config.connectGroupId(), new DataComplete(commitId, assignments));
     events.add(readyEvent);
 
-    send(events, results.sourceOffsets());
+    send(events, offsets);
 
     return true;
+  }
+
+  private boolean validateSourceOffset(Offset offset) {
+    return null != offset && offset != Offset.NULL_OFFSET && offset.offset() != null;
   }
 
   @Override
   void stop() {
     super.stop();
-    sinkWriter.close();
+    writers.values().forEach(SinkWriter::close);
+    writers.clear();
   }
 
   void save(Collection<SinkRecord> sinkRecords) {
-    sinkWriter.save(sinkRecords);
+    sinkRecords.forEach(sinkRecord -> writers.get(new TopicPartition(sinkRecord.topic(), sinkRecord.kafkaPartition())).save(sinkRecord));
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SinkWriterResult.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SinkWriterResult.java
@@ -19,24 +19,22 @@
 package org.apache.iceberg.connect.data;
 
 import java.util.List;
-import java.util.Map;
-import org.apache.kafka.common.TopicPartition;
 
 public class SinkWriterResult {
   private final List<IcebergWriterResult> writerResults;
-  private final Map<TopicPartition, Offset> sourceOffsets;
+  private final Offset sourceOffset;
 
   public SinkWriterResult(
-      List<IcebergWriterResult> writerResults, Map<TopicPartition, Offset> sourceOffsets) {
+          List<IcebergWriterResult> writerResults, Offset sourceOffset) {
     this.writerResults = writerResults;
-    this.sourceOffsets = sourceOffsets;
+    this.sourceOffset = sourceOffset;
   }
 
   public List<IcebergWriterResult> writerResults() {
     return writerResults;
   }
 
-  public Map<TopicPartition, Offset> sourceOffsets() {
-    return sourceOffsets;
+  public Offset sourceOffset() {
+    return sourceOffset;
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/BaseWriterTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/BaseWriterTest.java
@@ -29,8 +29,10 @@ import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.avro.IcebergDecoder;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.io.TaskWriter;
@@ -39,6 +41,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.types.Types;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.BeforeEach;
 
 public class BaseWriterTest {
@@ -73,7 +76,7 @@ public class BaseWriterTest {
 
   protected WriteResult writeTest(
       List<Record> rows, IcebergSinkConfig config, Class<?> expectedWriterClass) {
-    try (TaskWriter<Record> writer = RecordUtils.createTableWriter(table, "name", config)) {
+    try (TaskWriter<Record> writer = RecordUtils.createTableWriter(table, "name", config, "topic=test_topic/partition=test_partition/offset=test_offset_0")) {
       assertThat(writer.getClass()).isEqualTo(expectedWriterClass);
 
       rows.forEach(

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/SinkWriterTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/SinkWriterTest.java
@@ -196,11 +196,11 @@ public class SinkWriterTest {
             100L,
             now.toEpochMilli(),
             TimestampType.LOG_APPEND_TIME);
-    sinkWriter.save(ImmutableList.of(rec));
+    sinkWriter.save(rec);
 
     SinkWriterResult result = sinkWriter.completeWrite();
 
-    Offset offset = result.sourceOffsets().get(new TopicPartition("topic", 1));
+    Offset offset = result.sourceOffset();
     assertThat(offset).isNotNull();
     assertThat(offset.offset()).isEqualTo(101L); // should be 1 more than current offset
     assertThat(offset.timestamp()).isEqualTo(now.atOffset(ZoneOffset.UTC));


### PR DESCRIPTION
**Proposed Change**

This proposal aims to improve on the design of the Kafka-Connect-Iceberg to make it more **robust**, **resilient** and **performant**.
It is **build on lessons learnt from Incremental Cooperative Rebalancing(ICR)** Mode of Kafka and issues faced during deploying Iceberg Connector in ICR mode. It is also inspired from how confluent s3 connector use to handle the partitions of Kafka.

**Short-Comings of the current Design:**

1. **No-coordinator** situation(Already opened https://github.com/apache/iceberg/pull/11288 to handle in the current existing design):
2. Need to **sync Offset** at the **Open** Call, otherwise it leads to **data loss**(Already opened https://github.com/apache/iceberg/pull/11289 to handle this in the current existing design):
3. **Loss** of **work** due to current design **not** taking **advantage** of **Incremental Cooperative Mode**.
4. Files does not contain any topic partition information making very hard to debug:


**Improvement Proposal Doc:**
https://docs.google.com/document/d/1okqGq1HXu2rDnq88wIlVDv0EmNFZYB1PhgwyAzWIKT8/edit?usp=sharing