### PR TITLE
Spark: Remove extra columns for ColumnBatch

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -54,7 +54,7 @@ public abstract class DeleteFilter<T> {
   private final List<DeleteFile> posDeletes;
   private final List<DeleteFile> eqDeletes;
   private final Schema requiredSchema;
-  private final Schema requestedSchema;
+  private final Schema expectedSchema;
   private final Accessor<StructLike> posAccessor;
   private final boolean hasIsDeletedColumn;
   private final int isDeletedColumnPosition;
@@ -69,12 +69,12 @@ public abstract class DeleteFilter<T> {
       String filePath,
       List<DeleteFile> deletes,
       Schema tableSchema,
-      Schema requestedSchema,
+      Schema expectedSchema,
       DeleteCounter counter,
       boolean needRowPosCol) {
     this.filePath = filePath;
     this.counter = counter;
-    this.requestedSchema = requestedSchema;
+    this.expectedSchema = expectedSchema;
 
     ImmutableList.Builder<DeleteFile> posDeleteBuilder = ImmutableList.builder();
     ImmutableList.Builder<DeleteFile> eqDeleteBuilder = ImmutableList.builder();
@@ -97,7 +97,7 @@ public abstract class DeleteFilter<T> {
     this.posDeletes = posDeleteBuilder.build();
     this.eqDeletes = eqDeleteBuilder.build();
     this.requiredSchema =
-        fileProjection(tableSchema, requestedSchema, posDeletes, eqDeletes, needRowPosCol);
+        fileProjection(tableSchema, expectedSchema, posDeletes, eqDeletes, needRowPosCol);
     this.posAccessor = requiredSchema.accessorForField(MetadataColumns.ROW_POSITION.fieldId());
     this.hasIsDeletedColumn =
         requiredSchema.findField(MetadataColumns.IS_DELETED.fieldId()) != null;
@@ -126,8 +126,8 @@ public abstract class DeleteFilter<T> {
     return requiredSchema;
   }
 
-  public Schema requestedSchema() {
-    return requestedSchema;
+  public Schema expectedSchema() {
+    return expectedSchema;
   }
 
   public boolean hasPosDeletes() {

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -54,6 +54,7 @@ public abstract class DeleteFilter<T> {
   private final List<DeleteFile> posDeletes;
   private final List<DeleteFile> eqDeletes;
   private final Schema requiredSchema;
+  private final Schema requestedSchema;
   private final Accessor<StructLike> posAccessor;
   private final boolean hasIsDeletedColumn;
   private final int isDeletedColumnPosition;
@@ -73,6 +74,7 @@ public abstract class DeleteFilter<T> {
       boolean needRowPosCol) {
     this.filePath = filePath;
     this.counter = counter;
+    this.requestedSchema = requestedSchema;
 
     ImmutableList.Builder<DeleteFile> posDeleteBuilder = ImmutableList.builder();
     ImmutableList.Builder<DeleteFile> eqDeleteBuilder = ImmutableList.builder();
@@ -122,6 +124,10 @@ public abstract class DeleteFilter<T> {
 
   public Schema requiredSchema() {
     return requiredSchema;
+  }
+
+  public Schema requestedSchema() {
+    return requestedSchema;
   }
 
   public boolean hasPosDeletes() {

--- a/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
@@ -123,7 +123,7 @@ public abstract class DeleteReadTests {
     dropTable("test2");
   }
 
-  private void initDateTable() throws IOException {
+  protected void initDateTable() throws IOException {
     dropTable("test2");
     this.dateTableName = "test2";
     this.dateTable = createTable(dateTableName, DATE_SCHEMA, DATE_SPEC);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -248,6 +248,24 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
       columnarBatch.setNumRows(currentRowId);
     }
 
+    /**
+     * Removes extra columns added for processing equality delete filters that are not part of the
+     * final query output.
+     *
+     * <p>During query execution, additional columns may be included in the schema to evaluate
+     * equality delete filters. For example, if the table schema contains columns C1, C2, C3, C4,
+     * and C5, and the query is 'SELECT C5 FROM table' while equality delete filters are applied on
+     * C3 and C4, the processing schema includes C5, C3, and C4. These extra columns (C3 and C4) are
+     * needed to identify rows to delete but are not included in the final result.
+     *
+     * <p>This method removes these extra columns from the end of {@code arrowColumnVectors},
+     * ensuring only the expected columns remain.
+     *
+     * @param arrowColumnVectors the array of column vectors representing query result data
+     * @param columnarBatch the original {@code ColumnarBatch} containing query results
+     * @return a new {@code ColumnarBatch} with extra columns removed, or the original batch if no
+     *     extra columns were found
+     */
     ColumnarBatch removeExtraColumns(
         ColumnVector[] arrowColumnVectors, ColumnarBatch columnarBatch) {
       int expectedColumnSize = deletes.expectedSchema().columns().size();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.data.vectorized;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -87,12 +88,10 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
    * @return the number of extra columns that are read but not included in the final query result.
    */
   private int numOfExtraColumns(DeleteFilter<InternalRow> deleteFilter) {
-    if (deleteFilter != null) {
-      if (deleteFilter.hasEqDeletes()) {
-        List<Types.NestedField> requiredColumns = deleteFilter.requiredSchema().columns();
-        List<Types.NestedField> expectedColumns = deleteFilter.expectedSchema().columns();
-        return requiredColumns.size() - expectedColumns.size();
-      }
+    if (deleteFilter != null && deleteFilter.hasEqDeletes()) {
+      List<Types.NestedField> requiredColumns = deleteFilter.requiredSchema().columns();
+      List<Types.NestedField> expectedColumns = deleteFilter.expectedSchema().columns();
+      return requiredColumns.size() - expectedColumns.size();
     }
 
     return 0;
@@ -279,7 +278,7 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
         // In DeleteFilter.fileProjection, the columns for missingIds (the columns required
         // for equality delete or ROW_POSITION) are appended to the end of the expectedSchema.
         // Therefore, these extra columns can be removed from the end of arrowColumnVectors.
-        ColumnVector[] newColumns = java.util.Arrays.copyOf(arrowColumnVectors, newLength);
+        ColumnVector[] newColumns = Arrays.copyOf(arrowColumnVectors, newLength);
         return new ColumnarBatch(newColumns, columnarBatch.numRows());
       } else {
         return columnarBatch;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.parquet.VectorizedReader;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -45,23 +46,11 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
   private final boolean hasIsDeletedColumn;
   private DeleteFilter<InternalRow> deletes = null;
   private long rowStartPosInBatch = 0;
-  // In the case of Equality Delete, we have also built ColumnarBatchReader for the equality delete
-  // filter columns to read the value to find out which rows are deleted. If these deleted filter
-  // columns are not in the requested schema, then these are the extra columns that we want to
-  // remove before return the ColumnBatch to Spark.
-  // Supposed table schema is C1, C2, C3, C4, C5, The query is:
-  // SELECT C5 FROM table, and the equality delete Filter is on C3, C4,
-  // We read the values of C3, C4 to figure out which rows are deleted, but we don't want to include
-  // these values in the ColumnBatch that we return to Spark. In this example, the numOfExtraColumns
-  // is 2. Since when creating the DeleteFilter, we append these extra columns in the end of the
-  // requested schema, we can just remove them from the end of the ColumnVector.
-  private int numOfExtraColumns = 0;
 
-  public ColumnarBatchReader(List<VectorizedReader<?>> readers, int numExtraCol) {
+  public ColumnarBatchReader(List<VectorizedReader<?>> readers) {
     super(readers);
     this.hasIsDeletedColumn =
         readers.stream().anyMatch(reader -> reader instanceof DeletedVectorReader);
-    this.numOfExtraColumns = numExtraCol;
   }
 
   @Override
@@ -84,6 +73,29 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
     ColumnarBatch columnarBatch = new ColumnBatchLoader(numRowsToRead).loadDataToColumnBatch();
     rowStartPosInBatch += numRowsToRead;
     return columnarBatch;
+  }
+
+  /**
+   * Calculates the number of extra columns that are necessary for processing equality delete
+   * filters but are not part of the final output. For instance, if the table schema includes C1,
+   * C2, C3, C4, C5 and the query is 'SELECT C5 FROM table', and there are equality delete filters
+   * on C3 and C4, the required schema for processing would be C5, C3, C4. These extra columns (C3,
+   * C4) are needed to determine the rows to delete based on the filter criteria. After identifying
+   * the deletable rows, these extra column values are no longer needed to be returned to Spark.
+   *
+   * @param deleteFilter The delete filter applied for equality delete.
+   * @return the number of extra columns that are read but not included in the final query result.
+   */
+  private int numOfExtraColumns(DeleteFilter<InternalRow> deleteFilter) {
+    if (deleteFilter != null) {
+      if (deleteFilter.hasEqDeletes()) {
+        List<Types.NestedField> requiredColumns = deleteFilter.requiredSchema().columns();
+        List<Types.NestedField> expectedColumns = deleteFilter.expectedSchema().columns();
+        return requiredColumns.size() - expectedColumns.size();
+      }
+    }
+
+    return 0;
   }
 
   private class ColumnBatchLoader {
@@ -114,8 +126,7 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
 
       if (hasEqDeletes()) {
         applyEqDelete(newColumnarBatch);
-        newColumnarBatch =
-            removeExtraColumnsFromColumnarBatch(arrowColumnVectors, newColumnarBatch);
+        newColumnarBatch = removeExtraColumns(arrowColumnVectors, newColumnarBatch);
       }
 
       if (hasIsDeletedColumn && rowIdMapping != null) {
@@ -260,10 +271,14 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
       columnarBatch.setNumRows(currentRowId);
     }
 
-    ColumnarBatch removeExtraColumnsFromColumnarBatch(
+    ColumnarBatch removeExtraColumns(
         ColumnVector[] arrowColumnVectors, ColumnarBatch columnarBatch) {
+      int numOfExtraColumns = numOfExtraColumns(deletes);
       if (numOfExtraColumns > 0) {
         int newLength = arrowColumnVectors.length - numOfExtraColumns;
+        // In DeleteFilter.fileProjection, the columns for missingIds (the columns required
+        // for equality delete or ROW_POSITION) are appended to the end of the expectedSchema.
+        // Therefore, these extra columns can be removed from the end of arrowColumnVectors.
         ColumnVector[] newColumns = java.util.Arrays.copyOf(arrowColumnVectors, newLength);
         return new ColumnarBatch(newColumns, columnarBatch.numRows());
       } else {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
@@ -65,7 +65,7 @@ public class VectorizedSparkParquetReaders {
                 fileSchema,
                 NullCheckingForGet.NULL_CHECKING_ENABLED,
                 idToConstant,
-                readers -> new ColumnarBatchReader(readers),
+                ColumnarBatchReader::new,
                 deleteFilter));
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.arrow.vectorized.VectorizedReaderBuilder;
 import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.parquet.VectorizedReader;
-import org.apache.iceberg.types.Types;
 import org.apache.parquet.schema.MessageType;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.slf4j.Logger;
@@ -66,7 +65,7 @@ public class VectorizedSparkParquetReaders {
                 fileSchema,
                 NullCheckingForGet.NULL_CHECKING_ENABLED,
                 idToConstant,
-                readers -> new ColumnarBatchReader(readers, numOfExtraColumns(deleteFilter)),
+                readers -> new ColumnarBatchReader(readers),
                 deleteFilter));
   }
 
@@ -125,26 +124,5 @@ public class VectorizedSparkParquetReaders {
       }
       return reader;
     }
-  }
-
-  private static int numOfExtraColumns(DeleteFilter deleteFilter) {
-    if (deleteFilter != null) {
-      if (deleteFilter.hasEqDeletes()) {
-        // For Equality Delete, the requiredColumns and expectedColumns may not be the
-        // same. For example, supposed table schema is C1, C2, C3, C4, C5, The query is:
-        // SELECT C5 FROM table, and the equality delete Filter is on C3, C4, then
-        // the requestedSchema is C5, and the required schema is C5, C3 and C4. The
-        // vectorized reader reads also need to read C3 and C4 columns to figure out
-        // which rows are deleted. However, after figuring out the deleted rows, the
-        // extra columns values are not needed to returned to Spark.
-        // Getting the numOfExtraColumns so we can remove these extra columns
-        // from ColumnBatch later.
-        List<Types.NestedField> requiredColumns = deleteFilter.requiredSchema().columns();
-        List<Types.NestedField> expectedColumns = deleteFilter.requestedSchema().columns();
-        return requiredColumns.size() - expectedColumns.size();
-      }
-    }
-
-    return 0;
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -87,6 +87,7 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -658,7 +659,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
               // expected column is id, while the equality filter column is dt
               dateTable, task, dateTable.schema(), dateTable.schema().select("id"), false, 7)) {
         while (reader.next()) {
-          org.apache.spark.sql.vectorized.ColumnarBatch columnarBatch = reader.get();
+          ColumnarBatch columnarBatch = reader.get();
           int numOfCols = columnarBatch.numCols();
           assertThat(numOfCols).as("Number of columns").isEqualTo(1);
         }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.source;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 import static org.apache.iceberg.spark.source.SparkSQLExecutionHelper.lastExecutedMetricValue;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
@@ -662,6 +663,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
           ColumnarBatch columnarBatch = reader.get();
           int numOfCols = columnarBatch.numCols();
           assertThat(numOfCols).as("Number of columns").isEqualTo(1);
+          assertThat(columnarBatch.column(0).dataType()).as("Column type").isEqualTo(IntegerType);
         }
       }
     }


### PR DESCRIPTION
In Equality Delete, we build `ColumnarBatchReader` for the equality delete filter columns to read their values and determine which rows are deleted. If these filter columns are not among the requested columns, they are considered extra and should be removed before returning the `ColumnBatch` to Spark.

Suppose the table schema includes C1, C2, C3, C4, C5. If the query is: `SELECT C5 FROM table`, and the equality delete filter is on C3 and C4,

We read the values of C3 and C4 to identify which rows are deleted. However, we do not want to include these values in the `ColumnBatch` that we return to Spark.