### PR TITLE
Core, Flink, Spark, KafkaConnect: Remove remaining usage of deprecated path API

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -850,7 +850,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
     @Override
     public CharSequence path() {
-      return deleteFile.path();
+      return deleteFile.location();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -416,7 +416,7 @@ class V1Metadata {
 
     @Override
     public CharSequence path() {
-      return wrapped.path();
+      return wrapped.location();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -486,7 +486,7 @@ class V2Metadata {
 
     @Override
     public CharSequence path() {
-      return wrapped.path();
+      return wrapped.location();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V3Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V3Metadata.java
@@ -500,7 +500,7 @@ class V3Metadata {
 
     @Override
     public CharSequence path() {
-      return wrapped.path();
+      return wrapped.location();
     }
 
     @Override

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -164,7 +164,7 @@ public class TestRewriteManifests extends TestBase {
 
     // cluster by path will split the manifest into two
 
-    table.rewriteManifests().clusterBy(file -> file.location()).commit();
+    table.rewriteManifests().clusterBy(ContentFile::location).commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
     assertThat(manifests).hasSize(2);

--- a/data/src/test/java/org/apache/iceberg/data/TestDataFileIndexStatsFilters.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestDataFileIndexStatsFilters.java
@@ -451,7 +451,7 @@ public class TestDataFileIndexStatsFilters {
   }
 
   private CharSequenceSet deletePaths(FileScanTask task) {
-    return CharSequenceSet.of(Iterables.transform(task.deletes(), ContentFile::path));
+    return CharSequenceSet.of(Iterables.transform(task.deletes(), ContentFile::location));
   }
 
   private List<FileScanTask> planTasks() throws IOException {

--- a/data/src/test/java/org/apache/iceberg/io/TestTaskEqualityDeltaWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestTaskEqualityDeltaWriter.java
@@ -178,7 +178,7 @@ public class TestTaskEqualityDeltaWriter extends TestBase {
 
     // Check records in the data file.
     DataFile dataFile = result.dataFiles()[0];
-    assertThat(readRecordsAsList(table.schema(), dataFile.path()))
+    assertThat(readRecordsAsList(table.schema(), dataFile.location()))
         .isEqualTo(
             ImmutableList.of(
                 createRecord(1, "aaa"),
@@ -192,13 +192,13 @@ public class TestTaskEqualityDeltaWriter extends TestBase {
 
     // Check records in the pos-delete file.
     Schema posDeleteSchema = DeleteSchemaUtil.pathPosSchema();
-    assertThat(readRecordsAsList(posDeleteSchema, posDeleteFile.path()))
+    assertThat(readRecordsAsList(posDeleteSchema, posDeleteFile.location()))
         .isEqualTo(
             ImmutableList.of(
-                posRecord.copy("file_path", dataFile.path(), "pos", 0L),
-                posRecord.copy("file_path", dataFile.path(), "pos", 1L),
-                posRecord.copy("file_path", dataFile.path(), "pos", 2L),
-                posRecord.copy("file_path", dataFile.path(), "pos", 3L)));
+                posRecord.copy("file_path", dataFile.location(), "pos", 0L),
+                posRecord.copy("file_path", dataFile.location(), "pos", 1L),
+                posRecord.copy("file_path", dataFile.location(), "pos", 2L),
+                posRecord.copy("file_path", dataFile.location(), "pos", 3L)));
   }
 
   @TestTemplate
@@ -226,13 +226,13 @@ public class TestTaskEqualityDeltaWriter extends TestBase {
 
     // Check records in the data file.
     DataFile dataFile = result.dataFiles()[0];
-    assertThat(readRecordsAsList(table.schema(), dataFile.path()))
+    assertThat(readRecordsAsList(table.schema(), dataFile.location()))
         .isEqualTo(ImmutableList.of(record, record));
 
     // Check records in the pos-delete file.
     DeleteFile posDeleteFile = result.deleteFiles()[0];
-    assertThat(readRecordsAsList(DeleteSchemaUtil.pathPosSchema(), posDeleteFile.path()))
-        .isEqualTo(ImmutableList.of(posRecord.copy("file_path", dataFile.path(), "pos", 0L)));
+    assertThat(readRecordsAsList(DeleteSchemaUtil.pathPosSchema(), posDeleteFile.location()))
+        .isEqualTo(ImmutableList.of(posRecord.copy("file_path", dataFile.location(), "pos", 0L)));
 
     deltaWriter =
         createTaskWriter(eqDeleteFieldIds, eqDeleteRowSchema, DeleteGranularity.PARTITION);
@@ -312,7 +312,7 @@ public class TestTaskEqualityDeltaWriter extends TestBase {
 
     // Check records in the data file.
     DataFile dataFile = result.dataFiles()[0];
-    assertThat(readRecordsAsList(table.schema(), dataFile.path()))
+    assertThat(readRecordsAsList(table.schema(), dataFile.location()))
         .isEqualTo(
             ImmutableList.of(
                 createRecord(5, "aaa"), createRecord(6, "aaa"), createRecord(7, "ccc")));
@@ -320,7 +320,7 @@ public class TestTaskEqualityDeltaWriter extends TestBase {
     // Check records in the eq-delete file.
     DeleteFile eqDeleteFile = result.deleteFiles()[0];
     assertThat(eqDeleteFile.content()).isEqualTo(FileContent.EQUALITY_DELETES);
-    assertThat(readRecordsAsList(eqDeleteRowSchema, eqDeleteFile.path()))
+    assertThat(readRecordsAsList(eqDeleteRowSchema, eqDeleteFile.location()))
         .isEqualTo(
             ImmutableList.of(keyFunc.apply("aaa"), keyFunc.apply("ccc"), keyFunc.apply("bbb")));
 
@@ -328,8 +328,8 @@ public class TestTaskEqualityDeltaWriter extends TestBase {
     DeleteFile posDeleteFile = result.deleteFiles()[1];
     Schema posDeleteSchema = DeleteSchemaUtil.pathPosSchema();
     assertThat(posDeleteFile.content()).isEqualTo(FileContent.POSITION_DELETES);
-    assertThat(readRecordsAsList(posDeleteSchema, posDeleteFile.path()))
-        .isEqualTo(ImmutableList.of(posRecord.copy("file_path", dataFile.path(), "pos", 0L)));
+    assertThat(readRecordsAsList(posDeleteSchema, posDeleteFile.location()))
+        .isEqualTo(ImmutableList.of(posRecord.copy("file_path", dataFile.location(), "pos", 0L)));
   }
 
   @TestTemplate
@@ -397,7 +397,7 @@ public class TestTaskEqualityDeltaWriter extends TestBase {
 
     // Check records in the data file.
     DataFile dataFile = result.dataFiles()[0];
-    assertThat(readRecordsAsList(table.schema(), dataFile.path()))
+    assertThat(readRecordsAsList(table.schema(), dataFile.location()))
         .isEqualTo(
             ImmutableList.of(
                 createRecord(5, "aaa"), createRecord(6, "aaa"), createRecord(7, "ccc")));
@@ -405,7 +405,7 @@ public class TestTaskEqualityDeltaWriter extends TestBase {
     // Check records in the eq-delete file.
     DeleteFile eqDeleteFile = result.deleteFiles()[0];
     assertThat(eqDeleteFile.content()).isEqualTo(FileContent.EQUALITY_DELETES);
-    assertThat(readRecordsAsList(eqDeleteRowSchema, eqDeleteFile.path()))
+    assertThat(readRecordsAsList(eqDeleteRowSchema, eqDeleteFile.location()))
         .isEqualTo(
             ImmutableList.of(
                 createRecord(3, "aaa"), createRecord(4, "ccc"), createRecord(2, "bbb")));
@@ -414,8 +414,8 @@ public class TestTaskEqualityDeltaWriter extends TestBase {
     DeleteFile posDeleteFile = result.deleteFiles()[1];
     Schema posDeleteSchema = DeleteSchemaUtil.pathPosSchema();
     assertThat(posDeleteFile.content()).isEqualTo(FileContent.POSITION_DELETES);
-    assertThat(readRecordsAsList(posDeleteSchema, posDeleteFile.path()))
-        .isEqualTo(ImmutableList.of(posRecord.copy("file_path", dataFile.path(), "pos", 0L)));
+    assertThat(readRecordsAsList(posDeleteSchema, posDeleteFile.location()))
+        .isEqualTo(ImmutableList.of(posRecord.copy("file_path", dataFile.location(), "pos", 0L)));
   }
 
   @TestTemplate

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
@@ -220,7 +220,7 @@ public class RowDataFileScanTaskReader implements FileScanTaskReader<RowData> {
         Schema tableSchema,
         Schema requestedSchema,
         InputFilesDecryptor inputFilesDecryptor) {
-      super(task.file().path().toString(), task.deletes(), tableSchema, requestedSchema);
+      super(task.file().location(), task.deletes(), tableSchema, requestedSchema);
       this.requiredRowType = FlinkSchemaUtil.convert(requiredSchema());
       this.asStructLike = new RowDataWrapper(requiredRowType, requiredSchema().asStruct());
       this.inputFilesDecryptor = inputFilesDecryptor;

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
@@ -107,7 +107,7 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
             .map(
                 fileScanTask ->
                     MoreObjects.toStringHelper(fileScanTask)
-                        .add("file", fileScanTask.file().path().toString())
+                        .add("file", fileScanTask.file().location())
                         .add("start", fileScanTask.start())
                         .add("length", fileScanTask.length())
                         .toString())

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestBucketPartitionerFlinkIcebergSink.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestBucketPartitionerFlinkIcebergSink.java
@@ -184,7 +184,7 @@ public class TestBucketPartitionerFlinkIcebergSink {
       for (FileScanTask scanTask : fileScanTasks) {
         long recordCountInFile = scanTask.file().recordCount();
 
-        String[] splitFilePath = scanTask.file().path().toString().split("/");
+        String[] splitFilePath = scanTask.file().location().split("/");
         // Filename example: 00007-0-a7d3a29a-33e9-4740-88f4-0f494397d60c-00001.parquet
         // Writer ID: .......^^^^^
         String filename = splitFilePath[splitFilePath.length - 1];

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -241,6 +241,6 @@ public class TestFlinkIcebergSinkV2 extends TestFlinkIcebergSinkV2Base {
         new String(
             deleteFile.lowerBounds().get(MetadataColumns.DELETE_FILE_PATH.fieldId()).array());
     DataFile dataFile = table.currentSnapshot().addedDataFiles(table.io()).iterator().next();
-    assumeThat(fromStat).isEqualTo(dataFile.path().toString());
+    assumeThat(fromStat).isEqualTo(dataFile.location());
   }
 }

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
@@ -114,7 +114,7 @@ public class TestTaskWriters {
 
       FileSystem fs = FileSystem.get(CONF);
       for (DataFile dataFile : dataFiles) {
-        assertThat(fs.exists(new Path(dataFile.path().toString()))).isTrue();
+        assertThat(fs.exists(new Path(dataFile.location()))).isTrue();
       }
     }
   }
@@ -133,7 +133,7 @@ public class TestTaskWriters {
 
       FileSystem fs = FileSystem.get(CONF);
       for (DataFile dataFile : dataFiles) {
-        assertThat(fs.exists(new Path(dataFile.path().toString()))).isFalse();
+        assertThat(fs.exists(new Path(dataFile.location()))).isFalse();
       }
     }
   }
@@ -155,7 +155,7 @@ public class TestTaskWriters {
 
       FileSystem fs = FileSystem.get(CONF);
       for (DataFile dataFile : dataFiles) {
-        assertThat(fs.exists(new Path(dataFile.path().toString()))).isTrue();
+        assertThat(fs.exists(new Path(dataFile.location()))).isTrue();
       }
 
       AppendFiles appendFiles = table.newAppend();

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -161,10 +161,9 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(2);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
-    Set<String> expectedFiles =
-        ImmutableSet.of(dataFile1.path().toString(), dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile1.location(), dataFile2.location());
     assertThat(discoveredFiles).containsExactlyInAnyOrderElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = initialResult.toPosition();
@@ -244,10 +243,10 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     // should discover dataFile2 appended in snapshot2
-    Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile2.location());
     assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
@@ -316,11 +315,10 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(2);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     // should discover files appended in both snapshot1 and snapshot2
-    Set<String> expectedFiles =
-        ImmutableSet.of(dataFile1.path().toString(), dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile1.location(), dataFile2.location());
     assertThat(discoveredFiles).containsExactlyInAnyOrderElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
@@ -406,10 +404,10 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     // should  discover dataFile2 appended in snapshot2
-    Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile2.location());
     assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
@@ -489,10 +487,10 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     // should discover dataFile2 appended in snapshot2
-    Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile2.location());
     assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
@@ -529,12 +527,12 @@ public class TestContinuousSplitPlannerImpl {
     ContinuousEnumerationResult secondResult = splitPlanner.planSplits(initialResult.toPosition());
     // should discover dataFile1 appended in snapshot1
     verifyMaxPlanningSnapshotCountResult(
-        secondResult, null, snapshot1, ImmutableSet.of(dataFile1.path().toString()));
+        secondResult, null, snapshot1, ImmutableSet.of(dataFile1.location()));
 
     ContinuousEnumerationResult thirdResult = splitPlanner.planSplits(secondResult.toPosition());
     // should discover dataFile2 appended in snapshot2
     verifyMaxPlanningSnapshotCountResult(
-        thirdResult, snapshot1, snapshot2, ImmutableSet.of(dataFile2.path().toString()));
+        thirdResult, snapshot1, snapshot2, ImmutableSet.of(dataFile2.location()));
   }
 
   @Test
@@ -670,7 +668,7 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
   }

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
@@ -220,7 +220,7 @@ public class RowDataFileScanTaskReader implements FileScanTaskReader<RowData> {
         Schema tableSchema,
         Schema requestedSchema,
         InputFilesDecryptor inputFilesDecryptor) {
-      super(task.file().path().toString(), task.deletes(), tableSchema, requestedSchema);
+      super(task.file().location(), task.deletes(), tableSchema, requestedSchema);
       this.requiredRowType = FlinkSchemaUtil.convert(requiredSchema());
       this.asStructLike = new RowDataWrapper(requiredRowType, requiredSchema().asStruct());
       this.inputFilesDecryptor = inputFilesDecryptor;

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
@@ -107,7 +107,7 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
             .map(
                 fileScanTask ->
                     MoreObjects.toStringHelper(fileScanTask)
-                        .add("file", fileScanTask.file().path().toString())
+                        .add("file", fileScanTask.file().location())
                         .add("start", fileScanTask.start())
                         .add("length", fileScanTask.length())
                         .toString())

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -646,11 +646,11 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
   private void validateTableFiles(Table tbl, DataFile... expectedFiles) {
     tbl.refresh();
     Set<CharSequence> expectedFilePaths =
-        Arrays.stream(expectedFiles).map(DataFile::path).collect(Collectors.toSet());
+        Arrays.stream(expectedFiles).map(DataFile::location).collect(Collectors.toSet());
     Set<CharSequence> actualFilePaths =
         StreamSupport.stream(tbl.newScan().planFiles().spliterator(), false)
             .map(FileScanTask::file)
-            .map(ContentFile::path)
+            .map(ContentFile::location)
             .collect(Collectors.toSet());
     assertThat(actualFilePaths).as("Files should match").isEqualTo(expectedFilePaths);
   }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/TestHelpers.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/TestHelpers.java
@@ -602,7 +602,7 @@ public class TestHelpers {
     assertThat(actual).isNotNull();
     assertThat(actual.specId()).as("SpecId").isEqualTo(expected.specId());
     assertThat(actual.content()).as("Content").isEqualTo(expected.content());
-    assertThat(actual.path()).as("Path").isEqualTo(expected.path());
+    assertThat(actual.location()).as("Location").isEqualTo(expected.location());
     assertThat(actual.format()).as("Format").isEqualTo(expected.format());
     assertThat(actual.partition().size())
         .as("Partition size")

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -383,7 +383,7 @@ public class TestRewriteDataFilesAction extends CatalogTestBase {
     assertThat(dataFilesRewrote).hasSize(2);
     // the biggest file do not be rewrote
     List rewroteDataFileNames =
-        dataFilesRewrote.stream().map(ContentFile::path).collect(Collectors.toList());
+        dataFilesRewrote.stream().map(ContentFile::location).collect(Collectors.toList());
     assertThat(rewroteDataFileNames).contains(file.getAbsolutePath());
 
     // Assert the table records as expected.

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestBucketPartitionerFlinkIcebergSink.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestBucketPartitionerFlinkIcebergSink.java
@@ -184,7 +184,7 @@ public class TestBucketPartitionerFlinkIcebergSink {
       for (FileScanTask scanTask : fileScanTasks) {
         long recordCountInFile = scanTask.file().recordCount();
 
-        String[] splitFilePath = scanTask.file().path().toString().split("/");
+        String[] splitFilePath = scanTask.file().location().split("/");
         // Filename example: 00007-0-a7d3a29a-33e9-4740-88f4-0f494397d60c-00001.parquet
         // Writer ID: .......^^^^^
         String filename = splitFilePath[splitFilePath.length - 1];

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -241,6 +241,6 @@ public class TestFlinkIcebergSinkV2 extends TestFlinkIcebergSinkV2Base {
         new String(
             deleteFile.lowerBounds().get(MetadataColumns.DELETE_FILE_PATH.fieldId()).array());
     DataFile dataFile = table.currentSnapshot().addedDataFiles(table.io()).iterator().next();
-    assumeThat(fromStat).isEqualTo(dataFile.path().toString());
+    assumeThat(fromStat).isEqualTo(dataFile.location());
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSinkV2.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSinkV2.java
@@ -224,7 +224,7 @@ public class TestIcebergSinkV2 extends TestFlinkIcebergSinkV2Base {
         new String(
             deleteFile.lowerBounds().get(MetadataColumns.DELETE_FILE_PATH.fieldId()).array());
     DataFile dataFile = table.currentSnapshot().addedDataFiles(table.io()).iterator().next();
-    assumeThat(fromStat).isEqualTo(dataFile.path().toString());
+    assumeThat(fromStat).isEqualTo(dataFile.location());
   }
 
   protected void testChangeLogs(

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
@@ -114,7 +114,7 @@ public class TestTaskWriters {
 
       FileSystem fs = FileSystem.get(CONF);
       for (DataFile dataFile : dataFiles) {
-        assertThat(fs.exists(new Path(dataFile.path().toString()))).isTrue();
+        assertThat(fs.exists(new Path(dataFile.location()))).isTrue();
       }
     }
   }
@@ -133,7 +133,7 @@ public class TestTaskWriters {
 
       FileSystem fs = FileSystem.get(CONF);
       for (DataFile dataFile : dataFiles) {
-        assertThat(fs.exists(new Path(dataFile.path().toString()))).isFalse();
+        assertThat(fs.exists(new Path(dataFile.location()))).isFalse();
       }
     }
   }
@@ -155,7 +155,7 @@ public class TestTaskWriters {
 
       FileSystem fs = FileSystem.get(CONF);
       for (DataFile dataFile : dataFiles) {
-        assertThat(fs.exists(new Path(dataFile.path().toString()))).isTrue();
+        assertThat(fs.exists(new Path(dataFile.location()))).isTrue();
       }
 
       AppendFiles appendFiles = table.newAppend();

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -105,7 +105,8 @@ public class TestContinuousSplitPlannerImpl {
         .hasSize(1)
         .first()
         .satisfies(
-            fileScanTask -> assertThat(fileScanTask.file().path()).isEqualTo(dataFile.path()));
+            fileScanTask ->
+                assertThat(fileScanTask.file().location()).isEqualTo(dataFile.location()));
     return new CycleResult(result.toPosition(), split);
   }
 
@@ -161,10 +162,9 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(2);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
-    Set<String> expectedFiles =
-        ImmutableSet.of(dataFile1.path().toString(), dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile1.location(), dataFile2.location());
     assertThat(discoveredFiles).containsExactlyInAnyOrderElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = initialResult.toPosition();
@@ -244,10 +244,10 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     // should discover dataFile2 appended in snapshot2
-    Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile2.location());
     assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
@@ -316,11 +316,10 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(2);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     // should discover files appended in both snapshot1 and snapshot2
-    Set<String> expectedFiles =
-        ImmutableSet.of(dataFile1.path().toString(), dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile1.location(), dataFile2.location());
     assertThat(discoveredFiles).containsExactlyInAnyOrderElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
@@ -406,10 +405,10 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     // should  discover dataFile2 appended in snapshot2
-    Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile2.location());
     assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
@@ -489,10 +488,10 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     // should discover dataFile2 appended in snapshot2
-    Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile2.location());
     assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
@@ -529,12 +528,12 @@ public class TestContinuousSplitPlannerImpl {
     ContinuousEnumerationResult secondResult = splitPlanner.planSplits(initialResult.toPosition());
     // should discover dataFile1 appended in snapshot1
     verifyMaxPlanningSnapshotCountResult(
-        secondResult, null, snapshot1, ImmutableSet.of(dataFile1.path().toString()));
+        secondResult, null, snapshot1, ImmutableSet.of(dataFile1.location()));
 
     ContinuousEnumerationResult thirdResult = splitPlanner.planSplits(secondResult.toPosition());
     // should discover dataFile2 appended in snapshot2
     verifyMaxPlanningSnapshotCountResult(
-        thirdResult, snapshot1, snapshot2, ImmutableSet.of(dataFile2.path().toString()));
+        thirdResult, snapshot1, snapshot2, ImmutableSet.of(dataFile2.location()));
   }
 
   @Test
@@ -670,7 +669,7 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
   }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
@@ -170,7 +170,7 @@ public class TestIcebergSourceSplitSerializer {
     for (int i = 0; i < expectedTasks.size(); ++i) {
       FileScanTask expectedTask = expectedTasks.get(i);
       FileScanTask actualTask = actualTasks.get(i);
-      assertThat(actualTask.file().path()).isEqualTo(expectedTask.file().path());
+      assertThat(actualTask.file().location()).isEqualTo(expectedTask.file().location());
       assertThat(actualTask.sizeBytes()).isEqualTo(expectedTask.sizeBytes());
       assertThat(actualTask.filesCount()).isEqualTo(expectedTask.filesCount());
       assertThat(actualTask.start()).isEqualTo(expectedTask.start());

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
@@ -220,7 +220,7 @@ public class RowDataFileScanTaskReader implements FileScanTaskReader<RowData> {
         Schema tableSchema,
         Schema requestedSchema,
         InputFilesDecryptor inputFilesDecryptor) {
-      super(task.file().path().toString(), task.deletes(), tableSchema, requestedSchema);
+      super(task.file().location(), task.deletes(), tableSchema, requestedSchema);
       this.requiredRowType = FlinkSchemaUtil.convert(requiredSchema());
       this.asStructLike = new RowDataWrapper(requiredRowType, requiredSchema().asStruct());
       this.inputFilesDecryptor = inputFilesDecryptor;

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
@@ -107,7 +107,7 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
             .map(
                 fileScanTask ->
                     MoreObjects.toStringHelper(fileScanTask)
-                        .add("file", fileScanTask.file().path().toString())
+                        .add("file", fileScanTask.file().location())
                         .add("start", fileScanTask.start())
                         .add("length", fileScanTask.length())
                         .toString())

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -646,11 +646,11 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
   private void validateTableFiles(Table tbl, DataFile... expectedFiles) {
     tbl.refresh();
     Set<CharSequence> expectedFilePaths =
-        Arrays.stream(expectedFiles).map(DataFile::path).collect(Collectors.toSet());
+        Arrays.stream(expectedFiles).map(DataFile::location).collect(Collectors.toSet());
     Set<CharSequence> actualFilePaths =
         StreamSupport.stream(tbl.newScan().planFiles().spliterator(), false)
             .map(FileScanTask::file)
-            .map(ContentFile::path)
+            .map(ContentFile::location)
             .collect(Collectors.toSet());
     assertThat(actualFilePaths).as("Files should match").isEqualTo(expectedFilePaths);
   }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestHelpers.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestHelpers.java
@@ -602,7 +602,7 @@ public class TestHelpers {
     assertThat(actual).isNotNull();
     assertThat(actual.specId()).as("SpecId").isEqualTo(expected.specId());
     assertThat(actual.content()).as("Content").isEqualTo(expected.content());
-    assertThat(actual.path()).as("Path").isEqualTo(expected.path());
+    assertThat(actual.location()).as("Location").isEqualTo(expected.location());
     assertThat(actual.format()).as("Format").isEqualTo(expected.format());
     assertThat(actual.partition().size())
         .as("Partition size")

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -390,7 +390,7 @@ public class TestRewriteDataFilesAction extends CatalogTestBase {
     assertThat(dataFilesRewrote).hasSize(2);
     // the biggest file do not be rewrote
     List rewroteDataFileNames =
-        dataFilesRewrote.stream().map(ContentFile::path).collect(Collectors.toList());
+        dataFilesRewrote.stream().map(ContentFile::location).collect(Collectors.toList());
     assertThat(rewroteDataFileNames).contains(file.getAbsolutePath());
 
     // Assert the table records as expected.

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestBucketPartitionerFlinkIcebergSink.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestBucketPartitionerFlinkIcebergSink.java
@@ -184,7 +184,7 @@ public class TestBucketPartitionerFlinkIcebergSink {
       for (FileScanTask scanTask : fileScanTasks) {
         long recordCountInFile = scanTask.file().recordCount();
 
-        String[] splitFilePath = scanTask.file().path().toString().split("/");
+        String[] splitFilePath = scanTask.file().location().split("/");
         // Filename example: 00007-0-a7d3a29a-33e9-4740-88f4-0f494397d60c-00001.parquet
         // Writer ID: .......^^^^^
         String filename = splitFilePath[splitFilePath.length - 1];

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -241,6 +241,6 @@ public class TestFlinkIcebergSinkV2 extends TestFlinkIcebergSinkV2Base {
         new String(
             deleteFile.lowerBounds().get(MetadataColumns.DELETE_FILE_PATH.fieldId()).array());
     DataFile dataFile = table.currentSnapshot().addedDataFiles(table.io()).iterator().next();
-    assumeThat(fromStat).isEqualTo(dataFile.path().toString());
+    assumeThat(fromStat).isEqualTo(dataFile.location());
   }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSinkV2.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSinkV2.java
@@ -224,7 +224,7 @@ public class TestIcebergSinkV2 extends TestFlinkIcebergSinkV2Base {
         new String(
             deleteFile.lowerBounds().get(MetadataColumns.DELETE_FILE_PATH.fieldId()).array());
     DataFile dataFile = table.currentSnapshot().addedDataFiles(table.io()).iterator().next();
-    assumeThat(fromStat).isEqualTo(dataFile.path().toString());
+    assumeThat(fromStat).isEqualTo(dataFile.location());
   }
 
   protected void testChangeLogs(

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
@@ -114,7 +114,7 @@ public class TestTaskWriters {
 
       FileSystem fs = FileSystem.get(CONF);
       for (DataFile dataFile : dataFiles) {
-        assertThat(fs.exists(new Path(dataFile.path().toString()))).isTrue();
+        assertThat(fs.exists(new Path(dataFile.location()))).isTrue();
       }
     }
   }
@@ -133,7 +133,7 @@ public class TestTaskWriters {
 
       FileSystem fs = FileSystem.get(CONF);
       for (DataFile dataFile : dataFiles) {
-        assertThat(fs.exists(new Path(dataFile.path().toString()))).isFalse();
+        assertThat(fs.exists(new Path(dataFile.location()))).isFalse();
       }
     }
   }
@@ -155,7 +155,7 @@ public class TestTaskWriters {
 
       FileSystem fs = FileSystem.get(CONF);
       for (DataFile dataFile : dataFiles) {
-        assertThat(fs.exists(new Path(dataFile.path().toString()))).isTrue();
+        assertThat(fs.exists(new Path(dataFile.location()))).isTrue();
       }
 
       AppendFiles appendFiles = table.newAppend();

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -105,7 +105,8 @@ public class TestContinuousSplitPlannerImpl {
         .hasSize(1)
         .first()
         .satisfies(
-            fileScanTask -> assertThat(fileScanTask.file().path()).isEqualTo(dataFile.path()));
+            fileScanTask ->
+                assertThat(fileScanTask.file().location()).isEqualTo(dataFile.location()));
     return new CycleResult(result.toPosition(), split);
   }
 
@@ -161,10 +162,9 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(2);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
-    Set<String> expectedFiles =
-        ImmutableSet.of(dataFile1.path().toString(), dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile1.location(), dataFile2.location());
     assertThat(discoveredFiles).containsExactlyInAnyOrderElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = initialResult.toPosition();
@@ -244,10 +244,10 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     // should discover dataFile2 appended in snapshot2
-    Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile2.location());
     assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
@@ -316,11 +316,10 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(2);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     // should discover files appended in both snapshot1 and snapshot2
-    Set<String> expectedFiles =
-        ImmutableSet.of(dataFile1.path().toString(), dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile1.location(), dataFile2.location());
     assertThat(discoveredFiles).containsExactlyInAnyOrderElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
@@ -406,10 +405,10 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     // should  discover dataFile2 appended in snapshot2
-    Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile2.location());
     assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
@@ -489,10 +488,10 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     // should discover dataFile2 appended in snapshot2
-    Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile2.location());
     assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
 
     IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
@@ -529,12 +528,12 @@ public class TestContinuousSplitPlannerImpl {
     ContinuousEnumerationResult secondResult = splitPlanner.planSplits(initialResult.toPosition());
     // should discover dataFile1 appended in snapshot1
     verifyMaxPlanningSnapshotCountResult(
-        secondResult, null, snapshot1, ImmutableSet.of(dataFile1.path().toString()));
+        secondResult, null, snapshot1, ImmutableSet.of(dataFile1.location()));
 
     ContinuousEnumerationResult thirdResult = splitPlanner.planSplits(secondResult.toPosition());
     // should discover dataFile2 appended in snapshot2
     verifyMaxPlanningSnapshotCountResult(
-        thirdResult, snapshot1, snapshot2, ImmutableSet.of(dataFile2.path().toString()));
+        thirdResult, snapshot1, snapshot2, ImmutableSet.of(dataFile2.location()));
   }
 
   @Test
@@ -670,7 +669,7 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(split.task().files()).hasSize(1);
     Set<String> discoveredFiles =
         split.task().files().stream()
-            .map(fileScanTask -> fileScanTask.file().path().toString())
+            .map(fileScanTask -> fileScanTask.file().location())
             .collect(Collectors.toSet());
     assertThat(discoveredFiles).containsExactlyElementsOf(expectedFiles);
   }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
@@ -170,7 +170,7 @@ public class TestIcebergSourceSplitSerializer {
     for (int i = 0; i < expectedTasks.size(); ++i) {
       FileScanTask expectedTask = expectedTasks.get(i);
       FileScanTask actualTask = actualTasks.get(i);
-      assertThat(actualTask.file().path()).isEqualTo(expectedTask.file().path());
+      assertThat(actualTask.file().location()).isEqualTo(expectedTask.file().location());
       assertThat(actualTask.sizeBytes()).isEqualTo(expectedTask.sizeBytes());
       assertThat(actualTask.filesCount()).isEqualTo(expectedTask.filesCount());
       assertThat(actualTask.start()).isEqualTo(expectedTask.start());

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -497,7 +497,7 @@ public class HiveTableTest extends HiveTableBaseTest {
     String file1Location = appendData(table, "file1");
     List<FileScanTask> tasks = Lists.newArrayList(table.newScan().planFiles());
     assertThat(tasks).as("Should scan 1 file").hasSize(1);
-    assertThat(file1Location).isEqualTo(tasks.get(0).file().path());
+    assertThat(file1Location).isEqualTo(tasks.get(0).file().location());
 
     // collect metadata file
     List<String> metadataFiles =
@@ -528,7 +528,7 @@ public class HiveTableTest extends HiveTableBaseTest {
     tasks = Lists.newArrayList(table.newScan().planFiles());
     assertThat(tasks).as("Should scan 2 files").hasSize(2);
     Set<String> files =
-        tasks.stream().map(task -> task.file().path().toString()).collect(Collectors.toSet());
+        tasks.stream().map(task -> task.file().location()).collect(Collectors.toSet());
     assertThat(files).contains(file1Location, file2Location);
   }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -33,6 +33,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.RowDelta;
@@ -209,7 +210,7 @@ class Coordinator extends Channel {
             .filter(payload -> payload.dataFiles() != null)
             .flatMap(payload -> payload.dataFiles().stream())
             .filter(dataFile -> dataFile.recordCount() > 0)
-            .filter(distinctByKey(dataFile -> dataFile.path().toString()))
+            .filter(distinctByKey(ContentFile::location))
             .collect(Collectors.toList());
 
     List<DeleteFile> deleteFiles =
@@ -217,7 +218,7 @@ class Coordinator extends Channel {
             .filter(payload -> payload.deleteFiles() != null)
             .flatMap(payload -> payload.deleteFiles().stream())
             .filter(deleteFile -> deleteFile.recordCount() > 0)
-            .filter(distinctByKey(deleteFile -> deleteFile.path().toString()))
+            .filter(distinctByKey(ContentFile::location))
             .collect(Collectors.toList());
 
     if (terminated) {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -277,8 +277,10 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
                       .onFailure(
                           (file, exc) ->
                               LOG.warn(
-                                  "Failed to remove data file {} on abort job", file.path(), exc))
-                      .run(file -> table.io().deleteFile(file.path().toString()));
+                                  "Failed to remove data file {} on abort job",
+                                  file.location(),
+                                  exc))
+                      .run(file -> table.io().deleteFile(file.location()));
                 }
               });
     } finally {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
@@ -113,7 +113,7 @@ class HiveIcebergRecordWriter extends PartitionedFanoutWriter<Record>
           .onFailure(
               (file, exception) ->
                   LOG.debug("Failed on to remove file {} on abort", file, exception))
-          .run(dataFile -> io.deleteFile(dataFile.path().toString()));
+          .run(dataFile -> io.deleteFile(dataFile.location()));
     }
 
     LOG.info(

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -320,8 +320,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
       DataFile file = currentTask.file();
       InputFile inputFile =
           encryptionManager.decrypt(
-              EncryptedFiles.encryptedInput(
-                  io.newInputFile(file.path().toString()), file.keyMetadata()));
+              EncryptedFiles.encryptedInput(io.newInputFile(file.location()), file.keyMetadata()));
 
       CloseableIterable<T> iterable;
       switch (file.format()) {
@@ -336,7 +335,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
           break;
         default:
           throw new UnsupportedOperationException(
-              String.format("Cannot read %s file: %s", file.format().name(), file.path()));
+              String.format("Cannot read %s file: %s", file.format().name(), file.location()));
       }
 
       return iterable;

--- a/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataWriter.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataWriter.java
@@ -85,7 +85,7 @@ public class TestOrcDataWriter {
 
   private List<Long> stripeOffsetsFromReader(DataFile dataFile, OrcFile.ReaderOptions options)
       throws IOException {
-    return OrcFile.createReader(new Path(dataFile.path().toString()), options).getStripes().stream()
+    return OrcFile.createReader(new Path(dataFile.location()), options).getStripes().stream()
         .map(StripeInformation::getOffset)
         .collect(Collectors.toList());
   }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -300,7 +300,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
     Assert.assertEquals("Should have 1 delete file", 1, TestHelpers.deleteFiles(table).size());
     Path deleteManifestPath = new Path(TestHelpers.deleteManifests(table).iterator().next().path());
     DeleteFile deleteFile = TestHelpers.deleteFiles(table).iterator().next();
-    Path deleteFilePath = new Path(String.valueOf(deleteFile.path()));
+    Path deleteFilePath = new Path(deleteFile.location());
 
     sql(
         "CALL %s.system.rewrite_data_files("

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -433,8 +433,7 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
         "Should have 1 delete manifest", 1, TestHelpers.deleteManifests(table).size());
     Assert.assertEquals("Should have 1 delete file", 1, TestHelpers.deleteFiles(table).size());
     Path deleteManifestPath = new Path(TestHelpers.deleteManifests(table).iterator().next().path());
-    Path deleteFilePath =
-        new Path(String.valueOf(TestHelpers.deleteFiles(table).iterator().next().path()));
+    Path deleteFilePath = new Path(TestHelpers.deleteFiles(table).iterator().next().location());
 
     // wait to ensure files are old enough
     waitUntilAfter(System.currentTimeMillis());

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
@@ -305,7 +305,7 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
       List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
       for (DataFile partitionFile : partitionFiles) {
         for (int deletePos = 0; deletePos < DELETE_FILE_SIZE; deletePos++) {
-          deletes.add(Pair.of(partitionFile.path(), (long) deletePos));
+          deletes.add(Pair.of(partitionFile.location(), (long) deletePos));
           counter++;
           if (counter == deleteFileSize) {
             // Dump to file and reset variables

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -1131,7 +1131,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
 
     // remove the data file from the 'hr' partition to ensure it is not scanned
     DataFile dataFile = Iterables.getOnlyElement(snapshot.addedDataFiles(table.io()));
-    table.io().deleteFile(dataFile.path().toString());
+    table.io().deleteFile(dataFile.location());
 
     // disable dynamic pruning and rely only on static predicate pushdown
     withSQLConf(

--- a/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetMultiDeleteFileBenchmark.java
+++ b/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetMultiDeleteFileBenchmark.java
@@ -45,7 +45,7 @@ public class IcebergSourceParquetMultiDeleteFileBenchmark extends IcebergSourceD
 
       table().refresh();
       for (DataFile file : table().currentSnapshot().addedDataFiles(table().io())) {
-        writePosDeletes(file.path(), NUM_ROWS, 0.25, numDeleteFile);
+        writePosDeletes(file.location(), NUM_ROWS, 0.25, numDeleteFile);
       }
     }
   }

--- a/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetPosDeleteBenchmark.java
+++ b/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetPosDeleteBenchmark.java
@@ -47,7 +47,7 @@ public class IcebergSourceParquetPosDeleteBenchmark extends IcebergSourceDeleteB
         // add pos-deletes
         table().refresh();
         for (DataFile file : table().currentSnapshot().addedDataFiles(table().io())) {
-          writePosDeletes(file.path(), NUM_ROWS, percentDeleteRow);
+          writePosDeletes(file.location(), NUM_ROWS, percentDeleteRow);
         }
       }
     }

--- a/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetWithUnrelatedDeleteBenchmark.java
+++ b/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetWithUnrelatedDeleteBenchmark.java
@@ -48,7 +48,7 @@ public class IcebergSourceParquetWithUnrelatedDeleteBenchmark extends IcebergSou
       table().refresh();
       for (DataFile file : table().currentSnapshot().addedDataFiles(table().io())) {
         writePosDeletesWithNoise(
-            file.path(),
+            file.location(),
             NUM_ROWS,
             PERCENT_DELETE_ROW,
             (int) (percentUnrelatedDeletes / PERCENT_DELETE_ROW),

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
@@ -672,7 +673,7 @@ public class SparkTableUtil {
       if (checkDuplicateFiles) {
         Dataset<Row> importedFiles =
             spark
-                .createDataset(Lists.transform(files, f -> f.path().toString()), Encoders.STRING())
+                .createDataset(Lists.transform(files, ContentFile::location), Encoders.STRING())
                 .toDF("file_path");
         Dataset<Row> existingFiles =
             loadMetadataTable(spark, targetTable, MetadataTableType.ENTRIES).filter("status != 2");
@@ -800,7 +801,7 @@ public class SparkTableUtil {
     if (checkDuplicateFiles) {
       Dataset<Row> importedFiles =
           filesToImport
-              .map((MapFunction<DataFile, String>) f -> f.path().toString(), Encoders.STRING())
+              .map((MapFunction<DataFile, String>) ContentFile::location, Encoders.STRING())
               .toDF("file_path");
       Dataset<Row> existingFiles =
           loadMetadataTable(spark, targetTable, MetadataTableType.ENTRIES).filter("status != 2");
@@ -819,7 +820,7 @@ public class SparkTableUtil {
             .repartition(numShufflePartitions)
             .map(
                 (MapFunction<DataFile, Tuple2<String, DataFile>>)
-                    file -> Tuple2.apply(file.path().toString(), file),
+                    file -> Tuple2.apply(file.location(), file),
                 Encoders.tuple(Encoders.STRING(), Encoders.javaSerialization(DataFile.class)))
             .orderBy(col("_1"))
             .mapPartitions(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -440,7 +440,7 @@ abstract class BaseSparkAction<ThisT> {
     }
 
     static FileInfo toFileInfo(ContentFile<?> file) {
-      return new FileInfo(file.path().toString(), file.content().toString());
+      return new FileInfo(file.location(), file.content().toString());
     }
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -148,7 +148,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
       if (currentTask != null && !currentTask.isDataTask()) {
         String filePaths =
             referencedFiles(currentTask)
-                .map(file -> file.path().toString())
+                .map(ContentFile::location)
                 .collect(Collectors.joining(", "));
         LOG.error("Error reading file(s): {}", filePaths, e);
       }
@@ -194,7 +194,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
   }
 
   private EncryptedInputFile toEncryptedInputFile(ContentFile<?> file) {
-    InputFile inputFile = table.io().newInputFile(file.path().toString());
+    InputFile inputFile = table.io().newInputFile(file.location());
     return EncryptedFiles.encryptedInput(inputFile, file.keyMetadata());
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -82,7 +82,7 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
 
   @Override
   protected CloseableIterator<ColumnarBatch> open(FileScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     LOG.debug("Opening data file {}", filePath);
 
     // update the current file for Spark's filename() function

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
@@ -110,13 +110,13 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask>
   }
 
   CloseableIterable<InternalRow> openAddedRowsScanTask(AddedRowsScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     SparkDeleteFilter deletes = new SparkDeleteFilter(filePath, task.deletes(), counter(), true);
     return deletes.filter(rows(task, deletes.requiredSchema()));
   }
 
   private CloseableIterable<InternalRow> openDeletedDataFileScanTask(DeletedDataFileScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     SparkDeleteFilter deletes =
         new SparkDeleteFilter(filePath, task.existingDeletes(), counter(), true);
     return deletes.filter(rows(task, deletes.requiredSchema()));
@@ -125,7 +125,7 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask>
   private CloseableIterable<InternalRow> rows(ContentScanTask<DataFile> task, Schema readSchema) {
     Map<Integer, ?> idToConstant = constantsMap(task, readSchema);
 
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
 
     // update the current file for Spark's filename() function
     InputFileBlockHolder.set(filePath, task.start(), task.length());

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
@@ -41,7 +41,7 @@ public class EqualityDeleteRowReader extends RowDataReader {
   @Override
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
     SparkDeleteFilter matches =
-        new SparkDeleteFilter(task.file().path().toString(), task.deletes(), counter(), true);
+        new SparkDeleteFilter(task.file().location(), task.deletes(), counter(), true);
 
     // schema or rows returned by readers
     Schema requiredSchema = matches.requiredSchema();
@@ -49,7 +49,7 @@ public class EqualityDeleteRowReader extends RowDataReader {
     DataFile file = task.file();
 
     // update the current file for Spark's filename() function
-    InputFileBlockHolder.set(file.path().toString(), task.start(), task.length());
+    InputFileBlockHolder.set(file.location(), task.start(), task.length());
 
     return matches.findEqualityDeleteRows(open(task, requiredSchema, idToConstant)).iterator();
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
@@ -74,13 +74,13 @@ class PositionDeletesRowReader extends BaseRowReader<PositionDeletesScanTask>
 
   @Override
   protected CloseableIterator<InternalRow> open(PositionDeletesScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     LOG.debug("Opening position delete file {}", filePath);
 
     // update the current file for Spark's filename() function
     InputFileBlockHolder.set(filePath, task.start(), task.length());
 
-    InputFile inputFile = getInputFile(task.file().path().toString());
+    InputFile inputFile = getInputFile(task.file().location());
     Preconditions.checkNotNull(inputFile, "Could not find InputFile associated with %s", task);
 
     // select out constant fields when pushing down filter to row reader

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -81,7 +81,7 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
 
   @Override
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     LOG.debug("Opening data file {}", filePath);
     SparkDeleteFilter deleteFilter =
         new SparkDeleteFilter(filePath, task.deletes(), counter(), true);
@@ -101,7 +101,7 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
     if (task.isDataTask()) {
       return newDataIterable(task.asDataTask(), readSchema);
     } else {
-      InputFile inputFile = getInputFile(task.file().path().toString());
+      InputFile inputFile = getInputFile(task.file().location());
       Preconditions.checkNotNull(
           inputFile, "Could not find InputFile associated with FileScanTask");
       return newIterable(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -81,7 +81,7 @@ class SparkCleanupUtil {
    * @param files a list of files to delete
    */
   public static void deleteFiles(String context, FileIO io, List<? extends ContentFile<?>> files) {
-    List<String> paths = Lists.transform(files, file -> file.path().toString());
+    List<String> paths = Lists.transform(files, ContentFile::location);
     deletePaths(context, io, paths);
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -126,7 +126,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
           this.filteredLocations = fileLocations;
           List<FileScanTask> filteredTasks =
               tasks().stream()
-                  .filter(file -> fileLocations.contains(file.file().path().toString()))
+                  .filter(file -> fileLocations.contains(file.file().location()))
                   .collect(Collectors.toList());
 
           LOG.info(

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
@@ -60,7 +60,8 @@ public final class TaskCheckHelper {
   }
 
   public static void assertEquals(DataFile expected, DataFile actual) {
-    Assert.assertEquals("Should match the serialized record path", expected.path(), actual.path());
+    Assert.assertEquals(
+        "Should match the serialized record path", expected.location(), actual.location());
     Assert.assertEquals(
         "Should match the serialized record format", expected.format(), actual.format());
     Assert.assertEquals(
@@ -105,7 +106,7 @@ public final class TaskCheckHelper {
       ScanTaskGroup<FileScanTask> taskGroup) {
     return taskGroup.tasks().stream()
         // use file path + start position to differentiate the tasks
-        .sorted(Comparator.comparing(o -> o.file().path().toString() + "##" + o.start()))
+        .sorted(Comparator.comparing(o -> o.file().location() + "##" + o.start()))
         .collect(Collectors.toList());
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/ValidationHelpers.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/ValidationHelpers.java
@@ -42,7 +42,7 @@ public class ValidationHelpers {
   }
 
   public static List<String> files(ContentFile<?>... files) {
-    return Arrays.stream(files).map(file -> file.path().toString()).collect(Collectors.toList());
+    return Arrays.stream(files).map(ContentFile::location).collect(Collectors.toList());
   }
 
   public static void validateDataManifest(
@@ -62,7 +62,7 @@ public class ValidationHelpers {
       actualDataSeqs.add(entry.dataSequenceNumber());
       actualFileSeqs.add(entry.fileSequenceNumber());
       actualSnapshotIds.add(entry.snapshotId());
-      actualFiles.add(entry.file().path().toString());
+      actualFiles.add(entry.file().location());
     }
 
     assertSameElements("data seqs", actualDataSeqs, dataSeqs);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -142,7 +142,7 @@ public abstract class SparkTestBase extends SparkTestHelperBase {
   }
 
   protected void withUnavailableFiles(Iterable<? extends ContentFile<?>> files, Action action) {
-    Iterable<String> fileLocations = Iterables.transform(files, file -> file.path().toString());
+    Iterable<String> fileLocations = Iterables.transform(files, ContentFile::location);
     withUnavailableLocations(fileLocations, action);
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -204,7 +204,7 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
         .forEach(
             file ->
                 Assert.assertTrue(
-                    "FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString())));
+                    "FILE_A should be deleted", deletedFiles.contains(FILE_A.location())));
     checkRemoveFilesResults(4L, 0, 0, 6L, 4L, 6, result);
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -239,8 +239,8 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
         Sets.newHashSet(
             "remove-snapshot-0", "remove-snapshot-1", "remove-snapshot-2", "remove-snapshot-3"));
 
-    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
-    Assert.assertTrue("FILE_B should be deleted", deletedFiles.contains(FILE_B.path().toString()));
+    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.location()));
+    Assert.assertTrue("FILE_B should be deleted", deletedFiles.contains(FILE_B.location()));
 
     checkExpirationResults(2L, 0L, 0L, 3L, 3L, result);
   }
@@ -555,7 +555,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
+    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.location()));
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, result);
   }
 
@@ -584,7 +584,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
+    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.location()));
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, result);
   }
 
@@ -627,7 +627,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
         .addedDataFiles(table.io())
         .forEach(
             i -> {
-              expectedDeletes.add(i.path().toString());
+              expectedDeletes.add(i.location());
             });
 
     // ManifestList should be deleted too
@@ -696,7 +696,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        Assert.assertFalse(deletedFiles.contains(item.path().toString()));
+                        Assert.assertFalse(deletedFiles.contains(item.location()));
                       });
             });
 
@@ -745,7 +745,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        Assert.assertFalse(deletedFiles.contains(item.path().toString()));
+                        Assert.assertFalse(deletedFiles.contains(item.location()));
                       });
             });
     checkExpirationResults(0L, 0L, 0L, 1L, 1L, firstResult);
@@ -765,7 +765,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        Assert.assertFalse(deletedFiles.contains(item.path().toString()));
+                        Assert.assertFalse(deletedFiles.contains(item.location()));
                       });
             });
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, secondResult);
@@ -866,7 +866,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
                 .allManifests(table.io())
                 .get(0)
                 .path(), // manifest contained only deletes, was dropped
-            FILE_A.path()), // deleted
+            FILE_A.location()), // deleted
         deletedFiles);
 
     checkExpirationResults(1, 0, 0, 2, 2, result);
@@ -935,7 +935,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
                 .get(0)
                 .path(), // manifest was rewritten for delete
             secondSnapshot.manifestListLocation(), // snapshot expired
-            FILE_A.path()), // deleted
+            FILE_A.location()), // deleted
         deletedFiles);
 
     checkExpirationResults(1, 0, 0, 1, 2, result);
