### PR TITLE
API, Arrow, Core, Data, Spark: Replace usage of deprecated ContentFile#path API with location API

### DIFF
--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -649,7 +649,7 @@ public class TestHelpers {
 
     @Override
     public FileFormat format() {
-      return FileFormat.fromFileName(path());
+      return FileFormat.fromFileName(location());
     }
 
     @Override

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
@@ -260,7 +260,7 @@ public class ArrowReader extends CloseableGroup {
       Map<String, ByteBuffer> keyMetadata = Maps.newHashMap();
       fileTasks.stream()
           .map(FileScanTask::file)
-          .forEach(file -> keyMetadata.put(file.path().toString(), file.keyMetadata()));
+          .forEach(file -> keyMetadata.put(file.location(), file.keyMetadata()));
 
       Stream<EncryptedInputFile> encrypted =
           keyMetadata.entrySet().stream()
@@ -364,7 +364,7 @@ public class ArrowReader extends CloseableGroup {
 
     private InputFile getInputFile(FileScanTask task) {
       Preconditions.checkArgument(!task.isDataTask(), "Invalid task type");
-      return inputFiles.get(task.file().path().toString());
+      return inputFiles.get(task.file().location());
     }
 
     /**

--- a/core/src/main/java/org/apache/iceberg/encryption/InputFilesDecryptor.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/InputFilesDecryptor.java
@@ -40,7 +40,7 @@ public class InputFilesDecryptor {
         .flatMap(
             fileScanTask ->
                 Stream.concat(Stream.of(fileScanTask.file()), fileScanTask.deletes().stream()))
-        .forEach(file -> keyMetadata.put(file.path().toString(), file.keyMetadata()));
+        .forEach(file -> keyMetadata.put(file.location(), file.keyMetadata()));
     Stream<EncryptedInputFile> encrypted =
         keyMetadata.entrySet().stream()
             .map(

--- a/core/src/test/java/org/apache/iceberg/ScanPlanningAndReportingTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/ScanPlanningAndReportingTestBase.java
@@ -282,7 +282,7 @@ public abstract class ScanPlanningAndReportingTestBase<
     }
     assertThat(fileTasks)
         .singleElement()
-        .satisfies(task -> assertThat(task.file().path()).isEqualTo(FILE_D.path()));
+        .satisfies(task -> assertThat(task.file().location()).isEqualTo(FILE_D.location()));
 
     ScanReport scanReport = reporter.lastReport();
     assertThat(scanReport).isNotNull();

--- a/core/src/test/java/org/apache/iceberg/TestSnapshot.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshot.java
@@ -99,7 +99,7 @@ public class TestSnapshot extends TestBase {
     assertThat(removedDataFiles).as("Must have 1 removed data file").hasSize(1);
 
     DataFile removedDataFile = Iterables.getOnlyElement(removedDataFiles);
-    assertThat(removedDataFile.path()).isEqualTo(FILE_A.path());
+    assertThat(removedDataFile.location()).isEqualTo(FILE_A.location());
     assertThat(removedDataFile.specId()).isEqualTo(FILE_A.specId());
     assertThat(removedDataFile.partition()).isEqualTo(FILE_A.partition());
 
@@ -107,7 +107,7 @@ public class TestSnapshot extends TestBase {
     assertThat(addedDataFiles).as("Must have 1 added data file").hasSize(1);
 
     DataFile addedDataFile = Iterables.getOnlyElement(addedDataFiles);
-    assertThat(addedDataFile.path()).isEqualTo(thirdSnapshotDataFile.path());
+    assertThat(addedDataFile.location()).isEqualTo(thirdSnapshotDataFile.location());
     assertThat(addedDataFile.specId()).isEqualTo(thirdSnapshotDataFile.specId());
     assertThat(addedDataFile.partition()).isEqualTo(thirdSnapshotDataFile.partition());
   }
@@ -147,7 +147,7 @@ public class TestSnapshot extends TestBase {
     assertThat(removedDeleteFiles).as("Must have 1 removed delete file").hasSize(1);
 
     DeleteFile removedDeleteFile = Iterables.getOnlyElement(removedDeleteFiles);
-    assertThat(removedDeleteFile.path()).isEqualTo(secondSnapshotDeleteFile.path());
+    assertThat(removedDeleteFile.location()).isEqualTo(secondSnapshotDeleteFile.location());
     assertThat(removedDeleteFile.specId()).isEqualTo(secondSnapshotDeleteFile.specId());
     assertThat(removedDeleteFile.partition()).isEqualTo(secondSnapshotDeleteFile.partition());
 
@@ -155,7 +155,7 @@ public class TestSnapshot extends TestBase {
     assertThat(addedDeleteFiles).as("Must have 1 added delete file").hasSize(1);
 
     DeleteFile addedDeleteFile = Iterables.getOnlyElement(addedDeleteFiles);
-    assertThat(addedDeleteFile.path()).isEqualTo(thirdSnapshotDeleteFile.path());
+    assertThat(addedDeleteFile.location()).isEqualTo(thirdSnapshotDeleteFile.location());
     assertThat(addedDeleteFile.specId()).isEqualTo(thirdSnapshotDeleteFile.specId());
     assertThat(addedDeleteFile.partition()).isEqualTo(thirdSnapshotDeleteFile.partition());
   }

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -702,14 +702,9 @@ public class TestTransaction extends TestBase {
 
     Set<String> paths =
         Sets.newHashSet(
-            Iterables.transform(
-                table.newScan().planFiles(), task -> task.file().path().toString()));
+            Iterables.transform(table.newScan().planFiles(), task -> task.file().location()));
     Set<String> expectedPaths =
-        Sets.newHashSet(
-            FILE_A.path().toString(),
-            FILE_B.path().toString(),
-            FILE_C.path().toString(),
-            FILE_D.path().toString());
+        Sets.newHashSet(FILE_A.location(), FILE_B.location(), FILE_C.location(), FILE_D.location());
 
     assertThat(paths).isEqualTo(expectedPaths);
     assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(2);

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -2729,12 +2729,13 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       List<CharSequence> paths =
           Streams.stream(tasks)
               .map(FileScanTask::file)
-              .map(DataFile::path)
+              .map(DataFile::location)
               .collect(Collectors.toList());
       assertThat(paths).as("Should contain expected number of data files").hasSize(files.length);
       assertThat(CharSequenceSet.of(paths))
           .as("Should contain correct file paths")
-          .isEqualTo(CharSequenceSet.of(Iterables.transform(Arrays.asList(files), DataFile::path)));
+          .isEqualTo(
+              CharSequenceSet.of(Iterables.transform(Arrays.asList(files), DataFile::location)));
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
@@ -119,7 +119,7 @@ public class BaseDeleteLoader implements DeleteLoader {
   private Iterable<StructLike> getOrReadEqDeletes(DeleteFile deleteFile, Schema projection) {
     long estimatedSize = estimateEqDeletesSize(deleteFile, projection);
     if (canCache(estimatedSize)) {
-      String cacheKey = deleteFile.path().toString();
+      String cacheKey = deleteFile.location();
       return getOrLoad(cacheKey, () -> readEqDeletes(deleteFile, projection), estimatedSize);
     } else {
       return readEqDeletes(deleteFile, projection);
@@ -199,7 +199,7 @@ public class BaseDeleteLoader implements DeleteLoader {
   private PositionDeleteIndex getOrReadPosDeletes(DeleteFile deleteFile, CharSequence filePath) {
     long estimatedSize = estimatePosDeletesSize(deleteFile);
     if (canCache(estimatedSize)) {
-      String cacheKey = deleteFile.path().toString();
+      String cacheKey = deleteFile.location();
       CharSequenceMap<PositionDeleteIndex> indexes =
           getOrLoad(cacheKey, () -> readPosDeletes(deleteFile), estimatedSize);
       return indexes.getOrDefault(filePath, PositionDeleteIndex.empty());
@@ -227,7 +227,7 @@ public class BaseDeleteLoader implements DeleteLoader {
       DeleteFile deleteFile, Schema projection, Expression filter) {
 
     FileFormat format = deleteFile.format();
-    LOG.trace("Opening delete file {}", deleteFile.path());
+    LOG.trace("Opening delete file {}", deleteFile.location());
     InputFile inputFile = loadInputFile.apply(deleteFile);
 
     switch (format) {

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -79,11 +79,11 @@ public abstract class DeleteFilter<T> {
     for (DeleteFile delete : deletes) {
       switch (delete.content()) {
         case POSITION_DELETES:
-          LOG.debug("Adding position delete file {} to filter", delete.path());
+          LOG.debug("Adding position delete file {} to filter", delete.location());
           posDeleteBuilder.add(delete);
           break;
         case EQUALITY_DELETES:
-          LOG.debug("Adding equality delete file {} to filter", delete.path());
+          LOG.debug("Adding equality delete file {} to filter", delete.location());
           eqDeleteBuilder.add(delete);
           break;
         default:
@@ -145,7 +145,7 @@ public abstract class DeleteFilter<T> {
   protected abstract InputFile getInputFile(String location);
 
   protected InputFile loadInputFile(DeleteFile deleteFile) {
-    return getInputFile(deleteFile.path().toString());
+    return getInputFile(deleteFile.location());
   }
 
   protected long pos(T record) {

--- a/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
@@ -30,7 +30,7 @@ public class GenericDeleteFilter extends DeleteFilter<Record> {
 
   public GenericDeleteFilter(
       FileIO io, FileScanTask task, Schema tableSchema, Schema requestedSchema) {
-    super(task.file().path().toString(), task.deletes(), tableSchema, requestedSchema);
+    super(task.file().location(), task.deletes(), tableSchema, requestedSchema);
     this.io = io;
     this.asStructLike = new InternalRecordWrapper(requiredSchema().asStruct());
   }

--- a/data/src/main/java/org/apache/iceberg/data/GenericReader.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericReader.java
@@ -92,7 +92,7 @@ class GenericReader implements Serializable {
   }
 
   private CloseableIterable<Record> openFile(FileScanTask task, Schema fileProjection) {
-    InputFile input = io.newInputFile(task.file().path().toString());
+    InputFile input = io.newInputFile(task.file().location());
     Map<Integer, ?> partition =
         PartitionUtil.constantsMap(task, IdentityPartitionConverters::convertConstant);
 
@@ -147,7 +147,7 @@ class GenericReader implements Serializable {
       default:
         throw new UnsupportedOperationException(
             String.format(
-                "Cannot read %s file: %s", task.file().format().name(), task.file().path()));
+                "Cannot read %s file: %s", task.file().format().name(), task.file().location()));
     }
   }
 

--- a/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
@@ -379,9 +379,9 @@ public abstract class DeleteReadTests {
   public void testPositionDeletes() throws IOException {
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 0L), // id = 29
-            Pair.of(dataFile.path(), 3L), // id = 89
-            Pair.of(dataFile.path(), 6L) // id = 122
+            Pair.of(dataFile.location(), 0L), // id = 29
+            Pair.of(dataFile.location(), 3L), // id = 89
+            Pair.of(dataFile.location(), 6L) // id = 122
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -413,8 +413,8 @@ public abstract class DeleteReadTests {
 
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 0L), // id = 29
-            Pair.of(dataFile.path(), 3L) // id = 89
+            Pair.of(dataFile.location(), 0L), // id = 29
+            Pair.of(dataFile.location(), 3L) // id = 89
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -431,7 +431,7 @@ public abstract class DeleteReadTests {
         .validateDataFilesExist(posDeletes.second())
         .commit();
 
-    deletes = Lists.newArrayList(Pair.of(dataFile.path(), 6L)); // id = 122
+    deletes = Lists.newArrayList(Pair.of(dataFile.location(), 6L)); // id = 122
 
     posDeletes =
         FileHelpers.writeDeleteFile(
@@ -475,8 +475,8 @@ public abstract class DeleteReadTests {
 
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 3L), // id = 89
-            Pair.of(dataFile.path(), 5L) // id = 121
+            Pair.of(dataFile.location(), 3L), // id = 89
+            Pair.of(dataFile.location(), 5L) // id = 121
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =

--- a/data/src/test/java/org/apache/iceberg/data/TestDataFileIndexStatsFilters.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestDataFileIndexStatsFilters.java
@@ -116,12 +116,12 @@ public class TestDataFileIndexStatsFilters {
   }
 
   @Test
-  public void testPositionDeletePlanningPath() throws IOException {
+  public void testPositionDeletePlanninglocation() throws IOException {
     table.newAppend().appendFile(dataFile).commit();
 
     List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
-    deletes.add(Pair.of(dataFile.path(), 0L));
-    deletes.add(Pair.of(dataFile.path(), 1L));
+    deletes.add(Pair.of(dataFile.location(), 0L));
+    deletes.add(Pair.of(dataFile.location(), 1L));
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
         FileHelpers.writeDeleteFile(table, Files.localOutput(createTempFile()), deletes);
@@ -383,7 +383,7 @@ public class TestDataFileIndexStatsFilters {
         writePosDeletes(
             evenPartition,
             ImmutableList.of(
-                Pair.of(dataFileWithEvenRecords.path(), 0L),
+                Pair.of(dataFileWithEvenRecords.location(), 0L),
                 Pair.of("some-other-file.parquet", 0L)));
     table
         .newRowDelta()
@@ -396,8 +396,8 @@ public class TestDataFileIndexStatsFilters {
         writePosDeletes(
             evenPartition,
             ImmutableList.of(
-                Pair.of(dataFileWithEvenRecords.path(), 1L),
-                Pair.of(dataFileWithEvenRecords.path(), 2L)));
+                Pair.of(dataFileWithEvenRecords.location(), 1L),
+                Pair.of(dataFileWithEvenRecords.location(), 2L)));
     table
         .newRowDelta()
         .addDeletes(pathPosDeletes.first())
@@ -437,7 +437,7 @@ public class TestDataFileIndexStatsFilters {
   }
 
   private boolean coversDataFile(FileScanTask task, DataFile file) {
-    return task.file().path().toString().equals(file.path().toString());
+    return task.file().location().toString().equals(file.location().toString());
   }
 
   private void assertDeletes(FileScanTask task, DeleteFile... expectedDeleteFiles) {
@@ -446,7 +446,7 @@ public class TestDataFileIndexStatsFilters {
     assertThat(actualDeletePaths.size()).isEqualTo(expectedDeleteFiles.length);
 
     for (DeleteFile expectedDeleteFile : expectedDeleteFiles) {
-      assertThat(actualDeletePaths.contains(expectedDeleteFile.path())).isTrue();
+      assertThat(actualDeletePaths.contains(expectedDeleteFile.location())).isTrue();
     }
   }
 

--- a/data/src/test/java/org/apache/iceberg/io/TestAppenderFactory.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestAppenderFactory.java
@@ -219,9 +219,9 @@ public abstract class TestAppenderFactory<T> extends TestBase {
 
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 0L),
-            Pair.of(dataFile.path(), 2L),
-            Pair.of(dataFile.path(), 4L));
+            Pair.of(dataFile.location(), 0L),
+            Pair.of(dataFile.location(), 2L),
+            Pair.of(dataFile.location(), 4L));
 
     EncryptedOutputFile out = createEncryptedOutputFile();
     PositionDeleteWriter<T> eqDeleteWriter =
@@ -238,9 +238,9 @@ public abstract class TestAppenderFactory<T> extends TestBase {
     GenericRecord gRecord = GenericRecord.create(pathPosSchema);
     Set<Record> expectedDeletes =
         Sets.newHashSet(
-            gRecord.copy("file_path", dataFile.path(), "pos", 0L),
-            gRecord.copy("file_path", dataFile.path(), "pos", 2L),
-            gRecord.copy("file_path", dataFile.path(), "pos", 4L));
+            gRecord.copy("file_path", dataFile.location(), "pos", 0L),
+            gRecord.copy("file_path", dataFile.location(), "pos", 2L),
+            gRecord.copy("file_path", dataFile.location(), "pos", 4L));
     assertThat(
             Sets.newHashSet(createReader(pathPosSchema, out.encryptingOutputFile().toInputFile())))
         .isEqualTo(expectedDeletes);
@@ -268,9 +268,9 @@ public abstract class TestAppenderFactory<T> extends TestBase {
 
     List<PositionDelete<T>> deletes =
         Lists.newArrayList(
-            positionDelete(dataFile.path(), 0, rowSet.get(0)),
-            positionDelete(dataFile.path(), 2, rowSet.get(2)),
-            positionDelete(dataFile.path(), 4, rowSet.get(4)));
+            positionDelete(dataFile.location(), 0, rowSet.get(0)),
+            positionDelete(dataFile.location(), 2, rowSet.get(2)),
+            positionDelete(dataFile.location(), 4, rowSet.get(4)));
 
     EncryptedOutputFile out = createEncryptedOutputFile();
     PositionDeleteWriter<T> eqDeleteWriter =
@@ -290,21 +290,21 @@ public abstract class TestAppenderFactory<T> extends TestBase {
         Sets.newHashSet(
             gRecord.copy(
                 "file_path",
-                dataFile.path(),
+                dataFile.location(),
                 "pos",
                 0L,
                 "row",
                 rowRecord.copy("id", 1, "data", "aaa")),
             gRecord.copy(
                 "file_path",
-                dataFile.path(),
+                dataFile.location(),
                 "pos",
                 2L,
                 "row",
                 rowRecord.copy("id", 3, "data", "ccc")),
             gRecord.copy(
                 "file_path",
-                dataFile.path(),
+                dataFile.location(),
                 "pos",
                 4L,
                 "row",

--- a/data/src/test/java/org/apache/iceberg/io/TestFileWriterFactory.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestFileWriterFactory.java
@@ -144,7 +144,7 @@ public abstract class TestFileWriterFactory<T> extends WriterTestBase<T> {
     List<Record> expectedDeletes =
         ImmutableList.of(
             deleteRecord.copy("id", 1), deleteRecord.copy("id", 3), deleteRecord.copy("id", 5));
-    InputFile inputDeleteFile = table.io().newInputFile(deleteFile.path().toString());
+    InputFile inputDeleteFile = table.io().newInputFile(deleteFile.location());
     List<Record> actualDeletes = readFile(equalityDeleteRowSchema, inputDeleteFile);
     assertThat(actualDeletes).isEqualTo(expectedDeletes);
 
@@ -222,9 +222,9 @@ public abstract class TestFileWriterFactory<T> extends WriterTestBase<T> {
     // write a position delete file
     List<PositionDelete<T>> deletes =
         ImmutableList.of(
-            positionDelete(dataFile.path(), 0L, null),
-            positionDelete(dataFile.path(), 2L, null),
-            positionDelete(dataFile.path(), 4L, null));
+            positionDelete(dataFile.location(), 0L, null),
+            positionDelete(dataFile.location(), 2L, null),
+            positionDelete(dataFile.location(), 4L, null));
     Pair<DeleteFile, CharSequenceSet> result =
         writePositionDeletes(writerFactory, deletes, table.spec(), partition);
     DeleteFile deleteFile = result.first();
@@ -249,11 +249,13 @@ public abstract class TestFileWriterFactory<T> extends WriterTestBase<T> {
     GenericRecord deleteRecord = GenericRecord.create(DeleteSchemaUtil.pathPosSchema());
     List<Record> expectedDeletes =
         ImmutableList.of(
-            deleteRecord.copy(DELETE_FILE_PATH.name(), dataFile.path(), DELETE_FILE_POS.name(), 0L),
-            deleteRecord.copy(DELETE_FILE_PATH.name(), dataFile.path(), DELETE_FILE_POS.name(), 2L),
             deleteRecord.copy(
-                DELETE_FILE_PATH.name(), dataFile.path(), DELETE_FILE_POS.name(), 4L));
-    InputFile inputDeleteFile = table.io().newInputFile(deleteFile.path().toString());
+                DELETE_FILE_PATH.name(), dataFile.location(), DELETE_FILE_POS.name(), 0L),
+            deleteRecord.copy(
+                DELETE_FILE_PATH.name(), dataFile.location(), DELETE_FILE_POS.name(), 2L),
+            deleteRecord.copy(
+                DELETE_FILE_PATH.name(), dataFile.location(), DELETE_FILE_POS.name(), 4L));
+    InputFile inputDeleteFile = table.io().newInputFile(deleteFile.location());
     List<Record> actualDeletes = readFile(DeleteSchemaUtil.pathPosSchema(), inputDeleteFile);
     assertThat(actualDeletes).isEqualTo(expectedDeletes);
 
@@ -280,7 +282,7 @@ public abstract class TestFileWriterFactory<T> extends WriterTestBase<T> {
 
     // write a position delete file and persist the deleted row
     List<PositionDelete<T>> deletes =
-        ImmutableList.of(positionDelete(dataFile.path(), 0, dataRows.get(0)));
+        ImmutableList.of(positionDelete(dataFile.location(), 0, dataRows.get(0)));
     Pair<DeleteFile, CharSequenceSet> result =
         writePositionDeletes(writerFactory, deletes, table.spec(), partition);
     DeleteFile deleteFile = result.first();
@@ -323,13 +325,13 @@ public abstract class TestFileWriterFactory<T> extends WriterTestBase<T> {
     Map<String, Object> deleteRecordColumns =
         ImmutableMap.of(
             DELETE_FILE_PATH.name(),
-            dataFile.path(),
+            dataFile.location(),
             DELETE_FILE_POS.name(),
             0L,
             DELETE_FILE_ROW_FIELD_NAME,
             deletedRow.copy("id", 1, "data", "aaa"));
     List<Record> expectedDeletes = ImmutableList.of(deleteRecord.copy(deleteRecordColumns));
-    InputFile inputDeleteFile = table.io().newInputFile(deleteFile.path().toString());
+    InputFile inputDeleteFile = table.io().newInputFile(deleteFile.location());
     List<Record> actualDeletes = readFile(positionDeleteSchema, inputDeleteFile);
     assertThat(actualDeletes).isEqualTo(expectedDeletes);
 
@@ -359,9 +361,9 @@ public abstract class TestFileWriterFactory<T> extends WriterTestBase<T> {
     // write a position delete file referencing both
     List<PositionDelete<T>> deletes =
         ImmutableList.of(
-            positionDelete(dataFile1.path(), 0L, null),
-            positionDelete(dataFile1.path(), 2L, null),
-            positionDelete(dataFile2.path(), 4L, null));
+            positionDelete(dataFile1.location(), 0L, null),
+            positionDelete(dataFile1.location(), 2L, null),
+            positionDelete(dataFile2.location(), 4L, null));
     Pair<DeleteFile, CharSequenceSet> result =
         writePositionDeletes(writerFactory, deletes, table.spec(), partition);
     DeleteFile deleteFile = result.first();

--- a/data/src/test/java/org/apache/iceberg/io/TestGenericSortedPosDeleteWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestGenericSortedPosDeleteWriter.java
@@ -137,7 +137,7 @@ public class TestGenericSortedPosDeleteWriter extends TestBase {
         new SortedPosDeleteWriter<>(appenderFactory, fileFactory, format, null, 100);
     try (SortedPosDeleteWriter<Record> closeableWriter = writer) {
       for (int index = rowSet.size() - 1; index >= 0; index -= 2) {
-        closeableWriter.delete(dataFile.path(), index);
+        closeableWriter.delete(dataFile.location(), index);
       }
     }
 
@@ -150,10 +150,10 @@ public class TestGenericSortedPosDeleteWriter extends TestBase {
     Record record = GenericRecord.create(pathPosSchema);
     List<Record> expectedDeletes =
         Lists.newArrayList(
-            record.copy("file_path", dataFile.path(), "pos", 0L),
-            record.copy("file_path", dataFile.path(), "pos", 2L),
-            record.copy("file_path", dataFile.path(), "pos", 4L));
-    assertThat(readRecordsAsList(pathPosSchema, deleteFile.path())).isEqualTo(expectedDeletes);
+            record.copy("file_path", dataFile.location(), "pos", 0L),
+            record.copy("file_path", dataFile.location(), "pos", 2L),
+            record.copy("file_path", dataFile.location(), "pos", 4L));
+    assertThat(readRecordsAsList(pathPosSchema, deleteFile.location())).isEqualTo(expectedDeletes);
 
     table
         .newRowDelta()
@@ -181,7 +181,7 @@ public class TestGenericSortedPosDeleteWriter extends TestBase {
     assertThatThrownBy(
             () ->
                 new SortedPosDeleteWriter<>(appenderFactory, fileFactory, format, null, 1)
-                    .delete(dataFile.path(), 0L))
+                    .delete(dataFile.location(), 0L))
         .isInstanceOf(Exception.class);
   }
 
@@ -204,7 +204,7 @@ public class TestGenericSortedPosDeleteWriter extends TestBase {
     try (SortedPosDeleteWriter<Record> closeableWriter = writer) {
       for (int index = rowSet.size() - 1; index >= 0; index -= 2) {
         closeableWriter.delete(
-            dataFile.path(), index, rowSet.get(index)); // Write deletes with row.
+            dataFile.location(), index, rowSet.get(index)); // Write deletes with row.
       }
     }
 
@@ -217,10 +217,10 @@ public class TestGenericSortedPosDeleteWriter extends TestBase {
     Record record = GenericRecord.create(pathPosSchema);
     List<Record> expectedDeletes =
         Lists.newArrayList(
-            record.copy("file_path", dataFile.path(), "pos", 0L, "row", createRow(0, "aaa")),
-            record.copy("file_path", dataFile.path(), "pos", 2L, "row", createRow(2, "ccc")),
-            record.copy("file_path", dataFile.path(), "pos", 4L, "row", createRow(4, "eee")));
-    assertThat(readRecordsAsList(pathPosSchema, deleteFile.path())).isEqualTo(expectedDeletes);
+            record.copy("file_path", dataFile.location(), "pos", 0L, "row", createRow(0, "aaa")),
+            record.copy("file_path", dataFile.location(), "pos", 2L, "row", createRow(2, "ccc")),
+            record.copy("file_path", dataFile.location(), "pos", 4L, "row", createRow(4, "eee")));
+    assertThat(readRecordsAsList(pathPosSchema, deleteFile.location())).isEqualTo(expectedDeletes);
 
     table
         .newRowDelta()
@@ -267,7 +267,7 @@ public class TestGenericSortedPosDeleteWriter extends TestBase {
     try (SortedPosDeleteWriter<Record> closeableWriter = writer) {
       for (int pos = 0; pos < 100; pos++) {
         for (int fileIndex = 4; fileIndex >= 0; fileIndex--) {
-          closeableWriter.delete(dataFiles.get(fileIndex).path(), pos);
+          closeableWriter.delete(dataFiles.get(fileIndex).location(), pos);
         }
       }
     }
@@ -282,12 +282,13 @@ public class TestGenericSortedPosDeleteWriter extends TestBase {
       for (int dataFileIndex = 0; dataFileIndex < 5; dataFileIndex++) {
         DataFile dataFile = dataFiles.get(dataFileIndex);
         for (long pos = deleteFileIndex * 10; pos < deleteFileIndex * 10 + 10; pos++) {
-          expectedDeletes.add(record.copy("file_path", dataFile.path(), "pos", pos));
+          expectedDeletes.add(record.copy("file_path", dataFile.location(), "pos", pos));
         }
       }
 
       DeleteFile deleteFile = deleteFiles.get(deleteFileIndex);
-      assertThat(readRecordsAsList(pathPosSchema, deleteFile.path())).isEqualTo(expectedDeletes);
+      assertThat(readRecordsAsList(pathPosSchema, deleteFile.location()))
+          .isEqualTo(expectedDeletes);
     }
 
     rowDelta = table.newRowDelta();

--- a/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
@@ -362,14 +362,18 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
     PartitionSpec bucketSpec = table.specs().get(1);
     PartitionSpec identitySpec = table.specs().get(2);
 
-    writer.write(positionDelete(dataFile1.path(), 0L, null), unpartitionedSpec, null);
-    writer.write(positionDelete(dataFile1.path(), 1L, null), unpartitionedSpec, null);
+    writer.write(positionDelete(dataFile1.location(), 0L, null), unpartitionedSpec, null);
+    writer.write(positionDelete(dataFile1.location(), 1L, null), unpartitionedSpec, null);
     writer.write(
-        positionDelete(dataFile2.path(), 0L, null), bucketSpec, partitionKey(bucketSpec, "bbb"));
+        positionDelete(dataFile2.location(), 0L, null),
+        bucketSpec,
+        partitionKey(bucketSpec, "bbb"));
     writer.write(
-        positionDelete(dataFile2.path(), 1L, null), bucketSpec, partitionKey(bucketSpec, "bbb"));
+        positionDelete(dataFile2.location(), 1L, null),
+        bucketSpec,
+        partitionKey(bucketSpec, "bbb"));
     writer.write(
-        positionDelete(dataFile3.path(), 0L, null),
+        positionDelete(dataFile3.location(), 0L, null),
         identitySpec,
         partitionKey(identitySpec, "ccc"));
 
@@ -488,10 +492,10 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
     PartitionSpec spec = table.spec();
 
     // write deletes for both data files
-    writer.write(positionDelete(dataFile1.path(), 0L, null), spec, null);
-    writer.write(positionDelete(dataFile1.path(), 1L, null), spec, null);
-    writer.write(positionDelete(dataFile2.path(), 0L, null), spec, null);
-    writer.write(positionDelete(dataFile2.path(), 1L, null), spec, null);
+    writer.write(positionDelete(dataFile1.location(), 0L, null), spec, null);
+    writer.write(positionDelete(dataFile1.location(), 1L, null), spec, null);
+    writer.write(positionDelete(dataFile2.location(), 0L, null), spec, null);
+    writer.write(positionDelete(dataFile2.location(), 1L, null), spec, null);
     writer.close();
 
     // verify the writer result
@@ -636,25 +640,29 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
     PartitionSpec bucketSpec = table.specs().get(1);
     PartitionSpec identitySpec = table.specs().get(2);
 
-    writer.write(positionDelete(dataFile1.path(), 1L, null), unpartitionedSpec, null);
+    writer.write(positionDelete(dataFile1.location(), 1L, null), unpartitionedSpec, null);
     writer.write(
-        positionDelete(dataFile2.path(), 1L, null), bucketSpec, partitionKey(bucketSpec, "bbb"));
+        positionDelete(dataFile2.location(), 1L, null),
+        bucketSpec,
+        partitionKey(bucketSpec, "bbb"));
     writer.write(
-        positionDelete(dataFile2.path(), 0L, null), bucketSpec, partitionKey(bucketSpec, "bbb"));
+        positionDelete(dataFile2.location(), 0L, null),
+        bucketSpec,
+        partitionKey(bucketSpec, "bbb"));
     writer.write(
-        positionDelete(dataFile3.path(), 1L, null),
+        positionDelete(dataFile3.location(), 1L, null),
         identitySpec,
         partitionKey(identitySpec, "ccc"));
     writer.write(
-        positionDelete(dataFile3.path(), 2L, null),
+        positionDelete(dataFile3.location(), 2L, null),
         identitySpec,
         partitionKey(identitySpec, "ccc"));
-    writer.write(positionDelete(dataFile1.path(), 0L, null), unpartitionedSpec, null);
+    writer.write(positionDelete(dataFile1.location(), 0L, null), unpartitionedSpec, null);
     writer.write(
-        positionDelete(dataFile3.path(), 0L, null),
+        positionDelete(dataFile3.location(), 0L, null),
         identitySpec,
         partitionKey(identitySpec, "ccc"));
-    writer.write(positionDelete(dataFile1.path(), 2L, null), unpartitionedSpec, null);
+    writer.write(positionDelete(dataFile1.location(), 2L, null), unpartitionedSpec, null);
 
     writer.close();
 
@@ -703,10 +711,10 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
     PartitionSpec spec = table.spec();
 
     // write deletes for both data files (the order of records is mixed)
-    writer.write(positionDelete(dataFile1.path(), 1L, null), spec, null);
-    writer.write(positionDelete(dataFile2.path(), 0L, null), spec, null);
-    writer.write(positionDelete(dataFile1.path(), 0L, null), spec, null);
-    writer.write(positionDelete(dataFile2.path(), 1L, null), spec, null);
+    writer.write(positionDelete(dataFile1.location(), 1L, null), spec, null);
+    writer.write(positionDelete(dataFile2.location(), 0L, null), spec, null);
+    writer.write(positionDelete(dataFile1.location(), 0L, null), spec, null);
+    writer.write(positionDelete(dataFile2.location(), 1L, null), spec, null);
     writer.close();
 
     // verify the writer result
@@ -750,8 +758,8 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
             writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE, DeleteGranularity.FILE);
 
     // write initial deletes for both data files
-    writer1.write(positionDelete(dataFile1.path(), 1L), spec, null);
-    writer1.write(positionDelete(dataFile2.path(), 1L), spec, null);
+    writer1.write(positionDelete(dataFile1.location(), 1L), spec, null);
+    writer1.write(positionDelete(dataFile2.location(), 1L), spec, null);
     writer1.close();
 
     // verify the writer result
@@ -789,8 +797,8 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
             new PreviousDeleteLoader(table, previousDeletes));
 
     // write more deletes for both data files
-    writer2.write(positionDelete(dataFile1.path(), 0L), spec, null);
-    writer2.write(positionDelete(dataFile2.path(), 0L), spec, null);
+    writer2.write(positionDelete(dataFile1.location(), 0L), spec, null);
+    writer2.write(positionDelete(dataFile2.location(), 0L), spec, null);
     writer2.close();
 
     // verify the writer result

--- a/data/src/test/java/org/apache/iceberg/io/TestPositionDeltaWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestPositionDeltaWriters.java
@@ -164,8 +164,9 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
     PositionDeltaWriter<T> deltaWriter =
         new BasePositionDeltaWriter<>(insertWriter, updateWriter, deleteWriter);
 
-    deltaWriter.delete(dataFile1.path(), 2L, unpartitionedSpec, null);
-    deltaWriter.delete(dataFile2.path(), 1L, partitionedSpec, partitionKey(partitionedSpec, "bbb"));
+    deltaWriter.delete(dataFile1.location(), 2L, unpartitionedSpec, null);
+    deltaWriter.delete(
+        dataFile2.location(), 1L, partitionedSpec, partitionKey(partitionedSpec, "bbb"));
 
     deltaWriter.close();
 
@@ -219,8 +220,9 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
     PositionDeltaWriter<T> deltaWriter =
         new BasePositionDeltaWriter<>(insertWriter, updateWriter, deleteWriter);
 
-    deltaWriter.delete(dataFile1.path(), 2L, unpartitionedSpec, null);
-    deltaWriter.delete(dataFile2.path(), 1L, partitionedSpec, partitionKey(partitionedSpec, "bbb"));
+    deltaWriter.delete(dataFile1.location(), 2L, unpartitionedSpec, null);
+    deltaWriter.delete(
+        dataFile2.location(), 1L, partitionedSpec, partitionKey(partitionedSpec, "bbb"));
     deltaWriter.insert(toRow(10, "ccc"), partitionedSpec, partitionKey(partitionedSpec, "ccc"));
 
     deltaWriter.close();

--- a/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
+++ b/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
@@ -464,8 +464,8 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
         .addedDataFiles(icebergTable.io())
         .forEach(
             dataFile -> {
-              assertThat(URI.create(dataFile.path().toString()).isAbsolute()).isTrue();
-              assertThat(deltaTableDataFilePaths).contains(dataFile.path().toString());
+              assertThat(URI.create(dataFile.location()).isAbsolute()).isTrue();
+              assertThat(deltaTableDataFilePaths).contains(dataFile.location());
             });
   }
 

--- a/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
@@ -252,7 +252,7 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
         for (AddFile addFile : initDataFiles) {
           DataFile dataFile = buildDataFileFromAction(addFile, transaction.table());
           filesToAdd.add(dataFile);
-          migratedDataFilesBuilder.add(dataFile.path().toString());
+          migratedDataFilesBuilder.add(dataFile.location());
         }
 
         // AppendFiles case
@@ -309,7 +309,7 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
         throw new ValidationException(
             "The action %s's is unsupported", action.getClass().getSimpleName());
       }
-      migratedDataFilesBuilder.add(dataFile.path().toString());
+      migratedDataFilesBuilder.add(dataFile.location());
     }
 
     if (!filesToAdd.isEmpty() && !filesToRemove.isEmpty()) {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -283,7 +283,7 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
     assertThat(TestHelpers.deleteFiles(table)).as("Should have 1 delete file").hasSize(1);
     Path deleteManifestPath = new Path(TestHelpers.deleteManifests(table).iterator().next().path());
     Path deleteFilePath =
-        new Path(String.valueOf(TestHelpers.deleteFiles(table).iterator().next().path()));
+        new Path(String.valueOf(TestHelpers.deleteFiles(table).iterator().next().location()));
 
     sql(
         "CALL %s.system.rewrite_data_files("

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -412,7 +412,7 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
     assertThat(TestHelpers.deleteFiles(table)).as("Should have 1 delete file").hasSize(1);
     Path deleteManifestPath = new Path(TestHelpers.deleteManifests(table).iterator().next().path());
     Path deleteFilePath =
-        new Path(String.valueOf(TestHelpers.deleteFiles(table).iterator().next().path()));
+        new Path(String.valueOf(TestHelpers.deleteFiles(table).iterator().next().location()));
 
     // wait to ensure files are old enough
     waitUntilAfter(System.currentTimeMillis());

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
@@ -305,7 +305,7 @@ public class TestRewritePositionDeleteFiles extends ExtensionsTestBase {
       List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
       for (DataFile partitionFile : partitionFiles) {
         for (int deletePos = 0; deletePos < DELETE_FILE_SIZE; deletePos++) {
-          deletes.add(Pair.of(partitionFile.path(), (long) deletePos));
+          deletes.add(Pair.of(partitionFile.location(), (long) deletePos));
           counter++;
           if (counter == deleteFileSize) {
             // Dump to file and reset variables

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -1299,7 +1299,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
 
     // remove the data file from the 'hr' partition to ensure it is not scanned
     DataFile dataFile = Iterables.getOnlyElement(snapshot.addedDataFiles(table.io()));
-    table.io().deleteFile(dataFile.path().toString());
+    table.io().deleteFile(dataFile.location());
 
     // disable dynamic pruning and rely only on static predicate pushdown
     withSQLConf(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -432,7 +432,7 @@ abstract class BaseSparkAction<ThisT> {
     }
 
     static FileInfo toFileInfo(ContentFile<?> file) {
-      return new FileInfo(file.path().toString(), file.content().toString());
+      return new FileInfo(file.location(), file.content().toString());
     }
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
@@ -90,7 +90,7 @@ class RemoveDanglingDeletesSparkAction
     RewriteFiles rewriteFiles = table.newRewrite();
     List<DeleteFile> danglingDeletes = findDanglingDeletes();
     for (DeleteFile deleteFile : danglingDeletes) {
-      LOG.debug("Removing dangling delete file {}", deleteFile.path());
+      LOG.debug("Removing dangling delete file {}", deleteFile.location());
       rewriteFiles.deleteFile(deleteFile);
     }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -150,7 +150,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
       if (currentTask != null && !currentTask.isDataTask()) {
         String filePaths =
             referencedFiles(currentTask)
-                .map(file -> file.path().toString())
+                .map(ContentFile::location)
                 .collect(Collectors.joining(", "));
         LOG.error("Error reading file(s): {}", filePaths, e);
       }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -82,7 +82,7 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
 
   @Override
   protected CloseableIterator<ColumnarBatch> open(FileScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     LOG.debug("Opening data file {}", filePath);
 
     // update the current file for Spark's filename() function

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
@@ -110,7 +110,7 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask>
   }
 
   CloseableIterable<InternalRow> openAddedRowsScanTask(AddedRowsScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     SparkDeleteFilter deletes = new SparkDeleteFilter(filePath, task.deletes(), counter(), true);
     return deletes.filter(rows(task, deletes.requiredSchema()));
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
@@ -41,7 +41,7 @@ public class EqualityDeleteRowReader extends RowDataReader {
   @Override
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
     SparkDeleteFilter matches =
-        new SparkDeleteFilter(task.file().path().toString(), task.deletes(), counter(), true);
+        new SparkDeleteFilter(task.file().location(), task.deletes(), counter(), true);
 
     // schema or rows returned by readers
     Schema requiredSchema = matches.requiredSchema();
@@ -49,7 +49,7 @@ public class EqualityDeleteRowReader extends RowDataReader {
     DataFile file = task.file();
 
     // update the current file for Spark's filename() function
-    InputFileBlockHolder.set(file.path().toString(), task.start(), task.length());
+    InputFileBlockHolder.set(file.location(), task.start(), task.length());
 
     return matches.findEqualityDeleteRows(open(task, requiredSchema, idToConstant)).iterator();
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
@@ -74,13 +74,13 @@ class PositionDeletesRowReader extends BaseRowReader<PositionDeletesScanTask>
 
   @Override
   protected CloseableIterator<InternalRow> open(PositionDeletesScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     LOG.debug("Opening position delete file {}", filePath);
 
     // update the current file for Spark's filename() function
     InputFileBlockHolder.set(filePath, task.start(), task.length());
 
-    InputFile inputFile = getInputFile(task.file().path().toString());
+    InputFile inputFile = getInputFile(task.file().location());
     Preconditions.checkNotNull(inputFile, "Could not find InputFile associated with %s", task);
 
     // select out constant fields when pushing down filter to row reader

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -81,7 +81,7 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
 
   @Override
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     LOG.debug("Opening data file {}", filePath);
     SparkDeleteFilter deleteFilter =
         new SparkDeleteFilter(filePath, task.deletes(), counter(), true);
@@ -101,7 +101,7 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
     if (task.isDataTask()) {
       return newDataIterable(task.asDataTask(), readSchema);
     } else {
-      InputFile inputFile = getInputFile(task.file().path().toString());
+      InputFile inputFile = getInputFile(task.file().location());
       Preconditions.checkNotNull(
           inputFile, "Could not find InputFile associated with FileScanTask");
       return newIterable(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -81,7 +81,7 @@ class SparkCleanupUtil {
    * @param files a list of files to delete
    */
   public static void deleteFiles(String context, FileIO io, List<? extends ContentFile<?>> files) {
-    List<String> paths = Lists.transform(files, file -> file.path().toString());
+    List<String> paths = Lists.transform(files, ContentFile::location);
     deletePaths(context, io, paths);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -130,7 +130,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
           this.filteredLocations = fileLocations;
           List<FileScanTask> filteredTasks =
               tasks().stream()
-                  .filter(file -> fileLocations.contains(file.file().path().toString()))
+                  .filter(file -> fileLocations.contains(file.file().location()))
                   .collect(Collectors.toList());
 
           LOG.info(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
@@ -62,9 +62,9 @@ public final class TaskCheckHelper {
   }
 
   public static void assertEquals(DataFile expected, DataFile actual) {
-    assertThat(actual.path())
+    assertThat(actual.location())
         .as("Should match the serialized record path")
-        .isEqualTo(expected.path());
+        .isEqualTo(expected.location());
     assertThat(actual.format())
         .as("Should match the serialized record format")
         .isEqualTo(expected.format());
@@ -104,7 +104,7 @@ public final class TaskCheckHelper {
       ScanTaskGroup<FileScanTask> taskGroup) {
     return taskGroup.tasks().stream()
         // use file path + start position to differentiate the tasks
-        .sorted(Comparator.comparing(o -> o.file().path().toString() + "##" + o.start()))
+        .sorted(Comparator.comparing(o -> o.file().location() + "##" + o.start()))
         .collect(Collectors.toList());
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/ValidationHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/ValidationHelpers.java
@@ -42,7 +42,7 @@ public class ValidationHelpers {
   }
 
   public static List<String> files(ContentFile<?>... files) {
-    return Arrays.stream(files).map(file -> file.path().toString()).collect(Collectors.toList());
+    return Arrays.stream(files).map(file -> file.location()).collect(Collectors.toList());
   }
 
   public static void validateDataManifest(
@@ -62,7 +62,7 @@ public class ValidationHelpers {
       actualDataSeqs.add(entry.dataSequenceNumber());
       actualFileSeqs.add(entry.fileSequenceNumber());
       actualSnapshotIds.add(entry.snapshotId());
-      actualFiles.add(entry.file().path().toString());
+      actualFiles.add(entry.file().location());
     }
 
     assertSameElements("data seqs", actualDataSeqs, dataSeqs);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
@@ -142,7 +142,7 @@ public abstract class TestBase extends SparkTestHelperBase {
   }
 
   protected void withUnavailableFiles(Iterable<? extends ContentFile<?>> files, Action action) {
-    Iterable<String> fileLocations = Iterables.transform(files, file -> file.path().toString());
+    Iterable<String> fileLocations = Iterables.transform(files, file -> file.location());
     withUnavailableLocations(fileLocations, action);
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
@@ -350,7 +350,7 @@ public class TestSparkExecutorCache extends TestBaseWithCatalog {
   }
 
   private int streamCount(DeleteFile deleteFile) {
-    CustomInputFile inputFile = INPUT_FILES.get(deleteFile.path().toString());
+    CustomInputFile inputFile = INPUT_FILES.get(deleteFile.location());
     return inputFile.streamCount();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -220,7 +220,7 @@ public class TestDeleteReachableFilesAction extends TestBase {
             file ->
                 assertThat(deletedFiles)
                     .as("FILE_A should be deleted")
-                    .contains(FILE_A.path().toString()));
+                    .contains(FILE_A.location()));
     checkRemoveFilesResults(4L, 0, 0, 6L, 4L, 6, result);
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -261,8 +261,8 @@ public class TestExpireSnapshotsAction extends TestBase {
                 "remove-snapshot-2",
                 "remove-snapshot-3"));
 
-    assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.path().toString());
-    assertThat(deletedFiles).as("FILE_B should be deleted").contains(FILE_B.path().toString());
+    assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.location());
+    assertThat(deletedFiles).as("FILE_B should be deleted").contains(FILE_B.location());
 
     checkExpirationResults(2L, 0L, 0L, 3L, 3L, result);
   }
@@ -565,7 +565,7 @@ public class TestExpireSnapshotsAction extends TestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.path().toString());
+    assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.location());
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, result);
   }
 
@@ -594,7 +594,7 @@ public class TestExpireSnapshotsAction extends TestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.path().toString());
+    assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.location());
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, result);
   }
 
