### PR TITLE
Core,REST: extend httpClient builder to support tls factory

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -261,7 +261,7 @@ public class TestHTTPClient {
             HTTPClient.REST_MAX_CONNECTIONS_PER_ROUTE, String.valueOf(maxConnectionPerRoute));
 
     HttpClientConnectionManager connectionManager =
-        HTTPClient.configureConnectionManager(properties);
+        HTTPClient.configureConnectionManager(properties, null);
     assertThat(connectionManager).isInstanceOf(PoolingHttpClientConnectionManager.class);
     PoolingHttpClientConnectionManager poolingHttpClientConnectionManager =
         (PoolingHttpClientConnectionManager) connectionManager;
@@ -274,7 +274,7 @@ public class TestHTTPClient {
   public void testMaxConnectionSettingsFromDefaults() {
     Map<String, String> properties = ImmutableMap.of();
     HttpClientConnectionManager connectionManager =
-        HTTPClient.configureConnectionManager(properties);
+        HTTPClient.configureConnectionManager(properties, null);
     assertThat(connectionManager).isInstanceOf(PoolingHttpClientConnectionManager.class);
     PoolingHttpClientConnectionManager poolingHttpClientConnectionManager =
         (PoolingHttpClientConnectionManager) connectionManager;


### PR DESCRIPTION
Adds support to specify custom TlsSocketStrategy for HttpClient. This is useful in case of establishing the mTLS connection

Possible alternative to https://github.com/apache/iceberg/pull/11548