### PR TITLE
Docs: Add history to Hive's metadata tables

### DIFF
--- a/docs/docs/hive.md
+++ b/docs/docs/hive.md
@@ -747,18 +747,20 @@ To reference a metadata table the full name of the table should be used, like:
 
 Currently the following metadata tables are available in Hive:
 
-* all_data_files 
-* all_delete_files 
-* all_entries all_files 
-* all_manifests 
-* data_files 
-* delete_files 
-* entries 
-* files 
-* manifests 
-* metadata_log_entries 
-* partitions 
-* refs 
+* all_data_files
+* all_delete_files
+* all_entries
+* all_files
+* all_manifests
+* data_files
+* delete_files
+* entries
+* files
+* history
+* manifests
+* metadata_log_entries
+* partitions
+* refs
 * snapshots
 
 ```sql


### PR DESCRIPTION
Hive supports the `history` table.
https://github.com/apache/hive/blob/master/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergMetadataTables.java

I verified it would work with the latest version, 4.0.1.

```
0: jdbc:hive2://localhost:10000/> CREATE TABLE test (id INT) STORED BY ICEBERG;
...
0: jdbc:hive2://localhost:10000/> INSERT INTO test VALUES (1);
...
0: jdbc:hive2://localhost:10000/> INSERT INTO test VALUES (2);
...
0: jdbc:hive2://localhost:10000/> SELECT * FROM default.test.history;
...
+----------------------------------+----------------------+----------------------+---------------------------+
|       test.made_current_at       |   test.snapshot_id   |    test.parent_id    | test.is_current_ancestor  |
+----------------------------------+----------------------+----------------------+---------------------------+
| 2025-01-02 10:14:19.954 Etc/UTC  | 4408216953068462947  | NULL                 | true                      |
| 2025-01-02 10:14:22.559 Etc/UTC  | 4271863120661887759  | 4408216953068462947  | true                      |
+----------------------------------+----------------------+----------------------+---------------------------+
...
0: jdbc:hive2://localhost:10000/> SELECT version();
...
+--------------------------------------------------+
|                       _c0                        |
+--------------------------------------------------+
| 4.0.1 r3af4517eb8cfd9407ad34ed78a0b48b57dfaa264  |
+--------------------------------------------------+
```