### PR TITLE
API: Removes Explicit Parameterization of Schema Tests

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.BiMap;
@@ -54,8 +55,11 @@ public class Schema implements Serializable {
   private static final Joiner NEWLINE = Joiner.on('\n');
   private static final String ALL_COLUMNS = "*";
   private static final int DEFAULT_SCHEMA_ID = 0;
-  private static final int DEFAULT_VALUES_MIN_FORMAT_VERSION = 3;
-  private static final Map<Type.TypeID, Integer> MIN_FORMAT_VERSIONS =
+
+  @VisibleForTesting static final int DEFAULT_VALUES_MIN_FORMAT_VERSION = 3;
+
+  @VisibleForTesting
+  static final Map<Type.TypeID, Integer> MIN_FORMAT_VERSIONS =
       ImmutableMap.of(Type.TypeID.TIMESTAMP_NANO, 3);
 
   private final StructType struct;

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -54,6 +54,7 @@ public class TestHelpers {
   private TestHelpers() {}
 
   public static final int MAX_FORMAT_VERSION = 3;
+  public static final int[] ALL_VERSIONS = IntStream.rangeClosed(1, MAX_FORMAT_VERSION).toArray();
 
   /** Wait in a tight check loop until system clock is past {@code timestampMillis} */
   public static long waitUntilAfter(long timestampMillis) {

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -53,6 +53,8 @@ public class TestHelpers {
 
   private TestHelpers() {}
 
+  public static final int MAX_FORMAT_VERSION = 3;
+
   /** Wait in a tight check loop until system clock is past {@code timestampMillis} */
   public static long waitUntilAfter(long timestampMillis) {
     long current = System.currentTimeMillis();

--- a/api/src/test/java/org/apache/iceberg/TestSchema.java
+++ b/api/src/test/java/org/apache/iceberg/TestSchema.java
@@ -151,8 +151,8 @@ public class TestSchema {
 
   @ParameterizedTest
   @FieldSource
-  public void testSupportedInitialDefault() {
-    assertThatCode(() -> Schema.checkCompatibility(INITIAL_DEFAULT_SCHEMA, 3))
+  public void testSupportedInitialDefault(int formatVersion) {
+    assertThatCode(() -> Schema.checkCompatibility(INITIAL_DEFAULT_SCHEMA, formatVersion))
         .doesNotThrowAnyException();
   }
 

--- a/api/src/test/java/org/apache/iceberg/TestSchema.java
+++ b/api/src/test/java/org/apache/iceberg/TestSchema.java
@@ -150,7 +150,6 @@ public class TestSchema {
         .doesNotThrowAnyException();
   }
 
-
   @ParameterizedTest
   @FieldSource("org.apache.iceberg.TestHelpers#ALL_VERSIONS")
   public void testSupportedWriteDefault(int formatVersion) {

--- a/api/src/test/java/org/apache/iceberg/TestSchema.java
+++ b/api/src/test/java/org/apache/iceberg/TestSchema.java
@@ -18,15 +18,16 @@
  */
 package org.apache.iceberg;
 
+import static org.apache.iceberg.Schema.DEFAULT_VALUES_MIN_FORMAT_VERSION;
+import static org.apache.iceberg.Schema.MIN_FORMAT_VERSIONS;
+import static org.apache.iceberg.TestHelpers.MAX_FORMAT_VERSION;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,13 +39,6 @@ public class TestSchema {
 
   private static final List<Type> TESTTYPES =
       ImmutableList.of(Types.TimestampNanoType.withoutZone(), Types.TimestampNanoType.withZone());
-
-  private static final Map<Type.TypeID, Integer> MIN_FORMAT_VERSIONS =
-      ImmutableMap.of(Type.TypeID.TIMESTAMP_NANO, 3);
-
-  private static final Integer MIN_FORMAT_INITIAL_DEFAULT = 3;
-
-  private static final Integer MAX_FORMAT_VERSION = 3;
 
   private static final Schema INITIAL_DEFAULT_SCHEMA =
       new Schema(
@@ -120,8 +114,8 @@ public class TestSchema {
     return TESTTYPES.stream()
         .flatMap(
             type ->
-                IntStream.range(MIN_FORMAT_VERSIONS.get(type.typeId()), MAX_FORMAT_VERSION + 1)
-                    .mapToObj(unsupportedVersion -> Arguments.of(type, unsupportedVersion)));
+                IntStream.rangeClosed(MIN_FORMAT_VERSIONS.get(type.typeId()), MAX_FORMAT_VERSION)
+                    .mapToObj(supportedVersion -> Arguments.of(type, supportedVersion)));
   }
 
   @ParameterizedTest
@@ -132,7 +126,7 @@ public class TestSchema {
   }
 
   private static int[] testUnsupportedInitialDefault =
-      IntStream.range(1, MIN_FORMAT_INITIAL_DEFAULT).toArray();
+      IntStream.range(1, DEFAULT_VALUES_MIN_FORMAT_VERSION).toArray();
 
   @ParameterizedTest
   @FieldSource
@@ -147,7 +141,7 @@ public class TestSchema {
   }
 
   private static int[] testSupportedInitialDefault =
-      IntStream.rangeClosed(MIN_FORMAT_INITIAL_DEFAULT, MAX_FORMAT_VERSION).toArray();
+      IntStream.rangeClosed(DEFAULT_VALUES_MIN_FORMAT_VERSION, MAX_FORMAT_VERSION).toArray();
 
   @ParameterizedTest
   @FieldSource

--- a/api/src/test/java/org/apache/iceberg/TestSchema.java
+++ b/api/src/test/java/org/apache/iceberg/TestSchema.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestSchema {
 
-  private static final List<Type> TESTTYPES =
+  private static final List<Type> TEST_TYPES =
       ImmutableList.of(Types.TimestampNanoType.withoutZone(), Types.TimestampNanoType.withZone());
 
   private static final Schema INITIAL_DEFAULT_SCHEMA =
@@ -76,8 +76,8 @@ public class TestSchema {
                     Types.StructType.of(Types.NestedField.optional(9, "deep", type))))));
   }
 
-  private static Stream<Arguments> testTypeUnsupported() {
-    return TESTTYPES.stream()
+  private static Stream<Arguments> unsupportedTypes() {
+    return TEST_TYPES.stream()
         .flatMap(
             type ->
                 IntStream.range(1, MIN_FORMAT_VERSIONS.get(type.typeId()))
@@ -85,8 +85,8 @@ public class TestSchema {
   }
 
   @ParameterizedTest
-  @MethodSource
-  public void testTypeUnsupported(Type type, int unsupportedVersion) {
+  @MethodSource("unsupportedTypes")
+  public void testUnsupportedTypes(Type type, int unsupportedVersion) {
     assertThatThrownBy(
             () -> Schema.checkCompatibility(generateTypeSchema(type), unsupportedVersion))
         .isInstanceOf(IllegalStateException.class)
@@ -110,8 +110,8 @@ public class TestSchema {
             MIN_FORMAT_VERSIONS.get(type.typeId()));
   }
 
-  private static Stream<Arguments> testTypeSupported() {
-    return TESTTYPES.stream()
+  private static Stream<Arguments> supportedTypes() {
+    return TEST_TYPES.stream()
         .flatMap(
             type ->
                 IntStream.rangeClosed(MIN_FORMAT_VERSIONS.get(type.typeId()), MAX_FORMAT_VERSION)
@@ -119,17 +119,17 @@ public class TestSchema {
   }
 
   @ParameterizedTest
-  @MethodSource
+  @MethodSource("supportedTypes")
   public void testTypeSupported(Type type, int supportedVersion) {
     assertThatCode(() -> Schema.checkCompatibility(generateTypeSchema(type), supportedVersion))
         .doesNotThrowAnyException();
   }
 
-  private static int[] testUnsupportedInitialDefault =
+  private static int[] unsupportedInitialDefault =
       IntStream.range(1, DEFAULT_VALUES_MIN_FORMAT_VERSION).toArray();
 
   @ParameterizedTest
-  @FieldSource
+  @FieldSource("unsupportedInitialDefault")
   public void testUnsupportedInitialDefault(int formatVersion) {
     assertThatThrownBy(() -> Schema.checkCompatibility(INITIAL_DEFAULT_SCHEMA, formatVersion))
         .isInstanceOf(IllegalStateException.class)
@@ -140,21 +140,19 @@ public class TestSchema {
             formatVersion);
   }
 
-  private static int[] testSupportedInitialDefault =
+  private static int[] supportedInitialDefault =
       IntStream.rangeClosed(DEFAULT_VALUES_MIN_FORMAT_VERSION, MAX_FORMAT_VERSION).toArray();
 
   @ParameterizedTest
-  @FieldSource
+  @FieldSource("supportedInitialDefault")
   public void testSupportedInitialDefault(int formatVersion) {
     assertThatCode(() -> Schema.checkCompatibility(INITIAL_DEFAULT_SCHEMA, formatVersion))
         .doesNotThrowAnyException();
   }
 
-  private static int[] testSupportedWriteDefault =
-      IntStream.rangeClosed(1, MAX_FORMAT_VERSION).toArray();
 
   @ParameterizedTest
-  @FieldSource
+  @FieldSource("org.apache.iceberg.TestHelpers#ALL_VERSIONS")
   public void testSupportedWriteDefault(int formatVersion) {
     // only the initial default is a forward-incompatible change
     assertThatCode(() -> Schema.checkCompatibility(WRITE_DEFAULT_SCHEMA, formatVersion))


### PR DESCRIPTION
A lot of our tests are currently very specific but are going to be reused for various other types as they get added. We also currently hard code in the versions we are testing. This makes it a little more difficult whenever we add a new format version to correctly update all of the corresponding tests. 

I'm updating TestSchema to show what I think should be our general pattern for version specific testing where the versions tested are defined in a single location rather than each time per test. 

For the "type" tests, rather than making a named test per type, we parameterize over the type itself so that new types (Geo and Variant) can be added without duplicating code.