### PR TITLE
Core, Data, Flink, Spark: Improve tableDir initialization for tests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
@@ -266,11 +266,8 @@ public abstract class DeleteFileIndexTestBase<
 
   @TestTemplate
   public void testUnpartitionedTableScan() throws IOException {
-    File location = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(location.delete()).isTrue();
-
     Table unpartitioned =
-        TestTables.create(location, "unpartitioned", SCHEMA, PartitionSpec.unpartitioned(), 2);
+        TestTables.create(tableDir, "unpartitioned", SCHEMA, PartitionSpec.unpartitioned(), 2);
 
     DataFile unpartitionedFile = unpartitionedFile(unpartitioned.spec());
     unpartitioned.newAppend().appendFile(unpartitionedFile).commit();

--- a/core/src/test/java/org/apache/iceberg/FilterFilesTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/FilterFilesTestBase.java
@@ -22,9 +22,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import org.apache.iceberg.expressions.Expressions;
@@ -32,7 +30,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -50,12 +47,7 @@ public abstract class FilterFilesTestBase<
   private final Schema schema =
       new Schema(
           required(1, "id", Types.IntegerType.get()), required(2, "data", Types.StringType.get()));
-  private File tableDir = null;
-
-  @BeforeEach
-  public void setupTableDir() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-  }
+  @TempDir private File tableDir;
 
   @AfterEach
   public void cleanupTables() {

--- a/core/src/test/java/org/apache/iceberg/ScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/ScanTestBase.java
@@ -23,9 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Collections;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -149,9 +147,8 @@ public abstract class ScanTestBase<
             required(2, "b", Types.StringType.get()),
             required(3, "data", Types.IntegerType.get()));
     PartitionSpec initialSpec = PartitionSpec.builderFor(schema).identity("a").build();
