### PR TITLE
Spark 3.5, Core: Supplement test case for metadata_log_entries after expire snapshot

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataLogEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataLogEntriesTable.java
@@ -110,7 +110,8 @@ public class MetadataLogEntriesTable extends BaseMetadataTable {
       latestSnapshotId = SnapshotUtil.snapshotIdAsOfTime(table, metadataLogEntry.timestampMillis());
       latestSnapshot = table.snapshot(latestSnapshotId);
     } catch (IllegalArgumentException ignored) {
-      // implies this metadata file was created at table creation
+      // implies this metadata file was created at table creation or
+      // its corresponding or subsequent snapshot has been removed
     }
 
     return StaticDataTask.Row.of(

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1898,7 +1898,7 @@ public class TableMetadata implements Serializable {
           // any invalid entry causes the history before it to be removed. otherwise, there could be
           // history gaps that cause time-travel queries to produce incorrect results. for example,
           // if history is [(t1, s1), (t2, s2), (t3, s3)] and s2 is removed, the history cannot be
-          // [(t1, s1), (t3, s3)] because it appears that s3 was current during the time between t2
+          // [(t1, s1), (t3, s3)] because it appears that s1 was current during the time between t2
           // and t3 when in fact s2 was the current snapshot.
           newSnapshotLog.clear();
         }


### PR DESCRIPTION
When we query `metadata_log_entries` after expiring some intermediate snapshots, the log entries before the expired snapshot would not get their corresponding snapshots and then would show `null` in their result columns `latest_snapshot_id`, `latest_schema_id` and `latest_sequence_number`.

This PR supplement test case for this scenario to increase test coverage.

And fix some typos in the code comments in `TableMetadata` and `MetadataLogEntriesTable`.