### PR TITLE
GCS: Suppress JavaUtilDate in OAuth2RefreshCredentialsHandler

### DIFF
--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/OAuth2RefreshCredentialsHandler.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/OAuth2RefreshCredentialsHandler.java
@@ -46,6 +46,7 @@ public class OAuth2RefreshCredentialsHandler
     this.properties = properties;
   }
 
+  @SuppressWarnings("JavaUtilDate") // GCP API uses java.util.Date
   @Override
   public AccessToken refreshAccessToken() {
     LoadCredentialsResponse response;


### PR DESCRIPTION
The following line uses `java.util.Date`. 

https://github.com/apache/iceberg/blob/a3dcfd19fd1b2a709f7bdf013b83836953d49c6f/gcp/src/main/java/org/apache/iceberg/gcp/gcs/OAuth2RefreshCredentialsHandler.java#L80