### PR TITLE
Core: Fix numeric overflow of timestamp nano literal

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -300,8 +300,7 @@ class Literals {
         case TIMESTAMP:
           return (Literal<T>) new TimestampLiteral(value());
         case TIMESTAMP_NANO:
-          // assume micros and convert to nanos to match the behavior in the timestamp case above
-          return new TimestampLiteral(value()).to(type);
+          return (Literal<T>) new TimestampNanoLiteral(value());
         case DATE:
           if ((long) Integer.MAX_VALUE < value()) {
             return aboveMax();

--- a/api/src/test/java/org/apache/iceberg/expressions/TestTimestampLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestTimestampLiteralConversions.java
@@ -126,7 +126,12 @@ public class TestTimestampLiteralConversions {
     assertThat(longLiteral.to(Types.TimestampType.withoutZone()).value())
         .isEqualTo(1510842668000000L);
 
+    assertThat(longLiteral.to(Types.TimestampType.withZone()).value()).isEqualTo(1510842668000000L);
+
     assertThat(longLiteral.to(Types.TimestampNanoType.withoutZone()).value())
+        .isEqualTo(1510842668000000001L);
+
+    assertThat(longLiteral.to(Types.TimestampNanoType.withZone()).value())
         .isEqualTo(1510842668000000001L);
   }
 
@@ -179,6 +184,33 @@ public class TestTimestampLiteralConversions {
     ts = Literal.of("1969-12-31T23:59:59.999999000").to(Types.TimestampNanoType.withoutZone());
     dateOrdinal = (Integer) ts.to(Types.DateType.get()).value();
     assertThat(dateOrdinal).isEqualTo(-1);
+  }
+
+  @Test
+  public void testTimestampNanoWithZoneWithLongLiteral() {
+    // verify round-trip between timestamptz_ns and long
+    Literal<Long> timestampNanoWithZone =
+        Literal.of("2017-11-16T14:31:08.000000001+01:00").to(Types.TimestampNanoType.withZone());
+    assertThat(timestampNanoWithZone.value()).isEqualTo(1510839068000000001L);
+
+    Literal<Long> longLiteral =
+        Literal.of(1510839068000000001L).to(Types.TimestampNanoType.withZone());
+    assertThat(longLiteral).isEqualTo(timestampNanoWithZone);
+
+    // cast long literal to temporal types
+    assertThat(longLiteral.to(Types.DateType.get()).value())
+        .isEqualTo((int) LocalDate.of(2017, 11, 16).toEpochDay());
+
+    assertThat(longLiteral.to(Types.TimestampType.withoutZone()).value())
+        .isEqualTo(1510839068000000L);
+
+    assertThat(longLiteral.to(Types.TimestampType.withZone()).value()).isEqualTo(1510839068000000L);
+
+    assertThat(longLiteral.to(Types.TimestampNanoType.withoutZone()).value())
+        .isEqualTo(1510839068000000001L);
+
+    assertThat(longLiteral.to(Types.TimestampNanoType.withoutZone()).value())
+        .isEqualTo(1510839068000000001L);
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/expressions/TestTimestampLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestTimestampLiteralConversions.java
@@ -111,28 +111,33 @@ public class TestTimestampLiteralConversions {
   @Test
   public void testTimestampNanoWithLongLiteral() {
     // verify round-trip between timestamp_ns and long
-    Literal<Long> timestampNano =
-        Literal.of("2017-11-16T14:31:08.000000001").to(Types.TimestampNanoType.withoutZone());
-    assertThat(timestampNano.value()).isEqualTo(1510842668000000001L);
+    Literal<Long> timestampNanoFromStringLiteral =
+        Literal.of("2017-11-16T14:31:00.123456789").to(Types.TimestampNanoType.withoutZone());
+    assertThat(timestampNanoFromStringLiteral.getClass())
+        .isEqualTo(Literals.TimestampNanoLiteral.class);
+    assertThat(timestampNanoFromStringLiteral.value()).isEqualTo(1510842660123456789L);
 
-    Literal<Long> longLiteral =
-        Literal.of(1510842668000000001L).to(Types.TimestampNanoType.withoutZone());
-    assertThat(longLiteral).isEqualTo(timestampNano);
+    Literal<Long> timestampNanoFromlongLiteral =
+        Literal.of(1510842660123456789L).to(Types.TimestampNanoType.withoutZone());
+    assertThat(timestampNanoFromlongLiteral.getClass())
+        .isEqualTo(Literals.TimestampNanoLiteral.class);
+    assertThat(timestampNanoFromlongLiteral).isEqualTo(timestampNanoFromStringLiteral);
 
     // cast long literal to temporal types
-    assertThat(longLiteral.to(Types.DateType.get()).value())
+    assertThat(timestampNanoFromlongLiteral.to(Types.DateType.get()).value())
         .isEqualTo((int) LocalDate.of(2017, 11, 16).toEpochDay());
 
-    assertThat(longLiteral.to(Types.TimestampType.withoutZone()).value())
-        .isEqualTo(1510842668000000L);
+    assertThat(timestampNanoFromlongLiteral.to(Types.TimestampType.withoutZone()).value())
+        .isEqualTo(1510842660123456L);
 
-    assertThat(longLiteral.to(Types.TimestampType.withZone()).value()).isEqualTo(1510842668000000L);
+    assertThat(timestampNanoFromlongLiteral.to(Types.TimestampType.withZone()).value())
+        .isEqualTo(1510842660123456L);
 
-    assertThat(longLiteral.to(Types.TimestampNanoType.withoutZone()).value())
-        .isEqualTo(1510842668000000001L);
+    assertThat(timestampNanoFromlongLiteral.to(Types.TimestampNanoType.withoutZone()).value())
+        .isEqualTo(1510842660123456789L);
 
-    assertThat(longLiteral.to(Types.TimestampNanoType.withZone()).value())
-        .isEqualTo(1510842668000000001L);
+    assertThat(timestampNanoFromlongLiteral.to(Types.TimestampNanoType.withZone()).value())
+        .isEqualTo(1510842660123456789L);
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/expressions/TestTimestampLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestTimestampLiteralConversions.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.expressions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
@@ -105,6 +106,28 @@ public class TestTimestampLiteralConversions {
     ts = Literal.of("1969-12-31T23:59:59.999999000").to(Types.TimestampType.withoutZone());
     dateOrdinal = (Integer) ts.to(Types.DateType.get()).value();
     assertThat(dateOrdinal).isEqualTo(-1);
+  }
+
+  @Test
+  public void testTimestampNanoWithLongLiteral() {
+    // verify round-trip between timestamp_ns and long
+    Literal<Long> timestampNano =
+        Literal.of("2017-11-16T14:31:08.000000001").to(Types.TimestampNanoType.withoutZone());
+    assertThat(timestampNano.value()).isEqualTo(1510842668000000001L);
+
+    Literal<Long> longLiteral =
+        Literal.of(1510842668000000001L).to(Types.TimestampNanoType.withoutZone());
+    assertThat(longLiteral).isEqualTo(timestampNano);
+
+    // cast long literal to temporal types
+    assertThat(longLiteral.to(Types.DateType.get()).value())
+        .isEqualTo((int) LocalDate.of(2017, 11, 16).toEpochDay());
+
+    assertThat(longLiteral.to(Types.TimestampType.withoutZone()).value())
+        .isEqualTo(1510842668000000L);
+
+    assertThat(longLiteral.to(Types.TimestampNanoType.withoutZone()).value())
+        .isEqualTo(1510842668000000001L);
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/types/TestConversions.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestConversions.java
@@ -111,9 +111,9 @@ public class TestConversions {
     assertConversion(
         400000000L, TimestampNanoType.withZone(), new byte[] {0, -124, -41, 23, 0, 0, 0, 0});
     assertThat(Literal.of(400000L).to(TimestampNanoType.withoutZone()).toByteBuffer().array())
-        .isEqualTo(new byte[] {0, -124, -41, 23, 0, 0, 0, 0});
+        .isEqualTo(new byte[] {-128, 26, 6, 0, 0, 0, 0, 0});
     assertThat(Literal.of(400000L).to(TimestampNanoType.withZone()).toByteBuffer().array())
-        .isEqualTo(new byte[] {0, -124, -41, 23, 0, 0, 0, 0});
+        .isEqualTo(new byte[] {-128, 26, 6, 0, 0, 0, 0, 0});
 
     // strings are stored as UTF-8 bytes (without length)
     // 'A' -> 65, 'B' -> 66, 'C' -> 67

--- a/api/src/test/java/org/apache/iceberg/types/TestConversions.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestConversions.java
@@ -104,12 +104,10 @@ public class TestConversions {
         .isEqualTo(new byte[] {-128, 26, 6, 0, 0, 0, 0, 0});
     assertThat(Literal.of(400000L).to(TimestampType.withZone()).toByteBuffer().array())
         .isEqualTo(new byte[] {-128, 26, 6, 0, 0, 0, 0, 0});
-    // values passed to assertConversion and Literal.of differ because Literal.of(...) assumes
-    // the value is in micros, which gets converted when to(TimestampNanoType) is called
     assertConversion(
-        400000000L, TimestampNanoType.withoutZone(), new byte[] {0, -124, -41, 23, 0, 0, 0, 0});
+        400000L, TimestampNanoType.withoutZone(), new byte[] {-128, 26, 6, 0, 0, 0, 0, 0});
     assertConversion(
-        400000000L, TimestampNanoType.withZone(), new byte[] {0, -124, -41, 23, 0, 0, 0, 0});
+        400000L, TimestampNanoType.withZone(), new byte[] {-128, 26, 6, 0, 0, 0, 0, 0});
     assertThat(Literal.of(400000L).to(TimestampNanoType.withoutZone()).toByteBuffer().array())
         .isEqualTo(new byte[] {-128, 26, 6, 0, 0, 0, 0, 0});
     assertThat(Literal.of(400000L).to(TimestampNanoType.withZone()).toByteBuffer().array())


### PR DESCRIPTION
The previous logic leads to overflow when we pass timestamp nanos long value. 