### PR TITLE
Parquet: Fix Reader leak by removing useless copy

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
@@ -19,17 +19,10 @@
 package org.apache.iceberg.parquet;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.hadoop.HadoopOutputFile;
-import org.apache.iceberg.io.DelegatingInputStream;
-import org.apache.iceberg.io.DelegatingOutputStream;
-import org.apache.parquet.hadoop.util.HadoopStreams;
 import org.apache.parquet.io.DelegatingPositionOutputStream;
 import org.apache.parquet.io.DelegatingSeekableInputStream;
 import org.apache.parquet.io.InputFile;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
@@ -82,22 +82,10 @@ class ParquetIO {
   }
 
   static SeekableInputStream stream(org.apache.iceberg.io.SeekableInputStream stream) {
-    if (stream instanceof DelegatingInputStream) {
-      InputStream wrapped = ((DelegatingInputStream) stream).getDelegate();
-      if (wrapped instanceof FSDataInputStream) {
-        return HadoopStreams.wrap((FSDataInputStream) wrapped);
-      }
-    }
     return new ParquetInputStreamAdapter(stream);
   }
 
   static PositionOutputStream stream(org.apache.iceberg.io.PositionOutputStream stream) {
-    if (stream instanceof DelegatingOutputStream) {
-      OutputStream wrapped = ((DelegatingOutputStream) stream).getDelegate();
-      if (wrapped instanceof FSDataOutputStream) {
-        return HadoopStreams.wrap((FSDataOutputStream) wrapped);
-      }
-    }
     return new ParquetOutputStreamAdapter(stream);
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -80,7 +80,7 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
               reuseContainers,
               caseSensitive,
               null);
-      this.conf = readConf.copy();
+      this.conf = readConf;
       return readConf;
     }
     return conf;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -80,7 +80,7 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
               reuseContainers,
               caseSensitive,
               null);
