### PR TITLE
Remove `slf4j-api` reference in `LICENSE` (#12052)

### DIFF
--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -297,12 +297,6 @@ License: CC0 - http://creativecommons.org/publicdomain/zero/1.0/
 
 --------------------------------------------------------------------------------
 
-Group: org.slf4j  Name: slf4j-api  Version: 1.7.36
-Project URL: http://www.slf4j.org
-License: MIT License - http://www.opensource.org/licenses/mit-license.php
-
---------------------------------------------------------------------------------
-
 Group: software.amazon.awssdk  Name: annotations  Version: 2.28.5
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 

--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -511,9 +511,3 @@ License: The Apache Software License, Version 2.0 - http://www.apache.org/licens
 Group: org.reactivestreams  Name: reactive-streams  Version: 1.0.4
 Project URL: http://www.reactive-streams.org/
 License: MIT-0 - https://spdx.org/licenses/MIT-0.html
-
---------------------------------------------------------------------------------
-
-Group: org.slf4j  Name: slf4j-api  Version: 1.7.36
-Project URL: http://www.slf4j.org
-License: MIT License - http://www.opensource.org/licenses/mit-license.php

--- a/gcp-bundle/LICENSE
+++ b/gcp-bundle/LICENSE
@@ -549,12 +549,6 @@ License: Apache 2 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: org.slf4j  Name: slf4j-api  Version: 1.7.36
-Project URL: http://www.slf4j.org
-License: MIT License - http://www.opensource.org/licenses/mit-license.php
-
---------------------------------------------------------------------------------
-
 Group: org.threeten  Name: threetenbp  Version: 1.6.8
 Project URL: https://www.threeten.org
 Project URL: https://www.threeten.org/threetenbp


### PR DESCRIPTION
Work by @jbonofre, let's include this in 1.7.2 as well:

I've checked out the branch, and it is also excluded from the JAR on the `1.7.x` branch:
```
➜  azure find . | grep -i slf4j
./org/apache/iceberg/azure/shaded/io/netty/util/internal/logging/LocationAwareSlf4JLogger.class
./org/apache/iceberg/azure/shaded/io/netty/util/internal/logging/Slf4JLoggerFactory$NopInstanceHolder.class
./org/apache/iceberg/azure/shaded/io/netty/util/internal/logging/Slf4JLoggerFactory.class
./org/apache/iceberg/azure/shaded/io/netty/util/internal/logging/Slf4JLogger.class
./reactor/util/Loggers$Slf4JLoggerFactory.class
./reactor/util/Loggers$Slf4JLogger.class
```

```
➜  gcp find . | grep -i slf4j                                                                               
./io/grpc/netty/shaded/io/netty/util/internal/logging/LocationAwareSlf4JLogger.class
./io/grpc/netty/shaded/io/netty/util/internal/logging/Slf4JLoggerFactory$NopInstanceHolder.class
./io/grpc/netty/shaded/io/netty/util/internal/logging/Slf4JLoggerFactory.class
./io/grpc/netty/shaded/io/netty/util/internal/logging/Slf4JLogger.class
```

```
➜  aws find . | grep -i slf4j                     
./org/apache/iceberg/aws/shaded/io/netty/util/internal/logging/LocationAwareSlf4JLogger.class
./org/apache/iceberg/aws/shaded/io/netty/util/internal/logging/Slf4JLoggerFactory$NopInstanceHolder.class
./org/apache/iceberg/aws/shaded/io/netty/util/internal/logging/Slf4JLoggerFactory.class
./org/apache/iceberg/aws/shaded/io/netty/util/internal/logging/Slf4JLogger.class
```