### PR TITLE
Bug Fix: Expose tableExists endpoint on RESTCatalogAdapter

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -311,6 +311,13 @@ public class CatalogHandlers {
     }
   }
 
+  public static void tableExists(Catalog catalog, TableIdentifier ident) {
+    boolean exists = catalog.tableExists(ident);
+    if (!exists) {
+      throw new NoSuchTableException("Table does not exist: %s", ident);
+    }
+  }
+
   public static LoadTableResponse loadTable(Catalog catalog, TableIdentifier ident) {
     Table table = catalog.loadTable(ident);
 

--- a/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
+++ b/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
@@ -52,6 +52,7 @@ public class Endpoint {
   // table endpoints
   public static final Endpoint V1_LIST_TABLES = Endpoint.create("GET", ResourcePaths.V1_TABLES);
   public static final Endpoint V1_LOAD_TABLE = Endpoint.create("GET", ResourcePaths.V1_TABLE);
+  public static final Endpoint V1_TABLE_EXISTS = Endpoint.create("HEAD", ResourcePaths.V1_TABLE);
   public static final Endpoint V1_CREATE_TABLE = Endpoint.create("POST", ResourcePaths.V1_TABLES);
   public static final Endpoint V1_UPDATE_TABLE = Endpoint.create("POST", ResourcePaths.V1_TABLE);
   public static final Endpoint V1_DELETE_TABLE = Endpoint.create("DELETE", ResourcePaths.V1_TABLE);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -143,6 +143,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
           .add(Endpoint.V1_DELETE_NAMESPACE)
           .add(Endpoint.V1_LIST_TABLES)
           .add(Endpoint.V1_LOAD_TABLE)
+          .add(Endpoint.V1_TABLE_EXISTS)
           .add(Endpoint.V1_CREATE_TABLE)
           .add(Endpoint.V1_UPDATE_TABLE)
           .add(Endpoint.V1_DELETE_TABLE)
@@ -385,6 +386,18 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     } while (pageToken != null);
 
     return tables.build();
+  }
+
+  @Override
+  public boolean tableExists(SessionContext context, TableIdentifier identifier) {
+    Endpoint.check(endpoints, Endpoint.V1_TABLE_EXISTS);
+    checkIdentifierIsValid(identifier);
+    try {
+      client.head(paths.table(identifier), headers(context), ErrorHandlers.tableErrorHandler());
+      return true;
+    } catch (NoSuchTableException e) {
+      return false;
+    }
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -146,6 +146,7 @@ public class RESTCatalogAdapter implements RESTClient {
     UPDATE_TABLE(
         HTTPMethod.POST, ResourcePaths.V1_TABLE, UpdateTableRequest.class, LoadTableResponse.class),
     DROP_TABLE(HTTPMethod.DELETE, ResourcePaths.V1_TABLE),
+    TABLE_EXISTS(HTTPMethod.HEAD, ResourcePaths.V1_TABLE),
     RENAME_TABLE(HTTPMethod.POST, ResourcePaths.V1_TABLE_RENAME, RenameTableRequest.class, null),
     REPORT_METRICS(
         HTTPMethod.POST, ResourcePaths.V1_TABLE_METRICS, ReportMetricsRequest.class, null),
@@ -389,6 +390,12 @@ public class RESTCatalogAdapter implements RESTClient {
           } else {
             CatalogHandlers.dropTable(catalog, tableIdentFromPathVars(vars));
           }
+          return null;
+        }
+
+      case TABLE_EXISTS:
+        {
+          CatalogHandlers.tableExists(catalog, tableIdentFromPathVars(vars));
           return null;
         }
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -346,11 +346,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             any());
     Mockito.verify(adapter)
         .execute(
-            eq(HTTPMethod.GET),
+            eq(HTTPMethod.HEAD),
             eq("v1/namespaces/ns/tables/table"),
             any(),
             any(),
-            eq(LoadTableResponse.class),
+            eq(null),
             eq(catalogHeaders),
             any());
   }
@@ -393,11 +393,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // use the catalog token for all interactions
     Mockito.verify(adapter)
         .execute(
-            eq(HTTPMethod.GET),
+            eq(HTTPMethod.HEAD),
             eq("v1/namespaces/ns/tables/table"),
             any(),
             any(),
-            eq(LoadTableResponse.class),
+            eq(null),
             eq(catalogHeaders),
             any());
   }
