### PR TITLE
OpenAPI: Remove credentials from LoadViewResult

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1333,19 +1333,11 @@ class LoadViewResult(BaseModel):
 
     - `token`: Authorization bearer token to use for view requests if OAuth2 security is enabled
 
-    ## Storage Credentials
-
-    Credentials for ADLS / GCS / S3 / ... are provided through the `storage-credentials` field.
-    Clients must first check whether the respective credentials exist in the `storage-credentials` field before checking the `config` for credentials.
-
     """
 
     metadata_location: str = Field(..., alias='metadata-location')
     metadata: ViewMetadata
     config: Optional[Dict[str, str]] = None
-    storage_credentials: Optional[List[StorageCredential]] = Field(
-        None, alias='storage-credentials'
-    )
 
 
 class ReportMetricsRequest(BaseModel):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3466,11 +3466,6 @@ components:
         ## General Configurations
 
         - `token`: Authorization bearer token to use for view requests if OAuth2 security is enabled
-
-        ## Storage Credentials
-
-        Credentials for ADLS / GCS / S3 / ... are provided through the `storage-credentials` field.
-        Clients must first check whether the respective credentials exist in the `storage-credentials` field before checking the `config` for credentials.
       type: object
       required:
         - metadata-location
@@ -3484,10 +3479,6 @@ components:
           type: object
           additionalProperties:
             type: string
-        storage-credentials:
-          type: array
-          items:
-            $ref: '#/components/schemas/StorageCredential'
 
     TokenType:
       type: string


### PR DESCRIPTION
The original idea why credentials were added to `LoadViewResponse` was to pass back the credentials to the table that the view is referencing. However, we actually want to wait with this until we have the use case fully defined on how this will work and want to remove the functionality for now, as otherwise we'd have to maintain reading/writing credentials in `LoadViewResponse` forever.
We'll we sharing a separate proposal on how to realize this shortly on the mailing list. 