### PR TITLE
Spark: add property to disable client-side purging in spark

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -60,6 +60,10 @@ public class CachingCatalog implements Catalog {
     return new CachingCatalog(catalog, caseSensitive, expirationIntervalMillis);
   }
 
+  public boolean wrapped_is_instance(Class<?> cls) {
+    return cls.isInstance(catalog);
+  }
+
   private final Catalog catalog;
   private final boolean caseSensitive;
 

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -78,6 +78,15 @@ public class CatalogProperties {
 
   public static final boolean IO_MANIFEST_CACHE_ENABLED_DEFAULT = false;
 
+
+  /**
+   * Controls if client-side purging of files is enabled.
+   *
+   * When set to false, the client will not
+   */
+  public static final String IO_CLIENT_SIDE_PURGE_ENABLED = "io.client-side.purge-enabled";
+  public static final boolean IO_CLIENT_SIDE_PURGE_ENABLED_DEFAULT = true;
+
   /**
    * Controls the maximum duration for which an entry stays in the manifest cache.
    *

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -78,13 +78,13 @@ public class CatalogProperties {
 
   public static final boolean IO_MANIFEST_CACHE_ENABLED_DEFAULT = false;
 
-
   /**
    * Controls if client-side purging of files is enabled.
    *
-   * When set to false, the client will not
+   * <p>When set to false, the client will not
    */
   public static final String IO_CLIENT_SIDE_PURGE_ENABLED = "io.client-side.purge-enabled";
+
   public static final boolean IO_CLIENT_SIDE_PURGE_ENABLED_DEFAULT = true;
 
   /**

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -79,13 +79,12 @@ public class CatalogProperties {
   public static final boolean IO_MANIFEST_CACHE_ENABLED_DEFAULT = false;
 
   /**
-   * Controls if client-side purging of files is enabled.
-   *
-   * <p>When set to false, the client will not
+   * Controls whether engines using a REST Catalog should delegate the drop table purge requests to the Catalog.
+   * Defaults to false, allowing the engine to use its own implementation for purging.
    */
-  public static final String IO_CLIENT_SIDE_PURGE_ENABLED = "io.client-side.purge-enabled";
+  public static final String REST_SERVER_SIDE_PURGE = "rest.server-side-purge";
 
-  public static final boolean IO_CLIENT_SIDE_PURGE_ENABLED_DEFAULT = true;
+  public static final boolean REST_SERVER_SIDE_PURGE_DEFAULT = false;
 
   /**
    * Controls the maximum duration for which an entry stays in the manifest cache.

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -82,9 +82,9 @@ public class CatalogProperties {
    * Controls whether engines using a REST Catalog should delegate the drop table purge requests to the Catalog.
    * Defaults to false, allowing the engine to use its own implementation for purging.
    */
-  public static final String REST_SERVER_SIDE_PURGE = "rest.server-side-purge";
+  public static final String REST_CATALOG_PURGE = "rest.catalog-purge";
 
-  public static final boolean REST_SERVER_SIDE_PURGE_DEFAULT = false;
+  public static final boolean REST_CATALOG_PURGE_DEFAULT = false;
 
   /**
    * Controls the maximum duration for which an entry stays in the manifest cache.

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -139,6 +139,7 @@ public class SparkCatalog extends BaseCatalog
   private ViewCatalog asViewCatalog = null;
   private String[] defaultNamespace = null;
   private HadoopTables tables;
+  private boolean clientPurgeEnabled;
 
   /**
    * Build an Iceberg {@link Catalog} to be used by this Spark catalog adapter.
@@ -367,8 +368,7 @@ public class SparkCatalog extends BaseCatalog
       String metadataFileLocation =
           ((HasTableOperations) table).operations().current().metadataFileLocation();
 
-      boolean clientSidePurgeEnabled = PropertyUtil.propertyAsBoolean(table.properties(), IO_CLIENT_SIDE_PURGE_ENABLED, IO_CLIENT_SIDE_PURGE_ENABLED_DEFAULT);
-      if (clientSidePurgeEnabled) {
+      if (this.clientPurgeEnabled) {
         boolean dropped = dropTableWithoutPurging(ident);
 
         if (dropped) {
@@ -757,6 +757,11 @@ public class SparkCatalog extends BaseCatalog
             options,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
+
+    this.clientPurgeEnabled = PropertyUtil.propertyAsBoolean(
+            options,
+            IO_CLIENT_SIDE_PURGE_ENABLED,
+            IO_CLIENT_SIDE_PURGE_ENABLED_DEFAULT);
 
     // An expiration interval of 0ms effectively disables caching.
     // Do not wrap with CachingCatalog.

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -18,8 +18,8 @@
  */
 package org.apache.iceberg.spark;
 
-import static org.apache.iceberg.CatalogProperties.REST_SERVER_SIDE_PURGE;
-import static org.apache.iceberg.CatalogProperties.REST_SERVER_SIDE_PURGE_DEFAULT;
+import static org.apache.iceberg.CatalogProperties.REST_CATALOG_PURGE;
+import static org.apache.iceberg.CatalogProperties.REST_CATALOG_PURGE_DEFAULT;
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
 
@@ -764,8 +764,7 @@ public class SparkCatalog extends BaseCatalog
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
 
     this.restServerPurgeEnabled =
-        PropertyUtil.propertyAsBoolean(
-            options, REST_SERVER_SIDE_PURGE, REST_SERVER_SIDE_PURGE_DEFAULT);
+        PropertyUtil.propertyAsBoolean(options, REST_CATALOG_PURGE, REST_CATALOG_PURGE_DEFAULT);
 
     // An expiration interval of 0ms effectively disables caching.
     // Do not wrap with CachingCatalog.

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -141,7 +141,7 @@ public class SparkCatalog extends BaseCatalog
   private ViewCatalog asViewCatalog = null;
   private String[] defaultNamespace = null;
   private HadoopTables tables;
-  private boolean restServerPurgeEnabled;
+  private boolean restCatalogPurge;
 
   /**
    * Build an Iceberg {@link Catalog} to be used by this Spark catalog adapter.
@@ -371,8 +371,10 @@ public class SparkCatalog extends BaseCatalog
           ((HasTableOperations) table).operations().current().metadataFileLocation();
 
       if ((this.icebergCatalog instanceof RESTCatalog
-              || this.icebergCatalog instanceof RESTSessionCatalog)
-          && this.restServerPurgeEnabled) {
+              || this.icebergCatalog instanceof RESTSessionCatalog
+              || (this.icebergCatalog instanceof CachingCatalog
+                  && ((CachingCatalog) this.icebergCatalog).wrapped_is_instance(RESTCatalog.class)))
+          && this.restCatalogPurge) {
         return dropTableWithPurging(ident);
       }
 
@@ -763,7 +765,7 @@ public class SparkCatalog extends BaseCatalog
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
 
-    this.restServerPurgeEnabled =
+    this.restCatalogPurge =
         PropertyUtil.propertyAsBoolean(options, REST_CATALOG_PURGE, REST_CATALOG_PURGE_DEFAULT);
 
     // An expiration interval of 0ms effectively disables caching.

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestRestDropPurgeTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestRestDropPurgeTable.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import static org.apache.iceberg.CatalogProperties.CATALOG_IMPL;
+import static org.apache.iceberg.CatalogProperties.REST_CATALOG_PURGE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.TestBase;
+import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
+import org.apache.spark.sql.connector.catalog.Column;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRestDropPurgeTable extends TestBase {
+
+  private SparkCatalog sparkCatalog;
+  private static final Identifier id = Identifier.of(new String[] {"a"}, "db");
+
+  @Parameter(index = 0)
+  private boolean purge;
+
+  @Parameters(name = "purge = {0}")
+  protected static Object[][] parameters() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @BeforeEach
+  public void before() {
+    sparkCatalog = new SparkCatalog();
+    sparkCatalog.initialize(
+        "test_rest_catalog_purge",
+        new CaseInsensitiveStringMap(
+            ImmutableMap.of(
+                CATALOG_IMPL,
+                MockCatalog.class.getName(),
+                REST_CATALOG_PURGE,
+                Boolean.toString(purge),
+                MockCatalog.EXPECTATION,
+                Boolean.toString(purge))));
+    try {
+      sparkCatalog.createNamespace(new String[] {"a"}, ImmutableMap.of());
+      sparkCatalog.createTable(
+          id, new Column[] {Column.create("a", DataTypes.FloatType)}, null, ImmutableMap.of());
+
+    } catch (TableAlreadyExistsException
+        | NoSuchNamespaceException
+        | NamespaceAlreadyExistsException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @TestTemplate
+  public void testDropPurgeTableForwardsPurge() {
+    boolean dropped = sparkCatalog.purgeTable(id);
+    // we assert that dropped is True to make sure the code path in purgeTable we're testing
+    // actually ran
+    assertThat(dropped).isTrue();
+  }
+
+  public static class MockCatalog extends RESTCatalog {
+    private final InMemoryCatalog catalog;
+    private static final String EXPECTATION = "expectation";
+    private boolean expectation;
+
+    public MockCatalog() {
+      this.catalog = new InMemoryCatalog();
+      this.catalog.initialize("test", new HashMap<>());
+    }
+
+    @Override
+    public void initialize(String name, Map<String, String> props) {
+      this.expectation = Boolean.parseBoolean(props.get(EXPECTATION));
+    }
+
+    @Override
+    public Table createTable(TableIdentifier identifier, org.apache.iceberg.Schema schema) {
+      return catalog.createTable(identifier, schema);
+    }
+
+    @Override
+    public void createNamespace(Namespace ns, Map<String, String> props) {
+      catalog.createNamespace(ns, props);
+    }
+
+    @Override
+    public TableBuilder buildTable(TableIdentifier identifier, Schema schema) {
+      return catalog.buildTable(identifier, schema);
+    }
+
+    @Override
+    public boolean dropTable(TableIdentifier identifier, boolean purge) {
+      assertThat(purge).isEqualTo(expectation);
+      return true;
+    }
+
+    @Override
+    public Table loadTable(TableIdentifier identifier) {
+      return catalog.loadTable(identifier);
+    }
+  }
+}


### PR DESCRIPTION
closes #11023 

This PR adds a new table property `io.client-side.purge-enabled`. It allows a catalog to control spark's behavior on `DROP .. PURGE`. This in turn, enables  REST catalogs to offer an UNDROP feature for all storage providers. Currently, this is only possible with s3 due to the `s3.delete_enabled` property. 