### PR TITLE
Kafka Connect: Add config to prefix the control consumer group

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -77,7 +77,7 @@ for exactly-once semantics. This requires Kafka 2.5 or later.
 | iceberg.table.\<table name\>.partition-by  | Comma-separated list of partition fields to use when creating the table                                          |
 | iceberg.table.\<table name\>.route-regex   | The regex used to match a record's `routeField` to a table                                                       |
 | iceberg.control.topic                      | Name of the control topic, default is `control-iceberg`                                                          |
-| iceberg.control.group-id-prefix            | Prefix for the control consuler group, default is `cg-control`                                                   |
+| iceberg.control.consumer-group-id-prefix   | Prefix for the control consumer group, default is `cg-control`                                                   |
 | iceberg.control.commit.interval-ms         | Commit interval in msec, default is 300,000 (5 min)                                                              |
 | iceberg.control.commit.timeout-ms          | Commit timeout interval in msec, default is 30,000 (30 sec)                                                      |
 | iceberg.control.commit.threads             | Number of threads to use for commits, default is (cores * 2)                                                     |

--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -77,7 +77,7 @@ for exactly-once semantics. This requires Kafka 2.5 or later.
 | iceberg.table.\<table name\>.partition-by  | Comma-separated list of partition fields to use when creating the table                                          |
 | iceberg.table.\<table name\>.route-regex   | The regex used to match a record's `routeField` to a table                                                       |
 | iceberg.control.topic                      | Name of the control topic, default is `control-iceberg`                                                          |
-| iceberg.control.consumer-group-id-prefix   | Prefix for the control consumer group, default is `cg-control`                                                   |
+| iceberg.control.group-id-prefix            | Prefix for the control consumer group, default is `cg-control`                                                   |
 | iceberg.control.commit.interval-ms         | Commit interval in msec, default is 300,000 (5 min)                                                              |
 | iceberg.control.commit.timeout-ms          | Commit timeout interval in msec, default is 30,000 (30 sec)                                                      |
 | iceberg.control.commit.threads             | Number of threads to use for commits, default is (cores * 2)                                                     |

--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -77,6 +77,7 @@ for exactly-once semantics. This requires Kafka 2.5 or later.
 | iceberg.table.\<table name\>.partition-by  | Comma-separated list of partition fields to use when creating the table                                          |
 | iceberg.table.\<table name\>.route-regex   | The regex used to match a record's `routeField` to a table                                                       |
 | iceberg.control.topic                      | Name of the control topic, default is `control-iceberg`                                                          |
