### PR TITLE
Core: Merge conflicting deletion vectors

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
@@ -140,7 +140,7 @@ class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta
         validateNoNewDeleteFiles(base, startingSnapshotId, conflictDetectionFilter, parent);
       }
 
-      validateAddedDVs(base, startingSnapshotId, conflictDetectionFilter, parent);
+      mergeConflictingDVs(base, startingSnapshotId, conflictDetectionFilter, parent);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/deletes/BaseDVFileWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BaseDVFileWriter.java
@@ -72,6 +72,17 @@ public class BaseDVFileWriter implements DVFileWriter {
   }
 
   @Override
+  public void delete(
+      String path,
+      PositionDeleteIndex positionDeleteIndex,
+      PartitionSpec spec,
+      StructLike partition) {
+    Deletes deletes =
+        deletesByPath.computeIfAbsent(path, key -> new Deletes(path, spec, partition));
+    deletes.positions().merge(positionDeleteIndex);
+  }
+
+  @Override
   public DeleteWriteResult result() {
     Preconditions.checkState(result != null, "Cannot get result from unclosed writer");
     return result;

--- a/core/src/main/java/org/apache/iceberg/deletes/DVFileWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/DVFileWriter.java
@@ -37,6 +37,22 @@ public interface DVFileWriter extends Closeable {
   void delete(String path, long pos, PartitionSpec spec, StructLike partition);
 
   /**
+   * Marks every position that is deleted in positionDeleteIndex as deleted in the given data file.
+   *
+   * @param path the data file path
+   * @param positionDeleteIndex the position delete index containing all the positions to delete
+   * @param spec the data file partition spec
+   * @param partition the data file partition
+   */
+  default void delete(
+      String path,
+      PositionDeleteIndex positionDeleteIndex,
+      PartitionSpec spec,
+      StructLike partition) {
+    throw new UnsupportedOperationException("Delete with positionDeleteIndex is not supported");
+  }
+
+  /**
    * Returns a result that contains information about written {@link DeleteFile}s. The result is
    * valid only after the writer is closed.
    *

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -30,13 +30,20 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.encryption.EncryptingFileIO;
+import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.IOUtil;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceMap;
+import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.Filter;
 import org.apache.iceberg.util.ParallelIterable;
 import org.apache.iceberg.util.SortedMerge;
@@ -206,6 +213,18 @@ public class Deletes {
 
   public static PositionDeleteIndex toPositionIndex(CloseableIterable<Long> posDeletes) {
     return toPositionIndex(posDeletes, ImmutableList.of());
+  }
+
+  public static PositionDeleteIndex readDV(
+      DeleteFile deleteFile, FileIO fileIO, EncryptionManager encryptionManager) {
+    Preconditions.checkArgument(
+        ContentFileUtil.isDV(deleteFile), "Delete file must be a deletion vector");
+    InputFile inputFile =
+        EncryptingFileIO.combine(fileIO, encryptionManager).newInputFile(deleteFile);
+    long offset = deleteFile.contentOffset();
+    int length = deleteFile.contentSizeInBytes().intValue();
+    byte[] bytes = IOUtil.readBytes(inputFile, offset, length);
+    return PositionDeleteIndex.deserialize(bytes, deleteFile);
   }
 
   private static PositionDeleteIndex toPositionIndex(

--- a/core/src/main/java/org/apache/iceberg/io/OutputFileFactory.java
+++ b/core/src/main/java/org/apache/iceberg/io/OutputFileFactory.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptionManager;
 
@@ -90,6 +91,11 @@ public class OutputFileFactory {
     return new Builder(table, partitionId, taskId);
   }
 
+  public static Builder builderFor(
+      TableOperations ops, PartitionSpec spec, FileFormat format, int partitionId, long taskId) {
+    return new Builder(ops, spec, format, partitionId, taskId);
+  }
+
   private String generateFilename() {
     return format.addExtension(
         String.format(
@@ -121,9 +127,10 @@ public class OutputFileFactory {
   }
 
   public static class Builder {
-    private final Table table;
     private final int partitionId;
     private final long taskId;
+    private Table table;
+    private TableOperations ops;
     private PartitionSpec defaultSpec;
     private String operationId;
     private FileFormat format;
@@ -141,6 +148,17 @@ public class OutputFileFactory {
           table.properties().getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT);
       this.format = FileFormat.fromString(formatAsString);
       this.ioSupplier = table::io;
+    }
+
+    private Builder(
+        TableOperations ops, PartitionSpec spec, FileFormat format, int partitionId, long taskId) {
+      this.ops = ops;
+      this.ioSupplier = ops::io;
+      this.partitionId = partitionId;
+      this.taskId = taskId;
+      this.defaultSpec = spec;
+      this.operationId = UUID.randomUUID().toString();
+      this.format = format;
     }
 
     public Builder defaultSpec(PartitionSpec newDefaultSpec) {
@@ -176,8 +194,9 @@ public class OutputFileFactory {
     }
 
     public OutputFileFactory build() {
-      LocationProvider locations = table.locationProvider();
-      EncryptionManager encryption = table.encryption();
+      LocationProvider locations =
+          table != null ? table.locationProvider() : ops.locationProvider();
+      EncryptionManager encryption = table != null ? table.encryption() : ops.encryption();
       return new OutputFileFactory(
           defaultSpec,
           format,


### PR DESCRIPTION
This PR adds the ability to merge conflicting deletion vectors for a given data file instead of failing the commit. In parallel, every conflicting DV will be merged with the committed DV, and a new Puffin with the merged DV will be output per datafile which had conflicting DVs.
This PR also takes care of any tables that wrote multiple DVs for a given data file (which is not spec compliant) by opportunistically merging those as well