### PR TITLE
REST: Add missing default HEAD endpoints and V1_COMMIT_TRANSACTION

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -151,6 +151,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
           .add(Endpoint.V1_RENAME_TABLE)
           .add(Endpoint.V1_REGISTER_TABLE)
           .add(Endpoint.V1_REPORT_METRICS)
+          .add(Endpoint.V1_COMMIT_TRANSACTION)
           .build();
 
   private static final Set<Endpoint> VIEW_ENDPOINTS =

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -111,6 +111,8 @@ paths:
 
           - GET /v1/{prefix}/namespaces/{namespace}
 
+          - HEAD /v1/{prefix}/namespaces/{namespace}
+
           - DELETE /v1/{prefix}/namespaces/{namespace}
 
           - POST /v1/{prefix}/namespaces/{namespace}/properties
@@ -120,6 +122,8 @@ paths:
           - POST /v1/{prefix}/namespaces/{namespace}/tables
 
           - GET /v1/{prefix}/namespaces/{namespace}/tables/{table}
+
+          - HEAD /v1/{prefix}/namespaces/{namespace}/tables/{table}
 
           - POST /v1/{prefix}/namespaces/{namespace}/tables/{table}
 


### PR DESCRIPTION
`HEAD /v1/{prefix}/namespaces/{namespace}` and `HEAD /v1/{prefix}/namespaces/{namespace}/tables/{table}` look missing in default endpoints in open-api/rest-catalog-open-api.yaml. 

`POST /v1/{prefix}/transactions/commit` is mentioned in the above yaml, but `DEFAULT_ENDPOINTS` constant doesn't contain `Endpoint.V1_COMMIT_TRANSACTION`. 