### PR TITLE
[docs] Update docs link about Apache Doris and update vendors list

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -65,7 +65,7 @@ nav:
   - Google BigQuery: https://cloud.google.com/bigquery/docs/iceberg-tables
   - Snowflake: https://docs.snowflake.com/en/user-guide/tables-iceberg
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
-  - Doris: https://doris.apache.org/docs/dev/lakehouse/datalake-analytics/iceberg
+  - Doris: https://doris.apache.org/docs/dev/lakehouse/catalogs/iceberg-catalog
   - Druid: https://druid.apache.org/docs/latest/development/extensions-contrib/iceberg/
   - Kafka Connect: kafka-connect.md
   - Integrations:

--- a/site/docs/vendors.md
+++ b/site/docs/vendors.md
@@ -89,3 +89,8 @@ Starburst is a commercial offering for the [Trino query engine](https://trino.io
 ### [Upsolver](https://upsolver.com)
 
 [Upsolver](https://upsolver.com) is a streaming data ingestion and table management solution for Apache Iceberg. With Upsolver, users can easily ingest batch and streaming data from files, streams and databases (CDC) into [Iceberg tables](https://docs.upsolver.com/reference/sql-commands/iceberg-tables/upsolver-managed-tables). In addition, Upsolver connects to your existing REST and Hive catalogs, and [analyzes the health](https://docs.upsolver.com/how-to-guides/apache-iceberg/optimize-your-iceberg-tables) of your tables. Use Upsolver to continuously optimize tables by compacting small files, sorting and compressing, repartitioning, and cleaning up dangling files and expired manifests. Upsolver is available from the [Upsolver Cloud](https://www.upsolver.com/sqlake-signup-wp) or can be deployed in your AWS VPC.
+
+### [VeloDB](https://velodb.io)
+
+[VeloDB](https://www.velodb.io/) is a commercial data warehouse powered by [Apache Doris](https://doris.apache.org/), an open-source, real-time data warehouse. It also provides powerful [query acceleration for Iceberg tables and efficient data writeback](https://doris.apache.org/docs/dev/lakehouse/catalogs/iceberg-catalog). VeloDB offers [enterprise version](https://www.velodb.io/enterprise) and [cloud service](https://www.velodb.io/cloud), which are fully compatible with open-source Apache Doris. Quick start with Apache Doris and Apache Iceberg [here](https://doris.apache.org/docs/lakehouse/lakehouse-best-practices/doris-iceberg).
+


### PR DESCRIPTION
1. The Doris website has been upgraded so the link to Doris Iceberg Catalog is missing. Update to the new link.

2. Add VeloDB in vendors list.