### PR TITLE
Core: Add TableUtil to provide access to a table's format version

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableUtil.java
+++ b/core/src/main/java/org/apache/iceberg/TableUtil.java
@@ -29,8 +29,10 @@ public class TableUtil {
 
     // SerializableMetadataTable is a subclass of SerializableTable but does not support
     // operations()
-    if (table instanceof HasTableOperations
-        && !(table instanceof SerializableTable.SerializableMetadataTable)) {
+    if (table instanceof SerializableTable) {
+      SerializableTable serializableTable = (SerializableTable) table;
+      return serializableTable.formatVersion();
+    } else if (table instanceof HasTableOperations) {
       return ((HasTableOperations) table).operations().current().formatVersion();
     } else {
       throw new IllegalArgumentException(

--- a/core/src/main/java/org/apache/iceberg/TableUtil.java
+++ b/core/src/main/java/org/apache/iceberg/TableUtil.java
@@ -27,13 +27,12 @@ public class TableUtil {
   public static int formatVersion(Table table) {
     Preconditions.checkArgument(null != table, "Invalid table: null");
 
-    // SerializableMetadataTable is a subclass of SerializableTable but does not support
-    // operations()
     if (table instanceof SerializableTable) {
       SerializableTable serializableTable = (SerializableTable) table;
       return serializableTable.formatVersion();
     } else if (table instanceof HasTableOperations) {
-      return ((HasTableOperations) table).operations().current().formatVersion();
+      HasTableOperations ops = (HasTableOperations) table;
+      return ops.operations().current().formatVersion();
     } else {
       throw new IllegalArgumentException(
           String.format("%s does not have a format version", table.getClass().getSimpleName()));

--- a/core/src/main/java/org/apache/iceberg/TableUtil.java
+++ b/core/src/main/java/org/apache/iceberg/TableUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class TableUtil {
+  private TableUtil() {}
+
+  /** Returns the format version of the given table */
+  public static int formatVersion(Table table) {
+    Preconditions.checkArgument(null != table, "Invalid table: null");
+
+    // SerializableMetadataTable is a subclass of SerializableTable but does not support
+    // operations()
+    if (table instanceof HasTableOperations
+        && !(table instanceof SerializableTable.SerializableMetadataTable)) {
+      return ((HasTableOperations) table).operations().current().formatVersion();
+    } else {
+      throw new IllegalArgumentException(
+          String.format("%s does not have a format version", table.getClass().getSimpleName()));
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestTableUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableUtil.java
@@ -83,10 +83,10 @@ public class TestTableUtil {
               "%s does not have a format version", metadataTable.getClass().getSimpleName());
 
       assertThatThrownBy(() -> TableUtil.formatVersion(SerializableTable.copyOf(metadataTable)))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(UnsupportedOperationException.class)
           .hasMessage(
               "%s does not have a format version",
-              SerializableTable.SerializableMetadataTable.class.getSimpleName());
+              SerializableTable.SerializableMetadataTable.class.getName());
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTableUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableUtil.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TestTableUtil {
+  private static final Namespace NS = Namespace.of("ns");
+  private static final TableIdentifier IDENTIFIER = TableIdentifier.of(NS, "test");
+
+  @TempDir private File tmp;
+
+  private InMemoryCatalog catalog;
+
+  @BeforeEach
+  public void initCatalog() {
+    catalog = new InMemoryCatalog();
+    catalog.initialize("catalog", ImmutableMap.of());
+    catalog.createNamespace(NS);
+  }
+
+  @Test
+  public void nullTable() {
+    assertThatThrownBy(() -> TableUtil.formatVersion(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid table: null");
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3})
+  public void formatVersionForBaseTable(int formatVersion) {
+    Table table =
+        catalog.createTable(
+            IDENTIFIER,
+            new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get())),
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)));
+
+    assertThat(TableUtil.formatVersion(table)).isEqualTo(formatVersion);
+    assertThat(TableUtil.formatVersion(SerializableTable.copyOf(table))).isEqualTo(formatVersion);
+  }
+
+  @Test
+  public void formatVersionForMetadataTables() {
+    Table table =
+        catalog.createTable(
+            IDENTIFIER, new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get())));
+
+    for (MetadataTableType type : MetadataTableType.values()) {
+      Table metadataTable = MetadataTableUtils.createMetadataTableInstance(table, type);
+      assertThatThrownBy(() -> TableUtil.formatVersion(metadataTable))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(
+              "%s does not have a format version", metadataTable.getClass().getSimpleName());
+
+      assertThatThrownBy(() -> TableUtil.formatVersion(SerializableTable.copyOf(metadataTable)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(
+              "%s does not have a format version",
+              SerializableTable.SerializableMetadataTable.class.getSimpleName());
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdatePartitionSpec;
@@ -1282,9 +1283,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
             .withPartitionSpec(SPEC)
             .withProperty("format-version", "2")
             .create();
-    assertThat(((BaseTable) table).operations().current().formatVersion())
-        .as("Should be a v2 table")
-        .isEqualTo(2);
+    assertThat(TableUtil.formatVersion(table)).as("Should be a v2 table").isEqualTo(2);
 
     table.updateSpec().addField("id").commit();
 
@@ -2519,7 +2518,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {1, 2})
+  @ValueSource(ints = {1, 2, 3})
   public void createTableTransaction(int formatVersion) {
     if (requiresNamespaceCreate()) {
       catalog().createNamespace(NS);
@@ -2533,8 +2532,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
             ImmutableMap.of("format-version", String.valueOf(formatVersion)))
         .commitTransaction();
 
-    BaseTable table = (BaseTable) catalog().loadTable(TABLE);
-    assertThat(table.operations().current().formatVersion()).isEqualTo(formatVersion);
+    assertThat(TableUtil.formatVersion(catalog().loadTable(TABLE))).isEqualTo(formatVersion);
   }
 
   @ParameterizedTest

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
@@ -109,7 +109,7 @@ public class TestTableSerialization extends HadoopTableTestBase {
           .isInstanceOf(UnsupportedOperationException.class)
           .hasMessageEndingWith("does not support operations()");
       assertThatThrownBy(() -> TableUtil.formatVersion(serializableTable))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(UnsupportedOperationException.class)
           .hasMessageEndingWith("does not have a format version");
     }
   }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.StaticTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.io.CloseableIterable;
@@ -67,6 +68,7 @@ public class TestTableSerialization extends HadoopTableTestBase {
     assertThat(serializableTable).isInstanceOf(HasTableOperations.class);
     assertThat(((HasTableOperations) serializableTable).operations())
         .isInstanceOf(StaticTableOperations.class);
+    assertThat(TableUtil.formatVersion(serializableTable)).isEqualTo(2);
   }
 
   @Test
@@ -106,6 +108,9 @@ public class TestTableSerialization extends HadoopTableTestBase {
       assertThatThrownBy(() -> ((HasTableOperations) serializableTable).operations())
           .isInstanceOf(UnsupportedOperationException.class)
           .hasMessageEndingWith("does not support operations()");
+      assertThatThrownBy(() -> TableUtil.formatVersion(serializableTable))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageEndingWith("does not have a format version");
     }
   }
 


### PR DESCRIPTION
This is an alternative impl to https://github.com/apache/iceberg/pull/11587