### PR TITLE
[WIP][Core] Restrict adding column of StructType with Empty Fields

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -168,6 +168,17 @@ class SchemaUpdate implements UpdateSchema {
       fullName = name;
     }
 
+    // when adding structs with empty fields, Parquet fails complaining
+    // Cannot write a schema with an empty group, so fail on add column
+    // More details: https://issues.apache.org/jira/browse/SPARK-20593
+    Preconditions.checkArgument(
+        !type.isNestedType()
+            || !type.asNestedType().isStructType()
+            || (type.asNestedType().isStructType()
+                && !((Types.StructType) type).fields().isEmpty()),
+        "Cannot add struct with empty fields: %s",
+        type);
+
     // assign new IDs in order
     int newId = assignNewColumnId();
 

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -732,6 +732,17 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testAddStructTypeWithEmptyFields() {
+    assertThatThrownBy(
+            () -> {
+              UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
+              update.addColumn("empty_struct", Types.StructType.of());
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot add struct with empty fields: struct<>");
+  }
+
+  @Test
   public void testAddAlreadyExists() {
     assertThatThrownBy(
             () -> {


### PR DESCRIPTION
## About the change 

Recently stumbled on a schema where a column was of struct type but the underlying struct was empty, this lead to failure when writing the parquet file because : 

> This is not a bug. You cannot write a empty struct in parquet.
> 
> This is due to the way the parquet format works, a parquet file only consists of leaf field data,
> the intermediate structure is not stored and can be inferred using the schema and the repetition levels and definition levels of the written leaf fields.
> An empty struct (which is written as a group) has no leaf fields and that is why parquet fails to write this.

Taken from : https://issues.apache.org/jira/browse/SPARK-20593

I have not tested for ORC, but seems like we can ban this when updating the schema, our spec doesn't say much on this

> A struct is a tuple of typed values. 
> Each field in the tuple is named and has an integer id that is unique in the table schema. Each field can be either optional or required, meaning that values can (or cannot) be null.
> Fields may be any type. Fields may have an optional comment or doc string. Fields can have [default values](https://iceberg.apache.org/spec/?h=spec#default-values).



will update the spec if there is an alignment here 