### PR TITLE
Support sanitizing a `Literal<?>`

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -511,6 +511,10 @@ public class ExpressionUtil {
     return sanitizedValues;
   }
 
+  private static String sanitize(Type type, Literal<?> lit, long now, int today) {
+    return sanitize(type, lit.value(), now, today);
+  }
+
   private static String sanitize(Type type, Object value, long now, int today) {
     switch (type.typeId()) {
       case INTEGER:

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -418,6 +418,10 @@ public class TestExpressionUtil {
         ExpressionUtil.sanitize(Expressions.equal("test", "2022-04-29")));
 
     assertEquals(
+            Expressions.equal("date", "(date)"),
+            ExpressionUtil.sanitize(Expressions.equal("date", "2022-04-29").bind(STRUCT, true)));
+
+    assertEquals(
         Expressions.equal("date", "(date)"),
         ExpressionUtil.sanitize(STRUCT, Expressions.equal("date", "2022-04-29"), true));
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -418,8 +418,8 @@ public class TestExpressionUtil {
         ExpressionUtil.sanitize(Expressions.equal("test", "2022-04-29")));
 
     assertEquals(
-            Expressions.equal("date", "(date)"),
-            ExpressionUtil.sanitize(Expressions.equal("date", "2022-04-29").bind(STRUCT, true)));
+        Expressions.equal("date", "(date)"),
+        ExpressionUtil.sanitize(Expressions.equal("date", "2022-04-29").bind(STRUCT, true)));
 
     assertEquals(
         Expressions.equal("date", "(date)"),


### PR DESCRIPTION
This is the fixed code that corrected the casting error that occurred in the issue below.
I have also added one TestCode.

#11932