### PR TITLE
add checkClassName regex func

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -406,6 +406,7 @@ public class IcebergSinkConfig extends AbstractConfig {
     return jsonConverter;
   }
 
+  @VisibleForTesting
   static boolean checkClassName(String className) {
     return (className.matches(".*\\.ConnectDistributed.*") || className.matches(".*\\.ConnectStandalone.*"));
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -406,6 +406,10 @@ public class IcebergSinkConfig extends AbstractConfig {
     return jsonConverter;
   }
 
+  public static boolean checkClassName(String className) {
+    return (className.matches(".*\\.ConnectDistributed.*") || className.matches(".*\\.ConnectStandalone.*"));
+  }
+
   /**
    * This method attempts to load the Kafka Connect worker properties, which are not exposed to
    * connectors. It does this by parsing the Java command used to launch the worker, extracting the
@@ -422,9 +426,7 @@ public class IcebergSinkConfig extends AbstractConfig {
     String javaCmd = System.getProperty("sun.java.command");
     if (javaCmd != null && !javaCmd.isEmpty()) {
       List<String> args = Splitter.on(' ').splitToList(javaCmd);
-      if (args.size() > 1
-          && (args.get(0).endsWith(".ConnectDistributed")
-              || args.get(0).endsWith(".ConnectStandalone"))) {
+      if (args.size() > 1 && checkClassName(args.get(0))) {
         Properties result = new Properties();
         try (InputStream in = Files.newInputStream(Paths.get(args.get(1)))) {
           result.load(in);

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -408,7 +408,8 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   @VisibleForTesting
   static boolean checkClassName(String className) {
-    return (className.matches(".*\\.ConnectDistributed.*") || className.matches(".*\\.ConnectStandalone.*"));
+    return (className.matches(".*\\.ConnectDistributed.*")
+        || className.matches(".*\\.ConnectStandalone.*"));
   }
 
   /**

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -406,7 +406,7 @@ public class IcebergSinkConfig extends AbstractConfig {
     return jsonConverter;
   }
 
-  public static boolean checkClassName(String className) {
+  static boolean checkClassName(String className) {
     return (className.matches(".*\\.ConnectDistributed.*") || className.matches(".*\\.ConnectStandalone.*"));
   }
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/IcebergSinkConfigTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/IcebergSinkConfigTest.java
@@ -88,4 +88,25 @@ public class IcebergSinkConfigTest {
 
   @Test
   public void testStringWithParensToList() {}
+
+  @Test
+  public void testCheckClassName() {
+    Boolean result = IcebergSinkConfig.checkClassName("org.apache.kafka.connect.cli.ConnectDistributed");
+    assertThat(result).isTrue();
+
+    result = IcebergSinkConfig.checkClassName("org.apache.kafka.connect.cli.ConnectStandalone");
+    assertThat(result).isTrue();
+
+    result = IcebergSinkConfig.checkClassName("some.other.package.ConnectDistributed");
+    assertThat(result).isTrue();
+
+    result = IcebergSinkConfig.checkClassName("some.other.package.ConnectStandalone");
+    assertThat(result).isTrue();
+
+    result = IcebergSinkConfig.checkClassName("some.package.ConnectDistributedWrapper");
+    assertThat(result).isTrue();
+
+    result = IcebergSinkConfig.checkClassName("org.apache.kafka.clients.producer.KafkaProducer");
+    assertThat(result).isFalse();
+  }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/IcebergSinkConfigTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/IcebergSinkConfigTest.java
@@ -91,7 +91,8 @@ public class IcebergSinkConfigTest {
 
   @Test
   public void testCheckClassName() {
-    Boolean result = IcebergSinkConfig.checkClassName("org.apache.kafka.connect.cli.ConnectDistributed");
+    Boolean result =
+        IcebergSinkConfig.checkClassName("org.apache.kafka.connect.cli.ConnectDistributed");
     assertThat(result).isTrue();
 
     result = IcebergSinkConfig.checkClassName("org.apache.kafka.connect.cli.ConnectStandalone");


### PR DESCRIPTION
We have a custom wrapper on the ConnectDistributed class which does not match the regex check here. This PR expands the regex to be more generous but is still reasonable, especially considering the properties check afterwards.

Closes an issue in [tabular.io/iceberg-kafka-connect](https://github.com/tabular-io/iceberg-kafka-connect/issues/301)