### PR TITLE
OpenAPI: Deprecate snapshot-id of SetStatisticsUpdate

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1146,10 +1146,6 @@ acceptedBreaks:
         \ org.apache.iceberg.TableMetadata)"
       justification: "Removing deprecated code"
   "1.7.0":
-    org.apache.iceberg:iceberg-api:
-    - code: "java.method.addedToInterface"
-      new: "method org.apache.iceberg.UpdateStatistics org.apache.iceberg.UpdateStatistics::setStatistics(org.apache.iceberg.StatisticsFile)"
-      justification: "Redundant snapshot-id in UpdateStatistics"
     org.apache.iceberg:iceberg-core:
     - code: "java.method.removed"
       old: "method <T extends org.apache.iceberg.StructLike> org.apache.iceberg.deletes.PositionDeleteIndex\

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1146,6 +1146,10 @@ acceptedBreaks:
         \ org.apache.iceberg.TableMetadata)"
       justification: "Removing deprecated code"
   "1.7.0":
+    org.apache.iceberg:iceberg-api:
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.UpdateStatistics org.apache.iceberg.UpdateStatistics::setStatistics(org.apache.iceberg.StatisticsFile)"
+      justification: "Redundant snapshot-id in UpdateStatistics"
     org.apache.iceberg:iceberg-core:
     - code: "java.method.removed"
       old: "method <T extends org.apache.iceberg.StructLike> org.apache.iceberg.deletes.PositionDeleteIndex\

