### PR TITLE
Support wasb[s] paths in ADLSFileIO

### DIFF
--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
@@ -111,7 +111,7 @@ public class ADLSFileIO implements DelegateFileIO {
         new DataLakeFileSystemClientBuilder().httpClient(HTTP);
 
     location.container().ifPresent(clientBuilder::fileSystemName);
-    azureProperties.applyClientConfiguration(location.storageAccount(), clientBuilder);
+    azureProperties.applyClientConfiguration(location.storageEndpoint(), clientBuilder);
 
     return clientBuilder.buildClient();
   }

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/ADLSLocationTest.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/ADLSLocationTest.java
@@ -38,10 +38,25 @@ public class ADLSLocationTest {
     assertThat(location.path()).isEqualTo("path/to/file");
   }
 
-  @Test
-  public void testEncodedString() {
-    String p1 = "abfs://container@account.dfs.core.windows.net/path%20to%20file";
+  @ParameterizedTest
+  @ValueSource(strings = {"wasb", "wasbs"})
+  public void testWasbLocationParsing(String scheme) {
+    String p1 = scheme + "://container@account.blob.core.windows.net/path/to/file";
     ADLSLocation location = new ADLSLocation(p1);
+
+    assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
+    assertThat(location.container().get()).isEqualTo("container");
+    assertThat(location.path()).isEqualTo("path/to/file");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "abfs://container@account.dfs.core.windows.net/path%20to%20file",
+        "wasb://container@account.blob.core.windows.net/path%20to%20file"
+      })
+  public void testEncodedString(String path) {
+    ADLSLocation location = new ADLSLocation(path);
 
     assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
     assertThat(location.container().get()).isEqualTo("container");
@@ -62,40 +77,56 @@ public class ADLSLocationTest {
         .hasMessage("Invalid ADLS URI: s3://bucket/path/to/file");
   }
 
-  @Test
-  public void testNoContainer() {
-    String p1 = "abfs://account.dfs.core.windows.net/path/to/file";
-    ADLSLocation location = new ADLSLocation(p1);
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "abfs://account.dfs.core.windows.net/path/to/file",
+        "wasb://account.blob.core.windows.net/path/to/file"
+      })
+  public void testNoContainer(String path) {
+    ADLSLocation location = new ADLSLocation(path);
 
     assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
     assertThat(location.container().isPresent()).isFalse();
     assertThat(location.path()).isEqualTo("path/to/file");
   }
 
-  @Test
-  public void testNoPath() {
-    String p1 = "abfs://container@account.dfs.core.windows.net";
-    ADLSLocation location = new ADLSLocation(p1);
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "abfs://container@account.dfs.core.windows.net",
+        "wasb://container@account.blob.core.windows.net"
+      })
+  public void testNoPath(String path) {
+    ADLSLocation location = new ADLSLocation(path);
 
     assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("");
   }
 
-  @Test
-  public void testQueryAndFragment() {
-    String p1 = "abfs://container@account.dfs.core.windows.net/path/to/file?query=foo#123";
-    ADLSLocation location = new ADLSLocation(p1);
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "abfs://container@account.dfs.core.windows.net/path/to/file?query=foo#123",
+        "wasb://container@account.blob.core.windows.net/path/to/file?query=foo#123"
+      })
+  public void testQueryAndFragment(String path) {
+    ADLSLocation location = new ADLSLocation(path);
 
     assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("path/to/file");
   }
 
-  @Test
-  public void testQueryAndFragmentNoPath() {
-    String p1 = "abfs://container@account.dfs.core.windows.net?query=foo#123";
-    ADLSLocation location = new ADLSLocation(p1);
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "abfs://container@account.dfs.core.windows.net?query=foo#123",
+        "wasb://container@account.blob.core.windows.net?query=foo#123"
+      })
+  public void testQueryAndFragmentNoPath(String path) {
+    ADLSLocation location = new ADLSLocation(path);
 
     assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
     assertThat(location.container().get()).isEqualTo("container");

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/ADLSLocationTest.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/ADLSLocationTest.java
@@ -21,7 +21,8 @@ package org.apache.iceberg.azure.adlsv2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.iceberg.exceptions.ValidationException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -33,7 +34,7 @@ public class ADLSLocationTest {
     String p1 = scheme + "://container@account.dfs.core.windows.net/path/to/file";
     ADLSLocation location = new ADLSLocation(p1);
 
-    assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
+    assertThat(location.storageEndpoint()).isEqualTo("account.dfs.core.windows.net");
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("path/to/file");
   }
@@ -44,7 +45,7 @@ public class ADLSLocationTest {
     String p1 = scheme + "://container@account.blob.core.windows.net/path/to/file";
     ADLSLocation location = new ADLSLocation(p1);
 
-    assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
+    assertThat(location.storageEndpoint()).isEqualTo("account.blob.core.windows.net");
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("path/to/file");
   }
@@ -55,10 +56,11 @@ public class ADLSLocationTest {
         "abfs://container@account.dfs.core.windows.net/path%20to%20file",
         "wasb://container@account.blob.core.windows.net/path%20to%20file"
       })
