### PR TITLE
Doc: Do Not Modify the Source Data Table During MergeIntoCommand Exec…

### DIFF
--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -101,6 +101,9 @@ Spark 3.5 added support for `WHEN NOT MATCHED BY SOURCE ... THEN ...` to update 
 WHEN NOT MATCHED BY SOURCE THEN UPDATE SET status = 'invalid'
 ```
 
+!!! danger
+    Note: For copy on write table,Please Do Not Modify the Source Data Table During Execution.Due to the need for Spark to use the source table consecutively twice for computation,the relation which is created of source data must remain constant through the two different passes of the source data.If the source data query would return different results user will see odd behavior.
+
 ### `INSERT OVERWRITE`
 
 `INSERT OVERWRITE` can replace data in the table with the result of a query. Overwrites are atomic operations for Iceberg tables.

--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -102,7 +102,7 @@ WHEN NOT MATCHED BY SOURCE THEN UPDATE SET status = 'invalid'
 ```
 
 !!! danger
-    Note: For copy on write table,Please Do Not Modify the Source Data Table During Execution.Due to the need for Spark to use the source table consecutively twice for computation,the relation which is created of source data must remain constant through the two different passes of the source data.If the source data query would return different results user will see odd behavior(For example: data loss).
+    Note: For copy on write table,if source data table is not iceberg table,Please Do Not Modify the Source Data Table During Execution(For example:hive table,jdbc view table,another datalake table,etc.).Due to the need for Spark to use the source table consecutively twice for computation,the relation which is created of source data must remain constant through the two different passes of the source data.If the source data query would return different results user will see odd behavior(For example: data loss).
 
 ### `INSERT OVERWRITE`
 

--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -102,7 +102,7 @@ WHEN NOT MATCHED BY SOURCE THEN UPDATE SET status = 'invalid'
 ```
 
 !!! danger
-    Note: For copy on write table,Please Do Not Modify the Source Data Table During Execution.Due to the need for Spark to use the source table consecutively twice for computation,the relation which is created of source data must remain constant through the two different passes of the source data.If the source data query would return different results user will see odd behavior.
+    Note: For copy on write table,Please Do Not Modify the Source Data Table During Execution.Due to the need for Spark to use the source table consecutively twice for computation,the relation which is created of source data must remain constant through the two different passes of the source data.If the source data query would return different results user will see odd behavior(For example: data loss).
 
 ### `INSERT OVERWRITE`
 


### PR DESCRIPTION
…ution

If data in the source table is modified during the execution of the merge-into command, it may lead to incorrect results for the MergeIntoCommand. We need to alert users to avoid this risk.