@@ -1049,7 +1049,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             secondSnapshot.manifestListLocation(), // snapshot expired
             Iterables.getOnlyElement(secondSnapshotManifests)
                 .path(), // manifest is no longer referenced
-            FILE_B.path()), // added, but rolled back
+            FILE_B.location()), // added, but rolled back
         deletedFiles);
 
     checkExpirationResults(1, 0, 0, 1, 1, result);
@@ -1098,9 +1098,9 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             secondSnapshot.manifestListLocation(),
             thirdSnapshot.manifestListLocation(),
             fourthSnapshot.manifestListLocation(),
-            FILE_A.path().toString(),
-            FILE_A_POS_DELETES.path().toString(),
-            FILE_A_EQ_DELETES.path().toString());
+            FILE_A.location(),
+            FILE_A_POS_DELETES.location(),
+            FILE_A_EQ_DELETES.location());
 
     expectedDeletes.addAll(
         thirdSnapshot.allManifests(table.io()).stream()
@@ -1273,7 +1273,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
               .withPartitionPath("c1=1")
               .withRecordCount(1)
               .build();
-      dataFiles.add(df.path().toString());
+      dataFiles.add(df.location());
       table.newFastAppend().appendFile(df).commit();
     }
 
@@ -1346,9 +1346,9 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     // C, D should be retained (live)
     // B should be retained (previous snapshot points to it)
     // A should be deleted
