### PR TITLE
Core: Check referencedDataFile existence for DV

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -255,6 +255,8 @@ public class FileMetadata {
       if (format == FileFormat.PUFFIN) {
         Preconditions.checkArgument(contentOffset != null, "Content offset is required for DV");
         Preconditions.checkArgument(contentSizeInBytes != null, "Content size is required for DV");
+        Preconditions.checkArgument(
+            referencedDataFile != null, "Referenced data file is required for DV");
       } else {
         Preconditions.checkArgument(contentOffset == null, "Content offset can only be set for DV");
         Preconditions.checkArgument(

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeWrapper;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -441,6 +442,31 @@ public class TestDeleteFiles extends TestBase {
     Snapshot delete2 = commit(table, table.newDelete().deleteFile(FILE_B), branch);
     assertThat(delete2.allManifests(FILE_IO)).isEmpty();
     assertThat(delete2.removedDataFiles(FILE_IO)).isEmpty();
+  }
+
+  @Test
+  public void testPuffinRequiredFields() {
+    FileMetadata.Builder builder =
+        FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+            .ofPositionDeletes()
+            .withFormat(FileFormat.PUFFIN)
+            .withPath("/path/to/data-d-deletes.puffin")
+            .withFileSizeInBytes(4)
+            .withRecordCount(4);
+
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Content offset is required for DV");
+
+    builder.withContentOffset(1);
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Content size is required for DV");
+
+    builder.withContentSizeInBytes(10);
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Referenced data file is required for DV");
   }
 
   private static ByteBuffer longToBuffer(long value) {

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -445,7 +445,7 @@ public class TestDeleteFiles extends TestBase {
   }
 
   @Test
-  public void testPuffinRequiredFields() {
+  public void testRequiredFieldsForDV() {
     FileMetadata.Builder builder =
         FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
             .ofPositionDeletes()


### PR DESCRIPTION
This field is required for DV. I missed setting this field when preparing deletion vector's changes in Trino, and it resulted in incorrect results even though DELETE statement succeeded. It would be nice to fail early. 

https://github.com/apache/iceberg/blob/a04220a198a03f4116d3012330f99b787dabc8e1/api/src/main/java/org/apache/iceberg/DeleteFile.java#L35-L44