### PR TITLE
Core: Fix generated position delete file spec

### DIFF
--- a/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
@@ -102,13 +102,13 @@ public class FileGenerationUtil {
   }
 
   public static DeleteFile generatePositionDeleteFile(Table table, DataFile dataFile) {
-    PartitionSpec spec = table.spec();
+    PartitionSpec spec = table.specs().get(dataFile.specId());
     StructLike partition = dataFile.partition();
     LocationProvider locations = table.locationProvider();
     String path = locations.newDataLocation(spec, partition, generateFileName());
     long fileSize = generateFileSize();
     Metrics metrics = generatePositionDeleteMetrics(dataFile);
-    return FileMetadata.deleteFileBuilder(table.spec())
+    return FileMetadata.deleteFileBuilder(spec)
         .ofPositionDeletes()
         .withPath(path)
         .withPartition(partition)


### PR DESCRIPTION
This PR fixes generated position delete file spec. The current logic relies on the current table spec instead of the spec that the referenced data file belongs to.