### PR TITLE
Fix Hive FileIO closing with FileIOTracker

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.function.Suppliers;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/11783. `HiveCatalog` currently uses a single `FileIO` instance that is passed to each newly instantiated `HiveTableOperations`/`HiveViewOperations`. This issue is `FileIOTracker` tracks each operation and results in the underlying `FileIO` being closed even when it is then going to be reused for future `newTableOps` calls.

This change will instead initialize a new `FileIO` instance so that they are 1:1 with `HiveTableOperations`/`HiveViewOperations`, thus safe to close when the operations go out of scope.