-    File dir = Files.createTempDirectory(temp, "junit").toFile();
-    dir.delete();
-    this.table = TestTables.create(dir, "test_part_evolution", schema, initialSpec, formatVersion);
+    this.table =
+        TestTables.create(tableDir, "test_part_evolution", schema, initialSpec, formatVersion);
     table
         .newFastAppend()
         .appendFile(
@@ -222,11 +219,13 @@ public abstract class ScanTestBase<
     Schema schema =
         new Schema(
             required(1, "a", Types.IntegerType.get()), required(2, "b", Types.StringType.get()));
-    File dir = Files.createTempDirectory(temp, "junit").toFile();
-    dir.delete();
     this.table =
         TestTables.create(
-            dir, "test_data_file_sorted", schema, PartitionSpec.unpartitioned(), formatVersion);
+            tableDir,
+            "test_data_file_sorted",
+            schema,
+            PartitionSpec.unpartitioned(),
+            formatVersion);
     table
         .newFastAppend()
         .appendFile(

--- a/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
@@ -23,9 +23,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -45,9 +43,6 @@ public class TestCreateTransaction extends TestBase {
 
   @TestTemplate
   public void testCreateTransaction() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Transaction txn = TestTables.beginCreate(tableDir, "test_create", SCHEMA, unpartitioned());
 
     assertThat(TestTables.readMetadata("test_create")).isNull();
@@ -68,9 +63,6 @@ public class TestCreateTransaction extends TestBase {
 
   @TestTemplate
   public void testCreateTransactionAndUpdateSchema() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Transaction txn = TestTables.beginCreate(tableDir, "test_create", SCHEMA, unpartitioned());
 
     assertThat(TestTables.readMetadata("test_create")).isNull();
@@ -105,9 +97,6 @@ public class TestCreateTransaction extends TestBase {
 
   @TestTemplate
   public void testCreateAndAppendWithTransaction() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Transaction txn = TestTables.beginCreate(tableDir, "test_append", SCHEMA, unpartitioned());
 
     assertThat(TestTables.readMetadata("test_append")).isNull();
@@ -134,9 +123,6 @@ public class TestCreateTransaction extends TestBase {
 
   @TestTemplate
   public void testCreateAndAppendWithTable() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Transaction txn = TestTables.beginCreate(tableDir, "test_append", SCHEMA, unpartitioned());
 
     assertThat(TestTables.readMetadata("test_append"))
@@ -167,9 +153,6 @@ public class TestCreateTransaction extends TestBase {
 
   @TestTemplate
   public void testCreateAndUpdatePropertiesWithTransaction() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Transaction txn = TestTables.beginCreate(tableDir, "test_properties", SCHEMA, unpartitioned());
 
     assertThat(TestTables.readMetadata("test_properties")).isNull();
@@ -196,9 +179,6 @@ public class TestCreateTransaction extends TestBase {
 
   @TestTemplate
   public void testCreateAndUpdatePropertiesWithTable() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Transaction txn = TestTables.beginCreate(tableDir, "test_properties", SCHEMA, unpartitioned());
 
     assertThat(TestTables.readMetadata("test_properties")).isNull();
@@ -227,9 +207,6 @@ public class TestCreateTransaction extends TestBase {
 
   @TestTemplate
   public void testCreateDetectsUncommittedChange() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Transaction txn =
         TestTables.beginCreate(tableDir, "uncommitted_change", SCHEMA, unpartitioned());
 
@@ -245,9 +222,6 @@ public class TestCreateTransaction extends TestBase {
 
   @TestTemplate
   public void testCreateDetectsUncommittedChangeOnCommit() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Transaction txn =
         TestTables.beginCreate(tableDir, "uncommitted_change", SCHEMA, unpartitioned());
 
@@ -263,9 +237,6 @@ public class TestCreateTransaction extends TestBase {
 
   @TestTemplate
   public void testCreateTransactionConflict() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Transaction txn = TestTables.beginCreate(tableDir, "test_conflict", SCHEMA, SPEC);
 
     // append in the transaction to ensure a manifest file is created

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -1066,7 +1065,6 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   @TestTemplate
   public void testPartitionColumnNamedPartition() throws Exception {
     TestTables.clearTables();
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
 
     Schema schema =
         new Schema(

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -45,9 +44,6 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
   @BeforeEach
   public void createTable() throws IOException {
     TestTables.clearTables();
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    tableDir.delete();
-
     Schema schema =
         new Schema(
             required(1, "id", Types.IntegerType.get()),

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -30,7 +30,6 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -72,7 +71,8 @@ public abstract class TestMetrics {
     return Arrays.asList(1, 2, 3);
   }
 
-  @TempDir public Path temp;
+  @TempDir protected Path temp;
+  @TempDir private File tableDir;
 
   private static final StructType LEAF_STRUCT_TYPE =
       StructType.of(
@@ -676,9 +676,6 @@ public abstract class TestMetrics {
 
   @TestTemplate
   public void testSortedColumnMetrics() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue(); // created by table create
-
     SortOrder sortOrder =
         SortOrder.builderFor(SIMPLE_SCHEMA)
             .asc("booleanCol")
@@ -739,9 +736,6 @@ public abstract class TestMetrics {
 
   @TestTemplate
   public void testMetricsForSortedNestedStructFields() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue(); // created by table create
-
     SortOrder sortOrder =
         SortOrder.builderFor(NESTED_SCHEMA)
             .asc("nestedStructCol.longCol")

--- a/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -42,6 +41,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestMetricsModes {
+  @TempDir private File tableDir;
 
   @Parameter private int formatVersion;
 
@@ -108,9 +108,6 @@ public class TestMetricsModes {
 
   @TestTemplate
   public void testMetricsConfigSortedColsDefault() throws Exception {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Schema schema =
         new Schema(
             required(1, "col1", Types.IntegerType.get()),
@@ -145,9 +142,6 @@ public class TestMetricsModes {
 
   @TestTemplate
   public void testMetricsConfigSortedColsDefaultByInvalid() throws Exception {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Schema schema =
         new Schema(
             required(1, "col1", Types.IntegerType.get()),
@@ -180,9 +174,6 @@ public class TestMetricsModes {
             required(1, "col1", Types.IntegerType.get()),
             required(2, "col2", Types.IntegerType.get()),
             required(3, "col3", Types.IntegerType.get()));
-
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
 
     Table table =
         TestTables.create(

--- a/core/src/test/java/org/apache/iceberg/TestOverwrite.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwrite.java
@@ -27,11 +27,9 @@ import static org.apache.iceberg.util.SnapshotUtil.latestSnapshot;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.ManifestEntry.Status;
@@ -126,9 +124,6 @@ public class TestOverwrite extends TestBase {
 
   @BeforeEach
   public void createTestTable() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     this.table =
         TestTables.create(tableDir, TABLE_NAME, DATE_SCHEMA, PARTITION_BY_DATE, formatVersion);
 

--- a/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
@@ -30,11 +30,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -201,8 +199,6 @@ public class TestOverwriteWithValidation extends TestBase {
 
   @BeforeEach
   public void before() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
     this.table =
         TestTables.create(tableDir, TABLE_NAME, DATE_SCHEMA, PARTITION_SPEC, formatVersion);
   }

--- a/core/src/test/java/org/apache/iceberg/TestPartitionSpecBuilderCaseSensitivity.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitionSpecBuilderCaseSensitivity.java
@@ -22,17 +22,11 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 public class TestPartitionSpecBuilderCaseSensitivity {
 
@@ -56,14 +50,6 @@ public class TestPartitionSpecBuilderCaseSensitivity {
           required(5, "ORDER_DATE", Types.DateType.get()),
           required(6, "order_time", Types.TimestampType.withoutZone()),
           required(7, "ORDER_TIME", Types.TimestampType.withoutZone()));
-
-  @TempDir private Path temp;
-  private File tableDir = null;
-
-  @BeforeEach
-  public void setupTableDir() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-  }
 
   @AfterEach
   public void cleanupTables() {

--- a/core/src/test/java/org/apache/iceberg/TestPartitionSpecInfo.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitionSpecInfo.java
@@ -24,14 +24,10 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.entry;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -39,12 +35,11 @@ import org.junit.jupiter.api.io.TempDir;
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestPartitionSpecInfo {
 
-  @TempDir private Path temp;
+  @TempDir private File tableDir;
 
   private final Schema schema =
       new Schema(
           required(1, "id", Types.IntegerType.get()), required(2, "data", Types.StringType.get()));
-  private File tableDir = null;
 
   @Parameters(name = "formatVersion = {0}")
   protected static List<Object> parameters() {
@@ -52,11 +47,6 @@ public class TestPartitionSpecInfo {
   }
 
   @Parameter private int formatVersion;
-
-  @BeforeEach
-  public void setupTableDir() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-  }
 
   @AfterEach
   public void cleanupTables() {

--- a/core/src/test/java/org/apache/iceberg/TestPartitioning.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitioning.java
@@ -23,16 +23,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -52,13 +48,7 @@ public class TestPartitioning {
   private static final PartitionSpec BY_DATA_CATEGORY_BUCKET_SPEC =
       PartitionSpec.builderFor(SCHEMA).identity("data").bucket("category", 8).build();
 
-  @TempDir private Path temp;
-  private File tableDir = null;
-
-  @BeforeEach
-  public void setupTableDir() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-  }
+  @TempDir private File tableDir;
 
   @AfterEach
   public void cleanupTables() {

--- a/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
@@ -23,9 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.ManifestEntry.Status;
@@ -167,9 +165,6 @@ public class TestReplacePartitions extends TestBase {
 
   @TestTemplate
   public void testReplaceWithUnpartitionedTable() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Table unpartitioned =
         TestTables.create(
             tableDir, "unpartitioned", SCHEMA, PartitionSpec.unpartitioned(), formatVersion);
@@ -206,9 +201,6 @@ public class TestReplacePartitions extends TestBase {
 
   @TestTemplate
   public void testReplaceAndMergeWithUnpartitionedTable() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Table unpartitioned =
         TestTables.create(
             tableDir, "unpartitioned", SCHEMA, PartitionSpec.unpartitioned(), formatVersion);
@@ -369,9 +361,6 @@ public class TestReplacePartitions extends TestBase {
 
   @TestTemplate
   public void testValidateWithVoidTransform() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     Table tableVoid = TestTables.create(tableDir, "tablevoid", SCHEMA, SPEC_VOID, formatVersion);
     commit(tableVoid, tableVoid.newReplacePartitions().addFile(FILE_A_VOID_PARTITION), branch);
 

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -28,7 +28,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -324,9 +323,6 @@ public class TestReplaceTransaction extends TestBase {
 
   @TestTemplate
   public void testReplaceToCreateAndAppend() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     // this table doesn't exist.
     Transaction replace = TestTables.beginReplace(tableDir, "test_append", SCHEMA, unpartitioned());
 
@@ -398,9 +394,6 @@ public class TestReplaceTransaction extends TestBase {
 
   @TestTemplate
   public void testCreateTransactionWithUnknownState() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     // this table doesn't exist.
     TestTables.TestTableOperations ops =
         TestTables.opsWithCommitSucceedButStateUnknown(tableDir, "test_append");

--- a/core/src/test/java/org/apache/iceberg/TestSortOrder.java
+++ b/core/src/test/java/org/apache/iceberg/TestSortOrder.java
@@ -28,9 +28,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -39,7 +36,6 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SortOrderUtil;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -70,9 +66,7 @@ public class TestSortOrder {
           required(30, "ext", Types.StringType.get()),
           required(42, "Ext1", Types.StringType.get()));
 
-  @TempDir private Path temp;
-
-  private File tableDir = null;
+  @TempDir private File tableDir;
 
   @Parameters(name = "formatVersion = {0}")
   protected static List<Object> parameters() {
@@ -80,11 +74,6 @@ public class TestSortOrder {
   }
 
   @Parameter private int formatVersion;
-
-  @BeforeEach
-  public void setupTableDir() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-  }
 
   @AfterEach
   public void cleanupTables() {

--- a/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
@@ -22,9 +22,7 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -64,7 +62,6 @@ public class TestSplitPlanning extends TestBase {
   @Override
   @BeforeEach
   public void setupTable() throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
     String tableLocation = tableDir.toURI().toString();
     table = TABLES.create(SCHEMA, tableLocation);
     table

--- a/core/src/test/java/org/apache/iceberg/TestTimestampPartitions.java
+++ b/core/src/test/java/org/apache/iceberg/TestTimestampPartitions.java
@@ -22,9 +22,7 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.types.Types;
@@ -55,9 +53,6 @@ public class TestTimestampPartitions extends TestBase {
             .withRecordCount(0)
             .withPartitionPath("date=2018-06-08")
             .build();
-
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
 
     this.table =
         TestTables.create(

--- a/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
@@ -80,8 +80,6 @@ public class TestSnapshotUtil {
 
   @BeforeEach
   public void before() throws Exception {
-    tableDir.delete(); // created by table create
-
     this.metadataDir = new File(tableDir, "metadata");
 
     this.table = TestTables.create(tableDir, "test", SCHEMA, SPEC, 2);

--- a/data/src/test/java/org/apache/iceberg/TestSplitScan.java
+++ b/data/src/test/java/org/apache/iceberg/TestSplitScan.java
@@ -50,7 +50,7 @@ public class TestSplitScan {
           required(1, "id", Types.IntegerType.get()), required(2, "data", Types.StringType.get()));
 
   private Table table;
-  private File tableLocation;
+  @TempDir private File tableLocation;
   private List<Record> expectedRecords;
 
   @Parameters(name = "fileFormat = {0}")
@@ -59,11 +59,9 @@ public class TestSplitScan {
   }
 
   @Parameter private FileFormat format;
-  @TempDir private File tempDir;
 
   @BeforeEach
   public void before() throws IOException {
-    tableLocation = java.nio.file.Files.createTempDirectory(tempDir.toPath(), "table").toFile();
     setupTable();
   }
 
@@ -100,7 +98,7 @@ public class TestSplitScan {
   }
 
   private File writeToFile(List<Record> records, FileFormat fileFormat) throws IOException {
-    File file = File.createTempFile("junit", null, tempDir);
+    File file = File.createTempFile("junit", null, tableLocation);
     assertThat(file.delete()).isTrue();
 
     GenericAppenderFactory factory =

--- a/data/src/test/java/org/apache/iceberg/data/TestGenericReaderDeletes.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestGenericReaderDeletes.java
@@ -18,11 +18,8 @@
  */
 package org.apache.iceberg.data;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -32,15 +29,14 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.util.StructLikeSet;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestGenericReaderDeletes extends DeleteReadTests {
+  @TempDir private File tableDir;
 
   @Override
   protected Table createTable(String name, Schema schema, PartitionSpec spec) throws IOException {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     return TestTables.create(tableDir, name, schema, spec, 2);
   }
 

--- a/data/src/test/java/org/apache/iceberg/io/TestAppenderFactory.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestAppenderFactory.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -84,9 +83,6 @@ public abstract class TestAppenderFactory<T> extends TestBase {
   @Override
   @BeforeEach
   public void setupTable() throws Exception {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue(); // created by table create
-
     this.metadataDir = new File(tableDir, "metadata");
 
     if (partitioned) {

--- a/data/src/test/java/org/apache/iceberg/io/TestBaseTaskWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestBaseTaskWriter.java
@@ -69,9 +69,6 @@ public class TestBaseTaskWriter extends TestBase {
   @Override
   @BeforeEach
   public void setupTable() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue(); // created by table create
-
     this.metadataDir = new File(tableDir, "metadata");
 
     this.table = create(SCHEMA, PartitionSpec.unpartitioned());

--- a/data/src/test/java/org/apache/iceberg/io/TestFileWriterFactory.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestFileWriterFactory.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -95,9 +94,6 @@ public abstract class TestFileWriterFactory<T> extends WriterTestBase<T> {
   @Override
   @BeforeEach
   public void setupTable() throws Exception {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue(); // created during table creation
-
     this.metadataDir = new File(tableDir, "metadata");
 
     if (partitioned) {

--- a/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -80,9 +79,6 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
   @Override
   @BeforeEach
   public void setupTable() throws Exception {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue(); // created during table creation
-
     this.metadataDir = new File(tableDir, "metadata");
     this.table = create(SCHEMA, PartitionSpec.unpartitioned());
     this.fileFactory = OutputFileFactory.builderFor(table, 1, 1).format(fileFormat).build();

--- a/data/src/test/java/org/apache/iceberg/io/TestPositionDeltaWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestPositionDeltaWriters.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.DataFile;
@@ -67,9 +66,6 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
   @Override
   @BeforeEach
   public void setupTable() throws Exception {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue(); // created during table creation
-
     this.metadataDir = new File(tableDir, "metadata");
     this.table = create(SCHEMA, PartitionSpec.unpartitioned());
     this.fileFactory = OutputFileFactory.builderFor(table, 1, 1).format(fileFormat).build();

--- a/data/src/test/java/org/apache/iceberg/io/TestRollingFileWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestRollingFileWriters.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.FileFormat;
@@ -74,9 +73,6 @@ public abstract class TestRollingFileWriters<T> extends WriterTestBase<T> {
   @Override
   @BeforeEach
   public void setupTable() throws Exception {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue(); // created during table creation
-
     this.metadataDir = new File(tableDir, "metadata");
 
     if (partitioned) {

--- a/data/src/test/java/org/apache/iceberg/io/TestTaskEqualityDeltaWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestTaskEqualityDeltaWriter.java
@@ -85,9 +85,6 @@ public class TestTaskEqualityDeltaWriter extends TestBase {
   @Override
   @BeforeEach
   public void setupTable() throws IOException {
-    this.tableDir = java.nio.file.Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue(); // created by table create
-
     this.metadataDir = new File(tableDir, "metadata");
 
     this.table = create(SCHEMA, PartitionSpec.unpartitioned());

--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +78,7 @@ public abstract class TestWriterMetrics<T> {
   protected static final Map<String, String> PROPERTIES =
       ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, "none");
 
-  @TempDir private File tempDir;
+  @TempDir private File tableDir;
 
   protected FileFormat fileFormat;
   protected TestTables.TestTable table = null;
@@ -102,9 +101,6 @@ public abstract class TestWriterMetrics<T> {
 
   @BeforeEach
   public void setupTable() throws Exception {
-    File tableDir = Files.createTempDirectory(tempDir.toPath(), "junit").toFile();
-    tableDir.delete(); // created by table create
-
     this.table =
         TestTables.create(
             tableDir, "test", SCHEMA, PartitionSpec.unpartitioned(), SORT_ORDER, FORMAT_V2);
@@ -243,9 +239,6 @@ public abstract class TestWriterMetrics<T> {
 
   @TestTemplate
   public void testMaxColumns() throws IOException {
-    File tableDir = Files.createTempDirectory(tempDir.toPath(), "table").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     int numColumns = TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT + 1;
     List<Types.NestedField> fields = Lists.newArrayListWithCapacity(numColumns);
     for (int i = 0; i < numColumns; i++) {
@@ -306,9 +299,6 @@ public abstract class TestWriterMetrics<T> {
 
   @TestTemplate
   public void testMaxColumnsWithDefaultOverride() throws IOException {
-    File tableDir = Files.createTempDirectory(tempDir.toPath(), "table").toFile();
-    assertThat(tableDir.delete()).isTrue();
-
     int numColumns = TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT + 1;
     List<Types.NestedField> fields = Lists.newArrayListWithCapacity(numColumns);
     for (int i = 0; i < numColumns; i++) {

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -88,9 +88,6 @@ public class TestDeltaTaskWriter extends TestBase {
   @Override
   @BeforeEach
   public void setupTable() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue(); // created by table create
-
     this.metadataDir = new File(tableDir, "metadata");
   }
 

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -107,10 +107,7 @@ public class TestIcebergFilesCommitter extends TestBase {
   @BeforeEach
   public void setupTable() throws IOException {
     flinkManifestFolder = Files.createTempDirectory(temp, "flink").toFile();
-
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.metadataDir = new File(tableDir, "metadata");
-    assertThat(tableDir.delete()).isTrue();
 
     // Construct the iceberg table.
     table = create(SimpleDataUtil.SCHEMA, PartitionSpec.unpartitioned());

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -75,9 +74,7 @@ public class TestStreamingMonitorFunction extends TestBase {
   @BeforeEach
   @Override
   public void setupTable() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.metadataDir = new File(tableDir, "metadata");
-    assertThat(tableDir.delete()).isTrue();
 
     // Construct the iceberg table.
     table = create(SCHEMA, PartitionSpec.unpartitioned());

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -72,9 +71,7 @@ public class TestStreamingReaderOperator extends TestBase {
   @BeforeEach
   @Override
   public void setupTable() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.metadataDir = new File(tableDir, "metadata");
-    assertThat(tableDir.delete()).isTrue();
 
     // Construct the iceberg table.
     table = create(SCHEMA, PartitionSpec.unpartitioned());

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -88,9 +88,6 @@ public class TestDeltaTaskWriter extends TestBase {
   @Override
   @BeforeEach
   public void setupTable() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue(); // created by table create
-
     this.metadataDir = new File(tableDir, "metadata");
   }
 

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -107,10 +107,7 @@ public class TestIcebergFilesCommitter extends TestBase {
   @BeforeEach
   public void setupTable() throws IOException {
     flinkManifestFolder = Files.createTempDirectory(temp, "flink").toFile();
-
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.metadataDir = new File(tableDir, "metadata");
-    assertThat(tableDir.delete()).isTrue();
 
     // Construct the iceberg table.
     table = create(SimpleDataUtil.SCHEMA, PartitionSpec.unpartitioned());

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -75,9 +74,7 @@ public class TestStreamingMonitorFunction extends TestBase {
   @BeforeEach
   @Override
   public void setupTable() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.metadataDir = new File(tableDir, "metadata");
-    assertThat(tableDir.delete()).isTrue();
 
     // Construct the iceberg table.
     table = create(SCHEMA, PartitionSpec.unpartitioned());

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -72,9 +71,7 @@ public class TestStreamingReaderOperator extends TestBase {
   @BeforeEach
   @Override
   public void setupTable() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.metadataDir = new File(tableDir, "metadata");
-    assertThat(tableDir.delete()).isTrue();
 
     // Construct the iceberg table.
     table = create(SCHEMA, PartitionSpec.unpartitioned());

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -88,9 +88,6 @@ public class TestDeltaTaskWriter extends TestBase {
   @Override
   @BeforeEach
   public void setupTable() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(tableDir.delete()).isTrue(); // created by table create
-
     this.metadataDir = new File(tableDir, "metadata");
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -107,10 +107,7 @@ public class TestIcebergFilesCommitter extends TestBase {
   @BeforeEach
   public void setupTable() throws IOException {
     flinkManifestFolder = Files.createTempDirectory(temp, "flink").toFile();
-
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.metadataDir = new File(tableDir, "metadata");
-    assertThat(tableDir.delete()).isTrue();
 
     // Construct the iceberg table.
     table = create(SimpleDataUtil.SCHEMA, PartitionSpec.unpartitioned());

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -75,9 +74,7 @@ public class TestStreamingMonitorFunction extends TestBase {
   @BeforeEach
   @Override
   public void setupTable() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.metadataDir = new File(tableDir, "metadata");
-    assertThat(tableDir.delete()).isTrue();
 
     // Construct the iceberg table.
     table = create(SCHEMA, PartitionSpec.unpartitioned());

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -72,9 +71,7 @@ public class TestStreamingReaderOperator extends TestBase {
   @BeforeEach
   @Override
   public void setupTable() throws IOException {
-    this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.metadataDir = new File(tableDir, "metadata");
-    assertThat(tableDir.delete()).isTrue();
 
     // Construct the iceberg table.
     table = create(SCHEMA, PartitionSpec.unpartitioned());

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
@@ -62,12 +62,12 @@ public class TestScanTaskSerialization extends TestBase {
           optional(3, "c3", Types.StringType.get()));
 
   @TempDir private Path temp;
+  @TempDir private File tableDir;
 
   private String tableLocation = null;
 
   @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = Files.createTempDirectory(temp, "junit").toFile();
     this.tableLocation = tableDir.toURI().toString();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -77,6 +77,7 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.io.TempDir;
 import scala.Option;
 import scala.Some;
 import scala.collection.JavaConverters;
@@ -142,7 +143,7 @@ public class TestCreateActions extends CatalogTestBase {
   }
 
   private final String baseTableName = "baseTable";
-  private File tableDir;
+  @TempDir private File tableDir;
   private String tableLocation;
 
   @Parameter(index = 3)
@@ -154,11 +155,6 @@ public class TestCreateActions extends CatalogTestBase {
   @Override
   public void before() {
     super.before();
-    try {
-      this.tableDir = Files.createTempDirectory(temp, "junit").toFile();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
     this.tableLocation = tableDir.toURI().toString();
     this.catalog = (TableCatalog) spark.sessionState().catalogManager().catalog(catalogName);
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -112,13 +111,12 @@ public class TestDeleteReachableFilesAction extends TestBase {
           .withRecordCount(1)
           .build();
 
-  @TempDir private Path temp;
+  @TempDir private File tableDir;
 
   private Table table;
 
   @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.resolve("junit").toFile();
     String tableLocation = tableDir.toURI().toString();
     this.table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
     spark.conf().set("spark.sql.shuffle.partitions", SHUFFLE_PARTITIONS);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -121,13 +121,12 @@ public class TestExpireSnapshotsAction extends TestBase {
 
   @TempDir private Path temp;
 
-  private File tableDir;
+  @TempDir private File tableDir;
   private String tableLocation;
   private Table table;
 
   @BeforeEach
   public void setupTableLocation() throws Exception {
-    this.tableDir = temp.resolve("junit").toFile();
     this.tableLocation = tableDir.toURI().toString();
     this.table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
     spark.conf().set("spark.sql.shuffle.partitions", SHUFFLE_PARTITIONS);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
@@ -22,7 +22,6 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -202,14 +201,13 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
           .withRecordCount(1)
           .build();
 
-  @TempDir private Path temp;
+  @TempDir private File tableDir;
 
   private String tableLocation = null;
   private Table table;
 
   @BeforeEach
   public void before() throws Exception {
-    File tableDir = temp.resolve("junit").toFile();
     this.tableLocation = tableDir.toURI().toString();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -95,13 +95,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   protected static final PartitionSpec SPEC =
       PartitionSpec.builderFor(SCHEMA).truncate("c2", 2).identity("c3").build();
 
-  @TempDir private java.nio.file.Path temp;
-  private File tableDir = null;
+  @TempDir private File tableDir = null;
   protected String tableLocation = null;
 
   @BeforeEach
   public void setupTableLocation() throws Exception {
-    this.tableDir = temp.resolve("junit").toFile();
     this.tableLocation = tableDir.toURI().toString();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -126,6 +126,7 @@ import org.mockito.Mockito;
 
 public class TestRewriteDataFilesAction extends TestBase {
 
+  @TempDir private File tableDir;
   private static final int SCALE = 400000;
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
@@ -151,7 +152,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.resolve("junit").toFile();
     this.tableLocation = tableDir.toURI().toString();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -125,10 +125,10 @@ public class TestRewriteManifestsAction extends TestBase {
   private String tableLocation = null;
 
   @TempDir private Path temp;
+  @TempDir private File tableDir;
 
   @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.resolve("junit").toFile();
     this.tableLocation = tableDir.toURI().toString();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables.java
@@ -27,19 +27,16 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestIcebergSourceHadoopTables extends TestIcebergSourceTablesBase {
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
-
-  File tableDir = null;
+  @TempDir private File tableDir;
   String tableLocation = null;
 
   @BeforeEach
   public void setupTable() throws Exception {
-    this.tableDir = temp.toFile();
-    tableDir.delete(); // created by table create
-
     this.tableLocation = tableDir.toURI().toString();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -133,12 +132,11 @@ public class TestSparkDataFile {
     currentSpark.stop();
   }
 
-  @TempDir private Path temp;
+  @TempDir private File tableDir;
   private String tableLocation = null;
 
   @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.toFile();
     this.tableLocation = tableDir.toURI().toString();
   }
 


### PR DESCRIPTION
Typically initialization of a table dir is either already handled in a super class or we can make use of `@TempDir`, thus not requiring manual re-initialization