### PR TITLE
Build: Enable errorprone PatternMatchingInstanceof

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -131,6 +131,7 @@ subprojects {
           '-Xep:ObjectsHashCodeUnnecessaryVarargs:ERROR',
           '-Xep:OrphanedFormatString:ERROR',
           '-Xep:Overrides:ERROR',
+          '-Xep:PatternMatchingInstanceof:ERROR',
           // Triggers false-positives whenever relocated @VisibleForTesting is used
           '-Xep:PreferCommonAnnotations:OFF',
           // specific to Palantir


### PR DESCRIPTION
Enable `PatternMatchingInstanceof ` to simplify redundant lines with `instanceof`:
```java
if (obj instanceof Clazz) {
  ((Clazz) obj) ... 
}
↓
if (obj instanceof Clazz o) {
  o...
}

```