### PR TITLE
Fix rename then add column with same name failure if the renamed columns was an identity partition key

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -745,7 +745,12 @@ public class TableMetadata implements Serializable {
 
     // add all the fields to the builder. IDs should not change.
     for (PartitionField field : partitionSpec.fields()) {
-      specBuilder.add(field.sourceId(), field.fieldId(), field.name(), field.transform());
+      specBuilder.add(
+          field.sourceId(),
+          field.fieldId(),
+          // TODO: handle other partition types.
+          field.transform().isIdentity() ? schema.findColumnName(field.sourceId()) : field.name(),
+          field.transform());
     }
 
     // build without validation because the schema may have changed in a way that makes this spec
@@ -1071,7 +1076,6 @@ public class TableMetadata implements Serializable {
       Schema schema = schemasById.get(schemaId);
       Preconditions.checkArgument(
           schema != null, "Cannot set current schema to unknown schema: %s", schemaId);
-
       // rebuild all the partition specs and sort orders for the new current schema
       this.specs =
           Lists.newArrayList(Iterables.transform(specs, spec -> updateSpecSchema(schema, spec)));

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -1214,6 +1214,30 @@ public class TestTableMetadata {
   }
 
   @Test
+  public void testRenameIdentityPartitionKey() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "x", Types.LongType.get()),
+            Types.NestedField.required(2, "y", Types.LongType.get()));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).withSpecId(0).identity("x").build();
+    String location = "file://tmp/db/table";
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            schema, spec, SortOrder.unsorted(), location, ImmutableMap.of(), 2);
+    assertThat(metadata.spec()).isEqualTo(spec);
+    Schema updatedSchema =
+        new Schema(
+            Types.NestedField.required(1, "z", Types.LongType.get()),
+            Types.NestedField.required(2, "y", Types.LongType.get()));
+
+    TableMetadata updated = metadata.updateSchema(updatedSchema);
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(updated.schema()).add(1, 1000, "z", Transforms.identity()).build();
+    assertThat(updated.spec()).isEqualTo(expected);
+  }
+
+  @Test
   public void testStatistics() {
     Schema schema = new Schema(Types.NestedField.required(10, "x", Types.StringType.get()));
 


### PR DESCRIPTION
This PR tries to fix https://github.com/apache/iceberg/issues/11762 for the identity partition case. Other partition types may also requires the fix.