### PR TITLE
Open-API: Fix compilation errors in generated Java classes due to mismatched return types

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -267,6 +267,156 @@ class ViewVersion(BaseModel):
     default_namespace: Namespace = Field(..., alias='default-namespace')
 
 
+class ContentEnum(BaseModel):
+    __root__: Literal['data', 'equality-deletes', 'position-deletes']
+
+
+class ActionEnum(BaseModel):
+    __root__: Literal[
+        'add-spec',
+        'add-schema',
+        'add-snapshot',
+        'add-sort-order',
+        'add-view-version',
+        'assign-uuid',
+        'remove-partition-specs',
+        'remove-partition-statistics',
+        'remove-properties',
+        'remove-snapshot-ref',
+        'remove-snapshots',
+        'remove-statistics',
+        'set-current-schema',
+        'set-current-view-version',
+        'set-default-sort-order',
+        'set-default-spec',
+        'set-location',
+        'set-partition-statistics',
+        'set-properties',
+        'set-snapshot-ref',
+        'set-statistics',
+        'upgrade-format-version',
+    ]
+
+
+class BaseUpdate(BaseModel):
+    action: ActionEnum
+
+
+class AssignUUIDUpdate(BaseUpdate):
+    """
+    Assigning a UUID to a table/view should only be done when creating the table/view. It is not safe to re-assign the UUID if a table/view already has a UUID assigned
+    """
+
+    action: ActionEnum
+    uuid: str
+
+
+class UpgradeFormatVersionUpdate(BaseUpdate):
+    action: ActionEnum
+    format_version: int = Field(..., alias='format-version')
+
+
+class SetCurrentSchemaUpdate(BaseUpdate):
+    action: ActionEnum
+    schema_id: int = Field(
+        ...,
+        alias='schema-id',
+        description='Schema ID to set as current, or -1 to set last added schema',
+    )
+
+
+class AddPartitionSpecUpdate(BaseUpdate):
+    action: ActionEnum
+    spec: PartitionSpec
+
+
+class SetDefaultSpecUpdate(BaseUpdate):
+    action: ActionEnum
+    spec_id: int = Field(
+        ...,
+        alias='spec-id',
+        description='Partition spec ID to set as the default, or -1 to set last added spec',
+    )
+
+
+class AddSortOrderUpdate(BaseUpdate):
+    action: ActionEnum
+    sort_order: SortOrder = Field(..., alias='sort-order')
+
+
+class SetDefaultSortOrderUpdate(BaseUpdate):
+    action: ActionEnum
+    sort_order_id: int = Field(
+        ...,
+        alias='sort-order-id',
+        description='Sort order ID to set as the default, or -1 to set last added sort order',
+    )
+
+
+class AddSnapshotUpdate(BaseUpdate):
+    action: ActionEnum
+    snapshot: Snapshot
+
+
+class SetSnapshotRefUpdate(BaseUpdate, SnapshotReference):
+    action: ActionEnum
+    ref_name: str = Field(..., alias='ref-name')
+
+
+class RemoveSnapshotsUpdate(BaseUpdate):
+    action: ActionEnum
+    snapshot_ids: List[int] = Field(..., alias='snapshot-ids')
+
+
+class RemoveSnapshotRefUpdate(BaseUpdate):
+    action: ActionEnum
+    ref_name: str = Field(..., alias='ref-name')
+
+
+class SetLocationUpdate(BaseUpdate):
+    action: ActionEnum
+    location: str
+
+
+class SetPropertiesUpdate(BaseUpdate):
+    action: ActionEnum
+    updates: Dict[str, str]
+
+
+class RemovePropertiesUpdate(BaseUpdate):
+    action: ActionEnum
+    removals: List[str]
+
+
+class AddViewVersionUpdate(BaseUpdate):
+    action: ActionEnum
+    view_version: ViewVersion = Field(..., alias='view-version')
+
+
+class SetCurrentViewVersionUpdate(BaseUpdate):
+    action: ActionEnum
+    view_version_id: int = Field(
+        ...,
+        alias='view-version-id',
+        description='The view version id to set as current, or -1 to set last added view version id',
+    )
+
+
+class RemoveStatisticsUpdate(BaseUpdate):
+    action: ActionEnum
+    snapshot_id: int = Field(..., alias='snapshot-id')
+
+
+class RemovePartitionStatisticsUpdate(BaseUpdate):
+    action: ActionEnum
+    snapshot_id: int = Field(..., alias='snapshot-id')
+
+
+class RemovePartitionSpecsUpdate(BaseUpdate):
+    action: Optional[ActionEnum] = None
+    spec_ids: List[int] = Field(..., alias='spec-ids')
+
+
 class AssertCreate(BaseModel):
     """
     The table must not already exist; used for create transactions
@@ -714,6 +864,52 @@ class FileFormat(BaseModel):
     __root__: Literal['avro', 'orc', 'parquet', 'puffin']
 
 
+class ContentFile(BaseModel):
+    content: ContentEnum
+    file_path: str = Field(..., alias='file-path')
+    file_format: FileFormat = Field(..., alias='file-format')
+    spec_id: int = Field(..., alias='spec-id')
+    partition: List[PrimitiveTypeValue] = Field(
+        ...,
+        description='A list of partition field values ordered based on the fields of the partition spec specified by the `spec-id`',
+        example=[1, 'bar'],
+    )
+    file_size_in_bytes: int = Field(
+        ..., alias='file-size-in-bytes', description='Total file size in bytes'
+    )
+    record_count: int = Field(
+        ..., alias='record-count', description='Number of records in the file'
+    )
+    key_metadata: Optional[BinaryTypeValue] = Field(
+        None, alias='key-metadata', description='Encryption key metadata blob'
+    )
+    split_offsets: Optional[List[int]] = Field(
+        None, alias='split-offsets', description='List of splittable offsets'
+    )
+    sort_order_id: Optional[int] = Field(None, alias='sort-order-id')
+
+
+class PositionDeleteFile(ContentFile):
+    content: Literal['position-deletes']
+    content_offset: Optional[int] = Field(
+        None,
+        alias='content-offset',
+        description='Offset within the delete file of delete content',
+    )
+    content_size_in_bytes: Optional[int] = Field(
+        None,
+        alias='content-size-in-bytes',
+        description='Length, in bytes, of the delete content; required if content-offset is present',
+    )
+
+
+class EqualityDeleteFile(ContentFile):
+    content: Literal['equality-deletes']
+    equality_ids: Optional[List[int]] = Field(
+        None, alias='equality-ids', description='List of equality field IDs'
+    )
+
+
 class FieldName(BaseModel):
     __root__: str = Field(
         ...,
@@ -726,37 +922,6 @@ class PlanTask(BaseModel):
         ...,
         description='An opaque string provided by the REST server that represents a unit of work to produce file scan tasks for scan planning. This allows clients to fetch tasks across multiple requests to accommodate large result sets.',
     )
-
-
-class ContentEnum(BaseModel):
-    __root__: Literal['data', 'equality-deletes', 'position-deletes']
-
-
-class ActionEnum(BaseModel):
-    __root__: Literal[
-        'add-spec',
-        'add-schema',
-        'add-snapshot',
-        'add-sort-order',
-        'add-view-version',
-        'assign-uuid',
-        'remove-partition-specs',
-        'remove-partition-statistics',
-        'remove-properties',
-        'remove-snapshot-ref',
-        'remove-snapshots',
-        'remove-statistics',
-        'set-current-schema',
-        'set-current-view-version',
-        'set-default-sort-order',
-        'set-default-spec',
-        'set-location',
-        'set-partition-statistics',
-        'set-properties',
-        'set-snapshot-ref',
-        'set-statistics',
-        'upgrade-format-version',
-    ]
 
 
 class CreateNamespaceRequest(BaseModel):
@@ -779,130 +944,11 @@ class TransformTerm(BaseModel):
     term: Reference
 
 
-class BaseUpdate(BaseModel):
-    action: ActionEnum
-
-
-class AssignUUIDUpdate(BaseUpdate):
-    """
-    Assigning a UUID to a table/view should only be done when creating the table/view. It is not safe to re-assign the UUID if a table/view already has a UUID assigned
-    """
-
-    action: ActionEnum
-    uuid: str
-
-
-class UpgradeFormatVersionUpdate(BaseUpdate):
-    action: ActionEnum
-    format_version: int = Field(..., alias='format-version')
-
-
-class SetCurrentSchemaUpdate(BaseUpdate):
-    action: ActionEnum
-    schema_id: int = Field(
-        ...,
-        alias='schema-id',
-        description='Schema ID to set as current, or -1 to set last added schema',
-    )
-
-
-class AddPartitionSpecUpdate(BaseUpdate):
-    action: ActionEnum
-    spec: PartitionSpec
-
-
-class SetDefaultSpecUpdate(BaseUpdate):
-    action: ActionEnum
-    spec_id: int = Field(
-        ...,
-        alias='spec-id',
-        description='Partition spec ID to set as the default, or -1 to set last added spec',
-    )
-
-
-class AddSortOrderUpdate(BaseUpdate):
-    action: ActionEnum
-    sort_order: SortOrder = Field(..., alias='sort-order')
-
-
-class SetDefaultSortOrderUpdate(BaseUpdate):
-    action: ActionEnum
-    sort_order_id: int = Field(
-        ...,
-        alias='sort-order-id',
-        description='Sort order ID to set as the default, or -1 to set last added sort order',
-    )
-
-
-class AddSnapshotUpdate(BaseUpdate):
-    action: ActionEnum
-    snapshot: Snapshot
-
-
-class SetSnapshotRefUpdate(BaseUpdate, SnapshotReference):
-    action: ActionEnum
-    ref_name: str = Field(..., alias='ref-name')
-
-
-class RemoveSnapshotsUpdate(BaseUpdate):
-    action: ActionEnum
-    snapshot_ids: List[int] = Field(..., alias='snapshot-ids')
-
-
-class RemoveSnapshotRefUpdate(BaseUpdate):
-    action: ActionEnum
-    ref_name: str = Field(..., alias='ref-name')
-
-
-class SetLocationUpdate(BaseUpdate):
-    action: ActionEnum
-    location: str
-
-
-class SetPropertiesUpdate(BaseUpdate):
-    action: ActionEnum
-    updates: Dict[str, str]
-
-
-class RemovePropertiesUpdate(BaseUpdate):
-    action: ActionEnum
-    removals: List[str]
-
-
-class AddViewVersionUpdate(BaseUpdate):
-    action: ActionEnum
-    view_version: ViewVersion = Field(..., alias='view-version')
-
-
-class SetCurrentViewVersionUpdate(BaseUpdate):
-    action: ActionEnum
-    view_version_id: int = Field(
-        ...,
-        alias='view-version-id',
-        description='The view version id to set as current, or -1 to set last added view version id',
-    )
-
-
-class RemoveStatisticsUpdate(BaseUpdate):
-    action: ActionEnum
-    snapshot_id: int = Field(..., alias='snapshot-id')
-
-
 class SetPartitionStatisticsUpdate(BaseUpdate):
     action: ActionEnum
     partition_statistics: PartitionStatisticsFile = Field(
         ..., alias='partition-statistics'
     )
-
-
-class RemovePartitionStatisticsUpdate(BaseUpdate):
-    action: ActionEnum
-    snapshot_id: int = Field(..., alias='snapshot-id')
-
-
-class RemovePartitionSpecsUpdate(BaseUpdate):
-    action: Optional[ActionEnum] = None
-    spec_ids: List[int] = Field(..., alias='spec-ids')
 
 
 class TableRequirement(BaseModel):
@@ -966,31 +1012,6 @@ class ValueMap(BaseModel):
     )
 
 
-class ContentFile(BaseModel):
-    content: ContentEnum
-    file_path: str = Field(..., alias='file-path')
-    file_format: FileFormat = Field(..., alias='file-format')
-    spec_id: int = Field(..., alias='spec-id')
-    partition: List[PrimitiveTypeValue] = Field(
-        ...,
-        description='A list of partition field values ordered based on the fields of the partition spec specified by the `spec-id`',
-        example=[1, 'bar'],
-    )
-    file_size_in_bytes: int = Field(
-        ..., alias='file-size-in-bytes', description='Total file size in bytes'
-    )
-    record_count: int = Field(
-        ..., alias='record-count', description='Number of records in the file'
-    )
-    key_metadata: Optional[BinaryTypeValue] = Field(
-        None, alias='key-metadata', description='Encryption key metadata blob'
-    )
-    split_offsets: Optional[List[int]] = Field(
-        None, alias='split-offsets', description='List of splittable offsets'
-    )
-    sort_order_id: Optional[int] = Field(None, alias='sort-order-id')
-
-
 class DataFile(ContentFile):
     content: ContentEnum
     column_sizes: Optional[CountMap] = Field(
@@ -1023,24 +1044,9 @@ class DataFile(ContentFile):
     )
 
 
-class PositionDeleteFile(ContentFile):
-    content: Literal['position-deletes']
-    content_offset: Optional[int] = Field(
-        None,
-        alias='content-offset',
-        description='Offset within the delete file of delete content',
-    )
-    content_size_in_bytes: Optional[int] = Field(
-        None,
-        alias='content-size-in-bytes',
-        description='Length, in bytes, of the delete content; required if content-offset is present',
-    )
-
-
-class EqualityDeleteFile(ContentFile):
-    content: Literal['equality-deletes']
-    equality_ids: Optional[List[int]] = Field(
-        None, alias='equality-ids', description='List of equality field IDs'
+class DeleteFile(BaseModel):
+    __root__: Union[PositionDeleteFile, EqualityDeleteFile] = Field(
+        ..., discriminator='content'
     )
 
 
@@ -1056,12 +1062,6 @@ class SetStatisticsUpdate(BaseUpdate):
     action: ActionEnum
     snapshot_id: int = Field(..., alias='snapshot-id')
     statistics: StatisticsFile
-
-
-class DeleteFile(BaseModel):
-    __root__: Union[PositionDeleteFile, EqualityDeleteFile] = Field(
-        ..., discriminator='content'
-    )
 
 
 class UnaryExpression(BaseModel):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2650,6 +2650,7 @@ components:
       properties:
         action:
           type: string
+          $ref: '#/components/schemas/ActionEnum'
 
     AssignUUIDUpdate:
       description: Assigning a UUID to a table/view should only be done when creating the table/view. It is not safe to re-assign the UUID if a table/view already has a UUID assigned
@@ -2662,6 +2663,7 @@ components:
         action:
           type: string
           enum: ["assign-uuid"]
+          $ref: '#/components/schemas/ActionEnum'
         uuid:
           type: string
 
@@ -2675,6 +2677,7 @@ components:
         action:
           type: string
           enum: ["upgrade-format-version"]
+          $ref: '#/components/schemas/ActionEnum'
         format-version:
           type: integer
 
@@ -2688,6 +2691,7 @@ components:
         action:
           type: string
           enum: ["add-schema"]
+          $ref: '#/components/schemas/ActionEnum'
         schema:
           $ref: '#/components/schemas/Schema'
         last-column-id:
@@ -2710,6 +2714,7 @@ components:
         action:
           type: string
           enum: ["set-current-schema"]
+          $ref: '#/components/schemas/ActionEnum'
         schema-id:
           type: integer
           description: Schema ID to set as current, or -1 to set last added schema
@@ -2724,6 +2729,7 @@ components:
         action:
           type: string
           enum: ["add-spec"]
+          $ref: '#/components/schemas/ActionEnum'
         spec:
           $ref: '#/components/schemas/PartitionSpec'
 
@@ -2737,6 +2743,7 @@ components:
         action:
           type: string
           enum: [ "set-default-spec" ]
+          $ref: '#/components/schemas/ActionEnum'
         spec-id:
           type: integer
           description: Partition spec ID to set as the default, or -1 to set last added spec
@@ -2751,6 +2758,7 @@ components:
         action:
           type: string
           enum: [ "add-sort-order" ]
+          $ref: '#/components/schemas/ActionEnum'
         sort-order:
           $ref: '#/components/schemas/SortOrder'
 
@@ -2764,6 +2772,7 @@ components:
         action:
           type: string
           enum: [ "set-default-sort-order" ]
+          $ref: '#/components/schemas/ActionEnum'
         sort-order-id:
           type: integer
           description: Sort order ID to set as the default, or -1 to set last added sort order
@@ -2778,6 +2787,7 @@ components:
         action:
           type: string
           enum: [ "add-snapshot" ]
+          $ref: '#/components/schemas/ActionEnum'
         snapshot:
           $ref: '#/components/schemas/Snapshot'
 
@@ -2792,6 +2802,7 @@ components:
         action:
           type: string
           enum: [ "set-snapshot-ref" ]
+          $ref: '#/components/schemas/ActionEnum'
         ref-name:
           type: string
 
@@ -2805,6 +2816,7 @@ components:
         action:
           type: string
           enum: [ "remove-snapshots" ]
+          $ref: '#/components/schemas/ActionEnum'
         snapshot-ids:
           type: array
           items:
@@ -2821,6 +2833,7 @@ components:
         action:
           type: string
           enum: [ "remove-snapshot-ref" ]
+          $ref: '#/components/schemas/ActionEnum'
         ref-name:
           type: string
 
@@ -2834,6 +2847,7 @@ components:
         action:
           type: string
           enum: [ "set-location" ]
+          $ref: '#/components/schemas/ActionEnum'
         location:
           type: string
 
@@ -2847,6 +2861,7 @@ components:
         action:
           type: string
           enum: [ "set-properties" ]
+          $ref: '#/components/schemas/ActionEnum'
         updates:
           type: object
           additionalProperties:
@@ -2862,6 +2877,7 @@ components:
         action:
           type: string
           enum: [ "remove-properties" ]
+          $ref: '#/components/schemas/ActionEnum'
         removals:
           type: array
           items:
@@ -2877,6 +2893,7 @@ components:
         action:
           type: string
           enum: [ "add-view-version" ]
+          $ref: '#/components/schemas/ActionEnum'
         view-version:
           $ref: '#/components/schemas/ViewVersion'
 
@@ -2890,6 +2907,7 @@ components:
         action:
           type: string
           enum: [ "set-current-view-version" ]
+          $ref: '#/components/schemas/ActionEnum'
         view-version-id:
           type: integer
           description: The view version id to set as current, or -1 to set last added view version id
@@ -2905,6 +2923,7 @@ components:
         action:
           type: string
           enum: [ "set-statistics" ]
+          $ref: '#/components/schemas/ActionEnum'
         snapshot-id:
           type: integer
           format: int64
@@ -2921,6 +2940,7 @@ components:
         action:
           type: string
           enum: [ "remove-statistics" ]
+          $ref: '#/components/schemas/ActionEnum'
         snapshot-id:
           type: integer
           format: int64
@@ -2935,6 +2955,7 @@ components:
         action:
           type: string
           enum: [ "set-partition-statistics" ]
+          $ref: '#/components/schemas/ActionEnum'
         partition-statistics:
           $ref: '#/components/schemas/PartitionStatisticsFile'
 
@@ -2948,6 +2969,7 @@ components:
         action:
           type: string
           enum: [ "remove-partition-statistics" ]
+          $ref: '#/components/schemas/ActionEnum'
         snapshot-id:
           type: integer
           format: int64
@@ -2961,6 +2983,7 @@ components:
         action:
           type: string
           enum: [ "remove-partition-specs" ]
+          $ref: '#/components/schemas/ActionEnum'
         spec-ids:
           type: array
           items:
@@ -4159,6 +4182,7 @@ components:
       properties:
         content:
           type: string
+          $ref: '#/components/schemas/ContentEnum'
         file-path:
           type: string
         file-format:
@@ -4204,6 +4228,7 @@ components:
         content:
           type: string
           enum: [ "data" ]
+          $ref: '#/components/schemas/ContentEnum'
         column-sizes:
           allOf:
             - $ref: '#/components/schemas/CountMap'
@@ -4248,6 +4273,7 @@ components:
         content:
           type: string
           enum: [ "position-deletes" ]
+          $ref: '#/components/schemas/ContentEnum'
         content-offset:
           type: integer
           format: int64
@@ -4266,6 +4292,7 @@ components:
         content:
           type: string
           enum: [ "equality-deletes" ]
+          $ref: '#/components/schemas/ContentEnum'
         equality-ids:
           type: array
           items:
@@ -4371,6 +4398,39 @@ components:
             residual or use the original filter.
           allOf:
             - $ref: '#/components/schemas/Expression'
+
+    ContentEnum:
+      type: string
+      enum:
+        - data
+        - equality-deletes
+        - position-deletes
+
+    ActionEnum:
+      type: string
+      enum:
+        - add-spec
+        - add-schema
+        - add-snapshot
+        - add-sort-order
+        - add-view-version
+        - assign-uuid
+        - remove-partition-specs
+        - remove-partition-statistics
+        - remove-properties
+        - remove-snapshot-ref
+        - remove-snapshots
+        - remove-statistics
+        - set-current-schema
+        - set-current-view-version
+        - set-default-sort-order
+        - set-default-spec
+        - set-location
+        - set-partition-statistics
+        - set-properties
+        - set-snapshot-ref
+        - set-statistics
+        - upgrade-format-version
 
   #############################
   # Reusable Response Objects #

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2618,6 +2618,39 @@ components:
           additionalProperties:
             type: string
 
+    ContentEnum:
+      type: string
+      enum:
+        - data
+        - equality-deletes
+        - position-deletes
+
+    ActionEnum:
+      type: string
+      enum:
+        - add-spec
+        - add-schema
+        - add-snapshot
+        - add-sort-order
+        - add-view-version
+        - assign-uuid
+        - remove-partition-specs
+        - remove-partition-statistics
+        - remove-properties
+        - remove-snapshot-ref
+        - remove-snapshots
+        - remove-statistics
+        - set-current-schema
+        - set-current-view-version
+        - set-default-sort-order
+        - set-default-spec
+        - set-location
+        - set-partition-statistics
+        - set-properties
+        - set-snapshot-ref
+        - set-statistics
+        - upgrade-format-version
+
     BaseUpdate:
       discriminator:
         propertyName: action
@@ -4398,40 +4431,6 @@ components:
             residual or use the original filter.
           allOf:
             - $ref: '#/components/schemas/Expression'
-
-    ContentEnum:
-      type: string
-      enum:
-        - data
-        - equality-deletes
-        - position-deletes
-
-    ActionEnum:
-      type: string
-      enum:
-        - add-spec
-        - add-schema
-        - add-snapshot
-        - add-sort-order
-        - add-view-version
-        - assign-uuid
-        - remove-partition-specs
-        - remove-partition-statistics
-        - remove-properties
-        - remove-snapshot-ref
-        - remove-snapshots
-        - remove-statistics
-        - set-current-schema
-        - set-current-view-version
-        - set-default-sort-order
-        - set-default-spec
-        - set-location
-        - set-partition-statistics
-        - set-properties
-        - set-snapshot-ref
-        - set-statistics
-        - upgrade-format-version
-
   #############################
   # Reusable Response Objects #
   #############################


### PR DESCRIPTION
**Description**
This PR addresses a compilation issue in the generated java classes from `rest-catalog-open-api.yaml` specification.

**Problem**
The generated Java classes fail to compile due to incorrect return types for the `getAction()` and `getContent()` methods. While the parent classes expect these methods to return a `String`, the child classes return specific `ActionEnum` and `ContentEnum` types defined within each child class.

**Solution**
To resolve this, `ActionEnum` and `ContentEnum `types are now defined globally in the OpenAPI specification. Both the parent and child classes reference these global types, ensuring compatibility and eliminating the compile-time errors.

**Steps to Reproduce the Issue**
Create a `.openapi-generator-ignore` file with the following content:
```
src/main/java/org/openapitools/client/ProgressResponseBody.java  
```

Generate Java classes using the OpenAPI generator Docker image:
```
docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli generate \
-i /local/rest-catalog-open-api.yaml \
-g java \
-o /local/build/openapi \
--library jersey3  
```

Navigate to the generated stub:
```
cd open-api/build/openapi 
```

Add the missing `Swagger` dependency to `build.gradle`:
```
implementation 'io.swagger.core.v3:swagger-annotations:2.1.11' 
```

Run the Gradle build:
```
chmod -R 755 gradlew  
./gradlew build 
```

Observe the compilation errors, such as:
```
iceberg/open-api/build/openapi/src/main/java/org/openapitools/client/model/SetDefaultSortOrderUpdate.java:105: error: getAction() in SetDefaultSortOrderUpdate cannot override getAction() in BaseUpdate
  public ActionEnum getAction() {
                   ^
  return type ActionEnum is not compatible with String  
...
iceberg/open-api/build/openapi/src/main/java/org/openapitools/client/model/EqualityDeleteFile.java:109: error: getContent() in EqualityDeleteFile cannot override getContent() in ContentFile
  public ContentEnum getContent() {
                    ^
  return type ContentEnum is not compatible with String  
...
```