@@ -448,11 +448,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // use the catalog token for all interactions
     Mockito.verify(adapter)
         .execute(
-            eq(HTTPMethod.GET),
+            eq(HTTPMethod.HEAD),
             eq("v1/namespaces/ns/tables/table"),
             any(),
             any(),
-            eq(LoadTableResponse.class),
+            eq(null),
             eq(catalogHeaders),
             any());
   }
@@ -509,11 +509,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // use the context token for table load
     Mockito.verify(adapter)
         .execute(
-            eq(HTTPMethod.GET),
+            eq(HTTPMethod.HEAD),
             eq("v1/namespaces/ns/tables/table"),
             any(),
             any(),
-            eq(LoadTableResponse.class),
+            eq(null),
             eq(contextHeaders),
             any());
   }
@@ -582,11 +582,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // use the context token for table load
     Mockito.verify(adapter)
         .execute(
-            eq(HTTPMethod.GET),
+            eq(HTTPMethod.HEAD),
             eq("v1/namespaces/ns/tables/table"),
             any(),
             any(),
-            eq(LoadTableResponse.class),
+            eq(null),
             eq(contextHeaders),
             any());
   }
@@ -657,11 +657,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // use the context token for table load
     Mockito.verify(adapter)
         .execute(
-            eq(HTTPMethod.GET),
+            eq(HTTPMethod.HEAD),
             eq("v1/namespaces/ns/tables/table"),
             any(),
             any(),
-            eq(LoadTableResponse.class),
+            eq(null),
             eq(contextHeaders),
             any());
   }
@@ -845,11 +845,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     }
     Mockito.verify(adapter)
         .execute(
-            eq(HTTPMethod.GET),
+            eq(HTTPMethod.HEAD),
             eq("v1/namespaces/ns/tables/table"),
             any(),
             any(),
-            eq(LoadTableResponse.class),
+            eq(null),
             eq(expectedHeaders),
             any());
     if (!optionalOAuthParams.isEmpty()) {
@@ -1619,11 +1619,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                       "Bearer token-exchange-token:sub=client-credentials-token:sub=catalog");
               Mockito.verify(adapter)
                   .execute(
-                      eq(HTTPMethod.GET),
+                      eq(HTTPMethod.HEAD),
                       eq("v1/namespaces/ns/tables/table"),
                       any(),
                       any(),
-                      eq(LoadTableResponse.class),
+                      eq(null),
                       eq(refreshedCatalogHeader),
                       any());
             });
@@ -1735,11 +1735,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     Mockito.verify(adapter)
         .execute(
-            eq(HTTPMethod.GET),
+            eq(HTTPMethod.HEAD),
             eq("v1/namespaces/ns/tables/table"),
             any(),
             any(),
-            eq(LoadTableResponse.class),
+            eq(null),
             eq(ImmutableMap.of("Authorization", "Bearer token-exchange-token:sub=" + token)),
             any());
   }
@@ -1777,11 +1777,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     Mockito.verify(adapter)
         .execute(
-            eq(HTTPMethod.GET),
+            eq(HTTPMethod.HEAD),
             eq("v1/namespaces/ns/tables/table"),
             any(),
             any(),
-            eq(LoadTableResponse.class),
+            eq(null),
             eq(OAuth2Util.authHeaders(token)),
             any());
   }
@@ -1919,11 +1919,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                       "Bearer token-exchange-token:sub=client-credentials-token:sub=catalog");
               Mockito.verify(adapter)
                   .execute(
-                      eq(HTTPMethod.GET),
+                      eq(HTTPMethod.HEAD),
                       eq("v1/namespaces/ns/tables/table"),
                       any(),
                       any(),
-                      eq(LoadTableResponse.class),
+                      eq(null),
                       eq(refreshedCatalogHeader),
                       any());
             });


### PR DESCRIPTION
expose HEAD request endpoint at `/v1/{prefix}/namespaces/{namespace}/tables/{table}` path to be used for tableExists method calls as specified by The Open API Spec

https://github.com/apache/iceberg/blob/e770facc3e7cbccb719b3ae5263cd1ece181f9ea/open-api/rest-catalog-open-api.yaml#L1129-L1144