### PR TITLE
Spark: Fix changelog table bug for start time older than current snapshot

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
@@ -453,7 +453,6 @@ public class TestChangelogTable extends ExtensionsTestBase {
     // Verify no changes are returned since our window is after the inserts
     assertThat(results).as("Num records must be zero").isEmpty();
 
-
     // Clean up the changelog view
     sql("DROP VIEW IF EXISTS test_changelog_view");
   }

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
@@ -451,13 +451,6 @@ public class TestChangelogTable extends ExtensionsTestBase {
             "SELECT * FROM test_changelog_view WHERE _change_type IN ('INSERT', 'DELETE') ORDER BY _change_ordinal");
 
     // Verify no changes are returned since our window is after the inserts
-    // TODO: this currently fails here and returns all 4 records but should be 0 records
-    // TODO: becasue the records are not in the time range but prior to range
-    //    java.lang.AssertionError: [Num records must be zero]
-    //    Expecting empty but was: [[1, "a", "INSERT", 0, 1369318112747935444L],
-    //        [2, "b", "INSERT", 1, 8560714774500713640L],
-    //        [3, "c", "INSERT", 2, 7302500464847668500L],
-    //        [4, "d", "INSERT", 3, 7807948732874377651L]]
     assertThat(results).as("Num records must be zero").isEmpty();
 
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -562,7 +562,7 @@ public class SparkScanBuilder
     boolean emptyScan = false;
     if (startTimestamp != null) {
       if (table.currentSnapshot() != null
-              && table.currentSnapshot().timestampMillis() < startTimestamp) {
+          && table.currentSnapshot().timestampMillis() < startTimestamp) {
         emptyScan = true;
       }
       startSnapshotId = getStartSnapshotId(startTimestamp);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -560,11 +560,13 @@ public class SparkScanBuilder
     }
 
     boolean emptyScan = false;
+
     if (startTimestamp != null) {
+      boolean isBeforeCurrentSnapshot = table.currentSnapshot().timestampMillis() < startTimestamp;
       startSnapshotId = getStartSnapshotId(startTimestamp);
-      if (startSnapshotId == null && endTimestamp == null) {
-        emptyScan = true;
-      }
+      boolean hasNoValidStartSnapshot = startSnapshotId == null && endTimestamp == null;
+
+      emptyScan = isBeforeCurrentSnapshot || hasNoValidStartSnapshot;
     }
 
     if (endTimestamp != null) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -560,13 +560,15 @@ public class SparkScanBuilder
     }
 
     boolean emptyScan = false;
-
     if (startTimestamp != null) {
-      boolean isBeforeCurrentSnapshot = table.currentSnapshot().timestampMillis() < startTimestamp;
+      if (table.currentSnapshot() != null
+              && table.currentSnapshot().timestampMillis() < startTimestamp) {
+        emptyScan = true;
+      }
       startSnapshotId = getStartSnapshotId(startTimestamp);
-      boolean hasNoValidStartSnapshot = startSnapshotId == null && endTimestamp == null;
-
-      emptyScan = isBeforeCurrentSnapshot || hasNoValidStartSnapshot;
+      if (startSnapshotId == null && endTimestamp == null) {
+        emptyScan = true;
+      }
     }
 
     if (endTimestamp != null) {


### PR DESCRIPTION
# Add unit test for create_changelog_view time range behavior

## Problem
After upgrading to Iceberg 1.5 and Spark 3.5.1, the `create_changelog_view` procedure occasionally returns records that were inserted outside (before) the specified time range. Specifically:

- When querying for recent changes (e.g. last 10 minutes)
- The view sometimes includes records from 3-5 hours ago
- Re-running the same query returns the expected 0 records
- This inconsistency wasn't present in Iceberg 1.3

## Changes
Added a unit test `testChangelogViewOutsideTimeRange` to `TestChangelogTable` that:

1. Inserts test records into the table
2. Waits for a time period to ensure those records are "old"
3. Creates a changelog view with a time range that starts *after* the inserts
4. Verifies the view returns 0 records (expected behavior)
5. The test helps validate that records outside the specified time window are not incorrectly included

## Testing
- Added unit test directly targeting the time range filtering behavior
- Test runs as part of the existing TestChangelogTable suite
- Follows existing test patterns and conventions

To invoke the unit test:
`./gradlew :iceberg-spark:iceberg-spark-extensions-3.5_2.12:test --tests "org.apache.iceberg.spark.extensions.TestChangelogTable"`

## Related Issue
TBD

## Additional Context
- This test was added to help investigate reported production issues where changelog views were inconsistently including historical records
- The test provides a reproducible way to verify time range filtering behavior
- @flyrain discussed this on this thread in slack: https://apache-iceberg.slack.com/archives/C025PH0G1D4/p1728070484459789