### PR TITLE
Revert "API: add hashcode cache in StructType (#11764)"

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -729,9 +729,6 @@ public class Types {
 
   public static class StructType extends NestedType {
     private static final Joiner FIELD_SEP = Joiner.on(", ");
-    private static final int NO_HASHCODE = Integer.MIN_VALUE;
-
-    private transient int hashCode = NO_HASHCODE;
 
     public static StructType of(NestedField... fields) {
       return of(Arrays.asList(fields));
@@ -833,10 +830,7 @@ public class Types {
 
     @Override
     public int hashCode() {
-      if (hashCode == NO_HASHCODE) {
-        hashCode = Objects.hash(NestedField.class, Arrays.hashCode(fields));
-      }
-      return hashCode;
+      return Objects.hash(NestedField.class, Arrays.hashCode(fields));
     }
 
     private List<NestedField> lazyFieldList() {


### PR DESCRIPTION
It looks like it breaks some tests on the Flink side wrt serialization.

This reverts commit bed7c33174ca97809fc4a9657d39b1d09ae38b72.