### PR TITLE
Spark: Fix Puffin suffix for DV files

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadDelete.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.RowLevelOperationMode;
@@ -232,6 +233,7 @@ public class TestMergeOnReadDelete extends TestDelete {
         deleteFiles.stream().filter(ContentFileUtil::isDV).collect(Collectors.toList());
     assertThat(dvs).hasSize(1);
     assertThat(dvs).allMatch(dv -> dv.recordCount() == 3);
+    assertThat(dvs).allMatch(dv -> FileFormat.fromFileName(dv.location()) == FileFormat.PUFFIN);
   }
 
   private void checkDeleteFileGranularity(DeleteGranularity deleteGranularity)

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadMerge.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadMerge.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
@@ -129,6 +130,7 @@ public class TestMergeOnReadMerge extends TestMerge {
         deleteFiles.stream().filter(ContentFileUtil::isDV).collect(Collectors.toList());
     assertThat(dvs).hasSize(1);
     assertThat(dvs).allMatch(dv -> dv.recordCount() == 3);
+    assertThat(dvs).allMatch(dv -> FileFormat.fromFileName(dv.location()) == FileFormat.PUFFIN);
   }
 
   private void checkMergeDeleteGranularity(DeleteGranularity deleteGranularity) {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadUpdate.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadUpdate.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
@@ -209,6 +210,7 @@ public class TestMergeOnReadUpdate extends TestUpdate {
         deleteFiles.stream().filter(ContentFileUtil::isDV).collect(Collectors.toList());
     assertThat(dvs).hasSize(1);
     assertThat(dvs.get(0).recordCount()).isEqualTo(3);
+    assertThat(dvs).allMatch(dv -> FileFormat.fromFileName(dv.location()) == FileFormat.PUFFIN);
   }
 
   private void initTable(String partitionedBy, DeleteGranularity deleteGranularity) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -37,14 +37,14 @@ import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.DEL
 
 import java.util.Locale;
 import java.util.Map;
+import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.IsolationLevel;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.deletes.DeleteGranularity;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -214,6 +214,10 @@ public class SparkWriteConf {
   }
 
   public FileFormat deleteFileFormat() {
+    if (!(table instanceof BaseMetadataTable) && TableUtil.formatVersion(table) >= 3) {
+      return FileFormat.PUFFIN;
+    }
+
     String valueAsString =
         confParser
             .stringConf()
@@ -720,10 +724,5 @@ public class SparkWriteConf {
         .tableProperty(TableProperties.DELETE_GRANULARITY)
         .defaultValue(DeleteGranularity.FILE)
         .parse();
-  }
-
-  public boolean useDVs() {
-    TableOperations ops = ((HasTableOperations) table).operations();
-    return ops.current().formatVersion() >= 3;
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -786,7 +786,6 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     private final String queryId;
     private final boolean useFanoutWriter;
     private final boolean inputOrdered;
-    private final boolean useDVs;
 
     Context(
         Schema dataSchema,
@@ -805,7 +804,6 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       this.queryId = info.queryId();
       this.useFanoutWriter = writeConf.useFanoutWriter(writeRequirements);
       this.inputOrdered = writeRequirements.hasOrdering();
-      this.useDVs = writeConf.useDVs();
     }
 
     Schema dataSchema() {
@@ -853,7 +851,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     }
 
     boolean useDVs() {
-      return useDVs;
+      return deleteFileFormat == FileFormat.PUFFIN;
     }
 
     int specIdOrdinal() {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -51,6 +51,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateProperties;
@@ -538,6 +539,14 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
     for (List<Map<String, String>> propertiesSuite : propertiesSuites) {
       testWriteProperties(propertiesSuite);
     }
+  }
+
+  @TestTemplate
+  public void testDVWriteConf() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    table.updateProperties().set(TableProperties.FORMAT_VERSION, "3").commit();
+    SparkWriteConf writeConf = new SparkWriteConf(spark, table, ImmutableMap.of());
+    assertThat(writeConf.deleteFileFormat()).isEqualTo(FileFormat.PUFFIN);
   }
 
   private void testWriteProperties(List<Map<String, String>> propertiesSuite) {


### PR DESCRIPTION
Fixes #11968 

Currently, when writing DVs in Spark, the incorrect file suffix is being used. This is because the file format passed to the output file factory which produces the actual filename is not correct and uses the default conf delete file format (typically the same as the data file format).

Note, the actual Puffin DVs were always being written when the table format is V3, it just had the wrong suffix so users see "delete-foo.parquet" even though the file is really a Puffin file with DVs. 