### PR TITLE
Core: Snapshot `summary` map must have `operation` key

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -142,6 +142,9 @@ public class SnapshotParser {
         }
       }
       summary = builder.build();
+      Preconditions.checkArgument(
+        operation != null, 
+        "Operation must be present in summary if summary exists");
     }
 
     Integer schemaId = JsonUtil.getIntOrNull(SCHEMA_ID, node);

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -131,19 +131,16 @@ public class SnapshotParser {
           "Cannot parse summary from non-object value: %s",
           sNode);
 
+      operation = JsonUtil.getString(OPERATION, sNode);
       ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
       Iterator<String> fields = sNode.fieldNames();
       while (fields.hasNext()) {
         String field = fields.next();
-        if (field.equals(OPERATION)) {
-          operation = JsonUtil.getString(OPERATION, sNode);
-        } else {
+        if (!field.equals(OPERATION)) {
           builder.put(field, JsonUtil.getString(field, sNode));
         }
       }
       summary = builder.build();
-      Preconditions.checkArgument(
-          operation != null, "Operation must be present in summary if summary exists");
     }
 
     Integer schemaId = JsonUtil.getIntOrNull(SCHEMA_ID, node);

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -143,8 +143,7 @@ public class SnapshotParser {
       }
       summary = builder.build();
       Preconditions.checkArgument(
-        operation != null, 
-        "Operation must be present in summary if summary exists");
+          operation != null, "Operation must be present in summary if summary exists");
     }
 
     Integer schemaId = JsonUtil.getIntOrNull(SCHEMA_ID, node);

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -62,7 +62,6 @@ public class SnapshotParser {
 
     // if there is an operation, write the summary map
     if (snapshot.operation() != null) {
-      // this means if snapshot have operation, it must be in the summary map
       generator.writeObjectFieldStart(SUMMARY);
       generator.writeStringField(OPERATION, snapshot.operation());
       if (snapshot.summary() != null) {
@@ -76,7 +75,6 @@ public class SnapshotParser {
       }
       generator.writeEndObject();
     }
-    // what happens if snapshot does NOT have operation, but has summary?
 
     String manifestList = snapshot.manifestListLocation();
     if (manifestList != null) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -62,6 +62,7 @@ public class SnapshotParser {
 
     // if there is an operation, write the summary map
     if (snapshot.operation() != null) {
+      // this means if snapshot have operation, it must be in the summary map
       generator.writeObjectFieldStart(SUMMARY);
       generator.writeStringField(OPERATION, snapshot.operation());
       if (snapshot.summary() != null) {
@@ -75,6 +76,7 @@ public class SnapshotParser {
       }
       generator.writeEndObject();
     }
+    // what happens if snapshot does NOT have operation, but has summary?
 
     String manifestList = snapshot.manifestListLocation();
     if (manifestList != null) {

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -20,8 +20,7 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.Files.localInput;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -235,9 +234,9 @@ public class TestSnapshotJson {
                 + "}",
             System.currentTimeMillis());
 
-    IllegalArgumentException exception =
-        assertThrows(IllegalArgumentException.class, () -> SnapshotParser.fromJson(json));
-    assertEquals("Operation must be present in summary if summary exists", exception.getMessage());
+    assertThatThrownBy(() -> SnapshotParser.fromJson(json))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Operation must be present in summary if summary exists");
   }
 
   private String createManifestListWithManifestFiles(long snapshotId, Long parentSnapshotId)

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -75,7 +75,7 @@ public class TestSnapshotJson {
     Map<String, String> expectedSummary =
         ImmutableMap.<String, String>builder()
             .putAll(expected.summary())
-            .put("operation", expected.operation()) // operation is part of the summary
+            .put("operation", expected.operation()) // operation should be part of the summary
             .build();
 
     String json = SnapshotParser.toJson(expected);
@@ -85,7 +85,7 @@ public class TestSnapshotJson {
     // Assert that the summary node exists
     assertThat(jsonNode.get("summary")).isNotNull();
 
-    // Assert that the JSON contains the expected summary
+    // Assert that the "summary" field in the JSON matches the expected summary map
     Map<String, String> actualSummary =
         objectMapper.convertValue(
             jsonNode.get("summary"), new TypeReference<Map<String, String>>() {});
@@ -218,7 +218,6 @@ public class TestSnapshotJson {
 
   @Test
   public void testJsonConversionSummaryWithoutOperationFails() {
-    // summary field without operation key should fail
     String json =
         String.format(
             "{\n"

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -236,7 +236,7 @@ public class TestSnapshotJson {
 
     assertThatThrownBy(() -> SnapshotParser.fromJson(json))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Operation must be present in summary if summary exists");
+        .hasMessage("Cannot parse missing string: operation");
   }
 
   private String createManifestListWithManifestFiles(long snapshotId, Long parentSnapshotId)

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -82,7 +82,6 @@ public class TestSnapshotJson {
     ObjectMapper objectMapper = new ObjectMapper();
     JsonNode jsonNode = objectMapper.readTree(json);
 
-    // Assert that the summary node exists
     assertThat(jsonNode.get("summary")).isNotNull();
 
     // Assert that the "summary" field in the JSON matches the expected summary map

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -84,7 +84,6 @@ public class TestSnapshotJson {
 
     assertThat(jsonNode.get("summary")).isNotNull();
 
-    // Assert that the "summary" field in the JSON matches the expected summary map
     Map<String, String> actualSummary =
         objectMapper.convertValue(
             jsonNode.get("summary"), new TypeReference<Map<String, String>>() {});

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -23,18 +23,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Map;
 
 public class TestSnapshotJson {
   @TempDir private Path temp;
@@ -81,11 +81,14 @@ public class TestSnapshotJson {
     // Assert that the JSON contains the expected summary
     ObjectMapper objectMapper = new ObjectMapper();
     JsonNode jsonNode = objectMapper.readTree(json);
-    Map<String, String> actualSummary = objectMapper.convertValue(jsonNode.get("summary"), new TypeReference<Map<String, String>>() {});
-    Map<String, String> expectedSummary = ImmutableMap.<String, String>builder()
-      .putAll(expected.summary())
-      .put("operation", expected.operation()) // operation is part of the summary
-      .build();
+    Map<String, String> actualSummary =
+        objectMapper.convertValue(
+            jsonNode.get("summary"), new TypeReference<Map<String, String>>() {});
+    Map<String, String> expectedSummary =
+        ImmutableMap.<String, String>builder()
+            .putAll(expected.summary())
+            .put("operation", expected.operation()) // operation is part of the summary
+            .build();
     assertThat(jsonNode.has("summary")).isTrue();
     assertThat(actualSummary).isEqualTo(expectedSummary);
   }
@@ -230,12 +233,10 @@ public class TestSnapshotJson {
                 + "  \"manifests\" : [ \"/tmp/manifest1.avro\", \"/tmp/manifest2.avro\" ],\n"
                 + "  \"schema-id\" : 3\n"
                 + "}",
-                System.currentTimeMillis());
+            System.currentTimeMillis());
 
-    IllegalArgumentException exception = assertThrows(
-        IllegalArgumentException.class, 
-        () -> SnapshotParser.fromJson(json)
-    );
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> SnapshotParser.fromJson(json));
     assertEquals("Operation must be present in summary if summary exists", exception.getMessage());
   }
 


### PR DESCRIPTION
This PR adds additional constraints in the `SnapshotParser` and also includes tests to verify the behaviors.

`Snapshot`'s `summary` field is optional in V1 but required in V2. See https://iceberg.apache.org/spec/#snapshots
When serializing `Snapshot` to `JSON`, if the `summary` field exists, the `operation` key must also exist ([code](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/SnapshotParser.java#L63-L66)). In other words, the `summary` field without the `operation` key is considered invalid. 

Note that `operation` is a top-level field in the `Snapshot` class. But when serialized to JSON, the `operation` field is stored in the `summary` map. 

Devlist discussion https://lists.apache.org/thread/h9qmrmlgxh91ol0y2v8olt90b9q6p9xr
Relates to [apache/iceberg-python/#1106](https://github.com/apache/iceberg-python/issues/1106)