### PR TITLE
Spark 3.4: Add REST catalog to Spark integration tests

### DIFF
--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -107,9 +107,14 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
+    testImplementation (project(path: ':iceberg-open-api', configuration: 'testFixturesRuntimeElements')) {
+      transitive = false
+    }
     testImplementation libs.sqlite.jdbc
     testImplementation libs.awaitility
     testImplementation libs.junit.vintage.engine
+    // runtime dependencies for running REST Catalog based integration test
+    testRuntimeOnly libs.jetty.servlet
   }
 
   test {
@@ -174,6 +179,12 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+    testImplementation (project(path: ':iceberg-open-api', configuration: 'testFixturesRuntimeElements')) {
+      transitive = false
+    }
+    // runtime dependencies for running REST Catalog based integration test
+    testRuntimeOnly libs.jetty.servlet
+    testRuntimeOnly libs.sqlite.jdbc
 
     testImplementation libs.avro.avro
     testImplementation libs.parquet.hadoop
@@ -252,6 +263,17 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
     integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+
+    // runtime dependencies for running Hive Catalog based integration test
+    integrationRuntimeOnly project(':iceberg-hive-metastore')
+    // runtime dependencies for running REST Catalog based integration test
+    integrationRuntimeOnly project(path: ':iceberg-core', configuration: 'testArtifacts')
+    integrationRuntimeOnly (project(path: ':iceberg-open-api', configuration: 'testFixturesRuntimeElements')) {
+      transitive = false
+    }
+    integrationRuntimeOnly libs.jetty.servlet
+    integrationRuntimeOnly libs.sqlite.jdbc
+
     // Not allowed on our classpath, only the runtime jar is allowed
     integrationCompileOnly project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}")
     integrationCompileOnly project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}")

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -528,6 +528,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     spark.createDataFrame(newRecords, newSparkSchema).coalesce(1).writeTo(tableName).append();
 