-    Assert.assertTrue(deletedFiles.contains(FILE_A.path().toString()));
-    Assert.assertFalse(deletedFiles.contains(FILE_B.path().toString()));
-    Assert.assertFalse(deletedFiles.contains(FILE_C.path().toString()));
-    Assert.assertFalse(deletedFiles.contains(FILE_D.path().toString()));
+    Assert.assertTrue(deletedFiles.contains(FILE_A.location()));
+    Assert.assertFalse(deletedFiles.contains(FILE_B.location()));
+    Assert.assertFalse(deletedFiles.contains(FILE_C.location()));
+    Assert.assertFalse(deletedFiles.contains(FILE_D.location()));
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1814,8 +1814,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
 
   private List<DeleteFile> writePosDeletesToFile(
       Table table, DataFile dataFile, int outputDeleteFiles) {
-    return writePosDeletes(
-        table, dataFile.partition(), dataFile.path().toString(), outputDeleteFiles);
+    return writePosDeletes(table, dataFile.partition(), dataFile.location(), outputDeleteFiles);
   }
 
   private List<DeleteFile> writePosDeletes(

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -831,7 +831,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
       List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
       for (DataFile partitionFile : partitionFiles) {
         for (int deletePos = 0; deletePos < deletesPerDataFile; deletePos++) {
-          deletes.add(Pair.of(partitionFile.path(), (long) deletePos));
+          deletes.add(Pair.of(partitionFile.location(), (long) deletePos));
           counter++;
           if (counter == deleteFileSize) {
             // Dump to file and reset variables
@@ -868,17 +868,17 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
 
   private <T extends ContentFile<?>> List<T> except(List<T> first, List<T> second) {
     Set<String> secondPaths =
-        second.stream().map(f -> f.path().toString()).collect(Collectors.toSet());
+        second.stream().map(ContentFile::location).collect(Collectors.toSet());
     return first.stream()
-        .filter(f -> !secondPaths.contains(f.path().toString()))
+        .filter(f -> !secondPaths.contains(f.location()))
         .collect(Collectors.toList());
   }
 
   private void assertNotContains(List<DeleteFile> original, List<DeleteFile> rewritten) {
     Set<String> originalPaths =
-        original.stream().map(f -> f.path().toString()).collect(Collectors.toSet());
+        original.stream().map(ContentFile::location).collect(Collectors.toSet());
     Set<String> rewrittenPaths =
-        rewritten.stream().map(f -> f.path().toString()).collect(Collectors.toSet());
+        rewritten.stream().map(ContentFile::location).collect(Collectors.toSet());
     rewrittenPaths.retainAll(originalPaths);
     Assert.assertEquals(0, rewrittenPaths.size());
   }
@@ -887,7 +887,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     for (DeleteFile deleteFile : deleteFiles) {
       Dataset<Row> deletes =
           spark.read().format("iceberg").load("default." + TABLE_NAME + ".position_deletes");
-      deletes.filter(deletes.col("delete_file_path").equalTo(deleteFile.path().toString()));
+      deletes.filter(deletes.col("delete_file_path").equalTo(deleteFile.location()));
       List<Row> rows = deletes.collectAsList();
       Assert.assertFalse("Empty delete file found", rows.isEmpty());
       int lastPos = 0;

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -114,7 +114,7 @@ public class TestBaseReader {
     }
 
     private String getKey(FileScanTask task) {
-      return task.file().path().toString();
+      return task.file().location();
     }
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -197,8 +197,8 @@ public class TestDataFrameWrites extends AvroDataTest {
                 Assert.assertTrue(
                     String.format(
                         "File should have the parent directory %s, but has: %s.",
-                        expectedDataDir.getAbsolutePath(), dataFile.path()),
-                    URI.create(dataFile.path().toString())
+                        expectedDataDir.getAbsolutePath(), dataFile.location()),
+                    URI.create(dataFile.location())
                         .getPath()
                         .startsWith(expectedDataDir.getAbsolutePath())));
   }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -109,7 +109,7 @@ public class TestDataSourceOptions extends SparkTestBaseWithCatalog {
     try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
       tasks.forEach(
           task -> {
-            FileFormat fileFormat = FileFormat.fromFileName(task.file().path());
+            FileFormat fileFormat = FileFormat.fromFileName(task.file().location());
             Assert.assertEquals(FileFormat.PARQUET, fileFormat);
           });
     }
@@ -134,7 +134,7 @@ public class TestDataSourceOptions extends SparkTestBaseWithCatalog {
     try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
       tasks.forEach(
           task -> {
-            FileFormat fileFormat = FileFormat.fromFileName(task.file().path());
+            FileFormat fileFormat = FileFormat.fromFileName(task.file().location());
             Assert.assertEquals(FileFormat.AVRO, fileFormat);
           });
     }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -268,7 +268,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                 .select("data_file.file_path")
                 .collectAsList());
 
-    List<Object[]> singleExpected = ImmutableList.of(row(file.path()));
+    List<Object[]> singleExpected = ImmutableList.of(row(file.location()));
 
     assertEquals(
         "Should prune a single element from a nested struct", singleExpected, singleActual);
@@ -307,7 +307,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     List<Object[]> multiExpected =
         ImmutableList.of(
-            row(file.path(), file.valueCounts(), file.recordCount(), file.columnSizes()));
+            row(file.location(), file.valueCounts(), file.recordCount(), file.columnSizes()));
 
     assertEquals("Should prune a single element from a nested struct", multiExpected, multiActual);
   }
