### PR TITLE
Adding new rewrite manifest spark action to accept custom partition o…

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteManifests.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteManifests.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.actions;
 
+import java.util.List;
 import java.util.function.Predicate;
 import org.apache.iceberg.ManifestFile;
 
@@ -43,6 +44,28 @@ public interface RewriteManifests
    * @return this for method chaining
    */
   RewriteManifests rewriteIf(Predicate<ManifestFile> predicate);
+
+  /**
+   * Rewrite manifests in a given order, based on partition field names
+   *
+   * <p>Supply an optional set of partition field names to cluster the rewritten manifests by. For
+   * example, given a table PARTITIONED BY (a, b, c, d), one may wish to rewrite and cluster
+   * manifests by ('d', 'b') only, based on known query patterns. Rewriting Manifests in this way
+   * will yield manifest_lists that point to manifest_files containing data files for common 'd' and
+   * 'b' partitions.
+   *
+   * <p>If not set, manifests will be rewritten in the order of the transforms in the table's
+   * current partition spec.
+   *
+   * @param partitionFields Exact transformed column names used for partitioning; not the raw column
+   *     names that partitions are derived from. E.G. supply 'data_bucket' and not 'data' for a
+   *     bucket(N, data) partition * definition
+   * @return this for method chaining
+   */
+  default RewriteManifests clusterBy(List<String> partitionFields) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " doesn't implement clusterBy(List<String>)");
+  }
 
   /**
    * Passes a location where the staged manifests should be written.


### PR DESCRIPTION
**Note** this is a fresh PR replacing https://github.com/apache/iceberg/pull/9731. It had too much accumulated conflicts and changes, I rebased and messed it up. This is a clean start with all previous feedback incorporated. 

## What
This adds a simple `sort` method to the `RewriteManifests` spark action which lets user specify the partition column order to consider when grouping manifests. 

Illustration: 

```
RewriteManifests.Result result =
        actions
            .rewriteManifests(table)
            .sort("c", "b", "a")  < -- this is the new api piece
            .execute();
```

Closes https://github.com/apache/iceberg/issues/9615


## Why
Iceberg's metadata is organized into a forest of manifest_files which point to data files sharing common partitions. By default, and during `RewriteManifests`, the partition grouping is determined by the default `Spec` partition order. If the primary query pattern is more aligned with the last partition in the table's spec, manifests are poorly suited to quickly plan and prune around those partitions. 

EG 
```
CREATE TABLE
...
PARTITIONED BY (region, storeId, bucket(ipAddress, 100), days(event_time)
```
Will create manifests that first group by `region`, whose `manifest_file` contents may span a wide range of `event_time` values. For a primary query pattern that doesn't care about `region`, `storeId`, etc, this leads to inefficient queries. 

