### PR TITLE
Iceberg parser should passthrough unsupported procedure to delegate

### DIFF
--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -136,8 +136,10 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
       // Strip comments of the form  /* ... */. This must come after stripping newlines so that
       // comments that span multiple lines are caught.
       .replaceAll("/\\*.*?\\*/", " ")
+      .replace("`", "")
       .trim()
-    normalized.startsWith("call") || (
+    // All builtin Iceberg procedures are under the 'system' namespace
+    normalized.startsWith("call") && normalized.contains("system.") || (
         normalized.startsWith("alter table") && (
             normalized.contains("add partition field") ||
             normalized.contains("drop partition field") ||


### PR DESCRIPTION
Spark allows users to configure multiple extensions and each extension is allowed to inject its own SQL parser, there is a chance that the user configure multiple extensions that support `CALL` syntax, ideally, each extension should only intercept its supported procedure and invoke the `delegate` object to handle the unknowns.

Currently, all Iceberg builtin procedures are under `system` namespace, which is guard by https://github.com/apache/iceberg/blob/81b3310ab469408022cc14af51257b7e8b36614f/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/BaseCatalog.java#L51

so I propose to add a simple rule to check the SQL before doing parse