### PR TITLE
Open-API: Bump to OpenAPI 3.1

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -132,11 +132,15 @@ class ExpressionType(BaseModel):
 
 
 class TrueExpression(BaseModel):
-    type: ExpressionType
+    type: ExpressionType = Field(
+        default_factory=lambda: ExpressionType.parse_obj('true'), const=True
+    )
 
 
 class FalseExpression(BaseModel):
-    type: ExpressionType
+    type: ExpressionType = Field(
+        default_factory=lambda: ExpressionType.parse_obj('false'), const=True
+    )
 
 
 class Reference(BaseModel):
@@ -276,17 +280,17 @@ class AssignUUIDUpdate(BaseUpdate):
     Assigning a UUID to a table/view should only be done when creating the table/view. It is not safe to re-assign the UUID if a table/view already has a UUID assigned
     """
 
-    action: Literal['assign-uuid']
+    action: str = Field('assign-uuid', const=True)
     uuid: str
 
 
 class UpgradeFormatVersionUpdate(BaseUpdate):
-    action: Literal['upgrade-format-version']
+    action: str = Field('upgrade-format-version', const=True)
     format_version: int = Field(..., alias='format-version')
 
 
 class SetCurrentSchemaUpdate(BaseUpdate):
-    action: Literal['set-current-schema']
+    action: str = Field('set-current-schema', const=True)
     schema_id: int = Field(
         ...,
         alias='schema-id',
@@ -295,12 +299,12 @@ class SetCurrentSchemaUpdate(BaseUpdate):
 
 
 class AddPartitionSpecUpdate(BaseUpdate):
-    action: Literal['add-spec']
+    action: str = Field('add-spec', const=True)
     spec: PartitionSpec
 
 
 class SetDefaultSpecUpdate(BaseUpdate):
-    action: Literal['set-default-spec']
+    action: str = Field('set-default-spec', const=True)
     spec_id: int = Field(
         ...,
         alias='spec-id',
@@ -309,12 +313,12 @@ class SetDefaultSpecUpdate(BaseUpdate):
 
 
 class AddSortOrderUpdate(BaseUpdate):
-    action: Literal['add-sort-order']
+    action: str = Field('add-sort-order', const=True)
     sort_order: SortOrder = Field(..., alias='sort-order')
 
 
 class SetDefaultSortOrderUpdate(BaseUpdate):
-    action: Literal['set-default-sort-order']
+    action: str = Field('set-default-sort-order', const=True)
     sort_order_id: int = Field(
         ...,
         alias='sort-order-id',
@@ -323,47 +327,47 @@ class SetDefaultSortOrderUpdate(BaseUpdate):
 
 
 class AddSnapshotUpdate(BaseUpdate):
-    action: Literal['add-snapshot']
+    action: str = Field('add-snapshot', const=True)
     snapshot: Snapshot
 
 
 class SetSnapshotRefUpdate(BaseUpdate, SnapshotReference):
-    action: Literal['set-snapshot-ref']
+    action: str = Field('set-snapshot-ref', const=True)
     ref_name: str = Field(..., alias='ref-name')
 
 
 class RemoveSnapshotsUpdate(BaseUpdate):
-    action: Literal['remove-snapshots']
+    action: str = Field('remove-snapshots', const=True)
     snapshot_ids: List[int] = Field(..., alias='snapshot-ids')
 
 
 class RemoveSnapshotRefUpdate(BaseUpdate):
-    action: Literal['remove-snapshot-ref']
+    action: str = Field('remove-snapshot-ref', const=True)
     ref_name: str = Field(..., alias='ref-name')
 
 
 class SetLocationUpdate(BaseUpdate):
-    action: Literal['set-location']
+    action: str = Field('set-location', const=True)
     location: str
 
 
 class SetPropertiesUpdate(BaseUpdate):
-    action: Literal['set-properties']
+    action: str = Field('set-properties', const=True)
     updates: Dict[str, str]
 
 
 class RemovePropertiesUpdate(BaseUpdate):
-    action: Literal['remove-properties']
+    action: str = Field('remove-properties', const=True)
     removals: List[str]
 
 
 class AddViewVersionUpdate(BaseUpdate):
-    action: Literal['add-view-version']
+    action: str = Field('add-view-version', const=True)
     view_version: ViewVersion = Field(..., alias='view-version')
 
 
 class SetCurrentViewVersionUpdate(BaseUpdate):
-    action: Literal['set-current-view-version']
+    action: str = Field('set-current-view-version', const=True)
     view_version_id: int = Field(
         ...,
         alias='view-version-id',
@@ -372,89 +376,93 @@ class SetCurrentViewVersionUpdate(BaseUpdate):
 
 
 class RemoveStatisticsUpdate(BaseUpdate):
-    action: Literal['remove-statistics']
+    action: str = Field('remove-statistics', const=True)
     snapshot_id: int = Field(..., alias='snapshot-id')
 
 
 class RemovePartitionStatisticsUpdate(BaseUpdate):
-    action: Literal['remove-partition-statistics']
+    action: str = Field('remove-partition-statistics', const=True)
     snapshot_id: int = Field(..., alias='snapshot-id')
 
 
 class RemovePartitionSpecsUpdate(BaseUpdate):
-    action: Optional[Literal['remove-partition-specs']] = None
+    action: str = Field('remove-partition-specs', const=True)
     spec_ids: List[int] = Field(..., alias='spec-ids')
 
 
-class AssertCreate(BaseModel):
+class TableRequirement(BaseModel):
+    type: str
+
+
+class AssertCreate(TableRequirement):
     """
     The table must not already exist; used for create transactions
     """
 
-    type: Literal['assert-create']
+    type: str = Field(..., const=True)
 
 
-class AssertTableUUID(BaseModel):
+class AssertTableUUID(TableRequirement):
     """
     The table UUID must match the requirement's `uuid`
     """
 
-    type: Literal['assert-table-uuid']
+    type: str = Field(..., const=True)
     uuid: str
 
 
-class AssertRefSnapshotId(BaseModel):
+class AssertRefSnapshotId(TableRequirement):
     """
     The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; if `snapshot-id` is `null` or missing, the ref must not already exist
     """
 
-    type: Literal['assert-ref-snapshot-id']
+    type: str = Field('assert-ref-snapshot-id', const=True)
     ref: str
     snapshot_id: int = Field(..., alias='snapshot-id')
 
 
-class AssertLastAssignedFieldId(BaseModel):
+class AssertLastAssignedFieldId(TableRequirement):
     """
     The table's last assigned column id must match the requirement's `last-assigned-field-id`
     """
 
-    type: Literal['assert-last-assigned-field-id']
+    type: str = Field('assert-last-assigned-field-id', const=True)
     last_assigned_field_id: int = Field(..., alias='last-assigned-field-id')
 
 
-class AssertCurrentSchemaId(BaseModel):
+class AssertCurrentSchemaId(TableRequirement):
     """
     The table's current schema id must match the requirement's `current-schema-id`
     """
 
-    type: Literal['assert-current-schema-id']
+    type: str = Field('assert-current-schema-id', const=True)
     current_schema_id: int = Field(..., alias='current-schema-id')
 
 
-class AssertLastAssignedPartitionId(BaseModel):
+class AssertLastAssignedPartitionId(TableRequirement):
     """
     The table's last assigned partition id must match the requirement's `last-assigned-partition-id`
     """
 
-    type: Literal['assert-last-assigned-partition-id']
+    type: str = Field('assert-last-assigned-partition-id', const=True)
     last_assigned_partition_id: int = Field(..., alias='last-assigned-partition-id')
 
 
-class AssertDefaultSpecId(BaseModel):
+class AssertDefaultSpecId(TableRequirement):
     """
     The table's default spec id must match the requirement's `default-spec-id`
     """
 
-    type: Literal['assert-default-spec-id']
+    type: str = Field('assert-default-spec-id', const=True)
     default_spec_id: int = Field(..., alias='default-spec-id')
 
 
-class AssertDefaultSortOrderId(BaseModel):
+class AssertDefaultSortOrderId(TableRequirement):
     """
     The table's default sort order id must match the requirement's `default-sort-order-id`
     """
 
-    type: Literal['assert-default-sort-order-id']
+    type: str = Field('assert-default-sort-order-id', const=True)
     default_sort_order_id: int = Field(..., alias='default-sort-order-id')
 
 
@@ -463,7 +471,7 @@ class AssertViewUUID(BaseModel):
     The view UUID must match the requirement's `uuid`
     """
 
