### PR TITLE
Core: Add missing REST endpoint definitions

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
+++ b/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
@@ -40,20 +40,21 @@ public class Endpoint {
       Endpoint.create("GET", ResourcePaths.V1_NAMESPACES);
   public static final Endpoint V1_LOAD_NAMESPACE =
       Endpoint.create("GET", ResourcePaths.V1_NAMESPACE);
+  public static final Endpoint V1_NAMESPACE_EXISTS =
+      Endpoint.create("HEAD", ResourcePaths.V1_NAMESPACE);
   public static final Endpoint V1_CREATE_NAMESPACE =
       Endpoint.create("POST", ResourcePaths.V1_NAMESPACES);
   public static final Endpoint V1_UPDATE_NAMESPACE =
       Endpoint.create("POST", ResourcePaths.V1_NAMESPACE_PROPERTIES);
   public static final Endpoint V1_DELETE_NAMESPACE =
       Endpoint.create("DELETE", ResourcePaths.V1_NAMESPACE);
-  public static final Endpoint V1_NAMESPACE_EXISTS =
-      Endpoint.create("HEAD", ResourcePaths.V1_NAMESPACE);
   public static final Endpoint V1_COMMIT_TRANSACTION =
       Endpoint.create("POST", ResourcePaths.V1_TRANSACTIONS_COMMIT);
 
   // table endpoints
   public static final Endpoint V1_LIST_TABLES = Endpoint.create("GET", ResourcePaths.V1_TABLES);
   public static final Endpoint V1_LOAD_TABLE = Endpoint.create("GET", ResourcePaths.V1_TABLE);
+  public static final Endpoint V1_TABLE_EXISTS = Endpoint.create("HEAD", ResourcePaths.V1_TABLE);
   public static final Endpoint V1_CREATE_TABLE = Endpoint.create("POST", ResourcePaths.V1_TABLES);
   public static final Endpoint V1_UPDATE_TABLE = Endpoint.create("POST", ResourcePaths.V1_TABLE);
   public static final Endpoint V1_DELETE_TABLE = Endpoint.create("DELETE", ResourcePaths.V1_TABLE);
@@ -63,7 +64,6 @@ public class Endpoint {
       Endpoint.create("POST", ResourcePaths.V1_TABLE_REGISTER);
   public static final Endpoint V1_REPORT_METRICS =
       Endpoint.create("POST", ResourcePaths.V1_TABLE_METRICS);
-  public static final Endpoint V1_TABLE_EXISTS = Endpoint.create("HEAD", ResourcePaths.V1_TABLE);
   public static final Endpoint V1_TABLE_CREDENTIALS =
       Endpoint.create("GET", ResourcePaths.V1_TABLE_CREDENTIALS);
 
@@ -80,12 +80,12 @@ public class Endpoint {
   // view endpoints
   public static final Endpoint V1_LIST_VIEWS = Endpoint.create("GET", ResourcePaths.V1_VIEWS);
   public static final Endpoint V1_LOAD_VIEW = Endpoint.create("GET", ResourcePaths.V1_VIEW);
+  public static final Endpoint V1_VIEW_EXISTS = Endpoint.create("HEAD", ResourcePaths.V1_VIEW);
   public static final Endpoint V1_CREATE_VIEW = Endpoint.create("POST", ResourcePaths.V1_VIEWS);
   public static final Endpoint V1_UPDATE_VIEW = Endpoint.create("POST", ResourcePaths.V1_VIEW);
   public static final Endpoint V1_DELETE_VIEW = Endpoint.create("DELETE", ResourcePaths.V1_VIEW);
   public static final Endpoint V1_RENAME_VIEW =
       Endpoint.create("POST", ResourcePaths.V1_VIEW_RENAME);
-  public static final Endpoint V1_VIEW_EXISTS = Endpoint.create("HEAD", ResourcePaths.V1_VIEW);
 
   private static final Splitter ENDPOINT_SPLITTER = Splitter.on(" ");
   private static final Joiner ENDPOINT_JOINER = Joiner.on(" ");

--- a/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
+++ b/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
@@ -47,7 +47,7 @@ public class Endpoint {
   public static final Endpoint V1_DELETE_NAMESPACE =
       Endpoint.create("DELETE", ResourcePaths.V1_NAMESPACE);
   public static final Endpoint V1_NAMESPACE_EXISTS =
-          Endpoint.create("HEAD", ResourcePaths.V1_NAMESPACE);
+      Endpoint.create("HEAD", ResourcePaths.V1_NAMESPACE);
   public static final Endpoint V1_COMMIT_TRANSACTION =
       Endpoint.create("POST", ResourcePaths.V1_TRANSACTIONS_COMMIT);
 

--- a/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
+++ b/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
@@ -46,6 +46,8 @@ public class Endpoint {
       Endpoint.create("POST", ResourcePaths.V1_NAMESPACE_PROPERTIES);
   public static final Endpoint V1_DELETE_NAMESPACE =
       Endpoint.create("DELETE", ResourcePaths.V1_NAMESPACE);
+  public static final Endpoint V1_NAMESPACE_EXISTS =
+          Endpoint.create("HEAD", ResourcePaths.V1_NAMESPACE);
   public static final Endpoint V1_COMMIT_TRANSACTION =
       Endpoint.create("POST", ResourcePaths.V1_TRANSACTIONS_COMMIT);
 
@@ -61,6 +63,19 @@ public class Endpoint {
       Endpoint.create("POST", ResourcePaths.V1_TABLE_REGISTER);
   public static final Endpoint V1_REPORT_METRICS =
       Endpoint.create("POST", ResourcePaths.V1_TABLE_METRICS);
+  public static final Endpoint V1_TABLE_EXISTS = Endpoint.create("HEAD", ResourcePaths.V1_TABLE);
+  public static final Endpoint V1_TABLE_CREDENTIALS =
+      Endpoint.create("GET", ResourcePaths.V1_TABLE_CREDENTIALS);
+
+  // table scan plan endpoints
+  public static final Endpoint V1_SUBMIT_TABLE_SCAN_PLAN =
+      Endpoint.create("POST", ResourcePaths.V1_TABLE_SCAN_PLAN_SUBMIT);
+  public static final Endpoint V1_FETCH_TABLE_SCAN_PLAN =
+      Endpoint.create("GET", ResourcePaths.V1_TABLE_SCAN_PLAN);
+  public static final Endpoint V1_CANCEL_TABLE_SCAN_PLAN =
+      Endpoint.create("DELETE", ResourcePaths.V1_TABLE_SCAN_PLAN);
+  public static final Endpoint V1_FETCH_TABLE_SCAN_PLAN_TASKS =
+      Endpoint.create("POST", ResourcePaths.V1_TABLE_SCAN_PLAN_TASKS);
 
   // view endpoints
   public static final Endpoint V1_LIST_VIEWS = Endpoint.create("GET", ResourcePaths.V1_VIEWS);
@@ -70,6 +85,7 @@ public class Endpoint {
   public static final Endpoint V1_DELETE_VIEW = Endpoint.create("DELETE", ResourcePaths.V1_VIEW);
   public static final Endpoint V1_RENAME_VIEW =
       Endpoint.create("POST", ResourcePaths.V1_VIEW_RENAME);
+  public static final Endpoint V1_VIEW_EXISTS = Endpoint.create("HEAD", ResourcePaths.V1_VIEW);
 
   private static final Splitter ENDPOINT_SPLITTER = Splitter.on(" ");
   private static final Joiner ENDPOINT_JOINER = Joiner.on(" ");

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -138,24 +138,26 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       ImmutableSet.<Endpoint>builder()
           .add(Endpoint.V1_LIST_NAMESPACES)
           .add(Endpoint.V1_LOAD_NAMESPACE)
+          .add(Endpoint.V1_NAMESPACE_EXISTS)
           .add(Endpoint.V1_CREATE_NAMESPACE)
           .add(Endpoint.V1_UPDATE_NAMESPACE)
           .add(Endpoint.V1_DELETE_NAMESPACE)
           .add(Endpoint.V1_LIST_TABLES)
           .add(Endpoint.V1_LOAD_TABLE)
+          .add(Endpoint.V1_TABLE_EXISTS)
           .add(Endpoint.V1_CREATE_TABLE)
           .add(Endpoint.V1_UPDATE_TABLE)
           .add(Endpoint.V1_DELETE_TABLE)
           .add(Endpoint.V1_RENAME_TABLE)
           .add(Endpoint.V1_REGISTER_TABLE)
           .add(Endpoint.V1_REPORT_METRICS)
-          .add(Endpoint.V1_TABLE_EXISTS)
           .build();
 
   private static final Set<Endpoint> VIEW_ENDPOINTS =
       ImmutableSet.<Endpoint>builder()
           .add(Endpoint.V1_LIST_VIEWS)
           .add(Endpoint.V1_LOAD_VIEW)
+          .add(Endpoint.V1_VIEW_EXISTS)
           .add(Endpoint.V1_CREATE_VIEW)
           .add(Endpoint.V1_UPDATE_VIEW)
           .add(Endpoint.V1_DELETE_VIEW)
@@ -656,6 +658,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
   @Override
   public boolean namespaceExists(SessionContext context, Namespace namespace) {
+    Endpoint.check(endpoints, Endpoint.V1_NAMESPACE_EXISTS);
     checkNamespaceIsValid(namespace);
 
     try {
@@ -1229,6 +1232,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
   @Override
   public boolean viewExists(SessionContext context, TableIdentifier identifier) {
+    Endpoint.check(endpoints, Endpoint.V1_VIEW_EXISTS);
     checkViewIdentifierIsValid(identifier);
 
     try {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -149,6 +149,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
           .add(Endpoint.V1_RENAME_TABLE)
           .add(Endpoint.V1_REGISTER_TABLE)
           .add(Endpoint.V1_REPORT_METRICS)
+          .add(Endpoint.V1_TABLE_EXISTS)
           .build();
 
   private static final Set<Endpoint> VIEW_ENDPOINTS =
@@ -434,6 +435,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
   @Override
   public boolean tableExists(SessionContext context, TableIdentifier identifier) {
+    Endpoint.check(endpoints, Endpoint.V1_TABLE_EXISTS);
     checkIdentifierIsValid(identifier);
 
     try {

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -32,10 +32,15 @@ public class ResourcePaths {
       "/v1/{prefix}/namespaces/{namespace}/properties";
   public static final String V1_TABLES = "/v1/{prefix}/namespaces/{namespace}/tables";
   public static final String V1_TABLE = "/v1/{prefix}/namespaces/{namespace}/tables/{table}";
+  public static final String V1_TABLE_CREDENTIALS =
+      "/v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials";
   public static final String V1_TABLE_REGISTER = "/v1/{prefix}/namespaces/{namespace}/register";
   public static final String V1_TABLE_METRICS =
       "/v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics";
   public static final String V1_TABLE_RENAME = "/v1/{prefix}/tables/rename";
+  public static final String V1_TABLE_SCAN_PLAN_SUBMIT = "/v1/{prefix}/tables/{table}/plan";
+  public static final String V1_TABLE_SCAN_PLAN = "/v1/{prefix}/tables/{table}/plan/{plan-id}";
+  public static final String V1_TABLE_SCAN_PLAN_TASKS = "/v1/{prefix}/tables/{table}/tasks";
   public static final String V1_TRANSACTIONS_COMMIT = "/v1/{prefix}/transactions/commit";
   public static final String V1_VIEWS = "/v1/{prefix}/namespaces/{namespace}/views";
   public static final String V1_VIEW = "/v1/{prefix}/namespaces/{namespace}/views/{view}";


### PR DESCRIPTION
Noticed there were some definitions missing in the REST Endpoint class (most notably entries for tableExists and the new loadCredentials endpoints).

Added the following definitions in that class:
- tableExists (HEAD 
- loadCredentials
- namespaceExists
- viewExists
- scan plan endpoints (can remove these if don't want to add them yet)

Added the tableExists endpoint to the list of default endpoints.
- should the loadCredentials and namespaceExists endpoints be added as well?
- should the viewExists endpoint be added to the view endpoints list?

It doesn't appear that the REST catalog impl actually uses the namespaceExists or viewExists endpoints and instead falls back to the session and view session catalog impls which loads the namespace/view to check if exists -- is there a reason the REST catalog impl doesn't use the exists endpoints?