### PR TITLE
Hive: Optimize viewExists API in hive catalog

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
+import org.apache.iceberg.exceptions.NoSuchIcebergViewException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
@@ -446,6 +447,29 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
       Thread.currentThread().interrupt();
       throw new RuntimeException(
           "Interrupted in call to check table existence of " + baseTableIdentifier, e);
+    }
+  }
+
+  @Override
+  public boolean viewExists(TableIdentifier viewIdentifier) {
+    if (!isValidIdentifier(viewIdentifier)) {
+      return false;
+    }
+
+    String database = viewIdentifier.namespace().level(0);
+    String viewName = viewIdentifier.name();
+    try {
+      Table table = clients.run(client -> client.getTable(database, viewName));
+      HiveOperationsBase.validateTableIsIcebergView(table, fullTableName(name, viewIdentifier));
+      return true;
+    } catch (NoSuchIcebergViewException | NoSuchObjectException e) {
+      return false;
+    } catch (TException e) {
+      throw new RuntimeException("Failed to check view existence of " + viewIdentifier, e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(
+          "Interrupted in call to check view existence of " + viewIdentifier, e);
     }
   }
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCatalog.java
@@ -149,10 +149,24 @@ public class TestHiveViewCatalog extends ViewCatalogTests<HiveCatalog> {
         .create();
     assertThat(catalog.viewExists(identifier)).as("View should exist after create").isTrue();
 
-    catalog.dropView(identifier);
+    assertThat(catalog.dropView(identifier)).as("Should drop a view that does exist").isTrue();
     assertThat(catalog.viewExists(identifier)).as("View should not exist after drop").isFalse();
 
-    // create a hive table
+    // viewExits with existing hiveTable
+    String hiveTableName = "test_hive_table";
+    HIVE_METASTORE_EXTENSION
+        .metastoreClient()
+        .createTable(
+            createHiveTable(
+                hiveTableName,
+                dbName,
+                Files.createTempDirectory("hive-table-tests-name").toString()));
+    assertThat(catalog.viewExists(TableIdentifier.of(ns, hiveTableName)))
+        .as("ViewExists should return false if identifier refers to a hive table")
+        .isFalse();
+    HIVE_METASTORE_EXTENSION.metastoreClient().dropTable(dbName, hiveTableName);
+
+    // viewExits with existing hiveView
     Table hiveTable =
         createHiveView(
             viewName, dbName, Files.createTempDirectory("hive-view-tests-name").toString());
@@ -162,6 +176,7 @@ public class TestHiveViewCatalog extends ViewCatalogTests<HiveCatalog> {
         .isFalse();
     HIVE_METASTORE_EXTENSION.metastoreClient().dropTable(dbName, viewName);
 
+    // viewExits with existing icebergTable
     catalog.buildTable(identifier, SCHEMA).create();
     assertThat(catalog.viewExists(identifier))
         .as("ViewExists should return false if identifier refers to a iceberg table")
@@ -325,7 +340,8 @@ public class TestHiveViewCatalog extends ViewCatalogTests<HiveCatalog> {
     assertThat(catalog.viewExists(identifier)).isFalse();
   }
 
-  private Table createHiveView(String hiveViewName, String dbName, String location) {
+  private org.apache.hadoop.hive.metastore.api.Table createHiveTableWithType(
+      String hiveTableName, String dbName, String location, TableType type) {
     Map<String, String> parameters = Maps.newHashMap();
     parameters.put(
         serdeConstants.SERIALIZATION_CLASS, "org.apache.hadoop.hive.serde2.thrift.test.IntString");
@@ -349,9 +365,9 @@ public class TestHiveViewCatalog extends ViewCatalogTests<HiveCatalog> {
             Lists.newArrayList(),
             Maps.newHashMap());
 
-    Table hiveTable =
-        new Table(
-            hiveViewName,
+    org.apache.hadoop.hive.metastore.api.Table hiveTable =
+        new org.apache.hadoop.hive.metastore.api.Table(
+            hiveTableName,
             dbName,
             "test_owner",
             0,
@@ -362,7 +378,15 @@ public class TestHiveViewCatalog extends ViewCatalogTests<HiveCatalog> {
             Maps.newHashMap(),
             "viewOriginalText",
             "viewExpandedText",
-            TableType.VIRTUAL_VIEW.name());
+            type.name());
     return hiveTable;
+  }
+
+  private Table createHiveTable(String hiveViewName, String dbName, String location) {
+    return createHiveTableWithType(hiveViewName, dbName, location, TableType.EXTERNAL_TABLE);
+  }
+
+  private Table createHiveView(String hiveViewName, String dbName, String location) {
+    return createHiveTableWithType(hiveViewName, dbName, location, TableType.VIRTUAL_VIEW);
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCatalog.java
@@ -340,7 +340,7 @@ public class TestHiveViewCatalog extends ViewCatalogTests<HiveCatalog> {
     assertThat(catalog.viewExists(identifier)).isFalse();
   }
 
-  private org.apache.hadoop.hive.metastore.api.Table createHiveTableWithType(
+  private Table createHiveTableWithType(
       String hiveTableName, String dbName, String location, TableType type) {
     Map<String, String> parameters = Maps.newHashMap();
     parameters.put(
@@ -365,25 +365,23 @@ public class TestHiveViewCatalog extends ViewCatalogTests<HiveCatalog> {
             Lists.newArrayList(),
             Maps.newHashMap());
 
-    org.apache.hadoop.hive.metastore.api.Table hiveTable =
-        new org.apache.hadoop.hive.metastore.api.Table(
-            hiveTableName,
-            dbName,
-            "test_owner",
-            0,
-            0,
-            0,
-            sd,
-            Lists.newArrayList(),
-            Maps.newHashMap(),
-            "viewOriginalText",
-            "viewExpandedText",
-            type.name());
-    return hiveTable;
+    return new Table(
+        hiveTableName,
+        dbName,
+        "test_owner",
+        0,
+        0,
+        0,
+        sd,
+        Lists.newArrayList(),
+        Maps.newHashMap(),
+        "viewOriginalText",
+        "viewExpandedText",
+        type.name());
   }
 
-  private Table createHiveTable(String hiveViewName, String dbName, String location) {
-    return createHiveTableWithType(hiveViewName, dbName, location, TableType.EXTERNAL_TABLE);
+  private Table createHiveTable(String hiveTableName, String dbName, String location) {
+    return createHiveTableWithType(hiveTableName, dbName, location, TableType.EXTERNAL_TABLE);
   }
 
   private Table createHiveView(String hiveViewName, String dbName, String location) {


### PR DESCRIPTION
Similar to #11597 but apply same optimization for checking hive view existence check without instantiate the hive view operations based on the comment from https://github.com/apache/iceberg/pull/11597#issuecomment-2491144010