### PR TITLE
Core: Add InternalData read and write builders

### DIFF
--- a/core/src/main/java/org/apache/iceberg/InternalData.java
+++ b/core/src/main/java/org/apache/iceberg/InternalData.java
@@ -1,24 +1,21 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg;
 
 import java.io.IOException;

--- a/core/src/main/java/org/apache/iceberg/InternalData.java
+++ b/core/src/main/java/org/apache/iceberg/InternalData.java
@@ -42,7 +42,16 @@ public class InternalData {
   private static final Map<FileFormat, Function<InputFile, ReadBuilder>> READ_BUILDERS =
       Maps.newConcurrentMap();
 
-  static {
+  static void register(
+      FileFormat format,
+      Function<OutputFile, WriteBuilder> writeBuilder,
+      Function<InputFile, ReadBuilder> readBuilder) {
+    WRITE_BUILDERS.put(format, writeBuilder);
+    READ_BUILDERS.put(format, readBuilder);
+  }
+
+  @SuppressWarnings("CatchBlockLogException")
+  private static void registerSupportedFormats() {
     InternalData.register(
         FileFormat.AVRO,
         outputFile -> Avro.write(outputFile).createWriterFunc(InternalWriter::create),
@@ -62,12 +71,8 @@ public class InternalData {
     }
   }
 
-  static void register(
-      FileFormat format,
-      Function<OutputFile, WriteBuilder> writeBuilder,
-      Function<InputFile, ReadBuilder> readBuilder) {
-    WRITE_BUILDERS.put(format, writeBuilder);
-    READ_BUILDERS.put(format, readBuilder);
+  static {
+    registerSupportedFormats();
   }
 
   public static WriteBuilder write(FileFormat format, OutputFile file) {
@@ -147,7 +152,7 @@ public class InternalData {
     ReadBuilder project(Schema projectedSchema);
 
     /** Read only the split that is {@code length} bytes starting at {@code start}. */
-    ReadBuilder split(long start, long length);
+    ReadBuilder split(long newStart, long newLength);
 
     /** Reuse container classes, like structs, lists, and maps. */
     ReadBuilder reuseContainers();

--- a/core/src/main/java/org/apache/iceberg/InternalData.java
+++ b/core/src/main/java/org/apache/iceberg/InternalData.java
@@ -119,6 +119,20 @@ public class InternalData {
      */
     WriteBuilder meta(String property, String value);
 
+    /**
+     * Set a file metadata properties from a Map.
+     *
+     * <p>Metadata properties are written into file metadata. To alter a writer configuration
+     * property, use {@link #set(String, String)}.
+     *
+     * @param properties a map of file metadata properties
+     * @return this for method chaining
+     */
+    default WriteBuilder meta(Map<String, String> properties) {
+      properties.forEach(this::meta);
+      return this;
+    }
+
     /** Overwrite the file if it already exists. */
     WriteBuilder overwrite();
 

--- a/core/src/main/java/org/apache/iceberg/InternalData.java
+++ b/core/src/main/java/org/apache/iceberg/InternalData.java
@@ -1,0 +1,148 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InternalData {
+  private InternalData() {}
+
+  private static final Logger LOG = LoggerFactory.getLogger(InternalData.class);
+  private static final Map<FileFormat, Function<OutputFile, WriteBuilder>> WRITE_BUILDERS =
+      Maps.newConcurrentMap();
+  private static final Map<FileFormat, Function<InputFile, ReadBuilder>> READ_BUILDERS =
+      Maps.newConcurrentMap();
+
+  static {
+    Avro.register();
+
+    try {
+      DynMethods.StaticMethod registerParquet =
+          DynMethods.builder("register")
+              .impl("org.apache.iceberg.parquet.Parquet")
+              .buildStaticChecked();
+
+      registerParquet.invoke();
+
+    } catch (NoSuchMethodException e) {
+      // failing to load Parquet is normal and does not require a stack trace
+      LOG.info("Unable to register Parquet for metadata files: {}", e.getMessage());
+    }
+  }
+
+  public static void register(
+      FileFormat format,
+      Function<OutputFile, WriteBuilder> writeBuilder,
+      Function<InputFile, ReadBuilder> readBuilder) {
+    WRITE_BUILDERS.put(format, writeBuilder);
+    READ_BUILDERS.put(format, readBuilder);
+  }
+
+  public static WriteBuilder write(FileFormat format, OutputFile file) {
+    Function<OutputFile, WriteBuilder> writeBuilder = WRITE_BUILDERS.get(format);
+    if (writeBuilder != null) {
+      return writeBuilder.apply(file);
+    }
+
+    throw new UnsupportedOperationException(
+        "Cannot write using unregistered internal data format: " + format);
+  }
+
+  public static ReadBuilder read(FileFormat format, InputFile file) {
+    Function<InputFile, ReadBuilder> readBuilder = READ_BUILDERS.get(format);
+    if (readBuilder != null) {
+      return readBuilder.apply(file);
+    }
+
+    throw new UnsupportedOperationException(
+        "Cannot read using unregistered internal data format: " + format);
+  }
+
+  public interface WriteBuilder {
+    /** Set the file schema. */
+    WriteBuilder schema(Schema schema);
+
+    /** Set the file schema's root name. */
+    WriteBuilder named(String name);
+
+    /**
+     * Set a writer configuration property.
+     *
+     * <p>Write configuration affects writer behavior. To add file metadata properties, use {@link
+     * #meta(String, String)}.
+     *
+     * @param property a writer config property name
+     * @param value config value
+     * @return this for method chaining
+     */
+    WriteBuilder set(String property, String value);
+
+    /**
+     * Set a file metadata property.
+     *
+     * <p>Metadata properties are written into file metadata. To alter a writer configuration
+     * property, use {@link #set(String, String)}.
+     *
+     * @param property a file metadata property name
+     * @param value config value
+     * @return this for method chaining
+     */
+    WriteBuilder meta(String property, String value);
+
+    /** Overwrite the file if it already exists. */
+    WriteBuilder overwrite();
+
+    /** Build the configured {@link FileAppender}. */
+    <D> FileAppender<D> build() throws IOException;
+  }
+
+  public interface ReadBuilder {
+    /** Set the projection schema. */
+    ReadBuilder project(Schema projectedSchema);
+
+    /** Read only the split that is {@code length} bytes starting at {@code start}. */
+    ReadBuilder split(long start, long length);
+
+    /** Reuse container classes, like structs, lists, and maps. */
+    ReadBuilder reuseContainers();
+
+    /** Set a custom class for in-memory objects at the schema root. */
+    ReadBuilder setRootType(Class<? extends StructLike> rootClass);
+
+    /** Set a custom class for in-memory objects at the given field ID. */
+    ReadBuilder setCustomType(int fieldId, Class<? extends StructLike> structClass);
+
+    /** Build the configured reader. */
+    <D> CloseableIterable<D> build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/InternalData.java
+++ b/core/src/main/java/org/apache/iceberg/InternalData.java
@@ -43,7 +43,8 @@ public class InternalData {
       Maps.newConcurrentMap();
 
   static {
-    InternalData.register(FileFormat.AVRO,
+    InternalData.register(
+        FileFormat.AVRO,
         outputFile -> Avro.write(outputFile).createWriterFunc(InternalWriter::create),
         inputFile -> Avro.read(inputFile).createResolvingReader(InternalReader::create));
 

--- a/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
-import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
@@ -71,7 +70,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
   }
 
   static class V3Writer extends ManifestListWriter {
-    private final V3Metadata.IndexedManifestFile wrapper;
+    private final V3Metadata.ManifestFileWrapper wrapper;
 
     V3Writer(OutputFile snapshotFile, long snapshotId, Long parentSnapshotId, long sequenceNumber) {
       super(
@@ -81,7 +80,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
               "parent-snapshot-id", String.valueOf(parentSnapshotId),
               "sequence-number", String.valueOf(sequenceNumber),
               "format-version", "3"));
-      this.wrapper = new V3Metadata.IndexedManifestFile(snapshotId, sequenceNumber);
+      this.wrapper = new V3Metadata.ManifestFileWrapper(snapshotId, sequenceNumber);
     }
 
     @Override
@@ -92,7 +91,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
     @Override
     protected FileAppender<ManifestFile> newAppender(OutputFile file, Map<String, String> meta) {
       try {
-        return Avro.write(file)
+        return InternalData.write(FileFormat.AVRO, file)
             .schema(V3Metadata.MANIFEST_LIST_SCHEMA)
             .named("manifest_file")
             .meta(meta)
@@ -106,7 +105,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
   }
 
   static class V2Writer extends ManifestListWriter {
-    private final V2Metadata.IndexedManifestFile wrapper;
+    private final V2Metadata.ManifestFileWrapper wrapper;
 
     V2Writer(OutputFile snapshotFile, long snapshotId, Long parentSnapshotId, long sequenceNumber) {
       super(
@@ -116,7 +115,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
               "parent-snapshot-id", String.valueOf(parentSnapshotId),
               "sequence-number", String.valueOf(sequenceNumber),
               "format-version", "2"));
-      this.wrapper = new V2Metadata.IndexedManifestFile(snapshotId, sequenceNumber);
+      this.wrapper = new V2Metadata.ManifestFileWrapper(snapshotId, sequenceNumber);
     }
 
     @Override
@@ -127,7 +126,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
     @Override
     protected FileAppender<ManifestFile> newAppender(OutputFile file, Map<String, String> meta) {
       try {
-        return Avro.write(file)
+        return InternalData.write(FileFormat.AVRO, file)
             .schema(V2Metadata.MANIFEST_LIST_SCHEMA)
             .named("manifest_file")
             .meta(meta)
@@ -141,7 +140,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
   }
 
   static class V1Writer extends ManifestListWriter {
-    private final V1Metadata.IndexedManifestFile wrapper = new V1Metadata.IndexedManifestFile();
+    private final V1Metadata.ManifestFileWrapper wrapper = new V1Metadata.ManifestFileWrapper();
 
     V1Writer(OutputFile snapshotFile, long snapshotId, Long parentSnapshotId) {
       super(
@@ -163,7 +162,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
     @Override
     protected FileAppender<ManifestFile> newAppender(OutputFile file, Map<String, String> meta) {
       try {
-        return Avro.write(file)
+        return InternalData.write(FileFormat.AVRO, file)
             .schema(V1Metadata.MANIFEST_LIST_SCHEMA)
             .named("manifest_file")
             .meta(meta)

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -20,7 +20,6 @@ package org.apache.iceberg;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileAppender;
@@ -236,7 +235,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
         PartitionSpec spec, OutputFile file) {
       Schema manifestSchema = V3Metadata.entrySchema(spec.partitionType());
       try {
-        return Avro.write(file)
+        return InternalData.write(FileFormat.AVRO, file)
             .schema(manifestSchema)
             .named("manifest_entry")
             .meta("schema", SchemaParser.toJson(spec.schema()))

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -219,11 +219,11 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   }
 
   static class V3Writer extends ManifestWriter<DataFile> {
-    private final V3Metadata.IndexedManifestEntry<DataFile> entryWrapper;
+    private final V3Metadata.ManifestEntryWrapper<DataFile> entryWrapper;
 
     V3Writer(PartitionSpec spec, EncryptedOutputFile file, Long snapshotId) {
       super(spec, file, snapshotId);
-      this.entryWrapper = new V3Metadata.IndexedManifestEntry<>(snapshotId, spec.partitionType());
+      this.entryWrapper = new V3Metadata.ManifestEntryWrapper<>(snapshotId);
     }
 
     @Override
@@ -253,11 +253,11 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   }
 
   static class V3DeleteWriter extends ManifestWriter<DeleteFile> {
-    private final V3Metadata.IndexedManifestEntry<DeleteFile> entryWrapper;
+    private final V3Metadata.ManifestEntryWrapper<DeleteFile> entryWrapper;
 
     V3DeleteWriter(PartitionSpec spec, EncryptedOutputFile file, Long snapshotId) {
       super(spec, file, snapshotId);
-      this.entryWrapper = new V3Metadata.IndexedManifestEntry<>(snapshotId, spec.partitionType());
+      this.entryWrapper = new V3Metadata.ManifestEntryWrapper<>(snapshotId);
     }
 
     @Override
@@ -270,7 +270,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
         PartitionSpec spec, OutputFile file) {
       Schema manifestSchema = V3Metadata.entrySchema(spec.partitionType());
       try {
-        return Avro.write(file)
+        return InternalData.write(FileFormat.AVRO, file)
             .schema(manifestSchema)
             .named("manifest_entry")
             .meta("schema", SchemaParser.toJson(spec.schema()))
@@ -292,11 +292,11 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   }
 
   static class V2Writer extends ManifestWriter<DataFile> {
-    private final V2Metadata.IndexedManifestEntry<DataFile> entryWrapper;
+    private final V2Metadata.ManifestEntryWrapper<DataFile> entryWrapper;
 
     V2Writer(PartitionSpec spec, EncryptedOutputFile file, Long snapshotId) {
       super(spec, file, snapshotId);
-      this.entryWrapper = new V2Metadata.IndexedManifestEntry<>(snapshotId, spec.partitionType());
+      this.entryWrapper = new V2Metadata.ManifestEntryWrapper<>(snapshotId);
     }
 
     @Override
@@ -309,7 +309,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
         PartitionSpec spec, OutputFile file) {
       Schema manifestSchema = V2Metadata.entrySchema(spec.partitionType());
       try {
-        return Avro.write(file)
+        return InternalData.write(FileFormat.AVRO, file)
             .schema(manifestSchema)
             .named("manifest_entry")
             .meta("schema", SchemaParser.toJson(spec.schema()))
@@ -326,11 +326,11 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   }
 
   static class V2DeleteWriter extends ManifestWriter<DeleteFile> {
-    private final V2Metadata.IndexedManifestEntry<DeleteFile> entryWrapper;
+    private final V2Metadata.ManifestEntryWrapper<DeleteFile> entryWrapper;
 
     V2DeleteWriter(PartitionSpec spec, EncryptedOutputFile file, Long snapshotId) {
       super(spec, file, snapshotId);
-      this.entryWrapper = new V2Metadata.IndexedManifestEntry<>(snapshotId, spec.partitionType());
+      this.entryWrapper = new V2Metadata.ManifestEntryWrapper<>(snapshotId);
     }
 
     @Override
@@ -343,7 +343,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
         PartitionSpec spec, OutputFile file) {
       Schema manifestSchema = V2Metadata.entrySchema(spec.partitionType());
       try {
-        return Avro.write(file)
+        return InternalData.write(FileFormat.AVRO, file)
             .schema(manifestSchema)
             .named("manifest_entry")
             .meta("schema", SchemaParser.toJson(spec.schema()))
@@ -365,11 +365,11 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   }
 
   static class V1Writer extends ManifestWriter<DataFile> {
-    private final V1Metadata.IndexedManifestEntry entryWrapper;
+    private final V1Metadata.ManifestEntryWrapper entryWrapper;
 
     V1Writer(PartitionSpec spec, EncryptedOutputFile file, Long snapshotId) {
       super(spec, file, snapshotId);
-      this.entryWrapper = new V1Metadata.IndexedManifestEntry(spec.partitionType());
+      this.entryWrapper = new V1Metadata.ManifestEntryWrapper();
     }
 
     @Override
@@ -382,7 +382,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
         PartitionSpec spec, OutputFile file) {
       Schema manifestSchema = V1Metadata.entrySchema(spec.partitionType());
       try {
-        return Avro.write(file)
+        return InternalData.write(FileFormat.AVRO, file)
             .schema(manifestSchema)
             .named("manifest_entry")
             .meta("schema", SchemaParser.toJson(spec.schema()))

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -24,8 +24,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.avro.generic.IndexedRecord;
-import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.types.Types;
 
 class V1Metadata {
@@ -52,10 +50,7 @@ class V1Metadata {
    * <p>This is used to maintain compatibility with v1 by writing manifest list files with the old
    * schema, instead of writing a sequence number into metadata files in v1 tables.
    */
-  static class IndexedManifestFile implements ManifestFile, IndexedRecord {
-    private static final org.apache.avro.Schema AVRO_SCHEMA =
-        AvroSchemaUtil.convert(MANIFEST_LIST_SCHEMA, "manifest_file");
-
+  static class ManifestFileWrapper implements ManifestFile, StructLike {
     private ManifestFile wrapped = null;
 
     public ManifestFile wrap(ManifestFile file) {
@@ -64,17 +59,21 @@ class V1Metadata {
     }
 
     @Override
-    public org.apache.avro.Schema getSchema() {
-      return AVRO_SCHEMA;
+    public int size() {
+      return MANIFEST_LIST_SCHEMA.columns().size();
     }
 
     @Override
-    public void put(int i, Object v) {
-      throw new UnsupportedOperationException("Cannot modify IndexedManifestFile wrapper via put");
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("Cannot modify ManifestFileWrapper wrapper via set");
     }
 
     @Override
-    public Object get(int pos) {
+    public <T> T get(int pos, Class<T> javaClass) {
+      return javaClass.cast(get(pos));
+    }
+
+    private Object get(int pos) {
       switch (pos) {
         case 0:
           return path();
@@ -236,34 +235,38 @@ class V1Metadata {
   }
 
   /** Wrapper used to write a ManifestEntry to v1 metadata. */
-  static class IndexedManifestEntry implements ManifestEntry<DataFile>, IndexedRecord {
-    private final org.apache.avro.Schema avroSchema;
-    private final IndexedDataFile fileWrapper;
+  static class ManifestEntryWrapper implements ManifestEntry<DataFile>, StructLike {
+    private final int size;
+    private final DataFileWrapper fileWrapper;
     private ManifestEntry<DataFile> wrapped = null;
 
-    IndexedManifestEntry(Types.StructType partitionType) {
-      this.avroSchema = AvroSchemaUtil.convert(entrySchema(partitionType), "manifest_entry");
-      this.fileWrapper = new IndexedDataFile(avroSchema.getField("data_file").schema());
+    ManifestEntryWrapper() {
+      this.size = entrySchema(Types.StructType.of()).columns().size();
+      this.fileWrapper = new DataFileWrapper();
     }
 
-    public IndexedManifestEntry wrap(ManifestEntry<DataFile> entry) {
+    public ManifestEntryWrapper wrap(ManifestEntry<DataFile> entry) {
       this.wrapped = entry;
       return this;
     }
 
     @Override
-    public org.apache.avro.Schema getSchema() {
-      return avroSchema;
+    public int size() {
+      return size;
     }
 
     @Override
-    public void put(int i, Object v) {
-      throw new UnsupportedOperationException("Cannot modify IndexedManifestEntry wrapper via put");
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("Cannot modify ManifestEntryWrapper wrapper via set");
     }
 
     @Override
-    public Object get(int i) {
-      switch (i) {
+    public <T> T get(int pos, Class<T> javaClass) {
+      return javaClass.cast(get(pos));
+    }
+
+    private Object get(int pos) {
+      switch (pos) {
         case 0:
           return wrapped.status().id();
         case 1:
@@ -275,7 +278,7 @@ class V1Metadata {
           }
           return null;
         default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -330,32 +333,44 @@ class V1Metadata {
     }
   }
 
-  static class IndexedDataFile implements DataFile, IndexedRecord {
+  static class DataFileWrapper implements DataFile, StructLike {
     private static final long DEFAULT_BLOCK_SIZE = 64 * 1024 * 1024;
 
-    private final org.apache.avro.Schema avroSchema;
-    private final IndexedStructLike partitionWrapper;
+    private final int size;
     private DataFile wrapped = null;
 
-    IndexedDataFile(org.apache.avro.Schema avroSchema) {
-      this.avroSchema = avroSchema;
-      this.partitionWrapper = new IndexedStructLike(avroSchema.getField("partition").schema());
+    DataFileWrapper() {
+      this.size = dataFileSchema(Types.StructType.of()).fields().size();
     }
 
-    IndexedDataFile wrap(DataFile file) {
+    DataFileWrapper wrap(DataFile file) {
       this.wrapped = file;
       return this;
     }
 
     @Override
-    public Object get(int pos) {
+    public int size() {
+      return size;
+    }
+
+    @Override
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("Cannot modify DataFileWrapper wrapper via set");
+    }
+
+    @Override
+    public <T> T get(int pos, Class<T> javaClass) {
+      return javaClass.cast(get(pos));
+    }
+
+    private Object get(int pos) {
       switch (pos) {
         case 0:
           return wrapped.location();
         case 1:
           return wrapped.format() != null ? wrapped.format().toString() : null;
         case 2:
-          return partitionWrapper.wrap(wrapped.partition());
+          return wrapped.partition();
         case 3:
           return wrapped.recordCount();
         case 4:
@@ -382,16 +397,6 @@ class V1Metadata {
           return wrapped.sortOrderId();
       }
       throw new IllegalArgumentException("Unknown field ordinal: " + pos);
-    }
-
-    @Override
-    public void put(int i, Object v) {
-      throw new UnsupportedOperationException("Cannot modify IndexedDataFile wrapper via put");
-    }
-
-    @Override
-    public org.apache.avro.Schema getSchema() {
-      return avroSchema;
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V3Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V3Metadata.java
@@ -24,8 +24,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.avro.generic.IndexedRecord;
-import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Types;
 
@@ -56,15 +54,12 @@ class V3Metadata {
    * <p>This is used to maintain compatibility with v3 by writing manifest list files with the old
    * schema, instead of writing a sequence number into metadata files in v3 tables.
    */
-  static class IndexedManifestFile implements ManifestFile, IndexedRecord {
-    private static final org.apache.avro.Schema AVRO_SCHEMA =
-        AvroSchemaUtil.convert(MANIFEST_LIST_SCHEMA, "manifest_file");
-
+  static class ManifestFileWrapper implements ManifestFile, StructLike {
     private final long commitSnapshotId;
     private final long sequenceNumber;
     private ManifestFile wrapped = null;
 
-    IndexedManifestFile(long commitSnapshotId, long sequenceNumber) {
+    ManifestFileWrapper(long commitSnapshotId, long sequenceNumber) {
       this.commitSnapshotId = commitSnapshotId;
       this.sequenceNumber = sequenceNumber;
     }
@@ -75,17 +70,21 @@ class V3Metadata {
     }
 
     @Override
-    public org.apache.avro.Schema getSchema() {
-      return AVRO_SCHEMA;
+    public int size() {
+      return MANIFEST_LIST_SCHEMA.columns().size();
     }
 
     @Override
-    public void put(int i, Object v) {
-      throw new UnsupportedOperationException("Cannot modify IndexedManifestFile wrapper via put");
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("Cannot modify ManifestFileWrapper wrapper via set");
     }
 
     @Override
-    public Object get(int pos) {
+    public <T> T get(int pos, Class<T> javaClass) {
+      return javaClass.cast(get(pos));
+    }
+
+    private Object get(int pos) {
       switch (pos) {
         case 0:
           return wrapped.path();
@@ -280,37 +279,41 @@ class V3Metadata {
         DataFile.CONTENT_SIZE);
   }
 
-  static class IndexedManifestEntry<F extends ContentFile<F>>
-      implements ManifestEntry<F>, IndexedRecord {
-    private final org.apache.avro.Schema avroSchema;
+  static class ManifestEntryWrapper<F extends ContentFile<F>>
+      implements ManifestEntry<F>, StructLike {
+    private final int size;
     private final Long commitSnapshotId;
-    private final IndexedDataFile<?> fileWrapper;
+    private final DataFileWrapper<?> fileWrapper;
     private ManifestEntry<F> wrapped = null;
 
-    IndexedManifestEntry(Long commitSnapshotId, Types.StructType partitionType) {
-      this.avroSchema = AvroSchemaUtil.convert(entrySchema(partitionType), "manifest_entry");
+    ManifestEntryWrapper(Long commitSnapshotId) {
+      this.size = entrySchema(Types.StructType.of()).columns().size();
       this.commitSnapshotId = commitSnapshotId;
-      this.fileWrapper = new IndexedDataFile<>(partitionType);
+      this.fileWrapper = new DataFileWrapper<>();
     }
 
-    public IndexedManifestEntry<F> wrap(ManifestEntry<F> entry) {
+    public ManifestEntryWrapper<F> wrap(ManifestEntry<F> entry) {
       this.wrapped = entry;
       return this;
     }
 
     @Override
-    public org.apache.avro.Schema getSchema() {
-      return avroSchema;
+    public int size() {
+      return size;
     }
 
     @Override
-    public void put(int i, Object v) {
-      throw new UnsupportedOperationException("Cannot modify IndexedManifestEntry wrapper via put");
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("Cannot modify ManifestEntryWrapper wrapper via set");
     }
 
     @Override
-    public Object get(int i) {
-      switch (i) {
+    public <T> T get(int pos, Class<T> javaClass) {
+      return javaClass.cast(get(pos));
+    }
+
+    private Object get(int pos) {
+      switch (pos) {
         case 0:
           return wrapped.status().id();
         case 1:
@@ -339,7 +342,7 @@ class V3Metadata {
         case 4:
           return fileWrapper.wrap(wrapped.file());
         default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -395,29 +398,36 @@ class V3Metadata {
   }
 
   /** Wrapper used to write DataFile or DeleteFile to v3 metadata. */
-  static class IndexedDataFile<F> implements ContentFile<F>, IndexedRecord {
-    private final org.apache.avro.Schema avroSchema;
-    private final IndexedStructLike partitionWrapper;
+  static class DataFileWrapper<F> implements ContentFile<F>, StructLike {
+    private final int size;
     private ContentFile<F> wrapped = null;
 
-    IndexedDataFile(Types.StructType partitionType) {
-      this.avroSchema = AvroSchemaUtil.convert(fileType(partitionType), "data_file");
-      this.partitionWrapper = new IndexedStructLike(avroSchema.getField("partition").schema());
+    DataFileWrapper() {
+      this.size = fileType(Types.StructType.of()).fields().size();
     }
 
     @SuppressWarnings("unchecked")
-    IndexedDataFile<F> wrap(ContentFile<?> file) {
+    DataFileWrapper<F> wrap(ContentFile<?> file) {
       this.wrapped = (ContentFile<F>) file;
       return this;
     }
 
     @Override
-    public org.apache.avro.Schema getSchema() {
-      return avroSchema;
+    public int size() {
+      return size;
     }
 
     @Override
-    public Object get(int pos) {
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("Cannot modify DataFileWrapper wrapper via set");
+    }
+
+    @Override
+    public <T> T get(int pos, Class<T> javaClass) {
+      return javaClass.cast(get(pos));
+    }
+
+    private Object get(int pos) {
       switch (pos) {
         case 0:
           return wrapped.content().id();
@@ -426,7 +436,7 @@ class V3Metadata {
         case 2:
           return wrapped.format() != null ? wrapped.format().toString() : null;
         case 3:
-          return partitionWrapper.wrap(wrapped.partition());
+          return wrapped.partition();
         case 4:
           return wrapped.recordCount();
         case 5:
@@ -471,11 +481,6 @@ class V3Metadata {
           }
       }
       throw new IllegalArgumentException("Unknown field ordinal: " + pos);
-    }
-
-    @Override
-    public void put(int i, Object v) {
-      throw new UnsupportedOperationException("Cannot modify IndexedDataFile wrapper via put");
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -727,7 +727,8 @@ public class Avro {
     }
 
     @Override
-    public InternalData.ReadBuilder setCustomType(int fieldId, Class<? extends StructLike> structClass) {
+    public InternalData.ReadBuilder setCustomType(
+        int fieldId, Class<? extends StructLike> structClass) {
       typeMap.put(fieldId, structClass);
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -124,11 +124,13 @@ public class Avro {
       return this;
     }
 
+    @Override
     public WriteBuilder schema(org.apache.iceberg.Schema newSchema) {
       this.schema = newSchema;
       return this;
     }
 
+    @Override
     public WriteBuilder named(String newName) {
       this.name = newName;
       return this;
@@ -139,6 +141,7 @@ public class Avro {
       return this;
     }
 
+    @Override
     public WriteBuilder set(String property, String value) {
       config.put(property, value);
       return this;
@@ -149,11 +152,13 @@ public class Avro {
       return this;
     }
 
+    @Override
     public WriteBuilder meta(String property, String value) {
       metadata.put(property, value);
       return this;
     }
 
+    @Override
     public WriteBuilder meta(Map<String, String> properties) {
       metadata.putAll(properties);
       return this;
@@ -164,6 +169,7 @@ public class Avro {
       return this;
     }
 
+    @Override
     public WriteBuilder overwrite() {
       return overwrite(true);
     }
@@ -180,6 +186,7 @@ public class Avro {
       return this;
     }
 
+    @Override
     public <D> FileAppender<D> build() throws IOException {
       Preconditions.checkNotNull(schema, "Schema is required");
       Preconditions.checkNotNull(name, "Table name is required and cannot be null");
@@ -682,17 +689,20 @@ public class Avro {
      * @param newLength the length of the range this read should scan
      * @return this builder for method chaining
      */
+    @Override
     public ReadBuilder split(long newStart, long newLength) {
       this.start = newStart;
       this.length = newLength;
       return this;
     }
 
+    @Override
     public ReadBuilder project(org.apache.iceberg.Schema projectedSchema) {
       this.schema = projectedSchema;
       return this;
     }
 
+    @Override
     public ReadBuilder reuseContainers() {
       this.reuseContainers = true;
       return this;
@@ -731,6 +741,7 @@ public class Avro {
       return this;
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public <D> AvroIterable<D> build() {
       Preconditions.checkNotNull(schema, "Schema is required");

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -72,18 +72,6 @@ import org.apache.iceberg.util.ArrayUtil;
 public class Avro {
   private Avro() {}
 
-  public static void register() {
-    InternalData.register(FileFormat.AVRO, Avro::writeInternal, Avro::readInternal);
-  }
-
-  private static WriteBuilder writeInternal(OutputFile outputFile) {
-    return write(outputFile).createWriterFunc(InternalWriter::create);
-  }
-
-  private static ReadBuilder readInternal(InputFile inputFile) {
-    return read(inputFile).createResolvingReader(InternalReader::create);
-  }
-
   private enum Codec {
     UNCOMPRESSED,
     SNAPPY,

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -42,7 +42,7 @@ import org.apache.iceberg.util.Pair;
  *
  * @param <T> Java type returned by the reader
  */
-public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition {
+public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, SupportsCustomTypes {
   private static final int ROOT_ID = -1;
 
   private final Types.StructType expectedType;
@@ -74,6 +74,15 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition {
   public void setSchema(Schema schema) {
     this.fileSchema = schema;
     initReader();
+  }
+
+  @Override
+  public void setCustomTypes(
+      Class<? extends StructLike> rootType, Map<Integer, Class<? extends StructLike>> typesById) {
+    setRootType(rootType);
+    for (Map.Entry<Integer, Class<? extends StructLike>> entry : typesById.entrySet()) {
+      setCustomType(entry.getKey(), entry.getValue());
+    }
   }
 
   public InternalReader<T> setRootType(Class<? extends StructLike> rootClass) {

--- a/core/src/main/java/org/apache/iceberg/avro/SupportsCustomRecords.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SupportsCustomRecords.java
@@ -20,7 +20,7 @@ package org.apache.iceberg.avro;
 
 import java.util.Map;
 
-/** An interface for Avro DatumReaders to support custom record classes. */
+/** An interface for Avro DatumReaders to support custom record classes by name. */
 interface SupportsCustomRecords {
   void setClassLoader(ClassLoader loader);
 

--- a/core/src/main/java/org/apache/iceberg/avro/SupportsCustomTypes.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SupportsCustomTypes.java
@@ -1,0 +1,31 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.avro;
+
+import java.util.Map;
+import org.apache.iceberg.StructLike;
+
+/** An interface to support custom record types by ID. */
+public interface SupportsCustomTypes {
+  void setCustomTypes(
+      Class<? extends StructLike> rootType, Map<Integer, Class<? extends StructLike>> typesById);
+}

--- a/core/src/main/java/org/apache/iceberg/avro/SupportsCustomTypes.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SupportsCustomTypes.java
@@ -1,24 +1,21 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg.avro;
 
 import java.util.Map;

--- a/parquet/src/main/java/org/apache/iceberg/InternalParquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/InternalParquet.java
@@ -25,6 +25,8 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.parquet.Parquet;
 
 public class InternalParquet {
+  private InternalParquet() {}
+
   public static void register() {
     InternalData.register(
         FileFormat.PARQUET, InternalParquet::writeInternal, InternalParquet::readInternal);

--- a/parquet/src/main/java/org/apache/iceberg/InternalParquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/InternalParquet.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.data.parquet.InternalReader;
+import org.apache.iceberg.data.parquet.InternalWriter;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.parquet.Parquet;
+
+public class InternalParquet {
+  public static void register() {
+    InternalData.register(
+        FileFormat.PARQUET, InternalParquet::writeInternal, InternalParquet::readInternal);
+  }
+
+  private static Parquet.WriteBuilder writeInternal(OutputFile outputFile) {
+    return Parquet.write(outputFile).createWriterFunc(InternalWriter::create);
+  }
+
+  private static Parquet.ReadBuilder readInternal(InputFile inputFile) {
+    return Parquet.read(inputFile).createReaderFunc(InternalReader::create);
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/InternalParquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/InternalParquet.java
@@ -1,24 +1,21 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg;
 
 import org.apache.iceberg.data.parquet.InternalReader;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -185,11 +185,13 @@ public class Parquet {
       return this;
     }
 
+    @Override
     public WriteBuilder schema(Schema newSchema) {
       this.schema = newSchema;
       return this;
     }
 
+    @Override
     public WriteBuilder named(String newName) {
       this.name = newName;
       return this;
@@ -200,6 +202,7 @@ public class Parquet {
       return this;
     }
 
+    @Override
     public WriteBuilder set(String property, String value) {
       config.put(property, value);
       return this;
@@ -210,6 +213,7 @@ public class Parquet {
       return this;
     }
 
+    @Override
     public WriteBuilder meta(String property, String value) {
       metadata.put(property, value);
       return this;
@@ -226,6 +230,7 @@ public class Parquet {
       return this;
     }
 
+    @Override
     public WriteBuilder overwrite() {
       return overwrite(true);
     }
@@ -315,6 +320,7 @@ public class Parquet {
               });
     }
 
+    @Override
     public <D> FileAppender<D> build() throws IOException {
       Preconditions.checkNotNull(schema, "Schema is required");
       Preconditions.checkNotNull(name, "Table name is required and cannot be null");
@@ -1093,12 +1099,14 @@ public class Parquet {
      * @param newLength the length of the range this read should scan
      * @return this builder for method chaining
      */
+    @Override
     public ReadBuilder split(long newStart, long newLength) {
       this.start = newStart;
       this.length = newLength;
       return this;
     }
 
+    @Override
     public ReadBuilder project(Schema newSchema) {
       this.schema = newSchema;
       return this;
@@ -1181,6 +1189,7 @@ public class Parquet {
       return this;
     }
 
+    @Override
     public ReadBuilder reuseContainers() {
       this.reuseContainers = true;
       return this;
@@ -1216,6 +1225,7 @@ public class Parquet {
       return this;
     }
 
+    @Override
     @SuppressWarnings({"unchecked", "checkstyle:CyclomaticComplexity"})
     public <D> CloseableIterable<D> build() {
       FileDecryptionProperties fileDecryptionProperties = null;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -126,7 +126,7 @@ public class Parquet {
 
   private Parquet() {}
 
-  public void register() {
+  public static void register() {
     InternalData.register(FileFormat.PARQUET, Parquet::writeInternal, Parquet::readInternal);
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -138,7 +138,6 @@ public class Parquet {
     return read(inputFile);
   }
 
-
   private static final Collection<String> READ_PROPERTIES_TO_REMOVE =
       Sets.newHashSet(
           "parquet.read.filter",

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -74,8 +74,6 @@ import org.apache.iceberg.SystemConfigs;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
-import org.apache.iceberg.data.parquet.InternalReader;
-import org.apache.iceberg.data.parquet.InternalWriter;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
@@ -128,18 +126,6 @@ public class Parquet {
   private static final Logger LOG = LoggerFactory.getLogger(Parquet.class);
 
   private Parquet() {}
-
-  public static void register() {
-    InternalData.register(FileFormat.PARQUET, Parquet::writeInternal, Parquet::readInternal);
-  }
-
-  private static WriteBuilder writeInternal(OutputFile outputFile) {
-    return write(outputFile).createWriterFunc(InternalWriter::create);
-  }
-
-  private static ReadBuilder readInternal(InputFile inputFile) {
-    return read(inputFile).createReaderFunc(InternalReader::create);
-  }
 
   private static final Collection<String> READ_PROPERTIES_TO_REMOVE =
       Sets.newHashSet(
@@ -1158,7 +1144,7 @@ public class Parquet {
       return this;
     }
 
-    private ReadBuilder createReaderFunc(
+    public ReadBuilder createReaderFunc(
         BiFunction<Schema, MessageType, ParquetValueReader<?>> newReaderFunction) {
       Preconditions.checkArgument(
           this.readerFunc == null,


### PR DESCRIPTION
This adds `InternalData` with read and write builder interfaces that can be used with Avro and Parquet by passing a `FileFormat`. Formats are registered by calling `InternalData.register` with callbacks to create format-specific builders.

The class is `InternalData` because registered builders are expected to use the internal object model that is used for Iceberg metadata files. Using a specific object model avoids needing to register callbacks to create value readers and writers that produce the format needed by the caller.

To demonstrate the new interfaces, this PR implements them using both Avro and Parquet. Parquet can't be used because it would fail at runtime until #11904 is committed (it is also missing custom type support).

Avro is working. To demonstrate that the builders can be used for metadata, this updates `ManifestWriter`, `ManifestReader`, and `ManifestListWriter` to use `InternalData` builders. It was also necessary to migrate the metadata classes to extend `StructLike` for the internal writers instead of `IndexedRecord`.