@@ -637,7 +637,7 @@ public class TestExpireSnapshotsAction extends TestBase {
         .addedDataFiles(table.io())
         .forEach(
             i -> {
-              expectedDeletes.add(i.path().toString());
+              expectedDeletes.add(i.location());
             });
 
     // ManifestList should be deleted too
@@ -707,7 +707,7 @@ public class TestExpireSnapshotsAction extends TestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        assertThat(deletedFiles).doesNotContain(item.path().toString());
+                        assertThat(deletedFiles).doesNotContain(item.location());
                       });
             });
 
@@ -756,7 +756,7 @@ public class TestExpireSnapshotsAction extends TestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        assertThat(deletedFiles).doesNotContain(item.path().toString());
+                        assertThat(deletedFiles).doesNotContain(item.location());
                       });
             });
     checkExpirationResults(0L, 0L, 0L, 1L, 1L, firstResult);
@@ -776,7 +776,7 @@ public class TestExpireSnapshotsAction extends TestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        assertThat(deletedFiles).doesNotContain(item.path().toString());
+                        assertThat(deletedFiles).doesNotContain(item.location());
                       });
             });
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, secondResult);
@@ -1100,9 +1100,9 @@ public class TestExpireSnapshotsAction extends TestBase {
             secondSnapshot.manifestListLocation(),
             thirdSnapshot.manifestListLocation(),
             fourthSnapshot.manifestListLocation(),
-            FILE_A.path().toString(),
-            fileADeletes.path().toString(),
-            FILE_A_EQ_DELETES.path().toString());
+            FILE_A.location(),
+            fileADeletes.location(),
+            FILE_A_EQ_DELETES.location());
 
     expectedDeletes.addAll(
         thirdSnapshot.allManifests(table.io()).stream()
@@ -1277,7 +1277,7 @@ public class TestExpireSnapshotsAction extends TestBase {
               .withPartitionPath("c1=1")
               .withRecordCount(1)
               .build();
-      dataFiles.add(df.path().toString());
+      dataFiles.add(df.location());
       table.newFastAppend().appendFile(df).commit();
     }
 
@@ -1351,9 +1351,9 @@ public class TestExpireSnapshotsAction extends TestBase {
     // C, D should be retained (live)
     // B should be retained (previous snapshot points to it)
     // A should be deleted
-    assertThat(deletedFiles).contains(FILE_A.path().toString());
-    assertThat(deletedFiles).doesNotContain(FILE_B.path().toString());
-    assertThat(deletedFiles).doesNotContain(FILE_C.path().toString());
-    assertThat(deletedFiles).doesNotContain(FILE_D.path().toString());
+    assertThat(deletedFiles).contains(FILE_A.location());
+    assertThat(deletedFiles).doesNotContain(FILE_B.location());
+    assertThat(deletedFiles).doesNotContain(FILE_C.location());
+    assertThat(deletedFiles).doesNotContain(FILE_D.location());
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -114,7 +114,7 @@ public class TestBaseReader {
     }
 
     private String getKey(FileScanTask task) {
-      return task.file().path().toString();
+      return task.file().location();
     }
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
@@ -209,7 +209,7 @@ public class TestCompressionSettings extends CatalogTestBase {
     List<ManifestFile> manifestFiles = table.currentSnapshot().dataManifests(table.io());
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifestFiles.get(0), table.io())) {
       DataFile file = reader.iterator().next();
-      InputFile inputFile = table.io().newInputFile(file.path().toString());
+      InputFile inputFile = table.io().newInputFile(file.location());
       assertThat(getCompressionType(inputFile))
           .isEqualToIgnoringCase(properties.get(COMPRESSION_CODEC));
     }
@@ -223,7 +223,7 @@ public class TestCompressionSettings extends CatalogTestBase {
     try (ManifestReader<DeleteFile> reader =
         ManifestFiles.readDeleteManifest(deleteManifestFiles.get(0), table.io(), specMap)) {
       DeleteFile file = reader.iterator().next();
-      InputFile inputFile = table.io().newInputFile(file.path().toString());
+      InputFile inputFile = table.io().newInputFile(file.location());
       assertThat(getCompressionType(inputFile))
           .isEqualToIgnoringCase(properties.get(COMPRESSION_CODEC));
     }
@@ -237,7 +237,7 @@ public class TestCompressionSettings extends CatalogTestBase {
     try (ManifestReader<DeleteFile> reader =
         ManifestFiles.readDeleteManifest(deleteManifestFiles.get(0), table.io(), specMap)) {
       DeleteFile file = reader.iterator().next();
-      InputFile inputFile = table.io().newInputFile(file.path().toString());
+      InputFile inputFile = table.io().newInputFile(file.location());
       assertThat(getCompressionType(inputFile))
           .isEqualToIgnoringCase(properties.get(COMPRESSION_CODEC));
     }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -187,11 +187,11 @@ public class TestDataFrameWrites extends ParameterizedAvroDataTest {
         .addedDataFiles(table.io())
         .forEach(
             dataFile ->
-                assertThat(URI.create(dataFile.path().toString()).getPath())
+                assertThat(URI.create(dataFile.location()).getPath())
                     .as(
                         String.format(
                             "File should have the parent directory %s, but has: %s.",
-                            expectedDataDir.getAbsolutePath(), dataFile.path()))
+                            expectedDataDir.getAbsolutePath(), dataFile.location()))
                     .startsWith(expectedDataDir.getAbsolutePath()));
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -109,7 +109,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
     try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
       tasks.forEach(
           task -> {
-            FileFormat fileFormat = FileFormat.fromFileName(task.file().path());
+            FileFormat fileFormat = FileFormat.fromFileName(task.file().location());
             assertThat(fileFormat).isEqualTo(FileFormat.PARQUET);
           });
     }
@@ -134,7 +134,7 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
     try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
       tasks.forEach(
           task -> {
-            FileFormat fileFormat = FileFormat.fromFileName(task.file().path());
+            FileFormat fileFormat = FileFormat.fromFileName(task.file().location());
             assertThat(fileFormat).isEqualTo(FileFormat.AVRO);
           });
     }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesTable.java
