### PR TITLE
Reset Spark Conf for each test in TestCompressionSettings

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
@@ -267,12 +267,14 @@ public class TestCompressionSettings extends CatalogTestBase {
   private void assertSparkConf() {
     assertThat(spark.conf().get(COMPRESSION_CODEC))
         .isEqualToIgnoringCase(properties.get(COMPRESSION_CODEC));
+
     if (properties.get(COMPRESSION_LEVEL) != null) {
       assertThat(spark.conf().get(COMPRESSION_LEVEL))
           .isEqualToIgnoringCase(properties.get(COMPRESSION_LEVEL));
     } else {
       assertThat(spark.conf().contains(COMPRESSION_LEVEL)).isFalse();
     }
+
     if (properties.get(COMPRESSION_STRATEGY) != null) {
       assertThat(spark.conf().get(COMPRESSION_STRATEGY))
           .isEqualToIgnoringCase(properties.get(COMPRESSION_STRATEGY));

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
@@ -265,21 +265,11 @@ public class TestCompressionSettings extends CatalogTestBase {
   }
 
   private void assertSparkConf() {
-    assertThat(spark.conf().get(COMPRESSION_CODEC))
-        .isEqualToIgnoringCase(properties.get(COMPRESSION_CODEC));
-
-    if (properties.get(COMPRESSION_LEVEL) != null) {
-      assertThat(spark.conf().get(COMPRESSION_LEVEL))
-          .isEqualToIgnoringCase(properties.get(COMPRESSION_LEVEL));
-    } else {
-      assertThat(spark.conf().contains(COMPRESSION_LEVEL)).isFalse();
-    }
-
-    if (properties.get(COMPRESSION_STRATEGY) != null) {
-      assertThat(spark.conf().get(COMPRESSION_STRATEGY))
-          .isEqualToIgnoringCase(properties.get(COMPRESSION_STRATEGY));
-    } else {
-      assertThat(spark.conf().contains(COMPRESSION_STRATEGY)).isFalse();
+    String[] propertiesToCheck = {COMPRESSION_CODEC, COMPRESSION_LEVEL, COMPRESSION_STRATEGY};
+    for (String prop : propertiesToCheck) {
+      String expected = properties.getOrDefault(prop, null);
+      String actual = spark.conf().get(prop, null);
+      assertThat(actual).isEqualToIgnoringCase(expected);
     }
   }
 }


### PR DESCRIPTION
When running `TestCompressionSettings#testWriteDataWithDifferentSetting()`, we want to reset the Spark configuration between tests to ensure that previous settings do not influence subsequent ones. For instance, consider the following scenarios:
The first configuration uses:
```
ImmutableMap.of(COMPRESSION_CODEC, "zstd", COMPRESSION_LEVEL, "1")
```
The second configuration uses:
```
ImmutableMap.of(COMPRESSION_CODEC, "gzip")
```
Currently, the configuration does not reset, so the second setting unexpectedly retains the `COMPRESSION_LEVEL` from the first setting, resulting in `COMPRESSION_CODEC, "gzip", COMPRESSION_LEVEL, "1"`. This can lead to unexpected behavior.