### PR TITLE
Core: check catalog and schema for JdbcCatalog initialization

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -162,8 +162,8 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
             DatabaseMetaData dbMeta = conn.getMetaData();
             ResultSet tableExists =
                 dbMeta.getTables(
-                    null /* catalog name */,
-                    null /* schemaPattern */,
+                    conn.getCatalog() /* catalog name */,
+                    escape(conn.getSchema(), dbMeta.getSearchStringEscape()) /* schemaPattern */,
                     JdbcUtil.CATALOG_TABLE_VIEW_NAME /* tableNamePattern */,
                     null /* types */);
             if (tableExists.next()) {
@@ -181,8 +181,8 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
             DatabaseMetaData dbMeta = conn.getMetaData();
             ResultSet tableExists =
                 dbMeta.getTables(
-                    null /* catalog name */,
-                    null /* schemaPattern */,
+                    conn.getCatalog() /* catalog name */,
+                    escape(conn.getSchema(), dbMeta.getSearchStringEscape()) /* schemaPattern */,
                     JdbcUtil.NAMESPACE_PROPERTIES_TABLE_NAME /* tableNamePattern */,
                     null /* types */);
 
@@ -206,6 +206,10 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
       Thread.currentThread().interrupt();
       throw new UncheckedInterruptedException(e, "Interrupted in call to initialize");
     }
+  }
+
+  private static String escape(String name, String escape) {
+    return name.replace("_", escape + "_").replace("%", escape + "%");
   }
 
   private void updateSchemaIfRequired() {


### PR DESCRIPTION
Iceberg metadata table may not created automatically in some cases, see [#11423](https://github.com/apache/iceberg/issues/11423) and [#11862](https://github.com/apache/iceberg/issues/11862), In the semantics of JDBC, conn.getCatalog() and conn.getSchema() represent obtaining the catalog and schema of the current connection.I think this PR should be used to determine whether a table exists