@@ -134,8 +134,8 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     tab.newAppend().appendFile(dFile).commit();
 
     List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
-    deletes.add(Pair.of(dFile.path(), 0L));
-    deletes.add(Pair.of(dFile.path(), 1L));
+    deletes.add(Pair.of(dFile.location(), 0L));
+    deletes.add(Pair.of(dFile.location(), 1L));
     Pair<DeleteFile, CharSequenceSet> posDeletes =
         FileHelpers.writeDeleteFile(
             tab,
@@ -147,9 +147,9 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     StructLikeSet actual = actual(tableName, tab);
 
     List<PositionDelete<?>> expectedDeletes =
-        Lists.newArrayList(positionDelete(dFile.path(), 0L), positionDelete(dFile.path(), 1L));
-    StructLikeSet expected =
-        expected(tab, expectedDeletes, null, posDeletes.first().path().toString());
+        Lists.newArrayList(
+            positionDelete(dFile.location(), 0L), positionDelete(dFile.location(), 1L));
+    StructLikeSet expected = expected(tab, expectedDeletes, null, posDeletes.first().location());
 
     assertThat(actual).as("Position Delete table should contain expected rows").isEqualTo(expected);
     dropTable(tableName);
@@ -178,7 +178,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     GenericRecord partitionB = GenericRecord.create(tab.spec().partitionType());
     partitionB.setField("data", "b");
     StructLikeSet expected =
-        expected(tab, deletesB.first(), partitionB, deletesB.second().path().toString());
+        expected(tab, deletesB.first(), partitionB, deletesB.second().location());
 
     assertThat(actual).as("Position Delete table should contain expected rows").isEqualTo(expected);
     dropTable(tableName);
@@ -218,7 +218,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
         (delete, file) -> {
           int rowData = delete.get(2, GenericRecord.class).get(0, Integer.class);
           long pos = delete.get(1, Long.class);
-          return row(rowData, pos, file.path().toString(), file.path().toString());
+          return row(rowData, pos, file.location(), file.location());
         };
     expected.addAll(
         deletesA.first().stream()
@@ -270,7 +270,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
 
     List<PositionDelete<?>> deletes = Lists.newArrayList();
     for (long i = 0; i < records; i++) {
-      deletes.add(positionDelete(tab.schema(), dFile.path(), i, (int) i, String.valueOf(i)));
+      deletes.add(positionDelete(tab.schema(), dFile.location(), i, (int) i, String.valueOf(i)));
     }
     DeleteFile posDeletes =
         FileHelpers.writePosDeleteFile(
@@ -294,7 +294,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     }
 
     StructLikeSet actual = actual(tableName, tab);
-    StructLikeSet expected = expected(tab, deletes, null, posDeletes.path().toString());
+    StructLikeSet expected = expected(tab, deletes, null, posDeletes.location());
 
     assertThat(actual).as("Position Delete table should contain expected rows").isEqualTo(expected);
     dropTable(tableName);
@@ -324,9 +324,9 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     Record partitionA = partitionRecordTemplate.copy("data", "a");
     Record partitionB = partitionRecordTemplate.copy("data", "b");
     StructLikeSet expectedA =
-        expected(tab, deletesA.first(), partitionA, deletesA.second().path().toString());
+        expected(tab, deletesA.first(), partitionA, deletesA.second().location());
     StructLikeSet expectedB =
-        expected(tab, deletesB.first(), partitionB, deletesB.second().path().toString());
+        expected(tab, deletesB.first(), partitionB, deletesB.second().location());
     StructLikeSet allExpected = StructLikeSet.create(deletesTab.schema().asStruct());
     allExpected.addAll(expectedA);
     allExpected.addAll(expectedB);
@@ -371,9 +371,9 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     Record partitionA = partitionRecordTemplate.copy("data_trunc", "a");
     Record partitionB = partitionRecordTemplate.copy("data_trunc", "b");
     StructLikeSet expectedA =
-        expected(tab, deletesA.first(), partitionA, deletesA.second().path().toString());
+        expected(tab, deletesA.first(), partitionA, deletesA.second().location());
     StructLikeSet expectedB =
-        expected(tab, deletesB.first(), partitionB, deletesB.second().path().toString());
+        expected(tab, deletesB.first(), partitionB, deletesB.second().location());
     StructLikeSet allExpected = StructLikeSet.create(deletesTable.schema().asStruct());
     allExpected.addAll(expectedA);
     allExpected.addAll(expectedB);
@@ -425,7 +425,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     GenericRecord partitionRecordTemplate = GenericRecord.create(Partitioning.partitionType(tab));
     Record partitionA = partitionRecordTemplate.copy("data", "a");
     StructLikeSet expectedA =
-        expected(tab, deletesA.first(), partitionA, dataSpec, deletesA.second().path().toString());
+        expected(tab, deletesA.first(), partitionA, dataSpec, deletesA.second().location());
     StructLikeSet actualA = actual(tableName, tab, "partition.data = 'a' AND pos >= 0");
     assertThat(actualA)
         .as("Position Delete table should contain expected rows")
@@ -439,7 +439,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
             deletes10.first(),
             partition10,
             tab.spec().specId(),
-            deletes10.second().path().toString());
+            deletes10.second().location());
     StructLikeSet actual10 = actual(tableName, tab, "partition.id = 10 AND pos >= 0");
 
     assertThat(actual10)
