### PR TITLE
Add optional Glue Schema configuration to exclude Non-Current Fields

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java openjdk-21

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -98,6 +98,11 @@ public class AwsProperties implements Serializable {
    */
   public static final String GLUE_CATALOG_ENDPOINT = "glue.endpoint";
 
+  /** Option to disable including non-current fields in Glue Schema */
+  public static final String GLUE_NON_CURRENT_FIELDS_DISABLED = "glue.non-current-fields-disabled";
+
+  public static final boolean GLUE_NON_CURRENT_FIELDS_DISABLED_DEFAULT = false;
+
   /** Configure an alternative endpoint of the DynamoDB service to access. */
   public static final String DYNAMODB_ENDPOINT = "dynamodb.endpoint";
 
@@ -221,6 +226,7 @@ public class AwsProperties implements Serializable {
   private boolean glueCatalogSkipArchive;
   private boolean glueCatalogSkipNameValidation;
   private boolean glueLakeFormationEnabled;
+  private boolean glueNonCurrentFieldsDisabled;
 
   private String dynamoDbTableName;
   private final String dynamoDbEndpoint;
@@ -247,6 +253,7 @@ public class AwsProperties implements Serializable {
     this.glueCatalogSkipArchive = GLUE_CATALOG_SKIP_ARCHIVE_DEFAULT;
     this.glueCatalogSkipNameValidation = GLUE_CATALOG_SKIP_NAME_VALIDATION_DEFAULT;
     this.glueLakeFormationEnabled = GLUE_LAKEFORMATION_ENABLED_DEFAULT;
+    this.glueNonCurrentFieldsDisabled = GLUE_NON_CURRENT_FIELDS_DISABLED_DEFAULT;
 
     this.dynamoDbEndpoint = null;
     this.dynamoDbTableName = DYNAMODB_TABLE_NAME_DEFAULT;
@@ -283,6 +290,9 @@ public class AwsProperties implements Serializable {
     this.glueLakeFormationEnabled =
         PropertyUtil.propertyAsBoolean(
             properties, GLUE_LAKEFORMATION_ENABLED, GLUE_LAKEFORMATION_ENABLED_DEFAULT);
+    this.glueNonCurrentFieldsDisabled =
+        PropertyUtil.propertyAsBoolean(
+            properties, GLUE_NON_CURRENT_FIELDS_DISABLED, GLUE_NON_CURRENT_FIELDS_DISABLED_DEFAULT);
 
     this.dynamoDbEndpoint = properties.get(DYNAMODB_ENDPOINT);
     this.dynamoDbTableName =
@@ -349,6 +359,14 @@ public class AwsProperties implements Serializable {
 
   public void setGlueLakeFormationEnabled(boolean glueLakeFormationEnabled) {
     this.glueLakeFormationEnabled = glueLakeFormationEnabled;
+  }
+
+  public boolean glueNonCurrentFieldsDisabled() {
+    return glueNonCurrentFieldsDisabled;
+  }
+
+  public void setGlueNonCurrentFieldsDisabled(boolean glueNonCurrentFieldsDisabled) {
+    this.glueNonCurrentFieldsDisabled = glueNonCurrentFieldsDisabled;
   }
 
   public String dynamoDbTableName() {

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -319,7 +319,10 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
                       .applyMutation(
                           builder ->
                               IcebergToGlueConverter.setTableInputInformation(
-                                  builder, metadata, glueTable))
+                                  builder,
+                                  metadata,
+                                  glueTable,
+                                  awsProperties.glueNonCurrentFieldsDisabled()))
                       .name(tableName)
                       .tableType(GLUE_EXTERNAL_TABLE_TYPE)
                       .parameters(parameters)
@@ -341,7 +344,8 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
                   TableInput.builder()
                       .applyMutation(
                           builder ->
-                              IcebergToGlueConverter.setTableInputInformation(builder, metadata))
+                              IcebergToGlueConverter.setTableInputInformation(
+                                  builder, metadata, awsProperties.glueNonCurrentFieldsDisabled()))
                       .name(tableName)
                       .tableType(GLUE_EXTERNAL_TABLE_TYPE)
                       .parameters(parameters)

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
@@ -173,7 +173,7 @@ public class TestIcebergToGlueConverter {
         PartitionSpec.builderFor(schema).identity("x").withSpecId(1000).build();
     TableMetadata tableMetadata =
         TableMetadata.newTableMetadata(schema, partitionSpec, "s3://test", tableLocationProperties);
-    IcebergToGlueConverter.setTableInputInformation(actualTableInputBuilder, tableMetadata);
+    IcebergToGlueConverter.setTableInputInformation(actualTableInputBuilder, tableMetadata, false);
     TableInput actualTableInput = actualTableInputBuilder.build();
 
     // Expected TableInput
@@ -239,7 +239,7 @@ public class TestIcebergToGlueConverter {
     Schema newSchema =
         new Schema(Types.NestedField.required(1, "x", Types.StringType.get(), "comment1"));
     tableMetadata = tableMetadata.updateSchema(newSchema, 3);
-    IcebergToGlueConverter.setTableInputInformation(actualTableInputBuilder, tableMetadata);
+    IcebergToGlueConverter.setTableInputInformation(actualTableInputBuilder, tableMetadata, false);
     TableInput actualTableInput = actualTableInputBuilder.build();
 
     // Expected TableInput
@@ -300,7 +300,7 @@ public class TestIcebergToGlueConverter {
         TableMetadata.newTableMetadata(
             schema, PartitionSpec.unpartitioned(), "s3://test", tableProperties);
 
-    IcebergToGlueConverter.setTableInputInformation(actualTableInputBuilder, tableMetadata);
+    IcebergToGlueConverter.setTableInputInformation(actualTableInputBuilder, tableMetadata, false);
     TableInput actualTableInput = actualTableInputBuilder.build();
 
     assertThat(actualTableInput.description())
@@ -335,7 +335,7 @@ public class TestIcebergToGlueConverter {
             .build();
 
     IcebergToGlueConverter.setTableInputInformation(
-        actualTableInputBuilder, tableMetadata, existingGlueTable);
+        actualTableInputBuilder, tableMetadata, existingGlueTable, false);
     TableInput actualTableInput = actualTableInputBuilder.build();
 
     // Expected TableInput


### PR DESCRIPTION
This PR addresses a feature request for improving the Glue Schema generation process. It introduces a new configuration option that allows users to exclude non-current fields from the Glue Schema, providing clarity and reducing confusion for Athena users who primarily query current data.

In PR #3888, the Glue schema generation was modified to include all historical fields. This was intended to help users recognize previously used columns and avoid duplicating column names. However, in practice, this approach has led to confusion among users (for example, the same issue explained in #7584 ).