-      this.conf = readConf;
+      this.conf = readConf.copy();
       return readConf;
     }
     return conf;

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -274,7 +274,7 @@ public class TestParquet {
 
     boolean isClosed = false;
 
-    public CloseAwareFSDataInputStream(CloseAwareInputStream in) {
+    CloseAwareFSDataInputStream(CloseAwareInputStream in) {
       super(in);
     }
 
@@ -291,7 +291,7 @@ public class TestParquet {
     boolean isClosed = false;
     private final InputStream delegate;
 
-    public CloseAwareDelegatingInputStream(InputStream delegate) {
+    CloseAwareDelegatingInputStream(InputStream delegate) {
       this.delegate = delegate;
     }
 
@@ -322,6 +322,7 @@ public class TestParquet {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:NestedTryDepth")
   public void testDelegatingInputStreamCloseProperly() throws IOException {
     // prepare the underlying stream
     try (CloseAwareInputStream underlying = new CloseAwareInputStream()) {
@@ -331,12 +332,12 @@ public class TestParquet {
         try (CloseAwareDelegatingInputStream delegating =
             new CloseAwareDelegatingInputStream(fsInput)) {
           // ok, call the testing target, ensure no leek.
-          try (org.apache.parquet.io.SeekableInputStream _unused = ParquetIO.stream(delegating)) {
+          try (org.apache.parquet.io.SeekableInputStream unused = ParquetIO.stream(delegating)) {
             assertThat(underlying.isClosed).isFalse();
             assertThat(fsInput.isClosed).isFalse();
             assertThat(delegating.isClosed).isFalse();
           } finally {
-            // a try-catch-finally for `_unused` stream.
+            // a try-catch-finally for `unused` stream.
             // implies all stream crated before should be closed without leaking behavior.
             assertThat(delegating.isClosed).isTrue();
             assertThat(fsInput.isClosed).isTrue();
@@ -365,7 +366,7 @@ public class TestParquet {
 
     boolean isClosed = false;
 
-    public CloseAwareFSDataOutputStream(OutputStream out) throws IOException {
+    CloseAwareFSDataOutputStream(OutputStream out) throws IOException {
       super(out, null);
     }
 
@@ -382,7 +383,7 @@ public class TestParquet {
     boolean isClosed = false;
     private final OutputStream delegate;
 
-    public CloseAwareDelegatingOutputStream(OutputStream delegate) {
+    CloseAwareDelegatingOutputStream(OutputStream delegate) {
       this.delegate = delegate;
     }
 
@@ -408,6 +409,7 @@ public class TestParquet {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:NestedTryDepth")
   public void testDelegatingOutputStreamCloseProperly() throws IOException {
     // prepare the underlying stream
     try (CloseAwareOutputStream underlying = new CloseAwareOutputStream()) {
@@ -417,12 +419,12 @@ public class TestParquet {
         try (CloseAwareDelegatingOutputStream delegating =
             new CloseAwareDelegatingOutputStream(fsOutput)) {
           // ok, call the testing target, ensure no leek.
-          try (org.apache.parquet.io.PositionOutputStream _unused = ParquetIO.stream(delegating)) {
+          try (org.apache.parquet.io.PositionOutputStream unused = ParquetIO.stream(delegating)) {
             assertThat(underlying.isClosed).isFalse();
             assertThat(fsOutput.isClosed).isFalse();
             assertThat(delegating.isClosed).isFalse();
           } finally {
-            // a try-catch-finally for `_unused` stream.
+            // a try-catch-finally for `unused` stream.
             // implies all stream crated before should be closed without leaking behavior.
             assertThat(delegating.isClosed).isTrue();
             assertThat(fsOutput.isClosed).isTrue();

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -229,29 +229,32 @@ public class TestParquet {
   }
 
   @Test
-  public void testStreamClosedProperly() throws IOException{
+  public void testStreamClosedProperly() throws IOException {
     // test for input
     {
-      class TestStreamClosedProperlyStream extends SeekableInputStream implements DelegatingInputStream {
+      class TestStreamClosedProperlyStream extends SeekableInputStream
+          implements DelegatingInputStream {
         boolean thisClosed = false;
         boolean delegateClosed = false;
+
         {
           reset();
         }
 
         @Override
         public InputStream getDelegate() {
-          return new FSDataInputStream(new InputStream() {
-            @Override
-            public int read() throws IOException {
-              return 0;
-            }
+          return new FSDataInputStream(
+              new InputStream() {
+                @Override
+                public int read() throws IOException {
+                  return 0;
+                }
 
-            @Override
-            public void close() throws IOException {
-              delegateClosed = true;
-            }
-          });
+                @Override
+                public void close() throws IOException {
+                  delegateClosed = true;
+                }
+              });
         }
 
         @Override
@@ -260,8 +263,7 @@ public class TestParquet {
         }
 
         @Override
-        public void seek(long newPos) throws IOException {
-        }
+        public void seek(long newPos) throws IOException {}
 
         @Override
         public int read() throws IOException {
@@ -274,35 +276,38 @@ public class TestParquet {
           delegateClosed = true;
         }
 
-        public void reset(){
+        public void reset() {
           thisClosed = false;
           delegateClosed = false;
         }
       }
 
       try (TestStreamClosedProperlyStream stream = new TestStreamClosedProperlyStream()) {
-        try (org.apache.parquet.io.SeekableInputStream _unused = ParquetIO.file(new InputFile() {
-          @Override
-          public long getLength() {
-            return 0;
-          }
+        try (org.apache.parquet.io.SeekableInputStream _unused =
+            ParquetIO.file(
+                    new InputFile() {
+                      @Override
+                      public long getLength() {
+                        return 0;
+                      }
 
-          @Override
-          public SeekableInputStream newStream() {
-            stream.reset();
-            return stream;
-          }
+                      @Override
+                      public SeekableInputStream newStream() {
+                        stream.reset();
+                        return stream;
+                      }
 
-          @Override
-          public String location() {
-            return "";
-          }
+                      @Override
+                      public String location() {
+                        return "";
+                      }
 
-          @Override
-          public boolean exists() {
-            return false;
-          }
-        }).newStream()) {
+                      @Override
+                      public boolean exists() {
+                        return false;
+                      }
+                    })
+                .newStream()) {
           assertThat(stream.delegateClosed).isFalse();
           assertThat(stream.thisClosed).isFalse();
         } finally {
@@ -314,9 +319,11 @@ public class TestParquet {
 
     // test for output
     {
-      class TestStreamClosedProperlyStream extends PositionOutputStream implements DelegatingOutputStream {
+      class TestStreamClosedProperlyStream extends PositionOutputStream
+          implements DelegatingOutputStream {
         boolean thisClosed = false;
         boolean delegateClosed = false;
+
         {
           reset();
         }
@@ -327,22 +334,22 @@ public class TestParquet {
         }
 
         @Override
-        public void write(int b) throws IOException {
-        }
+        public void write(int b) throws IOException {}
 
         @Override
         public OutputStream getDelegate() {
           try {
-            return new FSDataOutputStream(new OutputStream() {
-              @Override
-              public void write(int b) {
-              }
+            return new FSDataOutputStream(
+                new OutputStream() {
+                  @Override
+                  public void write(int b) {}
 
-              @Override
-              public void close() throws IOException {
-                delegateClosed = true;
-              }
-            }, null);
+                  @Override
+                  public void close() throws IOException {
+                    delegateClosed = true;
+                  }
+                },
+                null);
           } catch (IOException e) {
             throw new RuntimeException(e);
           }
@@ -361,29 +368,31 @@ public class TestParquet {
       }
 
       try (TestStreamClosedProperlyStream stream = new TestStreamClosedProperlyStream()) {
-        OutputFile file = ParquetIO.file(new org.apache.iceberg.io.OutputFile() {
-          @Override
-          public PositionOutputStream create() {
-            stream.reset();
-            return stream;
-          }
+        OutputFile file =
+            ParquetIO.file(
+                new org.apache.iceberg.io.OutputFile() {
+                  @Override
+                  public PositionOutputStream create() {
+                    stream.reset();
+                    return stream;
+                  }
 
-          @Override
-          public PositionOutputStream createOrOverwrite() {
-            stream.reset();
-            return stream;
-          }
+                  @Override
+                  public PositionOutputStream createOrOverwrite() {
+                    stream.reset();
+                    return stream;
+                  }
 
-          @Override
-          public String location() {
-            return "";
-          }
+                  @Override
+                  public String location() {
+                    return "";
+                  }
 
-          @Override
-          public InputFile toInputFile() {
-            return null;
-          }
-        });
+                  @Override
+                  public InputFile toInputFile() {
+                    return null;
+                  }
+                });
 
         try (org.apache.parquet.io.PositionOutputStream _unused = file.create(0)) {
           assertThat(stream.delegateClosed).isFalse();

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -235,6 +235,9 @@ public class TestParquet {
       class TestStreamClosedProperlyStream extends SeekableInputStream implements DelegatingInputStream {
         boolean thisClosed = false;
         boolean delegateClosed = false;
+        {
+          reset();
+        }
 
         @Override
         public InputStream getDelegate() {
@@ -270,6 +273,11 @@ public class TestParquet {
           thisClosed = true;
           delegateClosed = true;
         }
+
+        public void reset(){
+          thisClosed = false;
+          delegateClosed = false;
+        }
       }
 
       try (TestStreamClosedProperlyStream stream = new TestStreamClosedProperlyStream()) {
@@ -281,6 +289,7 @@ public class TestParquet {
 
           @Override
           public SeekableInputStream newStream() {
+            stream.reset();
             return stream;
           }
 
@@ -308,6 +317,9 @@ public class TestParquet {
       class TestStreamClosedProperlyStream extends PositionOutputStream implements DelegatingOutputStream {
         boolean thisClosed = false;
         boolean delegateClosed = false;
+        {
+          reset();
+        }
 
         @Override
         public long getPos() throws IOException {


### PR DESCRIPTION
The ReadConf copy constructor will nullify the reader of source, leaving the reader of original unclosed