### PR TITLE
Fix comment on `WRITE_OBJECT_STORE_PARTITIONED_PATHS` table property

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -244,7 +244,7 @@ public class TableProperties {
   public static final String OBJECT_STORE_ENABLED = "write.object-storage.enabled";
   public static final boolean OBJECT_STORE_ENABLED_DEFAULT = false;
 
-  // Excludes the partition values in the path when set to true and object store is enabled
+  // Excludes the partition values in the path when set to false and object store is enabled
   public static final String WRITE_OBJECT_STORE_PARTITIONED_PATHS =
       "write.object-storage.partitioned-paths";
   public static final boolean WRITE_OBJECT_STORE_PARTITIONED_PATHS_DEFAULT = true;


### PR DESCRIPTION
The code comment above the `WRITE_OBJECT_STORE_PARTITIONED_PATHS` constant in `TableProperties` was incorrect - partition values are excluded when this property is set to *false*, not true, and object store is enabled, as stated in the [docs](https://iceberg.apache.org/docs/1.7.0/aws/#object-store-file-layout). This PR fixes the comment to be consistent.