### PR TITLE
Spark: Relativize in-memory paths for data file and rewritable delete file locations

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/RewritableDeletes.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/RewritableDeletes.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.DeleteFileSet;
+
+/** Wraps a set of rewritable delete files which are relativized to a given table location */
+class RewritableDeletes implements Serializable {
+  private final String tableLocation;
+  private final Map<String, DeleteFileSet> relativizedRewritableDeletes;
+
+  RewritableDeletes(String tableLocation) {
+    this.tableLocation = tableLocation;
+    this.relativizedRewritableDeletes = Maps.newHashMap();
+  }
+
+  /**
+   * @param dataFileLocation absolute data file location
+   * @param deleteFile delete file with absolute data file location
+   * @param specs map from spec ID to partition spec
+   */
+  public void addRewritableDelete(
+      String dataFileLocation, DeleteFile deleteFile, Map<Integer, PartitionSpec> specs) {
+    relativizedRewritableDeletes
+        .computeIfAbsent(relativizePath(dataFileLocation), ignored -> DeleteFileSet.create())
+        .add(relativizeDeleteFile(deleteFile, specs));
+  }
+
+  /**
+   * @return map of data to rewritable delete files with relativized paths
+   */
+  public Map<String, DeleteFileSet> relativizedDeletes() {
+    return relativizedRewritableDeletes;
+  }
+
+  /**
+   * Return an iterable of deletes for a given absolute data file location
+   *
+   * @param dataFileLocation absolute data file location
+   * @param specs map from spec ID to partition spec
+   */
+  public Iterable<DeleteFile> deletesFor(
+      String dataFileLocation, Map<Integer, PartitionSpec> specs) {
+    DeleteFileSet relativizedDeletes =
+        relativizedRewritableDeletes.get(relativizePath(dataFileLocation));
+    if (relativizedDeletes == null) {
+      return null;
+    }
+
+    return Iterables.transform(
+        relativizedDeletes,
+        deleteFile ->
+            FileMetadata.deleteFileBuilder(specs.get(deleteFile.specId()))
+                .copy(deleteFile)
+                .withPath(absolutePath(deleteFile.location()))
+                .build());
+  }
+
+  private String absolutePath(String path) {
+    return tableLocation + path;
+  }
+
+  private String relativizePath(String path) {
+    int indexOfRelativeLocation = path.indexOf(tableLocation);
+    Preconditions.checkArgument(
+        indexOfRelativeLocation != -1,
+        "Cannot relativize path: %s in relative location %s",
+        path,
+        tableLocation);
+    return path.substring(indexOfRelativeLocation + tableLocation.length());
+  }
+
+  private DeleteFile relativizeDeleteFile(
+      DeleteFile deleteFile, Map<Integer, PartitionSpec> specs) {
+    return FileMetadata.deleteFileBuilder(specs.get(deleteFile.specId()))
+        .copy(deleteFile)
+        .withPath(relativizePath(deleteFile.location()))
+        .build();
+  }
+}


### PR DESCRIPTION
This is a follow up to https://github.com/apache/iceberg/pull/11273/files# 

Instead of broadcasting a map with absolute paths for data files and delete files to executors, we could shrink the memory footprint by relativizing the in-memory mapping, and then just prior to lookup on executors, reconstruct the absolute path as for the relevant delete files.


There are a few ways to go about relativization, in the current implementation I just did the simplest thing which was to relativize to the table location. There are more sophisticated things that could be done to save even more memory consumer from paths such as relativize according to the data file location (requires surfacing more details from LocationProvider), find the longest common prefix between all data/delete files in the rewritable deletes (requires a double pass over tasks, once to identify the longest common prefix via smallest/largest lexicographical strings, and then another to actually reconstruct the delete files). Patricia tries are another possibility though the serialized representation seems to take about the same amount of memory, not sure why that's the case.

I'm also working on identifying if using spark bytestobytes offheap map will save us even more memory but in the mean time thought it made sense to at least get this improvement in the interim. This is all internal, so we can always remove it down the line if something better comes along.