### PR TITLE
Build: Delete branch automatically on PR merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,6 +39,8 @@ github:
         required_approving_review_count: 1
 
       required_linear_history: true
+
+  del_branch_on_merge: true
   
   features:
     wiki: true


### PR DESCRIPTION
This PR enables the GitHub feature that automatically deleting the head branch on PR merge.