@@ -341,7 +341,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     List<Object[]> multiExpected =
         ImmutableList.of(
-            row(file.path(), file.valueCounts(), file.recordCount(), file.columnSizes()));
+            row(file.location(), file.valueCounts(), file.recordCount(), file.columnSizes()));
 
     assertEquals("Should prune a single element from a row", multiExpected, multiActual);
   }
@@ -2316,7 +2316,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     StructLike dataFilePartition = dataFile.partition();
 
     PositionDelete<InternalRow> delete = PositionDelete.create();
-    delete.set(dataFile.path(), pos, null);
+    delete.set(dataFile.location(), pos, null);
 
     return writePositionDeletes(table, dataFileSpec, dataFilePartition, ImmutableList.of(delete));
   }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestRuntimeFiltering.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestRuntimeFiltering.java
@@ -444,7 +444,7 @@ public class TestRuntimeFiltering extends SparkTestBaseWithCatalog {
     Set<String> matchingFileLocations = Sets.newHashSet();
     try (CloseableIterable<FileScanTask> files = table.newScan().filter(filter).planFiles()) {
       for (FileScanTask file : files) {
-        String path = file.file().path().toString();
+        String path = file.file().location();
         matchingFileLocations.add(path);
       }
     } catch (IOException e) {
@@ -454,7 +454,7 @@ public class TestRuntimeFiltering extends SparkTestBaseWithCatalog {
     Set<String> deletedFileLocations = Sets.newHashSet();
     try (CloseableIterable<FileScanTask> files = table.newScan().planFiles()) {
       for (FileScanTask file : files) {
-        String path = file.file().path().toString();
+        String path = file.file().location();
         if (!matchingFileLocations.contains(path)) {
           io.deleteFile(path);
           deletedFileLocations.add(path);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
@@ -193,7 +193,7 @@ public class TestSparkDataFile {
   }
 
   private void checkDataFile(DataFile expected, DataFile actual) {
-    Assert.assertEquals("Path must match", expected.path(), actual.path());
+    Assert.assertEquals("Path must match", expected.location(), actual.location());
     Assert.assertEquals("Format must match", expected.format(), actual.format());
     Assert.assertEquals("Record count must match", expected.recordCount(), actual.recordCount());
     Assert.assertEquals("Size must match", expected.fileSizeInBytes(), actual.fileSizeInBytes());

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -343,10 +343,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     // deleted.
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 0L), // id = 29
-            Pair.of(dataFile.path(), 1L), // id = 43
-            Pair.of(dataFile.path(), 2L), // id = 61
-            Pair.of(dataFile.path(), 3L) // id = 89
+            Pair.of(dataFile.location(), 0L), // id = 29
+            Pair.of(dataFile.location(), 1L), // id = 43
+            Pair.of(dataFile.location(), 2L), // id = 61
+            Pair.of(dataFile.location(), 3L) // id = 89
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -376,10 +376,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     // deleted.
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 0L), // id = 29
-            Pair.of(dataFile.path(), 1L), // id = 43
-            Pair.of(dataFile.path(), 2L), // id = 61
-            Pair.of(dataFile.path(), 3L) // id = 89
+            Pair.of(dataFile.location(), 0L), // id = 29
+            Pair.of(dataFile.location(), 1L), // id = 43
+            Pair.of(dataFile.location(), 2L), // id = 61
+            Pair.of(dataFile.location(), 3L) // id = 89
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -455,8 +455,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
 
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 3L), // id = 89
-            Pair.of(dataFile.path(), 5L) // id = 121
+            Pair.of(dataFile.location(), 3L), // id = 89
+            Pair.of(dataFile.location(), 5L) // id = 121
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -486,10 +486,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
   public void testFilterOnDeletedMetadataColumn() throws IOException {
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 0L), // id = 29
-            Pair.of(dataFile.path(), 1L), // id = 43
-            Pair.of(dataFile.path(), 2L), // id = 61
-            Pair.of(dataFile.path(), 3L) // id = 89
+            Pair.of(dataFile.location(), 0L), // id = 29
+            Pair.of(dataFile.location(), 1L), // id = 43
+            Pair.of(dataFile.location(), 2L), // id = 61
+            Pair.of(dataFile.location(), 3L) // id = 89
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -611,13 +611,13 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     // Add positional deletes to the table
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 97L),
-            Pair.of(dataFile.path(), 98L),
-            Pair.of(dataFile.path(), 99L),
-            Pair.of(dataFile.path(), 101L),
-            Pair.of(dataFile.path(), 103L),
-            Pair.of(dataFile.path(), 107L),
-            Pair.of(dataFile.path(), 109L));
+            Pair.of(dataFile.location(), 97L),
+            Pair.of(dataFile.location(), 98L),
+            Pair.of(dataFile.location(), 99L),
+            Pair.of(dataFile.location(), 101L),
+            Pair.of(dataFile.location(), 103L),
+            Pair.of(dataFile.location(), 107L),
+            Pair.of(dataFile.location(), 109L));
     Pair<DeleteFile, CharSequenceSet> posDeletes =
         FileHelpers.writeDeleteFile(
             table,

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -292,7 +292,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
     Assert.assertEquals("Should have 1 delete file", 1, TestHelpers.deleteFiles(table).size());
     Path deleteManifestPath = new Path(TestHelpers.deleteManifests(table).iterator().next().path());
     DeleteFile deleteFile = TestHelpers.deleteFiles(table).iterator().next();
-    Path deleteFilePath = new Path(String.valueOf(deleteFile.path()));
+    Path deleteFilePath = new Path(deleteFile.location());
 
     sql(
         "CALL %s.system.rewrite_data_files("

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -424,8 +424,7 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
         "Should have 1 delete manifest", 1, TestHelpers.deleteManifests(table).size());
     Assert.assertEquals("Should have 1 delete file", 1, TestHelpers.deleteFiles(table).size());
     Path deleteManifestPath = new Path(TestHelpers.deleteManifests(table).iterator().next().path());
-    Path deleteFilePath =
-        new Path(String.valueOf(TestHelpers.deleteFiles(table).iterator().next().path()));
+    Path deleteFilePath = new Path(TestHelpers.deleteFiles(table).iterator().next().location());
 
     // wait to ensure files are old enough
     waitUntilAfter(System.currentTimeMillis());

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
@@ -314,7 +314,7 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
       List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
       for (DataFile partitionFile : partitionFiles) {
         for (int deletePos = 0; deletePos < DELETE_FILE_SIZE; deletePos++) {
-          deletes.add(Pair.of(partitionFile.path(), (long) deletePos));
+          deletes.add(Pair.of(partitionFile.location(), (long) deletePos));
           counter++;
           if (counter == deleteFileSize) {
             // Dump to file and reset variables

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSparkExecutorCache.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSparkExecutorCache.java
@@ -222,7 +222,7 @@ public class TestSparkExecutorCache extends SparkExtensionsTestBase {
   }
 
   private int streamCount(DeleteFile deleteFile) {
-    CustomInputFile inputFile = INPUT_FILES.get(deleteFile.path().toString());
+    CustomInputFile inputFile = INPUT_FILES.get(deleteFile.location());
     return inputFile.streamCount();
   }
 
@@ -247,7 +247,7 @@ public class TestSparkExecutorCache extends SparkExtensionsTestBase {
 
     List<Pair<CharSequence, Long>> posDeletes =
         dataFiles(table).stream()
-            .map(dataFile -> Pair.of(dataFile.path(), 0L))
+            .map(dataFile -> Pair.of((CharSequence) dataFile.location(), 0L))
             .collect(Collectors.toList());
     Pair<DeleteFile, CharSequenceSet> posDeleteResult = writePosDeletes(table, posDeletes);
     DeleteFile posDeleteFile = posDeleteResult.first();

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -1299,7 +1299,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
 
     // remove the data file from the 'hr' partition to ensure it is not scanned
     DataFile dataFile = Iterables.getOnlyElement(snapshot.addedDataFiles(table.io()));
-    table.io().deleteFile(dataFile.path().toString());
+    table.io().deleteFile(dataFile.location());
 
     // disable dynamic pruning and rely only on static predicate pushdown
     withSQLConf(

--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetMultiDeleteFileBenchmark.java
+++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetMultiDeleteFileBenchmark.java
@@ -45,7 +45,7 @@ public class IcebergSourceParquetMultiDeleteFileBenchmark extends IcebergSourceD
 
       table().refresh();
       for (DataFile file : table().currentSnapshot().addedDataFiles(table().io())) {
-        writePosDeletes(file.path(), NUM_ROWS, 0.25, numDeleteFile);
+        writePosDeletes(file.location(), NUM_ROWS, 0.25, numDeleteFile);
       }
     }
   }

--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetPosDeleteBenchmark.java
+++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetPosDeleteBenchmark.java
@@ -47,7 +47,7 @@ public class IcebergSourceParquetPosDeleteBenchmark extends IcebergSourceDeleteB
         // add pos-deletes
         table().refresh();
         for (DataFile file : table().currentSnapshot().addedDataFiles(table().io())) {
-          writePosDeletes(file.path(), NUM_ROWS, percentDeleteRow);
+          writePosDeletes(file.location(), NUM_ROWS, percentDeleteRow);
         }
       }
     }

--- a/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetWithUnrelatedDeleteBenchmark.java
+++ b/spark/v3.4/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetWithUnrelatedDeleteBenchmark.java
@@ -48,7 +48,7 @@ public class IcebergSourceParquetWithUnrelatedDeleteBenchmark extends IcebergSou
       table().refresh();
       for (DataFile file : table().currentSnapshot().addedDataFiles(table().io())) {
         writePosDeletesWithNoise(
-            file.path(),
+            file.location(),
             NUM_ROWS,
             PERCENT_DELETE_ROW,
             (int) (percentUnrelatedDeletes / PERCENT_DELETE_ROW),

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
@@ -635,7 +636,7 @@ public class SparkTableUtil {
       if (checkDuplicateFiles) {
         Dataset<Row> importedFiles =
             spark
-                .createDataset(Lists.transform(files, f -> f.path().toString()), Encoders.STRING())
+                .createDataset(Lists.transform(files, ContentFile::location), Encoders.STRING())
                 .toDF("file_path");
         Dataset<Row> existingFiles =
             loadMetadataTable(spark, targetTable, MetadataTableType.ENTRIES).filter("status != 2");
@@ -763,7 +764,7 @@ public class SparkTableUtil {
     if (checkDuplicateFiles) {
       Dataset<Row> importedFiles =
           filesToImport
-              .map((MapFunction<DataFile, String>) f -> f.path().toString(), Encoders.STRING())
+              .map((MapFunction<DataFile, String>) ContentFile::location, Encoders.STRING())
               .toDF("file_path");
       Dataset<Row> existingFiles =
           loadMetadataTable(spark, targetTable, MetadataTableType.ENTRIES).filter("status != 2");
@@ -782,7 +783,7 @@ public class SparkTableUtil {
             .repartition(numShufflePartitions)
             .map(
                 (MapFunction<DataFile, Tuple2<String, DataFile>>)
-                    file -> Tuple2.apply(file.path().toString(), file),
+                    file -> Tuple2.apply(file.location(), file),
                 Encoders.tuple(Encoders.STRING(), Encoders.javaSerialization(DataFile.class)))
             .orderBy(col("_1"))
             .mapPartitions(

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -433,7 +433,7 @@ abstract class BaseSparkAction<ThisT> {
     }
 
     static FileInfo toFileInfo(ContentFile<?> file) {
-      return new FileInfo(file.path().toString(), file.content().toString());
+      return new FileInfo(file.location(), file.content().toString());
     }
   }
 }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
@@ -88,7 +88,7 @@ class RemoveDanglingDeletesSparkAction
     RewriteFiles rewriteFiles = table.newRewrite();
     List<DeleteFile> danglingDeletes = findDanglingDeletes();
     for (DeleteFile deleteFile : danglingDeletes) {
-      LOG.debug("Removing dangling delete file {}", deleteFile.path());
+      LOG.debug("Removing dangling delete file {}", deleteFile.location());
       rewriteFiles.deleteFile(deleteFile);
     }
     if (!danglingDeletes.isEmpty()) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -153,7 +153,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
       if (currentTask != null && !currentTask.isDataTask()) {
         String filePaths =
             referencedFiles(currentTask)
-                .map(file -> file.path().toString())
+                .map(ContentFile::location)
                 .collect(Collectors.joining(", "));
         LOG.error("Error reading file(s): {}", filePaths, e);
       }
@@ -199,7 +199,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
   }
 
   private EncryptedInputFile toEncryptedInputFile(ContentFile<?> file) {
-    InputFile inputFile = table.io().newInputFile(file.path().toString());
+    InputFile inputFile = table.io().newInputFile(file.location());
     return EncryptedFiles.encryptedInput(inputFile, file.keyMetadata());
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -82,7 +82,7 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
 
   @Override
   protected CloseableIterator<ColumnarBatch> open(FileScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     LOG.debug("Opening data file {}", filePath);
 
     // update the current file for Spark's filename() function

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
@@ -110,13 +110,13 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask>
   }
 
   CloseableIterable<InternalRow> openAddedRowsScanTask(AddedRowsScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     SparkDeleteFilter deletes = new SparkDeleteFilter(filePath, task.deletes(), counter(), true);
     return deletes.filter(rows(task, deletes.requiredSchema()));
   }
 
   private CloseableIterable<InternalRow> openDeletedDataFileScanTask(DeletedDataFileScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     SparkDeleteFilter deletes =
         new SparkDeleteFilter(filePath, task.existingDeletes(), counter(), true);
     return deletes.filter(rows(task, deletes.requiredSchema()));
@@ -125,7 +125,7 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask>
   private CloseableIterable<InternalRow> rows(ContentScanTask<DataFile> task, Schema readSchema) {
     Map<Integer, ?> idToConstant = constantsMap(task, readSchema);
 
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
 
     // update the current file for Spark's filename() function
     InputFileBlockHolder.set(filePath, task.start(), task.length());

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
@@ -41,7 +41,7 @@ public class EqualityDeleteRowReader extends RowDataReader {
   @Override
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
     SparkDeleteFilter matches =
-        new SparkDeleteFilter(task.file().path().toString(), task.deletes(), counter(), true);
+        new SparkDeleteFilter(task.file().location(), task.deletes(), counter(), true);
 
     // schema or rows returned by readers
     Schema requiredSchema = matches.requiredSchema();
@@ -49,7 +49,7 @@ public class EqualityDeleteRowReader extends RowDataReader {
     DataFile file = task.file();
 
     // update the current file for Spark's filename() function
-    InputFileBlockHolder.set(file.path().toString(), task.start(), task.length());
+    InputFileBlockHolder.set(file.location(), task.start(), task.length());
 
     return matches.findEqualityDeleteRows(open(task, requiredSchema, idToConstant)).iterator();
   }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
@@ -74,13 +74,13 @@ class PositionDeletesRowReader extends BaseRowReader<PositionDeletesScanTask>
 
   @Override
   protected CloseableIterator<InternalRow> open(PositionDeletesScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     LOG.debug("Opening position delete file {}", filePath);
 
     // update the current file for Spark's filename() function
     InputFileBlockHolder.set(filePath, task.start(), task.length());
 
-    InputFile inputFile = getInputFile(task.file().path().toString());
+    InputFile inputFile = getInputFile(task.file().location());
     Preconditions.checkNotNull(inputFile, "Could not find InputFile associated with %s", task);
 
     // select out constant fields when pushing down filter to row reader

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -81,7 +81,7 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
 
   @Override
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     LOG.debug("Opening data file {}", filePath);
     SparkDeleteFilter deleteFilter =
         new SparkDeleteFilter(filePath, task.deletes(), counter(), true);
@@ -101,7 +101,7 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
     if (task.isDataTask()) {
       return newDataIterable(task.asDataTask(), readSchema);
     } else {
-      InputFile inputFile = getInputFile(task.file().path().toString());
+      InputFile inputFile = getInputFile(task.file().location());
       Preconditions.checkNotNull(
           inputFile, "Could not find InputFile associated with FileScanTask");
       return newIterable(

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -81,7 +81,7 @@ class SparkCleanupUtil {
    * @param files a list of files to delete
    */
   public static void deleteFiles(String context, FileIO io, List<? extends ContentFile<?>> files) {
-    List<String> paths = Lists.transform(files, file -> file.path().toString());
+    List<String> paths = Lists.transform(files, ContentFile::location);
     deletePaths(context, io, paths);
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -130,7 +130,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
           this.filteredLocations = fileLocations;
           List<FileScanTask> filteredTasks =
               tasks().stream()
-                  .filter(file -> fileLocations.contains(file.file().path().toString()))
+                  .filter(file -> fileLocations.contains(file.file().location()))
                   .collect(Collectors.toList());
 
           LOG.info(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
@@ -60,7 +60,8 @@ public final class TaskCheckHelper {
   }
 
   public static void assertEquals(DataFile expected, DataFile actual) {
-    Assert.assertEquals("Should match the serialized record path", expected.path(), actual.path());
+    Assert.assertEquals(
+        "Should match the serialized record path", expected.location(), actual.location());
     Assert.assertEquals(
         "Should match the serialized record format", expected.format(), actual.format());
     Assert.assertEquals(
@@ -105,7 +106,7 @@ public final class TaskCheckHelper {
       ScanTaskGroup<FileScanTask> taskGroup) {
     return taskGroup.tasks().stream()
         // use file path + start position to differentiate the tasks
-        .sorted(Comparator.comparing(o -> o.file().path().toString() + "##" + o.start()))
+        .sorted(Comparator.comparing(o -> o.file().location() + "##" + o.start()))
         .collect(Collectors.toList());
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/ValidationHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/ValidationHelpers.java
@@ -42,7 +42,7 @@ public class ValidationHelpers {
   }
 
   public static List<String> files(ContentFile<?>... files) {
-    return Arrays.stream(files).map(file -> file.path().toString()).collect(Collectors.toList());
+    return Arrays.stream(files).map(ContentFile::location).collect(Collectors.toList());
   }
 
   public static void validateDataManifest(
@@ -62,7 +62,7 @@ public class ValidationHelpers {
       actualDataSeqs.add(entry.dataSequenceNumber());
       actualFileSeqs.add(entry.fileSequenceNumber());
       actualSnapshotIds.add(entry.snapshotId());
-      actualFiles.add(entry.file().path().toString());
+      actualFiles.add(entry.file().location());
     }
 
     assertSameElements("data seqs", actualDataSeqs, dataSeqs);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -142,7 +142,7 @@ public abstract class SparkTestBase extends SparkTestHelperBase {
   }
 
   protected void withUnavailableFiles(Iterable<? extends ContentFile<?>> files, Action action) {
-    Iterable<String> fileLocations = Iterables.transform(files, file -> file.path().toString());
+    Iterable<String> fileLocations = Iterables.transform(files, ContentFile::location);
     withUnavailableLocations(fileLocations, action);
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
@@ -284,7 +284,7 @@ public class TestSparkExecutorCache extends SparkTestBaseWithCatalog {
   }
 
   private int streamCount(DeleteFile deleteFile) {
-    CustomInputFile inputFile = INPUT_FILES.get(deleteFile.path().toString());
+    CustomInputFile inputFile = INPUT_FILES.get(deleteFile.location());
     return inputFile.streamCount();
   }
 
@@ -309,7 +309,7 @@ public class TestSparkExecutorCache extends SparkTestBaseWithCatalog {
 
     List<Pair<CharSequence, Long>> posDeletes =
         dataFiles(table).stream()
-            .map(dataFile -> Pair.of(dataFile.path(), 0L))
+            .map(dataFile -> Pair.of((CharSequence) dataFile.location(), 0L))
             .collect(Collectors.toList());
     Pair<DeleteFile, CharSequenceSet> posDeleteResult = writePosDeletes(table, posDeletes);
     DeleteFile posDeleteFile = posDeleteResult.first();

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -204,7 +204,7 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
         .forEach(
             file ->
                 Assert.assertTrue(
-                    "FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString())));
+                    "FILE_A should be deleted", deletedFiles.contains(FILE_A.location())));
     checkRemoveFilesResults(4L, 0, 0, 6L, 4L, 6, result);
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -239,8 +239,8 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
         Sets.newHashSet(
             "remove-snapshot-0", "remove-snapshot-1", "remove-snapshot-2", "remove-snapshot-3"));
 
-    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
-    Assert.assertTrue("FILE_B should be deleted", deletedFiles.contains(FILE_B.path().toString()));
+    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.location()));
+    Assert.assertTrue("FILE_B should be deleted", deletedFiles.contains(FILE_B.location()));
 
     checkExpirationResults(2L, 0L, 0L, 3L, 3L, result);
   }
@@ -552,7 +552,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
+    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.location()));
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, result);
   }
 
@@ -581,7 +581,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
+    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.location()));
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, result);
   }
 
@@ -624,7 +624,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
         .addedDataFiles(table.io())
         .forEach(
             i -> {
-              expectedDeletes.add(i.path().toString());
+              expectedDeletes.add(i.location());
             });
 
     // ManifestList should be deleted too
@@ -693,7 +693,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        Assert.assertFalse(deletedFiles.contains(item.path().toString()));
+                        Assert.assertFalse(deletedFiles.contains(item.location()));
                       });
             });
 
@@ -742,7 +742,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        Assert.assertFalse(deletedFiles.contains(item.path().toString()));
+                        Assert.assertFalse(deletedFiles.contains(item.location()));
                       });
             });
     checkExpirationResults(0L, 0L, 0L, 1L, 1L, firstResult);
@@ -762,7 +762,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        Assert.assertFalse(deletedFiles.contains(item.path().toString()));
+                        Assert.assertFalse(deletedFiles.contains(item.location()));
                       });
             });
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, secondResult);
@@ -863,7 +863,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
                 .allManifests(table.io())
                 .get(0)
                 .path(), // manifest contained only deletes, was dropped
