### PR TITLE
Kafka Connect: fix Hadoop dependency exclusion

### DIFF
--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -96,7 +96,6 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
       exclude group: 'org.slf4j'
       exclude group: 'ch.qos.reload4j'
       exclude group: 'org.apache.avro', module: 'avro'
-      exclude group: 'com.fasterxml.woodstox'
       exclude group: 'com.google.guava'
       exclude group: 'com.google.protobuf'
       exclude group: 'org.apache.curator'

--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -73,6 +73,7 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
         force 'org.xerial.snappy:snappy-java:1.1.10.7'
         force 'org.apache.commons:commons-compress:1.27.1'
         force 'org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.3.0'
+        force 'com.fasterxml.woodstox:woodstox-core:6.7.0'
       }
     }
   }

--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -104,7 +104,6 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
       exclude group: 'org.apache.hadoop', module: 'hadoop-auth'
       exclude group: 'org.apache.commons', module: 'commons-configuration2'
       exclude group: 'org.apache.hadoop.thirdparty', module: 'hadoop-shaded-protobuf_3_7'
-      exclude group: 'org.codehaus.woodstox'
       exclude group: 'org.eclipse.jetty'
     }
     implementation project(':iceberg-orc')


### PR DESCRIPTION
This PR removes the exclusion of the woodstox libraries from the Hadoop transitive dependencies when building the Kafka Connect distribution, as they are needed to load Hadoop's `Configuration`.  Previously the required libraries were brought in by the Azure dependencies until that was upgraded in [this commit](https://github.com/apache/iceberg/commit/7ac617a5a8b0dedbaaa6e19caedfd846968c7cac), so the connector did not have any issues.

This addresses https://github.com/apache/iceberg/issues/11489.
