### PR TITLE
Spark 3.4: Backport rewriting historical file-scoped deletes (#11273) to 3.4

### DIFF
--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadDelete.java
@@ -39,9 +39,11 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkSQLProperties;
+import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.spark.source.TestSparkCatalog;
 import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.junit.Assert;
@@ -118,6 +120,87 @@ public class TestMergeOnReadDelete extends TestDelete {
   @Test
   public void testDeletePartitionGranularity() throws NoSuchTableException {
     checkDeleteFileGranularity(DeleteGranularity.PARTITION);
+  }
+
+  @Test
+  public void testPositionDeletesAreMaintainedDuringDelete() throws NoSuchTableException {
+    sql(
+        "CREATE TABLE %s (id int, data string) USING iceberg PARTITIONED BY (id) TBLPROPERTIES"
+            + "('%s'='%s', '%s'='%s', '%s'='%s')",
+        tableName,
+        TableProperties.FORMAT_VERSION,
+        2,
+        TableProperties.DELETE_MODE,
+        "merge-on-read",
+        TableProperties.DELETE_GRANULARITY,
+        "file");
+    createBranchIfNeeded();
+
+    List<SimpleRecord> records =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"),
+            new SimpleRecord(1, "b"),
+            new SimpleRecord(1, "c"),
+            new SimpleRecord(2, "d"),
+            new SimpleRecord(2, "e"));
+    spark
+        .createDataset(records, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(commitTarget())
+        .append();
+
+    sql("DELETE FROM %s WHERE id = 1 and data='a'", commitTarget());
+    sql("DELETE FROM %s WHERE id = 2 and data='d'", commitTarget());
+    sql("DELETE FROM %s WHERE id = 1 and data='c'", commitTarget());
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot latest = SnapshotUtil.latestSnapshot(table, branch);
+    assertThat(latest.removedDeleteFiles(table.io())).hasSize(1);
+    assertEquals(
+        "Should have expected rows",
+        ImmutableList.of(row(1, "b"), row(2, "e")),
+        sql("SELECT * FROM %s ORDER BY id ASC", selectTarget()));
+  }
+
+  @Test
+  public void testUnpartitionedPositionDeletesAreMaintainedDuringDelete()
+      throws NoSuchTableException {
+    sql(
+        "CREATE TABLE %s (id int, data string) USING iceberg TBLPROPERTIES"
+            + "('%s'='%s', '%s'='%s', '%s'='%s')",
+        tableName,
+        TableProperties.FORMAT_VERSION,
+        2,
+        TableProperties.DELETE_MODE,
+        "merge-on-read",
+        TableProperties.DELETE_GRANULARITY,
+        "file");
+    createBranchIfNeeded();
+
+    List<SimpleRecord> records =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"),
+            new SimpleRecord(1, "b"),
+            new SimpleRecord(1, "c"),
+            new SimpleRecord(2, "d"),
+            new SimpleRecord(2, "e"));
+    spark
+        .createDataset(records, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(commitTarget())
+        .append();
+
+    sql("DELETE FROM %s WHERE id = 1 and data='a'", commitTarget());
+    sql("DELETE FROM %s WHERE id = 2 and data='d'", commitTarget());
+    sql("DELETE FROM %s WHERE id = 1 and data='c'", commitTarget());
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot latest = SnapshotUtil.latestSnapshot(table, branch);
+    assertThat(latest.removedDeleteFiles(table.io())).hasSize(1);
+    assertEquals(
+        "Should have expected rows",
+        ImmutableList.of(row(1, "b"), row(2, "e")),
+        sql("SELECT * FROM %s ORDER BY id ASC", selectTarget()));
   }
 
   private void checkDeleteFileGranularity(DeleteGranularity deleteGranularity)

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -28,6 +28,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -42,8 +43,12 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.data.BaseDeleteLoader;
+import org.apache.iceberg.data.DeleteLoader;
 import org.apache.iceberg.deletes.DeleteGranularity;
 import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -67,6 +72,7 @@ import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.SparkWriteRequirements;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
+import org.apache.iceberg.util.DeleteFileSet;
 import org.apache.iceberg.util.StructProjection;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
@@ -155,10 +161,23 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     @Override
     public DeltaWriterFactory createBatchWriterFactory(PhysicalWriteInfo info) {
-      // broadcast the table metadata as the writer factory will be sent to executors
-      Broadcast<Table> tableBroadcast =
-          sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
-      return new PositionDeltaWriteFactory(tableBroadcast, command, context, writeProperties);
+      // broadcast large objects since the writer factory will be sent to executors
+      return new PositionDeltaWriteFactory(
+          sparkContext.broadcast(SerializableTableWithSize.copyOf(table)),
+          broadcastRewritableDeletes(),
+          command,
+          context,
+          writeProperties);
+    }
+
+    private Broadcast<Map<String, DeleteFileSet>> broadcastRewritableDeletes() {
+      if (context.deleteGranularity() == DeleteGranularity.FILE && scan != null) {
+        Map<String, DeleteFileSet> rewritableDeletes = scan.rewritableDeletes();
+        if (rewritableDeletes != null && !rewritableDeletes.isEmpty()) {
+          return sparkContext.broadcast(rewritableDeletes);
+        }
+      }
+      return null;
     }
 
     @Override
@@ -174,6 +193,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
       int addedDataFilesCount = 0;
       int addedDeleteFilesCount = 0;
+      int removedDeleteFilesCount = 0;
 
       for (WriterCommitMessage message : messages) {
         DeltaTaskCommit taskCommit = (DeltaTaskCommit) message;
@@ -181,6 +201,11 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
         for (DataFile dataFile : taskCommit.dataFiles()) {
           rowDelta.addRows(dataFile);
           addedDataFilesCount += 1;
+        }
+
+        for (DeleteFile deleteFile : taskCommit.rewrittenDeleteFiles()) {
+          rowDelta.removeDeletes(deleteFile);
+          removedDeleteFilesCount += 1;
         }
 
         for (DeleteFile deleteFile : taskCommit.deleteFiles()) {
@@ -216,10 +241,11 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
         String commitMsg =
             String.format(
-                "position delta with %d data files and %d delete files "
+                "position delta with %d data files, %d delete files and %d rewritten delete files"
                     + "(scanSnapshotId: %d, conflictDetectionFilter: %s, isolationLevel: %s)",
                 addedDataFilesCount,
                 addedDeleteFilesCount,
+                removedDeleteFilesCount,
                 scan.snapshotId(),
                 conflictDetectionFilter,
                 isolationLevel);
@@ -303,18 +329,21 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
   public static class DeltaTaskCommit implements WriterCommitMessage {
     private final DataFile[] dataFiles;
     private final DeleteFile[] deleteFiles;
+    private final DeleteFile[] rewrittenDeleteFiles;
     private final CharSequence[] referencedDataFiles;
 
     DeltaTaskCommit(WriteResult result) {
       this.dataFiles = result.dataFiles();
       this.deleteFiles = result.deleteFiles();
       this.referencedDataFiles = result.referencedDataFiles();
+      this.rewrittenDeleteFiles = result.rewrittenDeleteFiles();
     }
 
     DeltaTaskCommit(DeleteWriteResult result) {
       this.dataFiles = new DataFile[0];
       this.deleteFiles = result.deleteFiles().toArray(new DeleteFile[0]);
       this.referencedDataFiles = result.referencedDataFiles().toArray(new CharSequence[0]);
+      this.rewrittenDeleteFiles = result.rewrittenDeleteFiles().toArray(new DeleteFile[0]);
     }
 
     DataFile[] dataFiles() {
@@ -325,6 +354,10 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       return deleteFiles;
     }
 
+    DeleteFile[] rewrittenDeleteFiles() {
+      return rewrittenDeleteFiles;
+    }
+
     CharSequence[] referencedDataFiles() {
       return referencedDataFiles;
     }
@@ -332,16 +365,19 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
   private static class PositionDeltaWriteFactory implements DeltaWriterFactory {
     private final Broadcast<Table> tableBroadcast;
+    private final Broadcast<Map<String, DeleteFileSet>> rewritableDeletesBroadcast;
     private final Command command;
     private final Context context;
     private final Map<String, String> writeProperties;
 
     PositionDeltaWriteFactory(
         Broadcast<Table> tableBroadcast,
+        Broadcast<Map<String, DeleteFileSet>> rewritableDeletesBroadcast,
         Command command,
         Context context,
         Map<String, String> writeProperties) {
       this.tableBroadcast = tableBroadcast;
+      this.rewritableDeletesBroadcast = rewritableDeletesBroadcast;
       this.command = command;
       this.context = context;
       this.writeProperties = writeProperties;
@@ -374,16 +410,21 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
               .build();
 
       if (command == DELETE) {
-        return new DeleteOnlyDeltaWriter(table, writerFactory, deleteFileFactory, context);
+        return new DeleteOnlyDeltaWriter(
+            table, rewritableDeletes(), writerFactory, deleteFileFactory, context);
 
       } else if (table.spec().isUnpartitioned()) {
         return new UnpartitionedDeltaWriter(
-            table, writerFactory, dataFileFactory, deleteFileFactory, context);
+            table, rewritableDeletes(), writerFactory, dataFileFactory, deleteFileFactory, context);
 
       } else {
         return new PartitionedDeltaWriter(
-            table, writerFactory, dataFileFactory, deleteFileFactory, context);
+            table, rewritableDeletes(), writerFactory, dataFileFactory, deleteFileFactory, context);
       }
+    }
+
+    private Map<String, DeleteFileSet> rewritableDeletes() {
+      return rewritableDeletesBroadcast != null ? rewritableDeletesBroadcast.getValue() : null;
     }
   }
 
@@ -427,20 +468,55 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     // use a fanout writer if the input is unordered no matter whether fanout writers are enabled
     // clustered writers assume that the position deletes are already ordered by file and position
     protected PartitioningWriter<PositionDelete<InternalRow>, DeleteWriteResult> newDeleteWriter(
-        Table table, SparkFileWriterFactory writers, OutputFileFactory files, Context context) {
+        Table table,
+        Map<String, DeleteFileSet> rewritableDeletes,
+        SparkFileWriterFactory writers,
+        OutputFileFactory files,
+        Context context) {
 
       FileIO io = table.io();
       boolean inputOrdered = context.inputOrdered();
       long targetFileSize = context.targetDeleteFileSize();
       DeleteGranularity deleteGranularity = context.deleteGranularity();
 
-      if (inputOrdered) {
+      if (inputOrdered && rewritableDeletes == null) {
         return new ClusteredPositionDeleteWriter<>(
             writers, files, io, targetFileSize, deleteGranularity);
       } else {
         return new FanoutPositionOnlyDeleteWriter<>(
-            writers, files, io, targetFileSize, deleteGranularity);
+            writers,
+            files,
+            io,
+            targetFileSize,
+            deleteGranularity,
+            rewritableDeletes != null
+                ? new PreviousDeleteLoader(table, rewritableDeletes)
+                : path -> null /* no previous file scoped deletes */);
       }
+    }
+  }
+
+  private static class PreviousDeleteLoader implements Function<CharSequence, PositionDeleteIndex> {
+    private final Map<String, DeleteFileSet> deleteFiles;
+    private final DeleteLoader deleteLoader;
+
+    PreviousDeleteLoader(Table table, Map<String, DeleteFileSet> deleteFiles) {
+      this.deleteFiles = deleteFiles;
+      this.deleteLoader =
+          new BaseDeleteLoader(
+              deleteFile ->
+                  EncryptingFileIO.combine(table.io(), table.encryption())
+                      .newInputFile(deleteFile));
+    }
+
+    @Override
+    public PositionDeleteIndex apply(CharSequence path) {
+      DeleteFileSet deleteFileSet = deleteFiles.get(path.toString());
+      if (deleteFileSet == null) {
+        return null;
+      }
+
+      return deleteLoader.loadPositionDeletes(deleteFileSet, path);
     }
   }
 
@@ -460,11 +536,13 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     DeleteOnlyDeltaWriter(
         Table table,
+        Map<String, DeleteFileSet> rewritableDeletes,
         SparkFileWriterFactory writerFactory,
         OutputFileFactory deleteFileFactory,
         Context context) {
 
-      this.delegate = newDeleteWriter(table, writerFactory, deleteFileFactory, context);
+      this.delegate =
+          newDeleteWriter(table, rewritableDeletes, writerFactory, deleteFileFactory, context);
       this.positionDelete = PositionDelete.create();
       this.io = table.io();
       this.specs = table.specs();
@@ -547,6 +625,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     DeleteAndDataDeltaWriter(
         Table table,
+        Map<String, DeleteFileSet> rewritableDeletes,
         SparkFileWriterFactory writerFactory,
         OutputFileFactory dataFileFactory,
         OutputFileFactory deleteFileFactory,
@@ -554,7 +633,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       this.delegate =
           new BasePositionDeltaWriter<>(
               newDataWriter(table, writerFactory, dataFileFactory, context),
-              newDeleteWriter(table, writerFactory, deleteFileFactory, context));
+              newDeleteWriter(table, rewritableDeletes, writerFactory, deleteFileFactory, context));
       this.io = table.io();
       this.specs = table.specs();
 
@@ -619,11 +698,12 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     UnpartitionedDeltaWriter(
         Table table,
+        Map<String, DeleteFileSet> rewritableDeletes,
         SparkFileWriterFactory writerFactory,
         OutputFileFactory dataFileFactory,
         OutputFileFactory deleteFileFactory,
         Context context) {
-      super(table, writerFactory, dataFileFactory, deleteFileFactory, context);
+      super(table, rewritableDeletes, writerFactory, dataFileFactory, deleteFileFactory, context);
       this.dataSpec = table.spec();
     }
 
@@ -645,11 +725,12 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     PartitionedDeltaWriter(
         Table table,
+        Map<String, DeleteFileSet> rewritableDeletes,
         SparkFileWriterFactory writerFactory,
         OutputFileFactory dataFileFactory,
         OutputFileFactory deleteFileFactory,
         Context context) {
-      super(table, writerFactory, dataFileFactory, deleteFileFactory, context);
+      super(table, rewritableDeletes, writerFactory, dataFileFactory, deleteFileFactory, context);
 
       this.dataSpec = table.spec();
       this.dataPartitionKey = new PartitionKey(dataSpec, context.dataSchema());


### PR DESCRIPTION
Backport #11273 to Spark 3.4