+| iceberg.control.group-id-prefix            | Prefix for the control consuler group, default is `cg-control`                                                   |
 | iceberg.control.commit.interval-ms         | Commit interval in msec, default is 300,000 (5 min)                                                              |
 | iceberg.control.commit.timeout-ms          | Commit timeout interval in msec, default is 30,000 (30 sec)                                                      |
 | iceberg.control.commit.threads             | Number of threads to use for commits, default is (cores * 2)                                                     |

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -182,11 +182,11 @@ public class IcebergSinkConfig extends AbstractConfig {
         Importance.MEDIUM,
         "Name of the control topic");
     configDef.define(
-            CONTROL_GROUP_ID_PREFIX_PROP,
-            ConfigDef.Type.STRING,
-            DEFAULT_CONTROL_GROUP_PREFIX,
-            Importance.LOW,
-            "Prefix of the control consumer group");
+        CONTROL_GROUP_ID_PREFIX_PROP,
+        ConfigDef.Type.STRING,
+        DEFAULT_CONTROL_GROUP_PREFIX,
+        Importance.LOW,
+        "Prefix of the control consumer group");
     configDef.define(
         CONNECT_GROUP_ID_PROP,
         ConfigDef.Type.STRING,
@@ -367,7 +367,8 @@ public class IcebergSinkConfig extends AbstractConfig {
   }
 
   public String controlGroupIdPrefix() {
-    return getString(CONTROL_GROUP_ID_PREFIX_PROP); }
+    return getString(CONTROL_GROUP_ID_PREFIX_PROP);
+  }
 
   public String connectGroupId() {
     String result = getString(CONNECT_GROUP_ID_PROP);

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -80,7 +80,7 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String TABLES_SCHEMA_CASE_INSENSITIVE_PROP =
       "iceberg.tables.schema-case-insensitive";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
-  private static final String CONTROL_GROUP_ID_PREFIX_PROP = "iceberg.control.consumer-group-id-prefix";
+  private static final String CONTROL_GROUP_ID_PREFIX_PROP = "iceberg.control.group-id-prefix";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
   private static final int COMMIT_INTERVAL_MS_DEFAULT = 300_000;
   private static final String COMMIT_TIMEOUT_MS_PROP = "iceberg.control.commit.timeout-ms";
@@ -186,7 +186,7 @@ public class IcebergSinkConfig extends AbstractConfig {
             ConfigDef.Type.STRING,
             DEFAULT_CONTROL_GROUP_PREFIX,
             Importance.LOW,
-            "Prefix of the control consumer group, should not be set under normal conditions");
+            "Prefix of the control consumer group");
     configDef.define(
         CONNECT_GROUP_ID_PROP,
         ConfigDef.Type.STRING,
@@ -366,7 +366,7 @@ public class IcebergSinkConfig extends AbstractConfig {
     return getString(CONTROL_TOPIC_PROP);
   }
 
-  public String prefixControlConsumerGroup() {
+  public String controlGroupIdPrefix() {
     return getString(CONTROL_GROUP_ID_PREFIX_PROP); }
 
   public String connectGroupId() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -80,6 +80,7 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String TABLES_SCHEMA_CASE_INSENSITIVE_PROP =
       "iceberg.tables.schema-case-insensitive";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
+  private static final String CONTROL_GROUP_PREFIX_PROP = "iceberg.control.group-id-prefix";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
   private static final int COMMIT_INTERVAL_MS_DEFAULT = 300_000;
   private static final String COMMIT_TIMEOUT_MS_PROP = "iceberg.control.commit.timeout-ms";
@@ -180,6 +181,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         DEFAULT_CONTROL_TOPIC,
         Importance.MEDIUM,
         "Name of the control topic");
+    configDef.define(
+            CONTROL_GROUP_PREFIX_PROP,
+            ConfigDef.Type.STRING,
+            DEFAULT_CONTROL_GROUP_PREFIX,
+            Importance.LOW,
+            "Prefix of the control consumer group, should not be set under normal conditions");
     configDef.define(
         CONNECT_GROUP_ID_PROP,
         ConfigDef.Type.STRING,
@@ -358,6 +365,9 @@ public class IcebergSinkConfig extends AbstractConfig {
   public String controlTopic() {
     return getString(CONTROL_TOPIC_PROP);
   }
+
+  public String prefixControlGroup() {
+    return getString(CONTROL_GROUP_PREFIX_PROP); }
 
   public String connectGroupId() {
     String result = getString(CONNECT_GROUP_ID_PROP);

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -80,7 +80,7 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String TABLES_SCHEMA_CASE_INSENSITIVE_PROP =
       "iceberg.tables.schema-case-insensitive";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
-  private static final String CONTROL_GROUP_PREFIX_PROP = "iceberg.control.group-id-prefix";
+  private static final String CONTROL_GROUP_ID_PREFIX_PROP = "iceberg.control.consumer-group-id-prefix";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
   private static final int COMMIT_INTERVAL_MS_DEFAULT = 300_000;
   private static final String COMMIT_TIMEOUT_MS_PROP = "iceberg.control.commit.timeout-ms";
@@ -182,7 +182,7 @@ public class IcebergSinkConfig extends AbstractConfig {
         Importance.MEDIUM,
         "Name of the control topic");
     configDef.define(
-            CONTROL_GROUP_PREFIX_PROP,
+            CONTROL_GROUP_ID_PREFIX_PROP,
             ConfigDef.Type.STRING,
             DEFAULT_CONTROL_GROUP_PREFIX,
             Importance.LOW,
@@ -366,8 +366,8 @@ public class IcebergSinkConfig extends AbstractConfig {
     return getString(CONTROL_TOPIC_PROP);
   }
 
-  public String prefixControlGroup() {
-    return getString(CONTROL_GROUP_PREFIX_PROP); }
+  public String prefixControlConsumerGroup() {
+    return getString(CONTROL_GROUP_ID_PREFIX_PROP); }
 
   public String connectGroupId() {
     String result = getString(CONNECT_GROUP_ID_PROP);

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -51,7 +51,7 @@ class Worker extends Channel {
     // pass transient consumer group ID to which we never commit offsets
     super(
         "worker",
-        IcebergSinkConfig.DEFAULT_CONTROL_GROUP_PREFIX + UUID.randomUUID(),
+        config.prefixControlGroup() + UUID.randomUUID(),
         config,
         clientFactory,
         context);

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -51,7 +51,7 @@ class Worker extends Channel {
     // pass transient consumer group ID to which we never commit offsets
     super(
         "worker",
-        config.prefixControlGroup() + UUID.randomUUID(),
+        config.prefixControlConsumerGroup() + UUID.randomUUID(),
         config,
         clientFactory,
         context);

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -51,7 +51,7 @@ class Worker extends Channel {
     // pass transient consumer group ID to which we never commit offsets
     super(
         "worker",
-        config.prefixControlConsumerGroup() + UUID.randomUUID(),
+        config.controlGroupIdPrefix() + UUID.randomUUID(),
         config,
         clientFactory,
         context);


### PR DESCRIPTION
I would like to control the name of the control consumer group to have more fine grained accesses when deploying the Iceberg Sink connector on my infrastructure. 

This PR aims to replace the DEFAULT_CONTROL_GROUP_PREFIX by a configurable variable