### PR TITLE
Spark-3.5: Procedure to add view dialect

### DIFF
--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ViewUtil.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ViewUtil.scala
@@ -19,6 +19,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
+import org.apache.iceberg.spark.SparkSessionCatalog
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.catalog.View
@@ -37,7 +38,8 @@ object ViewUtil {
   }
 
   def isViewCatalog(catalog: CatalogPlugin): Boolean = {
-    catalog.isInstanceOf[ViewCatalog]
+    // Spark session catalog doesn't support the views yet.
+    catalog.isInstanceOf[ViewCatalog] && !catalog.isInstanceOf[SparkSessionCatalog[_]]
   }
 
   implicit class IcebergViewHelper(plugin: CatalogPlugin) {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddViewDialectProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddViewDialectProcedure.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
+import org.apache.iceberg.view.View;
+import org.apache.iceberg.view.ViewRepresentation;
+import org.apache.iceberg.view.ViewVersion;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestAddViewDialectProcedure extends ExtensionsTestBase {
+  private static final Namespace NAMESPACE = Namespace.of("default");
+  private static final String VIEW_NAME = "view_year";
+  private static final TableIdentifier VIEW_IDENTIFIER = TableIdentifier.of(NAMESPACE, VIEW_NAME);
+
+  @BeforeEach
+  public void before() {
+    super.before();
+    spark.conf().set("spark.sql.defaultCatalog", catalogName);
+    sql("USE %s", catalogName);
+    sql("CREATE NAMESPACE IF NOT EXISTS %s", NAMESPACE);
+  }
+
+  @AfterEach
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP VIEW IF EXISTS %s", VIEW_NAME);
+  }
+
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.SPARK_WITH_VIEWS.catalogName(),
+        SparkCatalogConfig.SPARK_WITH_VIEWS.implementation(),
+        SparkCatalogConfig.SPARK_WITH_VIEWS.properties()
+      }
+    };
+  }
+
+  private ViewCatalog viewCatalog() {
+    Catalog icebergCatalog = Spark3Util.loadIcebergCatalog(spark, catalogName);
+    assertThat(icebergCatalog).isInstanceOf(ViewCatalog.class);
+    return (ViewCatalog) icebergCatalog;
+  }
+
+  @TestTemplate
+  public void testAddNewViewDialect() {
+    String sparkViewSQL =
+        String.format("SELECT * FROM %s WHERE year(order_date) = year(current_date())", tableName);
+    ViewRepresentation sparkRep =
+        ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sparkViewSQL).build();
+
+    String trinoViewSQL =
+        String.format(
+            "SELECT * FROM %s WHERE extract(year FROM order_date) = extract(year FROM current_date))",
+            tableName);
+    ViewRepresentation trinoRep =
+        ImmutableSQLViewRepresentation.builder().dialect("trino").sql(trinoViewSQL).build();
+
+    sql("CREATE TABLE %s (order_id int NOT NULL, order_date date) USING iceberg", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, DATE '2024-10-08')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, DATE '2025-10-08')", tableName);
+
+    sql("CREATE VIEW %s AS %s", VIEW_NAME, sparkViewSQL);
+
+    ViewCatalog viewCatalog = viewCatalog();
+    View view = viewCatalog.loadView(VIEW_IDENTIFIER);
+    int oldVersion = view.currentVersion().versionId();
+    assertThat(view.currentVersion().representations()).containsExactly(sparkRep);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.add_view_dialect('%s', '%s', '%s')",
+            catalogName, VIEW_IDENTIFIER, "trino", trinoViewSQL);
+
+    ViewVersion newVersion = viewCatalog.loadView(VIEW_IDENTIFIER).currentVersion();
+    assertThat(output).containsExactly(new Object[] {newVersion.versionId()});
+    assertThat(newVersion.versionId()).isNotEqualTo(oldVersion);
+    assertThat(newVersion.representations()).containsExactlyInAnyOrder(sparkRep, trinoRep);
+
+    // test adding multiple SQL for same dialect
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.add_view_dialect('%s', '%s', '%s')",
+                    catalogName, VIEW_IDENTIFIER, "spark", "another sql"))
+        .hasMessageContaining("Invalid view version: Cannot add multiple queries for dialect spark")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @TestTemplate
+  public void testInvalidArgs() {
+    String sparkViewSQL =
+        String.format("SELECT * FROM %s WHERE year(order_date) = year(current_date())", tableName);
+
+    sql("CREATE TABLE %s (order_id int NOT NULL, order_date date) USING iceberg", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, DATE '2024-10-08')", tableName);
+
+    sql("CREATE VIEW %s AS %s", VIEW_NAME, sparkViewSQL);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.add_view_dialect('%s', '%s', '%s')",
+                    catalogName, VIEW_IDENTIFIER + "_invalid", "trino", "foo"))
+        .hasMessageContaining(
+            "Couldn't load view 'default.view_year_invalid' in catalog 'spark_with_views'")
+        .isInstanceOf(RuntimeException.class);
+
+    assertThatThrownBy(
+            () ->
+                sql("CALL %s.system.add_view_dialect('', '%s', '%s')", catalogName, "trino", "foo"))
+        .hasMessageContaining("Cannot handle an empty identifier for argument view")
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.add_view_dialect('%s', '', '%s')",
+                    catalogName, VIEW_IDENTIFIER, "foo"))
+        .hasMessageContaining("dialect should not be empty")
+        .isInstanceOf(RuntimeException.class);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.add_view_dialect('%s', '%s', '')",
+                    catalogName, VIEW_IDENTIFIER, "foo"))
+        .hasMessageContaining("sql should not be empty")
+        .isInstanceOf(RuntimeException.class);
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/BaseCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/BaseCatalog.java
@@ -30,12 +30,14 @@ import org.apache.spark.sql.connector.iceberg.catalog.Procedure;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureCatalog;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
-abstract class BaseCatalog
+public abstract class BaseCatalog
     implements StagingTableCatalog,
         ProcedureCatalog,
         SupportsNamespaces,
         HasIcebergCatalog,