-            FILE_A.path()), // deleted
+            FILE_A.location()), // deleted
         deletedFiles);
 
     checkExpirationResults(1, 0, 0, 2, 2, result);
@@ -932,7 +932,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
                 .get(0)
                 .path(), // manifest was rewritten for delete
             secondSnapshot.manifestListLocation(), // snapshot expired
-            FILE_A.path()), // deleted
+            FILE_A.location()), // deleted
         deletedFiles);
 
     checkExpirationResults(1, 0, 0, 1, 2, result);
@@ -1046,7 +1046,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             secondSnapshot.manifestListLocation(), // snapshot expired
             Iterables.getOnlyElement(secondSnapshotManifests)
                 .path(), // manifest is no longer referenced
-            FILE_B.path()), // added, but rolled back
+            FILE_B.location()), // added, but rolled back
         deletedFiles);
 
     checkExpirationResults(1, 0, 0, 1, 1, result);
@@ -1095,9 +1095,9 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             secondSnapshot.manifestListLocation(),
             thirdSnapshot.manifestListLocation(),
             fourthSnapshot.manifestListLocation(),
-            FILE_A.path().toString(),
-            FILE_A_POS_DELETES.path().toString(),
-            FILE_A_EQ_DELETES.path().toString());
+            FILE_A.location(),
+            FILE_A_POS_DELETES.location(),
+            FILE_A_EQ_DELETES.location());
 
     expectedDeletes.addAll(
         thirdSnapshot.allManifests(table.io()).stream()
@@ -1270,7 +1270,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
               .withPartitionPath("c1=1")
               .withRecordCount(1)
               .build();
-      dataFiles.add(df.path().toString());
+      dataFiles.add(df.location());
       table.newFastAppend().appendFile(df).commit();
     }
 
