### PR TITLE
Docs: Mention look-free requires HIVE-28121 for MySQL/MariaDB-based HMS 

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -186,6 +186,8 @@ This should only be set to `false` if all following conditions are met:
 
  - [HIVE-26882](https://issues.apache.org/jira/browse/HIVE-26882)
 is available on the Hive Metastore server
+ - [HIVE-28121](https://issues.apache.org/jira/browse/HIVE-28121)
+is available on the Hive Metastore server, if it is backed by MySQL or MariaDB
  - All other HiveCatalogs committing to tables that this HiveCatalog commits to are also on Iceberg 1.3 or later
  - All other HiveCatalogs committing to tables that this HiveCatalog commits to have also disabled Hive locks on commit.
 


### PR DESCRIPTION
In short, HIVE-26882 works for PostgreSQL-based HMS but has correctness issues for MySQL/MariaDB-based HMS, we should emphasize this in Iceberg docs to avoid corrupting users' data. For more tech details, please see conversations in https://issues.apache.org/jira/browse/HIVE-26882