### PR TITLE
[Docs] Update spark-getting-started docs page to make the example valid

### DIFF
--- a/docs/docs/spark-getting-started.md
+++ b/docs/docs/spark-getting-started.md
@@ -83,12 +83,16 @@ Iceberg also adds row-level SQL updates to Spark, [`MERGE INTO`](spark-writes.md
 
 ```sql
 CREATE TABLE local.db.updates (id bigint, data string) USING iceberg;
+
 INSERT INTO local.db.updates VALUES (1, 'x'), (2, 'y'), (4, 'z');
 
 MERGE INTO local.db.table t
 USING (SELECT * FROM local.db.updates) u ON t.id = u.id
 WHEN MATCHED THEN UPDATE SET t.data = u.data
 WHEN NOT MATCHED THEN INSERT *;
+
+-- ((1, 'x'), (2, 'y'), (3, 'c'), (4, 'z'))
+SELECT * FROM local.db.table;
 ```
 
 Iceberg supports writing DataFrames using the new [v2 DataFrame write API](spark-writes.md#writing-with-dataframes):
@@ -163,7 +167,7 @@ This type conversion table describes how Spark types are converted to the Iceber
 | map             | map                        |       |
 
 !!! info
-    The table is based on type conversions during table creation. Broader type conversions are applied on write:
+    Broader type conversions are applied on write:
 
     * Iceberg numeric types (`integer`, `long`, `float`, `double`, `decimal`) support promotion during writes. e.g. You can write Spark types `short`, `byte`, `integer`, `long` to Iceberg type `long`.
     * You can write to Iceberg `fixed` type using Spark `binary` type. Note that assertion on the length will be performed.

--- a/spark/v3.3/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
+++ b/spark/v3.3/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
@@ -80,9 +80,9 @@ public class SmokeTest extends SparkExtensionsTestBase {
         "x",
         scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
     Assert.assertEquals(
-            "Record 2 should now have data y",
-            "y",
-            scalarSql("SELECT data FROM %s WHERE id = 2", tableName));
+        "Record 2 should now have data y",
+        "y",
+        scalarSql("SELECT data FROM %s WHERE id = 2", tableName));
 
     // Not supported because of Spark limitation
     if (!catalogName.equals("spark_catalog")) {

--- a/spark/v3.3/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
+++ b/spark/v3.3/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
@@ -40,8 +40,6 @@ public class SmokeTest extends SparkExtensionsTestBase {
   }
 
   // Run through our Doc's Getting Started Example
-  // TODO Update doc example so that it can actually be run, modifications were required for this
-  // test suite to run
   @Test
   public void testGettingStarted() throws IOException {
     // Creating a table
@@ -66,25 +64,25 @@ public class SmokeTest extends SparkExtensionsTestBase {
     sql(
         "CREATE TABLE updates (id bigint, data string) USING parquet LOCATION '%s'",
         temp.newFolder());
-    sql("INSERT INTO updates VALUES (1, 'x'), (2, 'x'), (4, 'z')");
+    sql("INSERT INTO updates VALUES (1, 'x'), (2, 'y'), (4, 'z')");
 
     sql(
         "MERGE INTO %s t USING (SELECT * FROM updates) u ON t.id = u.id\n"
             + "WHEN MATCHED THEN UPDATE SET t.data = u.data\n"
             + "WHEN NOT MATCHED THEN INSERT *",
         tableName);
+
+    // Reading
     Assert.assertEquals(
         "Table should now have 5 rows", 5L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
     Assert.assertEquals(
         "Record 1 should now have data x",
         "x",
         scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
-
-    // Reading
     Assert.assertEquals(
-        "There should be 2 records with data x",
-        2L,
-        scalarSql("SELECT count(1) as count FROM %s WHERE data = 'x' GROUP BY data ", tableName));
+            "Record 2 should now have data y",
+            "y",
+            scalarSql("SELECT data FROM %s WHERE id = 2", tableName));
 
     // Not supported because of Spark limitation
     if (!catalogName.equals("spark_catalog")) {

--- a/spark/v3.4/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
+++ b/spark/v3.4/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
@@ -42,8 +42,6 @@ public class SmokeTest extends SparkExtensionsTestBase {
   }
 
   // Run through our Doc's Getting Started Example
-  // TODO Update doc example so that it can actually be run, modifications were required for this
-  // test suite to run
   @Test
   public void testGettingStarted() throws IOException {
     // Creating a table
@@ -68,25 +66,25 @@ public class SmokeTest extends SparkExtensionsTestBase {
     sql(
         "CREATE TABLE updates (id bigint, data string) USING parquet LOCATION '%s'",
         temp.newFolder());
-    sql("INSERT INTO updates VALUES (1, 'x'), (2, 'x'), (4, 'z')");
+    sql("INSERT INTO updates VALUES (1, 'x'), (2, 'y'), (4, 'z')");
 
     sql(
         "MERGE INTO %s t USING (SELECT * FROM updates) u ON t.id = u.id\n"
             + "WHEN MATCHED THEN UPDATE SET t.data = u.data\n"
             + "WHEN NOT MATCHED THEN INSERT *",
         tableName);
+
+    // Reading
     Assert.assertEquals(
         "Table should now have 5 rows", 5L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
     Assert.assertEquals(
         "Record 1 should now have data x",
         "x",
         scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
-
-    // Reading
     Assert.assertEquals(
-        "There should be 2 records with data x",
-        2L,
-        scalarSql("SELECT count(1) as count FROM %s WHERE data = 'x' GROUP BY data ", tableName));
+            "Record 2 should now have data y",
+            "y",
+            scalarSql("SELECT data FROM %s WHERE id = 2", tableName));
 
     // Not supported because of Spark limitation
     if (!catalogName.equals("spark_catalog")) {

--- a/spark/v3.4/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
+++ b/spark/v3.4/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
@@ -82,9 +82,9 @@ public class SmokeTest extends SparkExtensionsTestBase {
         "x",
         scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
     Assert.assertEquals(
-            "Record 2 should now have data y",
-            "y",
-            scalarSql("SELECT data FROM %s WHERE id = 2", tableName));
+        "Record 2 should now have data y",
+        "y",
+        scalarSql("SELECT data FROM %s WHERE id = 2", tableName));
 
     // Not supported because of Spark limitation
     if (!catalogName.equals("spark_catalog")) {

--- a/spark/v3.5/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
+++ b/spark/v3.5/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
@@ -80,8 +80,8 @@ public class SmokeTest extends ExtensionsTestBase {
         .as("Record 1 should now have data x")
         .isEqualTo("x");
     assertThat(scalarSql("SELECT data FROM %s WHERE id = 2", tableName))
-            .as("Record 2 should now have data y")
-            .isEqualTo("y");
+        .as("Record 2 should now have data y")
+        .isEqualTo("y");
 
     // Not supported because of Spark limitation
     if (!catalogName.equals("spark_catalog")) {


### PR DESCRIPTION
The [Spark Getting Started docs page](https://iceberg.apache.org/docs/nightly/spark-getting-started/) has intro Spark examples but they reference tables and columns that do not exist. This is one of the first docs pages that new Iceberg users will see ... having a correct example that someone can run is helpful to them.

I found this as I was reading the project's tests and saw this TODO marked in SmokeTest.java:

https://github.com/apache/iceberg/blob/67e084c8d47db68c6135f9837b9cff6f88da0309/spark/v3.3/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java#L42-L44

I've updated the docs in line with the test cases, and also made a minor change to the example a bit to make it more clear - each MERGE sets a unique `data` value for each `id`.


### Testing
- [x] Ran the tests modified in this PR - they pass
- [x] Built the site locally as documented [here](https://github.com/apache/iceberg/blob/main/site/README.md) and loaded the modified page

<img width="758" alt="spark-getting-started" src="https://github.com/user-attachments/assets/4a9338e2-ab38-48ae-9e9c-589b74a010bc" />