### PR TITLE
Core: Fix test failure caused by check empty namespace on REST session catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -438,9 +438,9 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   @Override
   public boolean tableExists(SessionContext context, TableIdentifier identifier) {
     Endpoint.check(endpoints, Endpoint.V1_TABLE_EXISTS);
-    checkIdentifierIsValid(identifier);
 
     try {
+      checkIdentifierIsValid(identifier);
       client.head(paths.table(identifier), headers(context), ErrorHandlers.tableErrorHandler());
       return true;
     } catch (NoSuchTableException e) {
@@ -659,9 +659,9 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   @Override
   public boolean namespaceExists(SessionContext context, Namespace namespace) {
     Endpoint.check(endpoints, Endpoint.V1_NAMESPACE_EXISTS);
-    checkNamespaceIsValid(namespace);
 
     try {
+      checkNamespaceIsValid(namespace);
       client.head(
           paths.namespace(namespace), headers(context), ErrorHandlers.namespaceErrorHandler());
       return true;
@@ -1233,9 +1233,9 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   @Override
   public boolean viewExists(SessionContext context, TableIdentifier identifier) {
     Endpoint.check(endpoints, Endpoint.V1_VIEW_EXISTS);
-    checkViewIdentifierIsValid(identifier);
 
     try {
+      checkViewIdentifierIsValid(identifier);
       client.head(paths.view(identifier), headers(context), ErrorHandlers.viewErrorHandler());
       return true;
     } catch (NoSuchViewException e) {


### PR DESCRIPTION
This PR fix the failure test `RESTCompatibilityKitCatalogTests.listNamespacesWithEmptyNamespace()` running based on `RESTSessionCatalog`.

In the original implementation, for empty namespaces, `RESTSessionCatalog.namespaceExists()` would directly throw an `NoSuchNamespaceException` rather than returning false. This will lead to the failure of the test.