### PR TITLE
Spark: support statistics files in RewriteTablePath

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.PositionDelete;
@@ -127,8 +128,8 @@ public class RewriteTablePathUtil {
         metadata.snapshotLog(),
         metadataLogEntries,
         metadata.refs(),
-        // TODO: update statistic file paths
-        metadata.statisticsFiles(),
+        updatePathInStatisticsFiles(metadata.statisticsFiles(), sourcePrefix, targetPrefix),
+        // TODO: update partition statistics file paths
         metadata.partitionStatisticsFiles(),
         metadata.changes(),
         metadata.rowLineageEnabled(),
@@ -158,6 +159,20 @@ public class RewriteTablePathUtil {
       properties.put(
           propertyName, newPath(properties.get(propertyName), sourcePrefix, targetPrefix));
     }
+  }
+
+  private static List<StatisticsFile> updatePathInStatisticsFiles(
+      List<StatisticsFile> statisticsFiles, String sourcePrefix, String targetPrefix) {
+    return statisticsFiles.stream()
+        .map(
+            existing ->
+                new GenericStatisticsFile(
+                    existing.snapshotId(),
+                    newPath(existing.path(), sourcePrefix, targetPrefix),
+                    existing.fileSizeInBytes(),
+                    existing.fileFooterSizeInBytes(),
+                    existing.blobMetadata()))
+        .collect(Collectors.toList());
   }
 
   private static List<TableMetadata.MetadataLogEntry> updatePathInMetadataLogs(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.RewriteTablePathUtil.RewriteResult;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
@@ -272,8 +273,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
         ((HasTableOperations) newStaticTable(endVersionName, table.io())).operations().current();
 
     Preconditions.checkArgument(
-        endMetadata.statisticsFiles() == null || endMetadata.statisticsFiles().isEmpty(),
-        "Statistic files are not supported yet.");
+        endMetadata.partitionStatisticsFiles() == null
+            || endMetadata.partitionStatisticsFiles().isEmpty(),
+        "Partition statistics files are not supported yet.");
 
     // rebuild version files
     RewriteResult<Snapshot> rewriteVersionResult = rewriteVersionFiles(endMetadata);
@@ -341,7 +343,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   private RewriteResult<Snapshot> rewriteVersionFiles(TableMetadata endMetadata) {
     RewriteResult<Snapshot> result = new RewriteResult<>();
     result.toRewrite().addAll(endMetadata.snapshots());
-    result.copyPlan().add(rewriteVersionFile(endMetadata, endVersionName));
+    result.copyPlan().addAll(rewriteVersionFile(endMetadata, endVersionName));
 
     List<MetadataLogEntry> versions = endMetadata.previousFiles();
     for (int i = versions.size() - 1; i >= 0; i--) {
@@ -357,19 +359,50 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
           new StaticTableOperations(versionFilePath, table.io()).current();
 
       result.toRewrite().addAll(tableMetadata.snapshots());
-      result.copyPlan().add(rewriteVersionFile(tableMetadata, versionFilePath));
+      result.copyPlan().addAll(rewriteVersionFile(tableMetadata, versionFilePath));
     }
 
     return result;
   }
 
-  private Pair<String, String> rewriteVersionFile(TableMetadata metadata, String versionFilePath) {
+  private Set<Pair<String, String>> rewriteVersionFile(
+      TableMetadata metadata, String versionFilePath) {
+    Set<Pair<String, String>> result = Sets.newHashSet();
     String stagingPath = RewriteTablePathUtil.stagingPath(versionFilePath, stagingDir);
     TableMetadata newTableMetadata =
         RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix);
     TableMetadataParser.overwrite(newTableMetadata, table.io().newOutputFile(stagingPath));
-    return Pair.of(
-        stagingPath, RewriteTablePathUtil.newPath(versionFilePath, sourcePrefix, targetPrefix));
+    result.add(
+        Pair.of(
+            stagingPath,
+            RewriteTablePathUtil.newPath(versionFilePath, sourcePrefix, targetPrefix)));
+
+    // include statistics files in copy plan
+    result.addAll(
+        copyPlanStatisticsFiles(metadata.statisticsFiles(), newTableMetadata.statisticsFiles()));
+    return result;
+  }
+
+  private Set<Pair<String, String>> copyPlanStatisticsFiles(
+      List<StatisticsFile> beforeStats, List<StatisticsFile> afterStats) {
+    Set<Pair<String, String>> result = Sets.newHashSet();
+    if (beforeStats.isEmpty()) {
+      return result;
+    }
+
+    Preconditions.checkArgument(
+        beforeStats.size() == afterStats.size(),
+        "Before and after path rewrite, statistic files count should be same");
+    for (int i = 0; i < beforeStats.size(); i++) {
+      StatisticsFile before = beforeStats.get(i);
+      StatisticsFile after = afterStats.get(i);
+      Preconditions.checkArgument(
+          before.fileSizeInBytes() == after.fileSizeInBytes(),
+          "Before and after path rewrite, statistic file size should be same");
+      result.add(
+          Pair.of(RewriteTablePathUtil.stagingPath(before.path(), stagingDir), after.path()));
+    }
+    return result;
   }
 
   /**

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -379,11 +379,11 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
 
     // include statistics files in copy plan
     result.addAll(
-        copyPlanStatisticsFiles(metadata.statisticsFiles(), newTableMetadata.statisticsFiles()));
+        statsFileCopyPlan(metadata.statisticsFiles(), newTableMetadata.statisticsFiles()));
     return result;
   }
 
-  private Set<Pair<String, String>> copyPlanStatisticsFiles(
+  private Set<Pair<String, String>> statsFileCopyPlan(
       List<StatisticsFile> beforeStats, List<StatisticsFile> afterStats) {
     Set<Pair<String, String>> result = Sets.newHashSet();
     if (beforeStats.isEmpty()) {


### PR DESCRIPTION
Statistics files are helpful to determine the NDV for each columns in a table and can be collected via engines like [trino](https://trino.io/docs/current/connector/iceberg.html#updating-table-statistics) or [spark ](https://iceberg.apache.org/docs/nightly/spark-procedures/#compute_table_stats)

This patch help support table statistics files as part of rewrite table path spark action. 

@szehon-ho @flyrain if you want to take a look