### PR TITLE
Flink Support for TIMESTAMP_NANOS

### DIFF
--- a/api/src/test/java/org/apache/iceberg/util/RandomUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/RandomUtil.java
@@ -119,6 +119,9 @@ public class RandomUtil {
       case TIMESTAMP:
         return random.nextLong() % FIFTY_YEARS_IN_MICROS;
 
+      case TIMESTAMP_NANO:
+        return random.nextLong() % (FIFTY_YEARS_IN_MICROS * 1000L);
+
       case STRING:
         return randomString(random);
 
@@ -166,6 +169,7 @@ public class RandomUtil {
       case LONG:
       case TIME:
       case TIMESTAMP:
+      case TIMESTAMP_NANO:
         return (long) value;
       case STRING:
         return String.valueOf(value);

--- a/api/src/test/java/org/apache/iceberg/util/RandomUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/RandomUtil.java
@@ -120,7 +120,7 @@ public class RandomUtil {
         return random.nextLong() % FIFTY_YEARS_IN_MICROS;
 
       case TIMESTAMP_NANO:
-        return random.nextLong() % (FIFTY_YEARS_IN_MICROS * 1000L);
+        return random.nextLong() % FIFTY_YEARS_IN_NANOS;
 
       case STRING:
         return randomString(random);
@@ -198,6 +198,7 @@ public class RandomUtil {
 
   private static final long FIFTY_YEARS_IN_MICROS =
       (50L * (365 * 3 + 366) * 24 * 60 * 60 * 1_000_000) / 4;
+  private static final long FIFTY_YEARS_IN_NANOS = FIFTY_YEARS_IN_MICROS * 1000L;
   private static final int ABOUT_380_YEARS_IN_DAYS = 380 * 365;
   private static final long ONE_DAY_IN_MICROS = 24 * 60 * 60 * 1_000_000L;
   private static final String CHARS =

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -154,7 +154,8 @@ public class AvroSchemaUtil {
   public static boolean isTimestamptz(Schema schema) {
     LogicalType logicalType = schema.getLogicalType();
     if (logicalType instanceof LogicalTypes.TimestampMillis
-        || logicalType instanceof LogicalTypes.TimestampMicros) {
+        || logicalType instanceof LogicalTypes.TimestampMicros
+        || logicalType instanceof LogicalTypes.TimestampNanos) {
       // timestamptz is adjusted to UTC
       Object value = schema.getObjectProp(ADJUST_TO_UTC_PROP);
 

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -45,6 +45,12 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
       LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
   private static final Schema TIMESTAMPTZ_SCHEMA =
       LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+
+  private static final Schema TIMESTAMP_NANO_SCHEMA =
+      LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
+  private static final Schema TIMESTAMPTZ_NANO_SCHEMA =
+      LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
+
   private static final Schema STRING_SCHEMA = Schema.create(Schema.Type.STRING);
   private static final Schema UUID_SCHEMA =
       LogicalTypes.uuid().addToSchema(Schema.createFixed("uuid_fixed", null, null, 16));
@@ -53,6 +59,8 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
   static {
     TIMESTAMP_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
     TIMESTAMPTZ_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, true);
+    TIMESTAMP_NANO_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
+    TIMESTAMPTZ_NANO_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, true);
   }
 
   private final Deque<Integer> fieldIds = Lists.newLinkedList();
@@ -211,6 +219,13 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
         break;
       case TIME:
         primitiveSchema = TIME_SCHEMA;
+        break;
+      case TIMESTAMP_NANO:
+        if (((Types.TimestampNanoType) primitive).shouldAdjustToUTC()) {
+          primitiveSchema = TIMESTAMPTZ_NANO_SCHEMA;
+        } else {
+          primitiveSchema = TIMESTAMP_NANO_SCHEMA;
+        }
         break;
       case TIMESTAMP:
         if (((Types.TimestampType) primitive).shouldAdjustToUTC()) {

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
@@ -117,6 +117,11 @@ public class DataWriter<T> implements MetricsAwareDatumWriter<T> {
               return GenericWriters.timestamptz();
             }
             return GenericWriters.timestamps();
+          case "timestamp-nanos":
+            if (AvroSchemaUtil.isTimestamptz(primitive)) {
+              return GenericWriters.timestamptzNano();
+            }
+            return GenericWriters.timestampsNano();
 
           case "decimal":
             LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) logicalType;

--- a/core/src/main/java/org/apache/iceberg/data/avro/GenericWriters.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/GenericWriters.java
@@ -51,6 +51,14 @@ class GenericWriters {
     return TimestamptzWriter.INSTANCE;
   }
 
+  static ValueWriter<LocalDateTime> timestampsNano() {
+    return TimestampNanoWriter.INSTANCE;
+  }
+
+  static ValueWriter<OffsetDateTime> timestamptzNano() {
+    return TimestamptzNanoWriter.INSTANCE;
+  }
+
   static ValueWriter<Record> struct(List<ValueWriter<?>> writers) {
     return new GenericRecordWriter(writers);
   }
@@ -99,6 +107,28 @@ class GenericWriters {
     @Override
     public void write(OffsetDateTime timestamptz, Encoder encoder) throws IOException {
       encoder.writeLong(ChronoUnit.MICROS.between(EPOCH, timestamptz));
+    }
+  }
+
+  private static class TimestampNanoWriter implements ValueWriter<LocalDateTime> {
+    private static final TimestampNanoWriter INSTANCE = new TimestampNanoWriter();
+
+    private TimestampNanoWriter() {}
+
+    @Override
+    public void write(LocalDateTime timestamp, Encoder encoder) throws IOException {
+      encoder.writeLong(ChronoUnit.NANOS.between(EPOCH, timestamp.atOffset(ZoneOffset.UTC)));
+    }
+  }
+
+  private static class TimestamptzNanoWriter implements ValueWriter<OffsetDateTime> {
+    private static final TimestamptzNanoWriter INSTANCE = new TimestamptzNanoWriter();
+
+    private TimestamptzNanoWriter() {}
+
+    @Override
+    public void write(OffsetDateTime timestamptz, Encoder encoder) throws IOException {
+      encoder.writeLong(ChronoUnit.NANOS.between(EPOCH, timestamptz));
     }
   }
 

--- a/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.data;
 
 import static java.time.temporal.ChronoUnit.MICROS;
+import static java.time.temporal.ChronoUnit.NANOS;
 
 import java.nio.ByteBuffer;
 import java.time.Instant;
@@ -247,6 +248,13 @@ public class RandomGenericData {
             return EPOCH.plus((long) result, MICROS);
           } else {
             return EPOCH.plus((long) result, MICROS).toLocalDateTime();
+          }
+        case TIMESTAMP_NANO:
+          Types.TimestampNanoType ts_nano = (Types.TimestampNanoType) primitive;
+          if (ts_nano.shouldAdjustToUTC()) {
+            return EPOCH.plus((long) result, NANOS);
+          } else {
+            return EPOCH.plus((long) result, NANOS).toLocalDateTime();
           }
         default:
           return result;

--- a/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
@@ -250,8 +250,8 @@ public class RandomGenericData {
             return EPOCH.plus((long) result, MICROS).toLocalDateTime();
           }
         case TIMESTAMP_NANO:
-          Types.TimestampNanoType ts_nano = (Types.TimestampNanoType) primitive;
-          if (ts_nano.shouldAdjustToUTC()) {
+          Types.TimestampNanoType tsNano = (Types.TimestampNanoType) primitive;
+          if (tsNano.shouldAdjustToUTC()) {
             return EPOCH.plus((long) result, NANOS);
           } else {
             return EPOCH.plus((long) result, NANOS).toLocalDateTime();

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
@@ -137,11 +137,17 @@ class FlinkTypeToType extends FlinkTypeVisitor<Type> {
 
   @Override
   public Type visit(TimestampType timestampType) {
+    if (timestampType.getPrecision() == 9) {
+      return Types.TimestampNanoType.withoutZone();
+    }
     return Types.TimestampType.withoutZone();
   }
 
   @Override
   public Type visit(LocalZonedTimestampType localZonedTimestampType) {
+    if (localZonedTimestampType.getPrecision() == 9) {
+      return Types.TimestampNanoType.withZone();
+    }
     return Types.TimestampType.withZone();
   }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
@@ -113,6 +113,15 @@ class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
           // MICROS
           return new TimestampType(6);
         }
+      case TIMESTAMP_NANO:
+        Types.TimestampNanoType timestampNano = (Types.TimestampNanoType) primitive;
+        if (timestampNano.shouldAdjustToUTC()) {
+          // NANOS
+          return new LocalZonedTimestampType(9);
+        } else {
+          // NANOS
+          return new TimestampType(9);
+        }
       case STRING:
         return new VarCharType(VarCharType.MAX_LENGTH);
       case UUID:

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroReader.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroReader.java
@@ -125,6 +125,9 @@ public class FlinkAvroReader implements DatumReader<RowData>, SupportsRowPositio
           case "timestamp-micros":
             return FlinkValueReaders.timestampMicros();
 
+          case "timestamp-nanos":
+            return FlinkValueReaders.timestampNanos();
+
           case "decimal":
             LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) logicalType;
             return FlinkValueReaders.decimal(

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueReaders.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueReaders.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.io.Decoder;
@@ -67,6 +68,10 @@ public class FlinkValueReaders {
 
   static ValueReader<TimestampData> timestampMicros() {
     return TimestampMicrosReader.INSTANCE;
+  }
+
+  static ValueReader<TimestampData> timestampNanos() {
+    return TimestampNanosReader.INSTANCE;
   }
 
   static ValueReader<DecimalData> decimal(
@@ -178,6 +183,16 @@ public class FlinkValueReaders {
         mills -= 1;
       }
       return TimestampData.fromEpochMillis(mills, nanos);
+    }
+  }
+
+  private static class TimestampNanosReader implements ValueReader<TimestampData> {
+    private static final TimestampNanosReader INSTANCE = new TimestampNanosReader();
+
+    @Override
+    public TimestampData read(Decoder decoder, Object reuse) throws IOException {
+      long nanos = decoder.readLong();
+      return TimestampData.fromInstant(Instant.ofEpochSecond(0, nanos));
     }
   }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
@@ -53,13 +53,24 @@ public class ColumnStatsWatermarkExtractor implements SplitWatermarkExtractor, S
     Types.NestedField field = schema.findField(eventTimeFieldName);
     TypeID typeID = field.type().typeId();
     Preconditions.checkArgument(
-        typeID.equals(TypeID.LONG) || typeID.equals(TypeID.TIMESTAMP),
+        typeID.equals(TypeID.LONG)
+            || typeID.equals(TypeID.TIMESTAMP)
+            || typeID.equals(TypeID.TIMESTAMP_NANO),
         "Found %s, expected a LONG or TIMESTAMP column for watermark generation.",
         typeID);
     this.eventTimeFieldId = field.fieldId();
     this.eventTimeFieldName = eventTimeFieldName;
     // Use the timeUnit only for Long columns.
-    this.timeUnit = typeID.equals(TypeID.LONG) ? timeUnit : TimeUnit.MICROSECONDS;
+    switch (typeID) {
+      case LONG:
+        this.timeUnit = timeUnit;
+        break;
+      case TIMESTAMP_NANO:
+        this.timeUnit = TimeUnit.NANOSECONDS;
+        break;
+      default:
+        this.timeUnit = TimeUnit.MICROSECONDS;
+    }
   }
 
   @VisibleForTesting

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/RowDataConverter.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/RowDataConverter.java
@@ -92,6 +92,12 @@ public class RowDataConverter {
         } else {
           return TimestampData.fromLocalDateTime((LocalDateTime) object);
         }
+      case TIMESTAMP_NANO:
+        if (((Types.TimestampNanoType) type).shouldAdjustToUTC()) {
+          return TimestampData.fromInstant(((OffsetDateTime) object).toInstant());
+        } else {
+          return TimestampData.fromLocalDateTime((LocalDateTime) object);
+        }
       case STRING:
         return StringData.fromString((String) object);
       case UUID:

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkScanTimestampNano.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkScanTimestampNano.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
 import org.apache.iceberg.FileFormat;
@@ -41,7 +40,6 @@ import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.source.FlinkInputFormat;
 import org.apache.iceberg.flink.source.FlinkSource;
-import org.apache.iceberg.flink.source.TestFlinkSource;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -81,22 +79,24 @@ public class TestFlinkScanTimestampNano {
 
   private Table createV3Table() {
     return CATALOG_EXTENSION
-                    .catalog()
-                    .createTable(
-                            TestFixtures.TABLE_IDENTIFIER,
-                            TS_SCHEMA,
-                            PartitionSpec.unpartitioned(),
-                            ImmutableMap.of(
-                                    TableProperties.DEFAULT_FILE_FORMAT,
-                                    format.name(),
-                                    TableProperties.FORMAT_VERSION,
-                                    "3"));
-
+        .catalog()
+        .createTable(
+            TestFixtures.TABLE_IDENTIFIER,
+            TS_SCHEMA,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(
+                TableProperties.DEFAULT_FILE_FORMAT,
+                format.name(),
+                TableProperties.FORMAT_VERSION,
+                "3"));
   }
+
   @TestTemplate
   public void testScanUseTimestampNano() throws Exception {
     // ORC doesnt support nano precision
-    assumeThat(format != FileFormat.ORC).as("nano precision is not supported").isTrue();
+    assumeThat(format != FileFormat.ORC)
+        .as("nano precision is not supported with ORC file format")
+        .isTrue();
     Table table = createV3Table();
     List<Record> expectedRecords = RandomGenericData.generate(TS_SCHEMA, 2, 0L);
     new GenericAppenderHelper(table, format, temporaryDirectory).appendToTable(expectedRecords);

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -69,6 +69,8 @@ public class TestFlinkSchemaUtil {
             .field("time", DataTypes.TIME())
             .field("timestampWithoutZone", DataTypes.TIMESTAMP())
             .field("timestampWithZone", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
+            .field("timestampNanoWithoutZone", DataTypes.TIMESTAMP(9))
+            .field("timestampNanoWithZone", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9))
             .field("date", DataTypes.DATE())
             .field("decimal", DataTypes.DECIMAL(2, 2))
             .field("decimal2", DataTypes.DECIMAL(38, 2))
@@ -85,17 +87,17 @@ public class TestFlinkSchemaUtil {
                 3,
                 "locations",
                 Types.MapType.ofOptional(
-                    24,
-                    25,
+                    26,
+                    27,
                     Types.StringType.get(),
                     Types.StructType.of(
-                        Types.NestedField.required(22, "posX", Types.DoubleType.get(), "X field"),
+                        Types.NestedField.required(24, "posX", Types.DoubleType.get(), "X field"),
                         Types.NestedField.required(
-                            23, "posY", Types.DoubleType.get(), "Y field")))),
+                            25, "posY", Types.DoubleType.get(), "Y field")))),
             Types.NestedField.optional(
-                4, "strArray", Types.ListType.ofOptional(26, Types.StringType.get())),
+                4, "strArray", Types.ListType.ofOptional(28, Types.StringType.get())),
             Types.NestedField.optional(
-                5, "intArray", Types.ListType.ofOptional(27, Types.IntegerType.get())),
+                5, "intArray", Types.ListType.ofOptional(29, Types.IntegerType.get())),
             Types.NestedField.required(6, "char", Types.StringType.get()),
             Types.NestedField.required(7, "varchar", Types.StringType.get()),
             Types.NestedField.optional(8, "boolean", Types.BooleanType.get()),
@@ -108,14 +110,18 @@ public class TestFlinkSchemaUtil {
             Types.NestedField.optional(
                 15, "timestampWithoutZone", Types.TimestampType.withoutZone()),
             Types.NestedField.optional(16, "timestampWithZone", Types.TimestampType.withZone()),
-            Types.NestedField.optional(17, "date", Types.DateType.get()),
-            Types.NestedField.optional(18, "decimal", Types.DecimalType.of(2, 2)),
-            Types.NestedField.optional(19, "decimal2", Types.DecimalType.of(38, 2)),
-            Types.NestedField.optional(20, "decimal3", Types.DecimalType.of(10, 1)),
             Types.NestedField.optional(
-                21,
+                17, "timestampNanoWithoutZone", Types.TimestampNanoType.withoutZone()),
+            Types.NestedField.optional(
+                18, "timestampNanoWithZone", Types.TimestampNanoType.withZone()),
+            Types.NestedField.optional(19, "date", Types.DateType.get()),
+            Types.NestedField.optional(20, "decimal", Types.DecimalType.of(2, 2)),
+            Types.NestedField.optional(21, "decimal2", Types.DecimalType.of(38, 2)),
+            Types.NestedField.optional(22, "decimal3", Types.DecimalType.of(10, 1)),
+            Types.NestedField.optional(
+                23,
                 "multiset",
-                Types.MapType.ofRequired(28, 29, Types.StringType.get(), Types.IntegerType.get())));
+                Types.MapType.ofRequired(30, 31, Types.StringType.get(), Types.IntegerType.get())));
 
     checkSchema(flinkSchema, icebergSchema);
   }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTimestampNano.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTimestampNano.java
