### PR TITLE
Spark3.4,3.5,Api,Hive: Fix using NullType in View.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Type.java
+++ b/api/src/main/java/org/apache/iceberg/types/Type.java
@@ -46,7 +46,8 @@ public interface Type extends Serializable {
     STRUCT(StructLike.class),
     LIST(List.class),
     MAP(Map.class),
-    VARIANT(Object.class);
+    VARIANT(Object.class),
+    NULL(CharSequence.class);
 
     private final Class<?> javaClass;
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -55,6 +55,7 @@ public class Types {
           .put(StringType.get().toString(), StringType.get())
           .put(UUIDType.get().toString(), UUIDType.get())
           .put(BinaryType.get().toString(), BinaryType.get())
+          .put(NullType.get().toString(), NullType.get())
           .buildOrThrow();
 
   private static final Pattern FIXED = Pattern.compile("fixed\\[\\s*(\\d+)\\s*\\]");
@@ -409,6 +410,24 @@ public class Types {
     @Override
     public String toString() {
       return "binary";
+    }
+  }
+
+  public static class NullType extends PrimitiveType {
+    private static final NullType INSTANCE = new NullType();
+
+    public static NullType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.NULL;
+    }
+
+    @Override
+    public String toString() {
+      return "null";
     }
   }
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -157,6 +157,7 @@ public final class HiveSchemaUtil {
       case TIME:
       case STRING:
       case UUID:
+      case NULL:
         return "string";
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -117,6 +117,31 @@ public class TestViews extends SparkExtensionsTestBase {
   }
 
   @Test
+  public void readFromViewWithNullColumn() throws NoSuchTableException {
+    insertRows(10);
+    String viewName = viewName("viewWithNullColumn");
+    String sql = String.format("SELECT id , NULL as col_test FROM %s WHERE id <=1", tableName);
+
+    assertThat(sql(sql)).hasSize(1);
+
+    ViewCatalog viewCatalog = viewCatalog();
+
+    viewCatalog
+        .buildView(TableIdentifier.of(NAMESPACE, viewName))
+        .withQuery("spark", sql)
+        // use non-existing column name to make sure only the SQL definition for spark is loaded
+        .withQuery("trino", String.format("SELECT non_existing FROM %s", tableName))
+        .withDefaultNamespace(NAMESPACE)
+        .withDefaultCatalog(catalogName)
+        .withSchema(schema(sql))
+        .create();
+
+    assertThat(sql("SELECT * FROM %s", viewName))
+        .hasSize(1)
+        .containsExactlyInAnyOrder(row(1, null));
+  }
+
+  @Test
   public void readFromTrinoView() throws NoSuchTableException {
     insertRows(10);
     String viewName = viewName("trinoView");

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.types.FloatType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.NullType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
@@ -155,6 +156,8 @@ class SparkTypeToType extends SparkTypeVisitor<Type> {
           ((DecimalType) atomic).precision(), ((DecimalType) atomic).scale());
     } else if (atomic instanceof BinaryType) {
       return Types.BinaryType.get();
+    } else if (atomic instanceof NullType) {
+      return Types.NullType.get();
     }
 
     throw new UnsupportedOperationException("Not a supported type: " + atomic.catalogString());

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
@@ -38,6 +38,7 @@ import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.MapType$;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.NullType$;
 import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType$;
@@ -124,6 +125,8 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;
         return DecimalType$.MODULE$.apply(decimal.precision(), decimal.scale());
+      case NULL:
+        return NullType$.MODULE$;
       default:
         throw new UnsupportedOperationException(
             "Cannot convert unknown type to Spark: " + primitive);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.types.FloatType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.NullType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
@@ -155,6 +156,8 @@ class SparkTypeToType extends SparkTypeVisitor<Type> {
           ((DecimalType) atomic).precision(), ((DecimalType) atomic).scale());
     } else if (atomic instanceof BinaryType) {
       return Types.BinaryType.get();
+    } else if (atomic instanceof NullType) {
+      return Types.NullType.get();
     }
 
     throw new UnsupportedOperationException("Not a supported type: " + atomic.catalogString());

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
@@ -38,6 +38,7 @@ import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.MapType$;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.NullType$;
 import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType$;
@@ -124,6 +125,8 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;
         return DecimalType$.MODULE$.apply(decimal.precision(), decimal.scale());
+      case NULL:
+        return NullType$.MODULE$;
       default:
         throw new UnsupportedOperationException(
             "Cannot convert unknown type to Spark: " + primitive);


### PR DESCRIPTION
This PR fixes an issue where using nulltype in views would return exception.