### PR TITLE
Make view metadata path configurable by `write.metadata.path`

### DIFF
--- a/core/src/main/java/org/apache/iceberg/view/BaseViewOperations.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseViewOperations.java
@@ -163,9 +163,15 @@ public abstract class BaseViewOperations extends BaseMetastoreOperations impleme
   }
 
   private String metadataFileLocation(ViewMetadata metadata, String filename) {
-    return String.format(
-        "%s/%s/%s",
-        LocationUtil.stripTrailingSlash(metadata.location()), METADATA_FOLDER_NAME, filename);
+    String metadataLocation = metadata.properties().get(ViewProperties.WRITE_METADATA_LOCATION);
+
+    if (metadataLocation != null) {
+      return String.format("%s/%s", LocationUtil.stripTrailingSlash(metadataLocation), filename);
+    } else {
+      return String.format(
+          "%s/%s/%s",
+          LocationUtil.stripTrailingSlash(metadata.location()), METADATA_FOLDER_NAME, filename);
+    }
   }
 
   protected void refreshFromMetadataLocation(String newLocation) {

--- a/core/src/main/java/org/apache/iceberg/view/ViewProperties.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewProperties.java
@@ -25,6 +25,7 @@ public class ViewProperties {
 
   public static final String METADATA_COMPRESSION = "write.metadata.compression-codec";
   public static final String METADATA_COMPRESSION_DEFAULT = "gzip";
+  public static final String WRITE_METADATA_LOCATION = "write.metadata.path";
   public static final String COMMENT = "comment";
   public static final String REPLACE_DROP_DIALECT_ALLOWED = "replace.drop-dialect.allowed";
   public static final boolean REPLACE_DROP_DIALECT_ALLOWED_DEFAULT = false;

--- a/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
@@ -259,14 +259,16 @@ public abstract class ViewCatalogTests<C extends ViewCatalog & SupportsNamespace
             .withDefaultNamespace(identifier.namespace())
             .withDefaultCatalog(catalog().name())
             .withQuery("spark", "select * from ns.tbl")
-            .withProperty("write.metadata.path", customLocation)
+            .withProperty(ViewProperties.WRITE_METADATA_LOCATION, customLocation)
             .withLocation(location)
             .create();
 
     assertThat(view).isNotNull();
     assertThat(catalog().viewExists(identifier)).as("View should exist").isTrue();
     assertThat(view.properties()).containsEntry("write.metadata.path", customLocation);
-    assertThat(((BaseView) view).operations().current().metadataFileLocation()).isNotNull();
+    assertThat(((BaseView) view).operations().current().metadataFileLocation())
+        .isNotNull()
+        .startsWith(customLocation);
   }
 
   @Test

--- a/docs/docs/view-configuration.md
+++ b/docs/docs/view-configuration.md
@@ -25,12 +25,12 @@ title: "Configuration"
 Iceberg views support properties to configure view behavior. Below is an overview of currently available view properties.
 
 
-| Property                         | Default                    | Description                                                                        |
-|----------------------------------|----------------------------|------------------------------------------------------------------------------------|
-| write.metadata.compression-codec | gzip                       | Metadata compression codec: `none` or `gzip`                                       |
-| write.metadata.path              | table location + /metadata | Base location for metadata files                                                   |
-| version.history.num-entries      | 10                         | Controls the number of `versions` to retain                                        |
-| replace.drop-dialect.allowed     | false                      | Controls whether a SQL dialect is allowed to be dropped during a replace operation |
+| Property                         | Default                   | Description                                                                        |
+|----------------------------------|---------------------------|------------------------------------------------------------------------------------|
+| write.metadata.compression-codec | gzip                      | Metadata compression codec: `none` or `gzip`                                       |
+| write.metadata.path              | view location + /metadata | Base location for metadata files                                                   |
+| version.history.num-entries      | 10                        | Controls the number of `versions` to retain                                        |
+| replace.drop-dialect.allowed     | false                     | Controls whether a SQL dialect is allowed to be dropped during a replace operation |
 
 
 ### View behavior properties

--- a/docs/docs/view-configuration.md
+++ b/docs/docs/view-configuration.md
@@ -28,6 +28,7 @@ Iceberg views support properties to configure view behavior. Below is an overvie
 | Property                                   | Default | Description                                                                        |
 |--------------------------------------------|---------|------------------------------------------------------------------------------------|
 | write.metadata.compression-codec           | gzip    | Metadata compression codec: `none` or `gzip`                                       |
+| write.metadata.path              | table location + /metadata | Base location for metadata files                                          |
 | version.history.num-entries                | 10      | Controls the number of `versions` to retain                                        |
 | replace.drop-dialect.allowed               | false   | Controls whether a SQL dialect is allowed to be dropped during a replace operation |
 

--- a/docs/docs/view-configuration.md
+++ b/docs/docs/view-configuration.md
@@ -25,12 +25,12 @@ title: "Configuration"
 Iceberg views support properties to configure view behavior. Below is an overview of currently available view properties.
 
 
-| Property                                   | Default | Description                                                                        |
-|--------------------------------------------|---------|------------------------------------------------------------------------------------|
-| write.metadata.compression-codec           | gzip    | Metadata compression codec: `none` or `gzip`                                       |
-| write.metadata.path              | table location + /metadata | Base location for metadata files                                          |
-| version.history.num-entries                | 10      | Controls the number of `versions` to retain                                        |
-| replace.drop-dialect.allowed               | false   | Controls whether a SQL dialect is allowed to be dropped during a replace operation |
+| Property                         | Default                    | Description                                                                        |
+|----------------------------------|----------------------------|------------------------------------------------------------------------------------|
+| write.metadata.compression-codec | gzip                       | Metadata compression codec: `none` or `gzip`                                       |
+| write.metadata.path              | table location + /metadata | Base location for metadata files                                                   |
+| version.history.num-entries      | 10                         | Controls the number of `versions` to retain                                        |
+| replace.drop-dialect.allowed     | false                      | Controls whether a SQL dialect is allowed to be dropped during a replace operation |
 
 
 ### View behavior properties


### PR DESCRIPTION
## Overview

This commit makes the View's metadata file location configurable by `write.metadata.path` as the table configuration, it and provides more flexible way to configure the metadata file path for Iceberg Views.

## Background

Currently, View's metadata file location respects its relevant database location first. If the database doesn't have the location, the View's metadata location is set to a warehouse location. 

For now, when you customize the View's metadata location, you need to set the `warehouse` parameter. However, if your database has the configured location in its property such as `location: /db/table/path`, you need to change the database location (this is not always easy).

## Example

```sql
-- SparkSQL
CREATE VIEW db.view TBLPROPERTIES('write.metadata.path'='s3://bucket/path/new-metadata-loc') 
AS SELECT year, count(*) as cnt FROM db.tbl GROUP BY year

DESCRIBE EXTENDED db.view
+---------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------+
|col_name                   |data_type                                                                                                                                                               |comment|
+---------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------+
|year                       |int                                                                                                                                                                     |       |
|cnt                        |bigint                                                                                                                                                                  |       |
|                           |                                                                                                                                                                        |       |
|# Detailed View Information|                                                                                                                                                                        |       |
|Comment                    |                                                                                                                                                                        |       |
|View Catalog and Namespace |hive_catalog.db                                                                                                                                                         |       |
|View Query Output Columns  |[year, cnt]                                                                                                                                                             |       |
|View Properties            |['format-version' = '1', 'location' = 's3://bucket/path/database-location', 'provider' = 'iceberg', 'write.metadata.path' = 's3://bucket/path/new-metadata-loc']        |       |
|Created By                 |Spark 3.5.3-amzn-0                                                                                                                                                      |       |
+---------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------+
```