### PR TITLE
Core: Bulk deletion in RemoveSnapshots

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -65,14 +65,6 @@ class RemoveSnapshots implements ExpireSnapshots {
   private static final ExecutorService DEFAULT_DELETE_EXECUTOR_SERVICE =
       MoreExecutors.newDirectExecutorService();
 
-  private final Consumer<String> defaultDelete =
-      new Consumer<String>() {
-        @Override
-        public void accept(String file) {
-          ops.io().deleteFile(file);
-        }
-      };
-
   private final TableOperations ops;
   private final Set<Long> idsToRemove = Sets.newHashSet();
   private final long now;
@@ -81,7 +73,7 @@ class RemoveSnapshots implements ExpireSnapshots {
   private TableMetadata base;
   private long defaultExpireOlderThan;
   private int defaultMinNumSnapshots;
-  private Consumer<String> deleteFunc = defaultDelete;
+  private Consumer<String> deleteFunc = null;
   private ExecutorService deleteExecutorService = DEFAULT_DELETE_EXECUTOR_SERVICE;
   private ExecutorService planExecutorService = ThreadPools.getWorkerPool();
   private Boolean incrementalCleanup;


### PR DESCRIPTION
The current implementation uses the deleteFile() of the FileIO even if it supports bulk operations. Even though the user of the RemoveSnapshots API can provide a custom Consumer to perform bulk deletion, Iceberg can be clever enough itself to find out if bulk deletion is possible on the FileIO.