### PR TITLE
[1.7.x] AWS, Core, GCP: Support relative credential endpoint / pass OAuth2 token to credential provider

### DIFF
--- a/aws/src/test/java/org/apache/iceberg/aws/AwsClientPropertiesTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/AwsClientPropertiesTest.java
@@ -21,9 +21,11 @@ package org.apache.iceberg.aws;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.aws.s3.VendedCredentialsProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.auth.OAuth2Properties;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -139,5 +141,81 @@ public class AwsClientPropertiesTest {
 
     assertThat(awsClientProperties.credentialsProvider("key", "secret", "token"))
         .isInstanceOf(StaticCredentialsProvider.class);
+  }
+
+  @Test
+  public void refreshCredentialsEndpointWithOAuthToken() {
+    AwsClientProperties awsClientProperties =
+        new AwsClientProperties(
+            ImmutableMap.of(
+                AwsClientProperties.REFRESH_CREDENTIALS_ENDPOINT,
+                "http://localhost:1234/v1/credentials",
+                OAuth2Properties.TOKEN,
+                "oauth-token"));
+
+    AwsCredentialsProvider provider =
+        awsClientProperties.credentialsProvider("key", "secret", "token");
+    assertThat(provider).isInstanceOf(VendedCredentialsProvider.class);
+    VendedCredentialsProvider vendedCredentialsProvider = (VendedCredentialsProvider) provider;
+    assertThat(vendedCredentialsProvider)
+        .extracting("properties")
+        .isEqualTo(
+            ImmutableMap.of(
+                "credentials.uri",
+                "http://localhost:1234/v1/credentials",
+                OAuth2Properties.TOKEN,
+                "oauth-token"));
+  }
+
+  @Test
+  public void refreshCredentialsEndpointWithOverridingOAuthToken() {
+    AwsClientProperties awsClientProperties =
+        new AwsClientProperties(
+            ImmutableMap.of(
+                AwsClientProperties.REFRESH_CREDENTIALS_ENDPOINT,
+                "http://localhost:1234/v1/credentials",
+                OAuth2Properties.TOKEN,
+                "oauth-token",
+                "client.credentials-provider.token",
+                "specific-token"));
+
+    AwsCredentialsProvider provider =
+        awsClientProperties.credentialsProvider("key", "secret", "token");
+    assertThat(provider).isInstanceOf(VendedCredentialsProvider.class);
+    VendedCredentialsProvider vendedCredentialsProvider = (VendedCredentialsProvider) provider;
+    assertThat(vendedCredentialsProvider)
+        .extracting("properties")
+        .isEqualTo(
+            ImmutableMap.of(
+                "credentials.uri",
+                "http://localhost:1234/v1/credentials",
+                OAuth2Properties.TOKEN,
+                "specific-token"));
+  }
+
+  @Test
+  public void refreshCredentialsEndpointWithRelativePath() {
+    AwsClientProperties awsClientProperties =
+        new AwsClientProperties(
+            ImmutableMap.of(
+                CatalogProperties.URI,
+                "http://localhost:1234/v1",
+                AwsClientProperties.REFRESH_CREDENTIALS_ENDPOINT,
+                "/relative/credentials/endpoint",
+                OAuth2Properties.TOKEN,
+                "oauth-token"));
+
+    AwsCredentialsProvider provider =
+        awsClientProperties.credentialsProvider("key", "secret", "token");
+    assertThat(provider).isInstanceOf(VendedCredentialsProvider.class);
+    VendedCredentialsProvider vendedCredentialsProvider = (VendedCredentialsProvider) provider;
+    assertThat(vendedCredentialsProvider)
+        .extracting("properties")
+        .isEqualTo(
+            ImmutableMap.of(
+                "credentials.uri",
+                "http://localhost:1234/v1/relative/credentials/endpoint",
+                OAuth2Properties.TOKEN,
+                "oauth-token"));
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -215,4 +215,31 @@ public class RESTUtil {
 
     return Namespace.of(levels);
   }
+
+  /**
+   * Returns the catalog URI suffixed by the relative endpoint path. If the endpoint path is an
+   * absolute path, then the absolute endpoint path is returned without using the catalog URI.
+   *
+   * @param catalogUri The catalog URI that is typically passed through {@link
+   *     org.apache.iceberg.CatalogProperties#URI}
+   * @param endpointPath Either an absolute or relative endpoint path
+   * @return The actual endpoint path if it's an absolute path or the catalog uri suffixed by the
+   *     endpoint path if the path is relative.
+   */
+  public static String resolveEndpoint(String catalogUri, String endpointPath) {
+    if (null == endpointPath) {
+      return null;
+    }
+
+    if (null == catalogUri
+        || endpointPath.startsWith("http://")
+        || endpointPath.startsWith("https://")) {
+      return endpointPath;
+    }
+
+    return String.format(
+        "%s%s",
+        RESTUtil.stripTrailingSlash(catalogUri),
+        endpointPath.startsWith("/") ? endpointPath : "/" + endpointPath);
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -139,4 +139,31 @@ public class TestRESTUtil {
 
     assertThat(RESTUtil.decodeFormData(formString)).isEqualTo(expected);
   }
+
+  @Test
+  public void testNullEndpointPath() {
+    assertThat(RESTUtil.resolveEndpoint("http://catalog-uri", null)).isNull();
+  }
+
+  @Test
+  public void testAbsoluteEndpointPath() {
+    assertThat(
+            RESTUtil.resolveEndpoint("http://catalog-uri", "http://catalog-uri/refresh-endpoint"))
+        .isEqualTo("http://catalog-uri/refresh-endpoint");
+    assertThat(
+            RESTUtil.resolveEndpoint("http://catalog-uri/", "http://catalog-uri/refresh-endpoint"))
+        .isEqualTo("http://catalog-uri/refresh-endpoint");
+  }
+
+  @Test
+  public void testRelativeEndpointPath() {
+    assertThat(RESTUtil.resolveEndpoint(null, "/refresh-endpoint")).isEqualTo("/refresh-endpoint");
+    assertThat(RESTUtil.resolveEndpoint("http://catalog-uri", "/refresh-endpoint"))
+        .isEqualTo("http://catalog-uri/refresh-endpoint");
+    assertThat(RESTUtil.resolveEndpoint("http://catalog-uri/", "/refresh-endpoint"))
+        .isEqualTo("http://catalog-uri/refresh-endpoint");
+    assertThat(
+            RESTUtil.resolveEndpoint("http://catalog-uri/", "relative-endpoint/refresh-endpoint"))
+        .isEqualTo("http://catalog-uri/relative-endpoint/refresh-endpoint");
+  }
 }

--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -22,7 +22,9 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.util.PropertyUtil;
 
 public class GCPProperties implements Serializable {
@@ -104,7 +106,10 @@ public class GCPProperties implements Serializable {
           new Date(Long.parseLong(properties.get(GCS_OAUTH2_TOKEN_EXPIRES_AT)));
     }
 
-    gcsOauth2RefreshCredentialsEndpoint = properties.get(GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT);
+    gcsOauth2RefreshCredentialsEndpoint =
+        RESTUtil.resolveEndpoint(
+            properties.get(CatalogProperties.URI),
+            properties.get(GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT));
     gcsOauth2RefreshCredentialsEnabled =
         PropertyUtil.propertyAsBoolean(properties, GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED, true);
     gcsNoAuth = Boolean.parseBoolean(properties.getOrDefault(GCS_NO_AUTH, "false"));


### PR DESCRIPTION
this backports https://github.com/apache/iceberg/pull/11954 to 1.7.x