### PR TITLE
Core: Add cardinality to PositionDeleteIndex

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -87,4 +87,9 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
   public Collection<DeleteFile> deleteFiles() {
     return deleteFiles;
   }
+
+  @Override
+  public long cardinality() {
+    return bitmap.cardinality();
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
@@ -87,6 +87,11 @@ public interface PositionDeleteIndex {
     return ImmutableList.of();
   }
 
+  /** Returns the cardinality of this index. */
+  default long cardinality() {
+    throw new UnsupportedOperationException(getClass().getName() + " does not support cardinality");
+  }
+
   /** Returns an empty immutable position delete index. */
   static PositionDeleteIndex empty() {
     return EmptyPositionDeleteIndex.get();


### PR DESCRIPTION
This PR adds `cardinality` to `PositionDeleteIndex`.