### PR TITLE
AWS: Add integration with Glue catalog extensions for Amazon SageMaker Lakehouse

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -273,7 +273,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
     }
   }
 
-  private Table getGlueTable() {
+  Table getGlueTable() {
     try {
       GetTableResponse response =
           glue.getTable(

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -66,6 +66,7 @@ import software.amazon.awssdk.services.glue.model.StorageDescriptor;
 import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.glue.model.UpdateDatabaseRequest;
 import software.amazon.awssdk.services.glue.model.UpdateDatabaseResponse;
+import software.amazon.glue.GlueExtensionsProperties;
 
 public class TestGlueCatalog {
 
@@ -85,7 +86,7 @@ public class TestGlueCatalog {
         new S3FileIOProperties(),
         glue,
         LockManagers.defaultLockManager(),
-        ImmutableMap.of());
+        ImmutableMap.of(GlueExtensionsProperties.GLUE_EXTENSIONS_ENABLED, "false"));
   }
 
   @Test
@@ -98,7 +99,7 @@ public class TestGlueCatalog {
         new S3FileIOProperties(),
         glue,
         LockManagers.defaultLockManager(),
-        ImmutableMap.of());
+        ImmutableMap.of(GlueExtensionsProperties.GLUE_EXTENSIONS_ENABLED, "false"));
     Mockito.doReturn(
             GetDatabaseResponse.builder().database(Database.builder().name("db").build()).build())
         .when(glue)
@@ -122,7 +123,7 @@ public class TestGlueCatalog {
         new S3FileIOProperties(),
         glue,
         LockManagers.defaultLockManager(),
-        ImmutableMap.of());
+        ImmutableMap.of(GlueExtensionsProperties.GLUE_EXTENSIONS_ENABLED, "false"));
     Mockito.doReturn(
             GetDatabaseResponse.builder().database(Database.builder().name("db").build()).build())
         .when(glue)
@@ -180,7 +181,7 @@ public class TestGlueCatalog {
         s3FileIOProperties,
         glue,
         LockManagers.defaultLockManager(),
-        ImmutableMap.of());
+        ImmutableMap.of(GlueExtensionsProperties.GLUE_EXTENSIONS_ENABLED, "false"));
 
     Mockito.doReturn(
             GetDatabaseResponse.builder()
@@ -643,7 +644,7 @@ public class TestGlueCatalog {
         s3FileIOProperties,
         glue,
         LockManagers.defaultLockManager(),
-        ImmutableMap.of());
+        ImmutableMap.of(GlueExtensionsProperties.GLUE_EXTENSIONS_ENABLED, "false"));
     assertThat(glueCatalog.isValidIdentifier(TableIdentifier.parse("db-1.a-1"))).isEqualTo(true);
   }
 
