### PR TITLE
Arrow: Deprecate unused fixed width binary reader classes

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedColumnIterator.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedColumnIterator.java
@@ -214,6 +214,10 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     }
   }
 
+  /**
+   * @deprecated since 1.7.0, will be removed in 1.8.0.
+   */
+  @Deprecated
   public class FixedWidthTypeBinaryBatchReader extends BatchReader {
     @Override
     protected int nextBatchOf(
@@ -278,6 +282,10 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
     return new VarWidthTypeBatchReader();
   }
 
+  /**
+   * @deprecated since 1.7.0, will be removed in 1.8.0.
+   */
+  @Deprecated
   public FixedWidthTypeBinaryBatchReader fixedWidthTypeBinaryBatchReader() {
     return new FixedWidthTypeBinaryBatchReader();
   }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
@@ -141,6 +141,10 @@ public class VectorizedDictionaryEncodedParquetValuesReader
     }
   }
 
+  /**
+   * @deprecated since 1.7.0, will be removed in 1.8.0.
+   */
+  @Deprecated
   class FixedWidthBinaryDictEncodedReader extends BaseDictEncodedReader {
     @Override
     protected void nextVal(
@@ -203,6 +207,10 @@ public class VectorizedDictionaryEncodedParquetValuesReader
     return new DoubleDictEncodedReader();
   }
 
+  /**
+   * @deprecated since 1.7.0, will be removed in 1.8.0.
+   */
+  @Deprecated
   public FixedWidthBinaryDictEncodedReader fixedWidthBinaryDictEncodedReader() {
     return new FixedWidthBinaryDictEncodedReader();
   }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPageIterator.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPageIterator.java
@@ -421,7 +421,10 @@ public class VectorizedPageIterator extends BasePageIterator {
    * Method for reading batches of fixed width binary type (e.g. BYTE[7]). Spark does not support
    * fixed width binary data type. To work around this limitation, the data is read as fixed width
    * binary from parquet and stored in a {@link VarBinaryVector} in Arrow.
+   *
+   * @deprecated since 1.7.0, will be removed in 1.8.0.
    */
+  @Deprecated
   class FixedWidthBinaryPageReader extends BasePageReader {
     @Override
     protected void nextVal(
@@ -496,6 +499,10 @@ public class VectorizedPageIterator extends BasePageIterator {
     return new VarWidthTypePageReader();
   }
 
+  /**
+   * @deprecated since 1.7.0, will be removed in 1.8.0.
+   */
+  @Deprecated
   FixedWidthBinaryPageReader fixedWidthBinaryPageReader() {
     return new FixedWidthBinaryPageReader();
   }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -493,6 +493,10 @@ public final class VectorizedParquetDefinitionLevelReader
     }
   }
 
+  /**
+   * @deprecated since 1.7.0, will be removed in 1.8.0.
+   */
+  @Deprecated
   class FixedWidthBinaryReader extends BaseReader {
     @Override
     protected void nextVal(
@@ -732,6 +736,10 @@ public final class VectorizedParquetDefinitionLevelReader
     return new TimestampInt96Reader();
   }
 
+  /**
+   * @deprecated since 1.7.0, will be removed in 1.8.0.
+   */
+  @Deprecated
   FixedWidthBinaryReader fixedWidthBinaryReader() {
     return new FixedWidthBinaryReader();
   }


### PR DESCRIPTION
For fixed width binary, the FixedSizeBinaryXXX readers are actually used.
In `VectorizedArrowReader::read`:
```
          case UUID:
          case FIXED_WIDTH_BINARY:
          case FIXED_LENGTH_DECIMAL:
            vectorizedColumnIterator
                .fixedSizeBinaryBatchReader()
                .nextBatch(vec, typeWidth, nullabilityHolder);
            break;
```

This is a follow-up to https://github.com/apache/iceberg/pull/11276.