### PR TITLE
Spark 3.5: Fix broadcasting specs in RewriteTablePath

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -925,12 +925,6 @@ public class TestRewriteTablePathsAction extends TestBase {
     // force deserializing broadcast values
     removeBroadcastValuesFromLocalBlockManager(tableBroadcast.id());
     assertThat(tableBroadcast.getValue().uuid()).isEqualTo(table.uuid());
-
-    Map<Integer, PartitionSpec> specs = table.specs();
-    Broadcast<Map<Integer, PartitionSpec>> specsBroadcast = action.specsBroadcast(specs);
-    // force deserializing broadcast values
-    removeBroadcastValuesFromLocalBlockManager(specsBroadcast.id());
-    assertThat(specsBroadcast.getValue()).isEqualTo(specs);
   }
 
   protected void checkFileNum(


### PR DESCRIPTION
This PR fixes following exception when running `rewrite_table_path` action with Spark

```
java.lang.UnsupportedOperationException
	at org.apache.iceberg.spark.actions.RewriteTablePathSparkAction.writeDataManifest(RewriteTablePathSparkAction.java:535)
	at org.apache.iceberg.spark.actions.RewriteTablePathSparkAction.lambda$toManifests$fbc8fb31$1(RewriteTablePathSparkAction.java:491)
	at org.apache.spark.sql.execution.MapElementsExec.$anonfun$doExecute$9(objects.scala:302)
	at org.apache.spark.sql.execution.MapElementsExec.$anonfun$doExecute$11(objects.scala:309)
	at scala.collection.Iterator$$anon$10.next(Iterator.scala:461)
	at scala.collection.Iterator$$anon$10.next(Iterator.scala:461)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
	at scala.collection.TraversableOnce.reduceLeft(TraversableOnce.scala:237)
	at scala.collection.TraversableOnce.reduceLeft$(TraversableOnce.scala:220)
	at scala.collection.AbstractIterator.reduceLeft(Iterator.scala:1431)
	at org.apache.spark.rdd.RDD.$anonfun$reduce$2(RDD.scala:1183)
	at org.apache.spark.SparkContext.$anonfun$runJob$6(SparkContext.scala:2637)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:93)
	at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:161)
	at org.apache.spark.scheduler.Task.run(Task.scala:152)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$4(Executor.scala:622)
	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:64)
	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:61)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:94)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:625)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.io.IOException: java.lang.UnsupportedOperationException
	at org.apache.spark.util.SparkErrorUtils.tryOrIOException(SparkErrorUtils.scala:42)
	at org.apache.spark.util.SparkErrorUtils.tryOrIOException$(SparkErrorUtils.scala:33)
	at org.apache.spark.util.Utils$.tryOrIOException(Utils.scala:94)
	at org.apache.spark.broadcast.TorrentBroadcast.readBroadcastBlock(TorrentBroadcast.scala:260)
	at org.apache.spark.broadcast.TorrentBroadcast.getValue(TorrentBroadcast.scala:117)
	at org.apache.iceberg.spark.actions.RewriteTablePathSparkAction.writeDataManifest(RewriteTablePathSparkAction.java:531)
	... 24 more
Caused by: java.lang.UnsupportedOperationException
	at org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap.put(ImmutableMap.java:814)
	at com.esotericsoftware.kryo.serializers.MapSerializer.read(MapSerializer.java:162)
	at com.esotericsoftware.kryo.serializers.MapSerializer.read(MapSerializer.java:39)
	at com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:813)
	at org.apache.spark.serializer.KryoDeserializationStream.readObject(KryoSerializer.scala:546)
	at org.apache.spark.broadcast.TorrentBroadcast$.$anonfun$unBlockifyObject$4(TorrentBroadcast.scala:390)
	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:64)
	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:61)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:94)
	at org.apache.spark.broadcast.TorrentBroadcast$.unBlockifyObject(TorrentBroadcast.scala:392)
	at org.apache.spark.broadcast.TorrentBroadcast.$anonfun$readBroadcastBlock$4(TorrentBroadcast.scala:293)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.broadcast.TorrentBroadcast.$anonfun$readBroadcastBlock$2(TorrentBroadcast.scala:265)
	at org.apache.spark.util.KeyLock.withLock(KeyLock.scala:64)
	at org.apache.spark.broadcast.TorrentBroadcast.$anonfun$readBroadcastBlock$1(TorrentBroadcast.scala:260)
	at org.apache.spark.util.SparkErrorUtils.tryOrIOException(SparkErrorUtils.scala:35)
	... 29 more
```