### PR TITLE
Build: Use the active shadow plugin

### DIFF
--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -19,7 +19,7 @@
 
 project(":iceberg-aws-bundle") {
 
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.gradleup.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -19,7 +19,7 @@
 
 project(":iceberg-azure-bundle") {
 
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.gradleup.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'io.github.goooler.shadow:shadow-gradle-plugin:8.1.8'
+    classpath 'com.gradleup.shadow:shadow-gradle-plugin:8.3.3'
     classpath 'com.palantir.baseline:gradle-baseline-java:5.69.0'
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.25.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'
@@ -246,7 +246,7 @@ subprojects {
 }
 
 project(':iceberg-bundled-guava') {
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.gradleup.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/flink/v1.18/build.gradle
+++ b/flink/v1.18/build.gradle
@@ -127,7 +127,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 }
 
 project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.gradleup.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/flink/v1.19/build.gradle
+++ b/flink/v1.19/build.gradle
@@ -128,7 +128,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 }
 
 project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.gradleup.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -128,7 +128,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 }
 
 project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.gradleup.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -19,7 +19,7 @@
 
 project(":iceberg-gcp-bundle") {
 
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.gradleup.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/hive-runtime/build.gradle
+++ b/hive-runtime/build.gradle
@@ -20,7 +20,7 @@
 def hiveVersions = (System.getProperty("hiveVersions") != null ? System.getProperty("hiveVersions") : System.getProperty("defaultHiveVersions")).split(",")
 
 project(':iceberg-hive-runtime') {
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.gradleup.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/hive3-orc-bundle/build.gradle
+++ b/hive3-orc-bundle/build.gradle
@@ -21,7 +21,7 @@
 // name. This is to be used by Hive3 for features including e.g. vectorization.
 project(':iceberg-hive3-orc-bundle') {
 
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.gradleup.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -187,7 +187,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
 }
 
 project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.gradleup.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -191,7 +191,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
 }
 
 project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.gradleup.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -193,7 +193,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
 }
 
 project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}") {
-  apply plugin: 'io.github.goooler.shadow'
+  apply plugin: 'com.gradleup.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
 


### PR DESCRIPTION
The Iceberg project uses `io.github.goooler.shadow` project which is archived. 
https://github.com/Goooler/shadow?tab=readme-ov-file#gradle-shadow

The old `com.github.johnrengelman.shadow` is now maintained under `com.gradleup.shadow` 
https://github.com/GradleUp/shadow?tab=readme-ov-file#gradle-shadow

So, updating the project to use https://plugins.gradle.org/plugin/com.gradleup.shadow