### PR TITLE
Spark 3.5: Fix comment and assertion mismatch in PartitionedWritesTestBase/TestRewritePositionDeleteFilesAction

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -275,7 +275,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
             .execute();
 
     List<DeleteFile> newDeleteFiles = except(deleteFiles(table), deleteFiles);
-    assertThat(newDeleteFiles).as("Should have 4 delete files").hasSize(2);
+    assertThat(newDeleteFiles).as("Should have 2 delete files").hasSize(2);
 
     List<DeleteFile> expectedRewrittenFiles =
         filterFiles(table, deleteFiles, ImmutableList.of(1), ImmutableList.of(2));
@@ -469,7 +469,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
             .execute();
 
     List<DeleteFile> newDeleteFiles = except(deleteFiles(table), deleteFiles);
-    assertThat(newDeleteFiles).as("Should have 2 new delete files").hasSize(0);
+    assertThat(newDeleteFiles).as("Should have 0 new delete files").hasSize(0);
 
     List<DeleteFile> expectedRewrittenFiles =
         filterFiles(table, deleteFiles, ImmutableList.of(0), ImmutableList.of(1));

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -275,7 +275,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
             .execute();
 
     List<DeleteFile> newDeleteFiles = except(deleteFiles(table), deleteFiles);
-    assertThat(newDeleteFiles).as("Should have 2 delete files").hasSize(2);
+    assertThat(newDeleteFiles).as("Delete files").hasSize(2);
 
     List<DeleteFile> expectedRewrittenFiles =
         filterFiles(table, deleteFiles, ImmutableList.of(1), ImmutableList.of(2));
@@ -469,7 +469,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
             .execute();
 
     List<DeleteFile> newDeleteFiles = except(deleteFiles(table), deleteFiles);
-    assertThat(newDeleteFiles).as("Should have 0 new delete files").hasSize(0);
+    assertThat(newDeleteFiles).as("New delete files").hasSize(0);
 
     List<DeleteFile> expectedRewrittenFiles =
         filterFiles(table, deleteFiles, ImmutableList.of(0), ImmutableList.of(1));

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/PartitionedWritesTestBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/PartitionedWritesTestBase.java
@@ -53,7 +53,7 @@ public abstract class PartitionedWritesTestBase extends CatalogTestBase {
   @TestTemplate
   public void testInsertAppend() {
     assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
-        .as("Should have 5 rows after insert")
+        .as("Should have 3 rows after insert")
         .isEqualTo(3L);
 
     sql("INSERT INTO %s VALUES (4, 'd'), (5, 'e')", commitTarget());
@@ -74,7 +74,7 @@ public abstract class PartitionedWritesTestBase extends CatalogTestBase {
   @TestTemplate
   public void testInsertOverwrite() {
     assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
-        .as("Should have 5 rows after insert")
+        .as("Should have 3 rows after insert")
         .isEqualTo(3L);
 
     // 4 and 5 replace 3 in the partition (id - (id % 3)) = 3

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/PartitionedWritesTestBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/PartitionedWritesTestBase.java
@@ -53,7 +53,7 @@ public abstract class PartitionedWritesTestBase extends CatalogTestBase {
   @TestTemplate
   public void testInsertAppend() {
     assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
-        .as("Should have 3 rows after insert")
+        .as("Rows after insert")
         .isEqualTo(3L);
 
     sql("INSERT INTO %s VALUES (4, 'd'), (5, 'e')", commitTarget());
@@ -74,7 +74,7 @@ public abstract class PartitionedWritesTestBase extends CatalogTestBase {
   @TestTemplate
   public void testInsertOverwrite() {
     assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
-        .as("Should have 3 rows after insert")
+        .as("Rows after insert")
         .isEqualTo(3L);
 
     // 4 and 5 replace 3 in the partition (id - (id % 3)) = 3

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/PartitionedWritesTestBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/PartitionedWritesTestBase.java
@@ -53,7 +53,7 @@ public abstract class PartitionedWritesTestBase extends CatalogTestBase {
   @TestTemplate
   public void testInsertAppend() {
     assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
-        .as("Rows after insert")
+        .as("Rows before insert")
         .isEqualTo(3L);
 
     sql("INSERT INTO %s VALUES (4, 'd'), (5, 'e')", commitTarget());
@@ -74,7 +74,7 @@ public abstract class PartitionedWritesTestBase extends CatalogTestBase {
   @TestTemplate
   public void testInsertOverwrite() {
     assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
-        .as("Rows after insert")
+        .as("Rows before overwrite")
         .isEqualTo(3L);
 
     // 4 and 5 replace 3 in the partition (id - (id % 3)) = 3


### PR DESCRIPTION
close #11747 