@@ -479,7 +479,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     GenericRecord partitionRecordTemplate = GenericRecord.create(Partitioning.partitionType(tab));
     Record partitionA = partitionRecordTemplate.copy("data", "a");
     StructLikeSet expectedA =
-        expected(tab, deletesA.first(), partitionA, specId1, deletesA.second().path().toString());
+        expected(tab, deletesA.first(), partitionA, specId1, deletesA.second().location());
     StructLikeSet actualA = actual(tableName, tab, "partition.data = 'a' AND pos >= 0");
     assertThat(actualA)
         .as("Position Delete table should contain expected rows")
@@ -493,7 +493,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
             deletesUnpartitioned.first(),
             unpartitionedRecord,
             specId0,
-            deletesUnpartitioned.second().path().toString());
+            deletesUnpartitioned.second().location());
     StructLikeSet actualUnpartitioned =
         actual(tableName, tab, "partition.data IS NULL and pos >= 0");
 
@@ -535,7 +535,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     GenericRecord partitionRecordTemplate = GenericRecord.create(Partitioning.partitionType(tab));
     Record partitionA = partitionRecordTemplate.copy("data", "a");
     StructLikeSet expectedA =
-        expected(tab, deletesA.first(), partitionA, specId0, deletesA.second().path().toString());
+        expected(tab, deletesA.first(), partitionA, specId0, deletesA.second().location());
     StructLikeSet actualA = actual(tableName, tab, "partition.data = 'a' AND pos >= 0");
     assertThat(actualA)
         .as("Position Delete table should contain expected rows")
