### PR TITLE
Flink: Upgrade Flink version 1.19.0 => 1.19.1 to mitigate NoSuchMethodError on commit

### DIFF
--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/util/TestFlinkPackage.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/util/TestFlinkPackage.java
@@ -29,7 +29,7 @@ public class TestFlinkPackage {
   /** This unit test would need to be adjusted as new Flink version is supported. */
   @Test
   public void testVersion() {
-    assertThat(FlinkPackage.version()).isEqualTo("1.19.0");
+    assertThat(FlinkPackage.version()).isEqualTo("1.19.1");
   }
 
   @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@ errorprone-annotations = "2.36.0"
 failsafe = "3.3.2"
 findbugs-jsr305 = "3.0.2"
 flink118 =  { strictly = "1.18.1"}
-flink119 =  { strictly = "1.19.0"}
+flink119 =  { strictly = "1.19.1"}
 flink120 = { strictly = "1.20.0"}
 google-libraries-bom = "26.53.0"
 guava = "33.4.0-jre"

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -80,7 +80,7 @@ markdown_extensions:
 extra:
   icebergVersion: '1.7.1'
   nessieVersion: '0.92.1'
-  flinkVersion: '1.19.0'
+  flinkVersion: '1.19.1'
   flinkVersionMajor: '1.19'
   social:
     - icon: fontawesome/regular/comments


### PR DESCRIPTION
If users run a Flink job on Flink 1.19.1 with IcebergSink compiled against 1.19.0, as is the case prior this change, they will get the following exception on commit:

```
java.lang.NoSuchMethodError: 'void org.apache.flink.streaming.api.connector.sink2.CommittableSummary.<init>(int, int, java.lang.Long, int, int, int)'
    at org.apache.iceberg.flink.sink.IcebergWriteAggregator.prepareSnapshotPreBarrier(IcebergWriteAggregator.java:91)
```

The reason is that from 1.19.0 to 1.19.1, Flink changed the signature of the constructor for `CommittableSummary` from

```
CommittableSummary(int, int, Long, int, int, int)
```
to
```
CommittableSummary(int, int, long, int, int, int)
```

Note the `Long` to `long` change. Since Flink 1.19.1 is the latest supported version and 1.19.0 is no longer supported, it is fair to upgrade.