### PR TITLE
Core: Add validation for table commit properties

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -98,12 +98,13 @@ class PropertiesUpdate implements UpdateProperties {
 
   @Override
   public void commit() {
+    // If existing table commit properties in base are corrupted, allow rectification
     Tasks.foreach(ops)
-        .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+        .retry(base.propertyTryAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
         .exponentialBackoff(
-            base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+            base.propertyTryAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+            base.propertyTryAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+            base.propertyTryAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
             2.0 /* exponential */)
         .onlyRetryOn(CommitFailedException.class)
         .run(

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
@@ -133,6 +134,8 @@ public class TableMetadata implements Serializable {
     // Validate the metrics configuration. Note: we only do this on new tables to we don't
     // break existing tables.
     MetricsConfig.fromProperties(properties).validateReferencedColumns(schema);
+
+    PropertyUtil.validateCommitProperties(properties);
 
     return new Builder()
         .setInitialFormatVersion(formatVersion)
@@ -484,6 +487,10 @@ public class TableMetadata implements Serializable {
 
   public int propertyAsInt(String property, int defaultValue) {
     return PropertyUtil.propertyAsInt(properties, property, defaultValue);
+  }
+
+  public int propertyTryAsInt(String property, int defaultValue) {
+    return NumberUtils.toInt(property, defaultValue);
   }
 
   public long propertyAsLong(String property, long defaultValue) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
@@ -490,7 +489,7 @@ public class TableMetadata implements Serializable {
   }
 
   public int propertyTryAsInt(String property, int defaultValue) {
-    return NumberUtils.toInt(property, defaultValue);
+    return PropertyUtil.propertyTryAsInt(properties, property, defaultValue);
   }
 
   public long propertyAsLong(String property, long defaultValue) {

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -95,6 +95,13 @@ public class TableProperties {
   public static final String COMMIT_TOTAL_RETRY_TIME_MS = "commit.retry.total-timeout-ms";
   public static final int COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT = 30 * 60 * 1000; // 30 minutes
 
+  public static final Set<String> COMMIT_PROPERTIES =
+      ImmutableSet.of(
+          COMMIT_NUM_RETRIES,
+          COMMIT_MIN_RETRY_WAIT_MS,
+          COMMIT_MAX_RETRY_WAIT_MS,
+          COMMIT_TOTAL_RETRY_TIME_MS);
+
   public static final String COMMIT_NUM_STATUS_CHECKS = "commit.status-check.num-retries";
   public static final int COMMIT_NUM_STATUS_CHECKS_DEFAULT = 3;
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -95,13 +95,6 @@ public class TableProperties {
   public static final String COMMIT_TOTAL_RETRY_TIME_MS = "commit.retry.total-timeout-ms";
   public static final int COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT = 30 * 60 * 1000; // 30 minutes
 
-  public static final Set<String> COMMIT_PROPERTIES =
-      ImmutableSet.of(
-          COMMIT_NUM_RETRIES,
-          COMMIT_MIN_RETRY_WAIT_MS,
-          COMMIT_MAX_RETRY_WAIT_MS,
-          COMMIT_TOTAL_RETRY_TIME_MS);
-
   public static final String COMMIT_NUM_STATUS_CHECKS = "commit.status-check.num-retries";
   public static final int COMMIT_NUM_STATUS_CHECKS_DEFAULT = 3;
 

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -27,9 +27,17 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class PropertyUtil {
+
+  public static final Set<String> COMMIT_PROPERTIES =
+      ImmutableSet.of(
+          TableProperties.COMMIT_NUM_RETRIES,
+          TableProperties.COMMIT_MIN_RETRY_WAIT_MS,
+          TableProperties.COMMIT_MAX_RETRY_WAIT_MS,
+          TableProperties.COMMIT_TOTAL_RETRY_TIME_MS);
 
   private PropertyUtil() {}
 
@@ -55,6 +63,19 @@ public class PropertyUtil {
     String value = properties.get(property);
     if (value != null) {
       return Double.parseDouble(value);
+    }
+    return defaultValue;
+  }
+
+  public static int propertyTryAsInt(
+      Map<String, String> properties, String property, int defaultValue) {
+    String value = properties.get(property);
+    if (value != null) {
+      try {
+        return Integer.parseInt(value);
+      } catch (NumberFormatException e) {
+        return defaultValue;
+      }
     }
     return defaultValue;
   }
@@ -105,11 +126,9 @@ public class PropertyUtil {
   /**
    * Validate the table commit related properties to have non-negative integer on table creation to
    * prevent commit failure
-   *
-   * @param properties input map
    */
   public static void validateCommitProperties(Map<String, String> properties) {
-    for (String commitProperty : TableProperties.COMMIT_PROPERTIES) {
+    for (String commitProperty : COMMIT_PROPERTIES) {
       if (properties.containsKey(commitProperty)) {
         int parsedValue;
         try {

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -29,8 +29,11 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PropertyUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(PropertyUtil.class);
 
   private static final Set<String> COMMIT_PROPERTIES =
       ImmutableSet.of(
@@ -75,7 +78,8 @@ public class PropertyUtil {
     }
     try {
       return Integer.parseInt(value);
-    } catch (NumberFormatException ignored) {
+    } catch (NumberFormatException e) {
+      LOG.warn("Failed to parse value of {} as integer, default to {}", property, defaultValue, e);
       return defaultValue;
     }
   }

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
@@ -98,6 +100,30 @@ public class PropertyUtil {
       return value;
     }
     return defaultValue;
+  }
+
+  /**
+   * Validate the table commit related properties to have non-negative integer on table creation to
+   * prevent commit failure
+   *
+   * @param properties input map
+   */
+  public static void validateCommitProperties(Map<String, String> properties) {
+    for (String commitProperty : TableProperties.COMMIT_PROPERTIES) {
+      if (properties.containsKey(commitProperty)) {
+        int parsedValue;
+        try {
+          parsedValue = Integer.parseInt(properties.get(commitProperty));
+        } catch (NumberFormatException e) {
+          throw new ValidationException(
+              "Table property %s must have integer value", commitProperty);
+        }
+        ValidationException.check(
+            parsedValue >= 0,
+            "Table property %s must have non negative integer value",
+            commitProperty);
+      }
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -32,7 +32,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class PropertyUtil {
 
-  public static final Set<String> COMMIT_PROPERTIES =
+  private static final Set<String> COMMIT_PROPERTIES =
       ImmutableSet.of(
           TableProperties.COMMIT_NUM_RETRIES,
           TableProperties.COMMIT_MIN_RETRY_WAIT_MS,

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -70,14 +70,14 @@ public class PropertyUtil {
   public static int propertyTryAsInt(
       Map<String, String> properties, String property, int defaultValue) {
     String value = properties.get(property);
-    if (value != null) {
-      try {
-        return Integer.parseInt(value);
-      } catch (NumberFormatException e) {
-        return defaultValue;
-      }
+    if (value == null) {
+      return defaultValue;
     }
-    return defaultValue;
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException ignored) {
+      return defaultValue;
+    }
   }
 
   public static int propertyAsInt(
@@ -129,10 +129,11 @@ public class PropertyUtil {
    */
   public static void validateCommitProperties(Map<String, String> properties) {
     for (String commitProperty : COMMIT_PROPERTIES) {
-      if (properties.containsKey(commitProperty)) {
+      String value = properties.get(commitProperty);
+      if (value != null) {
         int parsedValue;
         try {
-          parsedValue = Integer.parseInt(properties.get(commitProperty));
+          parsedValue = Integer.parseInt(value);
         } catch (NumberFormatException e) {
           throw new ValidationException(
               "Table property %s must have integer value", commitProperty);

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -714,4 +714,22 @@ public class TestTransaction extends TestBase {
     assertThat(paths).isEqualTo(expectedPaths);
     assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(2);
   }
+
+  @TestTemplate
+  public void testCommitProperties() {
+    table
+        .updateProperties()
+        .set(TableProperties.COMMIT_MAX_RETRY_WAIT_MS, "foo")
+        .set(TableProperties.COMMIT_NUM_RETRIES, "bar")
+        .set(TableProperties.COMMIT_TOTAL_RETRY_TIME_MS, Integer.toString(60 * 60 * 1000))
+        .commit();
+    table.updateProperties().remove(TableProperties.COMMIT_MAX_RETRY_WAIT_MS).commit();
+    table.updateProperties().remove(TableProperties.COMMIT_NUM_RETRIES).commit();
+
+    assertThat(table.properties())
+        .doesNotContainKey(TableProperties.COMMIT_NUM_RETRIES)
+        .doesNotContainKey(TableProperties.COMMIT_MAX_RETRY_WAIT_MS)
+        .containsEntry(
+            TableProperties.COMMIT_TOTAL_RETRY_TIME_MS, Integer.toString(60 * 60 * 1000));
+  }
 }


### PR DESCRIPTION
close #11435 

Total of 2 Changes proposed here

1. Add validation for creating new table where commit related table properties need to have value type checked (as integer) and value is non-negative. This apply to following 4 table properties as those are common set of properties to be used on commit for metadata changes
    1. commit.retry.num-retries
    1. commit.retry.min-wait-ms
    1. commit.retry.max-wait-ms
    1. commit.retry.total-timeout-ms
1. Relax the constrain of [PendingUpdate](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java#L100-L114) so that existing table with such corrupted table properties can proceed with correction (see example below)

    - ~~achieved by using [NumberUtils::toInt](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/math/NumberUtils.html#toInt(java.lang.String,int)) where return the default value if the conversion fails.~~

This allow for 
```java
// some mistake at first
table
    .updateProperties()
    .set(TableProperties.COMMIT_MAX_RETRY_WAIT_MS, "foo")
    .commit();
// fail before, pass after
table.updateProperties().remove(TableProperties.COMMIT_MAX_RETRY_WAIT_MS).commit();
```