### PR TITLE
Run `java-ci` on changes in `open-api/**`

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -49,7 +49,6 @@ on:
     - 'dev/**'
     - 'docs/**'
     - 'site/**'
-    - 'open-api/**'
     - 'format/**'
     - '.gitattributes'
     - 'README.md'


### PR DESCRIPTION
To avoid situations like https://github.com/apache/iceberg/pull/11970