@@ -549,7 +549,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
             deletesUnpartitioned.first(),
             unpartitionedRecord,
             specId1,
-            deletesUnpartitioned.second().path().toString());
+            deletesUnpartitioned.second().location());
     StructLikeSet actualUnpartitioned =
         actual(tableName, tab, "partition.data IS NULL and pos >= 0");
 
@@ -593,7 +593,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
             deletesUnpartitioned.first(),
             partitionRecordTemplate,
             unpartitionedSpec,
-            deletesUnpartitioned.second().path().toString());
+            deletesUnpartitioned.second().location());
     StructLikeSet actualUnpartitioned =
         actual(tableName, tab, String.format("spec_id = %d", unpartitionedSpec));
     assertThat(actualUnpartitioned)
@@ -604,9 +604,9 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     StructLike partitionA = partitionRecordTemplate.copy("data", "a");
     StructLike partitionB = partitionRecordTemplate.copy("data", "b");
     StructLikeSet expected =
-        expected(tab, deletesA.first(), partitionA, dataSpec, deletesA.second().path().toString());
+        expected(tab, deletesA.first(), partitionA, dataSpec, deletesA.second().location());
     expected.addAll(
-        expected(tab, deletesB.first(), partitionB, dataSpec, deletesB.second().path().toString()));
+        expected(tab, deletesB.first(), partitionB, dataSpec, deletesB.second().location()));
 
     StructLikeSet actual = actual(tableName, tab, String.format("spec_id = %d", dataSpec));
     assertThat(actual).as("Position Delete table should contain expected rows").isEqualTo(expected);
