### PR TITLE
Docs: Use DataFrameWriterV2 in Spark's example

### DIFF
--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -167,14 +167,14 @@ spark.read
 
 ### Write options
 
-Spark write options are passed when configuring the DataFrameWriter, like this:
+Spark write options are passed when configuring the DataFrameWriterV2, like this:
 
 ```scala
 // write with Avro instead of Parquet
-df.write
+df.writeTo("catalog.db.table")
     .option("write-format", "avro")
     .option("snapshot-property.key", "value")
-    .insertInto("catalog.db.table")
+    .append()
 ```
 
 | Spark option           | Default                    | Description                                                  |


### PR DESCRIPTION
Replace the example with `DataFrameWriterV2` because

https://github.com/apache/iceberg/blob/319f29ea860e42e7cc21cda8c05d882134e6431f/docs/docs/spark-writes.md#L264

This is consistent with other places.