### PR TITLE
Build: Nighly build for Iceberg REST fixtures

### DIFF
--- a/.github/workflows/publish-iceberg-rest-fixture-docker.yml
+++ b/.github/workflows/publish-iceberg-rest-fixture-docker.yml
@@ -20,9 +20,8 @@
 name: Build and Push 'iceberg-rest-fixture' Docker Image
 
 on:
-  push:
-    tags:
-      - 'apache-iceberg-[0-9]+.[0-9]+.[0-9]+'
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
While trying to downstream V3 into PyIceberg/Iceberg-Rust/etc, I think it would be good to rebuild the REST fixtures every night.