-        SupportsFunctions {
+        SupportsFunctions,
+        org.apache.spark.sql.connector.catalog.ViewCatalog,
+        SupportsReplaceView {
   private static final String USE_NULLABLE_QUERY_SCHEMA_CTAS_RTAS = "use-nullable-query-schema";
   private static final boolean USE_NULLABLE_QUERY_SCHEMA_CTAS_RTAS_DEFAULT = true;
 
@@ -51,7 +53,7 @@ abstract class BaseCatalog
     if (isSystemNamespace(namespace)) {
       ProcedureBuilder builder = SparkProcedures.newBuilder(name);
       if (builder != null) {
-        return builder.withTableCatalog(this).build();
+        return builder.withCatalog(this).build();
       }
     }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -120,8 +120,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *
  * <p>
  */
-public class SparkCatalog extends BaseCatalog
-    implements org.apache.spark.sql.connector.catalog.ViewCatalog, SupportsReplaceView {
+public class SparkCatalog extends BaseCatalog {
   private static final Set<String> DEFAULT_NS_KEYS = ImmutableSet.of(TableCatalog.PROP_OWNER);
   private static final Splitter COMMA = Splitter.on(",");
   private static final Joiner COMMA_JOINER = Joiner.on(",");

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -31,8 +31,10 @@ import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchFunctionException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchViewException;
 import org.apache.spark.sql.catalyst.analysis.NonEmptyNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
+import org.apache.spark.sql.catalyst.analysis.ViewAlreadyExistsException;
 import org.apache.spark.sql.connector.catalog.CatalogExtension;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.connector.catalog.FunctionCatalog;
@@ -44,6 +46,8 @@ import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.catalog.TableChange;
+import org.apache.spark.sql.connector.catalog.View;
+import org.apache.spark.sql.connector.catalog.ViewChange;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructType;
@@ -396,5 +400,62 @@ public class SparkSessionCatalog<T extends TableCatalog & FunctionCatalog & Supp
     } catch (NoSuchFunctionException e) {
       return getSessionCatalog().loadFunction(ident);
     }
+  }
+
+  @Override
+  public View replaceView(
+      Identifier ident,
+      String sql,
+      String currentCatalog,
+      String[] currentNamespace,
+      StructType schema,
+      String[] queryColumnNames,
+      String[] columnAliases,
+      String[] columnComments,
+      Map<String, String> properties)
+      throws NoSuchViewException, NoSuchNamespaceException {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
+  }
+
+  @Override
+  public Identifier[] listViews(String... namespace) throws NoSuchNamespaceException {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
+  }
+
+  @Override
+  public View loadView(Identifier ident) throws NoSuchViewException {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
+  }
+
+  @Override
+  public View createView(
+      Identifier ident,
+      String sql,
+      String currentCatalog,
+      String[] currentNamespace,
+      StructType schema,
+      String[] queryColumnNames,
+      String[] columnAliases,
+      String[] columnComments,
+      Map<String, String> properties)
+      throws ViewAlreadyExistsException, NoSuchNamespaceException {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
+  }
+
+  @Override
+  public View alterView(Identifier ident, ViewChange... changes)
+      throws NoSuchViewException, IllegalArgumentException {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
+  }
+
+  @Override
+  public boolean dropView(Identifier ident) {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
+  }
+
+  @Override
+  public void renameView(Identifier oldIdent, Identifier newIdent)
+      throws NoSuchViewException, ViewAlreadyExistsException {
+    throw new UnsupportedOperationException("SessionCatalog doesn't support views");
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
@@ -45,7 +46,6 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -82,15 +82,15 @@ class AddFilesProcedure extends BaseProcedure {
             new StructField("changed_partition_count", DataTypes.LongType, true, Metadata.empty()),
           });
 
-  private AddFilesProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private AddFilesProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   public static SparkProcedures.ProcedureBuilder builder() {
     return new BaseProcedure.Builder<AddFilesProcedure>() {
       @Override
       protected AddFilesProcedure doBuild() {
-        return new AddFilesProcedure(tableCatalog());
+        return new AddFilesProcedure(catalog());
       }
     };
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AddViewDialectProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AddViewDialectProcedure.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.procedures;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.BaseCatalog;
+import org.apache.iceberg.view.ReplaceViewVersion;
+import org.apache.iceberg.view.SQLViewRepresentation;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+public class AddViewDialectProcedure extends BaseProcedure {
+
+  private static final ProcedureParameter[] PARAMETERS =
+      new ProcedureParameter[] {
+        ProcedureParameter.required("view", DataTypes.StringType),
+        ProcedureParameter.required("dialect", DataTypes.StringType),
+        ProcedureParameter.required("sql", DataTypes.StringType)
+      };
+
+  private static final StructType OUTPUT_TYPE =
+      new StructType(
+          new StructField[] {
+            new StructField("updated_version_id", DataTypes.IntegerType, true, Metadata.empty()),
+          });
+
+  public static SparkProcedures.ProcedureBuilder builder() {
+    return new Builder<AddViewDialectProcedure>() {
+      @Override
+      protected AddViewDialectProcedure doBuild() {
+        return new AddViewDialectProcedure(catalog());
+      }
+    };
+  }
+
+  private AddViewDialectProcedure(BaseCatalog catalog) {
+    super(catalog);
+  }
+
+  @Override
+  public ProcedureParameter[] parameters() {
+    return PARAMETERS;
+  }
+
+  @Override
+  public StructType outputType() {
+    return OUTPUT_TYPE;
+  }
+
+  @Override
+  public InternalRow[] call(InternalRow args) {
+    Identifier viewIdentifier = toIdentifier(args.getString(0), PARAMETERS[0].name());
+    String dialect = args.getString(1);
+    String sql = args.getString(2);
+
+    Preconditions.checkArgument(!dialect.isEmpty(), "dialect should not be empty");
+    Preconditions.checkArgument(!sql.isEmpty(), "sql should not be empty");
+
+    return withIcebergView(
+        viewIdentifier,
+        view -> {
+          ReplaceViewVersion replaceViewVersion = view.replaceVersion();
+          replaceViewVersion
+              .withSchema(view.schema())
+              .withDefaultNamespace(view.currentVersion().defaultNamespace());
+
+          // retain old representations
+          view.currentVersion()
+              .representations()
+              .forEach(
+                  representation -> {
+                    SQLViewRepresentation viewRepresentation =
+                        (SQLViewRepresentation) representation;
+                    replaceViewVersion.withQuery(
+                        viewRepresentation.dialect(), viewRepresentation.sql());
+                  });
+
+          // add new representation
+          replaceViewVersion.withQuery(dialect, sql).commit();
+
+          InternalRow outputRow = newInternalRow(view.currentVersion().versionId());
+          return new InternalRow[] {outputRow};
+        });
+  }
+
+  @Override
+  public String description() {
+    return "AddViewDialectProcedure";
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AncestorsOfProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AncestorsOfProcedure.java
@@ -21,11 +21,11 @@ package org.apache.iceberg.spark.procedures;
 import java.util.List;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -49,15 +49,15 @@ public class AncestorsOfProcedure extends BaseProcedure {
             new StructField("timestamp", DataTypes.LongType, true, Metadata.empty())
           });
 
-  private AncestorsOfProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private AncestorsOfProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   public static SparkProcedures.ProcedureBuilder builder() {
     return new Builder<AncestorsOfProcedure>() {
       @Override
       protected AncestorsOfProcedure doBuild() {
-        return new AncestorsOfProcedure(tableCatalog());
+        return new AncestorsOfProcedure(catalog());
       }
     };
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/CherrypickSnapshotProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/CherrypickSnapshotProcedure.java
@@ -19,10 +19,10 @@
 package org.apache.iceberg.spark.procedures;
 
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -57,12 +57,12 @@ class CherrypickSnapshotProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<CherrypickSnapshotProcedure>() {
       @Override
       protected CherrypickSnapshotProcedure doBuild() {
-        return new CherrypickSnapshotProcedure(tableCatalog());
+        return new CherrypickSnapshotProcedure(catalog());
       }
     };
   }
 
-  private CherrypickSnapshotProcedure(TableCatalog catalog) {
+  private CherrypickSnapshotProcedure(BaseCatalog catalog) {
     super(catalog);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/CreateChangelogViewProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/CreateChangelogViewProcedure.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.ChangelogIterator;
 import org.apache.iceberg.spark.source.SparkChangelogTable;
 import org.apache.spark.api.java.function.MapPartitionsFunction;
@@ -40,7 +41,6 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.OrderUtils;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -118,13 +118,13 @@ public class CreateChangelogViewProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<CreateChangelogViewProcedure>() {
       @Override
       protected CreateChangelogViewProcedure doBuild() {
-        return new CreateChangelogViewProcedure(tableCatalog());
+        return new CreateChangelogViewProcedure(catalog());
       }
     };
   }
 
-  private CreateChangelogViewProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private CreateChangelogViewProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -22,13 +22,13 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ExpireSnapshots;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.actions.ExpireSnapshotsSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -76,13 +76,13 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<ExpireSnapshotsProcedure>() {
       @Override
       protected ExpireSnapshotsProcedure doBuild() {
-        return new ExpireSnapshotsProcedure(tableCatalog());
+        return new ExpireSnapshotsProcedure(catalog());
       }
     };
   }
 
-  private ExpireSnapshotsProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private ExpireSnapshotsProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
@@ -18,9 +18,9 @@
  */
 package org.apache.iceberg.spark.procedures;
 
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -49,13 +49,13 @@ public class FastForwardBranchProcedure extends BaseProcedure {
     return new Builder<FastForwardBranchProcedure>() {
       @Override
       protected FastForwardBranchProcedure doBuild() {
-        return new FastForwardBranchProcedure(tableCatalog());
+        return new FastForwardBranchProcedure(catalog());
       }
     };
   }
 
-  private FastForwardBranchProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private FastForwardBranchProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
@@ -22,11 +22,11 @@ import java.util.Map;
 import org.apache.iceberg.actions.MigrateTable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.actions.MigrateTableSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -50,15 +50,15 @@ class MigrateTableProcedure extends BaseProcedure {
             new StructField("migrated_files_count", DataTypes.LongType, false, Metadata.empty())
           });
 
-  private MigrateTableProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private MigrateTableProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   public static ProcedureBuilder builder() {
     return new BaseProcedure.Builder<MigrateTableProcedure>() {
       @Override
       protected MigrateTableProcedure doBuild() {
-        return new MigrateTableProcedure(tableCatalog());
+        return new MigrateTableProcedure(catalog());
       }
     };
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/PublishChangesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/PublishChangesProcedure.java
@@ -22,11 +22,11 @@ import java.util.Optional;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.util.WapUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -61,12 +61,12 @@ class PublishChangesProcedure extends BaseProcedure {
     return new Builder<PublishChangesProcedure>() {
       @Override
       protected PublishChangesProcedure doBuild() {
-        return new PublishChangesProcedure(tableCatalog());
+        return new PublishChangesProcedure(catalog());
       }
     };
   }
 
-  private PublishChangesProcedure(TableCatalog catalog) {
+  private PublishChangesProcedure(BaseCatalog catalog) {
     super(catalog);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RegisterTableProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RegisterTableProcedure.java
@@ -24,11 +24,11 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.spark.source.HasIcebergCatalog;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -50,15 +50,15 @@ class RegisterTableProcedure extends BaseProcedure {
             new StructField("total_data_files_count", DataTypes.LongType, true, Metadata.empty())
           });
 
-  private RegisterTableProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private RegisterTableProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   public static ProcedureBuilder builder() {
     return new BaseProcedure.Builder<RegisterTableProcedure>() {
       @Override
       protected RegisterTableProcedure doBuild() {
-        return new RegisterTableProcedure(tableCatalog());
+        return new RegisterTableProcedure(catalog());
       }
     };
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -27,13 +27,13 @@ import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.actions.DeleteOrphanFilesSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -75,12 +75,12 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<RemoveOrphanFilesProcedure>() {
       @Override
       protected RemoveOrphanFilesProcedure doBuild() {
-        return new RemoveOrphanFilesProcedure(tableCatalog());
+        return new RemoveOrphanFilesProcedure(catalog());
       }
     };
   }
 
-  private RemoveOrphanFilesProcedure(TableCatalog catalog) {
+  private RemoveOrphanFilesProcedure(BaseCatalog catalog) {
     super(catalog);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
@@ -29,11 +29,11 @@ import org.apache.iceberg.expressions.NamedReference;
 import org.apache.iceberg.expressions.Zorder;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.ExtendedParser;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -80,12 +80,12 @@ class RewriteDataFilesProcedure extends BaseProcedure {
     return new Builder<RewriteDataFilesProcedure>() {
       @Override
       protected RewriteDataFilesProcedure doBuild() {
-        return new RewriteDataFilesProcedure(tableCatalog());
+        return new RewriteDataFilesProcedure(catalog());
       }
     };
   }
 
-  private RewriteDataFilesProcedure(TableCatalog tableCatalog) {
+  private RewriteDataFilesProcedure(BaseCatalog tableCatalog) {
     super(tableCatalog);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -21,12 +21,12 @@ package org.apache.iceberg.spark.procedures;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.actions.RewriteManifestsSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -63,13 +63,13 @@ class RewriteManifestsProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<RewriteManifestsProcedure>() {
       @Override
       protected RewriteManifestsProcedure doBuild() {
-        return new RewriteManifestsProcedure(tableCatalog());
+        return new RewriteManifestsProcedure(catalog());
       }
     };
   }
 
-  private RewriteManifestsProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private RewriteManifestsProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewritePositionDeleteFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewritePositionDeleteFilesProcedure.java
@@ -24,9 +24,9 @@ import org.apache.iceberg.actions.RewritePositionDeleteFiles;
 import org.apache.iceberg.actions.RewritePositionDeleteFiles.Result;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -65,13 +65,13 @@ public class RewritePositionDeleteFilesProcedure extends BaseProcedure {
     return new Builder<RewritePositionDeleteFilesProcedure>() {
       @Override
       protected RewritePositionDeleteFilesProcedure doBuild() {
-        return new RewritePositionDeleteFilesProcedure(tableCatalog());
+        return new RewritePositionDeleteFilesProcedure(catalog());
       }
     };
   }
 
-  private RewritePositionDeleteFilesProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private RewritePositionDeleteFilesProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToSnapshotProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToSnapshotProcedure.java
@@ -19,10 +19,10 @@
 package org.apache.iceberg.spark.procedures;
 
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -56,13 +56,13 @@ class RollbackToSnapshotProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<RollbackToSnapshotProcedure>() {
       @Override
       public RollbackToSnapshotProcedure doBuild() {
-        return new RollbackToSnapshotProcedure(tableCatalog());
+        return new RollbackToSnapshotProcedure(catalog());
       }
     };
   }
 
-  private RollbackToSnapshotProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private RollbackToSnapshotProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
@@ -19,11 +19,11 @@
 package org.apache.iceberg.spark.procedures;
 
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -57,12 +57,12 @@ class RollbackToTimestampProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<RollbackToTimestampProcedure>() {
       @Override
       protected RollbackToTimestampProcedure doBuild() {
-        return new RollbackToTimestampProcedure(tableCatalog());
+        return new RollbackToTimestampProcedure(catalog());
       }
     };
   }
 
-  private RollbackToTimestampProcedure(TableCatalog catalog) {
+  private RollbackToTimestampProcedure(BaseCatalog catalog) {
     super(catalog);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SetCurrentSnapshotProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SetCurrentSnapshotProcedure.java
@@ -23,10 +23,10 @@ import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -61,12 +61,12 @@ class SetCurrentSnapshotProcedure extends BaseProcedure {
     return new BaseProcedure.Builder<SetCurrentSnapshotProcedure>() {
       @Override
       protected SetCurrentSnapshotProcedure doBuild() {
-        return new SetCurrentSnapshotProcedure(tableCatalog());
+        return new SetCurrentSnapshotProcedure(catalog());
       }
     };
   }
 
-  private SetCurrentSnapshotProcedure(TableCatalog catalog) {
+  private SetCurrentSnapshotProcedure(BaseCatalog catalog) {
     super(catalog);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
@@ -22,9 +22,9 @@ import java.util.Map;
 import org.apache.iceberg.actions.SnapshotTable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -48,15 +48,15 @@ class SnapshotTableProcedure extends BaseProcedure {
             new StructField("imported_files_count", DataTypes.LongType, false, Metadata.empty())
           });
 
-  private SnapshotTableProcedure(TableCatalog tableCatalog) {
-    super(tableCatalog);
+  private SnapshotTableProcedure(BaseCatalog catalog) {
+    super(catalog);
   }
 
   public static SparkProcedures.ProcedureBuilder builder() {
     return new BaseProcedure.Builder<SnapshotTableProcedure>() {
       @Override
       protected SnapshotTableProcedure doBuild() {
-        return new SnapshotTableProcedure(tableCatalog());
+        return new SnapshotTableProcedure(catalog());
       }
     };
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -56,6 +56,7 @@ public class SparkProcedures {
     mapBuilder.put("create_changelog_view", CreateChangelogViewProcedure::builder);
     mapBuilder.put("rewrite_position_delete_files", RewritePositionDeleteFilesProcedure::builder);
     mapBuilder.put("fast_forward", FastForwardBranchProcedure::builder);
+    mapBuilder.put("add_view_dialect", AddViewDialectProcedure::builder);
     return mapBuilder.build();
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -22,7 +22,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.iceberg.spark.BaseCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.Procedure;
 
 public class SparkProcedures {
@@ -60,7 +60,7 @@ public class SparkProcedures {
   }
 
   public interface ProcedureBuilder {
-    ProcedureBuilder withTableCatalog(TableCatalog tableCatalog);
+    ProcedureBuilder withCatalog(BaseCatalog catalog);
 
     Procedure build();
   }


### PR DESCRIPTION
Depends on https://github.com/apache/iceberg/pull/11326

Currently the Iceberg views are not interoperable. The views written by one engine cannot be understood by another because it cannot understand the dialect. 

Hence, SQL users need a manual way to add other engine's dialect. So, atleast the views can be interoperable from other engines. 

In future we need an automatic way of converting dialects in Iceberg. Until then, users can use this procedure. 