### PR TITLE
Remove calcite from versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,6 @@ awssdk-bom = "2.29.1"
 azuresdk-bom = "1.2.28"
 awssdk-s3accessgrants = "2.3.0"
 caffeine = "2.9.3"
-calcite = "1.10.0"
 datasketches = "6.1.1"
 delta-standalone = "3.2.1"
 delta-spark = "3.2.1"
@@ -102,8 +101,6 @@ awssdk-bom = { module = "software.amazon.awssdk:bom", version.ref = "awssdk-bom"
 awssdk-s3accessgrants = { module = "software.amazon.s3.accessgrants:aws-s3-accessgrants-java-plugin", version.ref = "awssdk-s3accessgrants" }
 azuresdk-bom = { module = "com.azure:azure-sdk-bom", version.ref = "azuresdk-bom" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
-calcite-core = { module = "org.apache.calcite:calcite-core", version.ref = "calcite" }
-calcite-druid = { module = "org.apache.calcite:calcite-druid", version.ref = "calcite" }
 datasketches = { module = "org.apache.datasketches:datasketches-java", version.ref = "datasketches" }
 delta-standalone = { module = "io.delta:delta-standalone_2.12", version.ref = "delta-standalone" }
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorprone-annotations" }

--- a/hive3/build.gradle
+++ b/hive3/build.gradle
@@ -92,7 +92,6 @@ project(':iceberg-hive3') {
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
 
     testImplementation libs.avro.avro
-    testImplementation libs.calcite.core
     testImplementation libs.kryo.shaded
     testImplementation platform(libs.jackson.bom)
     testImplementation(libs.hive3.service) {

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -57,16 +57,12 @@ project(':iceberg-mr') {
 
     implementation libs.caffeine
 
-    testImplementation libs.calcite.core
-    testImplementation libs.calcite.druid
-
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
 
     testImplementation libs.avro.avro
-    testImplementation libs.calcite.core
     testImplementation libs.kryo.shaded
     testImplementation platform(libs.jackson.bom)
     testImplementation libs.jackson.annotations


### PR DESCRIPTION
I noticed this while working on https://github.com/apache/iceberg/pull/11428 Do we still need this, since it is only used in tests?