@@ -1343,9 +1343,9 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     // C, D should be retained (live)
     // B should be retained (previous snapshot points to it)
     // A should be deleted
-    Assert.assertTrue(deletedFiles.contains(FILE_A.path().toString()));
-    Assert.assertFalse(deletedFiles.contains(FILE_B.path().toString()));
-    Assert.assertFalse(deletedFiles.contains(FILE_C.path().toString()));
-    Assert.assertFalse(deletedFiles.contains(FILE_D.path().toString()));
+    Assert.assertTrue(deletedFiles.contains(FILE_A.location()));
+    Assert.assertFalse(deletedFiles.contains(FILE_B.location()));
+    Assert.assertFalse(deletedFiles.contains(FILE_C.location()));
+    Assert.assertFalse(deletedFiles.contains(FILE_D.location()));
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
@@ -264,21 +264,21 @@ public class TestRemoveDanglingDeleteAction extends SparkTestBase {
             .collectAsList();
     List<Tuple2<Long, String>> expected =
         ImmutableList.of(
-            Tuple2.apply(1L, FILE_B.path().toString()),
-            Tuple2.apply(1L, FILE_C.path().toString()),
-            Tuple2.apply(1L, FILE_D.path().toString()),
-            Tuple2.apply(2L, FILE_A_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_A_POS_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_A2_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_A2_POS_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B_POS_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B2_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B2_POS_DELETES.path().toString()),
-            Tuple2.apply(3L, FILE_A2.path().toString()),
-            Tuple2.apply(3L, FILE_B2.path().toString()),
-            Tuple2.apply(3L, FILE_C2.path().toString()),
-            Tuple2.apply(3L, FILE_D2.path().toString()));
+            Tuple2.apply(1L, FILE_B.location()),
+            Tuple2.apply(1L, FILE_C.location()),
+            Tuple2.apply(1L, FILE_D.location()),
+            Tuple2.apply(2L, FILE_A_EQ_DELETES.location()),
+            Tuple2.apply(2L, FILE_A_POS_DELETES.location()),
+            Tuple2.apply(2L, FILE_A2_EQ_DELETES.location()),
+            Tuple2.apply(2L, FILE_A2_POS_DELETES.location()),
+            Tuple2.apply(2L, FILE_B_EQ_DELETES.location()),
+            Tuple2.apply(2L, FILE_B_POS_DELETES.location()),
+            Tuple2.apply(2L, FILE_B2_EQ_DELETES.location()),
+            Tuple2.apply(2L, FILE_B2_POS_DELETES.location()),
+            Tuple2.apply(3L, FILE_A2.location()),
+            Tuple2.apply(3L, FILE_B2.location()),
+            Tuple2.apply(3L, FILE_C2.location()),
+            Tuple2.apply(3L, FILE_D2.location()));
     assertThat(actual).isEqualTo(expected);
     RemoveDanglingDeleteFiles.Result result =
         SparkActions.get().removeDanglingDeleteFiles(table).execute();
@@ -286,16 +286,16 @@ public class TestRemoveDanglingDeleteAction extends SparkTestBase {
     // because there are no data files in partition with a lesser sequence number
     Set<CharSequence> removedDeleteFiles =
         StreamSupport.stream(result.removedDeleteFiles().spliterator(), false)
-            .map(DeleteFile::path)
+            .map(DeleteFile::location)
             .collect(Collectors.toSet());
     assertThat(removedDeleteFiles)
         .as("Expected 4 delete files removed")
         .hasSize(4)
         .containsExactlyInAnyOrder(
-            FILE_A_POS_DELETES.path(),
-            FILE_A2_POS_DELETES.path(),
-            FILE_A_EQ_DELETES.path(),
-            FILE_A2_EQ_DELETES.path());
+            FILE_A_POS_DELETES.location(),
+            FILE_A2_POS_DELETES.location(),
+            FILE_A_EQ_DELETES.location(),
+            FILE_A2_EQ_DELETES.location());
     List<Tuple2<Long, String>> actualAfter =
         spark
             .read()
@@ -308,17 +308,17 @@ public class TestRemoveDanglingDeleteAction extends SparkTestBase {
             .collectAsList();
     List<Tuple2<Long, String>> expectedAfter =
         ImmutableList.of(
-            Tuple2.apply(1L, FILE_B.path().toString()),
-            Tuple2.apply(1L, FILE_C.path().toString()),
-            Tuple2.apply(1L, FILE_D.path().toString()),
-            Tuple2.apply(2L, FILE_B_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B_POS_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B2_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B2_POS_DELETES.path().toString()),
-            Tuple2.apply(3L, FILE_A2.path().toString()),
-            Tuple2.apply(3L, FILE_B2.path().toString()),
-            Tuple2.apply(3L, FILE_C2.path().toString()),
-            Tuple2.apply(3L, FILE_D2.path().toString()));
+            Tuple2.apply(1L, FILE_B.location()),
+            Tuple2.apply(1L, FILE_C.location()),
+            Tuple2.apply(1L, FILE_D.location()),
+            Tuple2.apply(2L, FILE_B_EQ_DELETES.location()),
+            Tuple2.apply(2L, FILE_B_POS_DELETES.location()),
+            Tuple2.apply(2L, FILE_B2_EQ_DELETES.location()),
+            Tuple2.apply(2L, FILE_B2_POS_DELETES.location()),
+            Tuple2.apply(3L, FILE_A2.location()),
+            Tuple2.apply(3L, FILE_B2.location()),
+            Tuple2.apply(3L, FILE_C2.location()),
+            Tuple2.apply(3L, FILE_D2.location()));
     assertThat(actualAfter).isEqualTo(expectedAfter);
   }
 
@@ -354,21 +354,21 @@ public class TestRemoveDanglingDeleteAction extends SparkTestBase {
             .collectAsList();
     List<Tuple2<Long, String>> expected =
         ImmutableList.of(
-            Tuple2.apply(1L, FILE_A.path().toString()),
-            Tuple2.apply(1L, FILE_C.path().toString()),
-            Tuple2.apply(1L, FILE_D.path().toString()),
-            Tuple2.apply(2L, FILE_A_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_A_POS_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_A2.path().toString()),
-            Tuple2.apply(2L, FILE_A2_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_A2_POS_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B_POS_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B2.path().toString()),
-            Tuple2.apply(2L, FILE_B2_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B2_POS_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_C2.path().toString()),
-            Tuple2.apply(2L, FILE_D2.path().toString()));
+            Tuple2.apply(1L, FILE_A.location()),
+            Tuple2.apply(1L, FILE_C.location()),
+            Tuple2.apply(1L, FILE_D.location()),
+            Tuple2.apply(2L, FILE_A_EQ_DELETES.location()),
+            Tuple2.apply(2L, FILE_A_POS_DELETES.location()),
+            Tuple2.apply(2L, FILE_A2.location()),
+            Tuple2.apply(2L, FILE_A2_EQ_DELETES.location()),
+            Tuple2.apply(2L, FILE_A2_POS_DELETES.location()),
+            Tuple2.apply(2L, FILE_B_EQ_DELETES.location()),
+            Tuple2.apply(2L, FILE_B_POS_DELETES.location()),
+            Tuple2.apply(2L, FILE_B2.location()),
+            Tuple2.apply(2L, FILE_B2_EQ_DELETES.location()),
+            Tuple2.apply(2L, FILE_B2_POS_DELETES.location()),
+            Tuple2.apply(2L, FILE_C2.location()),
+            Tuple2.apply(2L, FILE_D2.location()));
     assertThat(actual).isEqualTo(expected);
     RemoveDanglingDeleteFiles.Result result =
         SparkActions.get().removeDanglingDeleteFiles(table).execute();
