### PR TITLE
Flink: Replace use of deprecated methods

### DIFF
--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TableSourceTestBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TableSourceTestBase.java
@@ -61,7 +61,7 @@ public abstract class TableSourceTestBase extends TestBase {
     super.getTableEnv()
         .getConfig()
         .getConfiguration()
-        .setBoolean(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_FLIP27_SOURCE.key(), useFlip27Source);
+        .set(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_FLIP27_SOURCE, useFlip27Source);
     return super.getTableEnv();
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestBoundedTableFactory.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestBoundedTableFactory.java
@@ -20,12 +20,12 @@ package org.apache.iceberg.flink.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.flink.types.Row;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.junit.jupiter.api.Test;
 
 public class TestBoundedTableFactory extends ChangeLogTableTestBase {
@@ -69,7 +69,7 @@ public class TestBoundedTableFactory extends ChangeLogTableTestBase {
         "CREATE TABLE %s(id INT, data STRING) WITH ('connector'='BoundedSource', 'data-id'='%s')",
         tableName, dataId);
 
-    List<Row> rowSet = dataSet.stream().flatMap(Streams::stream).collect(Collectors.toList());
+    List<Row> rowSet = dataSet.stream().flatMap(Collection::stream).collect(Collectors.toList());
     assertThat(sql("SELECT * FROM %s", tableName)).isEqualTo(rowSet);
 
     assertThat(sql("SELECT * FROM %s WHERE data='aaa'", tableName))

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBoundedGenericRecord.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBoundedGenericRecord.java
@@ -145,7 +145,7 @@ public class TestIcebergSourceBoundedGenericRecord {
     env.getConfig().enableObjectReuse();
 
     Configuration config = new Configuration();
-    config.setInteger(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 128);
+    config.set(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 128);
     Table table;
     try (TableLoader tableLoader = CATALOG_EXTENSION.tableLoader()) {
       tableLoader.open();

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
@@ -170,7 +170,7 @@ public class TestIcebergSourceSplitSerializer {
     for (int i = 0; i < expectedTasks.size(); ++i) {
       FileScanTask expectedTask = expectedTasks.get(i);
       FileScanTask actualTask = actualTasks.get(i);
-      assertThat(actualTask.file().path()).isEqualTo(expectedTask.file().path());
+      assertThat(actualTask.file().location()).isEqualTo(expectedTask.file().location());
       assertThat(actualTask.sizeBytes()).isEqualTo(expectedTask.sizeBytes());
       assertThat(actualTask.filesCount()).isEqualTo(expectedTask.filesCount());
       assertThat(actualTask.start()).isEqualTo(expectedTask.start());


### PR DESCRIPTION
This PR replaces use of deprecated method in Flink (1.20) tests.