### PR TITLE
[1.7] Revert "Support WASB scheme in ADLSFileIO" 

### DIFF
--- a/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java
@@ -77,17 +77,6 @@ public class AzureProperties implements Serializable {
     return Optional.ofNullable(adlsWriteBlockSize);
   }
 
-  /**
-   * Applies configuration to the {@link DataLakeFileSystemClientBuilder} to provide the endpoint
-   * and credentials required to create an instance of the client.
-   *
-   * <p>The default endpoint is constructed in the form {@code
-   * https://{account}.dfs.core.windows.net} and default credentials are provided via the {@link
-   * com.azure.identity.DefaultAzureCredential}.
-   *
-   * @param account the service account name
-   * @param builder the builder instance
-   */
   public void applyClientConfiguration(String account, DataLakeFileSystemClientBuilder builder) {
     String sasToken = adlsSasTokens.get(account);
     if (sasToken != null && !sasToken.isEmpty()) {
@@ -104,7 +93,7 @@ public class AzureProperties implements Serializable {
     if (connectionString != null && !connectionString.isEmpty()) {
       builder.endpoint(connectionString);
     } else {
-      builder.endpoint("https://" + account + ".dfs.core.windows.net");
+      builder.endpoint("https://" + account);
     }
   }
 }

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSLocation.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSLocation.java
@@ -30,21 +30,14 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  *
  * <p>Locations follow a URI like structure to identify resources
  *
- * <pre>{@code abfs[s]://[<container>@]<storageAccount>.dfs.core.windows.net/<path>}</pre>
- *
- * or
- *
- * <pre>{@code wasb[s]://<container>@<storageAccount>.blob.core.windows.net/<path>}</pre>
- *
- * For compatibility, locations using the wasb scheme are also accepted but will use the Azure Data
- * Lake Storage Gen2 REST APIs instead of the Blob Storage REST APIs.
+ * <pre>{@code abfs[s]://[<container>@]<storage account host>/<file path>}</pre>
  *
  * <p>See <a
  * href="https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri#uri-syntax">Azure
  * Data Lake Storage URI</a>
  */
 class ADLSLocation {
-  private static final Pattern URI_PATTERN = Pattern.compile("^(abfss?|wasbs?)://([^/?#]+)(.*)?$");
+  private static final Pattern URI_PATTERN = Pattern.compile("^abfss?://([^/?#]+)(.*)?$");
 
   private final String storageAccount;
   private final String container;
@@ -62,18 +55,17 @@ class ADLSLocation {
 
     ValidationException.check(matcher.matches(), "Invalid ADLS URI: %s", location);
 
-    String authority = matcher.group(2);
+    String authority = matcher.group(1);
     String[] parts = authority.split("@", -1);
     if (parts.length > 1) {
       this.container = parts[0];
-      String host = parts[1];
-      this.storageAccount = host.split("\\.", -1)[0];
+      this.storageAccount = parts[1];
     } else {
       this.container = null;
-      this.storageAccount = authority.split("\\.", -1)[0];
+      this.storageAccount = authority;
     }
 
-    String uriPath = matcher.group(3);
+    String uriPath = matcher.group(2);
     this.path = uriPath == null ? "" : uriPath.startsWith("/") ? uriPath.substring(1) : uriPath;
   }
 

--- a/azure/src/test/java/org/apache/iceberg/azure/AzurePropertiesTest.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/AzurePropertiesTest.java
@@ -97,13 +97,11 @@ public class AzurePropertiesTest {
   @Test
   public void testWithConnectionString() {
     AzureProperties props =
-        new AzureProperties(
-            ImmutableMap.of(
-                "adls.connection-string.account1", "https://account1.dfs.core.usgovcloudapi.net"));
+        new AzureProperties(ImmutableMap.of("adls.connection-string.account1", "http://endpoint"));
 
     DataLakeFileSystemClientBuilder clientBuilder = mock(DataLakeFileSystemClientBuilder.class);
     props.applyClientConfiguration("account1", clientBuilder);
-    verify(clientBuilder).endpoint("https://account1.dfs.core.usgovcloudapi.net");
+    verify(clientBuilder).endpoint("http://endpoint");
   }
 
   @Test
@@ -113,7 +111,7 @@ public class AzurePropertiesTest {
 
     DataLakeFileSystemClientBuilder clientBuilder = mock(DataLakeFileSystemClientBuilder.class);
     props.applyClientConfiguration("account1", clientBuilder);
-    verify(clientBuilder).endpoint("https://account1.dfs.core.windows.net");
+    verify(clientBuilder).endpoint("https://account1");
   }
 
   @Test
@@ -122,7 +120,7 @@ public class AzurePropertiesTest {
 
     DataLakeFileSystemClientBuilder clientBuilder = mock(DataLakeFileSystemClientBuilder.class);
     props.applyClientConfiguration("account", clientBuilder);
-    verify(clientBuilder).endpoint("https://account.dfs.core.windows.net");
+    verify(clientBuilder).endpoint("https://account");
   }
 
   @Test

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/ADLSLocationTest.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/ADLSLocationTest.java
@@ -33,18 +33,7 @@ public class ADLSLocationTest {
     String p1 = scheme + "://container@account.dfs.core.windows.net/path/to/file";
     ADLSLocation location = new ADLSLocation(p1);
 
-    assertThat(location.storageAccount()).isEqualTo("account");
-    assertThat(location.container().get()).isEqualTo("container");
-    assertThat(location.path()).isEqualTo("path/to/file");
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"wasb", "wasbs"})
-  public void testWasbLocatonParsing(String scheme) {
-    String p1 = scheme + "://container@account.blob.core.windows.net/path/to/file";
-    ADLSLocation location = new ADLSLocation(p1);
-
-    assertThat(location.storageAccount()).isEqualTo("account");
+    assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("path/to/file");
   }
@@ -54,7 +43,7 @@ public class ADLSLocationTest {
     String p1 = "abfs://container@account.dfs.core.windows.net/path%20to%20file";
     ADLSLocation location = new ADLSLocation(p1);
 
-    assertThat(location.storageAccount()).isEqualTo("account");
+    assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("path%20to%20file");
   }
@@ -78,7 +67,7 @@ public class ADLSLocationTest {
     String p1 = "abfs://account.dfs.core.windows.net/path/to/file";
     ADLSLocation location = new ADLSLocation(p1);
 
-    assertThat(location.storageAccount()).isEqualTo("account");
+    assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
     assertThat(location.container().isPresent()).isFalse();
     assertThat(location.path()).isEqualTo("path/to/file");
   }
@@ -88,7 +77,7 @@ public class ADLSLocationTest {
     String p1 = "abfs://container@account.dfs.core.windows.net";
     ADLSLocation location = new ADLSLocation(p1);
 
-    assertThat(location.storageAccount()).isEqualTo("account");
+    assertThat(location.storageAccount()).isEqualTo("account.dfs.core.windows.net");
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("");
   }

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -62,9 +62,7 @@ public class ResolvingFileIO implements HadoopConfigurable, DelegateFileIO {
           "s3n", S3_FILE_IO_IMPL,
           "gs", GCS_FILE_IO_IMPL,
           "abfs", ADLS_FILE_IO_IMPL,
-          "abfss", ADLS_FILE_IO_IMPL,
-          "wasb", ADLS_FILE_IO_IMPL,
-          "wasbs", ADLS_FILE_IO_IMPL);
+          "abfss", ADLS_FILE_IO_IMPL);
 
   private final Map<String, DelegateFileIO> ioInstances = Maps.newConcurrentMap();
   private final AtomicBoolean isClosed = new AtomicBoolean(false);


### PR DESCRIPTION
This cherry picks the revert PR https://github.com/apache/iceberg/pull/11812 into the 1.7.x branch to fix a breaking change introduced in 1.7.1