### PR TITLE
Fix for Timestamp and Date Conversion to Long in Iceberg Records

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
@@ -68,16 +68,12 @@ public class SparkValueConverter {
         }
         return convertedMap;
 
-      case DATE:
-        // if spark.sql.datetime.java8API.enabled is set to true, java.time.LocalDate
-        // for Spark SQL DATE type otherwise java.sql.Date is returned.
-        return DateTimeUtils.anyToDays(object);
-      case TIMESTAMP:
-        return DateTimeUtils.anyToMicros(object);
       case BINARY:
         return ByteBuffer.wrap((byte[]) object);
       case INTEGER:
         return ((Number) object).intValue();
+      case DATE:
+      case TIMESTAMP:
       case BOOLEAN:
       case LONG:
       case FLOAT:


### PR DESCRIPTION
This PR addresses the issue of timestamps and dates being converted into long values (epoch time in microseconds) when Spark data is written into Iceberg records.