### PR TITLE
Core: delete temp metadata file when version already exists

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -368,7 +368,13 @@ public class HadoopTableOperations implements TableOperations {
       }
 
       if (fs.exists(dst)) {
-        throw new CommitFailedException("Version %d already exists: %s", nextVersion, dst);
+        CommitFailedException cfe =
+            new CommitFailedException("Version %d already exists: %s", nextVersion, dst);
+        RuntimeException re = tryDelete(src);
+        if (re != null) {
+          cfe.addSuppressed(re);
+        }
+        throw cfe;
       }
 
       if (!fs.rename(src, dst)) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -374,6 +374,7 @@ public class HadoopTableOperations implements TableOperations {
         if (re != null) {
           cfe.addSuppressed(re);
         }
+
         throw cfe;
       }
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -207,8 +207,8 @@ public class TestHadoopCommits extends HadoopTableTestBase {
     assertThat(manifests).as("Should contain 0 Avro manifest files").isEmpty();
 
     // verifies that there is no temporary metadata.json files left on disk
-    Set<String> actual =
-        listMetadataJsonFiles().stream().map(File::getName).collect(Collectors.toSet());
+    List<String> actual =
+        listMetadataJsonFiles().stream().map(File::getName).sorted().collect(Collectors.toList());
     assertThat(actual)
         .as("only v1 and v2 metadata.json should exist.")
         .containsExactly("v1.metadata.json", "v2.metadata.json");

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -205,6 +205,12 @@ public class TestHadoopCommits extends HadoopTableTestBase {
 
     List<File> manifests = listManifestFiles();
     assertThat(manifests).as("Should contain 0 Avro manifest files").isEmpty();
+
+    // Verifies that there is no temporary metadata.json files left on dist file already exists failures.
+    Set<String> actual =
+            listMetadataJsonFiles().stream().map(File::getName).collect(Collectors.toSet());
+    Set<String> expected = Sets.newHashSet("v1.metadata.json", "v2.metadata.json");
+    assertThat(actual).as("only v1 and v2 metadata.json should exist.").isEqualTo(expected);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -206,9 +206,10 @@ public class TestHadoopCommits extends HadoopTableTestBase {
     List<File> manifests = listManifestFiles();
     assertThat(manifests).as("Should contain 0 Avro manifest files").isEmpty();
 
-    // Verifies that there is no temporary metadata.json files left on dist file already exists failures.
+    // Verifies that there is no temporary metadata.json files left on dist file already exists
+    // failures.
     Set<String> actual =
-            listMetadataJsonFiles().stream().map(File::getName).collect(Collectors.toSet());
+        listMetadataJsonFiles().stream().map(File::getName).collect(Collectors.toSet());
     Set<String> expected = Sets.newHashSet("v1.metadata.json", "v2.metadata.json");
     assertThat(actual).as("only v1 and v2 metadata.json should exist.").isEqualTo(expected);
   }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -206,12 +206,12 @@ public class TestHadoopCommits extends HadoopTableTestBase {
     List<File> manifests = listManifestFiles();
     assertThat(manifests).as("Should contain 0 Avro manifest files").isEmpty();
 
-    // Verifies that there is no temporary metadata.json files left on dist file already exists
-    // failures.
+    // verifies that there is no temporary metadata.json files left on disk
     Set<String> actual =
         listMetadataJsonFiles().stream().map(File::getName).collect(Collectors.toSet());
-    Set<String> expected = Sets.newHashSet("v1.metadata.json", "v2.metadata.json");
-    assertThat(actual).as("only v1 and v2 metadata.json should exist.").isEqualTo(expected);
+    assertThat(actual)
+        .as("only v1 and v2 metadata.json should exist.")
+        .containsExactly("v1.metadata.json", "v2.metadata.json");
   }
 
   @Test


### PR DESCRIPTION
When using HadoopCatalog, renameToFinal would fail with version already exists exception, we should also delete the temp metadata file in this case.