### PR TITLE
Flink: Fix disabling flaky range distribution bucketing tests

### DIFF
--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkRangeDistributionBucketing.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkRangeDistributionBucketing.java
@@ -58,9 +58,9 @@ import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
-import org.junit.Ignore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -78,7 +78,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * </ul>
  */
 @Timeout(value = 30)
-@Ignore // https://github.com/apache/iceberg/pull/11305#issuecomment-2415207097
+@Disabled // https://github.com/apache/iceberg/pull/11305#issuecomment-2415207097
 public class TestFlinkIcebergSinkRangeDistributionBucketing {
   private static final Configuration DISABLE_CLASSLOADER_CHECK_CONFIG =
       new Configuration()

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkRangeDistributionBucketing.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkRangeDistributionBucketing.java
@@ -58,9 +58,9 @@ import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
-import org.junit.Ignore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -78,7 +78,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * </ul>
  */
 @Timeout(value = 30)
-@Ignore // https://github.com/apache/iceberg/pull/11305#issuecomment-2415207097
+@Disabled // https://github.com/apache/iceberg/pull/11305#issuecomment-2415207097
 public class TestFlinkIcebergSinkRangeDistributionBucketing {
   private static final Configuration DISABLE_CLASSLOADER_CHECK_CONFIG =
       new Configuration()


### PR DESCRIPTION
This fixes #11397. cc @stevenzwu 