### PR TITLE
docker: Build for `arm64` architecture

### DIFF
--- a/.github/workflows/publish-iceberg-rest-fixture-docker.yml
+++ b/.github/workflows/publish-iceberg-rest-fixture-docker.yml
@@ -49,8 +49,15 @@ jobs:
       if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
       run: |
         echo "DOCKER_IMAGE_VERSION=`echo ${{ github.ref }} | tr -d -c 0-9.`" >> "$GITHUB_ENV"
-    - name: Build Docker Image
-      run: docker build -t $DOCKER_REPOSITORY/$DOCKER_IMAGE_TAG:$DOCKER_IMAGE_VERSION -f docker/iceberg-rest-fixture/Dockerfile .
-    - name: Push Docker Image
-      run: |
-        docker push $DOCKER_REPOSITORY/$DOCKER_IMAGE_TAG:$DOCKER_IMAGE_VERSION
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build and Push
+      uses: docker/build-push-action@v6
+      with:
+        context: ./
+        file: ./docker/iceberg-rest-fixture/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ env.DOCKER_REPOSITORY }}/${{ env.DOCKER_IMAGE_TAG }}:${{ env.DOCKER_IMAGE_VERSION }}


### PR DESCRIPTION
We should also publish the `arm64` arch next to `amd64`. I bumped into this when doing some checks on Iceberg-rust.

Successful run on my fork: https://github.com/Fokko/iceberg/actions/runs/12278801894

![image](https://github.com/user-attachments/assets/1626ff81-12e7-4c11-b589-034f7f1d5dbe)


