### PR TITLE
OpenAPI: Update Snapshots to be a common denominator of V1 and V2 specs

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2321,8 +2321,6 @@ components:
       required:
         - snapshot-id
         - timestamp-ms
-        - manifest-list
-        - summary
       properties:
         snapshot-id:
           type: integer
@@ -2339,6 +2337,11 @@ components:
         manifest-list:
           type: string
           description: Location of the snapshot's manifest list file
+        manifests:
+          type: array
+          items:
+            type: string
+          description: A list of manifest file locations. Must be omitted if manifest-list is present
         summary:
           type: object
           required:


### PR DESCRIPTION
In a recent [mail list discussion](https://lists.apache.org/thread/h9qmrmlgxh91ol0y2v8olt90b9q6p9xr), it has come to the community's attention that the Open API Spec does not conform to the current table Spec in the Snapshot component.

I am putting this PR together to help visualize the changes that would be required if we were to rectify the Spec in an effort to support both v1 and v2 spec, as has been suggested within the [REST API Open API Spec description](https://github.com/apache/iceberg/blob/8e743a5b5209569f84b6bace36e1106c67e1eab3/open-api/rest-catalog-open-api.yaml#L30-L30) itself.


The proposed change below removes `manifest-list` and `summary` fields which are `optional` fields in V1 spec, and adds `manifests` as an optional field (following the V1 spec).