### PR TITLE
API: Make the Field-ID required on the `UnboundPartitionSpec`

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -51,7 +51,7 @@ import org.apache.iceberg.types.Types.StructType;
  */
 public class PartitionSpec implements Serializable {
   // IDs for partition fields start at 1000
-  private static final int PARTITION_DATA_ID_START = 1000;
+  static final int PARTITION_DATA_ID_START = 1000;
 
   private final Schema schema;
 

--- a/api/src/main/java/org/apache/iceberg/UnboundPartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/UnboundPartitionSpec.java
@@ -61,8 +61,8 @@ public class UnboundPartitionSpec {
       } else {
         transform = Transforms.fromString(field.transform.toString());
       }
-      if (field.partitionId != null) {
-        builder.add(field.sourceId, field.partitionId, field.name, transform);
+      if (field.fieldId != null) {
+        builder.add(field.sourceId, field.fieldId, field.name, transform);
       } else {
         builder.add(field.sourceId, field.name, transform);
       }
@@ -93,6 +93,12 @@ public class UnboundPartitionSpec {
       return this;
     }
 
+    /**
+     * Add a field without a field-id
+     *
+     * @deprecated use {@link #addField(String, int, int, String)} instead; will be removed in 2.0.0
+     */
+    @Deprecated
     Builder addField(String transformAsString, int sourceId, String name) {
       fields.add(new UnboundPartitionField(transformAsString, sourceId, null, name));
       return this;
@@ -106,7 +112,7 @@ public class UnboundPartitionSpec {
   static class UnboundPartitionField {
     private final Transform<?, ?> transform;
     private final int sourceId;
-    private final Integer partitionId;
+    private final Integer fieldId;
     private final String name;
 
     public Transform<?, ?> transform() {
@@ -121,8 +127,18 @@ public class UnboundPartitionSpec {
       return sourceId;
     }
 
+    /**
+     * The id of the partition field
+     *
+     * @deprecated use {@link #fieldId()} instead; will be removed in 2.0.0
+     */
+    @Deprecated
     public Integer partitionId() {
-      return partitionId;
+      return fieldId;
+    }
+
+    public Integer fieldId() {
+      return fieldId;
     }
 
     public String name() {
@@ -130,10 +146,10 @@ public class UnboundPartitionSpec {
     }
 
     private UnboundPartitionField(
-        String transformAsString, int sourceId, Integer partitionId, String name) {
+        String transformAsString, int sourceId, Integer fieldId, String name) {
       this.transform = Transforms.fromString(transformAsString);
       this.sourceId = sourceId;
-      this.partitionId = partitionId;
+      this.fieldId = fieldId;
       this.name = name;
     }
   }

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -748,11 +748,6 @@ public class TestHelpers {
       return this;
     }
 
-    public ExpectedSpecBuilder addField(String transformAsString, int sourceId, String name) {
-      unboundPartitionSpecBuilder.addField(transformAsString, sourceId, name);
-      return this;
-    }
-
     public PartitionSpec build() {
       Preconditions.checkNotNull(schema, "Field schema is missing");
       return unboundPartitionSpecBuilder.build().bind(schema);

--- a/core/src/main/java/org/apache/iceberg/PartitionSpecParser.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionSpecParser.java
@@ -125,6 +125,7 @@ public class PartitionSpecParser {
 
     Iterator<JsonNode> elements = json.elements();
     int fieldIdCount = 0;
+    int fieldCount = 0;
     while (elements.hasNext()) {
       JsonNode element = elements.next();
       Preconditions.checkArgument(
@@ -140,7 +141,8 @@ public class PartitionSpecParser {
         builder.addField(transform, sourceId, JsonUtil.getInt(FIELD_ID, element), name);
         fieldIdCount++;
       } else {
-        builder.addField(transform, sourceId, name);
+        builder.addField(
+            transform, sourceId, PartitionSpec.PARTITION_DATA_ID_START + fieldCount++, name);
       }
     }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
@@ -77,7 +77,7 @@ public class TestForwardCompatibility {
       org.apache.iceberg.TestHelpers.newExpectedSpecBuilder()
           .withSchema(SCHEMA)
           .withSpecId(0)
-          .addField("zero", 1, "id_zero")
+          .addField("zero", 1, 1000, "id_zero")
           .build();
 
   // create a fake spec to use to write table metadata
@@ -85,7 +85,7 @@ public class TestForwardCompatibility {
       org.apache.iceberg.TestHelpers.newExpectedSpecBuilder()
           .withSchema(SCHEMA)
           .withSpecId(0)
-          .addField("identity", 1, "id_zero")
+          .addField("identity", 1, 1000, "id_zero")
           .build();
 
   @Rule public TemporaryFolder temp = new TemporaryFolder();

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
@@ -630,7 +630,7 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
         TestHelpers.newExpectedSpecBuilder()
             .withSchema(table.schema())
             .withSpecId(1)
-            .addField("zero", 1, "id_zero")
+            .addField("zero", 1, 1000, "id_zero")
             .build();
 
     // replace the table spec to include an unknown transform

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
@@ -81,7 +81,7 @@ public class TestSparkMetadataColumns extends SparkTestBase {
       TestHelpers.newExpectedSpecBuilder()
           .withSchema(SCHEMA)
           .withSpecId(1)
-          .addField("zero", 1, "id_zero")
+          .addField("zero", 1, 1000, "id_zero")
           .build();
 
   @Parameterized.Parameters(name = "fileFormat = {0}, vectorized = {1}, formatVersion = {2}")

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
@@ -77,7 +77,7 @@ public class TestForwardCompatibility {
       org.apache.iceberg.TestHelpers.newExpectedSpecBuilder()
           .withSchema(SCHEMA)
           .withSpecId(0)
-          .addField("zero", 1, "id_zero")
+          .addField("zero", 1, 1000, "id_zero")
           .build();
 
   // create a fake spec to use to write table metadata
@@ -85,7 +85,7 @@ public class TestForwardCompatibility {
       org.apache.iceberg.TestHelpers.newExpectedSpecBuilder()
           .withSchema(SCHEMA)
           .withSpecId(0)
-          .addField("identity", 1, "id_zero")
+          .addField("identity", 1, 1000, "id_zero")
           .build();
 
   @Rule public TemporaryFolder temp = new TemporaryFolder();

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
@@ -630,7 +630,7 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
         TestHelpers.newExpectedSpecBuilder()
             .withSchema(table.schema())
             .withSpecId(1)
-            .addField("zero", 1, "id_zero")
+            .addField("zero", 1, 1000, "id_zero")
             .build();
 
     // replace the table spec to include an unknown transform

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
@@ -81,7 +81,7 @@ public class TestSparkMetadataColumns extends SparkTestBase {
       TestHelpers.newExpectedSpecBuilder()
           .withSchema(SCHEMA)
           .withSpecId(1)
-          .addField("zero", 1, "id_zero")
+          .addField("zero", 1, 1000, "id_zero")
           .build();
 
   @Parameterized.Parameters(name = "fileFormat = {0}, vectorized = {1}, formatVersion = {2}")

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
@@ -77,14 +77,14 @@ public class TestForwardCompatibility {
       org.apache.iceberg.TestHelpers.newExpectedSpecBuilder()
           .withSchema(SCHEMA)
           .withSpecId(0)
-          .addField("zero", 1, "id_zero")
+          .addField("zero", 1, 1000, "id_zero")
           .build();
   // create a fake spec to use to write table metadata
   private static final PartitionSpec FAKE_SPEC =
       org.apache.iceberg.TestHelpers.newExpectedSpecBuilder()
           .withSchema(SCHEMA)
           .withSpecId(0)
-          .addField("identity", 1, "id_zero")
+          .addField("identity", 1, 1000, "id_zero")
           .build();
 
   @TempDir private Path temp;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
@@ -625,7 +625,7 @@ public class TestMetadataTablesWithPartitionEvolution extends CatalogTestBase {
         TestHelpers.newExpectedSpecBuilder()
             .withSchema(table.schema())
             .withSpecId(1)
-            .addField("zero", 1, "id_zero")
+            .addField("zero", 1, 1000, "id_zero")
             .build();
 
     // replace the table spec to include an unknown transform

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
@@ -84,7 +84,7 @@ public class TestSparkMetadataColumns extends TestBase {
       TestHelpers.newExpectedSpecBuilder()
           .withSchema(SCHEMA)
           .withSpecId(1)
-          .addField("zero", 1, "id_zero")
+          .addField("zero", 1, 1000, "id_zero")
           .build();
 
   @Parameters(name = "fileFormat = {0}, vectorized = {1}, formatVersion = {2}")


### PR DESCRIPTION
This caused some confusion, so I thought it would be good to clean this up in the reference impl.

- This renames `partitionId` to `fieldId` to align with the spec and the field name (`field-id`).
- It deprecates adding fields without a field-id. This way we can convert the `Integer` into an `int` once the method has been removed.

Since we write the [`field-id` for the V1 tables in Java](https://github.com/apache/iceberg/blob/36140b819c60743b39176e28a63ab588df445329/core/src/main/java/org/apache/iceberg/PartitionSpecParser.java#L102), I think it would be good to change it into optional for V1:

https://github.com/apache/iceberg/blob/36140b819c60743b39176e28a63ab588df445329/format/spec.md?plain=1#L1353

Would love to get some thoughts on that