### PR TITLE
Flink: Fix config key typo in error message of SplitComparators

### DIFF
--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitComparators.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitComparators.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.source.split;
 
+import org.apache.iceberg.flink.FlinkReadOptions;
 import org.apache.iceberg.flink.source.reader.SplitWatermarkExtractor;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
@@ -35,7 +36,8 @@ public class SplitComparators {
     return (IcebergSourceSplit o1, IcebergSourceSplit o2) -> {
       Preconditions.checkArgument(
           o1.task().files().size() == 1 && o2.task().files().size() == 1,
-          "Could not compare combined task. Please use 'split-open-file-cost' to prevent combining multiple files to a split");
+          "Could not compare combined task. Please use '%s' to prevent combining multiple files to a split",
+          FlinkReadOptions.SPLIT_FILE_OPEN_COST);
 
       Long seq1 = o1.task().files().iterator().next().file().fileSequenceNumber();
       Long seq2 = o2.task().files().iterator().next().file().fileSequenceNumber();

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
@@ -43,7 +43,7 @@ public class TestFileSequenceNumberBasedSplitAssigner extends SplitAssignerTestB
             () -> assigner.onDiscoveredSplits(createSplits(4, 2, "2")),
             "Multiple files in a split is not allowed")
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Please use 'split-open-file-cost'");
+        .hasMessageContaining("Please use 'split-file-open-cost'");
   }
 
   /** Test sorted splits */

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitComparators.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitComparators.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.source.split;
 
+import org.apache.iceberg.flink.FlinkReadOptions;
 import org.apache.iceberg.flink.source.reader.SplitWatermarkExtractor;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
@@ -35,7 +36,8 @@ public class SplitComparators {
     return (IcebergSourceSplit o1, IcebergSourceSplit o2) -> {
       Preconditions.checkArgument(
           o1.task().files().size() == 1 && o2.task().files().size() == 1,
-          "Could not compare combined task. Please use 'split-open-file-cost' to prevent combining multiple files to a split");
+          "Could not compare combined task. Please use '%s' to prevent combining multiple files to a split",
+          FlinkReadOptions.SPLIT_FILE_OPEN_COST);
 
       Long seq1 = o1.task().files().iterator().next().file().fileSequenceNumber();
       Long seq2 = o2.task().files().iterator().next().file().fileSequenceNumber();

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
@@ -43,7 +43,7 @@ public class TestFileSequenceNumberBasedSplitAssigner extends SplitAssignerTestB
             () -> assigner.onDiscoveredSplits(createSplits(4, 2, "2")),
             "Multiple files in a split is not allowed")
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Please use 'split-open-file-cost'");
+        .hasMessageContaining("Please use 'split-file-open-cost'");
   }
 
   /** Test sorted splits */

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitComparators.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitComparators.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.source.split;
 
+import org.apache.iceberg.flink.FlinkReadOptions;
 import org.apache.iceberg.flink.source.reader.SplitWatermarkExtractor;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
@@ -35,7 +36,8 @@ public class SplitComparators {
     return (IcebergSourceSplit o1, IcebergSourceSplit o2) -> {
       Preconditions.checkArgument(
           o1.task().files().size() == 1 && o2.task().files().size() == 1,
-          "Could not compare combined task. Please use 'split-open-file-cost' to prevent combining multiple files to a split");
+          "Could not compare combined task. Please use '%s' to prevent combining multiple files to a split",
+          FlinkReadOptions.SPLIT_FILE_OPEN_COST);
 
       Long seq1 = o1.task().files().iterator().next().file().fileSequenceNumber();
       Long seq2 = o2.task().files().iterator().next().file().fileSequenceNumber();

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
@@ -43,7 +43,7 @@ public class TestFileSequenceNumberBasedSplitAssigner extends SplitAssignerTestB
             () -> assigner.onDiscoveredSplits(createSplits(4, 2, "2")),
             "Multiple files in a split is not allowed")
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Please use 'split-open-file-cost'");
+        .hasMessageContaining("Please use 'split-file-open-cost'");
   }
 
   /** Test sorted splits */


### PR DESCRIPTION
`split-open-file-cost` should be `split-file-open-cost`. Or simply use the const variable for constructing the error message. Also updated the test that asserts error message.