### PR TITLE
Docs: add `WHEN NOT MATCHED BY SOURCE` to Spark `MERGE INTO` doc

### DIFF
--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -95,7 +95,7 @@ WHEN NOT MATCHED AND s.event_time > still_valid_threshold THEN INSERT (id, count
 
 Only one record in the source data can update any given row of the target table, or else an error will be thrown.
 
-Starting from Spark 3.5, you can use `WHEN NOT MATCHED BY SOURCE ... THEN ...` to update or delete rows that are not present in the source data:
+Spark 3.5 added support for `WHEN NOT MATCHED BY SOURCE ... THEN ...` to update or delete rows that are not present in the source data:
 
 ```sql
 WHEN NOT MATCHED BY SOURCE THEN UPDATE SET status = 'invalid'

--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -95,6 +95,11 @@ WHEN NOT MATCHED AND s.event_time > still_valid_threshold THEN INSERT (id, count
 
 Only one record in the source data can update any given row of the target table, or else an error will be thrown.
 
+Starting from Spark 3.5, you can use `WHEN NOT MATCHED BY SOURCE ... THEN ...` to update or delete rows that are not present in the source data:
+
+```sql
+WHEN NOT MATCHED BY SOURCE THEN UPDATE SET status = 'invalid'
+```
 
 ### `INSERT OVERWRITE`
 


### PR DESCRIPTION
`WHEN NOT MATCHED BY SOURCE` has been supported in Spark 3.5+ since [1.4.0](https://iceberg.apache.org/releases/#140-release), but most Iceberg users don't know that it is possible because it is not present in the documentation.

This PR adds an example of its usage to Spark writes documentation.