--- a/api/src/main/java/org/apache/iceberg/UpdateStatistics.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateStatistics.java
@@ -27,7 +27,8 @@ public interface UpdateStatistics extends PendingUpdate<List<StatisticsFile>> {
    * the snapshot if any exists.
    *
    * @return this for method chaining
-   * @deprecated since 1.8.0, will be removed 1.9.0 or 2.0.0, use {@link #setStatistics(StatisticsFile)}.
+   * @deprecated since 1.8.0, will be removed 1.9.0 or 2.0.0, use {@link
+   *     #setStatistics(StatisticsFile)}.
    */
   @Deprecated
   UpdateStatistics setStatistics(long snapshotId, StatisticsFile statisticsFile);

--- a/api/src/main/java/org/apache/iceberg/UpdateStatistics.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateStatistics.java
@@ -27,8 +27,18 @@ public interface UpdateStatistics extends PendingUpdate<List<StatisticsFile>> {
    * the snapshot if any exists.
    *
    * @return this for method chaining
+   * @deprecated since 1.8.0, will be removed 1.9.0 or 2.0.0, use setStatistics(statisticsFile).
    */
+  @Deprecated
   UpdateStatistics setStatistics(long snapshotId, StatisticsFile statisticsFile);
+
+  /**
+   * Set the table's statistics file for given snapshot, replacing the previous statistics file for
+   * the snapshot if any exists.
+   *
+   * @return this for method chaining
+   */
+  UpdateStatistics setStatistics(StatisticsFile statisticsFile);
 
   /**
    * Remove the table's statistics file for given snapshot.

--- a/api/src/main/java/org/apache/iceberg/UpdateStatistics.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateStatistics.java
@@ -35,7 +35,7 @@ public interface UpdateStatistics extends PendingUpdate<List<StatisticsFile>> {
 
   /**
    * Set the table's statistics file for given snapshot, replacing the previous statistics file for
-   * the snapshot if any exists.
+   * the snapshot if any exists. The snapshot id of the statistics file will be used.
    *
    * @return this for method chaining
    */

--- a/api/src/main/java/org/apache/iceberg/UpdateStatistics.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateStatistics.java
@@ -27,7 +27,7 @@ public interface UpdateStatistics extends PendingUpdate<List<StatisticsFile>> {
    * the snapshot if any exists.
    *
    * @return this for method chaining
-   * @deprecated since 1.8.0, will be removed 1.9.0 or 2.0.0, use setStatistics(statisticsFile).
+   * @deprecated since 1.8.0, will be removed 1.9.0 or 2.0.0, use {@link #setStatistics(StatisticsFile)}.
    */
   @Deprecated
   UpdateStatistics setStatistics(long snapshotId, StatisticsFile statisticsFile);

--- a/api/src/main/java/org/apache/iceberg/UpdateStatistics.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateStatistics.java
@@ -38,7 +38,9 @@ public interface UpdateStatistics extends PendingUpdate<List<StatisticsFile>> {
    *
    * @return this for method chaining
    */
-  UpdateStatistics setStatistics(StatisticsFile statisticsFile);
+  default UpdateStatistics setStatistics(StatisticsFile statisticsFile) {
+    throw new UnsupportedOperationException("Setting statistics is not supported");
+  }
 
   /**
    * Remove the table's statistics file for given snapshot.

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -231,16 +231,25 @@ public interface MetadataUpdate extends Serializable {
   }
 
   class SetStatistics implements MetadataUpdate {
-    private final long snapshotId;
     private final StatisticsFile statisticsFile;
 
+    /**
+     * Set statistics for a snapshot.
+     *
+     * @deprecated since 1.8.0, will be removed in 1.9.0 or 2.0.0, use
+     *     SetStatistics(statisticsFile).
+     */
+    @Deprecated
     public SetStatistics(long snapshotId, StatisticsFile statisticsFile) {
-      this.snapshotId = snapshotId;
+      this.statisticsFile = statisticsFile;
+    }
+
+    public SetStatistics(StatisticsFile statisticsFile) {
       this.statisticsFile = statisticsFile;
     }
 
     public long snapshotId() {
-      return snapshotId;
+      return statisticsFile.snapshotId();
     }
 
     public StatisticsFile statisticsFile() {
@@ -249,7 +258,7 @@ public interface MetadataUpdate extends Serializable {
 
     @Override
     public void applyTo(TableMetadata.Builder metadataBuilder) {
-      metadataBuilder.setStatistics(snapshotId, statisticsFile);
+      metadataBuilder.setStatistics(statisticsFile);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -512,10 +512,9 @@ public class MetadataUpdateParser {
   }
 
   private static MetadataUpdate readSetStatistics(JsonNode node) {
-    long snapshotId = JsonUtil.getLong(SNAPSHOT_ID, node);
     JsonNode statisticsFileNode = JsonUtil.get(STATISTICS, node);
     StatisticsFile statisticsFile = StatisticsFileParser.fromJson(statisticsFileNode);
-    return new MetadataUpdate.SetStatistics(snapshotId, statisticsFile);
+    return new MetadataUpdate.SetStatistics(statisticsFile);
   }
 
   private static MetadataUpdate readRemoveStatistics(JsonNode node) {

--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -35,7 +35,7 @@ public class SetStatistics implements UpdateStatistics {
   /**
    * Set the statistics file for a snapshot.
    *
-   * @deprecated since 1.8.0, will be removed in 1.9.0 or 2.0.0, use setStatistics(statisticsFile).
+   * @deprecated since 1.8.0, will be removed in 1.9.0 or 2.0.0, use {@link #setStatistics(StatisticsFile)}.
    */
   @Deprecated
   @Override

--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -32,10 +32,22 @@ public class SetStatistics implements UpdateStatistics {
     this.ops = ops;
   }
 
+  /**
+   * Add a new schema.
+   *
+   * @deprecated since 1.8.0, will be removed in 1.9.0 or 2.0.0, use setStatistics(statisticsFile).
+   */
+  @Deprecated
   @Override
   public UpdateStatistics setStatistics(long snapshotId, StatisticsFile statisticsFile) {
     Preconditions.checkArgument(snapshotId == statisticsFile.snapshotId());
-    statisticsToSet.put(snapshotId, Optional.of(statisticsFile));
+    statisticsToSet.put(statisticsFile.snapshotId(), Optional.of(statisticsFile));
+    return this;
+  }
+
+  @Override
+  public UpdateStatistics setStatistics(StatisticsFile statisticsFile) {
+    statisticsToSet.put(statisticsFile.snapshotId(), Optional.of(statisticsFile));
     return this;
   }
 

--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -35,7 +35,8 @@ public class SetStatistics implements UpdateStatistics {
   /**
    * Set the statistics file for a snapshot.
    *
-   * @deprecated since 1.8.0, will be removed in 1.9.0 or 2.0.0, use {@link #setStatistics(StatisticsFile)}.
+   * @deprecated since 1.8.0, will be removed in 1.9.0 or 2.0.0, use {@link
+   *     #setStatistics(StatisticsFile)}.
    */
   @Deprecated
   @Override

--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -33,7 +33,7 @@ public class SetStatistics implements UpdateStatistics {
   }
 
   /**
-   * Add a new schema.
+   * Set the statistics file for a snapshot.
    *
    * @deprecated since 1.8.0, will be removed in 1.9.0 or 2.0.0, use setStatistics(statisticsFile).
    */

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1319,6 +1319,12 @@ public class TableMetadata implements Serializable {
       return this;
     }
 
+    /**
+     * Set a statistics file for a snapshot.
+     *
+     * @deprecated since 1.8.0, will be removed 1.9.0 or 2.0.0, use setStatistics(statisticsFile).
+     */
+    @Deprecated
     public Builder setStatistics(long snapshotId, StatisticsFile statisticsFile) {
       Preconditions.checkNotNull(statisticsFile, "statisticsFile is null");
       Preconditions.checkArgument(
@@ -1327,7 +1333,14 @@ public class TableMetadata implements Serializable {
           snapshotId,
           statisticsFile.snapshotId());
       statisticsFiles.put(statisticsFile.snapshotId(), ImmutableList.of(statisticsFile));
-      changes.add(new MetadataUpdate.SetStatistics(snapshotId, statisticsFile));
+      changes.add(new MetadataUpdate.SetStatistics(statisticsFile));
+      return this;
+    }
+
+    public Builder setStatistics(StatisticsFile statisticsFile) {
+      Preconditions.checkNotNull(statisticsFile, "statisticsFile is null");
+      statisticsFiles.put(statisticsFile.snapshotId(), ImmutableList.of(statisticsFile));
+      changes.add(new MetadataUpdate.SetStatistics(statisticsFile));
       return this;
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -783,7 +783,6 @@ public class TestMetadataUpdateParser {
     long snapshotId = 1940541653261589030L;
     MetadataUpdate expected =
         new MetadataUpdate.SetStatistics(
-            snapshotId,
             new GenericStatisticsFile(
                 snapshotId,
                 "s3://bucket/warehouse/stats.puffin",

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1024,7 +1024,7 @@ class Term(BaseModel):
 
 class SetStatisticsUpdate(BaseUpdate):
     action: str = Field('set-statistics', const=True)
-    snapshot_id: int = Field(..., alias='snapshot-id')
+    snapshot_id: Optional[int] = Field(None, alias='snapshot-id')
     statistics: StatisticsFile
 
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1024,7 +1024,11 @@ class Term(BaseModel):
 
 class SetStatisticsUpdate(BaseUpdate):
     action: str = Field('set-statistics', const=True)
-    snapshot_id: Optional[int] = Field(None, alias='snapshot-id')
+    snapshot_id: Optional[int] = Field(
+        None,
+        alias='snapshot-id',
+        description='This optional field is **DEPRECATED for REMOVAL** since it contains redundant information. Clients should use the `statistics.snapshot-id` field instead.',
+    )
     statistics: StatisticsFile
 
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2889,6 +2889,7 @@ components:
         snapshot-id:
           type: integer
           format: int64
+          deprecated: true
           description:
             This optional field is **DEPRECATED for REMOVAL** since it contains redundant information.
             Clients should use the `statistics.snapshot-id` field instead.

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2881,7 +2881,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       required:
-        - snapshot-id
         - statistics
       properties:
         action:
@@ -2890,6 +2889,9 @@ components:
         snapshot-id:
           type: integer
           format: int64
+          description:
+            This optional field is **DEPRECATED for REMOVAL** since it contains redundant information.
+            Clients should use the `statistics.snapshot-id` field instead.
         statistics:
           $ref: '#/components/schemas/StatisticsFile'
 


### PR DESCRIPTION
Following the discussion on the Mailing List:
https://lists.apache.org/thread/phxjz196zbzg0fjpfkmnj0fpkshgh9z0

I would appreciate a more thorough look at the Java code changes, it's my first deprecation in iceberg and java is not my primary language.