### PR TITLE
Doc: Fix some Javadoc URLs.

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -844,7 +844,7 @@ Each version of table metadata is stored in a metadata folder under the table’
 
 Notes:
 
-1. The file system table scheme is implemented in [HadoopTableOperations](../javadoc/{{ icebergVersion }}/index.html?org/apache/iceberg/hadoop/HadoopTableOperations.html).
+1. The file system table scheme is implemented in [HadoopTableOperations](../javadoc/{{ icebergVersion }}/org/apache/iceberg/hadoop/HadoopTableOperations.html).
 
 ### Metastore Tables
 
@@ -860,7 +860,7 @@ Each version of table metadata is stored in a metadata folder under the table’
 
 Notes:
 
-1. The metastore table scheme is partly implemented in [BaseMetastoreTableOperations](../javadoc/{{ icebergVersion }}/index.html?org/apache/iceberg/BaseMetastoreTableOperations.html).
+1. The metastore table scheme is partly implemented in [BaseMetastoreTableOperations](../javadoc/{{ icebergVersion }}/org/apache/iceberg/BaseMetastoreTableOperations.html).
 
 
 ## Delete Formats


### PR DESCRIPTION
Currently, clicking on Javadoc links in the [doc](https://iceberg.apache.org/spec/#metastore-tables) does not navigate to the class page; instead, it remains on the index page. 
For example: https://iceberg.apache.org/javadoc/1.7.0/index.html?org/apache/iceberg/BaseMetastoreTableOperations.html