-    type: Literal['assert-view-uuid']
+    type: str = Field('assert-view-uuid', const=True)
     uuid: str
 
 
@@ -859,7 +867,7 @@ class ContentFile(BaseModel):
 
 
 class PositionDeleteFile(ContentFile):
-    content: Literal['position-deletes']
+    content: Literal['position-deletes'] = Field(..., const=True)
     content_offset: Optional[int] = Field(
         None,
         alias='content-offset',
@@ -873,7 +881,7 @@ class PositionDeleteFile(ContentFile):
 
 
 class EqualityDeleteFile(ContentFile):
-    content: Literal['equality-deletes']
+    content: Literal['equality-deletes'] = Field(..., const=True)
     equality_ids: Optional[List[int]] = Field(
         None, alias='equality-ids', description='List of equality field IDs'
     )
@@ -908,29 +916,16 @@ class RenameTableRequest(BaseModel):
 
 
 class TransformTerm(BaseModel):
-    type: Literal['transform']
+    type: str = Field('transform', const=True)
     transform: Transform
     term: Reference
 
 
 class SetPartitionStatisticsUpdate(BaseUpdate):
-    action: Literal['set-partition-statistics']
+    action: str = Field('set-partition-statistics', const=True)
     partition_statistics: PartitionStatisticsFile = Field(
         ..., alias='partition-statistics'
     )
-
-
-class TableRequirement(BaseModel):
-    __root__: Union[
-        AssertCreate,
-        AssertTableUUID,
-        AssertRefSnapshotId,
-        AssertLastAssignedFieldId,
-        AssertCurrentSchemaId,
-        AssertLastAssignedPartitionId,
-        AssertDefaultSpecId,
-        AssertDefaultSortOrderId,
-    ] = Field(..., discriminator='type')
 
 
 class ViewRequirement(BaseModel):
@@ -942,11 +937,11 @@ class FailedPlanningResult(IcebergErrorResponse):
     Failed server-side planning result
     """
 
-    status: Literal['failed']
+    status: Literal['failed'] = Field(..., const=True)
 
 
 class AsyncPlanningResult(BaseModel):
-    status: Literal['submitted']
+    status: Literal['submitted'] = Field(..., const=True)
     plan_id: Optional[str] = Field(
         None, alias='plan-id', description='ID used to track a planning request'
     )
@@ -982,7 +977,7 @@ class ValueMap(BaseModel):
 
 
 class DataFile(ContentFile):
-    content: Literal['data']
+    content: str = Field(..., const=True)
     column_sizes: Optional[CountMap] = Field(
         None,
         alias='column-sizes',
@@ -1028,7 +1023,7 @@ class Term(BaseModel):
 
 
 class SetStatisticsUpdate(BaseUpdate):
-    action: Literal['set-statistics']
+    action: str = Field('set-statistics', const=True)
     snapshot_id: int = Field(..., alias='snapshot-id')
     statistics: StatisticsFile
 
@@ -1060,19 +1055,19 @@ class StructField(BaseModel):
 
 
 class StructType(BaseModel):
-    type: Literal['struct']
+    type: str = Field('struct', const=True)
     fields: List[StructField]
 
 
 class ListType(BaseModel):
-    type: Literal['list']
+    type: str = Field('list', const=True)
     element_id: int = Field(..., alias='element-id')
     element: Type
     element_required: bool = Field(..., alias='element-required')
 
 
 class MapType(BaseModel):
-    type: Literal['map']
+    type: str = Field('map', const=True)
     key_id: int = Field(..., alias='key-id')
     key: Type
     value_id: int = Field(..., alias='value-id')
@@ -1103,7 +1098,9 @@ class AndOrExpression(BaseModel):
 
 
 class NotExpression(BaseModel):
-    type: ExpressionType
+    type: ExpressionType = Field(
+        default_factory=lambda: ExpressionType.parse_obj('not'), const=True
+    )
     child: Expression
 
 
@@ -1147,7 +1144,7 @@ class ViewMetadata(BaseModel):
 
 
 class AddSchemaUpdate(BaseUpdate):
-    action: Literal['add-schema']
+    action: str = Field('add-schema', const=True)
     schema_: Schema = Field(..., alias='schema')
     last_column_id: Optional[int] = Field(
         None,
@@ -1435,7 +1432,7 @@ class CompletedPlanningResult(ScanTasks):
     Completed server-side planning result
     """
 
-    status: Literal['completed']
+    status: Literal['completed'] = Field(..., const=True)
 
 
 class FetchScanTasksResult(ScanTasks):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -18,7 +18,7 @@
 #
 
 ---
-openapi: 3.0.3
+openapi: 3.1.1
 info:
   title: Apache Iceberg REST Catalog API
   license:
@@ -2057,7 +2057,7 @@ components:
       properties:
         type:
           type: string
-          enum: ["struct"]
+          const: "struct"
         fields:
           type: array
           items:
@@ -2073,7 +2073,7 @@ components:
       properties:
         type:
           type: string
-          enum: ["list"]
+          const: "list"
         element-id:
           type: integer
         element:
@@ -2093,7 +2093,7 @@ components:
       properties:
         type:
           type: string
-          enum: ["map"]
+          const: "map"
         key-id:
           type: integer
         key:
@@ -2165,7 +2165,7 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/ExpressionType'
-          enum: ["true"]
+          const: "true"
 
     FalseExpression:
       type: object
@@ -2174,7 +2174,7 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/ExpressionType'
-          enum: ["false"]
+          const: "false"
 
     AndOrExpression:
       type: object
@@ -2199,7 +2199,7 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/ExpressionType'
-          enum: ["not"]
+          const: "not"
         child:
           $ref: '#/components/schemas/Expression'
 
@@ -2269,7 +2269,7 @@ components:
       properties:
         type:
           type: string
-          enum: ["transform"]
+          const: "transform"
         transform:
           $ref: '#/components/schemas/Transform'
         term:
@@ -2656,12 +2656,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - uuid
       properties:
         action:
           type: string
-          enum: ["assign-uuid"]
+          const: "assign-uuid"
         uuid:
           type: string
 
@@ -2669,12 +2668,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - format-version
       properties:
         action:
           type: string
-          enum: ["upgrade-format-version"]
+          const: "upgrade-format-version"
         format-version:
           type: integer
 
@@ -2682,12 +2680,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - schema
       properties:
         action:
           type: string
-          enum: ["add-schema"]
+          const: "add-schema"
         schema:
           $ref: '#/components/schemas/Schema'
         last-column-id:
@@ -2704,12 +2701,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - schema-id
       properties:
         action:
           type: string
-          enum: ["set-current-schema"]
+          const: "set-current-schema"
         schema-id:
           type: integer
           description: Schema ID to set as current, or -1 to set last added schema
@@ -2718,12 +2714,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - spec
       properties:
         action:
           type: string
-          enum: ["add-spec"]
+          const: "add-spec"
         spec:
           $ref: '#/components/schemas/PartitionSpec'
 
@@ -2731,12 +2726,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - spec-id
       properties:
         action:
           type: string
-          enum: [ "set-default-spec" ]
+          const: "set-default-spec"
         spec-id:
           type: integer
           description: Partition spec ID to set as the default, or -1 to set last added spec
@@ -2745,12 +2739,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - sort-order
       properties:
         action:
           type: string
-          enum: [ "add-sort-order" ]
+          const: "add-sort-order"
         sort-order:
           $ref: '#/components/schemas/SortOrder'
 
@@ -2758,12 +2751,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - sort-order-id
       properties:
         action:
           type: string
-          enum: [ "set-default-sort-order" ]
+          const: "set-default-sort-order"
         sort-order-id:
           type: integer
           description: Sort order ID to set as the default, or -1 to set last added sort order
@@ -2772,12 +2764,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - snapshot
       properties:
         action:
           type: string
-          enum: [ "add-snapshot" ]
+          const: "add-snapshot"
         snapshot:
           $ref: '#/components/schemas/Snapshot'
 
@@ -2786,12 +2777,11 @@ components:
         - $ref: '#/components/schemas/BaseUpdate'
         - $ref: '#/components/schemas/SnapshotReference'
       required:
-        - action
         - ref-name
       properties:
         action:
           type: string
-          enum: [ "set-snapshot-ref" ]
+          const: "set-snapshot-ref"
         ref-name:
           type: string
 
@@ -2799,12 +2789,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - snapshot-ids
       properties:
         action:
           type: string
-          enum: [ "remove-snapshots" ]
+          const: "remove-snapshots"
         snapshot-ids:
           type: array
           items:
@@ -2815,12 +2804,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - ref-name
       properties:
         action:
           type: string
-          enum: [ "remove-snapshot-ref" ]
+          const: "remove-snapshot-ref"
         ref-name:
           type: string
 
@@ -2828,12 +2816,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - location
       properties:
         action:
           type: string
-          enum: [ "set-location" ]
+          const: "set-location"
         location:
           type: string
 
@@ -2841,12 +2828,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - updates
       properties:
         action:
           type: string
-          enum: [ "set-properties" ]
+          const: "set-properties"
         updates:
           type: object
           additionalProperties:
@@ -2856,12 +2842,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - removals
       properties:
         action:
           type: string
-          enum: [ "remove-properties" ]
+          const: "remove-properties"
         removals:
           type: array
           items:
@@ -2871,12 +2856,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - view-version
       properties:
         action:
           type: string
-          enum: [ "add-view-version" ]
+          const: "add-view-version"
         view-version:
           $ref: '#/components/schemas/ViewVersion'
 
@@ -2884,12 +2868,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - view-version-id
       properties:
         action:
           type: string
-          enum: [ "set-current-view-version" ]
+          const: "set-current-view-version"
         view-version-id:
           type: integer
           description: The view version id to set as current, or -1 to set last added view version id
@@ -2898,13 +2881,12 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - snapshot-id
         - statistics
       properties:
         action:
           type: string
-          enum: [ "set-statistics" ]
+          const: "set-statistics"
         snapshot-id:
           type: integer
           format: int64
@@ -2915,12 +2897,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - snapshot-id
       properties:
         action:
           type: string
-          enum: [ "remove-statistics" ]
+          const: "remove-statistics"
         snapshot-id:
           type: integer
           format: int64
@@ -2929,12 +2910,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - partition-statistics
       properties:
         action:
           type: string
-          enum: [ "set-partition-statistics" ]
+          const: "set-partition-statistics"
         partition-statistics:
           $ref: '#/components/schemas/PartitionStatisticsFile'
 
@@ -2942,12 +2922,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - action
         - snapshot-id
       properties:
         action:
           type: string
-          enum: [ "remove-partition-statistics" ]
+          const: "remove-partition-statistics"
         snapshot-id:
           type: integer
           format: int64
@@ -2960,7 +2939,7 @@ components:
       properties:
         action:
           type: string
-          enum: [ "remove-partition-specs" ]
+          const: "remove-partition-specs"
         spec-ids:
           type: array
           items:
@@ -3011,35 +2990,35 @@ components:
           assert-last-assigned-partition-id: '#/components/schemas/AssertLastAssignedPartitionId'
           assert-default-spec-id: '#/components/schemas/AssertDefaultSpecId'
           assert-default-sort-order-id: '#/components/schemas/AssertDefaultSortOrderId'
-      oneOf:
-        - $ref: '#/components/schemas/AssertCreate'
-        - $ref: '#/components/schemas/AssertTableUUID'
-        - $ref: '#/components/schemas/AssertRefSnapshotId'
-        - $ref: '#/components/schemas/AssertLastAssignedFieldId'
-        - $ref: '#/components/schemas/AssertCurrentSchemaId'
-        - $ref: '#/components/schemas/AssertLastAssignedPartitionId'
-        - $ref: '#/components/schemas/AssertDefaultSpecId'
-        - $ref: '#/components/schemas/AssertDefaultSortOrderId'
+      properties:
+        type:
+          type: string
+      required:
+        - type
 
     AssertCreate:
       type: object
       description: The table must not already exist; used for create transactions
+      allOf:
+        - $ref: '#/components/schemas/TableRequirement'
       required:
         - type
       properties:
         type:
           type: string
-          enum: ["assert-create"]
+          const: "assert-create"
 
     AssertTableUUID:
       description: The table UUID must match the requirement's `uuid`
+      allOf:
+        - $ref: '#/components/schemas/TableRequirement'
       required:
         - type
         - uuid
       properties:
         type:
           type: string
-          enum: ["assert-table-uuid"]
+          const: "assert-table-uuid"
         uuid:
           type: string
 
@@ -3047,14 +3026,15 @@ components:
       description:
         The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; 
         if `snapshot-id` is `null` or missing, the ref must not already exist
+      allOf:
+        - $ref: '#/components/schemas/TableRequirement'
       required:
-        - type
         - ref
         - snapshot-id
       properties:
         type:
           type: string
-          enum: [ "assert-ref-snapshot-id" ]
+          const: "assert-ref-snapshot-id"
         ref:
           type: string
         snapshot-id:
@@ -3064,65 +3044,70 @@ components:
     AssertLastAssignedFieldId:
       description:
         The table's last assigned column id must match the requirement's `last-assigned-field-id`
+      allOf:
+        - $ref: '#/components/schemas/TableRequirement'
       required:
-        - type
         - last-assigned-field-id
       properties:
         type:
           type: string
-          enum: [ "assert-last-assigned-field-id" ]
+          const: "assert-last-assigned-field-id"
         last-assigned-field-id:
           type: integer
 
     AssertCurrentSchemaId:
       description:
         The table's current schema id must match the requirement's `current-schema-id`
+      allOf:
+        - $ref: '#/components/schemas/TableRequirement'
       required:
-        - type
         - current-schema-id
       properties:
         type:
           type: string
-          enum: [ "assert-current-schema-id" ]
+          const: "assert-current-schema-id"
         current-schema-id:
           type: integer
 
     AssertLastAssignedPartitionId:
       description:
         The table's last assigned partition id must match the requirement's `last-assigned-partition-id`
+      allOf:
+        - $ref: '#/components/schemas/TableRequirement'
       required:
-        - type
         - last-assigned-partition-id
       properties:
         type:
           type: string
-          enum: [ "assert-last-assigned-partition-id" ]
+          const: "assert-last-assigned-partition-id"
         last-assigned-partition-id:
           type: integer
 
     AssertDefaultSpecId:
       description:
         The table's default spec id must match the requirement's `default-spec-id`
+      allOf:
+        - $ref: '#/components/schemas/TableRequirement'
       required:
-        - type
         - default-spec-id
       properties:
         type:
           type: string
-          enum: [ "assert-default-spec-id" ]
+          const: "assert-default-spec-id"
         default-spec-id:
           type: integer
 
     AssertDefaultSortOrderId:
       description:
         The table's default sort order id must match the requirement's `default-sort-order-id`
+      allOf:
+        - $ref: '#/components/schemas/TableRequirement'
       required:
-        - type
         - default-sort-order-id
       properties:
         type:
           type: string
-          enum: [ "assert-default-sort-order-id" ]
+          const: "assert-default-sort-order-id"
         default-sort-order-id:
           type: integer
 
@@ -3143,7 +3128,7 @@ components:
       properties:
         type:
           type: string
-          enum: [ "assert-view-uuid" ]
+          const: "assert-view-uuid"
         uuid:
           type: string
 
@@ -3266,7 +3251,7 @@ components:
           properties:
             status:
               $ref: '#/components/schemas/PlanStatus'
-              enum: ["completed"]
+              const: "completed"
 
     CompletedPlanningWithIDResult:
       type: object
@@ -3289,7 +3274,7 @@ components:
           properties:
             status:
               $ref: '#/components/schemas/PlanStatus'
-              enum: ["failed"]
+              const: "failed"
 
     AsyncPlanningResult:
       type: object
@@ -3298,7 +3283,7 @@ components:
       properties:
         status:
           $ref: '#/components/schemas/PlanStatus'
-          enum: ["submitted"]
+          const: "submitted"
         plan-id:
           description: ID used to track a planning request
           type: string
@@ -4203,7 +4188,7 @@ components:
       properties:
         content:
           type: string
-          enum: [ "data" ]
+          const: "data"
         column-sizes:
           allOf:
             - $ref: '#/components/schemas/CountMap'
@@ -4247,7 +4232,7 @@ components:
       properties:
         content:
           type: string
-          enum: [ "position-deletes" ]
+          const: "position-deletes"
         content-offset:
           type: integer
           format: int64
@@ -4265,7 +4250,7 @@ components:
       properties:
         content:
           type: string
-          enum: [ "equality-deletes" ]
+          const: "equality-deletes"
         equality-ids:
           type: array
           items:


### PR DESCRIPTION
The `const` has been added in Open API 3.1:

https://www.speakeasy.com/openapi/schemas/enums#constants-for-single-value-enums

This fixes the compilation issue reported in https://github.com/apache/iceberg/pull/11806 as well.

cc @VladimirYushkevich @jbonofre @amogh-jahagirdar @nastra @ajantha-bhat 