### PR TITLE
Revert "Hive: close the fileIO client when closing the hive catalog"

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.hive;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +52,6 @@ import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.io.FileIOTracker;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -92,7 +90,6 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
   private ClientPool<IMetaStoreClient, TException> clients;
   private boolean listAllTables = false;
   private Map<String, String> catalogProperties;
-  private FileIOTracker fileIOTracker;
 
   public HiveCatalog() {}
 
@@ -125,7 +122,6 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
             : CatalogUtil.loadFileIO(fileIOImpl, properties, conf);
 
     this.clients = new CachedClientPool(conf, properties);
-    this.fileIOTracker = new FileIOTracker();
   }
 
   @Override
@@ -666,10 +662,7 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
   public TableOperations newTableOps(TableIdentifier tableIdentifier) {
     String dbName = tableIdentifier.namespace().level(0);
     String tableName = tableIdentifier.name();
-    HiveTableOperations ops =
-        new HiveTableOperations(conf, clients, fileIO, name, dbName, tableName);
-    fileIOTracker.track(ops);
-    return ops;
+    return new HiveTableOperations(conf, clients, fileIO, name, dbName, tableName);
   }
 
   @Override
@@ -796,14 +789,6 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
   @Override
   protected Map<String, String> properties() {
     return catalogProperties == null ? ImmutableMap.of() : catalogProperties;
-  }
-
-  @Override
-  public void close() throws IOException {
-    super.close();
-    if (fileIOTracker != null) {
-      fileIOTracker.close();
-    }
   }
 
   @VisibleForTesting


### PR DESCRIPTION
This reverts commit 7e2920af400e5d559f8f1742b1043787b0477d74 from #10771.

Issue reported in https://github.com/apache/iceberg/issues/11783, https://github.com/apache/iceberg/issues/11633 and https://github.com/apache/iceberg/issues/11582. 

I was able to reproduce this on PyIceberg https://github.com/apache/iceberg-python/pull/1323, and while doing a `git bisect`, this led me to this PR:

```
➜  iceberg git:(7e2920af4) git bisect bad       
7e2920af400e5d559f8f1742b1043787b0477d74 is the first bad commit
commit 7e2920af400e5d559f8f1742b1043787b0477d74
Author: Hussein Awala <hussein@awala.fr>
Date:   Thu Jul 25 19:50:19 2024 +0200

    Hive: close the fileIO client when closing the hive catalog (#10771)
    
    Co-authored-by: Amogh Jahagirdar <amoghj@apache.org>
    Co-authored-by: Eduard Tudenhoefner <etudenhoefner@gmail.com>

 .../java/org/apache/iceberg/hive/HiveCatalog.java  | 33 +++++++++++++++++++++-
 1 file changed, 32 insertions(+), 1 deletion(-)
```

For now, I suggest reverting it to backport this to 1.7.2. 

Closes https://github.com/apache/iceberg/issues/11783
Closes https://github.com/apache/iceberg/issues/11633

cc @hussein-awala @nastra @amogh-jahagirdar 