### PR TITLE
ORC: Fix null map values and list elements in vectorized reads

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
@@ -394,8 +394,12 @@ public class VectorizedSparkOrcReaders {
         @Override
         public ColumnarArray getArray(int rowId) {
           int index = getRowIndex(rowId);
-          return new ColumnarArray(
-              elementVector, (int) listVector.offsets[index], (int) listVector.lengths[index]);
+          if (listVector.noNulls || !listVector.isNull[index]) {
+            return new ColumnarArray(
+                elementVector, (int) listVector.offsets[index], (int) listVector.lengths[index]);
+          }
+
+          return null;
         }
       };
     }
@@ -429,11 +433,15 @@ public class VectorizedSparkOrcReaders {
         @Override
         public ColumnarMap getMap(int rowId) {
           int index = getRowIndex(rowId);
-          return new ColumnarMap(
-              keyVector,
-              valueVector,
-              (int) mapVector.offsets[index],
-              (int) mapVector.lengths[index]);
+          if (mapVector.noNulls || !mapVector.isNull[index]) {
+            return new ColumnarMap(
+                keyVector,
+                valueVector,
+                (int) mapVector.offsets[index],
+                (int) mapVector.lengths[index]);
+          }
+
+          return null;
         }
       };
     }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -255,7 +255,8 @@ public class GenericsHelpers {
     for (int i = 0; i < expectedElements.size(); i += 1) {
       Map.Entry<?, ?> expectedPair = expectedElements.get(i);
       Object actualKey = actualKeys.isNullAt(i) ? null : actualKeys.get(i, convert(keyType));
-      Object actualValue = actualValues.isNullAt(i) ? null : actualValues.get(i, convert(valueType));
+      Object actualValue =
+          actualValues.isNullAt(i) ? null : actualValues.get(i, convert(valueType));
 
       assertEqualsUnsafe(keyType, expectedPair.getKey(), actualKey);
       assertEqualsUnsafe(valueType, expectedPair.getValue(), actualValue);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -238,7 +238,7 @@ public class GenericsHelpers {
     List<?> expectedElements = Lists.newArrayList(expected);
     for (int i = 0; i < expectedElements.size(); i += 1) {
       Object expectedValue = expectedElements.get(i);
-      Object actualValue = actual.get(i, convert(elementType));
+      Object actualValue = actual.isNullAt(i) ? null : actual.get(i, convert(elementType));
 
       assertEqualsUnsafe(elementType, expectedValue, actualValue);
     }
@@ -254,8 +254,8 @@ public class GenericsHelpers {
 
     for (int i = 0; i < expectedElements.size(); i += 1) {
       Map.Entry<?, ?> expectedPair = expectedElements.get(i);
-      Object actualKey = actualKeys.get(i, convert(keyType));
-      Object actualValue = actualValues.get(i, convert(valueType));
+      Object actualKey = actualKeys.isNullAt(i) ? null : actualKeys.get(i, convert(keyType));
+      Object actualValue = actualValues.isNullAt(i) ? null : actualValues.get(i, convert(valueType));
 
       assertEqualsUnsafe(keyType, expectedPair.getKey(), actualKey);
       assertEqualsUnsafe(valueType, expectedPair.getValue(), actualValue);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
@@ -44,11 +44,6 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.junit.jupiter.api.Test;
 
 public class TestSparkOrcReader extends AvroDataTest {
-//  @Override
-//  protected boolean supportsDefaultValues() {
-//    return true;
-//  }
-
   @Override
   protected void writeAndValidate(Schema writeSchema, Schema expectedSchema) throws IOException {
     List<Record> records = RandomGenericData.generate(writeSchema, 100, 0L);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
@@ -71,8 +71,7 @@ public class TestSparkOrcReader extends AvroDataTest {
   }
 
   private void writeAndValidateRecords(
-      Schema writeSchema, Schema expectedSchema, List<Record> records)
-      throws IOException {
+      Schema writeSchema, Schema expectedSchema, List<Record> records) throws IOException {
     File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 


### PR DESCRIPTION
While working on default value support that became #12026, I refactored the Spark ORC reader test to write generic records and use the generic data validation. This was needed because validating missing fields in the expected record requires knowing its schema.

That refactor caused `testMixedTypes` to fail. I tracked down the cause and it is that the ORC vector converters for lists and maps did not handle null values. As a result they would produce bad map and list values that were non-null and contained reused values and keys. This fixes the problem by checking `noNulls` and `isNull` in the ORC map or list vector.