### PR TITLE
Core,Format: Deprecate embedded manifests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -73,6 +73,12 @@ class BaseSnapshot implements Snapshot {
     this.v1ManifestLocations = null;
   }
 
+  /**
+   * Constructor with embedded manifests
+   *
+   * @deprecated since 1.8.0, will be removed 1.9.0 or 2.0.0
+   */
+  @Deprecated
   BaseSnapshot(
       long sequenceNumber,
       long snapshotId,

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -76,7 +76,7 @@ class BaseSnapshot implements Snapshot {
   /**
    * Constructor with embedded manifests
    *
-   * @deprecated since 1.8.0, will be removed 1.9.0 or 2.0.0
+   * @deprecated since 1.8.0, will be removed 2.0.0
    */
   @Deprecated
   BaseSnapshot(

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -85,7 +85,7 @@ public class SnapshotParser {
       generator.writeStringField(MANIFEST_LIST, manifestList);
     } else {
       LOG.warn(
-          "Support for embedded manifests are deprecated since Iceberg 1.8.0, will be removed in either 1.9.0 or 2.0.0");
+          "Support for embedded manifests are deprecated since Iceberg 1.8.0, will be removed in 2.0.0");
 
       // embed the manifest list in the JSON, v1 only
       JsonUtil.writeStringArray(
@@ -165,7 +165,7 @@ public class SnapshotParser {
 
     } else {
       LOG.warn(
-          "Support for embedded manifests are deprecated since Iceberg 1.8.0, will be removed in either 1.9.0 or 2.0.0");
+          "Support for embedded manifests are deprecated since Iceberg 1.8.0, will be removed in 2.0.0");
 
       // fall back to an embedded manifest list. pass in the manifest's InputFile so length can be
       // loaded lazily, if it is needed

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -31,8 +31,11 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.util.JsonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SnapshotParser {
+  private static final Logger LOG = LoggerFactory.getLogger(SnapshotParser.class);
 
   private SnapshotParser() {}
 
@@ -81,6 +84,9 @@ public class SnapshotParser {
       // write just the location. manifests should not be embedded in JSON along with a list
       generator.writeStringField(MANIFEST_LIST, manifestList);
     } else {
+      LOG.warn(
+          "Support for embedded manifests are deprecated since Iceberg 1.8.0, will be removed in either 1.9.0 or 2.0.0");
+
       // embed the manifest list in the JSON, v1 only
       JsonUtil.writeStringArray(
           MANIFESTS,
@@ -158,6 +164,9 @@ public class SnapshotParser {
           manifestList);
 
     } else {
+      LOG.warn(
+          "Support for embedded manifests are deprecated since Iceberg 1.8.0, will be removed in either 1.9.0 or 2.0.0");
+
       // fall back to an embedded manifest list. pass in the manifest's InputFile so length can be
       // loaded lazily, if it is needed
       return new BaseSnapshot(

--- a/format/spec.md
+++ b/format/spec.md
@@ -654,17 +654,17 @@ The `first_row_id` is only inherited for added data files. The inherited value m
 
 A snapshot consists of the following fields:
 
-| v1         | v2         | v3         | Field                        | Description                                                                                                                        |
-| ---------- | ---------- |------------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| _required_ | _required_ | _required_ | **`snapshot-id`**            | A unique long ID                                                                                                                   |
-| _optional_ | _optional_ | _optional_ | **`parent-snapshot-id`**     | The snapshot ID of the snapshot's parent. Omitted for any snapshot with no parent                                                  |
-|            | _required_ | _required_ | **`sequence-number`**        | A monotonically increasing long that tracks the order of changes to a table                                                        |
-| _required_ | _required_ | _required_ | **`timestamp-ms`**           | A timestamp when the snapshot was created, used for garbage collection and table inspection                                        |
-| _optional_ | _required_ | _required_ | **`manifest-list`**          | The location of a manifest list for this snapshot that tracks manifest files with additional metadata                              |
-| _optional_ |            |            | **`manifests`**              | A list of manifest file locations. Must be omitted if `manifest-list` is present                                                   |
-| _optional_ | _required_ | _required_ | **`summary`**                | A string map that summarizes the snapshot changes, including `operation` as a _required_ field (see below)                         |
-| _optional_ | _optional_ | _optional_ | **`schema-id`**              | ID of the table's current schema when the snapshot was created                                                                     |
-|            |            | _optional_ | **`first-row-id`**           | The first `_row_id` assigned to the first row in the first data file in the first manifest, see [Row Lineage](#row-lineage) |
+| v1         | v2         | v3         | Field                        | Description                                                                                                                         |
+| ---------- | ---------- |------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| _required_ | _required_ | _required_ | **`snapshot-id`**            | A unique long ID                                                                                                                    |
+| _optional_ | _optional_ | _optional_ | **`parent-snapshot-id`**     | The snapshot ID of the snapshot's parent. Omitted for any snapshot with no parent                                                   |
+|            | _required_ | _required_ | **`sequence-number`**        | A monotonically increasing long that tracks the order of changes to a table                                                         |
+| _required_ | _required_ | _required_ | **`timestamp-ms`**           | A timestamp when the snapshot was created, used for garbage collection and table inspection                                         |
+| _optional_ | _required_ | _required_ | **`manifest-list`**          | The location of a manifest list for this snapshot that tracks manifest files with additional metadata                               |
+| _optional_ |            |            | ~~**`manifests`**~~          | ~~A list of manifest file locations. Must be omitted if `manifest-list` is present.~~ (**Deprecated**: use `manifest-list` instead) |
+| _optional_ | _required_ | _required_ | **`summary`**                | A string map that summarizes the snapshot changes, including `operation` as a _required_ field (see below)                          |
+| _optional_ | _optional_ | _optional_ | **`schema-id`**              | ID of the table's current schema when the snapshot was created                                                                      |
+|            |            | _optional_ | **`first-row-id`**           | The first `_row_id` assigned to the first row in the first data file in the first manifest, see [Row Lineage](#row-lineage)         |
 
 The snapshot summary's `operation` field is used by some operations, like snapshot expiration, to skip processing certain snapshots. Possible `operation` values are:
 


### PR DESCRIPTION
The embedded manifests are not used outside of the company where Iceberg found its inception. I think it is a good thing to officially deprecate this field, and be able to remove the `DummyFileIO` from the Java codebase at some point.