@@ -376,12 +376,12 @@ public class TestRemoveDanglingDeleteAction extends SparkTestBase {
     // because there are no data files in partition with a lesser sequence number
     Set<CharSequence> removedDeleteFiles =
         StreamSupport.stream(result.removedDeleteFiles().spliterator(), false)
-            .map(DeleteFile::path)
+            .map(DeleteFile::location)
             .collect(Collectors.toSet());
     assertThat(removedDeleteFiles)
         .as("Expected two delete files removed")
         .hasSize(2)
-        .containsExactlyInAnyOrder(FILE_B_EQ_DELETES.path(), FILE_B2_EQ_DELETES.path());
+        .containsExactlyInAnyOrder(FILE_B_EQ_DELETES.location(), FILE_B2_EQ_DELETES.location());
     List<Tuple2<Long, String>> actualAfter =
         spark
             .read()
@@ -394,19 +394,19 @@ public class TestRemoveDanglingDeleteAction extends SparkTestBase {
             .collectAsList();
     List<Tuple2<Long, String>> expectedAfter =
         ImmutableList.of(
-            Tuple2.apply(1L, FILE_A.path().toString()),
-            Tuple2.apply(1L, FILE_C.path().toString()),
-            Tuple2.apply(1L, FILE_D.path().toString()),
-            Tuple2.apply(2L, FILE_A_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_A_POS_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_A2.path().toString()),
-            Tuple2.apply(2L, FILE_A2_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_A2_POS_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B_POS_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_B2.path().toString()),
-            Tuple2.apply(2L, FILE_B2_POS_DELETES.path().toString()),
-            Tuple2.apply(2L, FILE_C2.path().toString()),
-            Tuple2.apply(2L, FILE_D2.path().toString()));
+            Tuple2.apply(1L, FILE_A.location()),
+            Tuple2.apply(1L, FILE_C.location()),
+            Tuple2.apply(1L, FILE_D.location()),
+            Tuple2.apply(2L, FILE_A_EQ_DELETES.location()),
+            Tuple2.apply(2L, FILE_A_POS_DELETES.location()),
+            Tuple2.apply(2L, FILE_A2.location()),
+            Tuple2.apply(2L, FILE_A2_EQ_DELETES.location()),
+            Tuple2.apply(2L, FILE_A2_POS_DELETES.location()),
+            Tuple2.apply(2L, FILE_B_POS_DELETES.location()),
+            Tuple2.apply(2L, FILE_B2.location()),
+            Tuple2.apply(2L, FILE_B2_POS_DELETES.location()),
+            Tuple2.apply(2L, FILE_C2.location()),
+            Tuple2.apply(2L, FILE_D2.location()));
     assertThat(actualAfter).isEqualTo(expectedAfter);
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1983,8 +1983,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
 
   private List<DeleteFile> writePosDeletesToFile(
       Table table, DataFile dataFile, int outputDeleteFiles) {
-    return writePosDeletes(
-        table, dataFile.partition(), dataFile.path().toString(), outputDeleteFiles);
+    return writePosDeletes(table, dataFile.partition(), dataFile.location(), outputDeleteFiles);
   }
 
   private List<DeleteFile> writePosDeletes(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -867,7 +867,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
       List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
       for (DataFile partitionFile : partitionFiles) {
         for (int deletePos = 0; deletePos < deletesPerDataFile; deletePos++) {
-          deletes.add(Pair.of(partitionFile.path(), (long) deletePos));
+          deletes.add(Pair.of(partitionFile.location(), (long) deletePos));
           counter++;
           if (counter == deleteFileSize) {
             // Dump to file and reset variables
@@ -904,17 +904,17 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
 
   private <T extends ContentFile<?>> List<T> except(List<T> first, List<T> second) {
     Set<String> secondPaths =
-        second.stream().map(f -> f.path().toString()).collect(Collectors.toSet());
+        second.stream().map(ContentFile::location).collect(Collectors.toSet());
     return first.stream()
-        .filter(f -> !secondPaths.contains(f.path().toString()))
+        .filter(f -> !secondPaths.contains(f.location()))
         .collect(Collectors.toList());
   }
 
   private void assertNotContains(List<DeleteFile> original, List<DeleteFile> rewritten) {
     Set<String> originalPaths =
-        original.stream().map(f -> f.path().toString()).collect(Collectors.toSet());
+        original.stream().map(ContentFile::location).collect(Collectors.toSet());
     Set<String> rewrittenPaths =
-        rewritten.stream().map(f -> f.path().toString()).collect(Collectors.toSet());
+        rewritten.stream().map(ContentFile::location).collect(Collectors.toSet());
     rewrittenPaths.retainAll(originalPaths);
     Assert.assertEquals(0, rewrittenPaths.size());
   }
@@ -923,7 +923,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     for (DeleteFile deleteFile : deleteFiles) {
       Dataset<Row> deletes =
           spark.read().format("iceberg").load("default." + TABLE_NAME + ".position_deletes");
-      deletes.filter(deletes.col("delete_file_path").equalTo(deleteFile.path().toString()));
+      deletes.filter(deletes.col("delete_file_path").equalTo(deleteFile.location()));
       List<Row> rows = deletes.collectAsList();
       Assert.assertFalse("Empty delete file found", rows.isEmpty());
       int lastPos = 0;

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -114,7 +114,7 @@ public class TestBaseReader {
     }
 
     private String getKey(FileScanTask task) {
-      return task.file().path().toString();
+      return task.file().location();
     }
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
@@ -168,7 +168,7 @@ public class TestCompressionSettings extends SparkCatalogTestBase {
     List<ManifestFile> manifestFiles = table.currentSnapshot().dataManifests(table.io());
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifestFiles.get(0), table.io())) {
       DataFile file = reader.iterator().next();
-      InputFile inputFile = table.io().newInputFile(file.path().toString());
+      InputFile inputFile = table.io().newInputFile(file.location());
       assertThat(getCompressionType(inputFile))
           .isEqualToIgnoringCase(properties.get(COMPRESSION_CODEC));
     }
@@ -182,7 +182,7 @@ public class TestCompressionSettings extends SparkCatalogTestBase {
     try (ManifestReader<DeleteFile> reader =
         ManifestFiles.readDeleteManifest(deleteManifestFiles.get(0), table.io(), specMap)) {
       DeleteFile file = reader.iterator().next();
-      InputFile inputFile = table.io().newInputFile(file.path().toString());
+      InputFile inputFile = table.io().newInputFile(file.location());
       assertThat(getCompressionType(inputFile))
           .isEqualToIgnoringCase(properties.get(COMPRESSION_CODEC));
     }
@@ -196,7 +196,7 @@ public class TestCompressionSettings extends SparkCatalogTestBase {
     try (ManifestReader<DeleteFile> reader =
         ManifestFiles.readDeleteManifest(deleteManifestFiles.get(0), table.io(), specMap)) {
       DeleteFile file = reader.iterator().next();
-      InputFile inputFile = table.io().newInputFile(file.path().toString());
+      InputFile inputFile = table.io().newInputFile(file.location());
       assertThat(getCompressionType(inputFile))
           .isEqualToIgnoringCase(properties.get(COMPRESSION_CODEC));
     }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -197,8 +197,8 @@ public class TestDataFrameWrites extends AvroDataTest {
                 Assert.assertTrue(
                     String.format(
                         "File should have the parent directory %s, but has: %s.",
-                        expectedDataDir.getAbsolutePath(), dataFile.path()),
-                    URI.create(dataFile.path().toString())
+                        expectedDataDir.getAbsolutePath(), dataFile.location()),
+                    URI.create(dataFile.location())
                         .getPath()
                         .startsWith(expectedDataDir.getAbsolutePath())));
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -110,7 +110,7 @@ public class TestDataSourceOptions extends SparkTestBaseWithCatalog {
     try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
       tasks.forEach(
           task -> {
-            FileFormat fileFormat = FileFormat.fromFileName(task.file().path());
+            FileFormat fileFormat = FileFormat.fromFileName(task.file().location());
             Assert.assertEquals(FileFormat.PARQUET, fileFormat);
           });
     }
@@ -135,7 +135,7 @@ public class TestDataSourceOptions extends SparkTestBaseWithCatalog {
     try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
       tasks.forEach(
           task -> {
-            FileFormat fileFormat = FileFormat.fromFileName(task.file().path());
+            FileFormat fileFormat = FileFormat.fromFileName(task.file().location());
             Assert.assertEquals(FileFormat.AVRO, fileFormat);
           });
     }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -268,7 +268,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                 .select("data_file.file_path")
                 .collectAsList());
 
-    List<Object[]> singleExpected = ImmutableList.of(row(file.path()));
+    List<Object[]> singleExpected = ImmutableList.of(row(file.location()));
 
     assertEquals(
         "Should prune a single element from a nested struct", singleExpected, singleActual);
@@ -307,7 +307,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     List<Object[]> multiExpected =
         ImmutableList.of(
-            row(file.path(), file.valueCounts(), file.recordCount(), file.columnSizes()));
+            row(file.location(), file.valueCounts(), file.recordCount(), file.columnSizes()));
 
     assertEquals("Should prune a single element from a nested struct", multiExpected, multiActual);
   }
@@ -341,7 +341,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     List<Object[]> multiExpected =
         ImmutableList.of(
-            row(file.path(), file.valueCounts(), file.recordCount(), file.columnSizes()));
+            row(file.location(), file.valueCounts(), file.recordCount(), file.columnSizes()));
 
     assertEquals("Should prune a single element from a row", multiExpected, multiActual);
   }
@@ -2315,7 +2315,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     StructLike dataFilePartition = dataFile.partition();
 
     PositionDelete<InternalRow> delete = PositionDelete.create();
-    delete.set(dataFile.path(), pos, null);
+    delete.set(dataFile.location(), pos, null);
 
     return writePositionDeletes(table, dataFileSpec, dataFilePartition, ImmutableList.of(delete));
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestRuntimeFiltering.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestRuntimeFiltering.java
@@ -470,7 +470,7 @@ public class TestRuntimeFiltering extends SparkTestBaseWithCatalog {
     Set<String> matchingFileLocations = Sets.newHashSet();
     try (CloseableIterable<FileScanTask> files = table.newScan().filter(filter).planFiles()) {
       for (FileScanTask file : files) {
-        String path = file.file().path().toString();
+        String path = file.file().location();
         matchingFileLocations.add(path);
       }
     } catch (IOException e) {
@@ -480,7 +480,7 @@ public class TestRuntimeFiltering extends SparkTestBaseWithCatalog {
     Set<String> deletedFileLocations = Sets.newHashSet();
     try (CloseableIterable<FileScanTask> files = table.newScan().planFiles()) {
       for (FileScanTask file : files) {
-        String path = file.file().path().toString();
+        String path = file.file().location();
         if (!matchingFileLocations.contains(path)) {
           io.deleteFile(path);
           deletedFileLocations.add(path);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
@@ -281,7 +281,7 @@ public class TestSparkDataFile {
 
   private void checkContentFile(ContentFile<?> expected, ContentFile<?> actual) {
     assertThat(actual.content()).isEqualTo(expected.content());
-    assertThat(actual.path()).isEqualTo(expected.path());
+    assertThat(actual.location()).isEqualTo(expected.location());
     assertThat(actual.format()).isEqualTo(expected.format());
     assertThat(actual.recordCount()).isEqualTo(expected.recordCount());
     assertThat(actual.fileSizeInBytes()).isEqualTo(expected.fileSizeInBytes());
@@ -319,10 +319,10 @@ public class TestSparkDataFile {
                 null, // no NaN counts
                 ImmutableMap.of(
                     MetadataColumns.DELETE_FILE_PATH.fieldId(),
-                    Conversions.toByteBuffer(Types.StringType.get(), dataFile.path())),
+                    Conversions.toByteBuffer(Types.StringType.get(), dataFile.location())),
                 ImmutableMap.of(
                     MetadataColumns.DELETE_FILE_PATH.fieldId(),
-                    Conversions.toByteBuffer(Types.StringType.get(), dataFile.path()))))
+                    Conversions.toByteBuffer(Types.StringType.get(), dataFile.location()))))
         .withEncryptionKeyMetadata(ByteBuffer.allocate(4).putInt(35))
         .build();
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -343,10 +343,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     // deleted.
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 0L), // id = 29
-            Pair.of(dataFile.path(), 1L), // id = 43
-            Pair.of(dataFile.path(), 2L), // id = 61
-            Pair.of(dataFile.path(), 3L) // id = 89
+            Pair.of(dataFile.location(), 0L), // id = 29
+            Pair.of(dataFile.location(), 1L), // id = 43
+            Pair.of(dataFile.location(), 2L), // id = 61
+            Pair.of(dataFile.location(), 3L) // id = 89
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -376,10 +376,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     // deleted.
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 0L), // id = 29
-            Pair.of(dataFile.path(), 1L), // id = 43
-            Pair.of(dataFile.path(), 2L), // id = 61
-            Pair.of(dataFile.path(), 3L) // id = 89
+            Pair.of(dataFile.location(), 0L), // id = 29
+            Pair.of(dataFile.location(), 1L), // id = 43
+            Pair.of(dataFile.location(), 2L), // id = 61
+            Pair.of(dataFile.location(), 3L) // id = 89
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -455,8 +455,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
 
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 3L), // id = 89
-            Pair.of(dataFile.path(), 5L) // id = 121
+            Pair.of(dataFile.location(), 3L), // id = 89
+            Pair.of(dataFile.location(), 5L) // id = 121
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -486,10 +486,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
   public void testFilterOnDeletedMetadataColumn() throws IOException {
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 0L), // id = 29
-            Pair.of(dataFile.path(), 1L), // id = 43
-            Pair.of(dataFile.path(), 2L), // id = 61
-            Pair.of(dataFile.path(), 3L) // id = 89
+            Pair.of(dataFile.location(), 0L), // id = 29
+            Pair.of(dataFile.location(), 1L), // id = 43
+            Pair.of(dataFile.location(), 2L), // id = 61
+            Pair.of(dataFile.location(), 3L) // id = 89
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
@@ -611,13 +611,13 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     // Add positional deletes to the table
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
-            Pair.of(dataFile.path(), 97L),
-            Pair.of(dataFile.path(), 98L),
-            Pair.of(dataFile.path(), 99L),
-            Pair.of(dataFile.path(), 101L),
-            Pair.of(dataFile.path(), 103L),
-            Pair.of(dataFile.path(), 107L),
-            Pair.of(dataFile.path(), 109L));
+            Pair.of(dataFile.location(), 97L),
+            Pair.of(dataFile.location(), 98L),
+            Pair.of(dataFile.location(), 99L),
+            Pair.of(dataFile.location(), 101L),
+            Pair.of(dataFile.location(), 103L),
+            Pair.of(dataFile.location(), 107L),
+            Pair.of(dataFile.location(), 109L));
     Pair<DeleteFile, CharSequenceSet> posDeletes =
         FileHelpers.writeDeleteFile(
             table,

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -284,7 +284,7 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
     assertThat(TestHelpers.deleteFiles(table)).as("Should have 1 delete file").hasSize(1);
     Path deleteManifestPath = new Path(TestHelpers.deleteManifests(table).iterator().next().path());
     DeleteFile deleteFile = TestHelpers.deleteFiles(table).iterator().next();
-    Path deleteFilePath = new Path(String.valueOf(deleteFile.location()));
+    Path deleteFilePath = new Path(deleteFile.location());
 
     sql(
         "CALL %s.system.rewrite_data_files("

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -411,8 +411,7 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
     assertThat(TestHelpers.deleteManifests(table)).as("Should have 1 delete manifest").hasSize(1);
     assertThat(TestHelpers.deleteFiles(table)).as("Should have 1 delete file").hasSize(1);
     Path deleteManifestPath = new Path(TestHelpers.deleteManifests(table).iterator().next().path());
-    Path deleteFilePath =
-        new Path(String.valueOf(TestHelpers.deleteFiles(table).iterator().next().location()));
+    Path deleteFilePath = new Path(TestHelpers.deleteFiles(table).iterator().next().location());
 
     // wait to ensure files are old enough
     waitUntilAfter(System.currentTimeMillis());

--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetMultiDeleteFileBenchmark.java
+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetMultiDeleteFileBenchmark.java
@@ -45,7 +45,7 @@ public class IcebergSourceParquetMultiDeleteFileBenchmark extends IcebergSourceD
 
       table().refresh();
       for (DataFile file : table().currentSnapshot().addedDataFiles(table().io())) {
-        writePosDeletes(file.path(), NUM_ROWS, 0.25, numDeleteFile);
+        writePosDeletes(file.location(), NUM_ROWS, 0.25, numDeleteFile);
       }
     }
   }

--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetPosDeleteBenchmark.java
+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetPosDeleteBenchmark.java
@@ -47,7 +47,7 @@ public class IcebergSourceParquetPosDeleteBenchmark extends IcebergSourceDeleteB
         // add pos-deletes
         table().refresh();
         for (DataFile file : table().currentSnapshot().addedDataFiles(table().io())) {
-          writePosDeletes(file.path(), NUM_ROWS, percentDeleteRow);
+          writePosDeletes(file.location(), NUM_ROWS, percentDeleteRow);
         }
       }
     }

--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetWithUnrelatedDeleteBenchmark.java
+++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceParquetWithUnrelatedDeleteBenchmark.java
@@ -48,7 +48,7 @@ public class IcebergSourceParquetWithUnrelatedDeleteBenchmark extends IcebergSou
       table().refresh();
       for (DataFile file : table().currentSnapshot().addedDataFiles(table().io())) {
         writePosDeletesWithNoise(
-            file.path(),
+            file.location(),
             NUM_ROWS,
             PERCENT_DELETE_ROW,
             (int) (percentUnrelatedDeletes / PERCENT_DELETE_ROW),

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
@@ -116,7 +116,7 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask>
   }
 
   private CloseableIterable<InternalRow> openDeletedDataFileScanTask(DeletedDataFileScanTask task) {
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
     SparkDeleteFilter deletes =
         new SparkDeleteFilter(filePath, task.existingDeletes(), counter(), true);
     return deletes.filter(rows(task, deletes.requiredSchema()));
@@ -125,7 +125,7 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask>
   private CloseableIterable<InternalRow> rows(ContentScanTask<DataFile> task, Schema readSchema) {
     Map<Integer, ?> idToConstant = constantsMap(task, readSchema);
 
-    String filePath = task.file().path().toString();
+    String filePath = task.file().location();
 
     // update the current file for Spark's filename() function
     InputFileBlockHolder.set(filePath, task.start(), task.length());

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/ValidationHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/ValidationHelpers.java
@@ -42,7 +42,7 @@ public class ValidationHelpers {
   }
 
   public static List<String> files(ContentFile<?>... files) {
-    return Arrays.stream(files).map(file -> file.location()).collect(Collectors.toList());
+    return Arrays.stream(files).map(ContentFile::location).collect(Collectors.toList());
   }
 
   public static void validateDataManifest(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
@@ -142,7 +142,7 @@ public abstract class TestBase extends SparkTestHelperBase {
   }
 
   protected void withUnavailableFiles(Iterable<? extends ContentFile<?>> files, Action action) {
-    Iterable<String> fileLocations = Iterables.transform(files, file -> file.location());
+    Iterable<String> fileLocations = Iterables.transform(files, ContentFile::location);
     withUnavailableLocations(fileLocations, action);
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
@@ -375,7 +375,7 @@ public class TestSparkExecutorCache extends TestBaseWithCatalog {
 
     List<Pair<CharSequence, Long>> posDeletes =
         dataFiles(table).stream()
-            .map(dataFile -> Pair.of(dataFile.path(), 0L))
+            .map(dataFile -> Pair.of((CharSequence) dataFile.location(), 0L))
             .collect(Collectors.toList());
     Pair<DeleteFile, CharSequenceSet> posDeleteResult = writePosDeletes(table, posDeletes);
     DeleteFile posDeleteFile = posDeleteResult.first();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -874,7 +874,7 @@ public class TestExpireSnapshotsAction extends TestBase {
                     .allManifests(table.io())
                     .get(0)
                     .path(), // manifest contained only deletes, was dropped
-                FILE_A.path()) // deleted
+                FILE_A.location()) // deleted
             );
 
     checkExpirationResults(1, 0, 0, 2, 2, result);
@@ -941,7 +941,7 @@ public class TestExpireSnapshotsAction extends TestBase {
                     .get(0)
                     .path(), // manifest was rewritten for delete
                 secondSnapshot.manifestListLocation(), // snapshot expired
-                FILE_A.path()) // deleted
+                FILE_A.location()) // deleted
             );
     checkExpirationResults(1, 0, 0, 1, 2, result);
   }
@@ -1053,7 +1053,7 @@ public class TestExpireSnapshotsAction extends TestBase {
                 secondSnapshot.manifestListLocation(), // snapshot expired
                 Iterables.getOnlyElement(secondSnapshotManifests)
                     .path(), // manifest is no longer referenced
-                FILE_B.path()) // added, but rolled back
+                FILE_B.location()) // added, but rolled back
             );
 
     checkExpirationResults(1, 0, 0, 1, 1, result);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
