### PR TITLE
API, Core: Replace deprecated ContentFile#path usage with location

### DIFF
--- a/api/src/main/java/org/apache/iceberg/DeleteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/DeleteFiles.java
@@ -51,7 +51,7 @@ public interface DeleteFiles extends SnapshotUpdate<DeleteFiles> {
    * @return this for method chaining
    */
   default DeleteFiles deleteFile(DataFile file) {
-    deleteFile(file.path());
+    deleteFile(file.location());
     return this;
   }
 

--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
@@ -93,10 +93,9 @@ public class EncryptingFileIO implements FileIO, Serializable {
 
   private InputFile newInputFile(ContentFile<?> file) {
     if (file.keyMetadata() != null) {
-      return newDecryptingInputFile(
-          file.path().toString(), file.fileSizeInBytes(), file.keyMetadata());
+      return newDecryptingInputFile(file.location(), file.fileSizeInBytes(), file.keyMetadata());
     } else {
-      return newInputFile(file.path().toString(), file.fileSizeInBytes());
+      return newInputFile(file.location(), file.fileSizeInBytes());
     }
   }
 
@@ -148,7 +147,7 @@ public class EncryptingFileIO implements FileIO, Serializable {
   }
 
   private SimpleEncryptedInputFile wrap(ContentFile<?> file) {
-    InputFile encryptedInputFile = io.newInputFile(file.path().toString(), file.fileSizeInBytes());
+    InputFile encryptedInputFile = io.newInputFile(file.location(), file.fileSizeInBytes());
     return new SimpleEncryptedInputFile(encryptedInputFile, toKeyMetadata(file.keyMetadata()));
   }
 

--- a/api/src/main/java/org/apache/iceberg/io/FileIO.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileIO.java
@@ -50,16 +50,16 @@ public interface FileIO extends Serializable, Closeable {
     Preconditions.checkArgument(
         file.keyMetadata() == null,
         "Cannot decrypt data file: %s (use EncryptingFileIO)",
-        file.path());
-    return newInputFile(file.path().toString(), file.fileSizeInBytes());
+        file.location());
+    return newInputFile(file.location(), file.fileSizeInBytes());
   }
 
   default InputFile newInputFile(DeleteFile file) {
     Preconditions.checkArgument(
         file.keyMetadata() == null,
         "Cannot decrypt delete file: %s (use EncryptingFileIO)",
-        file.path());
-    return newInputFile(file.path().toString(), file.fileSizeInBytes());
+        file.location());
+    return newInputFile(file.location(), file.fileSizeInBytes());
   }
 
   default InputFile newInputFile(ManifestFile manifest) {

--- a/core/src/main/java/org/apache/iceberg/BaseChangelogContentScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseChangelogContentScanTask.java
@@ -56,7 +56,7 @@ abstract class BaseChangelogContentScanTask<
     return MoreObjects.toStringHelper(this)
         .add("change_ordinal", changeOrdinal)
         .add("commit_snapshot_id", commitSnapshotId)
-        .add("file", file().path())
+        .add("file", file().location())
         .add("partition_data", file().partition())
         .add("residual", residual())
         .toString();
@@ -142,7 +142,7 @@ abstract class BaseChangelogContentScanTask<
       return MoreObjects.toStringHelper(this)
           .add("change_ordinal", changeOrdinal())
           .add("commit_snapshot_id", commitSnapshotId())
-          .add("file", file().path())
+          .add("file", file().location())
           .add("partition_data", file().partition())
           .add("offset", offset)
           .add("length", length)

--- a/core/src/main/java/org/apache/iceberg/BaseContentScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseContentScanTask.java
@@ -117,7 +117,7 @@ abstract class BaseContentScanTask<ThisT extends ContentScanTask<F>, F extends C
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("file", file().path())
+        .add("file", file().location())
         .add("partition_data", file().partition())
         .add("residual", residual())
         .toString();

--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -141,7 +141,7 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles>
                 && (strict.eval(file.partition()) || metrics.eval(file)),
             "Cannot append file with rows that do not match filter: %s: %s",
             rowFilter,
-            file.path());
+            file.location());
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -175,7 +175,7 @@ public class CatalogUtil {
                 for (ManifestEntry<?> entry : reader.entries()) {
                   // intern the file path because the weak key map uses identity (==) instead of
                   // equals
-                  String path = entry.file().path().toString().intern();
+                  String path = entry.file().location().intern();
                   Boolean alreadyDeleted = deletedFiles.putIfAbsent(path, true);
                   if (alreadyDeleted == null || !alreadyDeleted) {
                     pathsToDelete.add(path);

--- a/core/src/main/java/org/apache/iceberg/ContentFileParser.java
+++ b/core/src/main/java/org/apache/iceberg/ContentFileParser.java
@@ -83,7 +83,7 @@ class ContentFileParser {
 
     generator.writeNumberField(SPEC_ID, contentFile.specId());
     generator.writeStringField(CONTENT, contentFile.content().name());
-    generator.writeStringField(FILE_PATH, contentFile.path().toString());
+    generator.writeStringField(FILE_PATH, contentFile.location());
     generator.writeStringField(FILE_FORMAT, contentFile.format().name());
 
     if (contentFile.partition() != null) {

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -186,7 +186,7 @@ public class DataFiles {
             specId == toCopy.specId(), "Cannot copy a DataFile with a different spec");
         this.partitionData = copyPartitionData(spec, toCopy.partition(), partitionData);
       }
-      this.filePath = toCopy.path().toString();
+      this.filePath = toCopy.location();
       this.format = toCopy.format();
       this.recordCount = toCopy.recordCount();
       this.fileSizeInBytes = toCopy.fileSizeInBytes();

--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -94,7 +94,7 @@ public class FileMetadata {
         this.partitionData = DataFiles.copyPartitionData(spec, toCopy.partition(), partitionData);
       }
       this.content = toCopy.content();
-      this.filePath = toCopy.path().toString();
+      this.filePath = toCopy.location();
       this.format = toCopy.format();
       this.recordCount = toCopy.recordCount();
       this.fileSizeInBytes = toCopy.fileSizeInBytes();

--- a/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
@@ -293,7 +293,7 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
                   if (entry.status() == ManifestEntry.Status.DELETED
                       && !validIds.contains(entry.snapshotId())) {
                     // use toString to ensure the path will not change (Utf8 is reused)
-                    filesToDelete.add(entry.file().path().toString());
+                    filesToDelete.add(entry.file().location());
                   }
                 }
               } catch (IOException e) {
@@ -317,7 +317,7 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
                   // delete any ADDED file from manifests that were reverted
                   if (entry.status() == ManifestEntry.Status.ADDED) {
                     // use toString to ensure the path will not change (Utf8 is reused)
-                    filesToDelete.add(entry.file().path().toString());
+                    filesToDelete.add(entry.file().location());
                   }
                 }
               } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -96,7 +96,7 @@ public class ManifestFiles {
   public static CloseableIterable<String> readPaths(ManifestFile manifest, FileIO io) {
     return CloseableIterable.transform(
         read(manifest, io, null).select(ImmutableList.of("file_path")).liveEntries(),
-        entry -> entry.file().path().toString());
+        entry -> entry.file().location());
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -246,7 +246,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
       CharSequenceSet deletedFilePaths =
           deletedFiles.stream()
-              .map(ContentFile::path)
+              .map(ContentFile::location)
               .collect(Collectors.toCollection(CharSequenceSet::empty));
 
       ValidationException.check(
@@ -388,7 +388,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     for (ManifestEntry<F> entry : reader.liveEntries()) {
       F file = entry.file();
       boolean markedForDelete =
-          deletePaths.contains(file.path())
+          deletePaths.contains(file.location())
               || deleteFiles.contains(file)
               || dropPartitions.contains(file.specId(), file.partition())
               || (isDelete
@@ -436,7 +436,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
                 entry -> {
                   F file = entry.file();
                   boolean markedForDelete =
-                      deletePaths.contains(file.path())
+                      deletePaths.contains(file.location())
                           || deleteFiles.contains(file)
                           || dropPartitions.contains(file.specId(), file.partition())
                           || (isDelete

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -355,7 +355,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
             "Found conflicting files that can contain records matching partitions %s: %s",
             partitionSet,
             Iterators.toString(
-                Iterators.transform(conflicts, entry -> entry.file().path().toString())));
+                Iterators.transform(conflicts, entry -> entry.file().location().toString())));
       }
 
     } catch (IOException e) {
@@ -386,7 +386,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
             "Found conflicting files that can contain records matching %s: %s",
             conflictDetectionFilter,
             Iterators.toString(
-                Iterators.transform(conflicts, entry -> entry.file().path().toString())));
+                Iterators.transform(conflicts, entry -> entry.file().location().toString())));
       }
 
     } catch (IOException e) {
@@ -550,7 +550,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         deletes.isEmpty(),
         "Found new conflicting delete files that can apply to records matching %s: %s",
         dataFilter,
-        Iterables.transform(deletes.referencedDeleteFiles(), ContentFile::path));
+        Iterables.transform(deletes.referencedDeleteFiles(), ContentFile::location));
   }
 
   /**
@@ -570,7 +570,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         deletes.isEmpty(),
         "Found new conflicting delete files that can apply to records matching %s: %s",
         partitionSet,
-        Iterables.transform(deletes.referencedDeleteFiles(), ContentFile::path));
+        Iterables.transform(deletes.referencedDeleteFiles(), ContentFile::location));
   }
 
   /**
@@ -628,7 +628,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
             "Found conflicting deleted files that can contain records matching %s: %s",
             dataFilter,
             Iterators.toString(
-                Iterators.transform(conflicts, entry -> entry.file().path().toString())));
+                Iterators.transform(conflicts, entry -> entry.file().location().toString())));
       }
 
     } catch (IOException e) {
@@ -657,7 +657,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
             "Found conflicting deleted files that can apply to records matching %s: %s",
             partitionSet,
             Iterators.toString(
-                Iterators.transform(conflicts, entry -> entry.file().path().toString())));
+                Iterators.transform(conflicts, entry -> entry.file().location().toString())));
       }
 
     } catch (IOException e) {
@@ -783,7 +783,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
                 entry ->
                     entry.status() != ManifestEntry.Status.ADDED
                         && newSnapshots.contains(entry.snapshotId())
-                        && requiredDataFiles.contains(entry.file().path()))
+                        && requiredDataFiles.contains(entry.file().location()))
             .specsById(base.specsById())
             .ignoreExisting();
 
@@ -797,7 +797,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         throw new ValidationException(
             "Cannot commit, missing data files: %s",
             Iterators.toString(
-                Iterators.transform(deletes, entry -> entry.file().path().toString())));
+                Iterators.transform(deletes, entry -> entry.file().location().toString())));
       }
 
     } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/SplitPositionDeletesScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/SplitPositionDeletesScanTask.java
@@ -80,7 +80,7 @@ class SplitPositionDeletesScanTask
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("file", file().path())
+        .add("file", file().location())
         .add("partition_data", file().partition())
         .add("offset", offset)
         .add("length", length)

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -351,7 +351,7 @@ class V1Metadata {
     public Object get(int pos) {
       switch (pos) {
         case 0:
-          return wrapped.path().toString();
+          return wrapped.location();
         case 1:
           return wrapped.format() != null ? wrapped.format().toString() : null;
         case 2:

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -420,7 +420,7 @@ class V2Metadata {
         case 0:
           return wrapped.content().id();
         case 1:
-          return wrapped.path().toString();
+          return wrapped.location();
         case 2:
           return wrapped.format() != null ? wrapped.format().toString() : null;
         case 3:

--- a/core/src/main/java/org/apache/iceberg/V3Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V3Metadata.java
@@ -422,7 +422,7 @@ class V3Metadata {
         case 0:
           return wrapped.content().id();
         case 1:
-          return wrapped.path().toString();
+          return wrapped.location();
         case 2:
           return wrapped.format() != null ? wrapped.format().toString() : null;
         case 3:

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
@@ -311,7 +312,7 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
     } catch (Exception e) {
       if (e instanceof CleanableFailure) {
         LOG.warn("Failed to commit rewrite, cleaning up rewritten files", e);
-        Tasks.foreach(Iterables.transform(addedDataFiles, f -> f.path().toString()))
+        Tasks.foreach(Iterables.transform(addedDataFiles, ContentFile::location))
             .noRetry()
             .suppressFailureWhenFinished()
             .onFailure((location, exc) -> LOG.warn("Failed to delete: {}", location, exc))

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -105,8 +105,8 @@ public class RewriteDataFilesCommitManager {
     Tasks.foreach(fileGroup.addedFiles())
         .noRetry()
         .suppressFailureWhenFinished()
-        .onFailure((dataFile, exc) -> LOG.warn("Failed to delete: {}", dataFile.path(), exc))
-        .run(dataFile -> table.io().deleteFile(dataFile.path().toString()));
+        .onFailure((dataFile, exc) -> LOG.warn("Failed to delete: {}", dataFile.location(), exc))
+        .run(dataFile -> table.io().deleteFile(dataFile.location()));
   }
 
   public void commitOrClean(Set<RewriteFileGroup> rewriteGroups) {

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.actions;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.Table;
@@ -89,7 +90,7 @@ public class RewritePositionDeletesCommitManager {
         fileGroup.addedDeleteFiles() != null, "Cannot abort a fileGroup that was not rewritten");
 
     Iterable<String> filePaths =
-        Iterables.transform(fileGroup.addedDeleteFiles(), f -> f.path().toString());
+        Iterables.transform(fileGroup.addedDeleteFiles(), ContentFile::location);
     CatalogUtil.deleteFiles(table.io(), filePaths, "position delete", true);
   }
 

--- a/core/src/main/java/org/apache/iceberg/encryption/InputFilesDecryptor.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/InputFilesDecryptor.java
@@ -59,7 +59,7 @@ public class InputFilesDecryptor {
 
   public InputFile getInputFile(FileScanTask task) {
     Preconditions.checkArgument(!task.isDataTask(), "Invalid task type");
-    return decryptedInputFiles.get(task.file().path().toString());
+    return decryptedInputFiles.get(task.file().location());
   }
 
   public InputFile getInputFile(String location) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/Util.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Util.java
@@ -62,7 +62,7 @@ public class Util {
   public static String[] blockLocations(CombinedScanTask task, Configuration conf) {
     Set<String> locationSets = Sets.newHashSet();
     for (FileScanTask f : task.files()) {
-      Path path = new Path(f.file().path().toString());
+      Path path = new Path(f.file().location());
       try {
         FileSystem fs = path.getFileSystem(conf);
         for (BlockLocation b : fs.getFileBlockLocations(path, f.start(), f.length())) {
@@ -104,7 +104,7 @@ public class Util {
   }
 
   private static String[] blockLocations(FileIO io, ContentScanTask<?> task) {
-    String location = task.file().path().toString();
+    String location = task.file().location();
     if (usesHadoopFileIO(io, location)) {
       InputFile inputFile = io.newInputFile(location);
       if (inputFile instanceof HadoopInputFile) {

--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -92,7 +92,7 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
         .executeWith(ThreadPools.getWorkerPool())
         .throwFailureWhenFinished()
         .noRetry()
-        .run(file -> io.deleteFile(file.path().toString()));
+        .run(file -> io.deleteFile(file.location()));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/util/PartitionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionUtil.java
@@ -56,7 +56,7 @@ public class PartitionUtil {
     // add _file
     idToConstant.put(
         MetadataColumns.FILE_PATH.fieldId(),
-        convertConstant.apply(Types.StringType.get(), task.file().path()));
+        convertConstant.apply(Types.StringType.get(), task.file().location()));
 
     // add _spec_id
     idToConstant.put(

--- a/core/src/test/java/org/apache/iceberg/DataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DataTableScanTestBase.java
@@ -108,10 +108,10 @@ public abstract class DataTableScanTestBase<
 
     ScanT testBranchScan = useRef(newScan(), "testBranch");
     validateExpectedFileScanTasks(
-        testBranchScan, ImmutableList.of(FILE_A.path(), FILE_B.path(), FILE_C.path()));
+        testBranchScan, ImmutableList.of(FILE_A.location(), FILE_B.location(), FILE_C.location()));
 
     ScanT mainScan = newScan();
-    validateExpectedFileScanTasks(mainScan, ImmutableList.of(FILE_A.path(), FILE_D.path()));
+    validateExpectedFileScanTasks(mainScan, ImmutableList.of(FILE_A.location(), FILE_D.location()));
   }
 
   @TestTemplate
@@ -120,10 +120,10 @@ public abstract class DataTableScanTestBase<
     table.manageSnapshots().createTag("tagB", table.currentSnapshot().snapshotId()).commit();
     table.newFastAppend().appendFile(FILE_C).commit();
     ScanT tagScan = useRef(newScan(), "tagB");
-    validateExpectedFileScanTasks(tagScan, ImmutableList.of(FILE_A.path(), FILE_B.path()));
+    validateExpectedFileScanTasks(tagScan, ImmutableList.of(FILE_A.location(), FILE_B.location()));
     ScanT mainScan = newScan();
     validateExpectedFileScanTasks(
-        mainScan, ImmutableList.of(FILE_A.path(), FILE_B.path(), FILE_C.path()));
+        mainScan, ImmutableList.of(FILE_A.location(), FILE_B.location(), FILE_C.location()));
   }
 
   @TestTemplate
@@ -196,9 +196,10 @@ public abstract class DataTableScanTestBase<
       List<CharSequence> actualFiles = Lists.newArrayList();
       for (T task : scanTasks) {
         DataFile dataFile = ((FileScanTask) task).file();
-        actualFiles.add(dataFile.path());
+        actualFiles.add(dataFile.location());
         if (fileToManifest != null) {
-          assertThat(fileToManifest.get(dataFile.path())).isEqualTo(dataFile.manifestLocation());
+          assertThat(fileToManifest.get(dataFile.location()))
+              .isEqualTo(dataFile.manifestLocation());
         }
       }
 
@@ -231,12 +232,12 @@ public abstract class DataTableScanTestBase<
       DataFile file = fileScanTask.file();
       long expectedDataSequenceNumber = 0L;
       long expectedDeleteSequenceNumber = 0L;
-      if (file.path().equals(dataFile1.path())) {
+      if (file.location().equals(dataFile1.location())) {
         expectedDataSequenceNumber = 1L;
         expectedDeleteSequenceNumber = 3L;
       }
 
-      if (file.path().equals(dataFile2.path())) {
+      if (file.location().equals(dataFile2.location())) {
         expectedDataSequenceNumber = 2L;
         expectedDeleteSequenceNumber = 4L;
       }
@@ -274,9 +275,9 @@ public abstract class DataTableScanTestBase<
             .collect(Collectors.toList())
             .get(0);
     CharSequenceMap<String> fileToManifest = CharSequenceMap.create();
-    fileToManifest.put(FILE_A.path(), firstDataManifest.path());
-    fileToManifest.put(FILE_B.path(), secondDataManifest.path());
-    fileToManifest.put(FILE_C.path(), secondDataManifest.path());
+    fileToManifest.put(FILE_A.location(), firstDataManifest.path());
+    fileToManifest.put(FILE_B.location(), secondDataManifest.path());
+    fileToManifest.put(FILE_C.location(), secondDataManifest.path());
 
     validateExpectedFileScanTasks(newScan(), fileToManifest.keySet(), fileToManifest);
   }
@@ -290,9 +291,9 @@ public abstract class DataTableScanTestBase<
     DeleteFile deleteFile = newDeleteFile("data_bucket=0");
     table.newRowDelta().addDeletes(deleteFile).commit();
     CharSequenceMap<String> fileToManifest = CharSequenceMap.create();
-    fileToManifest.put(FILE_A.path(), firstManifest.path());
+    fileToManifest.put(FILE_A.location(), firstManifest.path());
     ScanT scan = newScan();
-    validateExpectedFileScanTasks(scan, ImmutableList.of(FILE_A.path()), fileToManifest);
+    validateExpectedFileScanTasks(scan, ImmutableList.of(FILE_A.location()), fileToManifest);
     List<DeleteFile> deletes = Lists.newArrayList();
     try (CloseableIterable<T> scanTasks = scan.planFiles()) {
       for (T task : scanTasks) {

--- a/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
@@ -275,13 +275,13 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(tasks).as("Should have one task").hasSize(1);
 
     FileScanTask task = (FileScanTask) tasks.get(0);
-    assertThat(task.file().path())
+    assertThat(task.file().location())
         .as("Should have the correct data file path")
-        .isEqualTo(unpartitionedFile.path());
+        .isEqualTo(unpartitionedFile.location());
     assertThat(task.deletes()).as("Should have one associated delete file").hasSize(1);
-    assertThat(task.deletes().get(0).path())
+    assertThat(task.deletes().get(0).location())
         .as("Should have expected delete file")
-        .isEqualTo(unpartitionedPosDeletes.path());
+        .isEqualTo(unpartitionedPosDeletes.location());
 
     // add a second delete file
     DeleteFile unpartitionedEqDeletes = unpartitionedEqDeletes(unpartitioned.spec());
@@ -289,13 +289,14 @@ public abstract class DeleteFileIndexTestBase<
 
     tasks = Lists.newArrayList(newScan(unpartitioned).planFiles().iterator());
     task = (FileScanTask) tasks.get(0);
-    assertThat(task.file().path())
+    assertThat(task.file().location())
         .as("Should have the correct data file path")
-        .isEqualTo(unpartitionedFile.path());
+        .isEqualTo(unpartitionedFile.location());
     assertThat(task.deletes()).as("Should have two associated delete files").hasSize(2);
-    assertThat(Sets.newHashSet(Iterables.transform(task.deletes(), ContentFile::path)))
+    assertThat(Sets.newHashSet(Iterables.transform(task.deletes(), ContentFile::location)))
         .as("Should have expected delete files")
-        .isEqualTo(Sets.newHashSet(unpartitionedPosDeletes.path(), unpartitionedEqDeletes.path()));
+        .isEqualTo(
+            Sets.newHashSet(unpartitionedPosDeletes.location(), unpartitionedEqDeletes.location()));
   }
 
   @TestTemplate
@@ -308,13 +309,13 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(tasks).as("Should have one task").hasSize(1);
 
     FileScanTask task = (FileScanTask) tasks.get(0);
-    assertThat(task.file().path())
+    assertThat(task.file().location())
         .as("Should have the correct data file path")
-        .isEqualTo(FILE_A.path());
+        .isEqualTo(FILE_A.location());
     assertThat(task.deletes()).as("Should have one associated delete file").hasSize(1);
-    assertThat(task.deletes().get(0).path())
+    assertThat(task.deletes().get(0).location())
         .as("Should have only pos delete file")
-        .isEqualTo(fileADeletes().path());
+        .isEqualTo(fileADeletes().location());
   }
 
   @TestTemplate
@@ -327,13 +328,13 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(tasks).as("Should have one task").hasSize(1);
 
     FileScanTask task = (FileScanTask) tasks.get(0);
-    assertThat(task.file().path())
+    assertThat(task.file().location())
         .as("Should have the correct data file path")
-        .isEqualTo(FILE_A.path());
+        .isEqualTo(FILE_A.location());
     assertThat(task.deletes()).as("Should have one associated delete file").hasSize(1);
-    assertThat(task.deletes().get(0).path())
+    assertThat(task.deletes().get(0).location())
         .as("Should have only pos delete file")
-        .isEqualTo(FILE_A_EQ_1.path());
+        .isEqualTo(FILE_A_EQ_1.location());
   }
 
   @TestTemplate
@@ -346,9 +347,9 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(tasks).as("Should have one task").hasSize(1);
 
     FileScanTask task = (FileScanTask) tasks.get(0);
-    assertThat(task.file().path())
+    assertThat(task.file().location())
         .as("Should have the correct data file path")
-        .isEqualTo(FILE_B.path());
+        .isEqualTo(FILE_B.location());
     assertThat(task.deletes()).as("Should have no delete files to apply").hasSize(0);
   }
 
@@ -364,9 +365,9 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(tasks).as("Should have one task").hasSize(1);
 
     FileScanTask task = (FileScanTask) tasks.get(0);
-    assertThat(task.file().path())
+    assertThat(task.file().location())
         .as("Should have the correct data file path")
-        .isEqualTo(FILE_A.path());
+        .isEqualTo(FILE_A.location());
     assertThat(task.deletes()).as("Should have no delete files to apply").hasSize(0);
   }
 
@@ -391,13 +392,13 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(tasks).as("Should have one task").hasSize(1);
 
     FileScanTask task = (FileScanTask) tasks.get(0);
-    assertThat(task.file().path())
+    assertThat(task.file().location())
         .as("Should have the correct data file path")
-        .isEqualTo(FILE_A.path());
+        .isEqualTo(FILE_A.location());
     assertThat(task.deletes()).as("Should have one associated delete file").hasSize(1);
-    assertThat(task.deletes().get(0).path())
+    assertThat(task.deletes().get(0).location())
         .as("Should have expected delete file")
-        .isEqualTo(unpartitionedEqDeletes.path());
+        .isEqualTo(unpartitionedEqDeletes.location());
   }
 
   @TestTemplate
@@ -423,13 +424,13 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(tasks).as("Should have one task").hasSize(1);
 
     FileScanTask task = (FileScanTask) tasks.get(0);
-    assertThat(task.file().path())
+    assertThat(task.file().location())
         .as("Should have the correct data file path")
-        .isEqualTo(FILE_A.path());
+        .isEqualTo(FILE_A.location());
     assertThat(task.deletes()).as("Should have two associated delete files").hasSize(2);
-    assertThat(Sets.newHashSet(Iterables.transform(task.deletes(), ContentFile::path)))
+    assertThat(Sets.newHashSet(Iterables.transform(task.deletes(), ContentFile::location)))
         .as("Should have expected delete files")
-        .isEqualTo(Sets.newHashSet(unpartitionedEqDeletes.path(), FILE_A_EQ_1.path()));
+        .isEqualTo(Sets.newHashSet(unpartitionedEqDeletes.location(), FILE_A_EQ_1.location()));
   }
 
   @TestTemplate
@@ -440,13 +441,13 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(tasks).as("Should have one task").hasSize(1);
 
     FileScanTask task = (FileScanTask) tasks.get(0);
-    assertThat(task.file().path())
+    assertThat(task.file().location())
         .as("Should have the correct data file path")
-        .isEqualTo(FILE_A.path());
+        .isEqualTo(FILE_A.location());
     assertThat(task.deletes()).as("Should have one associated delete file").hasSize(1);
-    assertThat(task.deletes().get(0).path())
+    assertThat(task.deletes().get(0).location())
         .as("Should have only pos delete file")
-        .isEqualTo(fileADeletes().path());
+        .isEqualTo(fileADeletes().location());
   }
 
   @TestTemplate
@@ -481,13 +482,13 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(tasks).as("Should have one task").hasSize(1);
 
     FileScanTask task = tasks.get(0);
-    assertThat(task.file().path())
+    assertThat(task.file().location())
         .as("Should have the correct data file path")
-        .isEqualTo(unpartitionedFile.path());
+        .isEqualTo(unpartitionedFile.location());
     assertThat(task.deletes()).as("Should have one associated delete file").hasSize(1);
-    assertThat(task.deletes().get(0).path())
+    assertThat(task.deletes().get(0).location())
         .as("Should have only pos delete file")
-        .isEqualTo(unpartitionedPosDeleteFile.path());
+        .isEqualTo(unpartitionedPosDeleteFile.location());
   }
 
   @TestTemplate
@@ -548,13 +549,13 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(tasks).as("Should have one task").hasSize(1);
 
     FileScanTask task = (FileScanTask) tasks.get(0);
-    assertThat(task.file().path())
+    assertThat(task.file().location())
         .as("Should have the correct data file path")
-        .isEqualTo(FILE_A.path());
+        .isEqualTo(FILE_A.location());
     assertThat(task.deletes()).as("Should have two associated delete files").hasSize(2);
-    assertThat(Sets.newHashSet(Iterables.transform(task.deletes(), ContentFile::path)))
+    assertThat(Sets.newHashSet(Iterables.transform(task.deletes(), ContentFile::location)))
         .as("Should have expected delete files")
-        .isEqualTo(Sets.newHashSet(FILE_A_EQ_1.path(), fileADeletes().path()));
+        .isEqualTo(Sets.newHashSet(FILE_A_EQ_1.location(), fileADeletes().location()));
   }
 
   @TestTemplate
@@ -575,8 +576,10 @@ public abstract class DeleteFileIndexTestBase<
 
     // all files must be reported as referenced
     CharSequenceSet paths =
-        CharSequenceSet.of(Iterables.transform(group.referencedDeleteFiles(), ContentFile::path));
-    assertThat(paths).contains(file1.path(), file2.path(), file3.path(), file4.path());
+        CharSequenceSet.of(
+            Iterables.transform(group.referencedDeleteFiles(), ContentFile::location));
+    assertThat(paths)
+        .contains(file1.location(), file2.location(), file3.location(), file4.location());
 
     // position deletes are indexed by their data sequence numbers
     // so that position deletes can apply to data files added in the same snapshot
@@ -609,8 +612,10 @@ public abstract class DeleteFileIndexTestBase<
 
     // all files must be reported as referenced
     CharSequenceSet paths =
-        CharSequenceSet.of(Iterables.transform(group.referencedDeleteFiles(), ContentFile::path));
-    assertThat(paths).contains(file1.path(), file2.path(), file3.path(), file4.path());
+        CharSequenceSet.of(
+            Iterables.transform(group.referencedDeleteFiles(), ContentFile::location));
+    assertThat(paths)
+        .contains(file1.location(), file2.location(), file3.location(), file4.location());
 
     // equality deletes are indexed by data sequence number - 1 to apply to next snapshots
     assertThat(group.filter(0, FILE_A)).isEqualTo(new DeleteFile[] {file1, file2, file3, file4});

--- a/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
@@ -213,7 +213,7 @@ public class FileGenerationUtil {
       int fieldId = column.fieldId();
       columnSizes.put(fieldId, generateColumnSize());
       if (fieldId == MetadataColumns.DELETE_FILE_PATH.fieldId()) {
-        ByteBuffer bound = Conversions.toByteBuffer(Types.StringType.get(), dataFile.path());
+        ByteBuffer bound = Conversions.toByteBuffer(Types.StringType.get(), dataFile.location());
         lowerBounds.put(fieldId, bound);
         upperBounds.put(fieldId, bound);
       }

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -45,7 +45,7 @@ public abstract class MetadataTableScanTestBase extends TestBase {
 
   protected Set<String> scannedPaths(TableScan scan) {
     return StreamSupport.stream(scan.planFiles().spliterator(), false)
-        .map(t -> t.file().path().toString())
+        .map(t -> t.file().location().toString())
         .collect(Collectors.toSet());
   }
 

--- a/core/src/test/java/org/apache/iceberg/ScanPlanningAndReportingTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/ScanPlanningAndReportingTestBase.java
@@ -241,7 +241,7 @@ public abstract class ScanPlanningAndReportingTestBase<
     }
     assertThat(fileTasks)
         .singleElement()
-        .satisfies(task -> assertThat(task.file().path()).isEqualTo(FILE_D.path()));
+        .satisfies(task -> assertThat(task.file().location()).isEqualTo(FILE_D.location()));
 
     ScanReport scanReport = reporter.lastReport();
     assertThat(scanReport).isNotNull();

--- a/core/src/test/java/org/apache/iceberg/TestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TestBase.java
@@ -490,9 +490,7 @@ public class TestBase {
             snap.sequenceNumber(),
             entry.file().fileSequenceNumber().longValue());
       }
-      assertThat(file.path().toString())
-          .as("Path should match expected")
-          .isEqualTo(newPaths.next());
+      assertThat(file.location()).as("Path should match expected").isEqualTo(newPaths.next());
       assertThat(entry.snapshotId()).as("File's snapshot ID should match").isEqualTo(id);
     }
 
@@ -508,11 +506,11 @@ public class TestBase {
   void validateTableFiles(Table tbl, Collection<DataFile> expectedFiles) {
     Set<CharSequence> expectedFilePaths = Sets.newHashSet();
     for (DataFile file : expectedFiles) {
-      expectedFilePaths.add(file.path());
+      expectedFilePaths.add(file.location());
     }
     Set<CharSequence> actualFilePaths = Sets.newHashSet();
     for (FileScanTask task : tbl.newScan().planFiles()) {
-      actualFilePaths.add(task.file().path());
+      actualFilePaths.add(task.file().location());
     }
     assertThat(actualFilePaths).as("Files should match").isEqualTo(expectedFilePaths);
   }
@@ -520,11 +518,11 @@ public class TestBase {
   void validateBranchFiles(Table tbl, String ref, DataFile... expectedFiles) {
     Set<CharSequence> expectedFilePaths = Sets.newHashSet();
     for (DataFile file : expectedFiles) {
-      expectedFilePaths.add(file.path());
+      expectedFilePaths.add(file.location());
     }
     Set<CharSequence> actualFilePaths = Sets.newHashSet();
     for (FileScanTask task : tbl.newScan().useRef(ref).planFiles()) {
-      actualFilePaths.add(task.file().path());
+      actualFilePaths.add(task.file().location());
     }
     assertThat(actualFilePaths).as("Files should match").isEqualTo(expectedFilePaths);
   }
@@ -532,12 +530,12 @@ public class TestBase {
   void validateBranchDeleteFiles(Table tbl, String branch, DeleteFile... expectedFiles) {
     Set<CharSequence> expectedFilePaths = Sets.newHashSet();
     for (DeleteFile file : expectedFiles) {
-      expectedFilePaths.add(file.path());
+      expectedFilePaths.add(file.location());
     }
     Set<CharSequence> actualFilePaths = Sets.newHashSet();
     for (FileScanTask task : tbl.newScan().useRef(branch).planFiles()) {
       for (DeleteFile file : task.deletes()) {
-        actualFilePaths.add(file.path());
+        actualFilePaths.add(file.location());
       }
     }
     assertThat(actualFilePaths).as("Delete files should match").isEqualTo(expectedFilePaths);
@@ -546,7 +544,7 @@ public class TestBase {
   List<String> paths(DataFile... dataFiles) {
     List<String> paths = Lists.newArrayListWithExpectedSize(dataFiles.length);
     for (DataFile file : dataFiles) {
-      paths.add(file.path().toString());
+      paths.add(file.location());
     }
     return paths;
   }
@@ -578,9 +576,7 @@ public class TestBase {
 
       validateManifestSequenceNumbers(entry, dataSeqs, fileSeqs);
 
-      assertThat(file.path().toString())
-          .as("Path should match expected")
-          .isEqualTo(expected.path().toString());
+      assertThat(file.location()).as("Path should match expected").isEqualTo(expected.location());
       assertThat(entry.snapshotId())
           .as("Snapshot ID should match expected ID")
           .isEqualTo(ids.next());
@@ -606,9 +602,7 @@ public class TestBase {
 
       validateManifestSequenceNumbers(entry, dataSeqs, fileSeqs);
 
-      assertThat(file.path().toString())
-          .as("Path should match expected")
-          .isEqualTo(expected.path().toString());
+      assertThat(file.location()).as("Path should match expected").isEqualTo(expected.location());
       assertThat(entry.snapshotId())
           .as("Snapshot ID should match expected ID")
           .isEqualTo(ids.next());
@@ -763,9 +757,7 @@ public class TestBase {
       DataFile file = entry.file();
       DataFile expected = expectedFiles.next();
       final ManifestEntry.Status expectedStatus = expectedStatuses.next();
-      assertThat(file.path().toString())
-          .as("Path should match expected")
-          .isEqualTo(expected.path().toString());
+      assertThat(file.location()).as("Path should match expected").isEqualTo(expected.location());
       assertThat(entry.snapshotId())
           .as("Snapshot ID should match expected ID")
           .isEqualTo(ids.next());

--- a/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
@@ -73,7 +73,7 @@ public class TestBaseIncrementalChangelogScan
           AddedRowsScanTask t1 = (AddedRowsScanTask) Iterables.getOnlyElement(tasks);
           assertThat(t1.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
           assertThat(t1.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
-          assertThat(t1.file().path()).as("Data file must match").isEqualTo(FILE_B.path());
+          assertThat(t1.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
           assertThat(t1.deletes()).as("Must be no deletes").isEmpty();
         });
   }
@@ -98,13 +98,13 @@ public class TestBaseIncrementalChangelogScan
     AddedRowsScanTask t1 = (AddedRowsScanTask) tasks.get(0);
     assertThat(t1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
     assertThat(t1.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
-    assertThat(t1.file().path()).as("Data file must match").isEqualTo(FILE_A2.path());
+    assertThat(t1.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
     assertThat(t1.deletes()).as("Must be no deletes").isEmpty();
 
     DeletedDataFileScanTask t2 = (DeletedDataFileScanTask) tasks.get(1);
     assertThat(t2.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
     assertThat(t2.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
-    assertThat(t2.file().path()).as("Data file must match").isEqualTo(FILE_A.path());
+    assertThat(t2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
     assertThat(t2.existingDeletes()).as("Must be no deletes").isEmpty();
   }
 
@@ -128,7 +128,7 @@ public class TestBaseIncrementalChangelogScan
     DeletedDataFileScanTask t1 = (DeletedDataFileScanTask) Iterables.getOnlyElement(tasks);
     assertThat(t1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
     assertThat(t1.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
-    assertThat(t1.file().path()).as("Data file must match").isEqualTo(FILE_A.path());
+    assertThat(t1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
     assertThat(t1.existingDeletes()).as("Must be no deletes").isEmpty();
   }
 
@@ -161,7 +161,7 @@ public class TestBaseIncrementalChangelogScan
     AddedRowsScanTask t1 = (AddedRowsScanTask) Iterables.getOnlyElement(tasks);
     assertThat(t1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
     assertThat(t1.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap3.snapshotId());
-    assertThat(t1.file().path()).as("Data file must match").isEqualTo(FILE_C.path());
+    assertThat(t1.file().location()).as("Data file must match").isEqualTo(FILE_C.location());
     assertThat(t1.deletes()).as("Must be no deletes").isEmpty();
   }
 
@@ -202,19 +202,19 @@ public class TestBaseIncrementalChangelogScan
     AddedRowsScanTask t1 = (AddedRowsScanTask) tasks.get(0);
     assertThat(t1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
     assertThat(t1.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap1.snapshotId());
-    assertThat(t1.file().path()).as("Data file must match").isEqualTo(FILE_A.path());
+    assertThat(t1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
     assertThat(t1.deletes()).as("Must be no deletes").isEmpty();
 
     AddedRowsScanTask t2 = (AddedRowsScanTask) tasks.get(1);
     assertThat(t2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
     assertThat(t2.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
-    assertThat(t2.file().path()).as("Data file must match").isEqualTo(FILE_B.path());
+    assertThat(t2.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
     assertThat(t2.deletes()).as("Must be no deletes").isEmpty();
 
     AddedRowsScanTask t3 = (AddedRowsScanTask) tasks.get(2);
     assertThat(t3.changeOrdinal()).as("Ordinal must match").isEqualTo(2);
     assertThat(t3.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap4.snapshotId());
-    assertThat(t3.file().path()).as("Data file must match").isEqualTo(FILE_C.path());
+    assertThat(t3.file().location()).as("Data file must match").isEqualTo(FILE_C.location());
     assertThat(t3.deletes()).as("Must be no deletes").isEmpty();
   }
 
@@ -237,13 +237,13 @@ public class TestBaseIncrementalChangelogScan
     AddedRowsScanTask t1 = (AddedRowsScanTask) tasks.get(0);
     assertThat(t1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
     assertThat(t1.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap1.snapshotId());
-    assertThat(t1.file().path()).as("Data file must match").isEqualTo(FILE_A.path());
+    assertThat(t1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
     assertThat(t1.deletes()).as("Must be no deletes").isEmpty();
 
     AddedRowsScanTask t2 = (AddedRowsScanTask) tasks.get(1);
     assertThat(t2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
     assertThat(t2.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
-    assertThat(t2.file().path()).as("Data file must match").isEqualTo(FILE_B.path());
+    assertThat(t2.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
     assertThat(t2.deletes()).as("Must be no deletes").isEmpty();
   }
 
@@ -282,6 +282,6 @@ public class TestBaseIncrementalChangelogScan
   }
 
   private String path(ChangelogScanTask task) {
-    return ((ContentScanTask<?>) task).file().path().toString();
+    return ((ContentScanTask<?>) task).file().location().toString();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestBatchScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestBatchScans.java
@@ -51,12 +51,12 @@ public class TestBatchScans extends TestBase {
     assertThat(tasks).hasSize(2);
 
     FileScanTask t1 = tasks.get(0).asFileScanTask();
-    assertThat(FILE_A.path()).as("Task file must match").isEqualTo(t1.file().path());
+    assertThat(FILE_A.location()).as("Task file must match").isEqualTo(t1.file().location());
     V1Assert.assertEquals("Task deletes size must match", 0, t1.deletes().size());
     V2Assert.assertEquals("Task deletes size must match", 1, t1.deletes().size());
 
     FileScanTask t2 = tasks.get(1).asFileScanTask();
-    assertThat(FILE_B.path()).as("Task file must match").isEqualTo(t2.file().path());
+    assertThat(FILE_B.location()).as("Task file must match").isEqualTo(t2.file().location());
     assertThat(t2.deletes()).as("Task deletes size must match").hasSize(0);
 
     List<ScanTaskGroup<ScanTask>> taskGroups = planTaskGroups(scan);
@@ -88,10 +88,10 @@ public class TestBatchScans extends TestBase {
     assertThat(tasks).as("Expected 2 tasks").hasSize(2);
 
     FileScanTask t1 = tasks.get(0).asFileScanTask();
-    assertThat(manifestPaths).first().as("Task file must match").isEqualTo(t1.file().path());
+    assertThat(manifestPaths).first().as("Task file must match").isEqualTo(t1.file().location());
 
     FileScanTask t2 = tasks.get(1).asFileScanTask();
-    assertThat(manifestPaths).element(1).as("Task file must match").isEqualTo(t2.file().path());
+    assertThat(manifestPaths).element(1).as("Task file must match").isEqualTo(t2.file().location());
 
     List<ScanTaskGroup<ScanTask>> taskGroups = planTaskGroups(scan);
     assertThat(taskGroups).as("Expected 1 task group").hasSize(1);
@@ -121,6 +121,6 @@ public class TestBatchScans extends TestBase {
   }
 
   private String path(ScanTask task) {
-    return ((ContentScanTask<?>) task).file().path().toString();
+    return ((ContentScanTask<?>) task).file().location().toString();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestContentFileParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestContentFileParser.java
@@ -378,7 +378,7 @@ public class TestContentFileParser {
     assertThat(actual.getClass()).isEqualTo(expected.getClass());
     assertThat(actual.specId()).isEqualTo(expected.specId());
     assertThat(actual.content()).isEqualTo(expected.content());
-    assertThat(actual.path()).isEqualTo(expected.path());
+    assertThat(actual.location()).isEqualTo(expected.location());
     assertThat(actual.format()).isEqualTo(expected.format());
     assertThat(actual.partition())
         .usingComparator(Comparators.forType(spec.partitionType()))

--- a/core/src/test/java/org/apache/iceberg/TestEntriesMetadataTable.java
+++ b/core/src/test/java/org/apache/iceberg/TestEntriesMetadataTable.java
@@ -68,7 +68,7 @@ public class TestEntriesMetadataTable extends TestBase {
         .isEqualTo(expectedSchema.asStruct());
 
     FileScanTask file = Iterables.getOnlyElement(scan.planFiles());
-    assertThat(file.file().path())
+    assertThat(file.file().location())
         .as("Data file should be the table's manifest")
         .isEqualTo(table.currentSnapshot().allManifests(table.io()).get(0).path());
 
@@ -145,13 +145,13 @@ public class TestEntriesMetadataTable extends TestBase {
         .isEqualTo(expectedSchema.asStruct());
 
     List<FileScanTask> files = ImmutableList.copyOf(scan.planFiles());
-    assertThat(files.get(0).file().path())
+    assertThat(files.get(0).file().location())
         .as("Data file should be the table's manifest")
         .isEqualTo(table.currentSnapshot().dataManifests(table.io()).get(0).path());
     assertThat(files.get(0).file().recordCount())
         .as("Should contain 2 data file records")
         .isEqualTo(2);
-    assertThat(files.get(1).file().path())
+    assertThat(files.get(1).file().location())
         .as("Delete file should be in the table manifest")
         .isEqualTo(table.currentSnapshot().deleteManifests(table.io()).get(0).path());
     assertThat(files.get(1).file().recordCount())

--- a/core/src/test/java/org/apache/iceberg/TestFindFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestFindFiles.java
@@ -211,11 +211,10 @@ public class TestFindFiles extends TestBase {
   }
 
   private Set<String> pathSet(DataFile... files) {
-    return Sets.newHashSet(
-        Iterables.transform(Arrays.asList(files), file -> file.path().toString()));
+    return Sets.newHashSet(Iterables.transform(Arrays.asList(files), ContentFile::location));
   }
 
   private Set<String> pathSet(Iterable<DataFile> files) {
-    return Sets.newHashSet(Iterables.transform(files, file -> file.path().toString()));
+    return Sets.newHashSet(Iterables.transform(files, ContentFile::location));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
@@ -320,7 +320,7 @@ public class TestIncrementalDataTableScan extends TestBase {
         Iterables.transform(
             tableScan.planFiles(),
             t -> {
-              String path = t.file().path().toString();
+              String path = t.file().location();
               return path.split("\\.")[0];
             });
     return Lists.newArrayList(filesToRead);

--- a/core/src/test/java/org/apache/iceberg/TestManifestEncryption.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestEncryption.java
@@ -165,7 +165,7 @@ public class TestManifestEncryption {
   void checkDataFile(ContentFile<?> dataFile, FileContent content) {
     // DataFile is the superclass of DeleteFile, so this method can check both
     assertThat(dataFile.content()).isEqualTo(content);
-    assertThat(dataFile.path()).isEqualTo(PATH);
+    assertThat(dataFile.location()).isEqualTo(PATH);
     assertThat(dataFile.format()).isEqualTo(FORMAT);
     assertThat(dataFile.partition()).isEqualTo(PARTITION);
     assertThat(dataFile.recordCount()).isEqualTo(METRICS.recordCount());

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -54,7 +54,7 @@ public class TestManifestReader extends TestBase {
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO)) {
       ManifestEntry<DataFile> entry = Iterables.getOnlyElement(reader.entries());
       assertThat(entry.status()).isEqualTo(Status.EXISTING);
-      assertThat(entry.file().path()).isEqualTo(FILE_A.path());
+      assertThat(entry.file().location()).isEqualTo(FILE_A.location());
       assertThat(entry.snapshotId()).isEqualTo(1000L);
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
@@ -154,7 +154,7 @@ public class TestManifestReaderStats extends TestBase {
             .project(new Schema(ImmutableList.of(DataFile.FILE_PATH, DataFile.VALUE_COUNTS)))) {
       DataFile entry = reader.iterator().next();
 
-      assertThat(entry.path()).isEqualTo(FILE_PATH);
+      assertThat(entry.location()).isEqualTo(FILE_PATH);
       assertThat(entry.valueCounts()).isEqualTo(VALUE_COUNT);
       assertThat(entry.columnSizes()).isNull();
       assertThat(entry.nullValueCounts()).isNull();
@@ -175,7 +175,7 @@ public class TestManifestReaderStats extends TestBase {
       DataFile dataFile = entry.file();
 
       // selected field is populated
-      assertThat(dataFile.path()).isEqualTo(FILE_PATH);
+      assertThat(dataFile.location()).isEqualTo(FILE_PATH);
 
       // not selected fields are all null and not projected
       assertThat(dataFile.columnSizes()).isNull();
@@ -197,7 +197,7 @@ public class TestManifestReaderStats extends TestBase {
       DataFile dataFile = reader.iterator().next();
 
       // selected fields are populated
-      assertThat(dataFile.path()).isEqualTo(FILE_PATH);
+      assertThat(dataFile.location()).isEqualTo(FILE_PATH);
       assertThat(dataFile.valueCounts()).isEqualTo(VALUE_COUNT);
 
       // not selected fields are all null and not projected
@@ -249,7 +249,8 @@ public class TestManifestReaderStats extends TestBase {
           .isInstanceOf(UnsupportedOperationException.class);
     }
 
-    assertThat(dataFile.path()).isEqualTo(FILE_PATH); // always select file path in all test cases
+    assertThat(dataFile.location())
+        .isEqualTo(FILE_PATH); // always select file path in all test cases
   }
 
   private void assertStatsDropped(DataFile dataFile) {
@@ -262,7 +263,8 @@ public class TestManifestReaderStats extends TestBase {
     assertThat(dataFile.lowerBounds()).isNull();
     assertThat(dataFile.upperBounds()).isNull();
 
-    assertThat(dataFile.path()).isEqualTo(FILE_PATH); // always select file path in all test cases
+    assertThat(dataFile.location())
+        .isEqualTo(FILE_PATH); // always select file path in all test cases
   }
 
   private void assertNullRecordCount(DataFile dataFile) {

--- a/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
@@ -236,7 +236,7 @@ public class TestManifestWriterVersions {
   void checkDataFile(ContentFile<?> dataFile, FileContent content) {
     // DataFile is the superclass of DeleteFile, so this method can check both
     assertThat(dataFile.content()).isEqualTo(content);
-    assertThat(dataFile.path()).isEqualTo(PATH);
+    assertThat(dataFile.location()).isEqualTo(PATH);
     assertThat(dataFile.format()).isEqualTo(FORMAT);
     assertThat(dataFile.partition()).isEqualTo(PARTITION);
     assertThat(dataFile.recordCount()).isEqualTo(METRICS.recordCount());

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -1407,12 +1407,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     assertThat((Map<Integer, Integer>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct partition spec id on constant column")
         .containsEntry(MetadataColumns.SPEC_ID.fieldId(), 0);
-    assertThat(posDeleteTask.file().path())
+    assertThat(posDeleteTask.file().location())
         .as("Expected correct delete file on task")
-        .isEqualTo(fileBDeletes().path());
+        .isEqualTo(fileBDeletes().location());
     assertThat((Map<Integer, String>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct delete file on constant column")
-        .containsEntry(MetadataColumns.FILE_PATH.fieldId(), fileBDeletes().path().toString());
+        .containsEntry(MetadataColumns.FILE_PATH.fieldId(), fileBDeletes().location());
   }
 
   @TestTemplate
@@ -1477,12 +1477,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     assertThat((Map<Integer, Integer>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct partition spec id on constant column")
         .containsEntry(MetadataColumns.SPEC_ID.fieldId(), 0);
-    assertThat(posDeleteTask.file().path())
+    assertThat(posDeleteTask.file().location())
         .as("Expected correct delete file on task")
-        .isEqualTo(fileADeletes().path());
+        .isEqualTo(fileADeletes().location());
     assertThat((Map<Integer, String>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct delete file on constant column")
-        .containsEntry(MetadataColumns.FILE_PATH.fieldId(), fileADeletes().path().toString());
+        .containsEntry(MetadataColumns.FILE_PATH.fieldId(), fileADeletes().location());
   }
 
   @TestTemplate
@@ -1560,7 +1560,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         .as("Expected correct partition spec id on constant column")
         .containsEntry(MetadataColumns.SPEC_ID.fieldId(), 1);
 
-    assertThat(posDeleteTask.file().path())
+    assertThat(posDeleteTask.file().location())
         .as("Expected correct delete file on task")
         .isEqualTo(path1);
     assertThat((Map<Integer, String>) constantsMap(posDeleteTask, partitionType))

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -203,12 +203,12 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
     assertThat((Map<Integer, Integer>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct partition spec id on constant column")
         .containsEntry(MetadataColumns.SPEC_ID.fieldId(), table.ops().current().spec().specId());
-    assertThat(posDeleteTask.file().path())
+    assertThat(posDeleteTask.file().location())
         .as("Expected correct delete file on task")
-        .isEqualTo(deleteFile.path());
+        .isEqualTo(deleteFile.location());
     assertThat((Map<Integer, String>) constantsMap(posDeleteTask, partitionType))
         .as("Expected correct delete file on constant column")
-        .containsEntry(MetadataColumns.FILE_PATH.fieldId(), deleteFile.path().toString());
+        .containsEntry(MetadataColumns.FILE_PATH.fieldId(), deleteFile.location());
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
@@ -178,7 +178,7 @@ public class TestMicroBatchBuilder extends TestBase {
         Iterables.transform(
             tasks,
             t -> {
-              String path = t.file().path().toString();
+              String path = t.file().location();
               return path.split("\\.")[0];
             });
     return Lists.newArrayList(filesToRead);

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -141,7 +141,7 @@ public class TestRemoveSnapshots extends TestBase {
                     .allManifests(table.io())
                     .get(0)
                     .path(), // manifest contained only deletes, was dropped
-                FILE_A.path() // deleted
+                FILE_A.location() // deleted
                 ));
   }
 
@@ -196,7 +196,7 @@ public class TestRemoveSnapshots extends TestBase {
                     .get(0)
                     .path(), // manifest was rewritten for delete
                 secondSnapshot.manifestListLocation(), // snapshot expired
-                FILE_A.path() // deleted
+                FILE_A.location() // deleted
                 ));
   }
 
@@ -292,7 +292,7 @@ public class TestRemoveSnapshots extends TestBase {
                     .findFirst()
                     .get()
                     .path(), // manifest is no longer referenced
-                FILE_B.path()) // added, but rolled back
+                FILE_B.location()) // added, but rolled back
             );
   }
 
@@ -652,7 +652,7 @@ public class TestRemoveSnapshots extends TestBase {
 
     removeSnapshots(table).expireOlderThan(t3).deleteWith(deletedFiles::add).commit();
 
-    assertThat(deletedFiles).contains(FILE_A.path().toString());
+    assertThat(deletedFiles).contains(FILE_A.location().toString());
   }
 
   @TestTemplate
@@ -678,7 +678,7 @@ public class TestRemoveSnapshots extends TestBase {
 
     removeSnapshots(table).expireOlderThan(t3).deleteWith(deletedFiles::add).commit();
 
-    assertThat(deletedFiles).contains(FILE_A.path().toString());
+    assertThat(deletedFiles).contains(FILE_A.location().toString());
   }
 
   @TestTemplate
@@ -715,8 +715,8 @@ public class TestRemoveSnapshots extends TestBase {
 
     removeSnapshots(table).expireOlderThan(t4).deleteWith(deletedFiles::add).commit();
 
-    assertThat(deletedFiles).contains(FILE_A.path().toString());
-    assertThat(deletedFiles).contains(FILE_B.path().toString());
+    assertThat(deletedFiles).contains(FILE_A.location().toString());
+    assertThat(deletedFiles).contains(FILE_B.location().toString());
   }
 
   @TestTemplate
@@ -789,8 +789,8 @@ public class TestRemoveSnapshots extends TestBase {
         .containsExactly(
             "remove-snapshot-3", "remove-snapshot-2", "remove-snapshot-1", "remove-snapshot-0");
 
-    assertThat(deletedFiles).contains(FILE_A.path().toString());
-    assertThat(deletedFiles).contains(FILE_B.path().toString());
+    assertThat(deletedFiles).contains(FILE_A.location().toString());
+    assertThat(deletedFiles).contains(FILE_B.location().toString());
     assertThat(planThreadsIndex.get())
         .as("Thread should be created in provided pool")
         .isGreaterThan(0);
@@ -857,7 +857,7 @@ public class TestRemoveSnapshots extends TestBase {
         .addedDataFiles(table.io())
         .forEach(
             i -> {
-              expectedDeletes.add(i.path().toString());
+              expectedDeletes.add(i.location().toString());
             });
 
     // ManifestList should be deleted too
@@ -923,7 +923,7 @@ public class TestRemoveSnapshots extends TestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        assertThat(deletedFiles).doesNotContain(item.path().toString());
+                        assertThat(deletedFiles).doesNotContain(item.location().toString());
                       });
             });
   }
@@ -969,7 +969,7 @@ public class TestRemoveSnapshots extends TestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        assertThat(deletedFiles).doesNotContain(item.path().toString());
+                        assertThat(deletedFiles).doesNotContain(item.location().toString());
                       });
             });
 
@@ -986,7 +986,7 @@ public class TestRemoveSnapshots extends TestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        assertThat(deletedFiles).doesNotContain(item.path().toString());
+                        assertThat(deletedFiles).doesNotContain(item.location().toString());
                       });
             });
   }
@@ -1105,8 +1105,8 @@ public class TestRemoveSnapshots extends TestBase {
         .as("Should remove old delete files and delete file manifests")
         .isEqualTo(
             ImmutableSet.builder()
-                .add(FILE_A.path())
-                .add(FILE_A_DELETES.path())
+                .add(FILE_A.location())
+                .add(FILE_A_DELETES.location())
                 .add(firstSnapshot.manifestListLocation())
                 .add(secondSnapshot.manifestListLocation())
                 .add(thirdSnapshot.manifestListLocation())
@@ -1614,7 +1614,7 @@ public class TestRemoveSnapshots extends TestBase {
     expectedDeletes.addAll(manifestPaths(appendA, table.io()));
     expectedDeletes.add(branchDelete.manifestListLocation());
     expectedDeletes.addAll(manifestPaths(branchDelete, table.io()));
-    expectedDeletes.add(FILE_A.path().toString());
+    expectedDeletes.add(FILE_A.location().toString());
 
     assertThat(table.snapshots()).hasSize(2);
     assertThat(deletedFiles).isEqualTo(expectedDeletes);

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -138,7 +138,7 @@ public class TestRewriteManifests extends TestBase {
     List<DataFile> files;
     List<Long> ids;
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifests.get(0), table.io())) {
-      if (reader.iterator().next().path().equals(FILE_A.path())) {
+      if (reader.iterator().next().location().equals(FILE_A.location())) {
         files = Arrays.asList(FILE_A, FILE_B);
         ids = Arrays.asList(manifestAppendId, fileAppendId);
       } else {
@@ -164,7 +164,7 @@ public class TestRewriteManifests extends TestBase {
 
     // cluster by path will split the manifest into two
 
-    table.rewriteManifests().clusterBy(file -> file.path()).commit();
+    table.rewriteManifests().clusterBy(file -> file.location()).commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
     assertThat(manifests).hasSize(2);
@@ -198,7 +198,7 @@ public class TestRewriteManifests extends TestBase {
     List<DataFile> files;
     List<Long> ids;
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifests.get(0), table.io())) {
-      if (reader.iterator().next().path().equals(FILE_A.path())) {
+      if (reader.iterator().next().location().equals(FILE_A.location())) {
         files = Arrays.asList(FILE_A, FILE_B);
         ids = Arrays.asList(appendIdA, appendIdB);
       } else {
@@ -237,7 +237,7 @@ public class TestRewriteManifests extends TestBase {
         .rewriteIf(
             manifest -> {
               try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, table.io())) {
-                return !reader.iterator().next().path().equals(FILE_A.path());
+                return !reader.iterator().next().location().equals(FILE_A.location());
               } catch (IOException x) {
                 throw new RuntimeIOException(x);
               }
@@ -251,7 +251,7 @@ public class TestRewriteManifests extends TestBase {
     List<DataFile> files;
     List<Long> ids;
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifests.get(0), table.io())) {
-      if (reader.iterator().next().path().equals(FILE_B.path())) {
+      if (reader.iterator().next().location().equals(FILE_B.location())) {
         files = Arrays.asList(FILE_B, FILE_C);
         ids = Arrays.asList(appendIdB, appendIdC);
       } else {
@@ -312,7 +312,7 @@ public class TestRewriteManifests extends TestBase {
         .rewriteIf(
             manifest -> {
               try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, table.io())) {
-                return !reader.iterator().next().path().equals(FILE_A.path());
+                return !reader.iterator().next().location().equals(FILE_A.location());
               } catch (IOException x) {
                 throw new RuntimeIOException(x);
               }
@@ -332,7 +332,7 @@ public class TestRewriteManifests extends TestBase {
     List<DataFile> files;
     List<Long> ids;
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifests.get(0), table.io())) {
-      if (reader.iterator().next().path().equals(FILE_A.path())) {
+      if (reader.iterator().next().location().equals(FILE_A.location())) {
         files = Arrays.asList(FILE_A, FILE_B);
         ids = Arrays.asList(appendIdA, appendIdB);
       } else {
@@ -850,7 +850,7 @@ public class TestRewriteManifests extends TestBase {
         .rewriteIf(
             manifest -> {
               try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, table.io())) {
-                return !reader.iterator().next().path().equals(FILE_B.path());
+                return !reader.iterator().next().location().equals(FILE_B.location());
               } catch (IOException x) {
                 throw new RuntimeIOException(x);
               }
@@ -1107,7 +1107,7 @@ public class TestRewriteManifests extends TestBase {
     assertManifestCounts(table, 1, 1);
 
     // rewrite manifests and cluster entries by file path
-    table.rewriteManifests().clusterBy(file -> file.path().toString()).commit();
+    table.rewriteManifests().clusterBy(ContentFile::location).commit();
 
     Snapshot rewriteSnapshot = table.currentSnapshot();
 

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -137,7 +137,7 @@ public class TestRowDelta extends V2TableTestBase {
                         .newRowDelta()
                         .addDeletes(fileADeletes())
                         .validateFromSnapshot(validateFromSnapshotId)
-                        .validateDataFilesExist(ImmutableList.of(FILE_A.path())),
+                        .validateDataFilesExist(ImmutableList.of(FILE_A.location())),
                     branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, missing data files");
@@ -153,7 +153,7 @@ public class TestRowDelta extends V2TableTestBase {
         table
             .newRowDelta()
             .addDeletes(fileBDeletes())
-            .validateDataFilesExist(ImmutableList.of(FILE_B.path()))
+            .validateDataFilesExist(ImmutableList.of(FILE_B.location()))
             .validateFromSnapshot(validateFromSnapshotId),
         branch);
 
@@ -188,7 +188,7 @@ public class TestRowDelta extends V2TableTestBase {
                         .newRowDelta()
                         .addDeletes(fileADeletes())
                         .validateFromSnapshot(validateFromSnapshotId)
-                        .validateDataFilesExist(ImmutableList.of(FILE_A.path())),
+                        .validateDataFilesExist(ImmutableList.of(FILE_A.location())),
                     branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, missing data files");
@@ -220,7 +220,7 @@ public class TestRowDelta extends V2TableTestBase {
                         .newRowDelta()
                         .addDeletes(fileADeletes())
                         .validateFromSnapshot(validateFromSnapshotId)
-                        .validateDataFilesExist(ImmutableList.of(FILE_A.path())),
+                        .validateDataFilesExist(ImmutableList.of(FILE_A.location())),
                     branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, missing data files");
@@ -253,7 +253,7 @@ public class TestRowDelta extends V2TableTestBase {
             .newRowDelta()
             .addDeletes(fileADeletes())
             .validateFromSnapshot(validateFromSnapshotId)
-            .validateDataFilesExist(ImmutableList.of(FILE_A.path())),
+            .validateDataFilesExist(ImmutableList.of(FILE_A.location())),
         branch);
 
     Snapshot snap = latestSnapshot(table, branch);
@@ -312,7 +312,7 @@ public class TestRowDelta extends V2TableTestBase {
                         .newRowDelta()
                         .addDeletes(fileADeletes())
                         .validateFromSnapshot(validateFromSnapshotId)
-                        .validateDataFilesExist(ImmutableList.of(FILE_A.path())),
+                        .validateDataFilesExist(ImmutableList.of(FILE_A.location())),
                     branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, missing data files");
@@ -345,7 +345,7 @@ public class TestRowDelta extends V2TableTestBase {
                         .addDeletes(fileADeletes())
                         .validateDeletedFiles()
                         .validateFromSnapshot(validateFromSnapshotId)
-                        .validateDataFilesExist(ImmutableList.of(FILE_A.path())),
+                        .validateDataFilesExist(ImmutableList.of(FILE_A.location())),
                     branch))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith("Cannot commit, missing data files");
@@ -411,7 +411,7 @@ public class TestRowDelta extends V2TableTestBase {
             .addDeletes(fileADeletes())
             .validateDeletedFiles()
             .validateFromSnapshot(validateFromSnapshotId)
-            .validateDataFilesExist(ImmutableList.of(FILE_A.path()))
+            .validateDataFilesExist(ImmutableList.of(FILE_A.location()))
             .conflictDetectionFilter(Expressions.equal("data", "u")) // bucket16("u") -> 0
             .validateNoConflictingDataFiles(),
         branch);
@@ -744,7 +744,7 @@ public class TestRowDelta extends V2TableTestBase {
         table
             .newRowDelta()
             .addDeletes(deleteFile)
-            .validateDataFilesExist(ImmutableList.of(dataFile1.path()))
+            .validateDataFilesExist(ImmutableList.of(dataFile1.location()))
             .validateDeletedFiles()
             .validateFromSnapshot(baseSnapshot.snapshotId())
             .conflictDetectionFilter(conflictDetectionFilter)
@@ -798,7 +798,7 @@ public class TestRowDelta extends V2TableTestBase {
         table
             .newRowDelta()
             .addDeletes(deleteFile)
-            .validateDataFilesExist(ImmutableList.of(dataFile1.path()))
+            .validateDataFilesExist(ImmutableList.of(dataFile1.location()))
             .validateDeletedFiles()
             .validateFromSnapshot(baseSnapshot.snapshotId())
             .conflictDetectionFilter(conflictDetectionFilter)
@@ -1035,7 +1035,7 @@ public class TestRowDelta extends V2TableTestBase {
             .addDeletes(secondDeleteFile)
             .deleteWith(deletedFiles::add)
             .validateDeletedFiles()
-            .validateDataFilesExist(ImmutableList.of(firstSnapshotDataFile.path()));
+            .validateDataFilesExist(ImmutableList.of(firstSnapshotDataFile.location()));
 
     rowDelta.apply();
 

--- a/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
+++ b/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
@@ -73,7 +73,7 @@ public class TestSequenceNumberForV2Table extends TestBase {
 
     // FILE_A and FILE_B in manifest may reorder
     for (ManifestEntry<DataFile> entry : ManifestFiles.read(newManifest, FILE_IO).entries()) {
-      if (entry.file().path().equals(FILE_A.path())) {
+      if (entry.file().location().equals(FILE_A.location())) {
         V2Assert.assertEquals(
             "FILE_A sequence number should be 1", 1, entry.dataSequenceNumber().longValue());
         V2Assert.assertEquals(
@@ -86,7 +86,7 @@ public class TestSequenceNumberForV2Table extends TestBase {
             entry.file().fileSequenceNumber().longValue());
       }
 
-      if (entry.file().path().equals(FILE_B.path())) {
+      if (entry.file().location().equals(FILE_B.location())) {
         V2Assert.assertEquals(
             "FILE_b sequence number should be 2", 2, entry.dataSequenceNumber().longValue());
         V2Assert.assertEquals(

--- a/core/src/test/java/org/apache/iceberg/TestV1ToV2RowDeltaDelete.java
+++ b/core/src/test/java/org/apache/iceberg/TestV1ToV2RowDeltaDelete.java
@@ -84,12 +84,13 @@ public class TestV1ToV2RowDeltaDelete extends TestBase {
     verifyManifestSequenceNumber(deleteManifest, 1, 1);
     assertThat(table.newScan().planFiles())
         .hasSize(3)
-        .filteredOn(fileScanTask -> fileScanTask.file().path().equals(FILE_A.path()))
+        .filteredOn(fileScanTask -> fileScanTask.file().location().equals(FILE_A.location()))
         .first()
         .satisfies(
             fileScanTask -> {
               assertThat(fileScanTask.deletes()).hasSize(1);
-              assertThat(fileScanTask.deletes().get(0).path()).isEqualTo(FILE_A_EQ_1.path());
+              assertThat(fileScanTask.deletes().get(0).location())
+                  .isEqualTo(FILE_A_EQ_1.location());
             });
 
     // first commit after row-delta changes
@@ -103,7 +104,7 @@ public class TestV1ToV2RowDeltaDelete extends TestBase {
     verifyManifestSequenceNumber(dataManifest2, 2, 0);
     assertThat(table.newScan().planFiles())
         .hasSize(2)
-        .filteredOn(fileScanTask -> fileScanTask.file().path().equals(FILE_A.path()))
+        .filteredOn(fileScanTask -> fileScanTask.file().location().equals(FILE_A.location()))
         .first()
         .satisfies(fileScanTask -> assertThat(fileScanTask.deletes()).hasSize(1));
 
@@ -117,7 +118,7 @@ public class TestV1ToV2RowDeltaDelete extends TestBase {
     verifyManifestSequenceNumber(dataManifests.get(0), 3, 0);
     assertThat(table.newScan().planFiles())
         .hasSize(1)
-        .filteredOn(fileScanTask -> fileScanTask.file().path().equals(FILE_A.path()))
+        .filteredOn(fileScanTask -> fileScanTask.file().location().equals(FILE_A.location()))
         .first()
         .satisfies(fileScanTask -> assertThat(fileScanTask.deletes()).hasSize(1));
   }
@@ -138,7 +139,7 @@ public class TestV1ToV2RowDeltaDelete extends TestBase {
         .first()
         .satisfies(
             fileScanTask -> {
-              assertThat(fileScanTask.file().path()).isEqualTo(FILE_B.path());
+              assertThat(fileScanTask.file().location()).isEqualTo(FILE_B.location());
               assertThat(fileScanTask.deletes()).isEmpty();
             });
 
@@ -199,10 +200,10 @@ public class TestV1ToV2RowDeltaDelete extends TestBase {
     assertThat(tasks).hasSize(1);
 
     FileScanTask task = tasks.get(0);
-    assertThat(task.file().path()).isEqualTo(FILE_A.path());
+    assertThat(task.file().location()).isEqualTo(FILE_A.location());
     assertThat(task.deletes()).hasSize(2);
-    assertThat(task.deletes().get(0).path()).isEqualTo(FILE_A_EQ_1.path());
-    assertThat(task.deletes().get(1).path()).isEqualTo(FILE_A_POS_1.path());
+    assertThat(task.deletes().get(0).location()).isEqualTo(FILE_A_EQ_1.location());
+    assertThat(task.deletes().get(1).location()).isEqualTo(FILE_A_POS_1.location());
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -2744,7 +2744,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
       Streams.stream(tasks)
           .map(FileScanTask::file)
-          .filter(file -> file.path().equals(dataFile.path()))
+          .filter(file -> file.location().equals(dataFile.location()))
           .forEach(file -> assertThat(file.specId()).as("Spec ID should match").isEqualTo(specId));
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCatalogUtilDropTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCatalogUtilDropTable.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.GenericBlobMetadata;
@@ -220,7 +221,7 @@ public class TestCatalogUtilDropTable extends HadoopTableTestBase {
   private static Set<String> dataLocations(Set<Snapshot> snapshotSet, FileIO io) {
     return snapshotSet.stream()
         .flatMap(snapshot -> StreamSupport.stream(snapshot.addedDataFiles(io).spliterator(), false))
-        .map(dataFile -> dataFile.path().toString())
+        .map(ContentFile::location)
         .collect(Collectors.toSet());
   }
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
@@ -194,13 +194,13 @@ public class TestTableSerialization extends HadoopTableTestBase {
                 .equals(MetadataTableType.POSITION_DELETES))) {
       try (CloseableIterable<ScanTask> tasks = table.newBatchScan().planFiles()) {
         for (ScanTask task : tasks) {
-          files.add(((PositionDeletesScanTask) task).file().path());
+          files.add(((PositionDeletesScanTask) task).file().location());
         }
       }
     } else {
       try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
         for (FileScanTask task : tasks) {
-          files.add(task.file().path());
+          files.add(task.file().location());
         }
       }
     }


### PR DESCRIPTION
This change replaces the deprecated ContentFile#path usage with the recommended `location` API in the API, Core modules. Will have separate PRs for the other modules, just limited to Core/API for now for reviewer sanity.

See https://github.com/apache/iceberg/pull/11092 for context on why path was deprecated.