### PR TITLE
Core: Fix tests around empty namespaces

### DIFF
--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -985,6 +985,10 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   @Test
   public void listNamespacesWithEmptyNamespace() {
+    assumeThat(supportsEmptyNamespace())
+        .as("Only valid for catalogs that support listing empty namespaces")
+        .isTrue();
+
     catalog().createNamespace(NS);
 
     assertThat(catalog().namespaceExists(Namespace.empty())).isFalse();


### PR DESCRIPTION
I bisected this and looked why this test started to fail after it was merged to main. The reason is that with https://github.com/apache/iceberg/pull/11761 we changed namespace existence check for the REST catalog, which in turn does a namespace validation check. Prior to https://github.com/apache/iceberg/pull/11761 that validation error would be caught in https://github.com/apache/iceberg/blob/1ea185290ac505e6c2e4d6f4eb429448860701e8/api/src/main/java/org/apache/iceberg/catalog/SupportsNamespaces.java#L161