### PR TITLE
API: Add missing deprecations

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
@@ -43,6 +43,12 @@ class Bucket<T> implements Transform<T, Integer>, Serializable {
     return new Bucket<>(numBuckets);
   }
 
+  /**
+   * Instantiates a new Bucket Transform
+   *
+   * @deprecated will be removed in 2.0.0; use {@link #get(int)} instead
+   */
+  @Deprecated
   @SuppressWarnings("unchecked")
   static <T, B extends Bucket<T> & SerializableFunction<T, Integer>> B get(
       Type type, int numBuckets) {
@@ -94,6 +100,14 @@ class Bucket<T> implements Transform<T, Integer>, Serializable {
         "hash(value) is not supported on the base Bucket class");
   }
 
+  /**
+   * Transforms a value to its corresponding partition value.
+   *
+   * @param value a source value
+   * @return a transformed partition value
+   * @deprecated will be removed in 2.0.0; use {@link #bind(Type)} instead
+   */
+  @Deprecated
   @Override
   public Integer apply(T value) {
     if (value == null) {

--- a/api/src/main/java/org/apache/iceberg/transforms/Dates.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Dates.java
@@ -73,6 +73,14 @@ enum Dates implements Transform<Integer, Integer> {
     this.apply = new Apply(granularity);
   }
 
+  /**
+   * Transforms a value to its corresponding partition value.
+   *
+   * @param days a source value
+   * @return a transformed partition value
+   * @deprecated will be removed in 2.0.0; use {@link #bind(Type)} instead
+   */
+  @Deprecated
   @Override
   public Integer apply(Integer days) {
     return apply.apply(days);

--- a/api/src/main/java/org/apache/iceberg/transforms/Identity.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Identity.java
@@ -71,6 +71,14 @@ class Identity<T> implements Transform<T, T> {
     this.type = type;
   }
 
+  /**
+   * Transforms a value to its corresponding partition value.
+   *
+   * @param value a source value
+   * @return a transformed partition value
+   * @deprecated will be removed in 2.0.0; use {@link #bind(Type)} instead
+   */
+  @Deprecated
   @Override
   public T apply(T value) {
     return value;

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -52,6 +52,14 @@ enum Timestamps implements Transform<Long, Integer> {
     this.apply = apply;
   }
 
+  /**
+   * Transforms a value to its corresponding partition value.
+   *
+   * @param timestamp a source value
+   * @return a transformed partition value
+   * @deprecated will be removed in 2.0.0; use {@link #bind(Type)} instead
+   */
+  @Deprecated
   @Override
   public Integer apply(Long timestamp) {
     return apply.apply(timestamp);

--- a/api/src/main/java/org/apache/iceberg/transforms/UnknownTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/UnknownTransform.java
@@ -33,6 +33,14 @@ public class UnknownTransform<S, T> implements Transform<S, T> {
     this.transform = transform;
   }
 
+  /**
+   * Transforms a value to its corresponding partition value.
+   *
+   * @param value a source value
+   * @return a transformed partition value
+   * @deprecated will be removed in 2.0.0; use {@link #bind(Type)} instead
+   */
+  @Deprecated
   @Override
   public T apply(S value) {
     throw new UnsupportedOperationException(

--- a/api/src/main/java/org/apache/iceberg/transforms/UnknownTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/UnknownTransform.java
@@ -37,7 +37,8 @@ public class UnknownTransform<S, T> implements Transform<S, T> {
    * Transforms a value to its corresponding partition value.
    *
    * @param value a source value
-   * @return a transformed partition value
+   * @return ∅
+   * @throws UnsupportedOperationException Implementation is unknown
    * @deprecated will be removed in 2.0.0; use {@link #bind(Type)} instead
    */
   @Deprecated

--- a/api/src/main/java/org/apache/iceberg/transforms/VoidTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/VoidTransform.java
@@ -53,7 +53,7 @@ class VoidTransform<S> implements Transform<S, Void> {
    * Transforms a value to its corresponding partition value.
    *
    * @param value a source value
-   * @return a transformed partition value
+   * @return null
    * @deprecated will be removed in 2.0.0; use {@link #bind(Type)} instead
    */
   @Deprecated

--- a/api/src/main/java/org/apache/iceberg/transforms/VoidTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/VoidTransform.java
@@ -49,6 +49,14 @@ class VoidTransform<S> implements Transform<S, Void> {
 
   private VoidTransform() {}
 
+  /**
+   * Transforms a value to its corresponding partition value.
+   *
+   * @param value a source value
+   * @return a transformed partition value
+   * @deprecated will be removed in 2.0.0; use {@link #bind(Type)} instead
+   */
+  @Deprecated
   @Override
   public Void apply(Object value) {
     return null;
@@ -84,6 +92,16 @@ class VoidTransform<S> implements Transform<S, Void> {
     return true;
   }
 
+  /**
+   * Returns a human-readable String representation of a transformed value.
+   *
+   * <p>null values will return "null"
+   *
+   * @param value a transformed value
+   * @return a human-readable String representation of the value
+   * @deprecated will be removed in 2.0.0; use {@link #toHumanString(Type, Object)} instead
+   */
+  @Deprecated
   @Override
   public String toHumanString(Void value) {
     return "null";

--- a/api/src/main/java/org/apache/iceberg/transforms/VoidTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/VoidTransform.java
@@ -98,7 +98,7 @@ class VoidTransform<S> implements Transform<S, Void> {
    * <p>null values will return "null"
    *
    * @param value a transformed value
-   * @return a human-readable String representation of the value
+   * @return a human-readable String representation of null
    * @deprecated will be removed in 2.0.0; use {@link #toHumanString(Type, Object)} instead
    */
   @Deprecated


### PR DESCRIPTION
Adds some missing deprecations as based in https://github.com/apache/iceberg/pull/11691

Also, copied some deprecations from the interface to the implementations to make it more explicit.