### PR TITLE
Core: Fix typo in HadoopTableOperations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -344,7 +344,7 @@ public class HadoopTableOperations implements TableOperations {
 
         return maxVersion;
       } catch (IOException io) {
-        LOG.warn("Error trying to recover version-hint.txt data for {}", versionHintFile, e);
+        LOG.warn("Error trying to recover the latest version number for {}", versionHintFile, io);
         return 0;
       }
     }


### PR DESCRIPTION
`version-hint.txt` is incorrect and confusing as `version-hint.text` is the valid file name.