### PR TITLE
docs: fix spec sidebar

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -121,7 +121,7 @@ Tables do not require random-access writes. Once written, data and metadata file
 Tables do not require rename, except for tables that use atomic rename to implement the commit operation for new metadata files.
 
 
-# Specification
+## Specification
 
 ### Terms
 


### PR DESCRIPTION
Prior to this, the specification page sidebar does not show properly. It cuts off from the "File System Operations" section; whilst the anchor links do work, navigating this page is a little awkward when you need to jump way further down.

Now that this side bar is fixed, it should be much nicer. For reference, the same level of heading is used within the `view-spec.md` page, in which the side bar populates correctly.


# Example

<details>

<summary> before this change </summary>

Notice here how there are no other headings past the "File System Operations", there should be many more linking to the specification and data types etc.

![image](https://github.com/user-attachments/assets/1323a706-6551-41b0-bf03-7aebf304faad)

</details>

<details>

<summary> after this change </summary>

![image](https://github.com/user-attachments/assets/af9160a3-5581-45b7-8b3b-768dd87664c3)

</details>


