### PR TITLE
Spark 3.5: Add ignore-invalid-options to RewriteDataFilesSparkAction and RewritePositionDeleteFilesSparkAction

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -119,6 +119,15 @@ public interface RewriteDataFiles
   boolean REMOVE_DANGLING_DELETES_DEFAULT = false;
 
   /**
+   * If set to true, the rewrite operation will ignore invalid options.
+   *
+   * <p>Defaults to false.
+   */
+  String IGNORE_INVALID_OPTIONS = "ignore-invalid-options";
+
+  boolean IGNORE_INVALID_OPTIONS_DEFAULT = false;
+
+  /**
    * Forces the rewrite job order based on the value.
    *
    * <p>

--- a/api/src/main/java/org/apache/iceberg/actions/RewritePositionDeleteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewritePositionDeleteFiles.java
@@ -79,6 +79,15 @@ public interface RewritePositionDeleteFiles
   String REWRITE_JOB_ORDER_DEFAULT = RewriteJobOrder.NONE.orderName();
 
   /**
+   * If set to true, the rewrite operation will ignore invalid options.
+   *
+   * <p>Defaults to false.
+   */
+  String IGNORE_INVALID_OPTIONS = "ignore-invalid-options";
+
+  boolean IGNORE_INVALID_OPTIONS_DEFAULT = false;
+
+  /**
    * A filter for finding deletes to rewrite.
    *
    * <p>The filter will be converted to a partition filter with an inclusive projection. Any file

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1215,6 +1215,15 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testIgnoreInvalidOptions() {
+    Table table = createTable(20);
+    basicRewrite(table)
+        .option("ignore-invalid-options", "true")
+        .option("foobarity", "-5")
+        .execute();
+  }
+
+  @TestTemplate
   public void testSortMultipleGroups() {
     Table table = createTable(20);
     shouldHaveFiles(table, 20);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -728,6 +728,27 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     assertEquals("Position deletes must match", expectedDeletes, actualDeletes);
   }
 
+  @TestTemplate
+  public void testIgnoreInvalidOptions() {
+    Table table = createTableUnpartitioned(2, SCALE);
+    assertThatThrownBy(
+            () -> {
+              SparkActions.get(spark)
+                  .rewritePositionDeletes(table)
+                  .option("foobarity", "-5")
+                  .execute();
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot use options [foobarity], they are not supported by the action or the rewriter BIN-PACK");
+
+    SparkActions.get(spark)
+        .rewritePositionDeletes(table)
+        .option("ignore-invalid-options", "true")
+        .option("foobarity", "-5")
+        .execute();
+  }
+
   private Table createTablePartitioned(int partitions, int files, int numRecords) {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
     Table table =


### PR DESCRIPTION
This PR adds a new option `ignore-invalid-options` to RewriteDataFilesSparkAction and RewritePositionDeleteFilesSparkAction. 

It can be useful when we canary-release a new Iceberg version with new options for the above two actions.