### PR TITLE
Spark: Randomize view/function names in testing

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -91,7 +92,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromView() throws NoSuchTableException {
     insertRows(10);
-    String viewName = "simpleView";
+    String viewName = viewName("simpleView");
     String sql = String.format("SELECT id FROM %s", tableName);
 
     ViewCatalog viewCatalog = viewCatalog();
@@ -117,7 +118,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromTrinoView() throws NoSuchTableException {
     insertRows(10);
-    String viewName = "trinoView";
+    String viewName = viewName("trinoView");
     String sql = String.format("SELECT id FROM %s", tableName);
 
     ViewCatalog viewCatalog = viewCatalog();
@@ -142,8 +143,8 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromMultipleViews() throws NoSuchTableException {
     insertRows(6);
-    String viewName = "firstView";
-    String secondView = "secondView";
+    String viewName = viewName("firstView");
+    String secondView = viewName("secondView");
     String viewSQL = String.format("SELECT id FROM %s WHERE id <= 3", tableName);
     String secondViewSQL = String.format("SELECT id FROM %s WHERE id > 3", tableName);
 
@@ -175,7 +176,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromViewUsingNonExistingTable() throws NoSuchTableException {
     insertRows(10);
-    String viewName = "viewWithNonExistingTable";
+    String viewName = viewName("viewWithNonExistingTable");
 
     ViewCatalog viewCatalog = viewCatalog();
     Schema schema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
@@ -199,7 +200,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromViewUsingNonExistingTableColumn() throws NoSuchTableException {
     insertRows(10);
-    String viewName = "viewWithNonExistingColumn";
+    String viewName = viewName("viewWithNonExistingColumn");
 
     ViewCatalog viewCatalog = viewCatalog();
     Schema schema = new Schema(Types.NestedField.required(1, "non_existing", Types.LongType.get()));
@@ -221,7 +222,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromViewUsingInvalidSQL() throws NoSuchTableException {
     insertRows(10);
-    String viewName = "viewWithInvalidSQL";
+    String viewName = viewName("viewWithInvalidSQL");
 
     ViewCatalog viewCatalog = viewCatalog();
     Schema schema = tableCatalog().loadTable(TableIdentifier.of(NAMESPACE, tableName)).schema();
@@ -243,7 +244,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromViewWithStaleSchema() throws NoSuchTableException {
     insertRows(10);
-    String viewName = "staleView";
+    String viewName = viewName("staleView");
     String sql = String.format("SELECT id, data FROM %s", tableName);
 
     ViewCatalog viewCatalog = viewCatalog();
@@ -269,7 +270,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromViewHiddenByTempView() throws NoSuchTableException {
     insertRows(10);
-    String viewName = "viewHiddenByTempView";
+    String viewName = viewName("viewHiddenByTempView");
 
     ViewCatalog viewCatalog = viewCatalog();
     Schema schema = tableCatalog().loadTable(TableIdentifier.of(NAMESPACE, tableName)).schema();
@@ -296,7 +297,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromViewWithGlobalTempView() throws NoSuchTableException {
     insertRows(10);
-    String viewName = "viewWithGlobalTempView";
+    String viewName = viewName("viewWithGlobalTempView");
     String sql = String.format("SELECT id FROM %s WHERE id > 5", tableName);
 
     ViewCatalog viewCatalog = viewCatalog();
@@ -326,8 +327,8 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromViewReferencingAnotherView() throws NoSuchTableException {
     insertRows(10);
-    String firstView = "viewBeingReferencedInAnotherView";
-    String viewReferencingOtherView = "viewReferencingOtherView";
+    String firstView = viewName("viewBeingReferencedInAnotherView");
+    String viewReferencingOtherView = viewName("viewReferencingOtherView");
     String firstSQL = String.format("SELECT id FROM %s WHERE id <= 5", tableName);
     String secondSQL = String.format("SELECT id FROM %s WHERE id > 4", firstView);
 
@@ -357,8 +358,8 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromViewReferencingTempView() throws NoSuchTableException {
     insertRows(10);
-    String tempView = "tempViewBeingReferencedInAnotherView";
-    String viewReferencingTempView = "viewReferencingTempView";
+    String tempView = viewName("tempViewBeingReferencedInAnotherView");
+    String viewReferencingTempView = viewName("viewReferencingTempView");
     String sql = String.format("SELECT id FROM %s", tempView);
 
     ViewCatalog viewCatalog = viewCatalog();
@@ -393,8 +394,8 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromViewReferencingAnotherViewHiddenByTempView() throws NoSuchTableException {
     insertRows(10);
-    String innerViewName = "inner_view";
-    String outerViewName = "outer_view";
+    String innerViewName = viewName("inner_view");
+    String outerViewName = viewName("outer_view");
     String innerViewSQL = String.format("SELECT * FROM %s WHERE id > 5", tableName);
     String outerViewSQL = String.format("SELECT id FROM %s", innerViewName);
 
@@ -441,8 +442,8 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromViewReferencingGlobalTempView() throws NoSuchTableException {
     insertRows(10);
-    String globalTempView = "globalTempViewBeingReferenced";
-    String viewReferencingTempView = "viewReferencingGlobalTempView";
+    String globalTempView = viewName("globalTempViewBeingReferenced");
+    String viewReferencingTempView = viewName("viewReferencingGlobalTempView");
 
     ViewCatalog viewCatalog = viewCatalog();
     Schema schema = tableCatalog().loadTable(TableIdentifier.of(NAMESPACE, tableName)).schema();
@@ -480,7 +481,7 @@ public class TestViews extends ExtensionsTestBase {
   public void readFromViewReferencingTempFunction() throws NoSuchTableException {
     insertRows(10);
     String viewName = viewName("viewReferencingTempFunction");
-    String functionName = "test_avg";
+    String functionName = viewName("test_avg");
     String sql = String.format("SELECT %s(id) FROM %s", functionName, tableName);
     sql(
         "CREATE TEMPORARY FUNCTION %s AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage'",
@@ -511,7 +512,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void readFromViewWithCTE() throws NoSuchTableException {
     insertRows(10);
-    String viewName = "viewWithCTE";
+    String viewName = viewName("viewWithCTE");
     String sql =
         String.format(
             "WITH max_by_data AS (SELECT max(id) as max FROM %s) "
@@ -533,7 +534,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void rewriteFunctionIdentifier() {
-    String viewName = "rewriteFunctionIdentifier";
+    String viewName = viewName("rewriteFunctionIdentifier");
     String sql = "SELECT iceberg_version() AS version";
 
     assertThatThrownBy(() -> sql(sql))
@@ -559,7 +560,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void builtinFunctionIdentifierNotRewritten() {
-    String viewName = "builtinFunctionIdentifierNotRewritten";
+    String viewName = viewName("builtinFunctionIdentifierNotRewritten");
     String sql = "SELECT trim('  abc   ') AS result";
 
     ViewCatalog viewCatalog = viewCatalog();
@@ -578,7 +579,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void rewriteFunctionIdentifierWithNamespace() {
-    String viewName = "rewriteFunctionIdentifierWithNamespace";
+    String viewName = viewName("rewriteFunctionIdentifierWithNamespace");
     String sql = "SELECT system.bucket(100, 'a') AS bucket_result, 'a' AS value";
 
     ViewCatalog viewCatalog = viewCatalog();
@@ -605,7 +606,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void fullFunctionIdentifier() {
-    String viewName = "fullFunctionIdentifier";
+    String viewName = viewName("fullFunctionIdentifier");
     String sql =
         String.format(
             "SELECT %s.system.bucket(100, 'a') AS bucket_result, 'a' AS value", catalogName);
@@ -629,7 +630,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void fullFunctionIdentifierNotRewrittenLoadFailure() {
-    String viewName = "fullFunctionIdentifierNotRewrittenLoadFailure";
+    String viewName = viewName("fullFunctionIdentifierNotRewrittenLoadFailure");
     String sql = "SELECT spark_catalog.system.bucket(100, 'a') AS bucket_result, 'a' AS value";
 
     // avoid namespace failures
@@ -821,7 +822,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void dropView() {
-    String viewName = "viewToBeDropped";
+    String viewName = viewName("viewToBeDropped");
     String sql = String.format("SELECT id FROM %s", tableName);
 
     ViewCatalog viewCatalog = viewCatalog();
@@ -850,7 +851,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void dropViewIfExists() {
-    String viewName = "viewToBeDropped";
+    String viewName = viewName("viewToBeDropped");
     String sql = String.format("SELECT id FROM %s", tableName);
 
     ViewCatalog viewCatalog = viewCatalog();
@@ -875,7 +876,7 @@ public class TestViews extends ExtensionsTestBase {
   /** The purpose of this test is mainly to make sure that normal view deletion isn't messed up */
   @TestTemplate
   public void dropGlobalTempView() {
-    String globalTempView = "globalViewToBeDropped";
+    String globalTempView = viewName("globalViewToBeDropped");
     sql("CREATE GLOBAL TEMPORARY VIEW %s AS SELECT id FROM %s", globalTempView, tableName);
     assertThat(v1SessionCatalog().getGlobalTempView(globalTempView).isDefined()).isTrue();
 
@@ -886,7 +887,7 @@ public class TestViews extends ExtensionsTestBase {
   /** The purpose of this test is mainly to make sure that normal view deletion isn't messed up */
   @TestTemplate
   public void dropTempView() {
-    String tempView = "tempViewToBeDropped";
+    String tempView = viewName("tempViewToBeDropped");
     sql("CREATE TEMPORARY VIEW %s AS SELECT id FROM %s", tempView, tableName);
     assertThat(v1SessionCatalog().getTempView(tempView).isDefined()).isTrue();
 
@@ -897,7 +898,7 @@ public class TestViews extends ExtensionsTestBase {
   /** The purpose of this test is mainly to make sure that normal view deletion isn't messed up */
   @TestTemplate
   public void dropV1View() {
-    String v1View = "v1ViewToBeDropped";
+    String v1View = viewName("v1ViewToBeDropped");
     sql("USE spark_catalog");
     sql("CREATE NAMESPACE IF NOT EXISTS %s", NAMESPACE);
     sql("CREATE TABLE %s (id INT, data STRING)", tableName);
@@ -928,7 +929,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void createViewIfNotExists() {
-    String viewName = "viewThatAlreadyExists";
+    String viewName = viewName("viewThatAlreadyExists");
     sql("CREATE VIEW %s AS SELECT id FROM %s", viewName, tableName);
 
     assertThatThrownBy(() -> sql("CREATE VIEW %s AS SELECT id FROM %s", viewName, tableName))
@@ -969,8 +970,8 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void createViewReferencingTempView() throws NoSuchTableException {
     insertRows(10);
-    String tempView = "temporaryViewBeingReferencedInAnotherView";
-    String viewReferencingTempView = "viewReferencingTemporaryView";
+    String tempView = viewName("temporaryViewBeingReferencedInAnotherView");
+    String viewReferencingTempView = viewName("viewReferencingTemporaryView");
 
     sql("CREATE TEMPORARY VIEW %s AS SELECT id FROM %s WHERE id <= 5", tempView, tableName);
 
@@ -988,8 +989,8 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void createViewReferencingGlobalTempView() throws NoSuchTableException {
     insertRows(10);
-    String globalTempView = "globalTemporaryViewBeingReferenced";
-    String viewReferencingTempView = "viewReferencingGlobalTemporaryView";
+    String globalTempView = viewName("globalTemporaryViewBeingReferenced");
+    String viewReferencingTempView = viewName("viewReferencingGlobalTemporaryView");
 
     sql(
         "CREATE GLOBAL TEMPORARY VIEW %s AS SELECT id FROM %s WHERE id <= 5",
@@ -1012,7 +1013,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void createViewReferencingTempFunction() {
     String viewName = viewName("viewReferencingTemporaryFunction");
-    String functionName = "test_avg_func";
+    String functionName = viewName("test_avg_func");
 
     sql(
         "CREATE TEMPORARY FUNCTION %s AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage'",
@@ -1031,7 +1032,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void createViewReferencingQualifiedTempFunction() {
     String viewName = viewName("viewReferencingTemporaryFunction");
-    String functionName = "test_avg_func_qualified";
+    String functionName = viewName("test_avg_func_qualified");
 
     sql(
         "CREATE TEMPORARY FUNCTION %s AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage'",
@@ -1069,7 +1070,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void createViewWithMismatchedColumnCounts() {
-    String viewName = "viewWithMismatchedColumnCounts";
+    String viewName = viewName("viewWithMismatchedColumnCounts");
 
     assertThatThrownBy(
             () -> sql("CREATE VIEW %s (id, data) AS SELECT id FROM %s", viewName, tableName))
@@ -1093,7 +1094,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void createViewWithColumnAliases() throws NoSuchTableException {
     insertRows(6);
-    String viewName = "viewWithColumnAliases";
+    String viewName = viewName("viewWithColumnAliases");
 
     sql(
         "CREATE VIEW %s (new_id COMMENT 'ID', new_data COMMENT 'DATA') AS SELECT id, data FROM %s WHERE id <= 3",
@@ -1140,7 +1141,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void createViewWithDuplicateQueryColumnNames() throws NoSuchTableException {
     insertRows(3);
-    String viewName = "viewWithDuplicateQueryColumnNames";
+    String viewName = viewName("viewWithDuplicateQueryColumnNames");
     String sql = String.format("SELECT id, id FROM %s WHERE id <= 3", tableName);
 
     // not specifying column aliases in the view should fail
@@ -1158,7 +1159,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void createViewWithCTE() throws NoSuchTableException {
     insertRows(10);
-    String viewName = "simpleViewWithCTE";
+    String viewName = viewName("simpleViewWithCTE");
     String sql =
         String.format(
             "WITH max_by_data AS (SELECT max(id) as max FROM %s) "
@@ -1173,8 +1174,8 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void createViewWithConflictingNamesForCTEAndTempView() throws NoSuchTableException {
     insertRows(10);
-    String viewName = "viewWithConflictingNamesForCTEAndTempView";
-    String cteName = "cteName";
+    String viewName = viewName("viewWithConflictingNamesForCTEAndTempView");
+    String cteName = viewName("cteName");
     String sql =
         String.format(
             "WITH %s AS (SELECT max(id) as max FROM %s) "
@@ -1191,8 +1192,8 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void createViewWithCTEReferencingTempView() {
-    String viewName = "viewWithCTEReferencingTempView";
-    String tempViewInCTE = "tempViewInCTE";
+    String viewName = viewName("viewWithCTEReferencingTempView");
+    String tempViewInCTE = viewName("tempViewInCTE");
     String sql =
         String.format(
             "WITH max_by_data AS (SELECT max(id) as max FROM %s) "
@@ -1211,8 +1212,8 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void createViewWithCTEReferencingTempFunction() {
-    String viewName = "viewWithCTEReferencingTempFunction";
-    String functionName = "avg_function_in_cte";
+    String viewName = viewName("viewWithCTEReferencingTempFunction");
+    String functionName = viewName("avg_function_in_cte");
     String sql =
         String.format(
             "WITH avg_data AS (SELECT %s(id) as avg FROM %s) "
@@ -1245,8 +1246,8 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void createViewWithSubqueryExpressionUsingTempView() {
-    String viewName = "viewWithSubqueryExpression";
-    String tempView = "simpleTempView";
+    String viewName = viewName("viewWithSubqueryExpression");
+    String tempView = viewName("simpleTempView");
     String sql =
         String.format("SELECT * FROM %s WHERE id = (SELECT id FROM %s)", tableName, tempView);
 
@@ -1262,8 +1263,8 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void createViewWithSubqueryExpressionUsingGlobalTempView() {
-    String viewName = "simpleViewWithSubqueryExpression";
-    String globalTempView = "simpleGlobalTempView";
+    String viewName = viewName("simpleViewWithSubqueryExpression");
+    String globalTempView = viewName("simpleGlobalTempView");
     String sql =
         String.format(
             "SELECT * FROM %s WHERE id = (SELECT id FROM global_temp.%s)",
@@ -1284,7 +1285,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void createViewWithSubqueryExpressionUsingTempFunction() {
     String viewName = viewName("viewWithSubqueryExpression");
-    String functionName = "avg_function_in_subquery";
+    String functionName = viewName("avg_function_in_subquery");
     String sql =
         String.format(
             "SELECT * FROM %s WHERE id < (SELECT %s(id) FROM %s)",
@@ -1354,7 +1355,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void describeView() {
-    String viewName = "describeView";
+    String viewName = viewName("describeView");
 
     sql("CREATE VIEW %s AS SELECT id, data FROM %s WHERE id <= 3", viewName, tableName);
     assertThat(sql("DESCRIBE %s", viewName))
@@ -1363,7 +1364,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void describeExtendedView() {
-    String viewName = "describeExtendedView";
+    String viewName = viewName("describeExtendedView");
     String sql = String.format("SELECT id, data FROM %s WHERE id <= 3", tableName);
 
     sql(
@@ -1388,7 +1389,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void showViewProperties() {
-    String viewName = "showViewProps";
+    String viewName = viewName("showViewProps");
 
     sql(
         "CREATE VIEW %s TBLPROPERTIES ('key1'='val1', 'key2'='val2') AS SELECT id, data FROM %s WHERE id <= 3",
@@ -1399,7 +1400,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void showViewPropertiesByKey() {
-    String viewName = "showViewPropsByKey";
+    String viewName = viewName("showViewPropsByKey");
 
     sql("CREATE VIEW %s AS SELECT id, data FROM %s WHERE id <= 3", viewName, tableName);
     assertThat(sql("SHOW TBLPROPERTIES %s", viewName)).contains(row("provider", "iceberg"));
@@ -1420,39 +1421,43 @@ public class TestViews extends ExtensionsTestBase {
   public void showViews() throws NoSuchTableException {
     insertRows(6);
     String sql = String.format("SELECT * from %s", tableName);
-    sql("CREATE VIEW v1 AS %s", sql);
-    sql("CREATE VIEW prefixV2 AS %s", sql);
-    sql("CREATE VIEW prefixV3 AS %s", sql);
-    sql("CREATE GLOBAL TEMPORARY VIEW globalViewForListing AS %s", sql);
-    sql("CREATE TEMPORARY VIEW tempViewForListing AS %s", sql);
+    String v1 = viewName("v1");
+    String prefixV2 = viewName("prefixV2");
+    String prefixV3 = viewName("prefixV3");
+    String globalViewForListing = viewName("globalViewForListing");
+    String tempViewForListing = viewName("tempViewForListing");
+    sql("CREATE VIEW %s AS %s", v1, sql);
+    sql("CREATE VIEW %s AS %s", prefixV2, sql);
+    sql("CREATE VIEW %s AS %s", prefixV3, sql);
+    sql("CREATE GLOBAL TEMPORARY VIEW %s AS %s", globalViewForListing, sql);
+    sql("CREATE TEMPORARY VIEW %s AS %s", tempViewForListing, sql);
 
     // spark stores temp views case-insensitive by default
-    Object[] tempView = row("", "tempviewforlisting", true);
+    Object[] tempView = row("", tempViewForListing.toLowerCase(Locale.ROOT), true);
     assertThat(sql("SHOW VIEWS"))
         .contains(
-            row(NAMESPACE.toString(), "prefixV2", false),
-            row(NAMESPACE.toString(), "prefixV3", false),
-            row(NAMESPACE.toString(), "v1", false),
+            row(NAMESPACE.toString(), prefixV2, false),
+            row(NAMESPACE.toString(), prefixV3, false),
+            row(NAMESPACE.toString(), v1, false),
             tempView);
 
     assertThat(sql("SHOW VIEWS IN %s", catalogName))
         .contains(
-            row(NAMESPACE.toString(), "prefixV2", false),
-            row(NAMESPACE.toString(), "prefixV3", false),
-            row(NAMESPACE.toString(), "v1", false),
+            row(NAMESPACE.toString(), prefixV2, false),
+            row(NAMESPACE.toString(), prefixV3, false),
+            row(NAMESPACE.toString(), v1, false),
             tempView);
 
     assertThat(sql("SHOW VIEWS IN %s.%s", catalogName, NAMESPACE))
         .contains(
-            row(NAMESPACE.toString(), "prefixV2", false),
-            row(NAMESPACE.toString(), "prefixV3", false),
-            row(NAMESPACE.toString(), "v1", false),
+            row(NAMESPACE.toString(), prefixV2, false),
+            row(NAMESPACE.toString(), prefixV3, false),
+            row(NAMESPACE.toString(), v1, false),
             tempView);
 
     assertThat(sql("SHOW VIEWS LIKE 'pref*'"))
         .contains(
-            row(NAMESPACE.toString(), "prefixV2", false),
-            row(NAMESPACE.toString(), "prefixV3", false));
+            row(NAMESPACE.toString(), prefixV2, false), row(NAMESPACE.toString(), prefixV3, false));
 
     assertThat(sql("SHOW VIEWS LIKE 'non-existing'")).isEmpty();
 
@@ -1461,7 +1466,7 @@ public class TestViews extends ExtensionsTestBase {
     assertThat(sql("SHOW VIEWS IN global_temp"))
         .contains(
             // spark stores temp views case-insensitive by default
-            row("global_temp", "globalviewforlisting", true), tempView);
+            row("global_temp", globalViewForListing.toLowerCase(Locale.ROOT), true), tempView);
 
     sql("USE spark_catalog");
     assertThat(sql("SHOW VIEWS")).contains(tempView);
@@ -1502,7 +1507,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void showCreateSimpleView() {
-    String viewName = "showCreateSimpleView";
+    String viewName = viewName("showCreateSimpleView");
     String sql = String.format("SELECT id, data FROM %s WHERE id <= 3", tableName);
 
     sql("CREATE VIEW %s AS %s", viewName, sql);
@@ -1523,7 +1528,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void showCreateComplexView() {
-    String viewName = "showCreateComplexView";
+    String viewName = viewName("showCreateComplexView");
     String sql = String.format("SELECT id, data FROM %s WHERE id <= 3", tableName);
 
     sql(
@@ -1550,7 +1555,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void alterViewSetProperties() {
-    String viewName = "viewWithSetProperties";
+    String viewName = viewName("viewWithSetProperties");
 
     sql("CREATE VIEW %s AS SELECT id FROM %s WHERE id <= 3", viewName, tableName);
 
@@ -1572,7 +1577,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void alterViewSetReservedProperties() {
-    String viewName = "viewWithSetReservedProperties";
+    String viewName = viewName("viewWithSetReservedProperties");
 
     sql("CREATE VIEW %s AS SELECT id FROM %s WHERE id <= 3", viewName, tableName);
 
@@ -1603,7 +1608,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void alterViewUnsetProperties() {
-    String viewName = "viewWithUnsetProperties";
+    String viewName = viewName("viewWithUnsetProperties");
     sql("CREATE VIEW %s AS SELECT id FROM %s WHERE id <= 3", viewName, tableName);
 
     ViewCatalog viewCatalog = viewCatalog();
@@ -1624,7 +1629,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void alterViewUnsetUnknownProperty() {
-    String viewName = "viewWithUnsetUnknownProp";
+    String viewName = viewName("viewWithUnsetUnknownProp");
     sql("CREATE VIEW %s AS SELECT id FROM %s WHERE id <= 3", viewName, tableName);
 
     assertThatThrownBy(() -> sql("ALTER VIEW %s UNSET TBLPROPERTIES ('unknown-key')", viewName))
@@ -1638,7 +1643,7 @@ public class TestViews extends ExtensionsTestBase {
 
   @TestTemplate
   public void alterViewUnsetReservedProperties() {
-    String viewName = "viewWithUnsetReservedProperties";
+    String viewName = viewName("viewWithUnsetReservedProperties");
 
     sql("CREATE VIEW %s AS SELECT id FROM %s WHERE id <= 3", viewName, tableName);
 
@@ -1721,7 +1726,7 @@ public class TestViews extends ExtensionsTestBase {
   @TestTemplate
   public void alterViewIsNotSupported() throws NoSuchTableException {
     insertRows(6);
-    String viewName = "alteredView";
+    String viewName = viewName("alteredView");
 
     sql("CREATE VIEW %s AS SELECT id, data FROM %s WHERE id <= 3", viewName, tableName);
 


### PR DESCRIPTION
We already randomize some of the view names for testing but not all of them. This is in preparation for adding view support to `SparkSessionCatalog` and running `TestViews` against that catalog