### PR TITLE
Spark : Derive Stats From Manifest on the Fly

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -388,4 +388,8 @@ public class TableProperties {
   public static final int ENCRYPTION_DEK_LENGTH_DEFAULT = 16;
 
   public static final int ENCRYPTION_AAD_LENGTH_DEFAULT = 16;
+
+  public static final String DERIVE_STATS_FROM_MANIFEST_ENABLED =
+      "derive-stats-from-manifest-enabled";
+  public static final boolean DERIVE_STATS_FROM_MANIFEST_ENABLED_DEFAULT = false;
 }

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -389,7 +389,7 @@ public class TableProperties {
 
   public static final int ENCRYPTION_AAD_LENGTH_DEFAULT = 16;
 
-  public static final String DERIVE_STATS_FROM_MANIFEST_ENABLED =
-      "derive-stats-from-manifest-enabled";
-  public static final boolean DERIVE_STATS_FROM_MANIFEST_ENABLED_DEFAULT = false;
+  public static final String SPARK_DERIVE_STATS_FROM_MANIFEST_ENABLED =
+      "spark.derive-stats-from-manifest-enabled";
+  public static final boolean SPARK_DERIVE_STATS_FROM_MANIFEST_ENABLED_DEFAULT = false;
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -355,4 +355,21 @@ public class SparkReadConf {
         .defaultValue(SparkSQLProperties.REPORT_COLUMN_STATS_DEFAULT)
         .parse();
   }
+
+  public boolean deriveStatsFromManifestSessionConf() {
+    return confParser
+        .booleanConf()
+        .sessionConf(SparkSQLProperties.DERIVE_STATS_FROM_MANIFEST_ENABLED)
+        .defaultValue(SparkSQLProperties.DERIVE_STATS_FROM_MANIFEST_ENABLED_DEFAULT)
+        .parse();
+  }
+
+  public boolean deriveStatsFromManifestTableProperty() {
+    return confParser
+        .booleanConf()
+        .option(SparkReadOptions.DERIVE_STATS_FROM_MANIFEST_ENABLED)
+        .tableProperty(TableProperties.DERIVE_STATS_FROM_MANIFEST_ENABLED)
+        .defaultValue(TableProperties.DERIVE_STATS_FROM_MANIFEST_ENABLED_DEFAULT)
+        .parse();
+  }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -356,20 +356,13 @@ public class SparkReadConf {
         .parse();
   }
 
-  public boolean deriveStatsFromManifestSessionConf() {
+  public boolean deriveStatsFromManifestOnFly() {
     return confParser
         .booleanConf()
         .sessionConf(SparkSQLProperties.DERIVE_STATS_FROM_MANIFEST_ENABLED)
-        .defaultValue(SparkSQLProperties.DERIVE_STATS_FROM_MANIFEST_ENABLED_DEFAULT)
-        .parse();
-  }
-
-  public boolean deriveStatsFromManifestTableProperty() {
-    return confParser
-        .booleanConf()
         .option(SparkReadOptions.DERIVE_STATS_FROM_MANIFEST_ENABLED)
-        .tableProperty(TableProperties.DERIVE_STATS_FROM_MANIFEST_ENABLED)
-        .defaultValue(TableProperties.DERIVE_STATS_FROM_MANIFEST_ENABLED_DEFAULT)
+        .tableProperty(TableProperties.SPARK_DERIVE_STATS_FROM_MANIFEST_ENABLED)
+        .defaultValue(TableProperties.SPARK_DERIVE_STATS_FROM_MANIFEST_ENABLED_DEFAULT)
         .parse();
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -95,4 +95,7 @@ public class SparkReadOptions {
   public static final String TIMESTAMP_AS_OF = "timestampAsOf";
 
   public static final String AGGREGATE_PUSH_DOWN_ENABLED = "aggregate-push-down-enabled";
+
+  public static final String DERIVE_STATS_FROM_MANIFEST_ENABLED =
+      "derive-stats-from-manifest-enabled";
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -98,4 +98,9 @@ public class SparkSQLProperties {
   // Controls whether to report available column statistics to Spark for query optimization.
   public static final String REPORT_COLUMN_STATS = "spark.sql.iceberg.report-column-stats";
   public static final boolean REPORT_COLUMN_STATS_DEFAULT = true;
+
+  // Controls whether to enable flag for onFly Collection of nullCount.
+  public static final String DERIVE_STATS_FROM_MANIFEST_ENABLED =
+      "spark.sql.iceberg.derive-stats-from-manifest-enabled";
+  public static final boolean DERIVE_STATS_FROM_MANIFEST_ENABLED_DEFAULT = false;
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -99,7 +99,7 @@ public class SparkSQLProperties {
   public static final String REPORT_COLUMN_STATS = "spark.sql.iceberg.report-column-stats";
   public static final boolean REPORT_COLUMN_STATS_DEFAULT = true;
 
-  // Controls whether to enable flag for onFly Collection of nullCount.
+  // Controls whether to enable flag for deriving stats on the fly from manifest.
   public static final String DERIVE_STATS_FROM_MANIFEST_ENABLED =
       "spark.sql.iceberg.derive-stats-from-manifest-enabled";
   public static final boolean DERIVE_STATS_FROM_MANIFEST_ENABLED_DEFAULT = false;


### PR DESCRIPTION
This PR helps to derives min,max,numOfNulls Statistics on the fly from manifest files to report back them to Spark.

Currently only Ndv is calculated and reported back to Spark Engine, which leads to [inaccurate plans](https://github.com/apache/iceberg/pull/10659#issuecomment-2252176015) in Spark side since min,max,nullCount are returned as NULL 

As there is a discussion still going on whether to store stats partition level or table level, even if we calculate them in either ways there would be an issue as per this [comment](https://github.com/apache/iceberg/issues/10791#issuecomment-2326424328) in discussion #10791

These changes helps to enable the onFly collection of the stats using a table property or a session conf(by default it's false)

cc @guykhazma @jeesou 
