### PR TITLE
Spark: Fix typo in spark ddl document

### DIFF
--- a/docs/docs/spark-ddl.md
+++ b/docs/docs/spark-ddl.md
@@ -401,7 +401,7 @@ To set the write order for a table, use `WRITE ORDERED BY`:
 
 ```sql
 ALTER TABLE prod.db.sample WRITE ORDERED BY category, id
--- use optional ASC/DEC keyword to specify sort order of each field (default ASC)
+-- use optional ASC/DESC keyword to specify sort order of each field (default ASC)
 ALTER TABLE prod.db.sample WRITE ORDERED BY category ASC, id DESC
 -- use optional NULLS FIRST/NULLS LAST keyword to specify null order of each field (default FIRST)
 ALTER TABLE prod.db.sample WRITE ORDERED BY category ASC NULLS LAST, id DESC NULLS FIRST


### PR DESCRIPTION
This PR simply fix a typo in spark ddl document, the sort order key words should be `ASC/DESC` rather than `ASC/DEC`.