### PR TITLE
ORC: Fail when initial default support is required

### DIFF
--- a/orc/src/test/java/org/apache/iceberg/orc/TestBuildOrcProjection.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestBuildOrcProjection.java
@@ -162,6 +162,33 @@ public class TestBuildOrcProjection {
 
     assertThatThrownBy(() -> ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Field 4 of type long is required and was not found.");
+        .hasMessage("Missing required field: b.d (long)");
+  }
+
+  @Test
+  public void testRequiredNestedFieldWithDefaultMissingInFile() {
+    Schema baseSchema =
+        new Schema(
+            required(1, "a", Types.IntegerType.get()),
+            required(2, "b", Types.StructType.of(required(3, "c", Types.LongType.get()))));
+    TypeDescription baseOrcSchema = ORCSchemaUtil.convert(baseSchema);
+
+    Schema evolvedSchema =
+        new Schema(
+            required(1, "a", Types.IntegerType.get()),
+            required(
+                2,
+                "b",
+                Types.StructType.of(
+                    required(3, "c", Types.LongType.get()),
+                    Types.NestedField.required("d")
+                        .withId(4)
+                        .ofType(Types.LongType.get())
+                        .withInitialDefault(34L)
+                        .build())));
+
+    assertThatThrownBy(() -> ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("ORC cannot read default value for field b.d (long): 34");
   }
 }


### PR DESCRIPTION
Updates ORC's `buildOrcProjection` to fail with a good error message when a default value would be used, rather than failing with `ArrayIndexOutOfBoundsException`.

ORC readers are not built the same way that Parquet and Avro readers are built. ORC uses `buildOrcProjection` to create a requested ORC schema that matches the fields in the expected Iceberg schema. This schema is used for ORC projection, but is also used to produce ORC readers. As a result, ORC cannot currently detect missing columns when building readers, which is necessary for using a constant reader for the initial default.

Refactoring how ORC builds readers is a large task, so in the meantime this PR provides better error messages.