@@ -654,7 +655,9 @@ public class TestGlueCatalog {
             S3FileIOProperties.WRITE_TABLE_TAG_ENABLED,
             "true",
             S3FileIOProperties.WRITE_NAMESPACE_TAG_ENABLED,
-            "true");
+            "true",
+            GlueExtensionsProperties.GLUE_EXTENSIONS_ENABLED,
+            "false");
     AwsProperties awsProperties = new AwsProperties(properties);
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
     glueCatalog.initialize(

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueExtensionsCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueExtensionsCatalog.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.glue;
+
+import static org.apache.iceberg.aws.AwsProperties.GLUE_CATALOG_ID;
+import static org.apache.iceberg.aws.AwsProperties.GLUE_CATALOG_SKIP_NAME_VALIDATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.apache.iceberg.GlueTable;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.LockManagers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.Database;
+import software.amazon.awssdk.services.glue.model.FederatedDatabase;
+import software.amazon.awssdk.services.glue.model.GetDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.GetDatabaseResponse;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTableResponse;
+import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.glue.GlueCatalogExtensions;
+
+public class TestGlueExtensionsCatalog {
+
+  private static final String WAREHOUSE_PATH = "s3://bucket";
+  private static final String CATALOG_NAME = "glue";
+  private GlueClient glue;
+  private GlueCatalog glueCatalog;
+
+  @BeforeEach
+  public void before() {
+    glue = Mockito.mock(GlueClient.class);
+    glueCatalog = new GlueCatalog();
+    glueCatalog.initialize(
+        CATALOG_NAME,
+        WAREHOUSE_PATH,
+        new AwsProperties(),
+        new S3FileIOProperties(),
+        glue,
+        LockManagers.defaultLockManager(),
+        ImmutableMap.of());
+  }
+
+  @Test
+  public void testLoadRedshiftTable() {
+    TableIdentifier identifier = TableIdentifier.of("db", "tableName");
+    GlueCatalogExtensions glueCatalogExtensions = Mockito.mock(GlueCatalogExtensions.class);
+    GlueTable glueTable = Mockito.mock(GlueTable.class);
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GLUE_CATALOG_SKIP_NAME_VALIDATION, "true",
+            GLUE_CATALOG_ID, "123456789012/rs_ns/rs_db");
+    Mockito.doReturn(glueTable).when(glueCatalogExtensions).loadTable(identifier);
+    Mockito.doReturn(true)
+        .when(glueCatalogExtensions)
+        .useExtensionsForGlueTable(Mockito.any(Table.class));
+    Mockito.doReturn(
+            GetTableResponse.builder()
+                .table(
+                    Table.builder()
+                        .name("tableName")
+                        .storageDescriptor(
+                            StorageDescriptor.builder().inputFormat("RedshiftFormat").build())
+                        .build())
+                .build())
+        .when(glue)
+        .getTable(Mockito.any(GetTableRequest.class));
+
+    glueCatalog.initialize(
+        CATALOG_NAME,
+        WAREHOUSE_PATH,
+        new AwsProperties(properties),
+        new S3FileIOProperties(properties),
+        glue,
+        LockManagers.defaultLockManager(),
+        properties);
+    glueCatalog.setExtensions(glueCatalogExtensions);
+    org.apache.iceberg.Table table = glueCatalog.loadTable(identifier);
+    assertThat(table).isInstanceOf(GlueTable.class);
+  }
+
+  @Test
+  public void testCreateRedshiftTable() {
+    TableIdentifier identifier = TableIdentifier.of("db", "tableName");
+    GlueCatalogExtensions glueCatalogExtensions = Mockito.mock(GlueCatalogExtensions.class);
+    GlueTable glueTable = Mockito.mock(GlueTable.class);
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.StringType.get()));
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GLUE_CATALOG_SKIP_NAME_VALIDATION, "true",
+            GLUE_CATALOG_ID, "123456789012/rs_ns/rs_db");
+    Map<String, String> tableProperties = ImmutableMap.of("aws.write.format", "rms");
+    Catalog.TableBuilder builder = Mockito.mock(Catalog.TableBuilder.class);
+    Mockito.doReturn(builder).when(builder).withProperties(Mockito.any());
+    Mockito.doReturn(builder).when(builder).withLocation(Mockito.any());
+    Mockito.doReturn(builder).when(builder).withPartitionSpec(Mockito.any());
+    Mockito.doReturn(builder).when(builder).withSortOrder(Mockito.any());
+    Mockito.doReturn(builder).when(glueCatalogExtensions).buildTable(identifier, schema);
+    Mockito.doReturn(glueTable).when(builder).create();
+    Mockito.doReturn(
+            GetTableResponse.builder()
+                .table(
+                    Table.builder()
+                        .name("tableName")
+                        .storageDescriptor(
+                            StorageDescriptor.builder().inputFormat("RedshiftFormat").build())
+                        .build())
+                .build())
+        .when(glue)
+        .getTable(Mockito.any(GetTableRequest.class));
+
+    glueCatalog.initialize(
+        CATALOG_NAME,
+        WAREHOUSE_PATH,
+        new AwsProperties(properties),
+        new S3FileIOProperties(properties),
+        glue,
+        LockManagers.defaultLockManager(),
+        properties);
+    glueCatalog.setExtensions(glueCatalogExtensions);
+    org.apache.iceberg.Table table =
+        glueCatalog.createTable(identifier, schema, PartitionSpec.unpartitioned(), tableProperties);
+    assertThat(table).isInstanceOf(GlueTable.class);
+  }
+
+  @Test
+  public void testDropRedshiftTable() {
+    TableIdentifier identifier = TableIdentifier.of("db", "tableName");
+    GlueCatalogExtensions glueCatalogExtensions = Mockito.mock(GlueCatalogExtensions.class);
+    GlueTable glueTable = Mockito.mock(GlueTable.class);
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GLUE_CATALOG_SKIP_NAME_VALIDATION, "true",
+            GLUE_CATALOG_ID, "123456789012:rs_ns/rs_db");
+    Mockito.doReturn(glueTable).when(glueCatalogExtensions).loadTable(identifier);
+    Mockito.doReturn(true).when(glueCatalogExtensions).dropTable(identifier, true);
+    Mockito.doReturn(true)
+        .when(glueCatalogExtensions)
+        .useExtensionsForGlueTable(Mockito.any(Table.class));
+    Mockito.doReturn(
+            GetTableResponse.builder()
+                .table(
+                    Table.builder()
+                        .name("tableName")
+                        .storageDescriptor(
+                            StorageDescriptor.builder().inputFormat("RedshiftFormat").build())
+                        .build())
+                .build())
+        .when(glue)
+        .getTable(Mockito.any(GetTableRequest.class));
+
+    glueCatalog.initialize(
+        CATALOG_NAME,
+        WAREHOUSE_PATH,
+        new AwsProperties(properties),
+        new S3FileIOProperties(properties),
+        glue,
+        LockManagers.defaultLockManager(),
+        properties);
+    glueCatalog.setExtensions(glueCatalogExtensions);
+    glueCatalog.dropTable(identifier);
+    Mockito.verify(glueCatalogExtensions).dropTable(identifier, true);
+  }
+
+  @Test
+  public void testRenameRedshiftTable() {
+    TableIdentifier identifier = TableIdentifier.of("db", "tableName");
+    GlueCatalogExtensions glueCatalogExtensions = Mockito.mock(GlueCatalogExtensions.class);
+    GlueTable glueTable = Mockito.mock(GlueTable.class);
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GLUE_CATALOG_SKIP_NAME_VALIDATION, "true",
+            GLUE_CATALOG_ID, "123456789012/rs_ns/rs_db");
+    Mockito.doReturn(glueTable).when(glueCatalogExtensions).loadTable(identifier);
+    Mockito.doReturn(true).when(glueCatalogExtensions).dropTable(identifier, true);
+    Mockito.doReturn(true)
+        .when(glueCatalogExtensions)
+        .useExtensionsForGlueTable(Mockito.any(Table.class));
+    Mockito.doReturn(
+            GetTableResponse.builder()
+                .table(
+                    Table.builder()
+                        .name("tableName")
+                        .storageDescriptor(
+                            StorageDescriptor.builder().inputFormat("RedshiftFormat").build())
+                        .build())
+                .build())
+        .when(glue)
+        .getTable(Mockito.any(GetTableRequest.class));
+
+    glueCatalog.initialize(
+        CATALOG_NAME,
+        WAREHOUSE_PATH,
+        new AwsProperties(properties),
+        new S3FileIOProperties(properties),
+        glue,
+        LockManagers.defaultLockManager(),
+        properties);
+    glueCatalog.setExtensions(glueCatalogExtensions);
+    glueCatalog.dropTable(identifier);
+    Mockito.verify(glueCatalogExtensions).dropTable(identifier, true);
+  }
+
+  @Test
+  public void testCreateRedshiftNamespace() {
+    Namespace namespace = Namespace.of("ns");
+    GlueCatalogExtensions glueCatalogExtensions = Mockito.mock(GlueCatalogExtensions.class);
+    Map<String, String> properties = ImmutableMap.of("type", "redshift");
+    Mockito.doNothing().when(glueCatalogExtensions).createNamespace(namespace, properties);
+    Mockito.doReturn(glueCatalogExtensions).when(glueCatalogExtensions).namespaces();
+
+    glueCatalog.initialize(
+        CATALOG_NAME,
+        WAREHOUSE_PATH,
+        new AwsProperties(properties),
+        new S3FileIOProperties(properties),
+        glue,
+        LockManagers.defaultLockManager(),
+        properties);
+    glueCatalog.setExtensions(glueCatalogExtensions);
+    glueCatalog.createNamespace(namespace, ImmutableMap.of("type", "redshift"));
+  }
+
+  @Test
+  public void testDropRedshiftNamespace() {
+    Namespace namespace = Namespace.of("ns");
+    GlueCatalogExtensions glueCatalogExtensions = Mockito.mock(GlueCatalogExtensions.class);
+    Map<String, String> properties = ImmutableMap.of("type", "redshift");
+    Database database =
+        Database.builder()
+            .name("ns")
+            .federatedDatabase(FederatedDatabase.builder().connectionName("aws:redshift").build())
+            .build();
+    Mockito.doReturn(true).when(glueCatalogExtensions).dropNamespace(namespace);
+    Mockito.doReturn(true).when(glueCatalogExtensions).useExtensionsForGlueDatabase(database);
+    Mockito.doReturn(glueCatalogExtensions).when(glueCatalogExtensions).namespaces();
+    Mockito.doReturn(GetDatabaseResponse.builder().database(database).build())
+        .when(glue)
+        .getDatabase(Mockito.any(GetDatabaseRequest.class));
+
+    glueCatalog.initialize(
+        CATALOG_NAME,
+        WAREHOUSE_PATH,
+        new AwsProperties(properties),
+        new S3FileIOProperties(properties),
+        glue,
+        LockManagers.defaultLockManager(),
+        properties);
+    glueCatalog.setExtensions(glueCatalogExtensions);
+    glueCatalog.dropNamespace(namespace);
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -470,6 +470,7 @@ project(':iceberg-aws') {
     compileOnly("software.amazon.awssdk:sts")
     compileOnly("software.amazon.awssdk:dynamodb")
     compileOnly("software.amazon.awssdk:lakeformation")
+    compileOnly(libs.awssdk.glue.extensions)
 
     compileOnly(libs.hadoop2.common) {
       exclude group: 'org.apache.avro', module: 'avro'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ awaitility = "4.2.2"
 awssdk-bom = "2.29.23"
 azuresdk-bom = "1.2.29"
 awssdk-s3accessgrants = "2.3.0"
+awssdk-glue-extensions = "0.1.0"
 caffeine = "2.9.3"
 calcite = "1.10.0"
 datasketches = "6.1.1"
@@ -99,6 +100,7 @@ arrow-vector = { module = "org.apache.arrow:arrow-vector", version.ref = "arrow"
 avro-avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 awssdk-bom = { module = "software.amazon.awssdk:bom", version.ref = "awssdk-bom" }
 awssdk-s3accessgrants = { module = "software.amazon.s3.accessgrants:aws-s3-accessgrants-java-plugin", version.ref = "awssdk-s3accessgrants" }
+awssdk-glue-extensions = { module = "software.amazon.glue:glue-catalog-extensions-for-iceberg", version.ref = "awssdk-glue-extensions" }
 azuresdk-bom = { module = "com.azure:azure-sdk-bom", version.ref = "azuresdk-bom" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 calcite-core = { module = "org.apache.calcite:calcite-core", version.ref = "calcite" }


### PR DESCRIPTION
This PR adds integration with [Glue extensions for Iceberg](https://github.com/awslabs/glue-extensions-for-iceberg/), to enable access to the new Glue multi-catalog hierarchy in the Amazon SageMaker Lakehouse, as announced in the CEO Keynote with Matt Garman during AWS re:Invent 2024. This will allow access to read non-Iceberg data sources through Iceberg GlueCatalog, starting with Amazon Redshift data right away, and will be extended to many more federated data sources in subsequent releases of the Glue service in 2025.

The extensions library is used to communicate with the [Glue catalog extensions API](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/awslabs/glue-extensions-for-iceberg/refs/heads/main/glue-extensions-api.yaml) is another set of APIs in OpenAPI specification that we have added and can be viewed as extensions to the Glue Catalog APIs and Glue IRC APIs to enable additional functionalities that we have been discussing in open source Iceberg IRC spec for scan planning, fine-grained data commit and long-running transaction supports. As we continue to discuss these IRC features in open source, AWS Glue customers will be able to use these features early with all AWS analytics service integrations through this extensions API that is integrated with the GlueCatalog component in Iceberg.

@jackye1995 @yyanyy
