### PR TITLE
Core: Use FileIO for hadoop table metadata file operations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -236,16 +236,14 @@ public class HadoopTableOperations implements TableOperations {
   Path getMetadataFile(int metadataVersion) throws IOException {
     for (TableMetadataParser.Codec codec : TABLE_METADATA_PARSER_CODEC_VALUES) {
       Path metadataFile = metadataFilePath(metadataVersion, codec);
-      FileSystem fs = getFileSystem(metadataFile, conf);
-      if (fs.exists(metadataFile)) {
+      if (io().newInputFile(metadataFile.toString()).exists()) {
         return metadataFile;
       }
 
       if (codec.equals(TableMetadataParser.Codec.GZIP)) {
         // we have to be backward-compatible with .metadata.json.gz files
         metadataFile = oldMetadataFilePath(metadataVersion, codec);
-        fs = getFileSystem(metadataFile, conf);
-        if (fs.exists(metadataFile)) {
+        if (io().newInputFile(metadataFile.toString()).exists()) {
           return metadataFile;
         }
       }
@@ -364,7 +362,7 @@ public class HadoopTableOperations implements TableOperations {
             "Failed to acquire lock on file: %s with owner: %s", dst, src);
       }
 
-      if (fs.exists(dst)) {
+      if (io().newInputFile(dst.toString()).exists()) {
         CommitFailedException cfe =
             new CommitFailedException("Version %d already exists: %s", nextVersion, dst);
         RuntimeException re = tryDelete(src);


### PR DESCRIPTION
The s3a filesystem implementation of `exists` calls are headobject and listobjects, where listobjects do not scale well in some self hosted s3 implementations (minio).

This PR replace `exists` calls with `isFile` which is implemented as headobject only in s3a filesystem.