### PR TITLE
Remove slf4j-api reference in LICENSE as it's now excluded from the distributed jar files

### DIFF
--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -297,12 +297,6 @@ License: CC0 - http://creativecommons.org/publicdomain/zero/1.0/
 
 --------------------------------------------------------------------------------
 
-Group: org.slf4j  Name: slf4j-api  Version: 1.7.36
-Project URL: http://www.slf4j.org
-License: MIT License - http://www.opensource.org/licenses/mit-license.php
-
---------------------------------------------------------------------------------
-
 Group: software.amazon.awssdk  Name: annotations  Version: 2.28.5
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 

--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -511,9 +511,3 @@ License: The Apache Software License, Version 2.0 - http://www.apache.org/licens
 Group: org.reactivestreams  Name: reactive-streams  Version: 1.0.4
 Project URL: http://www.reactive-streams.org/
 License: MIT-0 - https://spdx.org/licenses/MIT-0.html
-
---------------------------------------------------------------------------------
-
-Group: org.slf4j  Name: slf4j-api  Version: 1.7.36
-Project URL: http://www.slf4j.org
-License: MIT License - http://www.opensource.org/licenses/mit-license.php

--- a/gcp-bundle/LICENSE
+++ b/gcp-bundle/LICENSE
@@ -549,12 +549,6 @@ License: Apache 2 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: org.slf4j  Name: slf4j-api  Version: 1.7.36
-Project URL: http://www.slf4j.org
-License: MIT License - http://www.opensource.org/licenses/mit-license.php
-
---------------------------------------------------------------------------------
-
 Group: org.threeten  Name: threetenbp  Version: 1.6.8
 Project URL: https://www.threeten.org
 Project URL: https://www.threeten.org/threetenbp


### PR DESCRIPTION
https://github.com/apache/iceberg/pull/10665 updated the bundle jar files by removing slf4j-api.

However, the `LICENSE` file in these bundle jar files has not been updated and still contain reference to `slf4j-api`.