@@ -313,21 +313,21 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
             .collectAsList();
     List<Tuple2<Long, String>> expected =
         ImmutableList.of(
-            Tuple2.apply(1L, FILE_B.path().toString()),
-            Tuple2.apply(1L, FILE_C.path().toString()),
-            Tuple2.apply(1L, FILE_D.path().toString()),
-            Tuple2.apply(2L, FILE_A_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, fileADeletes.path().toString()),
-            Tuple2.apply(2L, FILE_A2_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, fileA2Deletes.path().toString()),
-            Tuple2.apply(2L, FILE_B_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, fileBDeletes.path().toString()),
-            Tuple2.apply(2L, FILE_B2_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, fileB2Deletes.path().toString()),
-            Tuple2.apply(3L, FILE_A2.path().toString()),
-            Tuple2.apply(3L, FILE_B2.path().toString()),
-            Tuple2.apply(3L, FILE_C2.path().toString()),
-            Tuple2.apply(3L, FILE_D2.path().toString()));
+            Tuple2.apply(1L, FILE_B.location()),
+            Tuple2.apply(1L, FILE_C.location()),
+            Tuple2.apply(1L, FILE_D.location()),
+            Tuple2.apply(2L, FILE_A_EQ_DELETES.location()),
+            Tuple2.apply(2L, fileADeletes.location()),
+            Tuple2.apply(2L, FILE_A2_EQ_DELETES.location()),
+            Tuple2.apply(2L, fileA2Deletes.location()),
+            Tuple2.apply(2L, FILE_B_EQ_DELETES.location()),
+            Tuple2.apply(2L, fileBDeletes.location()),
+            Tuple2.apply(2L, FILE_B2_EQ_DELETES.location()),
+            Tuple2.apply(2L, fileB2Deletes.location()),
+            Tuple2.apply(3L, FILE_A2.location()),
+            Tuple2.apply(3L, FILE_B2.location()),
+            Tuple2.apply(3L, FILE_C2.location()),
+            Tuple2.apply(3L, FILE_D2.location()));
     assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
 
     RemoveDanglingDeleteFiles.Result result =
@@ -338,16 +338,16 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
 
     Set<CharSequence> removedDeleteFiles =
         StreamSupport.stream(result.removedDeleteFiles().spliterator(), false)
-            .map(DeleteFile::path)
+            .map(DeleteFile::location)
             .collect(Collectors.toSet());
     assertThat(removedDeleteFiles)
         .as("Expected 4 delete files removed")
         .hasSize(4)
         .containsExactlyInAnyOrder(
-            fileADeletes.path(),
-            fileA2Deletes.path(),
-            FILE_A_EQ_DELETES.path(),
-            FILE_A2_EQ_DELETES.path());
+            fileADeletes.location(),
+            fileA2Deletes.location(),
+            FILE_A_EQ_DELETES.location(),
+            FILE_A2_EQ_DELETES.location());
 
     List<Tuple2<Long, String>> actualAfter =
         spark
@@ -361,17 +361,17 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
             .collectAsList();
     List<Tuple2<Long, String>> expectedAfter =
         ImmutableList.of(
-            Tuple2.apply(1L, FILE_B.path().toString()),
-            Tuple2.apply(1L, FILE_C.path().toString()),
-            Tuple2.apply(1L, FILE_D.path().toString()),
-            Tuple2.apply(2L, FILE_B_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, fileBDeletes.path().toString()),
-            Tuple2.apply(2L, FILE_B2_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, fileB2Deletes.path().toString()),
-            Tuple2.apply(3L, FILE_A2.path().toString()),
-            Tuple2.apply(3L, FILE_B2.path().toString()),
-            Tuple2.apply(3L, FILE_C2.path().toString()),
-            Tuple2.apply(3L, FILE_D2.path().toString()));
+            Tuple2.apply(1L, FILE_B.location()),
+            Tuple2.apply(1L, FILE_C.location()),
+            Tuple2.apply(1L, FILE_D.location()),
+            Tuple2.apply(2L, FILE_B_EQ_DELETES.location()),
+            Tuple2.apply(2L, fileBDeletes.location()),
+            Tuple2.apply(2L, FILE_B2_EQ_DELETES.location()),
+            Tuple2.apply(2L, fileB2Deletes.location()),
+            Tuple2.apply(3L, FILE_A2.location()),
+            Tuple2.apply(3L, FILE_B2.location()),
+            Tuple2.apply(3L, FILE_C2.location()),
+            Tuple2.apply(3L, FILE_D2.location()));
     assertThat(actualAfter).containsExactlyInAnyOrderElementsOf(expectedAfter);
   }
 
@@ -414,21 +414,21 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
             .collectAsList();
     List<Tuple2<Long, String>> expected =
         ImmutableList.of(
-            Tuple2.apply(1L, FILE_A.path().toString()),
-            Tuple2.apply(1L, FILE_C.path().toString()),
-            Tuple2.apply(1L, FILE_D.path().toString()),
-            Tuple2.apply(2L, FILE_A_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, fileADeletes.path().toString()),
-            Tuple2.apply(2L, FILE_A2.path().toString()),
-            Tuple2.apply(2L, FILE_A2_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, fileA2Deletes.path().toString()),
-            Tuple2.apply(2L, FILE_B_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, fileBDeletes.path().toString()),
-            Tuple2.apply(2L, FILE_B2.path().toString()),
-            Tuple2.apply(2L, FILE_B2_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, fileB2Deletes.path().toString()),
-            Tuple2.apply(2L, FILE_C2.path().toString()),
-            Tuple2.apply(2L, FILE_D2.path().toString()));
+            Tuple2.apply(1L, FILE_A.location()),
+            Tuple2.apply(1L, FILE_C.location()),
+            Tuple2.apply(1L, FILE_D.location()),
+            Tuple2.apply(2L, FILE_A_EQ_DELETES.location()),
+            Tuple2.apply(2L, fileADeletes.location()),
+            Tuple2.apply(2L, FILE_A2.location()),
+            Tuple2.apply(2L, FILE_A2_EQ_DELETES.location()),
+            Tuple2.apply(2L, fileA2Deletes.location()),
+            Tuple2.apply(2L, FILE_B_EQ_DELETES.location()),
+            Tuple2.apply(2L, fileBDeletes.location()),
+            Tuple2.apply(2L, FILE_B2.location()),
+            Tuple2.apply(2L, FILE_B2_EQ_DELETES.location()),
+            Tuple2.apply(2L, fileB2Deletes.location()),
+            Tuple2.apply(2L, FILE_C2.location()),
+            Tuple2.apply(2L, FILE_D2.location()));
     assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
 
     RemoveDanglingDeleteFiles.Result result =
@@ -438,12 +438,12 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
     // because there are no data files in partition with a lesser sequence number
     Set<CharSequence> removedDeleteFiles =
         StreamSupport.stream(result.removedDeleteFiles().spliterator(), false)
-            .map(DeleteFile::path)
+            .map(DeleteFile::location)
             .collect(Collectors.toSet());
     assertThat(removedDeleteFiles)
         .as("Expected two delete files removed")
         .hasSize(2)
-        .containsExactlyInAnyOrder(FILE_B_EQ_DELETES.path(), FILE_B2_EQ_DELETES.path());
+        .containsExactlyInAnyOrder(FILE_B_EQ_DELETES.location(), FILE_B2_EQ_DELETES.location());
 
     List<Tuple2<Long, String>> actualAfter =
         spark
@@ -457,19 +457,19 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
             .collectAsList();
     List<Tuple2<Long, String>> expectedAfter =
         ImmutableList.of(
-            Tuple2.apply(1L, FILE_A.path().toString()),
-            Tuple2.apply(1L, FILE_C.path().toString()),
-            Tuple2.apply(1L, FILE_D.path().toString()),
-            Tuple2.apply(2L, FILE_A_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, fileADeletes.path().toString()),
-            Tuple2.apply(2L, FILE_A2.path().toString()),
-            Tuple2.apply(2L, FILE_A2_EQ_DELETES.path().toString()),
-            Tuple2.apply(2L, fileA2Deletes.path().toString()),
-            Tuple2.apply(2L, fileBDeletes.path().toString()),
-            Tuple2.apply(2L, FILE_B2.path().toString()),
-            Tuple2.apply(2L, fileB2Deletes.path().toString()),
-            Tuple2.apply(2L, FILE_C2.path().toString()),
-            Tuple2.apply(2L, FILE_D2.path().toString()));
+            Tuple2.apply(1L, FILE_A.location()),
+            Tuple2.apply(1L, FILE_C.location()),
+            Tuple2.apply(1L, FILE_D.location()),
+            Tuple2.apply(2L, FILE_A_EQ_DELETES.location()),
+            Tuple2.apply(2L, fileADeletes.location()),
+            Tuple2.apply(2L, FILE_A2.location()),
+            Tuple2.apply(2L, FILE_A2_EQ_DELETES.location()),
+            Tuple2.apply(2L, fileA2Deletes.location()),
+            Tuple2.apply(2L, fileBDeletes.location()),
+            Tuple2.apply(2L, FILE_B2.location()),
+            Tuple2.apply(2L, fileB2Deletes.location()),
+            Tuple2.apply(2L, FILE_C2.location()),
+            Tuple2.apply(2L, FILE_D2.location()));
     assertThat(actualAfter).containsExactlyInAnyOrderElementsOf(expectedAfter);
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -2152,8 +2152,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   private List<DeleteFile> writePosDeletesToFile(
       Table table, DataFile dataFile, int outputDeleteFiles) {
-    return writePosDeletes(
-        table, dataFile.partition(), dataFile.path().toString(), outputDeleteFiles);
+    return writePosDeletes(table, dataFile.partition(), dataFile.location(), outputDeleteFiles);
   }
 
   private List<DeleteFile> writePosDeletes(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -898,7 +898,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
       List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
       for (DataFile partitionFile : partitionFiles) {
         for (int deletePos = 0; deletePos < deletesPerDataFile; deletePos++) {
-          deletes.add(Pair.of(partitionFile.path(), (long) deletePos));
+          deletes.add(Pair.of(partitionFile.location(), (long) deletePos));
           counter++;
           if (counter == deleteFileSize) {
             // Dump to file and reset variables
@@ -936,17 +936,17 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
 
   private <T extends ContentFile<?>> List<T> except(List<T> first, List<T> second) {
     Set<String> secondPaths =
-        second.stream().map(f -> f.path().toString()).collect(Collectors.toSet());
+        second.stream().map(ContentFile::location).collect(Collectors.toSet());
     return first.stream()
-        .filter(f -> !secondPaths.contains(f.path().toString()))
+        .filter(f -> !secondPaths.contains(f.location()))
         .collect(Collectors.toList());
   }
 
   private void assertNotContains(List<DeleteFile> original, List<DeleteFile> rewritten) {
     Set<String> originalPaths =
-        original.stream().map(f -> f.path().toString()).collect(Collectors.toSet());
+        original.stream().map(ContentFile::location).collect(Collectors.toSet());
     Set<String> rewrittenPaths =
-        rewritten.stream().map(f -> f.path().toString()).collect(Collectors.toSet());
+        rewritten.stream().map(ContentFile::location).collect(Collectors.toSet());
     rewrittenPaths.retainAll(originalPaths);
     assertThat(rewrittenPaths).hasSize(0);
   }
@@ -955,7 +955,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     for (DeleteFile deleteFile : deleteFiles) {
       Dataset<Row> deletes =
           spark.read().format("iceberg").load("default." + TABLE_NAME + ".position_deletes");
-      deletes.filter(deletes.col("delete_file_path").equalTo(deleteFile.path().toString()));
+      deletes.filter(deletes.col("delete_file_path").equalTo(deleteFile.location()));
       List<Row> rows = deletes.collectAsList();
       assertThat(rows).as("Empty delete file found").isNotEmpty();
       int lastPos = 0;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -266,7 +266,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                 .select("data_file.file_path")
                 .collectAsList());
 
-    List<Object[]> singleExpected = ImmutableList.of(row(file.path()));
+    List<Object[]> singleExpected = ImmutableList.of(row(file.location()));
 
     assertEquals(
         "Should prune a single element from a nested struct", singleExpected, singleActual);
@@ -305,7 +305,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
     List<Object[]> multiExpected =
         ImmutableList.of(
-            row(file.path(), file.valueCounts(), file.recordCount(), file.columnSizes()));
+            row(file.location(), file.valueCounts(), file.recordCount(), file.columnSizes()));
 
     assertEquals("Should prune a single element from a nested struct", multiExpected, multiActual);
   }
@@ -339,7 +339,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
 
     List<Object[]> multiExpected =
         ImmutableList.of(
-            row(file.path(), file.valueCounts(), file.recordCount(), file.columnSizes()));
+            row(file.location(), file.valueCounts(), file.recordCount(), file.columnSizes()));
 
     assertEquals("Should prune a single element from a row", multiExpected, multiActual);
   }
@@ -2341,7 +2341,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     StructLike dataFilePartition = dataFile.partition();
 
     PositionDelete<InternalRow> delete = PositionDelete.create();
-    delete.set(dataFile.path(), pos, null);
+    delete.set(dataFile.location(), pos, null);
 
     return writePositionDeletes(table, dataFileSpec, dataFilePartition, ImmutableList.of(delete));
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesTable.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
@@ -1586,9 +1587,9 @@ public class TestPositionDeletesTable extends CatalogTestBase {
     assertThat(addedFiles).hasSize(expectedTargetFiles);
 
     List<String> sortedAddedFiles =
-        addedFiles.stream().map(f -> f.location()).sorted().collect(Collectors.toList());
+        addedFiles.stream().map(ContentFile::location).sorted().collect(Collectors.toList());
     List<String> sortedRewrittenFiles =
-        rewrittenFiles.stream().map(f -> f.location()).sorted().collect(Collectors.toList());
+        rewrittenFiles.stream().map(ContentFile::location).sorted().collect(Collectors.toList());
     assertThat(sortedRewrittenFiles)
         .as("Lists should not be the same")
         .isNotEqualTo(sortedAddedFiles);


### PR DESCRIPTION
Same as https://github.com/apache/iceberg/pull/11563, removing the remaining usages of the path API and replacing it with location API