### PR TITLE
Core, Spark, Flink, Hive: Remove unused failsafe dependency from core and add Failsafe to runtime LICENSE(s)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -347,7 +347,6 @@ project(':iceberg-core') {
     implementation libs.jackson.core
     implementation libs.jackson.databind
     implementation libs.caffeine
-    implementation libs.failsafe
     implementation libs.roaringbitmap
     compileOnly(libs.hadoop2.client) {
       exclude group: 'org.apache.avro', module: 'avro'

--- a/flink/v1.18/flink-runtime/LICENSE
+++ b/flink/v1.18/flink-runtime/LICENSE
@@ -500,3 +500,11 @@ This product includes code from Apache HttpComponents Client.
 Copyright: 1999-2022 The Apache Software Foundation.
 Home page: https://hc.apache.org/
 License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains failsafe.
+
+Copyright: Jonathan Halterman and friends
+Home page: https://failsafe.dev/
+License: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/flink/v1.19/flink-runtime/LICENSE
+++ b/flink/v1.19/flink-runtime/LICENSE
@@ -500,3 +500,11 @@ This product includes code from Apache HttpComponents Client.
 Copyright: 1999-2022 The Apache Software Foundation.
 Home page: https://hc.apache.org/
 License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains failsafe.
+
+Copyright: Jonathan Halterman and friends
+Home page: https://failsafe.dev/
+License: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/flink/v1.20/flink-runtime/LICENSE
+++ b/flink/v1.20/flink-runtime/LICENSE
@@ -500,3 +500,11 @@ This product includes code from Apache HttpComponents Client.
 Copyright: 1999-2022 The Apache Software Foundation.
 Home page: https://hc.apache.org/
 License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains failsafe.
+
+Copyright: Jonathan Halterman and friends
+Home page: https://failsafe.dev/
+License: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/hive-runtime/LICENSE
+++ b/hive-runtime/LICENSE
@@ -500,3 +500,11 @@ This product includes code from Apache HttpComponents Client.
 Copyright: 1999-2022 The Apache Software Foundation.
 Home page: https://hc.apache.org/
 License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains failsafe.
+
+Copyright: Jonathan Halterman and friends
+Home page: https://failsafe.dev/
+License: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/kafka-connect/kafka-connect-runtime/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/LICENSE
@@ -722,6 +722,12 @@ License (from POM): The Apache Software License, Version 2.0 - http://www.apache
 
 --------------------------------------------------------------------------------
 
+Group: dev.failsafe  Name: failsafe  Version: 3.3.2
+Project URL (from POM): https://github.com/failsafe-lib/failsafe
+License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
 Group: dnsjava  Name: dnsjava  Version: 2.1.7
 Project URL (from POM): http://www.dnsjava.org
 License (from POM): BSD 2-Clause license - http://opensource.org/licenses/BSD-2-Clause

--- a/spark/v3.3/spark-runtime/LICENSE
+++ b/spark/v3.3/spark-runtime/LICENSE
@@ -637,3 +637,11 @@ This product includes code from Apache HttpComponents Client.
 Copyright: 1999-2022 The Apache Software Foundation.
 Home page: https://hc.apache.org/
 License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains failsafe.
+
+Copyright: Jonathan Halterman and friends
+Home page: https://failsafe.dev/
+License: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/spark/v3.4/spark-runtime/LICENSE
+++ b/spark/v3.4/spark-runtime/LICENSE
@@ -637,3 +637,11 @@ This product includes code from Apache HttpComponents Client.
 Copyright: 1999-2022 The Apache Software Foundation.
 Home page: https://hc.apache.org/
 License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains failsafe.
+
+Copyright: Jonathan Halterman and friends
+Home page: https://failsafe.dev/
+License: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/spark/v3.5/spark-runtime/LICENSE
+++ b/spark/v3.5/spark-runtime/LICENSE
@@ -637,3 +637,11 @@ This product includes code from Apache HttpComponents Client.
 Copyright: 1999-2022 The Apache Software Foundation.
 Home page: https://hc.apache.org/
 License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains failsafe.
+
+Copyright: Jonathan Halterman and friends
+Home page: https://failsafe.dev/
+License: https://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
This change removes unused failsafe from core (it was an oversight to include it in core as part of https://github.com/apache/iceberg/commit/c0d73f4ef5c16401bdfd62e1745faf2fbbf62177#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7 , we ended up isolating the retry behavior just to AWS). 

For clarity this change also adds Failsafe to the Runtime LICENSE(s) for the runtime artifacts which depend on iceberg-aws just to fall in line with our practice of including dependencies (although it's not required as per https://infra.apache.org/licensing-howto.html#alv2-dep since Failsafe is Apache 2.0 Licensed). 

Note Failsafe has no Notice of its own.