### PR TITLE
Spark 3.5: Fix flaky tests `withSnapshotIsolation`

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -25,6 +25,7 @@ import static org.apache.iceberg.SnapshotSummary.ADDED_DVS_PROP;
 import static org.apache.iceberg.SnapshotSummary.ADD_POS_DELETE_FILES_PROP;
 import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.TableProperties.DELETE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.DELETE_MODE;
@@ -1154,14 +1155,16 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     createOrReplaceView("deleted_id", Collections.singletonList(1), Encoders.INT());
 
     sql(
-        "ALTER TABLE %s SET TBLPROPERTIES('%s'='%s', '%s'='%s', '%s'='%s')",
+        "ALTER TABLE %s SET TBLPROPERTIES('%s'='%s', '%s'='%s', '%s'='%s', '%s'='%s')",
         tableName,
         DELETE_ISOLATION_LEVEL,
         "snapshot",
         COMMIT_MIN_RETRY_WAIT_MS,
         "10",
         COMMIT_MAX_RETRY_WAIT_MS,
-        "1000");
+        "1000",
+        COMMIT_NUM_RETRIES,
+        "7");
 
     sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
     createBranchIfNeeded();

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.RowLevelOperationMode.COPY_ON_WRITE;
 import static org.apache.iceberg.RowLevelOperationMode.MERGE_ON_READ;
 import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.TableProperties.MERGE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.MERGE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.MERGE_MODE;
@@ -1618,14 +1619,16 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     createOrReplaceView("source", Collections.singletonList(1), Encoders.INT());
 
     sql(
-        "ALTER TABLE %s SET TBLPROPERTIES('%s'='%s', '%s'='%s', '%s'='%s')",
+        "ALTER TABLE %s SET TBLPROPERTIES('%s'='%s', '%s'='%s', '%s'='%s', '%s'='%s')",
         tableName,
         MERGE_ISOLATION_LEVEL,
         "snapshot",
         COMMIT_MIN_RETRY_WAIT_MS,
         "10",
         COMMIT_MAX_RETRY_WAIT_MS,
-        "1000");
+        "1000",
+        COMMIT_NUM_RETRIES,
+        "7");
 
     sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
     createBranchIfNeeded();


### PR DESCRIPTION
https://github.com/apache/iceberg/pull/11654 attempted to fix flaky tests (https://github.com/apache/iceberg/issues/11066, https://github.com/apache/iceberg/issues/11651) due to timeout by adding two table properties `COMMIT_MIN_RETRY_WAIT_MS=10` and `COMMIT_MAX_RETRY_WAIT_MS=1000`. However, it has brought in more failures due to `CommitFailedException`. The max retry wait time is actually not effective, since the default retry times is 4 (max wait time is 10 * 2^4 = 80ms). This PR attempts to fix it by increasing the retry times to 7 (10 * 2^7 = 1280ms)