### PR TITLE
Hive3: Fix tests not running

### DIFF
--- a/hive3/build.gradle
+++ b/hive3/build.gradle
@@ -27,8 +27,9 @@ project(':iceberg-hive3') {
     }
   }
 
-  // exclude these Hive2-specific tests from iceberg-mr
   test {
+    useJUnitPlatform()
+    // exclude these Hive2-specific tests from iceberg-mr
     exclude '**/TestIcebergDateObjectInspector.class'
     exclude '**/TestIcebergTimestampObjectInspector.class'
     exclude '**/TestIcebergTimestampWithZoneObjectInspector.class'


### PR DESCRIPTION
This fix actually exposes test failure due to [Hive 3 not supporting JDK 11+](https://issues.apache.org/jira/browse/HIVE-21584).

cc @pvary @nastra @Fokko 