@@ -19,9 +19,8 @@
 package org.apache.iceberg.flink;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
-import static org.junit.Assume.assumeThat;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTimestampNano.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTimestampNano.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.junit.Assume.assumeThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.source.FlinkInputFormat;
+import org.apache.iceberg.flink.source.FlinkSource;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestFlinkTimestampNano {
+
+  @Parameter(index = 0)
+  private FileFormat format;
+
+  @Parameters(name = "format = {0},")
+  public static Object[][] parameters() {
+    return new Object[][] {{FileFormat.ORC}, {FileFormat.PARQUET}, {FileFormat.AVRO}};
+  }
+
+  public static final Schema TS_SCHEMA =
+      new Schema(
+          required(1, "ts_nano", Types.TimestampNanoType.withoutZone()),
+          required(2, "ts_nano_tz", Types.TimestampNanoType.withZone()));
+  @TempDir protected Path temporaryDirectory;
+
+  @RegisterExtension
+  private static final HadoopCatalogExtension CATALOG_EXTENSION =
+      new HadoopCatalogExtension(TestFixtures.DATABASE, TestFixtures.TABLE);
+
+  @Test
+  public void testInvalidVersion() throws Exception {
+    assertThatThrownBy(
+            () -> CATALOG_EXTENSION.catalog().createTable(TestFixtures.TABLE_IDENTIFIER, TS_SCHEMA))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Invalid type in v2 schema: ts_nano timestamp_ns is not supported until v3");
+  }
+
+  @TestTemplate
+  public void testUseTimestampNano() throws Exception {
+    assumeThat(format == FileFormat.PARQUET)
+        .as("TIMESTAMP_NANO only supported for Parquet")
+        .isTrue();
+
+    Table table =
+        CATALOG_EXTENSION
+            .catalog()
+            .createTable(
+                TestFixtures.TABLE_IDENTIFIER,
+                TS_SCHEMA,
+                PartitionSpec.unpartitioned(),
+                ImmutableMap.of(
+                    TableProperties.DEFAULT_FILE_FORMAT,
+                    format.name(),
+                    TableProperties.FORMAT_VERSION,
+                    "3"));
+
+    List<Record> expectedRecords = RandomGenericData.generate(TS_SCHEMA, 2, 0L);
+    new GenericAppenderHelper(table, format, temporaryDirectory).appendToTable(expectedRecords);
+    FlinkSource.Builder builder =
+        FlinkSource.forRowData().table(table).tableLoader(CATALOG_EXTENSION.tableLoader());
+    List<Row> actual = runFormat(builder.buildFormat());
+    TestHelpers.assertRecords(actual, expectedRecords, TS_SCHEMA);
+  }
+
+  private List<Row> runFormat(FlinkInputFormat inputFormat) throws IOException {
+    RowType rowType = FlinkSchemaUtil.convert(TS_SCHEMA);
+    return TestHelpers.readRows(inputFormat, rowType);
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
@@ -21,11 +21,21 @@ package org.apache.iceberg.flink.source.reader;
 import static org.apache.iceberg.flink.TestFixtures.DATABASE;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.HadoopTableExtension;
 import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -38,6 +48,12 @@ public class TestColumnStatsWatermarkExtractor extends TestColumnStatsWatermarkE
           required(2, "timestamptz_column", Types.TimestampType.withZone()),
           required(3, "long_column", Types.LongType.get()),
           required(4, "string_column", Types.StringType.get()));
+  private static final List<List<Record>> TEST_RECORDS =
+      ImmutableList.of(
+          RandomGenericData.generate(SCHEMA, 3, 2L), RandomGenericData.generate(SCHEMA, 3, 19L));
+
+  protected static final List<Map<String, Long>> MIN_VALUES =
+      ImmutableList.of(Maps.newHashMapWithExpectedSize(3), Maps.newHashMapWithExpectedSize(3));
 
   @RegisterExtension
   private static final HadoopTableExtension SOURCE_TABLE_EXTENSION =
@@ -46,5 +62,33 @@ public class TestColumnStatsWatermarkExtractor extends TestColumnStatsWatermarkE
   @Override
   public Schema getSchema() {
     return SCHEMA;
+  }
+
+  @Override
+  public List<List<Record>> getTestRecords() {
+    return TEST_RECORDS;
+  }
+
+  @Override
+  public List<Map<String, Long>> getMinValues() {
+    return MIN_VALUES;
+  }
+
+  @BeforeAll
+  public static void updateMinValue() {
+    for (int i = 0; i < TEST_RECORDS.size(); ++i) {
+      for (Record r : TEST_RECORDS.get(i)) {
+        Map<String, Long> minValues = MIN_VALUES.get(i);
+
+        LocalDateTime localDateTime = (LocalDateTime) r.get(0);
+        minValues.merge(
+            "timestamp_column", localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli(), Math::min);
+
+        OffsetDateTime offsetDateTime = (OffsetDateTime) r.get(1);
+        minValues.merge("timestamptz_column", offsetDateTime.toInstant().toEpochMilli(), Math::min);
+
+        minValues.merge("long_column", (Long) r.get(2), Math::min);
+      }
+    }
   }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestColumnStatsWatermarkExtractor extends TestColumnStatsWatermarkExtractorBase {
 
-  public static Schema SCHEMA =
+  public static final Schema SCHEMA =
       new Schema(
           required(1, "timestamp_column", Types.TimestampType.withoutZone()),
           required(2, "timestamptz_column", Types.TimestampType.withZone()),

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractorBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractorBase.java
@@ -51,9 +51,10 @@ import org.junit.jupiter.api.io.TempDir;
 public abstract class TestColumnStatsWatermarkExtractorBase {
   public abstract Schema getSchema();
 
-  private final GenericAppenderFactory APPENDER_FACTORY = new GenericAppenderFactory(getSchema());
+  private final GenericAppenderFactory genericAppenderFactory =
+      new GenericAppenderFactory(getSchema());
 
-  private final List<List<Record>> TEST_RECORDS =
+  private final List<List<Record>> testRecords =
       ImmutableList.of(
           RandomGenericData.generate(getSchema(), 3, 2L),
           RandomGenericData.generate(getSchema(), 3, 19L));
@@ -68,8 +69,8 @@ public abstract class TestColumnStatsWatermarkExtractorBase {
 
   @BeforeEach
   public void updateMinValue() {
-    for (int i = 0; i < TEST_RECORDS.size(); ++i) {
-      for (Record r : TEST_RECORDS.get(i)) {
+    for (int i = 0; i < testRecords.size(); ++i) {
+      for (Record r : testRecords.get(i)) {
         Map<String, Long> minValues = MIN_VALUES.get(i);
 
         LocalDateTime localDateTime = (LocalDateTime) r.get(0);
@@ -117,7 +118,7 @@ public abstract class TestColumnStatsWatermarkExtractorBase {
     IcebergSourceSplit combinedSplit =
         IcebergSourceSplit.fromCombinedScanTask(
             ReaderUtil.createCombinedScanTask(
-                TEST_RECORDS, temporaryFolder, FileFormat.PARQUET, APPENDER_FACTORY));
+                testRecords, temporaryFolder, FileFormat.PARQUET, genericAppenderFactory));
 
     ColumnStatsWatermarkExtractor extractor =
         new ColumnStatsWatermarkExtractor(getSchema(), columnName, null);
@@ -154,9 +155,9 @@ public abstract class TestColumnStatsWatermarkExtractorBase {
   private IcebergSourceSplit split(int id) throws IOException {
     return IcebergSourceSplit.fromCombinedScanTask(
         ReaderUtil.createCombinedScanTask(
-            ImmutableList.of(TEST_RECORDS.get(id)),
+            ImmutableList.of(testRecords.get(id)),
             temporaryFolder,
             FileFormat.PARQUET,
-            APPENDER_FACTORY));
+            genericAppenderFactory));
   }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractorBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractorBase.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public abstract class TestColumnStatsWatermarkExtractorBase {
+  public abstract Schema getSchema();
+
+  private final GenericAppenderFactory APPENDER_FACTORY = new GenericAppenderFactory(getSchema());
+
+  private final List<List<Record>> TEST_RECORDS =
+      ImmutableList.of(
+          RandomGenericData.generate(getSchema(), 3, 2L),
+          RandomGenericData.generate(getSchema(), 3, 19L));
+
+  protected static final List<Map<String, Long>> MIN_VALUES =
+      ImmutableList.of(Maps.newHashMapWithExpectedSize(3), Maps.newHashMapWithExpectedSize(3));
+
+  @TempDir protected Path temporaryFolder;
+
+  @Parameter(index = 0)
+  private String columnName;
+
+  @BeforeEach
+  public void updateMinValue() {
+    for (int i = 0; i < TEST_RECORDS.size(); ++i) {
+      for (Record r : TEST_RECORDS.get(i)) {
+        Map<String, Long> minValues = MIN_VALUES.get(i);
+
+        LocalDateTime localDateTime = (LocalDateTime) r.get(0);
+        minValues.merge(
+            "timestamp_column", localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli(), Math::min);
+
+        OffsetDateTime offsetDateTime = (OffsetDateTime) r.get(1);
+        minValues.merge("timestamptz_column", offsetDateTime.toInstant().toEpochMilli(), Math::min);
+
+        minValues.merge("long_column", (Long) r.get(2), Math::min);
+      }
+    }
+  }
+
+  @Parameters(name = "columnName = {0}")
+  public static Collection<Object[]> data() {
+    return ImmutableList.of(
+        new Object[] {"timestamp_column"},
+        new Object[] {"timestamptz_column"},
+        new Object[] {"long_column"});
+  }
+
+  @TestTemplate
+  public void testSingle() throws IOException {
+    ColumnStatsWatermarkExtractor extractor =
+        new ColumnStatsWatermarkExtractor(getSchema(), columnName, TimeUnit.MILLISECONDS);
+
+    assertThat(extractor.extractWatermark(split(0)))
+        .isEqualTo(MIN_VALUES.get(0).get(columnName).longValue());
+  }
+
+  @TestTemplate
+  public void testTimeUnit() throws IOException {
+    assumeThat(columnName).isEqualTo("long_column");
+    ColumnStatsWatermarkExtractor extractor =
+        new ColumnStatsWatermarkExtractor(getSchema(), columnName, TimeUnit.MICROSECONDS);
+
+    assertThat(extractor.extractWatermark(split(0)))
+        .isEqualTo(MIN_VALUES.get(0).get(columnName) / 1000L);
+  }
+
+  @TestTemplate
+  public void testMultipleFiles() throws IOException {
+    assumeThat(columnName).isEqualTo("timestamp_column");
+    IcebergSourceSplit combinedSplit =
+        IcebergSourceSplit.fromCombinedScanTask(
+            ReaderUtil.createCombinedScanTask(
+                TEST_RECORDS, temporaryFolder, FileFormat.PARQUET, APPENDER_FACTORY));
+
+    ColumnStatsWatermarkExtractor extractor =
+        new ColumnStatsWatermarkExtractor(getSchema(), columnName, null);
+
+    assertThat(extractor.extractWatermark(split(0)))
+        .isEqualTo(MIN_VALUES.get(0).get(columnName).longValue());
+    assertThat(extractor.extractWatermark(split(1)))
+        .isEqualTo(MIN_VALUES.get(1).get(columnName).longValue());
+    assertThat(extractor.extractWatermark(combinedSplit))
+        .isEqualTo(Math.min(MIN_VALUES.get(0).get(columnName), MIN_VALUES.get(1).get(columnName)));
+  }
+
+  @TestTemplate
+  public void testWrongColumn() {
+    assumeThat(columnName).isEqualTo("string_column");
+    assertThatThrownBy(() -> new ColumnStatsWatermarkExtractor(getSchema(), columnName, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Found STRING, expected a LONG or TIMESTAMP column for watermark generation.");
+  }
+
+  @TestTemplate
+  public void testEmptyStatistics() throws IOException {
+    assumeThat(columnName).isEqualTo("timestamp_column");
+
+    // Create an extractor for a column we do not have statistics
+    ColumnStatsWatermarkExtractor extractor =
+        new ColumnStatsWatermarkExtractor(10, "missing_field");
+    assertThatThrownBy(() -> extractor.extractWatermark(split(0)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Missing statistics for column");
+  }
+
+  private IcebergSourceSplit split(int id) throws IOException {
+    return IcebergSourceSplit.fromCombinedScanTask(
+        ReaderUtil.createCombinedScanTask(
+            ImmutableList.of(TEST_RECORDS.get(id)),
+            temporaryFolder,
+            FileFormat.PARQUET,
+            APPENDER_FACTORY));
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractorNano.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractorNano.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestColumnStatsWatermarkExtractorNano extends TestColumnStatsWatermarkExtractorBase {
 
-  public static Schema SCHEMA =
+  public static final Schema SCHEMA =
       new Schema(
           required(1, "timestamp_column", Types.TimestampNanoType.withoutZone()),
           required(2, "timestamptz_column", Types.TimestampNanoType.withZone()),

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractorNano.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractorNano.java
@@ -30,18 +30,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 @ExtendWith(ParameterizedTestExtension.class)
-public class TestColumnStatsWatermarkExtractor extends TestColumnStatsWatermarkExtractorBase {
+public class TestColumnStatsWatermarkExtractorNano extends TestColumnStatsWatermarkExtractorBase {
 
   public static Schema SCHEMA =
       new Schema(
-          required(1, "timestamp_column", Types.TimestampType.withoutZone()),
-          required(2, "timestamptz_column", Types.TimestampType.withZone()),
+          required(1, "timestamp_column", Types.TimestampNanoType.withoutZone()),
+          required(2, "timestamptz_column", Types.TimestampNanoType.withZone()),
           required(3, "long_column", Types.LongType.get()),
           required(4, "string_column", Types.StringType.get()));
 
   @RegisterExtension
   private static final HadoopTableExtension SOURCE_TABLE_EXTENSION =
-      new HadoopTableExtension(DATABASE, TestFixtures.TABLE, SCHEMA, false);
+      new HadoopTableExtension(DATABASE, TestFixtures.TABLE, SCHEMA, true);
 
   @Override
   public Schema getSchema() {

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractorNano.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractorNano.java
@@ -21,11 +21,21 @@ package org.apache.iceberg.flink.source.reader;
 import static org.apache.iceberg.flink.TestFixtures.DATABASE;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.HadoopTableExtension;
 import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -39,6 +49,13 @@ public class TestColumnStatsWatermarkExtractorNano extends TestColumnStatsWaterm
           required(3, "long_column", Types.LongType.get()),
           required(4, "string_column", Types.StringType.get()));
 
+  private static final List<List<Record>> TEST_RECORDS =
+      ImmutableList.of(
+          RandomGenericData.generate(SCHEMA, 3, 2L), RandomGenericData.generate(SCHEMA, 3, 19L));
+
+  protected static final List<Map<String, Long>> MIN_VALUES =
+      ImmutableList.of(Maps.newHashMapWithExpectedSize(3), Maps.newHashMapWithExpectedSize(3));
+
   @RegisterExtension
   private static final HadoopTableExtension SOURCE_TABLE_EXTENSION =
       new HadoopTableExtension(DATABASE, TestFixtures.TABLE, SCHEMA, true);
@@ -46,5 +63,33 @@ public class TestColumnStatsWatermarkExtractorNano extends TestColumnStatsWaterm
   @Override
   public Schema getSchema() {
     return SCHEMA;
+  }
+
+  @Override
+  public List<List<Record>> getTestRecords() {
+    return TEST_RECORDS;
+  }
+
+  @Override
+  public List<Map<String, Long>> getMinValues() {
+    return MIN_VALUES;
+  }
+
+  @BeforeAll
+  public static void updateMinValue() {
+    for (int i = 0; i < TEST_RECORDS.size(); ++i) {
+      for (Record r : TEST_RECORDS.get(i)) {
+        Map<String, Long> minValues = MIN_VALUES.get(i);
+
+        LocalDateTime localDateTime = (LocalDateTime) r.get(0);
+        minValues.merge(
+            "timestamp_column", localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli(), Math::min);
+
+        OffsetDateTime offsetDateTime = (OffsetDateTime) r.get(1);
+        minValues.merge("timestamptz_column", offsetDateTime.toInstant().toEpochMilli(), Math::min);
+
+        minValues.merge("long_column", (Long) r.get(2), Math::min);
+      }
+    }
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.types.Types.ListType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.TimestampNanoType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
@@ -56,6 +57,10 @@ public class TypeToMessageType {
       LogicalTypeAnnotation.timestampType(false /* not adjusted to UTC */, TimeUnit.MICROS);
   private static final LogicalTypeAnnotation TIMESTAMPTZ_MICROS =
       LogicalTypeAnnotation.timestampType(true /* adjusted to UTC */, TimeUnit.MICROS);
+  private static final LogicalTypeAnnotation TIMESTAMP_NANOS =
+      LogicalTypeAnnotation.timestampType(false /* not adjusted to UTC */, TimeUnit.NANOS);
+  private static final LogicalTypeAnnotation TIMESTAMPTZ_NANOS =
+      LogicalTypeAnnotation.timestampType(true /* not adjusted to UTC */, TimeUnit.NANOS);
 
   public MessageType convert(Schema schema, String name) {
     Types.MessageTypeBuilder builder = Types.buildMessage();
@@ -140,6 +145,12 @@ public class TypeToMessageType {
           return Types.primitive(INT64, repetition).as(TIMESTAMPTZ_MICROS).id(id).named(name);
         } else {
           return Types.primitive(INT64, repetition).as(TIMESTAMP_MICROS).id(id).named(name);
+        }
+      case TIMESTAMP_NANO:
+        if (((TimestampNanoType) primitive).shouldAdjustToUTC()) {
+          return Types.primitive(INT64, repetition).as(TIMESTAMPTZ_NANOS).id(id).named(name);
+        } else {
+          return Types.primitive(INT64, repetition).as(TIMESTAMP_NANOS).id(id).named(name);
         }
       case STRING:
         return Types.primitive(BINARY, repetition).as(STRING).id(id).named(name);


### PR DESCRIPTION
Supports the new TIMESTAMP_NANOS (v3 format) for Flink, including watermark generation