### PR TITLE
Core: Try create Iceberg metadata table for Jdbc catalog in initialization

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -159,17 +159,6 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
     try {
       connections.run(
           conn -> {
-            DatabaseMetaData dbMeta = conn.getMetaData();
-            ResultSet tableExists =
-                dbMeta.getTables(
-                    null /* catalog name */,
-                    null /* schemaPattern */,
-                    JdbcUtil.CATALOG_TABLE_VIEW_NAME /* tableNamePattern */,
-                    null /* types */);
-            if (tableExists.next()) {
-              return true;
-            }
-
             LOG.debug(
                 "Creating table {} to store iceberg catalog tables",
                 JdbcUtil.CATALOG_TABLE_VIEW_NAME);
@@ -178,18 +167,6 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
 
       connections.run(
           conn -> {
-            DatabaseMetaData dbMeta = conn.getMetaData();
-            ResultSet tableExists =
-                dbMeta.getTables(
-                    null /* catalog name */,
-                    null /* schemaPattern */,
-                    JdbcUtil.NAMESPACE_PROPERTIES_TABLE_NAME /* tableNamePattern */,
-                    null /* types */);
-
-            if (tableExists.next()) {
-              return true;
-            }
-
             LOG.debug(
                 "Creating table {} to store iceberg catalog namespace properties",
                 JdbcUtil.NAMESPACE_PROPERTIES_TABLE_NAME);

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
@@ -123,7 +123,7 @@ final class JdbcUtil {
           + JdbcTableOperations.METADATA_LOCATION_PROP
           + " = ?";
   static final String V0_CREATE_CATALOG_SQL =
-      "CREATE TABLE "
+      "CREATE TABLE IF NOT EXISTS "
           + CATALOG_TABLE_VIEW_NAME
           + "("
           + CATALOG_NAME
@@ -400,7 +400,7 @@ final class JdbcUtil {
   static final String NAMESPACE_PROPERTY_VALUE = "property_value";
 
   static final String CREATE_NAMESPACE_PROPERTIES_TABLE_SQL =
-      "CREATE TABLE "
+      "CREATE TABLE IF NOT EXISTS "
           + NAMESPACE_PROPERTIES_TABLE_NAME
           + "("
           + CATALOG_NAME


### PR DESCRIPTION
Iceberg metadata table may not created in some cases, see #11423 , this PR removes the table exists check (the check result may not correct) and using `CREAT TABLE IF NOT EXISTS` to try create metadata table.

fixes: #11423 