### PR TITLE
Support partitioning spec during data file rewrites in Spark.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/UpdatePartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/UpdatePartitionSpec.java
@@ -133,4 +133,16 @@ public interface UpdatePartitionSpec extends PendingUpdate<PartitionSpec> {
     throw new UnsupportedOperationException(
         this.getClass().getName() + " doesn't implement addNonDefaultSpec()");
   }
+
+  /**
+   * Explicitly providing the partition spec that we would like to use. When a spec has been
+   * provided then modifications should not be done afterwards through this class.
+   *
+   * @param newSpec partition spec to override the builder use during commit
+   * @return this for method chaining names.
+   */
+  default UpdatePartitionSpec useSpec(PartitionSpec newSpec) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " doesn't implement useSpec(PartitionSpec)");
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/util/PartitionSpecUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionSpecUtil.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+
+// TODO - This was copied from the kafka-connect package almost verbatim, can copy their tests for
+// this utility
+
+// TODO - Ask if backwards compatibility is important -- I removed the 'hours','days', (etc)
+// transforms
+
+public class PartitionSpecUtil {
+  private PartitionSpecUtil() {}
+
+  private static final Pattern TRANSFORM_REGEX = Pattern.compile("(\\w+)\\((.+)\\)");
+
+  public static PartitionSpec createPartitionSpec(
+      org.apache.iceberg.Schema schema, String partitionByStatement) {
+    if (partitionByStatement.isEmpty()) {
+      return PartitionSpec.unpartitioned();
+    }
+
+    List<String> partitionBy = Splitter.on(',').splitToList(partitionByStatement);
+
+    PartitionSpec.Builder specBuilder = PartitionSpec.builderFor(schema);
+    partitionBy.forEach(
+        partitionField -> {
+          Matcher matcher = TRANSFORM_REGEX.matcher(partitionField);
+          if (matcher.matches()) {
+            String transform = matcher.group(1);
+            switch (transform) {
+              case "year":
+                specBuilder.year(matcher.group(2));
+                break;
+              case "month":
+                specBuilder.month(matcher.group(2));
+                break;
+              case "day":
+                specBuilder.day(matcher.group(2));
+                break;
+              case "hour":
+                specBuilder.hour(matcher.group(2));
+                break;
+              case "bucket":
+                {
+                  Pair<String, Integer> args = transformArgPair(matcher.group(2));
+                  specBuilder.bucket(args.first(), args.second());
+                  break;
+                }
+              case "truncate":
+                {
+                  Pair<String, Integer> args = transformArgPair(matcher.group(2));
+                  specBuilder.truncate(args.first(), args.second());
+                  break;
+                }
+              default:
+                throw new UnsupportedOperationException("Unsupported transform: " + transform);
+            }
+          } else {
+            specBuilder.identity(partitionField);
+          }
+        });
+    return specBuilder.build();
+  }
+
+  private static Pair<String, Integer> transformArgPair(String argsStr) {
+    List<String> parts = Splitter.on(',').splitToList(argsStr);
+    if (parts.size() != 2) {
+      throw new IllegalArgumentException("Invalid argument " + argsStr + ", should have 2 parts");
+    }
+    return Pair.of(parts.get(0).trim(), Integer.parseInt(parts.get(1).trim()));
+  }
+}


### PR DESCRIPTION
# Description
Currently, data file rewrites supports specifying the output spec ID to be used. Added functionality to provide a partition spec itself and have it added as a non-default spec if it does not already exist on the table.

Edit: I've added a Github issue to track this potential improvement here: #11459

# Benefits
These changes would make it simpler to tier partition granularity by time ranges. As an example: Say your table is heavily used but mostly targets most recent data and you still want to provide the ability for folks to query back in time. You could achieve additional performance improvements by applying more granular partitions in the base table and then have a compaction job that runs by tiers:

1. Short term compaction (reuses the table definition - high granularity, get rid of as many small files as you can)
2. Long term compaction (specified partition spec that is not the default - lower granularity, will cut down the metadata stored for the table)

# Notes for Reviewers

**Note: This is definitely not complete and I am open to all feedback. Whether some functionalities already exist outside OR if it should be done differently.**

The part I'm mostly iffy on is modifying `BaseUpdatePartitionSpec.java` with `table.updateSpec()` instead of having something like `table.addSpec(partitionSpec). addNonDefaultSpec().commit()`