### PR TITLE
[Core] Support Truncate(0) for metrics

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/BinaryUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BinaryUtil.java
@@ -69,6 +69,9 @@ public class BinaryUtil {
    * the given input
    */
   public static Literal<ByteBuffer> truncateBinaryMin(Literal<ByteBuffer> input, int length) {
+    if (length == 0) {
+      return null;
+    }
     ByteBuffer inputBuffer = input.value();
     if (length >= inputBuffer.remaining()) {
       return input;
@@ -81,6 +84,9 @@ public class BinaryUtil {
    * than the given input
    */
   public static Literal<ByteBuffer> truncateBinaryMax(Literal<ByteBuffer> input, int length) {
+    if (length == 0) {
+      return null;
+    }
     ByteBuffer inputBuffer = input.value();
     if (length >= inputBuffer.remaining()) {
       return input;

--- a/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
@@ -39,7 +39,7 @@ public class UnicodeUtil {
    * length
    */
   public static CharSequence truncateString(CharSequence input, int length) {
-    Preconditions.checkArgument(length > 0, "Truncate length should be positive");
+    Preconditions.checkArgument(length >= 0, "Truncate length should be non-negative");
     StringBuilder sb = new StringBuilder(input);
     // Get the number of unicode characters in the input
     int numUniCodeCharacters = sb.codePointCount(0, sb.length());
@@ -60,6 +60,9 @@ public class UnicodeUtil {
    */
   public static Literal<CharSequence> truncateStringMin(Literal<CharSequence> input, int length) {
     // Truncate the input to the specified truncate length.
+    if (length == 0) {
+      return null;
+    }
     CharSequence truncatedInput = truncateString(input.value(), length);
     return Literal.of(truncatedInput);
   }
@@ -69,6 +72,9 @@ public class UnicodeUtil {
    * of unicode characters in the truncated charSequence is lesser than or equal to length
    */
   public static Literal<CharSequence> truncateStringMax(Literal<CharSequence> input, int length) {
+    if (length == 0) {
+      return null;
+    }
     CharSequence inputCharSeq = input.value();
     // Truncate the input to the specified truncate length.
     StringBuilder truncatedStringBuilder = new StringBuilder(truncateString(inputCharSeq, length));

--- a/core/src/main/java/org/apache/iceberg/MetricsModes.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsModes.java
@@ -94,7 +94,8 @@ public class MetricsModes {
 
   /**
    * Under this mode, value_counts, null_value_counts, nan_value_counts and truncated lower_bounds,
-   * upper_bounds are persisted.
+   * upper_bounds are persisted. If truncate is set to 0 then the no values will be persisted for
+   * binaries or strings.
    */
   public static class Truncate extends ProxySerializableMetricsMode {
     private final int length;
@@ -104,7 +105,7 @@ public class MetricsModes {
     }
 
     public static Truncate withLength(int length) {
-      Preconditions.checkArgument(length > 0, "Truncate length should be positive");
+      Preconditions.checkArgument(length >= 0, "Truncate length should be non-negative");
       return new Truncate(length);
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
@@ -63,6 +63,7 @@ public class TestMetricsModes {
     assertThat(MetricsModes.fromString("nOnE")).isEqualTo(None.get());
     assertThat(MetricsModes.fromString("counts")).isEqualTo(Counts.get());
     assertThat(MetricsModes.fromString("coUntS")).isEqualTo(Counts.get());
+    assertThat(MetricsModes.fromString("truncate(0)")).isEqualTo(Truncate.withLength(0));
     assertThat(MetricsModes.fromString("truncate(1)")).isEqualTo(Truncate.withLength(1));
     assertThat(MetricsModes.fromString("truNcAte(10)")).isEqualTo(Truncate.withLength(10));
     assertThat(MetricsModes.fromString("full")).isEqualTo(Full.get());
@@ -71,9 +72,9 @@ public class TestMetricsModes {
 
   @TestTemplate
   public void testInvalidTruncationLength() {
-    assertThatThrownBy(() -> MetricsModes.fromString("truncate(0)"))
+    assertThatThrownBy(() -> MetricsModes.fromString("truncate(-1)"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Truncate length should be positive");
+        .hasMessage("Truncate length should be non-negative");
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestMetricsTruncation.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsTruncation.java
@@ -96,6 +96,7 @@ public class TestMetricsTruncation {
             "Output must have the first two bytes of the input. A lower bound exists "
                 + "even though the first two bytes are the max value")
         .isEqualTo(0);
+    assertThat(truncateBinaryMin(Literal.of(test2), 0)).isNull();
   }
 
   @Test
@@ -135,6 +136,7 @@ public class TestMetricsTruncation {
             "Since a shorter sequence is considered smaller, output must have two bytes "
                 + "and the second byte of the input must be incremented")
         .isEqualTo(0);
+    assertThat(truncateBinaryMax(Literal.of(test4), 0)).isNull();
   }
 
   @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
@@ -182,6 +184,7 @@ public class TestMetricsTruncation {
     assertThat(cmp.compare(truncateStringMin(Literal.of(test4), 1).value(), test4_1_expected))
         .as("Output must have the first 4 byte UTF-8 character of the input")
         .isEqualTo(0);
+    assertThat(truncateStringMax(Literal.of(test4), 0)).isNull();
   }
 
   @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
@@ -301,5 +304,6 @@ public class TestMetricsTruncation {
             "Test the last character is `Character.MIN_SURROGATE - 1` after truncated, it should be incremented to "
                 + "next valid Unicode scalar value `Character.MAX_SURROGATE + 1`")
         .isEqualTo(0);
+    assertThat(truncateStringMax(Literal.of(test9), 0)).isNull();
   }
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -335,7 +335,6 @@ public class OrcMetrics {
     CharSequence charSequence = (CharSequence) value;
     MetricsModes.Truncate truncateMode = (MetricsModes.Truncate) metricsMode;
     int truncateLength = truncateMode.length();
-
     switch (bound) {
       case UPPER:
         return Optional.ofNullable(

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -286,13 +286,19 @@ public class ParquetUtil {
         int truncateLength = truncateMode.length();
         switch (type.typeId()) {
           case STRING:
-            lowerBounds.put(
-                id, UnicodeUtil.truncateStringMin((Literal<CharSequence>) min, truncateLength));
+            Literal<CharSequence> truncatedStringMin =
+                UnicodeUtil.truncateStringMin((Literal<CharSequence>) min, truncateLength);
+            if (truncatedStringMin != null) {
+              lowerBounds.put(id, truncatedStringMin);
+            }
             break;
           case FIXED:
           case BINARY:
-            lowerBounds.put(
-                id, BinaryUtil.truncateBinaryMin((Literal<ByteBuffer>) min, truncateLength));
+            Literal<ByteBuffer> truncatedBinaryMin =
+                BinaryUtil.truncateBinaryMin((Literal<ByteBuffer>) min, truncateLength);
+            if (truncatedBinaryMin != null) {
+              lowerBounds.put(id, truncatedBinaryMin);
+            }
             break;
           default:
             lowerBounds.put(id, min);
@@ -322,6 +328,7 @@ public class ParquetUtil {
             if (truncatedMaxString != null) {
               upperBounds.put(id, truncatedMaxString);
             }
+
             break;
           case FIXED:
           case BINARY:


### PR DESCRIPTION
**Background**
At Pinterest, we've started utilizing iceberg metrics considerably for offline validation as well as query speedups. Counts are consistently useful for all columns and upper/lowerbound is useful for numeric columns.; however, for struct columns (typically objects with encoded strings), ranges are relatively useless and just cause space overhead with potential driver OOM. There isn't an easy way to specify metrics per data type so wanted to contribute a solution which allows to specify truncate limit as 0 which just causes strings and binaries to be fully truncated.

**Changes**
Updated checks in Truncate MetricsMode to allow for non-negative rather than strictly positive length. Updated appropriate checks in order to only input into bounds map if non null 

**Tests**

Added appropriate unit tests 