### PR TITLE
Bugfix for incorrect Deletion of Snapshot Metadata Due to OutOfMemoryError

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -292,6 +292,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
             database,
             tableName,
             e);
+        commitStatus = BaseMetastoreOperations.CommitStatus.UNKNOWN;
         commitStatus =
             BaseMetastoreOperations.CommitStatus.valueOf(
                 checkCommitStatus(newMetadataLocation, metadata).name());

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.iceberg.BaseMetastoreOperations;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ClientPool;
@@ -226,6 +227,7 @@ final class HiveViewOperations extends BaseViewOperations implements HiveOperati
             database,
             viewName,
             e);
+        commitStatus = BaseMetastoreOperations.CommitStatus.UNKNOWN;
         commitStatus =
             checkCommitStatus(
                 viewName,

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.hive;
 import static org.apache.iceberg.TableProperties.HIVE_LOCK_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
@@ -44,6 +45,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.apache.thrift.TException;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.support.ReflectionSupport;
 
 public class TestHiveCommits extends HiveTableBaseTest {
 
@@ -388,6 +390,59 @@ public class TestHiveCommits extends HiveTableBaseTest {
     assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .hasMessageContaining("Failed to heartbeat for hive lock while")
         .isInstanceOf(CommitStateUnknownException.class);
+
+    ops.refresh();
+
+    assertThat(ops.current().location())
+        .as("Current metadata should have changed to metadata V1")
+        .isEqualTo(metadataV1.location());
+    assertThat(metadataFileExists(ops.current()))
+        .as("Current metadata file should still exist")
+        .isTrue();
+  }
+
+  @Test
+  public void testSuccessCommitWhenCheckCommitStatusOOM() throws TException, InterruptedException {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+
+    TableMetadata metadataV1 = ops.current();
+
+    table.updateSchema().addColumn("n", Types.IntegerType.get()).commit();
+
+    ops.refresh();
+
+    TableMetadata metadataV2 = ops.current();
+
+    assertThat(ops.current().schema().columns()).hasSize(2);
+
+    HiveTableOperations spyOps = spy(ops);
+
+    // Simulate a communication error after a successful commit
+    doAnswer(
+            i -> {
+              org.apache.hadoop.hive.metastore.api.Table tbl =
+                  i.getArgument(0, org.apache.hadoop.hive.metastore.api.Table.class);
+              String location = i.getArgument(2, String.class);
+              ops.persistTable(tbl, true, location);
+              throw new UnknownError();
+            })
+        .when(spyOps)
+        .persistTable(any(), anyBoolean(), any());
+    try {
+      ReflectionSupport.invokeMethod(
+          ops.getClass()
+              .getSuperclass()
+              .getDeclaredMethod("checkCommitStatus", String.class, TableMetadata.class),
+          doThrow(new OutOfMemoryError()).when(spyOps),
+          anyString(),
+          any());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+        .isInstanceOf(OutOfMemoryError.class);
 
     ops.refresh();
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.hive;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
@@ -31,8 +32,10 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
@@ -53,6 +56,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.platform.commons.support.ReflectionSupport;
 
 /** Test Hive locks and Hive errors and retry during commits. */
 public class TestHiveViewCommits {
@@ -422,6 +426,60 @@ public class TestHiveViewCommits {
     assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
         .hasMessageContaining("Failed to heartbeat for hive lock while")
         .isInstanceOf(CommitStateUnknownException.class);
+
+    ops.refresh();
+
+    assertThat(metadataV2.location())
+        .as("Current metadata should have changed to metadata V1")
+        .isEqualTo(metadataV1.location());
+    assertThat(metadataFileExists(metadataV2))
+        .as("Current metadata file should still exist")
+        .isTrue();
+    assertThat(metadataFileCount(metadataV2)).as("New metadata file should exist").isEqualTo(2);
+  }
+
+  @Test
+  public void testSuccessCommitWhenCheckCommitStatusOOM() throws TException, InterruptedException {
+    HiveViewOperations ops = (HiveViewOperations) ((BaseView) view).operations();
+    ViewMetadata metadataV1 = ops.current();
+    assertThat(metadataV1.properties()).hasSize(0);
+
+    view.updateProperties().set("k1", "v1").commit();
+    ops.refresh();
+    ViewMetadata metadataV2 = ops.current();
+    assertThat(metadataV2.properties()).hasSize(1).containsEntry("k1", "v1");
+
+    HiveViewOperations spyOps = spy(ops);
+
+    // Simulate a communication error after a successful commit
+    doAnswer(
+            i -> {
+              org.apache.hadoop.hive.metastore.api.Table tbl =
+                  i.getArgument(0, org.apache.hadoop.hive.metastore.api.Table.class);
+              String location = i.getArgument(2, String.class);
+              ops.persistTable(tbl, true, location);
+              throw new UnknownError();
+            })
+        .when(spyOps)
+        .persistTable(any(), anyBoolean(), any());
+    try {
+      ReflectionSupport.invokeMethod(
+          ops.getClass()
+              .getSuperclass()
+              .getSuperclass()
+              .getDeclaredMethod(
+                  "checkCommitStatus", String.class, String.class, Map.class, Supplier.class),
+          doThrow(new OutOfMemoryError()).when(spyOps),
+          anyString(),
+          anyString(),
+          any(),
+          any());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+        .isInstanceOf(OutOfMemoryError.class);
 
     ops.refresh();
 


### PR DESCRIPTION
bugfix for #11575 
Fixed the problem of mistakenly deleting table snapshot metadata file in the event of unexpected errors, like OutOfMemoryError, during the checkCommitStatus method execution.
While the org.apache.iceberg.hive.HiveViewOperations.checkCurrentMetadataLocation method performs a refresh operation to download and update the current table metadata, this action consumes memory. 
To address this, we now set the commit status to UNKNOWN before checking the commit status, thus preventing inadvertent deletion of snapshot metadata files.