### PR TITLE
Spark 3.5: Support RewriteManifestsProcedure with a target size parameter

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteManifests.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteManifests.java
@@ -45,6 +45,16 @@ public interface RewriteManifests
   RewriteManifests rewriteIf(Predicate<ManifestFile> predicate);
 
   /**
+   * Sets the target size of rewritten manifests.
+   *
+   * <p>If not set, defaults to the value from table config.
+   *
+   * @param targetSizeBytes a target size in bytes
+   * @return this for method chaining
+   */
+  RewriteManifests targetSizeBytes(long targetSizeBytes);
+
+  /**
    * Passes a location where the staged manifests should be written.
    *
    * <p>If not set, defaults to the table's metadata location.

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -100,11 +100,11 @@ public class RewriteManifestsSparkAction
 
   private final Table table;
   private final int formatVersion;
-  private final long targetManifestSizeBytes;
   private final boolean shouldStageManifests;
 
   private PartitionSpec spec;
   private Predicate<ManifestFile> predicate = manifest -> true;
+  private long targetManifestSizeBytes;
   private String outputLocation;
 
   RewriteManifestsSparkAction(SparkSession spark, Table table) {
@@ -148,6 +148,12 @@ public class RewriteManifestsSparkAction
   @Override
   public RewriteManifestsSparkAction rewriteIf(Predicate<ManifestFile> newPredicate) {
     this.predicate = newPredicate;
+    return this;
+  }
+
+  @Override
+  public  RewriteManifestsSparkAction targetSizeBytes(long newTargetSizeBytes) {
+    this.targetManifestSizeBytes = newTargetSizeBytes;
     return this;
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -47,7 +47,8 @@ class RewriteManifestsProcedure extends BaseProcedure {
       new ProcedureParameter[] {
         ProcedureParameter.required("table", DataTypes.StringType),
         ProcedureParameter.optional("use_caching", DataTypes.BooleanType),
-        ProcedureParameter.optional("spec_id", DataTypes.IntegerType)
+        ProcedureParameter.optional("spec_id", DataTypes.IntegerType),
+        ProcedureParameter.optional("target_manifest_size_bytes", DataTypes.LongType)
       };
 
   // counts are not nullable since the action result is never null
@@ -87,6 +88,7 @@ class RewriteManifestsProcedure extends BaseProcedure {
     Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
     Boolean useCaching = args.isNullAt(1) ? null : args.getBoolean(1);
     Integer specId = args.isNullAt(2) ? null : args.getInt(2);
+    Long targetManifestFileSize = args.isNullAt(3) ? null : args.getLong(3);
 
     return modifyIcebergTable(
         tableIdent,

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TotalDataFileSize.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TotalDataFileSize.java
@@ -24,6 +24,10 @@ public class TotalDataFileSize extends CustomSumMetric {
 
   static final String NAME = "totalDataFileSize";
 
+  public TotalDataFileSize() {
+    super();
+  }
+
   @Override
   public String name() {
     return NAME;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TotalDataFileSize.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TotalDataFileSize.java
@@ -24,10 +24,6 @@ public class TotalDataFileSize extends CustomSumMetric {
 
   static final String NAME = "totalDataFileSize";
 
-  public TotalDataFileSize() {
-    super();
-  }
-
   @Override
   public String name() {
     return NAME;


### PR DESCRIPTION
Current Limitations: The rewrite manifest currently has limited parameters. To set or change the manifest size, you must go through the table config, which restricts flexibility. We wish for rewriting and setting the target size to be a unified operation that only impacts that particular rewrite. During tuning, we test various sizes for the manifest. In contrast, when rewriting data files, we can specify files directly without altering table properties, and other files remain unaffected by the target size.

Consideration for Options: I initially considered using options to specify parameters, but since few are needed for rewriting the manifest, adding just one parameter for the target size seems sufficient. This approach is open to further discussion.