### PR TITLE
Use SupportsPrefixOperations for Remove OrphanFile Procedure

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/LocationProvider.java
+++ b/api/src/main/java/org/apache/iceberg/io/LocationProvider.java
@@ -45,4 +45,6 @@ public interface LocationProvider extends Serializable {
    * @return a fully-qualified location URI for a data file
    */
   String newDataLocation(PartitionSpec spec, StructLike partitionData, String filename);
+
+  String dataLocationRoot();
 }

--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -102,9 +102,14 @@ public class LocationProviders {
     public String newDataLocation(String filename) {
       return String.format("%s/%s", dataLocation, filename);
     }
+
+    @Override
+    public String dataLocationRoot() {
+      return dataLocation;
+    }
   }
 
-  static class ObjectStoreLocationProvider implements LocationProvider {
+  public static class ObjectStoreLocationProvider implements LocationProvider {
 
     private static final HashFunction HASH_FUNC = Hashing.murmur3_32_fixed();
     // Length of entropy generated in the file location
@@ -227,6 +232,11 @@ public class LocationProviders {
       }
 
       return hashWithDirs.toString();
+    }
+
+    @Override
+    public String dataLocationRoot() {
+      return storageLocation;
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -57,6 +57,11 @@ public class TestLocationProvider extends TestBase {
     public String newDataLocation(PartitionSpec spec, StructLike partitionData, String filename) {
       throw new RuntimeException("Test custom provider does not expect any invocation");
     }
+
+    @Override
+    public String dataLocationRoot() {
+      return tableLocation;
+    }
   }
 
   // publicly visible for testing to be dynamically loaded
@@ -71,6 +76,11 @@ public class TestLocationProvider extends TestBase {
     @Override
     public String newDataLocation(PartitionSpec spec, StructLike partitionData, String filename) {
       throw new RuntimeException("Test custom provider does not expect any invocation");
+    }
+
+    @Override
+    public String dataLocationRoot() {
+      return "";
     }
   }
 
@@ -87,6 +97,11 @@ public class TestLocationProvider extends TestBase {
     @Override
     public String newDataLocation(PartitionSpec spec, StructLike partitionData, String filename) {
       throw new RuntimeException("Invalid provider should have not been instantiated!");
+    }
+
+    @Override
+    public String dataLocationRoot() {
+      return "";
     }
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -634,11 +634,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
       }
 
       // if any of the parent folders is not accepted then return false
-      if (hasHiddenPttParentFolder(path)) {
-        return false;
-      }
-
-      return doAccept(path);
+      return doAccept(path) && !hasHiddenPttParentFolder(path);
     }
 
     private boolean doAccept(Path path) {


### PR DESCRIPTION
Continuing  #7914

- [x] added pathFilter to new method (`listWithPrefix`), `PartitionAwareHiddenPathFilter`
- [x] Added tests that new method and previous one returns same values
- [x] Fix failing test `testHiddenPathsStartingWithPartitionNamesAreIgnored`


With this change, current executions now use `HadoopFileIO`, which implements `DelegateFileIO` and `SupportPrefixOperations`. This results in calls to the new `listWithPrefix` method.