@@ -660,7 +660,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
           d.set(2, padded);
         });
     StructLikeSet expectedA =
-        expected(tab, expectedDeletesA, partitionA, deletesA.second().path().toString());
+        expected(tab, expectedDeletesA, partitionA, deletesA.second().location());
     StructLikeSet actualA = actual(tableName, tab, "partition.data = 'a' AND pos >= 0");
     assertThat(actualA)
         .as("Position Delete table should contain expected rows")
@@ -669,7 +669,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     // Select deletes from new schema
     Record partitionC = partitionRecordTemplate.copy("data", "c");
     StructLikeSet expectedC =
-        expected(tab, deletesC.first(), partitionC, deletesC.second().path().toString());
+        expected(tab, deletesC.first(), partitionC, deletesC.second().location());
     StructLikeSet actualC = actual(tableName, tab, "partition.data = 'c' and pos >= 0");
 
     assertThat(actualC)
@@ -726,7 +726,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
           d.set(2, padded);
         });
     StructLikeSet expectedA =
-        expected(tab, expectedDeletesA, partitionA, deletesA.second().path().toString());
+        expected(tab, expectedDeletesA, partitionA, deletesA.second().location());
     StructLikeSet actualA = actual(tableName, tab, "partition.data = 'a' AND pos >= 0");
     assertThat(actualA)
         .as("Position Delete table should contain expected rows")
