### PR TITLE
Core, Flink, Spark: Verify maintenance actions with DVs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseContentScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseContentScanTask.java
@@ -23,6 +23,7 @@ import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.util.ArrayUtil;
+import org.apache.iceberg.util.ScanTaskUtil;
 
 abstract class BaseContentScanTask<ThisT extends ContentScanTask<F>, F extends ContentFile<F>>
     implements ContentScanTask<F>, SplittableScanTask<ThisT> {
@@ -82,7 +83,7 @@ abstract class BaseContentScanTask<ThisT extends ContentScanTask<F>, F extends C
 
   @Override
   public long length() {
-    return file.fileSizeInBytes();
+    return ScanTaskUtil.contentSizeInBytes(file);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -176,6 +176,8 @@ public class BaseFileScanTask extends BaseContentScanTask<FileScanTask, DataFile
     @Override
     public SplitScanTask merge(ScanTask other) {
       SplitScanTask that = (SplitScanTask) other;
+      // don't use deletesSizeBytes() here so that deletesSizeBytes is only calculated once after
+      // merging rather than for each task before merging
       return new SplitScanTask(offset, len + that.length(), fileScanTask, deletesSizeBytes);
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -1733,7 +1733,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     assertEstimatedRowCount(new AllDataFilesTable(table), 4);
     assertEstimatedRowCount(new AllFilesTable(table), 4);
 
-    if (formatVersion == 2) {
+    if (formatVersion >= 2) {
       assertEstimatedRowCount(new DeleteFilesTable(table), 4);
       assertEstimatedRowCount(new AllDeleteFilesTable(table), 4);
     }

--- a/data/src/test/java/org/apache/iceberg/data/FileHelpers.java
+++ b/data/src/test/java/org/apache/iceberg/data/FileHelpers.java
@@ -23,9 +23,12 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.deletes.BaseDVFileWriter;
+import org.apache.iceberg.deletes.DVFileWriter;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
@@ -35,6 +38,8 @@ import org.apache.iceberg.encryption.EncryptionKeyMetadata;
 import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
 import org.apache.iceberg.util.Pair;
@@ -48,20 +53,52 @@ public class FileHelpers {
   }
 
   public static Pair<DeleteFile, CharSequenceSet> writeDeleteFile(
+      Table table, OutputFile out, List<Pair<CharSequence, Long>> deletes, int formatVersion)
+      throws IOException {
+    return writeDeleteFile(table, out, null, deletes, formatVersion);
+  }
+
+  public static Pair<DeleteFile, CharSequenceSet> writeDeleteFile(
       Table table, OutputFile out, StructLike partition, List<Pair<CharSequence, Long>> deletes)
       throws IOException {
-    FileWriterFactory<Record> factory = GenericFileWriterFactory.builderFor(table).build();
+    return writeDeleteFile(table, out, partition, deletes, 2);
+  }
 
-    PositionDeleteWriter<Record> writer =
-        factory.newPositionDeleteWriter(encrypt(out), table.spec(), partition);
-    PositionDelete<Record> posDelete = PositionDelete.create();
-    try (Closeable toClose = writer) {
-      for (Pair<CharSequence, Long> delete : deletes) {
-        writer.write(posDelete.set(delete.first(), delete.second(), null));
+  public static Pair<DeleteFile, CharSequenceSet> writeDeleteFile(
+      Table table,
+      OutputFile out,
+      StructLike partition,
+      List<Pair<CharSequence, Long>> deletes,
+      int formatVersion)
+      throws IOException {
+    if (formatVersion >= 3) {
+      OutputFileFactory fileFactory =
+          OutputFileFactory.builderFor(table, 1, 1).format(FileFormat.PUFFIN).build();
+      DVFileWriter writer = new BaseDVFileWriter(fileFactory, p -> null);
+      try (DVFileWriter closeableWriter = writer) {
+        for (Pair<CharSequence, Long> delete : deletes) {
+          closeableWriter.delete(
+              delete.first().toString(), delete.second(), table.spec(), partition);
+        }
       }
-    }
 
-    return Pair.of(writer.toDeleteFile(), writer.referencedDataFiles());
+      return Pair.of(
+          Iterables.getOnlyElement(writer.result().deleteFiles()),
+          writer.result().referencedDataFiles());
+    } else {
+      FileWriterFactory<Record> factory = GenericFileWriterFactory.builderFor(table).build();
+
+      PositionDeleteWriter<Record> writer =
+          factory.newPositionDeleteWriter(encrypt(out), table.spec(), partition);
+      PositionDelete<Record> posDelete = PositionDelete.create();
+      try (Closeable toClose = writer) {
+        for (Pair<CharSequence, Long> delete : deletes) {
+          writer.write(posDelete.set(delete.first(), delete.second(), null));
+        }
+      }
+
+      return Pair.of(writer.toDeleteFile(), writer.referencedDataFiles());
+    }
   }
 
   public static DeleteFile writeDeleteFile(
@@ -121,18 +158,43 @@ public class FileHelpers {
   public static DeleteFile writePosDeleteFile(
       Table table, OutputFile out, StructLike partition, List<PositionDelete<?>> deletes)
       throws IOException {
-    FileWriterFactory<Record> factory =
-        GenericFileWriterFactory.builderFor(table).positionDeleteRowSchema(table.schema()).build();
+    return writePosDeleteFile(table, out, partition, deletes, 2);
+  }
 
-    PositionDeleteWriter<?> writer =
-        factory.newPositionDeleteWriter(encrypt(out), table.spec(), partition);
-    try (Closeable toClose = writer) {
-      for (PositionDelete delete : deletes) {
-        writer.write(delete);
+  public static DeleteFile writePosDeleteFile(
+      Table table,
+      OutputFile out,
+      StructLike partition,
+      List<PositionDelete<?>> deletes,
+      int formatVersion)
+      throws IOException {
+    if (formatVersion >= 3) {
+      OutputFileFactory fileFactory =
+          OutputFileFactory.builderFor(table, 1, 1).format(FileFormat.PUFFIN).build();
+      DVFileWriter writer = new BaseDVFileWriter(fileFactory, p -> null);
+      try (DVFileWriter closeableWriter = writer) {
+        for (PositionDelete<?> delete : deletes) {
+          closeableWriter.delete(delete.path().toString(), delete.pos(), table.spec(), partition);
+        }
       }
-    }
 
-    return writer.toDeleteFile();
+      return Iterables.getOnlyElement(writer.result().deleteFiles());
+    } else {
+      FileWriterFactory<Record> factory =
+          GenericFileWriterFactory.builderFor(table)
+              .positionDeleteRowSchema(table.schema())
+              .build();
+
+      PositionDeleteWriter<?> writer =
+          factory.newPositionDeleteWriter(encrypt(out), table.spec(), partition);
+      try (Closeable toClose = writer) {
+        for (PositionDelete delete : deletes) {
+          writer.write(delete);
+        }
+      }
+
+      return writer.toDeleteFile();
+    }
   }
 
   private static EncryptedOutputFile encrypt(OutputFile out) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -21,10 +21,12 @@ package org.apache.iceberg.spark.actions;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,8 +38,12 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReachableFileUtil;
 import org.apache.iceberg.Schema;
@@ -53,16 +59,17 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestExpireSnapshotsAction extends TestBase {
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
@@ -120,6 +127,12 @@ public class TestExpireSnapshotsAction extends TestBase {
           .build();
 
   @TempDir private Path temp;
+  @Parameter private int formatVersion;
+
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(2, 3);
+  }
 
   @TempDir private File tableDir;
   private String tableLocation;
@@ -128,7 +141,12 @@ public class TestExpireSnapshotsAction extends TestBase {
   @BeforeEach
   public void setupTableLocation() throws Exception {
     this.tableLocation = tableDir.toURI().toString();
-    this.table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
+    this.table =
+        TABLES.create(
+            SCHEMA,
+            SPEC,
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
     spark.conf().set("spark.sql.shuffle.partitions", SHUFFLE_PARTITIONS);
   }
 
@@ -142,6 +160,10 @@ public class TestExpireSnapshotsAction extends TestBase {
       end = System.currentTimeMillis();
     }
     return end;
+  }
+
+  private DeleteFile fileADeletes() {
+    return formatVersion >= 3 ? FileGenerationUtil.generateDV(table, FILE_A) : FILE_A_POS_DELETES;
   }
 
   private void checkExpirationResults(
@@ -173,7 +195,7 @@ public class TestExpireSnapshotsAction extends TestBase {
         .isEqualTo(expectedManifestListsDeleted);
   }
 
-  @Test
+  @TestTemplate
   public void testFilesCleaned() throws Exception {
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -191,7 +213,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, results);
   }
 
-  @Test
+  @TestTemplate
   public void dataFilesCleanupWithParallelTasks() throws IOException {
 
     table.newFastAppend().appendFile(FILE_A).commit();
@@ -245,7 +267,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(2L, 0L, 0L, 3L, 3L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testNoFilesDeletedWhenNoSnapshotsExpired() throws Exception {
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -253,7 +275,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 0L, results);
   }
 
-  @Test
+  @TestTemplate
   public void testCleanupRepeatedOverwrites() throws Exception {
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -269,7 +291,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(1L, 0L, 0L, 39L, 20L, results);
   }
 
-  @Test
+  @TestTemplate
   public void testRetainLastWithExpireOlderThan() {
     table
         .newAppend()
@@ -300,7 +322,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     assertThat(table.snapshot(firstSnapshotId)).as("First snapshot should not present.").isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testExpireTwoSnapshotsById() throws Exception {
     table
         .newAppend()
@@ -335,7 +357,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRetainLastWithExpireById() {
     table
         .newAppend()
@@ -366,7 +388,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 1L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRetainLastWithTooFewSnapshots() {
     table
         .newAppend()
@@ -393,7 +415,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 0L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRetainLastKeepsExpiringSnapshot() {
     table
         .newAppend()
@@ -432,7 +454,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 1L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireSnapshotsWithDisabledGarbageCollection() {
     table.updateProperties().set(TableProperties.GC_ENABLED, "false").commit();
 
@@ -444,7 +466,7 @@ public class TestExpireSnapshotsAction extends TestBase {
             "Cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)");
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThanMultipleCalls() {
     table
         .newAppend()
@@ -480,7 +502,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRetainLastMultipleCalls() {
     table
         .newAppend()
@@ -517,14 +539,14 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRetainZeroSnapshots() {
     assertThatThrownBy(() -> SparkActions.get().expireSnapshots(table).retainLast(0).execute())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Number of snapshots to retain must be at least 1, cannot be: 0");
   }
 
-  @Test
+  @TestTemplate
   public void testScanExpiredManifestInValidSnapshotAppend() {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -547,7 +569,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testScanExpiredManifestInValidSnapshotFastAppend() {
     table
         .updateProperties()
@@ -580,7 +602,7 @@ public class TestExpireSnapshotsAction extends TestBase {
    * Test on table below, and expiring the staged commit `B` using `expireOlderThan` API. Table: A -
    * C ` B (staged)
    */
-  @Test
+  @TestTemplate
   public void testWithExpiringDanglingStageCommit() {
     // `A` commit
     table.newAppend().appendFile(FILE_A).commit();
@@ -641,7 +663,7 @@ public class TestExpireSnapshotsAction extends TestBase {
    * Expire cherry-pick the commit as shown below, when `B` is in table's current state Table: A - B
    * - C <--current snapshot `- D (source=B)
    */
-  @Test
+  @TestTemplate
   public void testWithCherryPickTableSnapshot() {
     // `A` commit
     table.newAppend().appendFile(FILE_A).commit();
@@ -696,7 +718,7 @@ public class TestExpireSnapshotsAction extends TestBase {
    * Test on table below, and expiring `B` which is not in current table state. 1) Expire `B` 2) All
    * commit Table: A - C - D (B) ` B (staged)
    */
-  @Test
+  @TestTemplate
   public void testWithExpiringStagedThenCherrypick() {
     // `A` commit
     table.newAppend().appendFile(FILE_A).commit();
@@ -760,7 +782,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, secondResult);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThan() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -796,7 +818,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(0, 0, 0, 0, 1, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThanWithDelete() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -858,7 +880,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(1, 0, 0, 2, 2, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThanWithDeleteInMergedManifests() {
     // merge every commit
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "0").commit();
@@ -924,7 +946,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(1, 0, 0, 1, 2, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThanWithRollback() {
     // merge every commit
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "0").commit();
@@ -982,7 +1004,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(0, 0, 0, 1, 1, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThanWithRollbackAndMergedManifests() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -1037,20 +1059,18 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(1, 0, 0, 1, 1, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThanWithDeleteFile() {
-    table
-        .updateProperties()
-        .set(TableProperties.FORMAT_VERSION, "2")
-        .set(TableProperties.MANIFEST_MERGE_ENABLED, "false")
-        .commit();
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
+    table.updateProperties().set(TableProperties.MANIFEST_MERGE_ENABLED, "false").commit();
 
     // Add Data File
     table.newAppend().appendFile(FILE_A).commit();
     Snapshot firstSnapshot = table.currentSnapshot();
 
     // Add POS Delete
-    table.newRowDelta().addDeletes(FILE_A_POS_DELETES).commit();
+    DeleteFile fileADeletes = fileADeletes();
+    table.newRowDelta().addDeletes(fileADeletes).commit();
     Snapshot secondSnapshot = table.currentSnapshot();
 
     // Add EQ Delete
@@ -1081,7 +1101,7 @@ public class TestExpireSnapshotsAction extends TestBase {
             thirdSnapshot.manifestListLocation(),
             fourthSnapshot.manifestListLocation(),
             FILE_A.path().toString(),
-            FILE_A_POS_DELETES.path().toString(),
+            fileADeletes.path().toString(),
             FILE_A_EQ_DELETES.path().toString());
 
     expectedDeletes.addAll(
@@ -1103,7 +1123,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(1, 1, 1, 6, 4, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOnEmptyTable() {
     Set<String> deletedFiles = Sets.newHashSet();
 
@@ -1118,7 +1138,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     checkExpirationResults(0, 0, 0, 0, 0, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireAction() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -1167,7 +1187,7 @@ public class TestExpireSnapshotsAction extends TestBase {
         .isEqualTo(pendingDeletes.count());
   }
 
-  @Test
+  @TestTemplate
   public void testUseLocalIterator() {
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -1201,7 +1221,7 @@ public class TestExpireSnapshotsAction extends TestBase {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testExpireAfterExecute() {
     table
         .newAppend()
@@ -1236,12 +1256,12 @@ public class TestExpireSnapshotsAction extends TestBase {
     assertThat(untypedExpiredFiles).as("Expired results must match").hasSize(1);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireFileDeletionMostExpired() {
     textExpireAllCheckFilesDeleted(5, 2);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireFileDeletionMostRetained() {
     textExpireAllCheckFilesDeleted(2, 5);
   }
@@ -1303,7 +1323,7 @@ public class TestExpireSnapshotsAction extends TestBase {
         .isEqualTo(expectedDeletes);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireSomeCheckFilesDeleted() {
 
     table.newAppend().appendFile(FILE_A).commit();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -27,6 +27,7 @@ import static org.apache.spark.sql.functions.expr;
 import static org.apache.spark.sql.functions.min;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
@@ -38,7 +39,7 @@ import static org.mockito.Mockito.spy;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -56,6 +57,9 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
@@ -77,6 +81,8 @@ import org.apache.iceberg.actions.SizeBasedFileRewriter;
 import org.apache.iceberg.data.GenericAppenderFactory;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.BaseDVFileWriter;
+import org.apache.iceberg.deletes.DVFileWriter;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
@@ -96,7 +102,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.ScanTaskSetManager;
@@ -119,11 +124,13 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.internal.SQLConf;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestRewriteDataFilesAction extends TestBase {
 
   @TempDir private File tableDir;
@@ -138,7 +145,12 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   private static final PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
 
-  @TempDir private Path temp;
+  @Parameter private int formatVersion;
+
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(2, 3);
+  }
 
   private final FileRewriteCoordinator coordinator = FileRewriteCoordinator.get();
   private final ScanTaskSetManager manager = ScanTaskSetManager.get();
@@ -161,10 +173,11 @@ public class TestRewriteDataFilesAction extends TestBase {
     return actions().rewriteDataFiles(table).option(SizeBasedFileRewriter.MIN_INPUT_FILES, "1");
   }
 
-  @Test
+  @TestTemplate
   public void testEmptyTable() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
-    Map<String, String> options = Maps.newHashMap();
+    Map<String, String> options =
+        ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
 
     assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
@@ -174,7 +187,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(table.currentSnapshot()).as("Table must stay empty").isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testBinPackUnpartitionedTable() {
     Table table = createTable(4);
     shouldHaveFiles(table, 4);
@@ -194,7 +207,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertEquals("Rows must match", expectedRecords, actual);
   }
 
-  @Test
+  @TestTemplate
   public void testBinPackPartitionedTable() {
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
@@ -214,7 +227,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertEquals("Rows must match", expectedRecords, actualRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testBinPackWithFilter() {
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
@@ -239,7 +252,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertEquals("Rows must match", expectedRecords, actualRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testBinPackWithFilterOnBucketExpression() {
     Table table = createTablePartitioned(4, 2);
 
@@ -265,7 +278,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertEquals("Rows must match", expectedRecords, actualRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testBinPackAfterPartitionChange() {
     Table table = createTable();
 
@@ -300,10 +313,10 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveFiles(table, 20);
   }
 
-  @Test
-  public void testBinPackWithDeletes() {
+  @TestTemplate
+  public void testBinPackWithDeletes() throws IOException {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = createTablePartitioned(4, 2);
-    table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
     shouldHaveFiles(table, 8);
     table.refresh();
 
@@ -311,14 +324,28 @@ public class TestRewriteDataFilesAction extends TestBase {
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
 
     RowDelta rowDelta = table.newRowDelta();
-    // add 1 delete file for data files 0, 1, 2
-    for (int i = 0; i < 3; i++) {
-      writePosDeletesToFile(table, dataFiles.get(i), 1).forEach(rowDelta::addDeletes);
-    }
+    if (formatVersion >= 3) {
+      // delete 1 position for data files 0, 1, 2
+      for (int i = 0; i < 3; i++) {
+        writeDV(table, dataFiles.get(i).partition(), dataFiles.get(i).location(), 1)
+            .forEach(rowDelta::addDeletes);
+      }
 
-    // add 2 delete files for data files 3, 4
-    for (int i = 3; i < 5; i++) {
-      writePosDeletesToFile(table, dataFiles.get(i), 2).forEach(rowDelta::addDeletes);
+      // delete 2 positions for data files 3, 4
+      for (int i = 3; i < 5; i++) {
+        writeDV(table, dataFiles.get(i).partition(), dataFiles.get(i).location(), 2)
+            .forEach(rowDelta::addDeletes);
+      }
+    } else {
+      // add 1 delete file for data files 0, 1, 2
+      for (int i = 0; i < 3; i++) {
+        writePosDeletesToFile(table, dataFiles.get(i), 1).forEach(rowDelta::addDeletes);
+      }
+
+      // add 2 delete files for data files 3, 4
+      for (int i = 3; i < 5; i++) {
+        writePosDeletesToFile(table, dataFiles.get(i), 2).forEach(rowDelta::addDeletes);
+      }
     }
 
     rowDelta.commit();
@@ -326,32 +353,49 @@ public class TestRewriteDataFilesAction extends TestBase {
     List<Object[]> expectedRecords = currentData();
     long dataSizeBefore = testDataSize(table);
 
-    Result result =
-        actions()
-            .rewriteDataFiles(table)
-            // do not include any file based on bin pack file size configs
-            .option(SizeBasedFileRewriter.MIN_FILE_SIZE_BYTES, "0")
-            .option(RewriteDataFiles.TARGET_FILE_SIZE_BYTES, Long.toString(Long.MAX_VALUE - 1))
-            .option(SizeBasedFileRewriter.MAX_FILE_SIZE_BYTES, Long.toString(Long.MAX_VALUE))
-            .option(SizeBasedDataRewriter.DELETE_FILE_THRESHOLD, "2")
-            .execute();
-    assertThat(result.rewrittenDataFilesCount())
-        .as("Action should rewrite 2 data files")
-        .isEqualTo(2);
-    assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
+    if (formatVersion >= 3) {
+      Result result =
+          actions()
+              .rewriteDataFiles(table)
+              // do not include any file based on bin pack file size configs
+              .option(SizeBasedFileRewriter.MIN_FILE_SIZE_BYTES, "0")
+              .option(RewriteDataFiles.TARGET_FILE_SIZE_BYTES, Long.toString(Long.MAX_VALUE - 1))
+              .option(SizeBasedFileRewriter.MAX_FILE_SIZE_BYTES, Long.toString(Long.MAX_VALUE))
+              // set DELETE_FILE_THRESHOLD to 1 since DVs only produce one delete file per data file
+              .option(SizeBasedDataRewriter.DELETE_FILE_THRESHOLD, "1")
+              .execute();
+      assertThat(result.rewrittenDataFilesCount())
+          .as("Action should rewrite 5 data files")
+          .isEqualTo(5);
+      assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
+    } else {
+      Result result =
+          actions()
+              .rewriteDataFiles(table)
+              // do not include any file based on bin pack file size configs
+              .option(SizeBasedFileRewriter.MIN_FILE_SIZE_BYTES, "0")
+              .option(RewriteDataFiles.TARGET_FILE_SIZE_BYTES, Long.toString(Long.MAX_VALUE - 1))
+              .option(SizeBasedFileRewriter.MAX_FILE_SIZE_BYTES, Long.toString(Long.MAX_VALUE))
+              .option(SizeBasedDataRewriter.DELETE_FILE_THRESHOLD, "2")
+              .execute();
+      assertThat(result.rewrittenDataFilesCount())
+          .as("Action should rewrite 2 data files")
+          .isEqualTo(2);
+      assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
+    }
 
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
     assertThat(actualRecords).as("7 rows are removed").hasSize(total - 7);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveDangledEqualityDeletesPartitionEvolution() {
     Table table =
         TABLES.create(
             SCHEMA,
             SPEC,
-            Collections.singletonMap(TableProperties.FORMAT_VERSION, "2"),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
             tableLocation);
 
     // data seq = 1, write 4 files in 2 partitions
@@ -414,13 +458,13 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveFiles(table, 5);
   }
 
-  @Test
-  public void testRemoveDangledPositionDeletesPartitionEvolution() {
+  @TestTemplate
+  public void testRemoveDangledPositionDeletesPartitionEvolution() throws IOException {
     Table table =
         TABLES.create(
             SCHEMA,
             SPEC,
-            Collections.singletonMap(TableProperties.FORMAT_VERSION, "2"),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
             tableLocation);
 
     // data seq = 1, write 4 files in 2 partitions
@@ -428,11 +472,15 @@ public class TestRewriteDataFilesAction extends TestBase {
     List<DataFile> dataFilesBefore = TestHelpers.dataFiles(table, null);
     shouldHaveFiles(table, 4);
 
+    DeleteFile deleteFile;
     // data seq = 2, write 1 position deletes in c1=1
-    table
-        .newRowDelta()
-        .addDeletes(writePosDeletesToFile(table, dataFilesBefore.get(3), 1).get(0))
-        .commit();
+    DataFile dataFile = dataFilesBefore.get(3);
+    if (formatVersion >= 3) {
+      deleteFile = writeDV(table, dataFile.partition(), dataFile.location(), 1).get(0);
+    } else {
+      deleteFile = writePosDeletesToFile(table, dataFile, 1).get(0);
+    }
+    table.newRowDelta().addDeletes(deleteFile).commit();
 
     // partition evolution
     table.updateSpec().addField(Expressions.ref("c3")).commit();
@@ -464,11 +512,10 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertEquals("Rows must match", expectedRecords, currentData());
   }
 
-  @Test
-  public void testBinPackWithDeleteAllData() {
-    Map<String, String> options = Maps.newHashMap();
-    options.put(TableProperties.FORMAT_VERSION, "2");
-    Table table = createTablePartitioned(1, 1, 1, options);
+  @TestTemplate
+  public void testBinPackWithDeleteAllData() throws IOException {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
+    Table table = createTablePartitioned(1, 1, 1);
     shouldHaveFiles(table, 1);
     table.refresh();
 
@@ -476,8 +523,14 @@ public class TestRewriteDataFilesAction extends TestBase {
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
 
     RowDelta rowDelta = table.newRowDelta();
+    DataFile dataFile = dataFiles.get(0);
     // remove all data
-    writePosDeletesToFile(table, dataFiles.get(0), total).forEach(rowDelta::addDeletes);
+    if (formatVersion >= 3) {
+      writeDV(table, dataFile.partition(), dataFile.location(), total)
+          .forEach(rowDelta::addDeletes);
+    } else {
+      writePosDeletesToFile(table, dataFile, total).forEach(rowDelta::addDeletes);
+    }
 
     rowDelta.commit();
     table.refresh();
@@ -507,12 +560,12 @@ public class TestRewriteDataFilesAction extends TestBase {
         .isEqualTo(total);
   }
 
-  @Test
+  @TestTemplate
   public void testBinPackWithStartingSequenceNumber() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
     List<Object[]> expectedRecords = currentData();
-    table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
     table.refresh();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     long dataSizeBefore = testDataSize(table);
@@ -544,7 +597,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testBinPackWithStartingSequenceNumberV1Compatibility() {
     Map<String, String> properties = ImmutableMap.of(TableProperties.FORMAT_VERSION, "1");
     Table table = createTablePartitioned(4, 2, SCALE, properties);
@@ -580,11 +633,15 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteLargeTableHasResiduals() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).build();
-    Map<String, String> options = Maps.newHashMap();
-    options.put(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, "100");
+    Map<String, String> options =
+        ImmutableMap.of(
+            TableProperties.FORMAT_VERSION,
+            String.valueOf(formatVersion),
+            TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES,
+            "100");
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
 
     // all records belong to the same partition
@@ -622,7 +679,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertEquals("Rows must match", expectedRecords, actualRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testBinPackSplitLargeFile() {
     Table table = createTable(1);
     shouldHaveFiles(table, 1);
@@ -647,7 +704,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertEquals("Rows must match", expectedRecords, actualRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testBinPackCombineMixedFiles() {
     Table table = createTable(1); // 400000
     shouldHaveFiles(table, 1);
@@ -683,7 +740,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertEquals("Rows must match", expectedRecords, actualRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testBinPackCombineMediumFiles() {
     Table table = createTable(4);
     shouldHaveFiles(table, 4);
@@ -716,7 +773,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertEquals("Rows must match", expectedRecords, actualRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testPartialProgressEnabled() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
@@ -747,7 +804,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
   }
 
-  @Test
+  @TestTemplate
   public void testMultipleGroups() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
@@ -775,7 +832,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveACleanCache(table);
   }
 
-  @Test
+  @TestTemplate
   public void testPartialProgressMaxCommits() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
@@ -804,7 +861,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveACleanCache(table);
   }
 
-  @Test
+  @TestTemplate
   public void testSingleCommitWithRewriteFailure() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
@@ -838,7 +895,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveACleanCache(table);
   }
 
-  @Test
+  @TestTemplate
   public void testSingleCommitWithCommitFailure() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
@@ -872,7 +929,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveACleanCache(table);
   }
 
-  @Test
+  @TestTemplate
   public void testCommitFailsWithUncleanableFailure() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
@@ -906,7 +963,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveACleanCache(table);
   }
 
-  @Test
+  @TestTemplate
   public void testParallelSingleCommitWithRewriteFailure() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
@@ -941,7 +998,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveACleanCache(table);
   }
 
-  @Test
+  @TestTemplate
   public void testPartialProgressWithRewriteFailure() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
@@ -983,7 +1040,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveACleanCache(table);
   }
 
-  @Test
+  @TestTemplate
   public void testParallelPartialProgressWithRewriteFailure() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
@@ -1026,7 +1083,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveACleanCache(table);
   }
 
-  @Test
+  @TestTemplate
   public void testParallelPartialProgressWithCommitFailure() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
@@ -1071,7 +1128,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveACleanCache(table);
   }
 
-  @Test
+  @TestTemplate
   public void testParallelPartialProgressWithMaxFailedCommits() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
@@ -1113,7 +1170,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveACleanCache(table);
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidOptions() {
     Table table = createTable(20);
 
@@ -1157,7 +1214,7 @@ public class TestRewriteDataFilesAction extends TestBase {
         .hasMessageContaining("requires enabling Iceberg Spark session extensions");
   }
 
-  @Test
+  @TestTemplate
   public void testSortMultipleGroups() {
     Table table = createTable(20);
     shouldHaveFiles(table, 20);
@@ -1189,7 +1246,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveACleanCache(table);
   }
 
-  @Test
+  @TestTemplate
   public void testSimpleSort() {
     Table table = createTable(20);
     shouldHaveFiles(table, 20);
@@ -1222,7 +1279,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitSorted(table, "c2");
   }
 
-  @Test
+  @TestTemplate
   public void testSortAfterPartitionChange() {
     Table table = createTable(20);
     shouldHaveFiles(table, 20);
@@ -1258,7 +1315,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitSorted(table, "c2");
   }
 
-  @Test
+  @TestTemplate
   public void testSortCustomSortOrder() {
     Table table = createTable(20);
     shouldHaveLastCommitUnsorted(table, "c2");
@@ -1289,7 +1346,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitSorted(table, "c2");
   }
 
-  @Test
+  @TestTemplate
   public void testSortCustomSortOrderRequiresRepartition() {
     int partitions = 4;
     Table table = createTable();
@@ -1329,7 +1386,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitSorted(table, "c3");
   }
 
-  @Test
+  @TestTemplate
   public void testAutoSortShuffleOutput() {
     Table table = createTable(20);
     shouldHaveLastCommitUnsorted(table, "c2");
@@ -1369,7 +1426,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitSorted(table, "c2");
   }
 
-  @Test
+  @TestTemplate
   public void testCommitStateUnknownException() {
     Table table = createTable(20);
     shouldHaveFiles(table, 20);
@@ -1401,7 +1458,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveSnapshots(table, 2); // Commit actually Succeeded
   }
 
-  @Test
+  @TestTemplate
   public void testZOrderSort() {
     int originalFiles = 20;
     Table table = createTable(originalFiles);
@@ -1461,7 +1518,7 @@ public class TestRewriteDataFilesAction extends TestBase {
         .isGreaterThan(filesScannedC2C3);
   }
 
-  @Test
+  @TestTemplate
   public void testZOrderAllTypesSort() {
     Table table = createTypeTestTable();
     shouldHaveFiles(table, 10);
@@ -1505,7 +1562,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveACleanCache(table);
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidAPIUsage() {
     Table table = createTable(1);
 
@@ -1524,14 +1581,14 @@ public class TestRewriteDataFilesAction extends TestBase {
         .hasMessage("Must use only one rewriter type (bin-pack, sort, zorder)");
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteJobOrderBytesAsc() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = createTablePartitioned(4, 2);
     writeRecords(1, SCALE, 1);
     writeRecords(2, SCALE, 2);
     writeRecords(3, SCALE, 3);
     writeRecords(4, SCALE, 4);
-    table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
 
     RewriteDataFilesSparkAction basicRewrite = basicRewrite(table).binPack();
     List<Long> expected =
@@ -1556,14 +1613,14 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(actual).as("Size in bytes order should not be descending").isNotEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteJobOrderBytesDesc() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = createTablePartitioned(4, 2);
     writeRecords(1, SCALE, 1);
     writeRecords(2, SCALE, 2);
     writeRecords(3, SCALE, 3);
     writeRecords(4, SCALE, 4);
-    table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
 
     RewriteDataFilesSparkAction basicRewrite = basicRewrite(table).binPack();
     List<Long> expected =
@@ -1588,14 +1645,14 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(actual).as("Size in bytes order should not be ascending").isNotEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteJobOrderFilesAsc() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = createTablePartitioned(4, 2);
     writeRecords(1, SCALE, 1);
     writeRecords(2, SCALE, 2);
     writeRecords(3, SCALE, 3);
     writeRecords(4, SCALE, 4);
-    table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
 
     RewriteDataFilesSparkAction basicRewrite = basicRewrite(table).binPack();
     List<Long> expected =
@@ -1620,14 +1677,14 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(actual).as("Number of files order should not be descending").isNotEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteJobOrderFilesDesc() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = createTablePartitioned(4, 2);
     writeRecords(1, SCALE, 1);
     writeRecords(2, SCALE, 2);
     writeRecords(3, SCALE, 3);
     writeRecords(4, SCALE, 4);
-    table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
 
     RewriteDataFilesSparkAction basicRewrite = basicRewrite(table).binPack();
     List<Long> expected =
@@ -1652,7 +1709,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(actual).as("Number of files order should not be ascending").isNotEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotProperty() {
     Table table = createTable(4);
     Result ignored = basicRewrite(table).snapshotProperty("key", "value").execute();
@@ -1669,7 +1726,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(table.currentSnapshot().summary()).containsKeys(commitMetricsKeys);
   }
 
-  @Test
+  @TestTemplate
   public void testBinPackRewriterWithSpecificUnparitionedOutputSpec() {
     Table table = createTable(10);
     shouldHaveFiles(table, 10);
@@ -1691,7 +1748,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldRewriteDataFilesWithPartitionSpec(table, outputSpecId);
   }
 
-  @Test
+  @TestTemplate
   public void testBinPackRewriterWithSpecificOutputSpec() {
     Table table = createTable(10);
     shouldHaveFiles(table, 10);
@@ -1714,7 +1771,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldRewriteDataFilesWithPartitionSpec(table, outputSpecId);
   }
 
-  @Test
+  @TestTemplate
   public void testBinpackRewriteWithInvalidOutputSpecId() {
     Table table = createTable(10);
     shouldHaveFiles(table, 10);
@@ -1730,7 +1787,7 @@ public class TestRewriteDataFilesAction extends TestBase {
             "Cannot use output spec id 1234 because the table does not contain a reference to this spec-id.");
   }
 
-  @Test
+  @TestTemplate
   public void testSortRewriterWithSpecificOutputSpecId() {
     Table table = createTable(10);
     shouldHaveFiles(table, 10);
@@ -1753,7 +1810,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldRewriteDataFilesWithPartitionSpec(table, outputSpecId);
   }
 
-  @Test
+  @TestTemplate
   public void testZOrderRewriteWithSpecificOutputSpecId() {
     Table table = createTable(10);
     shouldHaveFiles(table, 10);
@@ -1956,7 +2013,8 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   protected Table createTable() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
-    Map<String, String> options = Maps.newHashMap();
+    Map<String, String> options =
+        ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
     table
         .updateProperties()
@@ -1989,7 +2047,19 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected Table createTablePartitioned(int partitions, int files) {
-    return createTablePartitioned(partitions, files, SCALE, Maps.newHashMap());
+    return createTablePartitioned(
+        partitions,
+        files,
+        SCALE,
+        ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)));
+  }
+
+  protected Table createTablePartitioned(int partitions, int files, int numRecords) {
+    return createTablePartitioned(
+        partitions,
+        files,
+        numRecords,
+        ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)));
   }
 
   private Table createTypeTestTable() {
@@ -2005,7 +2075,8 @@ public class TestRewriteDataFilesAction extends TestBase {
             optional(8, "booleanCol", Types.BooleanType.get()),
             optional(9, "binaryCol", Types.BinaryType.get()));
 
-    Map<String, String> options = Maps.newHashMap();
+    Map<String, String> options =
+        ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
     Table table = TABLES.create(schema, PartitionSpec.unpartitioned(), options, tableLocation);
 
     spark
@@ -2121,6 +2192,20 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
 
     return results;
+  }
+
+  private List<DeleteFile> writeDV(
+      Table table, StructLike partition, String path, int numPositionsToDelete) throws IOException {
+    OutputFileFactory fileFactory =
+        OutputFileFactory.builderFor(table, 1, 1).format(FileFormat.PUFFIN).build();
+    DVFileWriter writer = new BaseDVFileWriter(fileFactory, p -> null);
+    try (DVFileWriter closeableWriter = writer) {
+      for (int row = 0; row < numPositionsToDelete; row++) {
+        closeableWriter.delete(path, row, table.spec(), partition);
+      }
+    }
+
+    return writer.result().deleteFiles();
   }
 
   private void writeEqDeleteRecord(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -107,6 +108,7 @@ public class TestRewriteManifestsAction extends TestBase {
       new Object[] {"false", "true", true, 1},
       new Object[] {"true", "false", false, 2},
       new Object[] {"false", "false", false, 2},
+      new Object[] {"true", "false", false, 3},
       new Object[] {"false", "false", false, 3}
     };
   }
@@ -1108,13 +1110,23 @@ public class TestRewriteManifestsAction extends TestBase {
   }
 
   private DeleteFile newDeleteFile(Table table, String partitionPath) {
-    return FileMetadata.deleteFileBuilder(table.spec())
-        .ofPositionDeletes()
-        .withPath("/path/to/pos-deletes-" + UUID.randomUUID() + ".parquet")
-        .withFileSizeInBytes(5)
-        .withPartitionPath(partitionPath)
-        .withRecordCount(1)
-        .build();
+    return formatVersion >= 3
+        ? FileMetadata.deleteFileBuilder(table.spec())
+            .ofPositionDeletes()
+            .withPath("/path/to/pos-deletes-" + UUID.randomUUID() + ".puffin")
+            .withFileSizeInBytes(5)
+            .withPartitionPath(partitionPath)
+            .withRecordCount(1)
+            .withContentOffset(ThreadLocalRandom.current().nextInt())
+            .withContentSizeInBytes(ThreadLocalRandom.current().nextInt())
+            .build()
+        : FileMetadata.deleteFileBuilder(table.spec())
+            .ofPositionDeletes()
+            .withPath("/path/to/pos-deletes-" + UUID.randomUUID() + ".parquet")
+            .withFileSizeInBytes(5)
+            .withPartitionPath(partitionPath)
+            .withRecordCount(1)
+            .build();
   }
 
   private List<Pair<CharSequence, Long>> generatePosDeletes(String predicate) {
@@ -1145,7 +1157,7 @@ public class TestRewriteManifestsAction extends TestBase {
       Table table, StructLike partition, List<Pair<CharSequence, Long>> deletes)
       throws IOException {
     OutputFile outputFile = Files.localOutput(File.createTempFile("junit", null, temp.toFile()));
-    return FileHelpers.writeDeleteFile(table, outputFile, partition, deletes);
+    return FileHelpers.writeDeleteFile(table, outputFile, partition, deletes, formatVersion);
   }
 
   private DeleteFile writeEqDeletes(Table table, String key, Object... values) throws IOException {


### PR DESCRIPTION
This verifies that existing maintenance actions work with format-version=3 and DVs. There are still a few tests like `TestPositionDeletesTable`/ `TestRewritePositionDeleteFiles` that need some additional work, which will be done in a separate PR