### PR TITLE
Docs: add iceberg-go to doc site

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -79,3 +79,4 @@ nav:
   - Javadoc: ../../javadoc/latest/
   - PyIceberg: https://py.iceberg.apache.org/
   - IcebergRust: https://rust.iceberg.apache.org/
+  - IcebergGo: https://pkg.go.dev/github.com/apache/iceberg-go/


### PR DESCRIPTION
Add a link to the Documentation for the Golang implementation of Iceberg for the iceberg.apache.org website.