### PR TITLE
Spark-3.5: Refactor BaseProcedure to support views

### DIFF
--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ViewUtil.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ViewUtil.scala
@@ -19,6 +19,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
+import org.apache.iceberg.spark.SparkSessionCatalog
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.catalog.View
@@ -37,7 +38,8 @@ object ViewUtil {
   }
 
   def isViewCatalog(catalog: CatalogPlugin): Boolean = {
-    catalog.isInstanceOf[ViewCatalog]
+    // Spark session catalog doesn't support the views yet.
+    catalog.isInstanceOf[ViewCatalog] && !catalog.isInstanceOf[SparkSessionCatalog[_]]
   }
 
   implicit class IcebergViewHelper(plugin: CatalogPlugin) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/BaseCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/BaseCatalog.java
@@ -30,12 +30,14 @@ import org.apache.spark.sql.connector.iceberg.catalog.Procedure;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureCatalog;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
-abstract class BaseCatalog
+public abstract class BaseCatalog
     implements StagingTableCatalog,
         ProcedureCatalog,
         SupportsNamespaces,
         HasIcebergCatalog,
-        SupportsFunctions {
+        SupportsFunctions,
+        org.apache.spark.sql.connector.catalog.ViewCatalog,
+        SupportsReplaceView {
   private static final String USE_NULLABLE_QUERY_SCHEMA_CTAS_RTAS = "use-nullable-query-schema";
   private static final boolean USE_NULLABLE_QUERY_SCHEMA_CTAS_RTAS_DEFAULT = true;
 
@@ -51,7 +53,7 @@ abstract class BaseCatalog
     if (isSystemNamespace(namespace)) {
       ProcedureBuilder builder = SparkProcedures.newBuilder(name);
       if (builder != null) {
-        return builder.withTableCatalog(this).build();
+        return builder.withCatalog(this).build();
       }
     }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -120,8 +120,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *
  * <p>
  */
-public class SparkCatalog extends BaseCatalog
-    implements org.apache.spark.sql.connector.catalog.ViewCatalog, SupportsReplaceView {
+public class SparkCatalog extends BaseCatalog {
   private static final Set<String> DEFAULT_NS_KEYS = ImmutableSet.of(TableCatalog.PROP_OWNER);
   private static final Splitter COMMA = Splitter.on(",");
   private static final Joiner COMMA_JOINER = Joiner.on(",");

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -31,8 +31,10 @@ import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchFunctionException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchViewException;
 import org.apache.spark.sql.catalyst.analysis.NonEmptyNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
+import org.apache.spark.sql.catalyst.analysis.ViewAlreadyExistsException;
 import org.apache.spark.sql.connector.catalog.CatalogExtension;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.connector.catalog.FunctionCatalog;
@@ -44,6 +46,8 @@ import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.catalog.TableChange;
+import org.apache.spark.sql.connector.catalog.View;
+import org.apache.spark.sql.connector.catalog.ViewChange;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructType;
@@ -396,5 +400,62 @@ public class SparkSessionCatalog<T extends TableCatalog & FunctionCatalog & Supp
     } catch (NoSuchFunctionException e) {
       return getSessionCatalog().loadFunction(ident);
     }
+  }
+
+  @Override
+  public View replaceView(
+      Identifier ident,
+      String sql,
+      String currentCatalog,
+      String[] currentNamespace,
+      StructType schema,
+      String[] queryColumnNames,
+      String[] columnAliases,
+      String[] columnComments,
+      Map<String, String> properties)
+      throws NoSuchViewException, NoSuchNamespaceException {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
+  }
+
+  @Override
+  public Identifier[] listViews(String... namespace) throws NoSuchNamespaceException {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
+  }
+
+  @Override
+  public View loadView(Identifier ident) throws NoSuchViewException {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
+  }
+
+  @Override
+  public View createView(
+      Identifier ident,
+      String sql,
+      String currentCatalog,
+      String[] currentNamespace,
+      StructType schema,
+      String[] queryColumnNames,
+      String[] columnAliases,
+      String[] columnComments,
+      Map<String, String> properties)
+      throws ViewAlreadyExistsException, NoSuchNamespaceException {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
+  }
+
+  @Override
+  public View alterView(Identifier ident, ViewChange... changes)
+      throws NoSuchViewException, IllegalArgumentException {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
+  }
+
+  @Override
+  public boolean dropView(Identifier ident) {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
+  }
+
+  @Override
+  public void renameView(Identifier oldIdent, Identifier newIdent)
+      throws NoSuchViewException, ViewAlreadyExistsException {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
@@ -45,7 +46,6 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -82,15 +82,15 @@ class AddFilesProcedure extends BaseProcedure {
             new StructField("changed_partition_count", DataTypes.LongType, true, Metadata.empty()),
           });
 
-  private AddFilesProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private AddFilesProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   public static SparkProcedures.ProcedureBuilder builder() {
     return new BaseProcedure.Builder<AddFilesProcedure>() {
       @Override
       protected AddFilesProcedure doBuild() {
-        return new AddFilesProcedure(tableCatalog());
+        return new AddFilesProcedure(catalog());
       }
     };
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AncestorsOfProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AncestorsOfProcedure.java
@@ -21,11 +21,11 @@ package org.apache.iceberg.spark.procedures;
 import java.util.List;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -49,15 +49,15 @@ public class AncestorsOfProcedure extends BaseProcedure {
             new StructField("timestamp", DataTypes.LongType, true, Metadata.empty())
           });
 
-  private AncestorsOfProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private AncestorsOfProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   public static SparkProcedures.ProcedureBuilder builder() {
     return new Builder<AncestorsOfProcedure>() {
       @Override
       protected AncestorsOfProcedure doBuild() {
-        return new AncestorsOfProcedure(tableCatalog());
+        return new AncestorsOfProcedure(catalog());
       }
     };
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/CherrypickSnapshotProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/CherrypickSnapshotProcedure.java
@@ -19,10 +19,10 @@
 package org.apache.iceberg.spark.procedures;
 
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -57,12 +57,12 @@ class CherrypickSnapshotProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<CherrypickSnapshotProcedure>() {
       @Override
       protected CherrypickSnapshotProcedure doBuild() {
-        return new CherrypickSnapshotProcedure(tableCatalog());
+        return new CherrypickSnapshotProcedure(catalog());
       }
     };
   }
 
-  private CherrypickSnapshotProcedure(TableCatalog catalog) {
+  private CherrypickSnapshotProcedure(BaseCatalog catalog) {
     super(catalog);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/CreateChangelogViewProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/CreateChangelogViewProcedure.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.ChangelogIterator;
 import org.apache.iceberg.spark.source.SparkChangelogTable;
 import org.apache.spark.api.java.function.MapPartitionsFunction;
@@ -40,7 +41,6 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.OrderUtils;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -118,13 +118,13 @@ public class CreateChangelogViewProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<CreateChangelogViewProcedure>() {
       @Override
       protected CreateChangelogViewProcedure doBuild() {
-        return new CreateChangelogViewProcedure(tableCatalog());
+        return new CreateChangelogViewProcedure(catalog());
       }
     };
   }
 
-  private CreateChangelogViewProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private CreateChangelogViewProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -22,13 +22,13 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ExpireSnapshots;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.actions.ExpireSnapshotsSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -76,13 +76,13 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<ExpireSnapshotsProcedure>() {
       @Override
       protected ExpireSnapshotsProcedure doBuild() {
-        return new ExpireSnapshotsProcedure(tableCatalog());
+        return new ExpireSnapshotsProcedure(catalog());
       }
     };
   }
 
-  private ExpireSnapshotsProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private ExpireSnapshotsProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
@@ -18,9 +18,9 @@
  */
 package org.apache.iceberg.spark.procedures;
 
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -49,13 +49,13 @@ public class FastForwardBranchProcedure extends BaseProcedure {
     return new Builder<FastForwardBranchProcedure>() {
       @Override
       protected FastForwardBranchProcedure doBuild() {
-        return new FastForwardBranchProcedure(tableCatalog());
+        return new FastForwardBranchProcedure(catalog());
       }
     };
   }
 
-  private FastForwardBranchProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private FastForwardBranchProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
@@ -22,11 +22,11 @@ import java.util.Map;
 import org.apache.iceberg.actions.MigrateTable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.actions.MigrateTableSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -50,15 +50,15 @@ class MigrateTableProcedure extends BaseProcedure {
             new StructField("migrated_files_count", DataTypes.LongType, false, Metadata.empty())
           });
 
-  private MigrateTableProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private MigrateTableProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   public static ProcedureBuilder builder() {
     return new BaseProcedure.Builder<MigrateTableProcedure>() {
       @Override
       protected MigrateTableProcedure doBuild() {
-        return new MigrateTableProcedure(tableCatalog());
+        return new MigrateTableProcedure(catalog());
       }
     };
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/PublishChangesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/PublishChangesProcedure.java
@@ -22,11 +22,11 @@ import java.util.Optional;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.util.WapUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -61,12 +61,12 @@ class PublishChangesProcedure extends BaseProcedure {
     return new Builder<PublishChangesProcedure>() {
       @Override
       protected PublishChangesProcedure doBuild() {
-        return new PublishChangesProcedure(tableCatalog());
+        return new PublishChangesProcedure(catalog());
       }
     };
   }
 
-  private PublishChangesProcedure(TableCatalog catalog) {
+  private PublishChangesProcedure(BaseCatalog catalog) {
     super(catalog);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RegisterTableProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RegisterTableProcedure.java
@@ -24,11 +24,11 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.spark.source.HasIcebergCatalog;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -50,15 +50,15 @@ class RegisterTableProcedure extends BaseProcedure {
             new StructField("total_data_files_count", DataTypes.LongType, true, Metadata.empty())
           });
 
-  private RegisterTableProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private RegisterTableProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   public static ProcedureBuilder builder() {
     return new BaseProcedure.Builder<RegisterTableProcedure>() {
       @Override
       protected RegisterTableProcedure doBuild() {
-        return new RegisterTableProcedure(tableCatalog());
+        return new RegisterTableProcedure(catalog());
       }
     };
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -27,13 +27,13 @@ import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.actions.DeleteOrphanFilesSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -75,12 +75,12 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<RemoveOrphanFilesProcedure>() {
       @Override
       protected RemoveOrphanFilesProcedure doBuild() {
-        return new RemoveOrphanFilesProcedure(tableCatalog());
+        return new RemoveOrphanFilesProcedure(catalog());
       }
     };
   }
 
-  private RemoveOrphanFilesProcedure(TableCatalog catalog) {
+  private RemoveOrphanFilesProcedure(BaseCatalog catalog) {
     super(catalog);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
@@ -29,11 +29,11 @@ import org.apache.iceberg.expressions.NamedReference;
 import org.apache.iceberg.expressions.Zorder;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.ExtendedParser;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -80,12 +80,12 @@ class RewriteDataFilesProcedure extends BaseProcedure {
     return new Builder<RewriteDataFilesProcedure>() {
       @Override
       protected RewriteDataFilesProcedure doBuild() {
-        return new RewriteDataFilesProcedure(tableCatalog());
+        return new RewriteDataFilesProcedure(catalog());
       }
     };
   }
 
-  private RewriteDataFilesProcedure(TableCatalog tableCatalog) {
+  private RewriteDataFilesProcedure(BaseCatalog tableCatalog) {
     super(tableCatalog);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -21,12 +21,12 @@ package org.apache.iceberg.spark.procedures;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.actions.RewriteManifestsSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -63,13 +63,13 @@ class RewriteManifestsProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<RewriteManifestsProcedure>() {
       @Override
       protected RewriteManifestsProcedure doBuild() {
-        return new RewriteManifestsProcedure(tableCatalog());
+        return new RewriteManifestsProcedure(catalog());
       }
     };
   }
 
-  private RewriteManifestsProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private RewriteManifestsProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewritePositionDeleteFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewritePositionDeleteFilesProcedure.java
@@ -24,9 +24,9 @@ import org.apache.iceberg.actions.RewritePositionDeleteFiles;
 import org.apache.iceberg.actions.RewritePositionDeleteFiles.Result;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -65,13 +65,13 @@ public class RewritePositionDeleteFilesProcedure extends BaseProcedure {
     return new Builder<RewritePositionDeleteFilesProcedure>() {
       @Override
       protected RewritePositionDeleteFilesProcedure doBuild() {
-        return new RewritePositionDeleteFilesProcedure(tableCatalog());
+        return new RewritePositionDeleteFilesProcedure(catalog());
       }
     };
   }
 
-  private RewritePositionDeleteFilesProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private RewritePositionDeleteFilesProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToSnapshotProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToSnapshotProcedure.java
@@ -19,10 +19,10 @@
 package org.apache.iceberg.spark.procedures;
 
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -56,13 +56,13 @@ class RollbackToSnapshotProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<RollbackToSnapshotProcedure>() {
       @Override
       public RollbackToSnapshotProcedure doBuild() {
-        return new RollbackToSnapshotProcedure(tableCatalog());
+        return new RollbackToSnapshotProcedure(catalog());
       }
     };
   }
 
-  private RollbackToSnapshotProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private RollbackToSnapshotProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
@@ -19,11 +19,11 @@
 package org.apache.iceberg.spark.procedures;
 
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -57,12 +57,12 @@ class RollbackToTimestampProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<RollbackToTimestampProcedure>() {
       @Override
       protected RollbackToTimestampProcedure doBuild() {
-        return new RollbackToTimestampProcedure(tableCatalog());
+        return new RollbackToTimestampProcedure(catalog());
       }
     };
   }
 
-  private RollbackToTimestampProcedure(TableCatalog catalog) {
+  private RollbackToTimestampProcedure(BaseCatalog catalog) {
     super(catalog);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SetCurrentSnapshotProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SetCurrentSnapshotProcedure.java
@@ -23,10 +23,10 @@ import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -61,12 +61,12 @@ class SetCurrentSnapshotProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<SetCurrentSnapshotProcedure>() {
       @Override
       protected SetCurrentSnapshotProcedure doBuild() {
-        return new SetCurrentSnapshotProcedure(tableCatalog());
+        return new SetCurrentSnapshotProcedure(catalog());
       }
     };
   }
 
-  private SetCurrentSnapshotProcedure(TableCatalog catalog) {
+  private SetCurrentSnapshotProcedure(BaseCatalog catalog) {
     super(catalog);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
@@ -22,9 +22,9 @@ import java.util.Map;
 import org.apache.iceberg.actions.SnapshotTable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -48,15 +48,15 @@ class SnapshotTableProcedure extends BaseProcedure {
             new StructField("imported_files_count", DataTypes.LongType, false, Metadata.empty())
           });
 
-  private SnapshotTableProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private SnapshotTableProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   public static SparkProcedures.ProcedureBuilder builder() {
     return new BaseProcedure.Builder<SnapshotTableProcedure>() {
       @Override
       protected SnapshotTableProcedure doBuild() {
-        return new SnapshotTableProcedure(tableCatalog());
+        return new SnapshotTableProcedure(catalog());
       }
     };
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -22,7 +22,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.Procedure;
 
 public class SparkProcedures {
@@ -60,7 +60,7 @@ public class SparkProcedures {
   }
 
   public interface ProcedureBuilder {
-    ProcedureBuilder withTableCatalog(TableCatalog tableCatalog);
+    ProcedureBuilder withCatalog(BaseCatalog catalog);
 
     Procedure build();
   }


### PR DESCRIPTION
Would like to add some procedures for Iceberg views and the current framework doesn't support it. 
Hence, the refactor. 