### PR TITLE
Hadoop: Log where the missing metadata file is located

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -107,7 +107,8 @@ public class HadoopTableOperations implements TableOperations {
         // no v0 metadata means the table doesn't exist yet
         return null;
       } else if (metadataFile == null) {
-        throw new ValidationException("Metadata file for version %d is missing", ver);
+        throw new ValidationException(
+            "Metadata file for version %d is missing under %s", ver, metadataRoot());
       }
 
       Path nextMetadataFile = getMetadataFile(ver + 1);


### PR DESCRIPTION
Currently, in `HadoopTableOperations` when the metadata file is missing, we can't know where it's located. This PR adds metadata location to the exception message. Besides, a UT is added for metedata file missing.

cc @pvary 