### PR TITLE
Core: Select for rewriting the files belonging to old partitioning schemes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedDataRewriter.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedDataRewriter.java
@@ -75,11 +75,18 @@ public abstract class SizeBasedDataRewriter extends SizeBasedFileRewriter<FileSc
   }
 
   private boolean shouldRewrite(FileScanTask task) {
-    return wronglySized(task) || tooManyDeletes(task) || tooHighDeleteRatio(task);
+    return wronglySized(task)
+        || tooManyDeletes(task)
+        || tooHighDeleteRatio(task)
+        || oldPartitioning(task);
   }
 
   private boolean tooManyDeletes(FileScanTask task) {
     return task.deletes() != null && task.deletes().size() >= deleteFileThreshold;
+  }
+
+  private boolean oldPartitioning(FileScanTask task) {
+    return task.file().specId() != table().spec().specId();
   }
 
   @Override
@@ -92,7 +99,12 @@ public abstract class SizeBasedDataRewriter extends SizeBasedFileRewriter<FileSc
         || enoughContent(group)
         || tooMuchContent(group)
         || anyTaskHasTooManyDeletes(group)
-        || anyTaskHasTooHighDeleteRatio(group);
+        || anyTaskHasTooHighDeleteRatio(group)
+        || anyTaskHasOldPartitioning(group);
+  }
+
+  private boolean anyTaskHasOldPartitioning(List<FileScanTask> group) {
+    return group.stream().anyMatch(this::oldPartitioning);
   }
 
   private boolean anyTaskHasTooManyDeletes(List<FileScanTask> group) {


### PR DESCRIPTION
After doing a partition-evolution attempt, the implicit `rewrite_data_files` procedure will not pick up files belonging to the old partitioning schema.

The only way to rewrite those files is to use the `rewrite-all` parameter (and have to rewrite even files that are correctly-sized and correctly-placed - this becomes problematic for tables larger with more than 1TB in size) or through a series of Copy-On-Write updates (which doesn't fit the environment I work on, since that table will not be used for writing in a while).

In this fix, I've modified the implicit criteria for selection in the `rewrite_data_files` procedure in order to also target the files of the old partitioning scheme.