@@ -735,7 +735,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     // Select deletes from new schema
     Record partitionC = partitionRecordTemplate.copy("data", "c");
     StructLikeSet expectedC =
-        expected(tab, deletesC.first(), partitionC, deletesC.second().path().toString());
+        expected(tab, deletesC.first(), partitionC, deletesC.second().location());
     StructLikeSet actualC = actual(tableName, tab, "partition.data = 'c' and pos >= 0");
 
     assertThat(actualC)
@@ -817,8 +817,8 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     tab.newAppend().appendFile(dFile).commit();
 
     List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
-    deletes.add(Pair.of(dFile.path(), 0L));
-    deletes.add(Pair.of(dFile.path(), 1L));
+    deletes.add(Pair.of(dFile.location(), 0L));
+    deletes.add(Pair.of(dFile.location(), 1L));
     Pair<DeleteFile, CharSequenceSet> posDeletes =
         FileHelpers.writeDeleteFile(
             tab,
@@ -855,7 +855,8 @@ public class TestPositionDeletesTable extends CatalogTestBase {
         actual(tableName, tab, null, ImmutableList.of("file_path", "pos", "row", "spec_id"));
 
     List<PositionDelete<?>> expectedDeletes =
-        Lists.newArrayList(positionDelete(dFile.path(), 0L), positionDelete(dFile.path(), 1L));
+        Lists.newArrayList(
+            positionDelete(dFile.location(), 0L), positionDelete(dFile.location(), 1L));
     StructLikeSet expected = expected(tab, expectedDeletes, null, null);
 
     assertThat(actual).as("Position Delete table should contain expected rows").isEqualTo(expected);
@@ -874,8 +875,8 @@ public class TestPositionDeletesTable extends CatalogTestBase {
 
     // Add a delete file with row and without row
     List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
-    deletes.add(Pair.of(dataFileA.path(), 0L));
-    deletes.add(Pair.of(dataFileA.path(), 1L));
+    deletes.add(Pair.of(dataFileA.location(), 0L));
+    deletes.add(Pair.of(dataFileA.location(), 1L));
     Pair<DeleteFile, CharSequenceSet> deletesWithoutRow =
         FileHelpers.writeDeleteFile(
             tab,
@@ -936,7 +937,7 @@ public class TestPositionDeletesTable extends CatalogTestBase {
         expected(
             tab,
             Lists.newArrayList(
-                positionDelete(dataFileA.path(), 0L), positionDelete(dataFileA.path(), 1L)),
+                positionDelete(dataFileA.location(), 0L), positionDelete(dataFileA.location(), 1L)),
             partitionA,
             null));
     allExpected.addAll(expected(tab, deletesWithRow.first(), partitionB, null));
@@ -1530,13 +1531,13 @@ public class TestPositionDeletesTable extends CatalogTestBase {
         Lists.newArrayList(
             positionDelete(
                 tab.schema(),
-                dataFile.path(),
+                dataFile.location(),
                 0L,
                 idPartition != null ? idPartition : 29,
                 dataPartition != null ? dataPartition : "c"),
             positionDelete(
                 tab.schema(),
-                dataFile.path(),
+                dataFile.location(),
                 1L,
                 idPartition != null ? idPartition : 61,
                 dataPartition != null ? dataPartition : "r"));
@@ -1585,9 +1586,9 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     assertThat(addedFiles).hasSize(expectedTargetFiles);
 
     List<String> sortedAddedFiles =
-        addedFiles.stream().map(f -> f.path().toString()).sorted().collect(Collectors.toList());
+        addedFiles.stream().map(f -> f.location()).sorted().collect(Collectors.toList());
     List<String> sortedRewrittenFiles =
-        rewrittenFiles.stream().map(f -> f.path().toString()).sorted().collect(Collectors.toList());
+        rewrittenFiles.stream().map(f -> f.location()).sorted().collect(Collectors.toList());
     assertThat(sortedRewrittenFiles)
         .as("Lists should not be the same")
         .isNotEqualTo(sortedAddedFiles);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestRuntimeFiltering.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestRuntimeFiltering.java
@@ -483,7 +483,7 @@ public class TestRuntimeFiltering extends TestBaseWithCatalog {
     Set<String> matchingFileLocations = Sets.newHashSet();
     try (CloseableIterable<FileScanTask> files = table.newScan().filter(filter).planFiles()) {
       for (FileScanTask file : files) {
-        String path = file.file().path().toString();
+        String path = file.file().location();
         matchingFileLocations.add(path);
       }
     } catch (IOException e) {
@@ -493,7 +493,7 @@ public class TestRuntimeFiltering extends TestBaseWithCatalog {
     Set<String> deletedFileLocations = Sets.newHashSet();
     try (CloseableIterable<FileScanTask> files = table.newScan().planFiles()) {
       for (FileScanTask file : files) {
-        String path = file.file().path().toString();
+        String path = file.file().location();
         if (!matchingFileLocations.contains(path)) {
           io.deleteFile(path);
           deletedFileLocations.add(path);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
@@ -279,7 +279,7 @@ public class TestSparkDataFile {
 
   private void checkContentFile(ContentFile<?> expected, ContentFile<?> actual) {
     assertThat(actual.content()).isEqualTo(expected.content());
-    assertThat(actual.path()).isEqualTo(expected.path());
+    assertThat(actual.location()).isEqualTo(expected.location());
     assertThat(actual.format()).isEqualTo(expected.format());
     assertThat(actual.recordCount()).isEqualTo(expected.recordCount());
     assertThat(actual.fileSizeInBytes()).isEqualTo(expected.fileSizeInBytes());
@@ -317,10 +317,10 @@ public class TestSparkDataFile {
                 null, // no NaN counts
                 ImmutableMap.of(
                     MetadataColumns.DELETE_FILE_PATH.fieldId(),
-                    Conversions.toByteBuffer(Types.StringType.get(), dataFile.path())),
+                    Conversions.toByteBuffer(Types.StringType.get(), dataFile.location())),
                 ImmutableMap.of(
                     MetadataColumns.DELETE_FILE_PATH.fieldId(),
-                    Conversions.toByteBuffer(Types.StringType.get(), dataFile.path()))))
+                    Conversions.toByteBuffer(Types.StringType.get(), dataFile.location()))))
         .withEncryptionKeyMetadata(ByteBuffer.allocate(4).putInt(35))
         .build();
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -343,10 +343,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     // deleted.
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 0L), // id = 29
-            Pair.of(dataFile.path(), 1L), // id = 43
-            Pair.of(dataFile.path(), 2L), // id = 61
-            Pair.of(dataFile.path(), 3L) // id = 89
+            Pair.of(dataFile.location(), 0L), // id = 29
+            Pair.of(dataFile.location(), 1L), // id = 43
+            Pair.of(dataFile.location(), 2L), // id = 61
+            Pair.of(dataFile.location(), 3L) // id = 89
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -376,10 +376,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     // deleted.
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 0L), // id = 29
-            Pair.of(dataFile.path(), 1L), // id = 43
-            Pair.of(dataFile.path(), 2L), // id = 61
-            Pair.of(dataFile.path(), 3L) // id = 89
+            Pair.of(dataFile.location(), 0L), // id = 29
+            Pair.of(dataFile.location(), 1L), // id = 43
+            Pair.of(dataFile.location(), 2L), // id = 61
+            Pair.of(dataFile.location(), 3L) // id = 89
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -455,8 +455,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
 
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 3L), // id = 89
-            Pair.of(dataFile.path(), 5L) // id = 121
+            Pair.of(dataFile.location(), 3L), // id = 89
+            Pair.of(dataFile.location(), 5L) // id = 121
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -486,10 +486,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
   public void testFilterOnDeletedMetadataColumn() throws IOException {
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 0L), // id = 29
-            Pair.of(dataFile.path(), 1L), // id = 43
-            Pair.of(dataFile.path(), 2L), // id = 61
-            Pair.of(dataFile.path(), 3L) // id = 89
+            Pair.of(dataFile.location(), 0L), // id = 29
+            Pair.of(dataFile.location(), 1L), // id = 43
+            Pair.of(dataFile.location(), 2L), // id = 61
+            Pair.of(dataFile.location(), 3L) // id = 89
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -611,13 +611,13 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     // Add positional deletes to the table
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 97L),
-            Pair.of(dataFile.path(), 98L),
-            Pair.of(dataFile.path(), 99L),
-            Pair.of(dataFile.path(), 101L),
-            Pair.of(dataFile.path(), 103L),
-            Pair.of(dataFile.path(), 107L),
-            Pair.of(dataFile.path(), 109L));
+            Pair.of(dataFile.location(), 97L),
+            Pair.of(dataFile.location(), 98L),
+            Pair.of(dataFile.location(), 99L),
+            Pair.of(dataFile.location(), 101L),
+            Pair.of(dataFile.location(), 103L),
+            Pair.of(dataFile.location(), 107L),
+            Pair.of(dataFile.location(), 109L));
     Pair<DeleteFile, CharSequenceSet> posDeletes =
         FileHelpers.writeDeleteFile(
             table,


### PR DESCRIPTION
Same as #11550, but for Arrow/Data/Spark/Delta lake modules. Also missed some other call sites in API, Core in my prev PR so just fixed those up here as well. 