### PR TITLE
Backport Avro planned reader (and corresponding tests) on Flink v1.18 and v1.19

### DIFF
--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/data/FlinkPlannedAvroReader.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/data/FlinkPlannedAvroReader.java
@@ -28,54 +28,51 @@ import org.apache.avro.Schema;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.flink.table.data.RowData;
-import org.apache.iceberg.avro.AvroSchemaWithTypeVisitor;
+import org.apache.iceberg.avro.AvroWithPartnerVisitor;
 import org.apache.iceberg.avro.SupportsRowPosition;
 import org.apache.iceberg.avro.ValueReader;
 import org.apache.iceberg.avro.ValueReaders;
-import org.apache.iceberg.data.avro.DecoderResolver;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
 
-/**
- * @deprecated will be removed in 1.8.0; use FlinkPlannedAvroReader instead.
- */
-@Deprecated
-public class FlinkAvroReader implements DatumReader<RowData>, SupportsRowPosition {
+public class FlinkPlannedAvroReader implements DatumReader<RowData>, SupportsRowPosition {
 
-  private final Schema readSchema;
-  private final ValueReader<RowData> reader;
-  private Schema fileSchema = null;
+  private final Types.StructType expectedType;
+  private final Map<Integer, ?> idToConstant;
+  private ValueReader<RowData> reader;
 
-  /**
-   * @deprecated will be removed in 1.8.0; use FlinkPlannedAvroReader instead.
-   */
-  @Deprecated
-  public FlinkAvroReader(org.apache.iceberg.Schema expectedSchema, Schema readSchema) {
-    this(expectedSchema, readSchema, ImmutableMap.of());
+  public static FlinkPlannedAvroReader create(org.apache.iceberg.Schema schema) {
+    return create(schema, ImmutableMap.of());
   }
 
-  /**
-   * @deprecated will be removed in 1.8.0; use FlinkPlannedAvroReader instead.
-   */
-  @Deprecated
-  @SuppressWarnings("unchecked")
-  public FlinkAvroReader(
-      org.apache.iceberg.Schema expectedSchema, Schema readSchema, Map<Integer, ?> constants) {
-    this.readSchema = readSchema;
-    this.reader =
-        (ValueReader<RowData>)
-            AvroSchemaWithTypeVisitor.visit(expectedSchema, readSchema, new ReadBuilder(constants));
+  public static FlinkPlannedAvroReader create(
+      org.apache.iceberg.Schema schema, Map<Integer, ?> constants) {
+    return new FlinkPlannedAvroReader(schema, constants);
+  }
+
+  private FlinkPlannedAvroReader(
+      org.apache.iceberg.Schema expectedSchema, Map<Integer, ?> constants) {
+    this.expectedType = expectedSchema.asStruct();
+    this.idToConstant = constants;
   }
 
   @Override
-  public void setSchema(Schema newFileSchema) {
-    this.fileSchema = Schema.applyAliases(newFileSchema, readSchema);
+  @SuppressWarnings("unchecked")
+  public void setSchema(Schema fileSchema) {
+    this.reader =
+        (ValueReader<RowData>)
+            AvroWithPartnerVisitor.visit(
+                expectedType,
+                fileSchema,
+                new ReadBuilder(idToConstant),
+                AvroWithPartnerVisitor.FieldIDAccessors.get());
   }
 
   @Override
   public RowData read(RowData reuse, Decoder decoder) throws IOException {
-    return DecoderResolver.resolveAndRead(decoder, readSchema, fileSchema, reader, reuse);
+    return reader.read(decoder, reuse);
   }
 
   @Override
@@ -85,7 +82,7 @@ public class FlinkAvroReader implements DatumReader<RowData>, SupportsRowPositio
     }
   }
 
-  private static class ReadBuilder extends AvroSchemaWithTypeVisitor<ValueReader<?>> {
+  private static class ReadBuilder extends AvroWithPartnerVisitor<Type, ValueReader<?>> {
     private final Map<Integer, ?> idToConstant;
 
     private ReadBuilder(Map<Integer, ?> idToConstant) {
@@ -93,39 +90,47 @@ public class FlinkAvroReader implements DatumReader<RowData>, SupportsRowPositio
     }
 
     @Override
-    public ValueReader<?> record(
-        Types.StructType expected, Schema record, List<String> names, List<ValueReader<?>> fields) {
-      return FlinkValueReaders.struct(fields, expected.asStructType(), idToConstant);
+    public ValueReader<?> record(Type partner, Schema record, List<ValueReader<?>> fieldReaders) {
+      if (partner == null) {
+        return ValueReaders.skipStruct(fieldReaders);
+      }
+
+      Types.StructType expected = partner.asStructType();
+      List<Pair<Integer, ValueReader<?>>> readPlan =
+          ValueReaders.buildReadPlan(expected, record, fieldReaders, idToConstant);
+
+      // TODO: should this pass expected so that struct.get can reuse containers?
+      return FlinkValueReaders.struct(readPlan, expected.fields().size());
     }
 
     @Override
-    public ValueReader<?> union(Type expected, Schema union, List<ValueReader<?>> options) {
+    public ValueReader<?> union(Type partner, Schema union, List<ValueReader<?>> options) {
       return ValueReaders.union(options);
     }
 
     @Override
-    public ValueReader<?> array(
-        Types.ListType expected, Schema array, ValueReader<?> elementReader) {
+    public ValueReader<?> array(Type partner, Schema array, ValueReader<?> elementReader) {
       return FlinkValueReaders.array(elementReader);
     }
 
     @Override
-    public ValueReader<?> map(
-        Types.MapType expected, Schema map, ValueReader<?> keyReader, ValueReader<?> valueReader) {
+    public ValueReader<?> arrayMap(
+        Type partner, Schema map, ValueReader<?> keyReader, ValueReader<?> valueReader) {
       return FlinkValueReaders.arrayMap(keyReader, valueReader);
     }
 
     @Override
-    public ValueReader<?> map(Types.MapType expected, Schema map, ValueReader<?> valueReader) {
+    public ValueReader<?> map(Type partner, Schema map, ValueReader<?> valueReader) {
       return FlinkValueReaders.map(FlinkValueReaders.strings(), valueReader);
     }
 
     @Override
-    public ValueReader<?> primitive(Type.PrimitiveType expected, Schema primitive) {
+    public ValueReader<?> primitive(Type partner, Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
           case "date":
+            // Flink uses the same representation
             return ValueReaders.ints();
 
           case "time-micros":
@@ -148,7 +153,7 @@ public class FlinkAvroReader implements DatumReader<RowData>, SupportsRowPositio
             return FlinkValueReaders.uuids();
 
           default:
-            throw new IllegalArgumentException("Unknown logical type: " + logicalType);
+            throw new IllegalArgumentException("Unknown logical type: " + logicalType.getName());
         }
       }
 
@@ -158,10 +163,16 @@ public class FlinkAvroReader implements DatumReader<RowData>, SupportsRowPositio
         case BOOLEAN:
           return ValueReaders.booleans();
         case INT:
+          if (partner != null && partner.typeId() == Type.TypeID.LONG) {
+            return ValueReaders.intsAsLongs();
+          }
           return ValueReaders.ints();
         case LONG:
           return ValueReaders.longs();
         case FLOAT:
+          if (partner != null && partner.typeId() == Type.TypeID.DOUBLE) {
+            return ValueReaders.floatsAsDoubles();
+          }
           return ValueReaders.floats();
         case DOUBLE:
           return ValueReaders.doubles();

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
@@ -35,9 +35,9 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.FlinkSourceFilter;
 import org.apache.iceberg.flink.RowDataWrapper;
-import org.apache.iceberg.flink.data.FlinkAvroReader;
 import org.apache.iceberg.flink.data.FlinkOrcReader;
 import org.apache.iceberg.flink.data.FlinkParquetReaders;
+import org.apache.iceberg.flink.data.FlinkPlannedAvroReader;
 import org.apache.iceberg.flink.data.RowDataProjection;
 import org.apache.iceberg.flink.data.RowDataUtil;
 import org.apache.iceberg.io.CloseableIterable;
@@ -154,7 +154,7 @@ public class RowDataFileScanTaskReader implements FileScanTaskReader<RowData> {
             .reuseContainers()
             .project(schema)
             .split(task.start(), task.length())
-            .createReaderFunc(readSchema -> new FlinkAvroReader(schema, readSchema, idToConstant));
+            .createReaderFunc(readSchema -> FlinkPlannedAvroReader.create(schema, idToConstant));
 
     if (nameMapping != null) {
       builder.withNameMapping(NameMappingParser.fromJson(nameMapping));

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/data/AbstractTestFlinkAvroReaderWriter.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/data/AbstractTestFlinkAvroReaderWriter.java
@@ -48,7 +48,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.junit.jupiter.api.Test;
 
-public class TestFlinkAvroReaderWriter extends DataTest {
+public abstract class AbstractTestFlinkAvroReaderWriter extends DataTest {
 
   private static final int NUM_RECORDS = 100;
 
@@ -70,6 +70,8 @@ public class TestFlinkAvroReaderWriter extends DataTest {
     writeAndValidate(schema, expectedRecords, NUM_RECORDS);
   }
 
+  protected abstract Avro.ReadBuilder createAvroReadBuilder(File recordsFile, Schema schema);
+
   private void writeAndValidate(Schema schema, List<Record> expectedRecords, int numRecord)
       throws IOException {
     RowType flinkSchema = FlinkSchemaUtil.convert(schema);
@@ -88,11 +90,7 @@ public class TestFlinkAvroReaderWriter extends DataTest {
       writer.addAll(expectedRecords);
     }
 
-    try (CloseableIterable<RowData> reader =
-        Avro.read(Files.localInput(recordsFile))
-            .project(schema)
-            .createReaderFunc(FlinkAvroReader::new)
-            .build()) {
+    try (CloseableIterable<RowData> reader = createAvroReadBuilder(recordsFile, schema).build()) {
       Iterator<Record> expected = expectedRecords.iterator();
       Iterator<RowData> rows = reader.iterator();
       for (int i = 0; i < numRecord; i++) {
@@ -156,7 +154,6 @@ public class TestFlinkAvroReaderWriter extends DataTest {
 
   @Test
   public void testNumericTypes() throws IOException {
-
     List<Record> expected =
         ImmutableList.of(
             recordNumType(

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkAvroDeprecatedReaderWriter.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkAvroDeprecatedReaderWriter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.data;
+
+import java.io.File;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.Avro;
+
+/**
+ * @deprecated should be removed in 1.8.0; along with FlinkAvroReader.
+ */
+@Deprecated
+public class TestFlinkAvroDeprecatedReaderWriter extends AbstractTestFlinkAvroReaderWriter {
+
+  @Override
+  protected Avro.ReadBuilder createAvroReadBuilder(File recordsFile, Schema schema) {
+    return Avro.read(Files.localInput(recordsFile))
+        .project(schema)
+        .createReaderFunc(FlinkAvroReader::new);
+  }
+}

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkAvroPlannedReaderWriter.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkAvroPlannedReaderWriter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.data;
+
+import java.io.File;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.Avro;
+
+public class TestFlinkAvroPlannedReaderWriter extends AbstractTestFlinkAvroReaderWriter {
+
+  @Override
+  protected Avro.ReadBuilder createAvroReadBuilder(File recordsFile, Schema schema) {
+    return Avro.read(Files.localInput(recordsFile))
+        .project(schema)
+        .createResolvingReader(FlinkPlannedAvroReader::create);
+  }
+}

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroReader.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroReader.java
@@ -37,16 +37,28 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
+/**
+ * @deprecated will be removed in 1.8.0; use FlinkPlannedAvroReader instead.
+ */
+@Deprecated
 public class FlinkAvroReader implements DatumReader<RowData>, SupportsRowPosition {
 
   private final Schema readSchema;
   private final ValueReader<RowData> reader;
   private Schema fileSchema = null;
 
+  /**
+   * @deprecated will be removed in 1.8.0; use FlinkPlannedAvroReader instead.
+   */
+  @Deprecated
   public FlinkAvroReader(org.apache.iceberg.Schema expectedSchema, Schema readSchema) {
     this(expectedSchema, readSchema, ImmutableMap.of());
   }
 
+  /**
+   * @deprecated will be removed in 1.8.0; use FlinkPlannedAvroReader instead.
+   */
+  @Deprecated
   @SuppressWarnings("unchecked")
   public FlinkAvroReader(
       org.apache.iceberg.Schema expectedSchema, Schema readSchema, Map<Integer, ?> constants) {

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/data/FlinkPlannedAvroReader.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/data/FlinkPlannedAvroReader.java
@@ -28,54 +28,51 @@ import org.apache.avro.Schema;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.flink.table.data.RowData;
-import org.apache.iceberg.avro.AvroSchemaWithTypeVisitor;
+import org.apache.iceberg.avro.AvroWithPartnerVisitor;
 import org.apache.iceberg.avro.SupportsRowPosition;
 import org.apache.iceberg.avro.ValueReader;
 import org.apache.iceberg.avro.ValueReaders;
-import org.apache.iceberg.data.avro.DecoderResolver;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
 
-/**
- * @deprecated will be removed in 1.8.0; use FlinkPlannedAvroReader instead.
- */
-@Deprecated
-public class FlinkAvroReader implements DatumReader<RowData>, SupportsRowPosition {
+public class FlinkPlannedAvroReader implements DatumReader<RowData>, SupportsRowPosition {
 
-  private final Schema readSchema;
-  private final ValueReader<RowData> reader;
-  private Schema fileSchema = null;
+  private final Types.StructType expectedType;
+  private final Map<Integer, ?> idToConstant;
+  private ValueReader<RowData> reader;
 
-  /**
-   * @deprecated will be removed in 1.8.0; use FlinkPlannedAvroReader instead.
-   */
-  @Deprecated
-  public FlinkAvroReader(org.apache.iceberg.Schema expectedSchema, Schema readSchema) {
-    this(expectedSchema, readSchema, ImmutableMap.of());
+  public static FlinkPlannedAvroReader create(org.apache.iceberg.Schema schema) {
+    return create(schema, ImmutableMap.of());
   }
 
-  /**
-   * @deprecated will be removed in 1.8.0; use FlinkPlannedAvroReader instead.
-   */
-  @Deprecated
-  @SuppressWarnings("unchecked")
-  public FlinkAvroReader(
-      org.apache.iceberg.Schema expectedSchema, Schema readSchema, Map<Integer, ?> constants) {
-    this.readSchema = readSchema;
-    this.reader =
-        (ValueReader<RowData>)
-            AvroSchemaWithTypeVisitor.visit(expectedSchema, readSchema, new ReadBuilder(constants));
+  public static FlinkPlannedAvroReader create(
+      org.apache.iceberg.Schema schema, Map<Integer, ?> constants) {
+    return new FlinkPlannedAvroReader(schema, constants);
+  }
+
+  private FlinkPlannedAvroReader(
+      org.apache.iceberg.Schema expectedSchema, Map<Integer, ?> constants) {
+    this.expectedType = expectedSchema.asStruct();
+    this.idToConstant = constants;
   }
 
   @Override
-  public void setSchema(Schema newFileSchema) {
-    this.fileSchema = Schema.applyAliases(newFileSchema, readSchema);
+  @SuppressWarnings("unchecked")
+  public void setSchema(Schema fileSchema) {
+    this.reader =
+        (ValueReader<RowData>)
+            AvroWithPartnerVisitor.visit(
+                expectedType,
+                fileSchema,
+                new ReadBuilder(idToConstant),
+                AvroWithPartnerVisitor.FieldIDAccessors.get());
   }
 
   @Override
   public RowData read(RowData reuse, Decoder decoder) throws IOException {
-    return DecoderResolver.resolveAndRead(decoder, readSchema, fileSchema, reader, reuse);
+    return reader.read(decoder, reuse);
   }
 
   @Override
@@ -85,7 +82,7 @@ public class FlinkAvroReader implements DatumReader<RowData>, SupportsRowPositio
     }
   }
 
-  private static class ReadBuilder extends AvroSchemaWithTypeVisitor<ValueReader<?>> {
+  private static class ReadBuilder extends AvroWithPartnerVisitor<Type, ValueReader<?>> {
     private final Map<Integer, ?> idToConstant;
 
     private ReadBuilder(Map<Integer, ?> idToConstant) {
@@ -93,39 +90,47 @@ public class FlinkAvroReader implements DatumReader<RowData>, SupportsRowPositio
     }
 
     @Override
-    public ValueReader<?> record(
-        Types.StructType expected, Schema record, List<String> names, List<ValueReader<?>> fields) {
-      return FlinkValueReaders.struct(fields, expected.asStructType(), idToConstant);
+    public ValueReader<?> record(Type partner, Schema record, List<ValueReader<?>> fieldReaders) {
+      if (partner == null) {
+        return ValueReaders.skipStruct(fieldReaders);
+      }
+
+      Types.StructType expected = partner.asStructType();
+      List<Pair<Integer, ValueReader<?>>> readPlan =
+          ValueReaders.buildReadPlan(expected, record, fieldReaders, idToConstant);
+
+      // TODO: should this pass expected so that struct.get can reuse containers?
+      return FlinkValueReaders.struct(readPlan, expected.fields().size());
     }
 
     @Override
-    public ValueReader<?> union(Type expected, Schema union, List<ValueReader<?>> options) {
+    public ValueReader<?> union(Type partner, Schema union, List<ValueReader<?>> options) {
       return ValueReaders.union(options);
     }
 
     @Override
-    public ValueReader<?> array(
-        Types.ListType expected, Schema array, ValueReader<?> elementReader) {
+    public ValueReader<?> array(Type partner, Schema array, ValueReader<?> elementReader) {
       return FlinkValueReaders.array(elementReader);
     }
 
     @Override
-    public ValueReader<?> map(
-        Types.MapType expected, Schema map, ValueReader<?> keyReader, ValueReader<?> valueReader) {
+    public ValueReader<?> arrayMap(
+        Type partner, Schema map, ValueReader<?> keyReader, ValueReader<?> valueReader) {
       return FlinkValueReaders.arrayMap(keyReader, valueReader);
     }
 
     @Override
-    public ValueReader<?> map(Types.MapType expected, Schema map, ValueReader<?> valueReader) {
+    public ValueReader<?> map(Type partner, Schema map, ValueReader<?> valueReader) {
       return FlinkValueReaders.map(FlinkValueReaders.strings(), valueReader);
     }
 
     @Override
-    public ValueReader<?> primitive(Type.PrimitiveType expected, Schema primitive) {
+    public ValueReader<?> primitive(Type partner, Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
           case "date":
+            // Flink uses the same representation
             return ValueReaders.ints();
 
           case "time-micros":
@@ -148,7 +153,7 @@ public class FlinkAvroReader implements DatumReader<RowData>, SupportsRowPositio
             return FlinkValueReaders.uuids();
 
           default:
-            throw new IllegalArgumentException("Unknown logical type: " + logicalType);
+            throw new IllegalArgumentException("Unknown logical type: " + logicalType.getName());
         }
       }
 
@@ -158,10 +163,16 @@ public class FlinkAvroReader implements DatumReader<RowData>, SupportsRowPositio
         case BOOLEAN:
           return ValueReaders.booleans();
         case INT:
+          if (partner != null && partner.typeId() == Type.TypeID.LONG) {
+            return ValueReaders.intsAsLongs();
+          }
           return ValueReaders.ints();
         case LONG:
           return ValueReaders.longs();
         case FLOAT:
+          if (partner != null && partner.typeId() == Type.TypeID.DOUBLE) {
+            return ValueReaders.floatsAsDoubles();
+          }
           return ValueReaders.floats();
         case DOUBLE:
           return ValueReaders.doubles();

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
@@ -35,9 +35,9 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.FlinkSourceFilter;
 import org.apache.iceberg.flink.RowDataWrapper;
-import org.apache.iceberg.flink.data.FlinkAvroReader;
 import org.apache.iceberg.flink.data.FlinkOrcReader;
 import org.apache.iceberg.flink.data.FlinkParquetReaders;
+import org.apache.iceberg.flink.data.FlinkPlannedAvroReader;
 import org.apache.iceberg.flink.data.RowDataProjection;
 import org.apache.iceberg.flink.data.RowDataUtil;
 import org.apache.iceberg.io.CloseableIterable;
@@ -154,7 +154,7 @@ public class RowDataFileScanTaskReader implements FileScanTaskReader<RowData> {
             .reuseContainers()
             .project(schema)
             .split(task.start(), task.length())
-            .createReaderFunc(readSchema -> new FlinkAvroReader(schema, readSchema, idToConstant));
+            .createReaderFunc(readSchema -> FlinkPlannedAvroReader.create(schema, idToConstant));
 
     if (nameMapping != null) {
       builder.withNameMapping(NameMappingParser.fromJson(nameMapping));

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/data/AbstractTestFlinkAvroReaderWriter.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/data/AbstractTestFlinkAvroReaderWriter.java
@@ -48,7 +48,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.junit.jupiter.api.Test;
 
-public class TestFlinkAvroReaderWriter extends DataTest {
+public abstract class AbstractTestFlinkAvroReaderWriter extends DataTest {
 
   private static final int NUM_RECORDS = 100;
 
@@ -70,6 +70,8 @@ public class TestFlinkAvroReaderWriter extends DataTest {
     writeAndValidate(schema, expectedRecords, NUM_RECORDS);
   }
 
+  protected abstract Avro.ReadBuilder createAvroReadBuilder(File recordsFile, Schema schema);
+
   private void writeAndValidate(Schema schema, List<Record> expectedRecords, int numRecord)
       throws IOException {
     RowType flinkSchema = FlinkSchemaUtil.convert(schema);
@@ -88,11 +90,7 @@ public class TestFlinkAvroReaderWriter extends DataTest {
       writer.addAll(expectedRecords);
     }
 
-    try (CloseableIterable<RowData> reader =
-        Avro.read(Files.localInput(recordsFile))
-            .project(schema)
-            .createReaderFunc(FlinkAvroReader::new)
-            .build()) {
+    try (CloseableIterable<RowData> reader = createAvroReadBuilder(recordsFile, schema).build()) {
       Iterator<Record> expected = expectedRecords.iterator();
       Iterator<RowData> rows = reader.iterator();
       for (int i = 0; i < numRecord; i++) {
@@ -156,7 +154,6 @@ public class TestFlinkAvroReaderWriter extends DataTest {
 
   @Test
   public void testNumericTypes() throws IOException {
-
     List<Record> expected =
         ImmutableList.of(
             recordNumType(

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkAvroDeprecatedReaderWriter.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkAvroDeprecatedReaderWriter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.data;
+
+import java.io.File;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.Avro;
+
+/**
+ * @deprecated should be removed in 1.8.0; along with FlinkAvroReader.
+ */
+@Deprecated
+public class TestFlinkAvroDeprecatedReaderWriter extends AbstractTestFlinkAvroReaderWriter {
+
+  @Override
+  protected Avro.ReadBuilder createAvroReadBuilder(File recordsFile, Schema schema) {
+    return Avro.read(Files.localInput(recordsFile))
+        .project(schema)
+        .createReaderFunc(FlinkAvroReader::new);
+  }
+}

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkAvroPlannedReaderWriter.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkAvroPlannedReaderWriter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.data;
+
+import java.io.File;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.Avro;
+
+public class TestFlinkAvroPlannedReaderWriter extends AbstractTestFlinkAvroReaderWriter {
+
+  @Override
+  protected Avro.ReadBuilder createAvroReadBuilder(File recordsFile, Schema schema) {
+    return Avro.read(Files.localInput(recordsFile))
+        .project(schema)
+        .createResolvingReader(FlinkPlannedAvroReader::create);
+  }
+}

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/data/TestRowProjection.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/data/TestRowProjection.java
@@ -24,6 +24,8 @@ import static org.assertj.core.api.Assertions.withPrecision;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.GenericArrayData;
@@ -32,6 +34,9 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -41,12 +46,22 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestRowProjection {
 
   @TempDir private Path temp;
+
+  @Parameter(index = 0)
+  protected Boolean useAvroPlannedReader;
+
+  @Parameters(name = "useAvroPlannedReader={0}")
+  protected static List<Object[]> parameters() {
+    return Arrays.asList(new Object[] {Boolean.FALSE}, new Object[] {Boolean.TRUE});
+  }
 
   private RowData writeAndRead(String desc, Schema writeSchema, Schema readSchema, RowData row)
       throws IOException {
@@ -61,16 +76,23 @@ public class TestRowProjection {
       appender.add(row);
     }
 
-    Iterable<RowData> records =
+    Avro.ReadBuilder builder =
         Avro.read(Files.localInput(file))
             .project(readSchema)
-            .createReaderFunc(FlinkAvroReader::new)
-            .build();
+            .createReaderFunc(FlinkAvroReader::new);
+    if (useAvroPlannedReader) {
+      builder =
+          Avro.read(Files.localInput(file))
+              .project(readSchema)
+              .createResolvingReader(FlinkPlannedAvroReader::create);
+    }
+
+    Iterable<RowData> records = builder.build();
 
     return Iterables.getOnlyElement(records);
   }
 
-  @Test
+  @TestTemplate
   public void testFullProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -85,7 +107,7 @@ public class TestRowProjection {
     assertThat(projected.getString(1)).asString().isEqualTo("test");
   }
 
-  @Test
+  @TestTemplate
   public void testSpecialCharacterProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -105,7 +127,7 @@ public class TestRowProjection {
     assertThat(projected.getString(0)).asString().isEqualTo("test");
   }
 
-  @Test
+  @TestTemplate
   public void testReorderedFullProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -125,7 +147,7 @@ public class TestRowProjection {
     assertThat(projected.getLong(1)).isEqualTo(34);
   }
 
-  @Test
+  @TestTemplate
   public void testReorderedProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -147,7 +169,7 @@ public class TestRowProjection {
     assertThat(projected.isNullAt(2)).isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testRenamedAddedField() throws Exception {
     Schema schema =
         new Schema(
@@ -177,7 +199,7 @@ public class TestRowProjection {
     assertThat(projected.isNullAt(3)).as("Should contain empty value on new column 4").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testEmptyProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -192,7 +214,7 @@ public class TestRowProjection {
     assertThat(projected.getArity()).isEqualTo(0);
   }
 
-  @Test
+  @TestTemplate
   public void testBasicProjection() throws Exception {
     Schema writeSchema =
         new Schema(
@@ -216,7 +238,7 @@ public class TestRowProjection {
     assertThat(projected.getString(0)).asString().isEqualTo("test");
   }
 
-  @Test
+  @TestTemplate
   public void testRename() throws Exception {
     Schema writeSchema =
         new Schema(
@@ -239,7 +261,7 @@ public class TestRowProjection {
         .isEqualTo("test");
   }
 
-  @Test
+  @TestTemplate
   public void testNestedStructProjection() throws Exception {
     Schema writeSchema =
         new Schema(
@@ -305,7 +327,7 @@ public class TestRowProjection {
         .isEqualTo(-1.539054f, withPrecision(0.000001f));
   }
 
-  @Test
+  @TestTemplate
   public void testMapProjection() throws IOException {
     Schema writeSchema =
         new Schema(
@@ -359,7 +381,7 @@ public class TestRowProjection {
     return stringMap;
   }
 
-  @Test
+  @TestTemplate
   public void testMapOfStructsProjection() throws IOException {
     Schema writeSchema =
         new Schema(
@@ -459,7 +481,7 @@ public class TestRowProjection {
         .isEqualTo(52.995143f, withPrecision(0.000001f));
   }
 
-  @Test
+  @TestTemplate
   public void testListProjection() throws IOException {
     Schema writeSchema =
         new Schema(
@@ -488,7 +510,7 @@ public class TestRowProjection {
     assertThat(projected.getArray(0)).isEqualTo(values);
   }
 
-  @Test
+  @TestTemplate
   @SuppressWarnings("unchecked")
   public void testListOfStructsProjection() throws IOException {
     Schema writeSchema =
@@ -565,7 +587,7 @@ public class TestRowProjection {
     assertThat(projectedP2.isNullAt(0)).as("Should project null z").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testAddedFieldsWithRequiredChildren() throws Exception {
     Schema schema = new Schema(Types.NestedField.required(1, "a", Types.LongType.get()));
 


### PR DESCRIPTION
This PR backports the Avro planned reader (and corresponding tests).