### PR TITLE
Flink: Avoid RANGE mode broken chain when write parallelism changes

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
@@ -666,8 +667,16 @@ public class FlinkSink {
 
           return shuffleStream
               .partitionCustom(new RangePartitioner(iSchema, sortOrder), r -> r)
-              .filter(StatisticsOrRecord::hasRecord)
-              .map(StatisticsOrRecord::record);
+              .flatMap(
+                  (FlatMapFunction<StatisticsOrRecord, RowData>)
+                      (statisticsOrRecord, out) -> {
+                        if (statisticsOrRecord.hasRecord()) {
+                          out.collect(statisticsOrRecord.record());
+                        }
+                      })
+              // Set the parallelism same as writerParallelism avoid broken chain
+              .setParallelism(writerParallelism)
+              .returns(RowData.class);
 
         default:
           throw new RuntimeException("Unrecognized " + WRITE_DISTRIBUTION_MODE + ": " + writeMode);

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -674,7 +674,8 @@ public class FlinkSink {
                           out.collect(statisticsOrRecord.record());
                         }
                       })
-              // Set the parallelism same as writerParallelism avoid broken chain
+              // Set the parallelism same as writerParallelism to
+              // promote operator chaining with the downstream writer operator
               .setParallelism(writerParallelism)
               .returns(RowData.class);
 


### PR DESCRIPTION
Detailed： #11543

This fix will modify the data processing process in RANGE mode, set the filter link of `StatisticsOrRecord` and actively set it to `writeParallelism` to avoid the shuffle mode changing to rebalance due to changes in parallelism in subsequent write operators.

