### PR TITLE
AWS: Fix S3InputStream retry policy

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.Counter;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.metrics.MetricsContext.Unit;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -242,6 +243,7 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
     }
   }
 
+  @VisibleForTesting
   void resetForRetry() throws IOException {
     openStream(true);
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -69,7 +69,7 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
           .handle(
               ImmutableList.of(
                   SSLException.class, SocketTimeoutException.class, SocketException.class))
-          .onFailure(failure -> openStream(true))
+          .onFailure(failure -> resetForRetry())
           .withMaxRetries(3)
           .build();
 
@@ -228,6 +228,10 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
     } catch (NoSuchKeyException e) {
       throw new NotFoundException(e, "Location does not exist: %s", location);
     }
+  }
+
+  void resetForRetry() throws IOException {
+    openStream(true);
   }
 
   private void closeStream(boolean closeQuietly) throws IOException {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -71,7 +71,14 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
   private RetryPolicy<Object> retryPolicy =
       RetryPolicy.builder()
           .handle(RETRYABLE_EXCEPTIONS)
-          .onRetry(failure -> resetForRetry())
+          .onRetry(
+              failure -> {
+                LOG.warn(
+                    "Retrying read from S3, reopening stream (attempt {})",
+                    failure.getAttemptCount());
+                resetForRetry();
+              })
+          .onFailure(e -> LOG.error("Failed to read from S3 after retry policy", e.getException()))
           .withMaxRetries(3)
           .build();
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -77,7 +77,11 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
                     "Retrying read from S3, reopening stream (attempt {})", e.getAttemptCount());
                 resetForRetry();
               })
-          .onFailure(e -> LOG.error("Failed to read from S3 after retry policy", e.getException()))
+          .onFailure(
+              e ->
+                  LOG.error(
+                      "Failed to read from S3 input stream after exhausting all retries",
+                      e.getException()))
           .withMaxRetries(3)
           .build();
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -72,10 +72,9 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
       RetryPolicy.builder()
           .handle(RETRYABLE_EXCEPTIONS)
           .onRetry(
-              failure -> {
+              e -> {
                 LOG.warn(
-                    "Retrying read from S3, reopening stream (attempt {})",
-                    failure.getAttemptCount());
+                    "Retrying read from S3, reopening stream (attempt {})", e.getAttemptCount());
                 resetForRetry();
               })
           .onFailure(e -> LOG.error("Failed to read from S3 after retry policy", e.getException()))

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
@@ -57,6 +57,10 @@ public class TestS3InputStream {
     testRead(s3);
   }
 
+  S3InputStream newInputStream(S3Client s3Client, S3URI uri) {
+    return new S3InputStream(s3Client, uri);
+  }
+
   protected void testRead(S3Client s3Client) throws Exception {
     S3URI uri = new S3URI("s3://bucket/path/to/read.dat");
     int dataSize = 1024 * 1024 * 10;
@@ -64,7 +68,7 @@ public class TestS3InputStream {
 
     writeS3Data(uri, data);
 
-    try (SeekableInputStream in = new S3InputStream(s3Client, uri)) {
+    try (SeekableInputStream in = newInputStream(s3Client, uri)) {
       int readSize = 1024;
       readAndCheck(in, in.getPos(), readSize, data, false);
       readAndCheck(in, in.getPos(), readSize, data, true);
@@ -128,7 +132,7 @@ public class TestS3InputStream {
 
     writeS3Data(uri, expected);
 
-    try (RangeReadable in = new S3InputStream(s3Client, uri)) {
+    try (RangeReadable in = newInputStream(s3Client, uri)) {
       // first 1k
       position = 0;
       offset = 0;
@@ -160,7 +164,7 @@ public class TestS3InputStream {
   @Test
   public void testClose() throws Exception {
     S3URI uri = new S3URI("s3://bucket/path/to/closed.dat");
-    SeekableInputStream closed = new S3InputStream(s3, uri);
+    SeekableInputStream closed = newInputStream(s3, uri);
     closed.close();
     assertThatThrownBy(() -> closed.seek(0))
         .isInstanceOf(IllegalStateException.class)
@@ -178,7 +182,7 @@ public class TestS3InputStream {
 
     writeS3Data(uri, expected);
 
-    try (SeekableInputStream in = new S3InputStream(s3Client, uri)) {
+    try (SeekableInputStream in = newInputStream(s3Client, uri)) {
       in.seek(expected.length / 2);
       byte[] actual = new byte[expected.length / 2];
       IOUtil.readFully(in, actual, 0, expected.length / 2);


### PR DESCRIPTION
The retry policy for `S3InputStream` reads introduced in https://github.com/apache/iceberg/commit/c0d73f4ef5c16401bdfd62e1745faf2fbbf62177 (https://github.com/apache/iceberg/pull/10433) is not actually re-opening the stream on each retry attempt given that it uses `onFailure` which, as per the [documentation](https://failsafe.dev/javadoc/core/dev/failsafe/PolicyBuilder.html#onFailure-dev.failsafe.event.EventListener-), it is triggered after the whole (retry) policy has failed completely and was unable to produce a successful result, i.e. all retries have been exhausted and failed. With the existing implementation, once a stream fails with something like `SSLException` due to a socket connection reset, the retries will keep failing (due to not actually reopening the stream) and therefore this won't work. The `onFailure` call does not work either because by the time `openStream` is called, the retry policy failure has already been propagated, failing the read operation.
The tests also were not testing that the retry policy actually called `openStream(true)` to reset the stream, it only tested that the calls went through the retry policy a given number of times, generally always succeeding on the last one.

This PR fixes the problem by using `onRetry` instead, as per the [documentation](https://failsafe.dev/javadoc/core/dev/failsafe/RetryPolicyBuilder.html#onRetry-dev.failsafe.event.EventListener-), to re-open the stream right before we attempt the read again. Also, it fixes the tests by actually checking that the stream is reset (re-opened).