### PR TITLE
open-api: Fix testFixtures dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -973,10 +973,28 @@ project(':iceberg-open-api') {
     testFixturesImplementation project(':iceberg-api')
     testFixturesImplementation project(':iceberg-core')
     testFixturesImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
-    testFixturesImplementation project(':iceberg-core').sourceSets.test.runtimeClasspath
     testFixturesImplementation project(':iceberg-aws')
     testFixturesImplementation project(':iceberg-gcp')
     testFixturesImplementation project(':iceberg-azure')
+    testFixturesImplementation(libs.hadoop3.common) {
+      exclude group: 'log4j'
+      exclude group: 'org.slf4j'
+      exclude group: 'ch.qos.reload4j'
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'com.fasterxml.woodstox'
+      exclude group: 'com.google.guava'
+      exclude group: 'com.google.protobuf'
+      exclude group: 'org.apache.curator'
+      exclude group: 'org.apache.zookeeper'
+      exclude group: 'org.apache.kerby'
+      exclude group: 'org.apache.hadoop', module: 'hadoop-auth'
+      exclude group: 'org.apache.commons', module: 'commons-configuration2'
+      exclude group: 'org.apache.hadoop.thirdparty', module: 'hadoop-shaded-protobuf_3_7'
+      exclude group: 'org.codehaus.woodstox'
+      exclude group: 'org.eclipse.jetty'
+    }
+    testFixturesImplementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+    testFixturesImplementation libs.junit.jupiter
 
     testFixturesImplementation libs.jetty.servlet
     testFixturesImplementation libs.jetty.server


### PR DESCRIPTION
Importing 
`testFixturesImplementation project(':iceberg-core').sourceSets.test.runtimeClasspath`
brings everything to class path and creates problem for shadow jar. 

Need to depend only on required classes.