+    table.refresh();
+
     Long currentSnapshotId = table.currentSnapshot().snapshotId();
 
     Dataset<Row> actualFilesDs =

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/rest/RESTServerRule.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/rest/RESTServerRule.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import java.util.Map;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.rules.ExternalResource;
+
+/**
+ * This class is to make the {@link RESTCatalogServer} usable for JUnit4 in a similar way to {@link
+ * RESTServerExtension}.
+ */
+public class RESTServerRule extends ExternalResource {
+  public static final String FREE_PORT = "0";
+
+  private volatile RESTCatalogServer localServer;
+  private RESTCatalog client;
+  private final Map<String, String> config;
+
+  public RESTServerRule() {
+    config = Maps.newHashMap();
+  }
+
+  public RESTServerRule(Map<String, String> config) {
+    Map<String, String> conf = Maps.newHashMap(config);
+    if (conf.containsKey(RESTCatalogServer.REST_PORT)
+        && conf.get(RESTCatalogServer.REST_PORT).equals(FREE_PORT)) {
+      conf.put(RESTCatalogServer.REST_PORT, String.valueOf(RCKUtils.findFreePort()));
+    }
+    this.config = conf;
+  }
+
+  public Map<String, String> config() {
+    return config;
+  }
+
+  public RESTCatalog client() {
+    if (null == client) {
+      try {
+        maybeInitClientAndServer();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    return client;
+  }
+
+  public String uri() {
+    return client().properties().get(CatalogProperties.URI);
+  }
+
+  private void maybeInitClientAndServer() throws Exception {
+    if (null == localServer) {
+      synchronized (this) {
+        if (null == localServer) {
+          this.localServer = new RESTCatalogServer(config);
+          this.localServer.start(false);
+          this.client = RCKUtils.initCatalogClient(config);
+        }
+      }
+    }
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    maybeShutdownClientAndServer();
+    maybeInitClientAndServer();
+  }
+
+  @Override
+  protected void after() {
+    maybeShutdownClientAndServer();
+  }
+
+  private void maybeShutdownClientAndServer() {
+    try {
+      if (localServer != null) {
+        localServer.stop();
+        localServer = null;
+      }
+      if (client != null) {
+        client.close();
+        client = null;
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
@@ -34,6 +34,10 @@ public enum SparkCatalogConfig {
       "testhadoop",
       SparkCatalog.class.getName(),
       ImmutableMap.of("type", "hadoop", "cache-enabled", "false")),
+  REST(
+      "testrest",
+      SparkCatalog.class.getName(),
+      ImmutableMap.of("type", "rest", "cache-enabled", "false")),
   SPARK(
       "spark_catalog",
       SparkSessionCatalog.class.getName(),

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.spark;
 
 import java.util.Map;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -45,6 +47,14 @@ public abstract class SparkCatalogTestBase extends SparkTestBaseWithCatalog {
         SparkCatalogConfig.SPARK.catalogName(),
         SparkCatalogConfig.SPARK.implementation(),
         SparkCatalogConfig.SPARK.properties()
+      },
+      {
+        SparkCatalogConfig.REST.catalogName(),
+        SparkCatalogConfig.REST.implementation(),
+        ImmutableMap.builder()
+            .putAll(SparkCatalogConfig.REST.properties())
+            .put(CatalogProperties.URI, REST_SERVER_RULE.uri())
+            .build()
       }
     };
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableStatsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableStatsAction.java
@@ -116,6 +116,7 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
             new SimpleRecord(4, "d"));
     spark.createDataset(records, Encoders.bean(SimpleRecord.class)).writeTo(tableName).append();
     SparkActions actions = SparkActions.get();
+    table.refresh();
     ComputeTableStats.Result results =
         actions.computeTableStats(table).columns("id", "data").execute();
     assertThat(results).isNotNull();

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
@@ -18,8 +18,11 @@
  */
 package org.apache.iceberg.spark.sql;
 
+import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE;
+import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE_REST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.Map;
 import org.apache.iceberg.catalog.Namespace;
@@ -32,7 +35,6 @@ import org.apache.spark.SparkException;
 import org.apache.spark.sql.AnalysisException;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -293,8 +295,13 @@ public class TestAlterTable extends SparkCatalogTestBase {
 
   @Test
   public void testTableRename() {
-    Assume.assumeFalse(
-        "Hadoop catalog does not support rename", validationCatalog instanceof HadoopCatalog);
+    assumeThat(catalogConfig.get(ICEBERG_CATALOG_TYPE))
+        .as(
+            "need to fix https://github.com/apache/iceberg/issues/11154 before enabling this for the REST catalog")
+        .isNotEqualTo(ICEBERG_CATALOG_TYPE_REST);
+    assumeThat(validationCatalog)
+        .as("Hadoop catalog does not support rename")
+        .isNotInstanceOf(HadoopCatalog.class);
 
     Assert.assertTrue("Initial name should exist", validationCatalog.tableExists(tableIdent));
     Assert.assertFalse("New name should not exist", validationCatalog.tableExists(renamedIdent));

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTableAsSelect.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTableAsSelect.java
@@ -394,6 +394,8 @@ public class TestCreateTableAsSelect extends SparkCatalogTestBase {
             + "FROM %s ORDER BY 3, 1",
         tableName, sourceName);
 
+    rtasTable.refresh();
+
     Schema expectedSchema =
         new Schema(
             Types.NestedField.optional(1, "id", Types.LongType.get()),

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestRefreshTable.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestRefreshTable.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.sql;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -50,8 +51,11 @@ public class TestRefreshTable extends SparkCatalogTestBase {
   public void testRefreshCommand() {
     // We are not allowed to change the session catalog after it has been initialized, so build a
     // new one
-    if (catalogName.equals(SparkCatalogConfig.SPARK.catalogName())
-        || catalogName.equals(SparkCatalogConfig.HADOOP.catalogName())) {
+    if (Set.of(
+            SparkCatalogConfig.SPARK.catalogName(),
+            SparkCatalogConfig.HADOOP.catalogName(),
+            SparkCatalogConfig.REST.catalogName())
+        .contains(catalogName)) {
       spark.conf().set("spark.sql.catalog." + catalogName + ".cache-enabled", true);
       spark = spark.cloneSession();
     }


### PR DESCRIPTION
This backports https://github.com/apache/iceberg/pull/11093 to Spark 3.4 as this is required in order to be able to backport the tests to Spark 3.4 of https://github.com/apache/iceberg/pull/11388