### PR TITLE
Fix when reading struct-type data without an id in iceberg-parquet

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -245,7 +245,7 @@ public abstract class BaseParquetReaders<T> {
         if (fieldReader != null) {
           Type fieldType = fields.get(i);
           int fieldD = type.getMaxDefinitionLevel(path(fieldType.getName())) - 1;
-          int id = fieldType.getId().intValue();
+          int id = findIdFromStruct(expected, fieldType);
           readersById.put(id, ParquetValueReaders.option(fieldType, fieldD, fieldReader));
           typesById.put(id, fieldType);
           if (idToConstant.containsKey(id)) {
@@ -289,6 +289,13 @@ public abstract class BaseParquetReaders<T> {
       }
 
       return createStructReader(types, reorderedFields, expected);
+    }
+
+    private int findIdFromStruct(Types.StructType expected, Type field) {
+      if (field.getId() != null) {
+        return field.getId().intValue();
+      }
+      return expected.field(field.getName()).fieldId();
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -49,7 +49,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
   private final long targetRowGroupSize;
   private final Map<String, String> metadata;
   private final ParquetProperties props;
-  private final CodecFactory.BytesCompressor compressor;
+  private final CodecFactory.BytesInputCompressor compressor;
   private final MessageType parquetSchema;
   private final ParquetValueWriter<T> model;
   private final MetricsConfig metricsConfig;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
@@ -190,15 +190,23 @@ public class TypeWithSchemaVisitor<T> {
       Types.StructType struct, GroupType group, TypeWithSchemaVisitor<T> visitor) {
     List<T> results = Lists.newArrayListWithExpectedSize(group.getFieldCount());
     for (Type field : group.getFields()) {
-      int id = -1;
-      if (field.getId() != null) {
-        id = field.getId().intValue();
-      }
-      Types.NestedField iField = (struct != null && id >= 0) ? struct.field(id) : null;
+      Types.NestedField iField = findField(struct, field);
       results.add(visitField(iField, field, visitor));
     }
 
     return results;
+  }
+
+  private static Types.NestedField findField(Types.StructType struct, Type field) {
+    if (struct == null) {
+      return null;
+    }
+
+    if (field.getId() != null) {
+      return struct.field(field.getId().intValue());
+    }
+
+    return struct.field(field.getName());
   }
 
   public T message(Types.StructType iStruct, MessageType message, List<T> fields) {


### PR DESCRIPTION
Fix issue: #11214
Fix when reading struct-type data without an id in iceberg-parquet, it returns null values.