### PR TITLE
Core: Prevent dropping column which is referenced by active partition specs

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -29,6 +30,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.spark.SparkException;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -538,7 +540,9 @@ public class TestAlterTablePartitionFields extends ExtensionsTestBase {
 
     sql("ALTER TABLE %s REPLACE PARTITION FIELD day_of_ts WITH days(ts)", tableName);
 
-    sql("ALTER TABLE %s DROP COLUMN day_of_ts", tableName);
+    assertThatThrownBy(() -> sql("ALTER TABLE %s DROP COLUMN day_of_ts", tableName))
+        .hasMessageContaining("Cannot delete field id")
+        .isInstanceOf(SparkException.class);
   }
 
   @TestTemplate
@@ -549,7 +553,9 @@ public class TestAlterTablePartitionFields extends ExtensionsTestBase {
 
     sql("ALTER TABLE %s REPLACE PARTITION FIELD day_of_ts WITH days(ts)", tableName);
 
-    sql("ALTER TABLE %s DROP COLUMN day_of_ts", tableName);
+    assertThatThrownBy(() -> sql("ALTER TABLE %s DROP COLUMN day_of_ts", tableName))
+        .hasMessageContaining("Cannot delete field id")
+        .isInstanceOf(SparkException.class);
   }
 
   private void assertPartitioningEquals(SparkTable table, int len, String transform) {


### PR DESCRIPTION
Prevents 
- https://github.com/apache/iceberg/issues/10234
- https://github.com/apache/iceberg/issues/10626
- https://github.com/apache/iceberg/issues/11314
- and any other similar reports. 

Supersedes: https://github.com/apache/iceberg/pull/10352

Co-authored by: @amogh-jahagirdar 

**Summary**

If we drop a partition column that is still referenced in an older spec, this will break the table. This can be easily reproduced in Spark by adding a SELECT after these tests
- https://github.com/apache/iceberg/blob/dea2fd1d9debfd23aeda9403ed3eb81c6aebf30f/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java#L533
- https://github.com/apache/iceberg/blob/dea2fd1d9debfd23aeda9403ed3eb81c6aebf30f/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java#L544

```
   sql("SELECT * FROM %s LIMIT 1", tableName);
```

Will throw 

```
Type cannot be null
java.lang.NullPointerException: Type cannot be null
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkNotNull(Preconditions.java:922)
	at org.apache.iceberg.types.Types$NestedField.<init>(Types.java:615)
	at org.apache.iceberg.types.Types$NestedField.optional(Types.java:508)
	at org.apache.iceberg.PartitionSpec.partitionType(PartitionSpec.java:134)
	at org.apache.iceberg.Partitioning.buildPartitionProjectionType(Partitioning.java:284)
	at org.apache.iceberg.Partitioning.partitionType(Partitioning.java:242)
	at org.apache.iceberg.spark.source.SparkTable.metadataColumns(SparkTable.java:258)
```

As discussed by @amogh-jahagirdar and @advancedxy [here](https://github.com/apache/iceberg/pull/10352#discussion_r1676213273), the solution is two parts 

Part 1: Prevent dropping the column referenced in older specs (This PR)
Part 2: Provide a maintenance API for users to remove all unused specs (https://github.com/apache/iceberg/pull/10755)

Both can be merged independently. 

