### PR TITLE
[docs] Replace examples of Hadoop catalog with JDBC & REST catalog

### DIFF
--- a/docs/docs/spark-getting-started.md
+++ b/docs/docs/spark-getting-started.md
@@ -56,7 +56,8 @@ spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ iceber
     --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
     --conf spark.sql.catalog.local.type=jdbc \
     --conf spark.sql.catalog.local.uri=jdbc:sqlite:$PWD/iceberg_catalog_db.sqlite \
-    --conf spark.sql.catalog.local.warehouse=$PWD/warehouse
+    --conf spark.sql.catalog.local.warehouse=$PWD/warehouse \
+    --conf spark.sql.defaultCatalog=local
 ```
 
 For example configuring a REST-based catalog, see [Configuring REST Catalog](/spark-quickstart#configuring-rest-catalog)

--- a/docs/docs/spark-getting-started.md
+++ b/docs/docs/spark-getting-started.md
@@ -43,7 +43,7 @@ spark-shell --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ iceb
 
 Iceberg comes with [catalogs](spark-configuration.md#catalogs) that enable SQL commands to manage tables and load them by name. Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)`.
 
-This command creates a jdbc-based catalog named `local` for tables under `$PWD` and adds support for Iceberg tables to Spark's built-in catalog:
+This command creates a JDBC-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog:
 
 ```sh
 spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.46.1.3 \

--- a/docs/docs/spark-getting-started.md
+++ b/docs/docs/spark-getting-started.md
@@ -39,10 +39,9 @@ spark-shell --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ iceb
     If you want to include Iceberg in your Spark installation, add the [`iceberg-spark-runtime-3.5_2.12` Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/{{ icebergVersion }}/iceberg-spark-runtime-3.5_2.12-{{ icebergVersion }}.jar) to Spark's `jars` folder.
 
 
-### Adding catalogs
+### Catalogs
 
-Apache Iceberg provides several [catalog](spark-configuration.md#catalogs) implementations to manage tables and enable SQL operations. 
-Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)`.
+Apache Iceberg uses [catalogs](https://iceberg.apache.org/concepts/catalog/) to track and manage table metadata and enable SQL operations. Iceberg provides several [catalog implementations](spark-configuration.md#catalogs), which can be configured using properties under `spark.sql.catalog.(catalog_name)`.
 
 This command creates a JDBC-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog. 
 

--- a/docs/docs/spark-getting-started.md
+++ b/docs/docs/spark-getting-started.md
@@ -43,15 +43,16 @@ spark-shell --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ iceb
 
 Iceberg comes with [catalogs](spark-configuration.md#catalogs) that enable SQL commands to manage tables and load them by name. Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)`.
 
-This command creates a path-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog:
+This command creates a jdbc-based catalog named `local` for tables under `$PWD` and adds support for Iceberg tables to Spark's built-in catalog:
 
 ```sh
-spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }}\
+spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.46.1.3 \
     --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
     --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
     --conf spark.sql.catalog.spark_catalog.type=hive \
     --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
-    --conf spark.sql.catalog.local.type=hadoop \
+    --conf spark.sql.catalog.local.type=jdbc \
+    --conf spark.sql.catalog.local.uri=jdbc:sqlite:$PWD/iceberg_catalog_db.sqlite \
     --conf spark.sql.catalog.local.warehouse=$PWD/warehouse
 ```
 

--- a/docs/docs/spark-getting-started.md
+++ b/docs/docs/spark-getting-started.md
@@ -41,9 +41,12 @@ spark-shell --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ iceb
 
 ### Adding catalogs
 
-Iceberg comes with [catalogs](spark-configuration.md#catalogs) that enable SQL commands to manage tables and load them by name. Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)`.
+Apache Iceberg provides several [catalog](spark-configuration.md#catalogs) implementations to manage tables and enable SQL operations. 
+Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)`.
 
-This command creates a JDBC-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog:
+This command creates a JDBC-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog. 
+
+The JDBC catalog uses file-based SQLite database as the backend.
 
 ```sh
 spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.46.1.3 \
@@ -55,6 +58,8 @@ spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ iceber
     --conf spark.sql.catalog.local.uri=jdbc:sqlite:$PWD/iceberg_catalog_db.sqlite \
     --conf spark.sql.catalog.local.warehouse=$PWD/warehouse
 ```
+
+For example configuring a REST-based catalog, see [Configuring REST Catalog](spark-quickstart.md#configuring-rest-catalog)
 
 ### Creating a table
 

--- a/docs/docs/spark-getting-started.md
+++ b/docs/docs/spark-getting-started.md
@@ -59,7 +59,7 @@ spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ iceber
     --conf spark.sql.catalog.local.warehouse=$PWD/warehouse
 ```
 
-For example configuring a REST-based catalog, see [Configuring REST Catalog](spark-quickstart.md#configuring-rest-catalog)
+For example configuring a REST-based catalog, see [Configuring REST Catalog](/spark-quickstart#configuring-rest-catalog)
 
 ### Creating a table
 

--- a/site/docs/how-to-release.md
+++ b/site/docs/how-to-release.md
@@ -422,10 +422,11 @@ spark-runtime jar for the Spark installation):
 ```bash
 spark-shell \
     --conf spark.jars.repositories=${MAVEN_URL} \
-    --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }} \
+    --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.46.1.3 \
     --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
     --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
-    --conf spark.sql.catalog.local.type=hadoop \
+    --conf spark.sql.catalog.local.type=jdbc \
+    --conf spark.sql.catalog.local.uri=jdbc:sqlite:$PWD/iceberg_catalog_db.sqlite \
     --conf spark.sql.catalog.local.warehouse=$PWD/warehouse \
     --conf spark.sql.catalog.local.default-namespace=default \
     --conf spark.sql.defaultCatalog=local

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -316,7 +316,7 @@ The JDBC catalog uses file-based SQLite database as the backend.
     spark.sql.catalog.local                              org.apache.iceberg.spark.SparkCatalog
     spark.sql.catalog.local.type                         jdbc
     spark.sql.catalog.local.uri                          jdbc:sqlite:iceberg_catalog_db.sqlite
-    spark.sql.catalog.local.warehouse                    $PWD/warehouse
+    spark.sql.catalog.local.warehouse                    warehouse
     spark.sql.defaultCatalog                             local
     ```
 

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -25,7 +25,7 @@ highlight some powerful features. You can learn more about Iceberg's Spark runti
 - [Creating a table](#creating-a-table)
 - [Writing Data to a Table](#writing-data-to-a-table)
 - [Reading Data from a Table](#reading-data-from-a-table)
-- [Adding A Catalog](#adding-a-catalog)
+- [Adding catalogs](#adding-catalogs)
 	- [Configuring JDBC Catalog](#configuring-jdbc-catalog)
 	- [Configuring REST Catalog](#configuring-rest-catalog)
 - [Next steps](#next-steps)
@@ -271,7 +271,7 @@ To read a table, simply use the Iceberg table's name.
     df = spark.table("demo.nyc.taxis").show()
     ```
 
-### Adding A Catalog
+### Adding catalogs
 
 Apache Iceberg provides several catalog implementations to manage tables and enable SQL operations. 
 Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)`.

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -26,11 +26,11 @@ highlight some powerful features. You can learn more about Iceberg's Spark runti
 - [Writing Data to a Table](#writing-data-to-a-table)
 - [Reading Data from a Table](#reading-data-from-a-table)
 - [Adding A Catalog](#adding-a-catalog)
-    - [Configuring JDBC Catalog](#configuring-jdbc-catalog)
-    - [Configuring REST Catalog](#configuring-rest-catalog)
+	- [Configuring JDBC Catalog](#configuring-jdbc-catalog)
+	- [Configuring REST Catalog](#configuring-rest-catalog)
 - [Next steps](#next-steps)
-    - [Adding Iceberg to Spark](#adding-iceberg-to-spark)
-    - [Learn More](#learn-more)
+	- [Adding Iceberg to Spark](#adding-iceberg-to-spark)
+	- [Learn More](#learn-more)
 
 ### Docker-Compose
 
@@ -334,7 +334,7 @@ The REST catalog uses the `apache/iceberg-rest-fixture` docker container from th
 === "CLI"
 
     ```sh
-    spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.46.1.3 \
+    spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }} \
         --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
         --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
         --conf spark.sql.catalog.spark_catalog.type=hive \
@@ -358,17 +358,17 @@ The REST catalog uses the `apache/iceberg-rest-fixture` docker container from th
     spark.sql.extensions                                 org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
     spark.sql.catalog.spark_catalog                      org.apache.iceberg.spark.SparkSessionCatalog
     spark.sql.catalog.spark_catalog.type                 hive
-    spark.sql.catalog.rest                              org.apache.iceberg.spark.SparkCatalog
-    spark.sql.catalog.rest.type                         rest
-    spark.sql.catalog.rest.uri                         http://localhost:8181
-    spark.sql.catalog.rest.warehouse                   s3://warehouse/
-    spark.sql.catalog.rest.io-impl                     org.apache.iceberg.aws.s3.S3FileIO
-    spark.sql.catalog.rest.s3.endpoint                 http://localhost:9000
-    spark.sql.catalog.rest.s3.access-key-id            admin
-    spark.sql.catalog.rest.s3.secret-access-key        password
-    spark.sql.catalog.rest.s3.path-style-access        true
-    spark.sql.catalog.rest.s3.region                   us-east-1
-    spark.sql.defaultCatalog                            rest
+    spark.sql.catalog.rest                               org.apache.iceberg.spark.SparkCatalog
+    spark.sql.catalog.rest.type                          rest
+    spark.sql.catalog.rest.uri                           http://localhost:8181
+    spark.sql.catalog.rest.warehouse                     s3://warehouse/
+    spark.sql.catalog.rest.io-impl                       org.apache.iceberg.aws.s3.S3FileIO
+    spark.sql.catalog.rest.s3.endpoint                   http://localhost:9000
+    spark.sql.catalog.rest.s3.path-style-access          true
+    spark.sql.catalog.rest.s3.access-key-id              admin
+    spark.sql.catalog.rest.s3.secret-access-key          password
+    spark.sql.catalog.rest.s3.region                     us-east-1
+    spark.sql.defaultCatalog                             rest
     ```
 
 !!! note

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -334,7 +334,7 @@ The REST catalog uses the `apache/iceberg-rest-fixture` docker container from th
 === "CLI"
 
     ```sh
-    spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }} \
+    spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.apache.iceberg:iceberg-aws-bundle:1.7.1 \
         --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
         --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
         --conf spark.sql.catalog.spark_catalog.type=hive \
@@ -347,14 +347,14 @@ The REST catalog uses the `apache/iceberg-rest-fixture` docker container from th
         --conf spark.sql.catalog.rest.s3.path-style-access=true \
         --conf spark.sql.catalog.rest.s3.access-key-id=admin \
         --conf spark.sql.catalog.rest.s3.secret-access-key=password \
-        --conf spark.sql.catalog.rest.s3.region=us-east-1 \
+        --conf spark.sql.catalog.rest.client.region=us-east-1 \
         --conf spark.sql.defaultCatalog=rest
     ```
 
 === "spark-defaults.conf"
 
     ```sh
-    spark.jars.packages                                  org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }}
+    spark.jars.packages                                  org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.apache.iceberg:iceberg-aws-bundle:1.7.1
     spark.sql.extensions                                 org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
     spark.sql.catalog.spark_catalog                      org.apache.iceberg.spark.SparkSessionCatalog
     spark.sql.catalog.spark_catalog.type                 hive
@@ -367,7 +367,7 @@ The REST catalog uses the `apache/iceberg-rest-fixture` docker container from th
     spark.sql.catalog.rest.s3.path-style-access          true
     spark.sql.catalog.rest.s3.access-key-id              admin
     spark.sql.catalog.rest.s3.secret-access-key          password
-    spark.sql.catalog.rest.s3.region                     us-east-1
+    spark.sql.catalog.rest.client.region                 us-east-1
     spark.sql.defaultCatalog                             rest
     ```
 

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -25,7 +25,7 @@ highlight some powerful features. You can learn more about Iceberg's Spark runti
 - [Creating a table](#creating-a-table)
 - [Writing Data to a Table](#writing-data-to-a-table)
 - [Reading Data from a Table](#reading-data-from-a-table)
-- [Adding catalogs](#adding-catalogs)
+- [Catalogs](#catalogs)
     - [Configuring JDBC Catalog](#configuring-jdbc-catalog)
     - [Configuring REST Catalog](#configuring-rest-catalog)
 - [Next steps](#next-steps)
@@ -271,7 +271,7 @@ To read a table, simply use the Iceberg table's name.
     df = spark.table("demo.nyc.taxis").show()
     ```
 
-### Adding catalogs
+### Catalogs
 
 Apache Iceberg provides several catalog implementations to manage tables and enable SQL operations. 
 Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)`.

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -26,11 +26,11 @@ highlight some powerful features. You can learn more about Iceberg's Spark runti
 - [Writing Data to a Table](#writing-data-to-a-table)
 - [Reading Data from a Table](#reading-data-from-a-table)
 - [Adding A Catalog](#adding-a-catalog)
-  - [Configuring JDBC Catalog](#configuring-jdbc-catalog)
-  - [Configuring REST Catalog](#configuring-rest-catalog)
+    - [Configuring JDBC Catalog](#configuring-jdbc-catalog)
+    - [Configuring REST Catalog](#configuring-rest-catalog)
 - [Next steps](#next-steps)
-  - [Adding Iceberg to Spark](#adding-iceberg-to-spark)
-  - [Learn More](#learn-more)
+    - [Adding Iceberg to Spark](#adding-iceberg-to-spark)
+    - [Learn More](#learn-more)
 
 ### Docker-Compose
 

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -26,11 +26,11 @@ highlight some powerful features. You can learn more about Iceberg's Spark runti
 - [Writing Data to a Table](#writing-data-to-a-table)
 - [Reading Data from a Table](#reading-data-from-a-table)
 - [Adding catalogs](#adding-catalogs)
-	- [Configuring JDBC Catalog](#configuring-jdbc-catalog)
-	- [Configuring REST Catalog](#configuring-rest-catalog)
+    - [Configuring JDBC Catalog](#configuring-jdbc-catalog)
+    - [Configuring REST Catalog](#configuring-rest-catalog)
 - [Next steps](#next-steps)
-	- [Adding Iceberg to Spark](#adding-iceberg-to-spark)
-	- [Learn More](#learn-more)
+    - [Adding Iceberg to Spark](#adding-iceberg-to-spark)
+    - [Learn More](#learn-more)
 
 ### Docker-Compose
 

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -321,7 +321,7 @@ The JDBC catalog uses file-based SQLite database as the backend.
     ```
 
 !!! note
-    If your Iceberg catalog is not set as the default catalog, you will have to switch to it by executing `USE local;`
+    If your Iceberg catalog is not set as the default catalog using `spark.sql.defaultCatalog`, you will have to switch to it by executing `USE local;`
 
 #### Configuring REST Catalog
 
@@ -372,7 +372,7 @@ The REST catalog uses the `apache/iceberg-rest-fixture` docker container from th
     ```
 
 !!! note
-    If your Iceberg catalog is not set as the default catalog, you will have to switch to it by executing `USE rest;`
+    If your Iceberg catalog is not set as the default catalog using `spark.sql.defaultCatalog`, you will have to switch to it by executing `USE rest;`
 
 ### Next steps
 

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -278,6 +278,7 @@ Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)
 You can configure different catalog types, such as JDBC, Hive Metastore, Glue, and REST, to manage Iceberg tables in Spark.
 
 This guide covers the configuration of two popular catalog types:
+
 * JDBC Catalog
 * REST Catalog
 
@@ -288,6 +289,7 @@ To learn more, check out the [Catalog](docs/latest/spark-configuration.md#catalo
 The JDBC catalog stores Iceberg table metadata in a relational database. 
 
 This configuration creates a JDBC-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog.
+
 The JDBC catalog uses file-based SQLite database as the backend.
 
 === "CLI"
@@ -326,6 +328,7 @@ The JDBC catalog uses file-based SQLite database as the backend.
 The REST catalog provides a language-agnostic way to manage Iceberg tables through a RESTful service. 
 
 This configuration creates a REST-based catalog named `rest` for tables under `s3://warehouse/` and adds support for Iceberg tables to Spark's built-in catalog.
+
 The REST catalog uses the `apache/iceberg-rest-fixture` docker container from the `docker-compose.yml` above as the backend service with MinIO for S3-compatible storage.
 
 === "CLI"

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -26,7 +26,9 @@ highlight some powerful features. You can learn more about Iceberg's Spark runti
 - [Writing Data to a Table](#writing-data-to-a-table)
 - [Reading Data from a Table](#reading-data-from-a-table)
 - [Adding A Catalog](#adding-a-catalog)
-- [Next Steps](#next-steps)
+- [Next steps](#next-steps)
+  - [Adding Iceberg to Spark](#adding-iceberg-to-spark)
+  - [Learn More](#learn-more)
 
 ### Docker-Compose
 
@@ -274,17 +276,18 @@ Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)
 we use JDBC, but you can follow these instructions to configure other catalog types. To learn more, check out
 the [Catalog](docs/latest/spark-configuration.md#catalogs) page in the Spark section.
 
-This configuration creates a path-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog.
+This configuration creates a jdbc-based catalog named `local` for tables under `$PWD` and adds support for Iceberg tables to Spark's built-in catalog.
 
 === "CLI"
 
     ```sh
-    spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }}\
+    spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.46.1.3 \
         --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
         --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
         --conf spark.sql.catalog.spark_catalog.type=hive \
         --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
-        --conf spark.sql.catalog.local.type=hadoop \
+        --conf spark.sql.catalog.local.type=jdbc \
+        --conf spark.sql.catalog.local.uri=jdbc:sqlite:$PWD/iceberg_catalog_db.sqlite \
         --conf spark.sql.catalog.local.warehouse=$PWD/warehouse \
         --conf spark.sql.defaultCatalog=local
     ```
@@ -292,12 +295,13 @@ This configuration creates a path-based catalog named `local` for tables under `
 === "spark-defaults.conf"
 
     ```sh
-    spark.jars.packages                                  org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }}
+    spark.jars.packages                                  org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.46.1.3
     spark.sql.extensions                                 org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
     spark.sql.catalog.spark_catalog                      org.apache.iceberg.spark.SparkSessionCatalog
     spark.sql.catalog.spark_catalog.type                 hive
     spark.sql.catalog.local                              org.apache.iceberg.spark.SparkCatalog
-    spark.sql.catalog.local.type                         hadoop
+    spark.sql.catalog.local.type                         jdbc
+    spark.sql.catalog.local.uri                          jdbc:sqlite:iceberg_catalog_db.sqlite
     spark.sql.catalog.local.warehouse                    $PWD/warehouse
     spark.sql.defaultCatalog                             local
     ```

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -26,8 +26,8 @@ highlight some powerful features. You can learn more about Iceberg's Spark runti
 - [Writing Data to a Table](#writing-data-to-a-table)
 - [Reading Data from a Table](#reading-data-from-a-table)
 - [Catalogs](#catalogs)
-    - [Configuring JDBC Catalog](#configuring-jdbc-catalog)
     - [Configuring REST Catalog](#configuring-rest-catalog)
+    - [Configuring JDBC Catalog](#configuring-jdbc-catalog)
 - [Next steps](#next-steps)
     - [Adding Iceberg to Spark](#adding-iceberg-to-spark)
     - [Learn More](#learn-more)
@@ -279,49 +279,10 @@ You can configure different catalog types, such as JDBC, Hive Metastore, Glue, a
 
 This guide covers the configuration of two popular catalog types:
 
-* JDBC Catalog
 * REST Catalog
+* JDBC Catalog
 
 To learn more, check out the [Catalog](docs/latest/spark-configuration.md#catalogs) page in the Spark section.
-
-#### Configuring JDBC Catalog
-
-The JDBC catalog stores Iceberg table metadata in a relational database. 
-
-This configuration creates a JDBC-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog.
-
-The JDBC catalog uses file-based SQLite database as the backend.
-
-=== "CLI"
-
-    ```sh
-    spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.46.1.3 \
-        --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
-        --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
-        --conf spark.sql.catalog.spark_catalog.type=hive \
-        --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
-        --conf spark.sql.catalog.local.type=jdbc \
-        --conf spark.sql.catalog.local.uri=jdbc:sqlite:$PWD/iceberg_catalog_db.sqlite \
-        --conf spark.sql.catalog.local.warehouse=$PWD/warehouse \
-        --conf spark.sql.defaultCatalog=local
-    ```
-
-=== "spark-defaults.conf"
-
-    ```sh
-    spark.jars.packages                                  org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.46.1.3
-    spark.sql.extensions                                 org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
-    spark.sql.catalog.spark_catalog                      org.apache.iceberg.spark.SparkSessionCatalog
-    spark.sql.catalog.spark_catalog.type                 hive
-    spark.sql.catalog.local                              org.apache.iceberg.spark.SparkCatalog
-    spark.sql.catalog.local.type                         jdbc
-    spark.sql.catalog.local.uri                          jdbc:sqlite:iceberg_catalog_db.sqlite
-    spark.sql.catalog.local.warehouse                    warehouse
-    spark.sql.defaultCatalog                             local
-    ```
-
-!!! note
-    If your Iceberg catalog is not set as the default catalog using `spark.sql.defaultCatalog`, you will have to switch to it by executing `USE local;`
 
 #### Configuring REST Catalog
 
@@ -373,6 +334,45 @@ The REST catalog uses the `apache/iceberg-rest-fixture` docker container from th
 
 !!! note
     If your Iceberg catalog is not set as the default catalog using `spark.sql.defaultCatalog`, you will have to switch to it by executing `USE rest;`
+
+#### Configuring JDBC Catalog
+
+The JDBC catalog stores Iceberg table metadata in a relational database. 
+
+This configuration creates a JDBC-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog.
+
+The JDBC catalog uses file-based SQLite database as the backend.
+
+=== "CLI"
+
+    ```sh
+    spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.46.1.3 \
+        --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
+        --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
+        --conf spark.sql.catalog.spark_catalog.type=hive \
+        --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
+        --conf spark.sql.catalog.local.type=jdbc \
+        --conf spark.sql.catalog.local.uri=jdbc:sqlite:$PWD/iceberg_catalog_db.sqlite \
+        --conf spark.sql.catalog.local.warehouse=$PWD/warehouse \
+        --conf spark.sql.defaultCatalog=local
+    ```
+
+=== "spark-defaults.conf"
+
+    ```sh
+    spark.jars.packages                                  org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.46.1.3
+    spark.sql.extensions                                 org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
+    spark.sql.catalog.spark_catalog                      org.apache.iceberg.spark.SparkSessionCatalog
+    spark.sql.catalog.spark_catalog.type                 hive
+    spark.sql.catalog.local                              org.apache.iceberg.spark.SparkCatalog
+    spark.sql.catalog.local.type                         jdbc
+    spark.sql.catalog.local.uri                          jdbc:sqlite:iceberg_catalog_db.sqlite
+    spark.sql.catalog.local.warehouse                    warehouse
+    spark.sql.defaultCatalog                             local
+    ```
+
+!!! note
+    If your Iceberg catalog is not set as the default catalog using `spark.sql.defaultCatalog`, you will have to switch to it by executing `USE local;`
 
 ### Next steps
 


### PR DESCRIPTION
Closes #11284
[devlist discussion](https://lists.apache.org/thread/2too7vobf4f4h99qonbl2ok06slsww43)

This PR replaces examples of Hadoop catalog with examples of JDBC catalog and add examples of setting up a REST catalog

## Testing
### `spark-quickstart.md` using JDBC catalog
Using `spark-sql` CLI config:
```
spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.7.1,org.xerial:sqlite-jdbc:3.46.1.3 \
    --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
    --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
    --conf spark.sql.catalog.spark_catalog.type=hive \
    --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
    --conf spark.sql.catalog.local.type=jdbc \
    --conf spark.sql.catalog.local.uri=jdbc:sqlite:$PWD/iceberg_catalog_db.sqlite \
    --conf spark.sql.catalog.local.warehouse=$PWD/warehouse \
    --conf spark.sql.defaultCatalog=local
```

Using `spark-defaults.conf` file:
```
spark.jars.packages                                  org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.7.1,org.xerial:sqlite-jdbc:3.46.1.3
spark.sql.extensions                                 org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
spark.sql.catalog.spark_catalog                      org.apache.iceberg.spark.SparkSessionCatalog
spark.sql.catalog.spark_catalog.type                 hive
spark.sql.catalog.local                              org.apache.iceberg.spark.SparkCatalog
spark.sql.catalog.local.type                         jdbc
spark.sql.catalog.local.uri                          jdbc:sqlite:iceberg_catalog_db.sqlite
spark.sql.catalog.local.warehouse                    warehouse
spark.sql.defaultCatalog                             local
```
```
spark-sql --properties-file ./spark-defaults.conf
```

### `spark-quickstart.md` using REST catalog
With `spark-sql` CLI config:
```
spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.7.1,org.apache.iceberg:iceberg-aws-bundle:1.7.1 \
    --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
    --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
    --conf spark.sql.catalog.spark_catalog.type=hive \
    --conf spark.sql.catalog.rest=org.apache.iceberg.spark.SparkCatalog \
    --conf spark.sql.catalog.rest.type=rest \
    --conf spark.sql.catalog.rest.uri=http://localhost:8181 \
    --conf spark.sql.catalog.rest.warehouse=s3://warehouse/ \
    --conf spark.sql.catalog.rest.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
    --conf spark.sql.catalog.rest.s3.endpoint=http://localhost:9000 \
    --conf spark.sql.catalog.rest.s3.path-style-access=true \
    --conf spark.sql.catalog.rest.s3.access-key-id=admin \
    --conf spark.sql.catalog.rest.s3.secret-access-key=password \
    --conf spark.sql.catalog.rest.client.region=us-east-1 \
    --conf spark.sql.defaultCatalog=rest
```

With `spark-defaults.conf` file:
```
spark.jars.packages                                  org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.7.1,org.apache.iceberg:iceberg-aws-bundle:1.7.1
spark.sql.extensions                                 org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
spark.sql.catalog.spark_catalog                      org.apache.iceberg.spark.SparkSessionCatalog
spark.sql.catalog.spark_catalog.type                 hive
spark.sql.catalog.rest                               org.apache.iceberg.spark.SparkCatalog
spark.sql.catalog.rest.type                          rest
spark.sql.catalog.rest.uri                           http://localhost:8181
spark.sql.catalog.rest.warehouse                     s3://warehouse/
spark.sql.catalog.rest.io-impl                       org.apache.iceberg.aws.s3.S3FileIO
spark.sql.catalog.rest.s3.endpoint                   http://localhost:9000
spark.sql.catalog.rest.s3.path-style-access          true
spark.sql.catalog.rest.s3.access-key-id              admin
spark.sql.catalog.rest.s3.secret-access-key          password
spark.sql.catalog.rest.client.region                 us-east-1
spark.sql.defaultCatalog                             rest
```
```
spark-sql --properties-file ./spark-defaults.conf
```

## Rendered Docs
### `site/docs/spark-quickstart.md` (`http://127.0.0.1:8000/spark-quickstart/#adding-catalogs`)
![Screenshot 2024-12-22 at 2 23 16 PM](https://github.com/user-attachments/assets/b13fed25-4d76-481e-9c6f-defdc5a7cfe0)

### `docs/docs/spark-getting-started.md` (`http://127.0.0.1:8000/docs/nightly/spark-getting-started/#adding-catalogs`)
![Screenshot 2024-12-22 at 2 24 07 PM](https://github.com/user-attachments/assets/a5d7056e-820b-4c42-a292-a14b5575f802)

### `site/docs/how-to-release.md` (`http://127.0.0.1:8000/how-to-release/#verifying-with-spark`)
![Screenshot 2024-12-22 at 2 24 28 PM](https://github.com/user-attachments/assets/48b934ba-c941-41f1-aed0-b176d7cf0af1)