-  public void testEncodedString(String path) {
+  public void testEncodedString(String path) throws URISyntaxException {
     ADLSLocation location = new ADLSLocation(path);
+    String expectedEndpoint = new URI(path).getHost();
 
-    assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
+    assertThat(location.storageEndpoint()).isEqualTo(expectedEndpoint);
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("path%20to%20file");
   }
@@ -66,15 +68,23 @@ public class ADLSLocationTest {
   @Test
   public void testMissingScheme() {
     assertThatThrownBy(() -> new ADLSLocation("/path/to/file"))
-        .isInstanceOf(ValidationException.class)
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid ADLS URI: /path/to/file");
   }
 
   @Test
   public void testInvalidScheme() {
     assertThatThrownBy(() -> new ADLSLocation("s3://bucket/path/to/file"))
-        .isInstanceOf(ValidationException.class)
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid ADLS URI: s3://bucket/path/to/file");
+  }
+
+  @Test
+  public void testInvalidURI() {
+    String invalidUri = "abfs://container@account.dfs.core.windows.net/#invalidPath#";
+    assertThatThrownBy(() -> new ADLSLocation(invalidUri))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(String.format("Invalid ADLS URI: %s", invalidUri));
   }
 
   @ParameterizedTest
@@ -83,10 +93,11 @@ public class ADLSLocationTest {
         "abfs://account.dfs.core.windows.net/path/to/file",
         "wasb://account.blob.core.windows.net/path/to/file"
       })
-  public void testNoContainer(String path) {
+  public void testNoContainer(String path) throws URISyntaxException {
     ADLSLocation location = new ADLSLocation(path);
+    String expectedEndpoint = new URI(path).getHost();
 
-    assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
+    assertThat(location.storageEndpoint()).isEqualTo(expectedEndpoint);
     assertThat(location.container().isPresent()).isFalse();
     assertThat(location.path()).isEqualTo("path/to/file");
   }
@@ -97,10 +108,11 @@ public class ADLSLocationTest {
         "abfs://container@account.dfs.core.windows.net",
         "wasb://container@account.blob.core.windows.net"
       })
-  public void testNoPath(String path) {
+  public void testNoPath(String path) throws URISyntaxException {
     ADLSLocation location = new ADLSLocation(path);
+    String expectedEndpoint = new URI(path).getHost();
 
-    assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
+    assertThat(location.storageEndpoint()).isEqualTo(expectedEndpoint);
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("");
   }
@@ -111,10 +123,11 @@ public class ADLSLocationTest {
         "abfs://container@account.dfs.core.windows.net/path/to/file?query=foo#123",
         "wasb://container@account.blob.core.windows.net/path/to/file?query=foo#123"
       })
-  public void testQueryAndFragment(String path) {
+  public void testQueryAndFragment(String path) throws URISyntaxException {
     ADLSLocation location = new ADLSLocation(path);
+    String expectedEndpoint = new URI(path).getHost();
 
-    assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
+    assertThat(location.storageEndpoint()).isEqualTo(expectedEndpoint);
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("path/to/file");
   }
@@ -125,10 +138,11 @@ public class ADLSLocationTest {
         "abfs://container@account.dfs.core.windows.net?query=foo#123",
         "wasb://container@account.blob.core.windows.net?query=foo#123"
       })
-  public void testQueryAndFragmentNoPath(String path) {
+  public void testQueryAndFragmentNoPath(String path) throws URISyntaxException {
     ADLSLocation location = new ADLSLocation(path);
+    String expectedEndpoint = new URI(path).getHost();
 
-    assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
+    assertThat(location.storageEndpoint()).isEqualTo(expectedEndpoint);
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("");
   }

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -62,7 +62,9 @@ public class ResolvingFileIO implements HadoopConfigurable, DelegateFileIO {
           "s3n", S3_FILE_IO_IMPL,
           "gs", GCS_FILE_IO_IMPL,
           "abfs", ADLS_FILE_IO_IMPL,
-          "abfss", ADLS_FILE_IO_IMPL);
+          "abfss", ADLS_FILE_IO_IMPL,
+          "wasb", ADLS_FILE_IO_IMPL,
+          "wasbs", ADLS_FILE_IO_IMPL);
 
   private final Map<String, DelegateFileIO> ioInstances = Maps.newConcurrentMap();
   private final AtomicBoolean isClosed = new AtomicBoolean(false);


### PR DESCRIPTION
Resolves https://github.com/apache/iceberg/issues/10127 by delegating wasb[s] paths to the ADLSFileIO via ResolvingFileIO.

Additionally, I refactored the parsing logic to use java.net.URI because I believe it's clearer.  This also led me to change the invalid URI exception to `IllegalArgumentException` instead of a `ValidationException` b/c this seems more appropriate. 