### PR TITLE
Spark3.5 deprecate a few SparkCatalog APIs

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCachedTableCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCachedTableCatalog.java
@@ -33,8 +33,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
+import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.catalog.TableChange;
@@ -91,10 +93,18 @@ public class SparkCachedTableCatalog implements TableCatalog, SupportsFunctions 
     throw new UnsupportedOperationException(CLASS_NAME + " does not support table invalidation");
   }
 
+  @Deprecated
   @Override
   public SparkTable createTable(
       Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
       throws TableAlreadyExistsException {
+    throw new UnsupportedOperationException(CLASS_NAME + " does not support creating tables");
+  }
+
+  @Override
+  public org.apache.spark.sql.connector.catalog.Table createTable(
+      Identifier ident, Column[] columns, Transform[] partitions, Map<String, String> properties)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
     throw new UnsupportedOperationException(CLASS_NAME + " does not support creating tables");
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -76,6 +76,8 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchViewException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.ViewAlreadyExistsException;
+import org.apache.spark.sql.connector.catalog.CatalogV2Util;
+import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.NamespaceChange;
 import org.apache.spark.sql.connector.catalog.StagedTable;
@@ -231,6 +233,7 @@ public class SparkCatalog extends BaseCatalog {
     }
   }
 
+  @Deprecated
   @Override
   public Table createTable(
       Identifier ident, StructType schema, Transform[] transforms, Map<String, String> properties)
@@ -251,6 +254,14 @@ public class SparkCatalog extends BaseCatalog {
   }
 
   @Override
+  public Table createTable(
+      Identifier ident, Column[] columns, Transform[] transforms, Map<String, String> properties)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
+    return createTable(ident, CatalogV2Util.v2ColumnsToStructType(columns), transforms, properties);
+  }
+
+  @Deprecated
+  @Override
   public StagedTable stageCreate(
       Identifier ident, StructType schema, Transform[] transforms, Map<String, String> properties)
       throws TableAlreadyExistsException {
@@ -269,6 +280,14 @@ public class SparkCatalog extends BaseCatalog {
     }
   }
 
+  @Override
+  public StagedTable stageCreate(
+      Identifier ident, Column[] columns, Transform[] partitions, Map<String, String> properties)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
+    return stageCreate(ident, CatalogV2Util.v2ColumnsToStructType(columns), partitions, properties);
+  }
+
+  @Deprecated
   @Override
   public StagedTable stageReplace(
       Identifier ident, StructType schema, Transform[] transforms, Map<String, String> properties)
@@ -289,6 +308,15 @@ public class SparkCatalog extends BaseCatalog {
   }
 
   @Override
+  public StagedTable stageReplace(
+      Identifier ident, Column[] columns, Transform[] partitions, Map<String, String> properties)
+      throws NoSuchNamespaceException, NoSuchTableException {
+    return stageReplace(
+        ident, CatalogV2Util.v2ColumnsToStructType(columns), partitions, properties);
+  }
+
+  @Deprecated
+  @Override
   public StagedTable stageCreateOrReplace(
       Identifier ident, StructType schema, Transform[] transforms, Map<String, String> properties) {
     Schema icebergSchema = SparkSchemaUtil.convert(schema);
@@ -300,6 +328,14 @@ public class SparkCatalog extends BaseCatalog {
             .withProperties(Spark3Util.rebuildCreateProperties(properties))
             .createOrReplaceTransaction();
     return new StagedSparkTable(transaction);
+  }
+
+  @Override
+  public StagedTable stageCreateOrReplace(
+      Identifier ident, Column[] columns, Transform[] partitions, Map<String, String> properties)
+      throws NoSuchNamespaceException {
+    return stageCreateOrReplace(
+        ident, CatalogV2Util.v2ColumnsToStructType(columns), partitions, properties);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -37,6 +37,8 @@ import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.ViewAlreadyExistsException;
 import org.apache.spark.sql.connector.catalog.CatalogExtension;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.CatalogV2Util;
+import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.catalog.FunctionCatalog;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.NamespaceChange;
@@ -175,6 +177,7 @@ public class SparkSessionCatalog<
     getSessionCatalog().invalidateTable(ident);
   }
 
+  @Deprecated
   @Override
   public Table createTable(
       Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
@@ -188,6 +191,14 @@ public class SparkSessionCatalog<
     }
   }
 
+  @Override
+  public Table createTable(
+      Identifier ident, Column[] columns, Transform[] partitions, Map<String, String> properties)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
+    return createTable(ident, CatalogV2Util.v2ColumnsToStructType(columns), partitions, properties);
+  }
+
+  @Deprecated
   @Override
   public StagedTable stageCreate(
       Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
@@ -209,6 +220,14 @@ public class SparkSessionCatalog<
     return new RollbackStagedTable(catalog, ident, table);
   }
 
+  @Override
+  public StagedTable stageCreate(
+      Identifier ident, Column[] columns, Transform[] partitions, Map<String, String> properties)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
+    return stageCreate(ident, CatalogV2Util.v2ColumnsToStructType(columns), partitions, properties);
+  }
+
+  @Deprecated
   @Override
   public StagedTable stageReplace(
       Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
@@ -242,6 +261,15 @@ public class SparkSessionCatalog<
   }
 
   @Override
+  public StagedTable stageReplace(
+      Identifier ident, Column[] columns, Transform[] partitions, Map<String, String> properties)
+      throws NoSuchNamespaceException, NoSuchTableException {
+    return stageReplace(
+        ident, CatalogV2Util.v2ColumnsToStructType(columns), partitions, properties);
+  }
+
+  @Deprecated
+  @Override
   public StagedTable stageCreateOrReplace(
       Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
       throws NoSuchNamespaceException {
@@ -269,6 +297,14 @@ public class SparkSessionCatalog<
       // the table was deleted, but now already exists again. retry the replace.
       return stageCreateOrReplace(ident, schema, partitions, properties);
     }
+  }
+
+  @Override
+  public StagedTable stageCreateOrReplace(
+      Identifier ident, Column[] columns, Transform[] partitions, Map<String, String> properties)
+      throws NoSuchNamespaceException {
+    return stageCreateOrReplace(
+        ident, CatalogV2Util.v2ColumnsToStructType(columns), partitions, properties);
   }
 
   @Override


### PR DESCRIPTION
Spark has deprecated the following APIs in `TableCatalog` and `StagingTableCatalog`. 

- [TableCatalog.createTable](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalog.java#L197)
-  [StagingTableCatalog.stageCreate](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/StagingTableCatalog.java#L67)
-  [StagingTableCatalog.stageReplace](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/StagingTableCatalog.java#L109)
-  [StagingTableCatalog.stageCreateOrReplace](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/StagingTableCatalog.java#L163)

We need to deprecate the corresponding APIs in iceberg as well.