### PR TITLE
Core: Reset to main as part of replace shouldn't remove main ref

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -338,7 +338,11 @@ public interface MetadataUpdate extends Serializable {
 
     @Override
     public void applyTo(TableMetadata.Builder metadataBuilder) {
-      metadataBuilder.removeRef(refName);
+      if (refName.equals(SnapshotRef.MAIN_BRANCH)) {
+        metadataBuilder.resetMainBranch();
+      } else {
+        metadataBuilder.removeRef(refName);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1297,7 +1297,7 @@ public class TableMetadata implements Serializable {
       return this;
     }
 
-    private Builder resetMainBranch() {
+    protected Builder resetMainBranch() {
       this.currentSnapshotId = -1;
       SnapshotRef ref = refs.remove(SnapshotRef.MAIN_BRANCH);
       if (ref != null) {


### PR DESCRIPTION
RemoveRef(main) will clear history, we don't want to do that during a replace. 