### PR TITLE
Core: Change RemoveSnapshots to remove unused schemas

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -180,6 +180,23 @@ public interface MetadataUpdate extends Serializable {
     }
   }
 
+  class RemoveSchemas implements MetadataUpdate {
+    private final Set<Integer> schemaIds;
+
+    public RemoveSchemas(Set<Integer> schemaIds) {
+      this.schemaIds = schemaIds;
+    }
+
+    public Set<Integer> schemaIds() {
+      return schemaIds;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.removeSchemas(schemaIds);
+    }
+  }
+
   class AddSortOrder implements MetadataUpdate {
     private final UnboundSortOrder sortOrder;
 

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -60,6 +60,7 @@ public class MetadataUpdateParser {
   static final String SET_PARTITION_STATISTICS = "set-partition-statistics";
   static final String REMOVE_PARTITION_STATISTICS = "remove-partition-statistics";
   static final String REMOVE_PARTITION_SPECS = "remove-partition-specs";
+  static final String REMOVE_SCHEMAS = "remove-schemas";
   static final String ENABLE_ROW_LINEAGE = "enable-row-lineage";
 
   // AssignUUID
@@ -131,6 +132,9 @@ public class MetadataUpdateParser {
   // RemovePartitionSpecs
   private static final String SPEC_IDS = "spec-ids";
 
+  // RemoveSchemas
+  private static final String SCHEMA_IDS = "schema-ids";
+
   private static final Map<Class<? extends MetadataUpdate>, String> ACTIONS =
       ImmutableMap.<Class<? extends MetadataUpdate>, String>builder()
           .put(MetadataUpdate.AssignUUID.class, ASSIGN_UUID)
@@ -155,6 +159,7 @@ public class MetadataUpdateParser {
           .put(MetadataUpdate.AddViewVersion.class, ADD_VIEW_VERSION)
           .put(MetadataUpdate.SetCurrentViewVersion.class, SET_CURRENT_VIEW_VERSION)
           .put(MetadataUpdate.RemovePartitionSpecs.class, REMOVE_PARTITION_SPECS)
+          .put(MetadataUpdate.RemoveSchemas.class, REMOVE_SCHEMAS)
           .put(MetadataUpdate.EnableRowLineage.class, ENABLE_ROW_LINEAGE)
           .buildOrThrow();
 
@@ -251,6 +256,9 @@ public class MetadataUpdateParser {
       case REMOVE_PARTITION_SPECS:
         writeRemovePartitionSpecs((MetadataUpdate.RemovePartitionSpecs) metadataUpdate, generator);
         break;
+      case REMOVE_SCHEMAS:
+        writeRemoveSchemas((MetadataUpdate.RemoveSchemas) metadataUpdate, generator);
+        break;
       case ENABLE_ROW_LINEAGE:
         break;
       default:
@@ -326,6 +334,8 @@ public class MetadataUpdateParser {
         return readCurrentViewVersionId(jsonNode);
       case REMOVE_PARTITION_SPECS:
         return readRemovePartitionSpecs(jsonNode);
+      case REMOVE_SCHEMAS:
+        return readRemoveSchemas(jsonNode);
       case ENABLE_ROW_LINEAGE:
         return new MetadataUpdate.EnableRowLineage();
       default:
@@ -466,6 +476,11 @@ public class MetadataUpdateParser {
   private static void writeRemovePartitionSpecs(
       MetadataUpdate.RemovePartitionSpecs metadataUpdate, JsonGenerator gen) throws IOException {
     JsonUtil.writeIntegerArray(SPEC_IDS, metadataUpdate.specIds(), gen);
+  }
+
+  private static void writeRemoveSchemas(
+      MetadataUpdate.RemoveSchemas metadataUpdate, JsonGenerator gen) throws IOException {
+    JsonUtil.writeIntegerArray(SCHEMA_IDS, metadataUpdate.schemaIds(), gen);
   }
 
   private static MetadataUpdate readAssignUUID(JsonNode node) {
@@ -613,5 +628,9 @@ public class MetadataUpdateParser {
 
   private static MetadataUpdate readRemovePartitionSpecs(JsonNode node) {
     return new MetadataUpdate.RemovePartitionSpecs(JsonUtil.getIntegerSet(SPEC_IDS, node));
+  }
+
+  private static MetadataUpdate readRemoveSchemas(JsonNode node) {
+    return new MetadataUpdate.RemoveSchemas(JsonUtil.getIntegerSet(SCHEMA_IDS, node));
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -913,7 +913,7 @@ public class TableMetadata implements Serializable {
     private long lastSequenceNumber;
     private int lastColumnId;
     private int currentSchemaId;
-    private final List<Schema> schemas;
+    private List<Schema> schemas;
     private int defaultSpecId;
     private List<PartitionSpec> specs;
     private int lastAssignedPartitionId;
@@ -1168,6 +1168,23 @@ public class TableMetadata implements Serializable {
               .filter(s -> !specIdsToRemove.contains(s.specId()))
               .collect(Collectors.toList());
       changes.add(new MetadataUpdate.RemovePartitionSpecs(specIdsToRemove));
+
+      return this;
+    }
+
+    Builder removeSchemas(Iterable<Integer> schemaIds) {
+      Set<Integer> schemaIdsToRemove = Sets.newHashSet(schemaIds);
+      Preconditions.checkArgument(
+          !schemaIdsToRemove.contains(currentSchemaId), "Cannot remove the current schema");
+
+      if (!schemaIdsToRemove.isEmpty()) {
+        this.schemas =
+            schemas.stream()
+                .filter(s -> !schemaIdsToRemove.contains(s.schemaId()))
+                .collect(Collectors.toList());
+        changes.add(new MetadataUpdate.RemoveSchemas(schemaIdsToRemove));
+      }
+
       return this;
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -931,6 +931,17 @@ public class TestMetadataUpdateParser {
   }
 
   @Test
+  public void testRemoveSchemas() {
+    String action = MetadataUpdateParser.REMOVE_SCHEMAS;
+    String json = "{\"action\":\"remove-schemas\",\"schema-ids\":[1,2,3]}";
+    MetadataUpdate expected = new MetadataUpdate.RemoveSchemas(ImmutableSet.of(1, 2, 3));
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+    assertThat(MetadataUpdateParser.toJson(expected))
+        .as("Remove schemas should convert to the correct JSON value")
+        .isEqualTo(json);
+  }
+
+  @Test
   public void testEnableRowLineage() {
     String action = MetadataUpdateParser.ENABLE_ROW_LINEAGE;
     String json = "{\"action\":\"enable-row-lineage\"}";
@@ -1049,6 +1060,11 @@ public class TestMetadataUpdateParser {
         assertEqualsRemovePartitionSpecs(
             (MetadataUpdate.RemovePartitionSpecs) expectedUpdate,
             (MetadataUpdate.RemovePartitionSpecs) actualUpdate);
+        break;
+      case MetadataUpdateParser.REMOVE_SCHEMAS:
+        assertEqualsRemoveSchemas(
+            (MetadataUpdate.RemoveSchemas) expectedUpdate,
+            (MetadataUpdate.RemoveSchemas) actualUpdate);
         break;
       case MetadataUpdateParser.ENABLE_ROW_LINEAGE:
         assertThat(actualUpdate).isInstanceOf(MetadataUpdate.EnableRowLineage.class);
@@ -1277,6 +1293,11 @@ public class TestMetadataUpdateParser {
   private static void assertEqualsRemovePartitionSpecs(
       MetadataUpdate.RemovePartitionSpecs expected, MetadataUpdate.RemovePartitionSpecs actual) {
     assertThat(actual.specIds()).containsExactlyInAnyOrderElementsOf(expected.specIds());
+  }
+
+  private static void assertEqualsRemoveSchemas(
+      MetadataUpdate.RemoveSchemas expected, MetadataUpdate.RemoveSchemas actual) {
+    assertThat(actual.schemaIds()).containsExactlyInAnyOrderElementsOf(expected.schemaIds());
   }
 
   private String createManifestListWithManifestFiles(long snapshotId, Long parentSnapshotId)

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -1858,4 +1858,20 @@ public class TestTableMetadata {
     assertThat(updatedMetadata.metadataFileLocation()).isEqualTo("updated-metadata-location");
     assertThat(updatedMetadata.previousFiles()).isEmpty();
   }
+
+  @Test
+  public void testMetadataWithRemoveSchemas() {
+    TableMetadata meta =
+        TableMetadata.buildFrom(
+                TableMetadata.newTableMetadata(
+                    TestBase.SCHEMA, PartitionSpec.unpartitioned(), null, ImmutableMap.of()))
+            .removeSchemas(Sets.newHashSet())
+            .build();
+
+    assertThat(meta.changes()).noneMatch(u -> u instanceof MetadataUpdate.RemoveSchemas);
+
+    meta = TableMetadata.buildFrom(meta).removeSchemas(Sets.newHashSet(1, 2)).build();
+
+    assertThat(meta.changes()).anyMatch(u -> u instanceof MetadataUpdate.RemoveSchemas);
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -59,7 +59,22 @@ public class TestTables {
       PartitionSpec spec,
       SortOrder sortOrder,
       int formatVersion) {
-    return createTable(temp, name, schema, spec, formatVersion, ImmutableMap.of(), sortOrder, null);
+    TestTableOperations ops = new TestTableOperations(name, temp);
+
+    return createTable(
+        temp, name, schema, spec, formatVersion, ImmutableMap.of(), sortOrder, null, ops);
+  }
+
+  public static TestTable create(
+      File temp,
+      String name,
+      Schema schema,
+      PartitionSpec spec,
+      SortOrder sortOrder,
+      int formatVersion,
+      TestTableOperations ops) {
+    return createTable(
+        temp, name, schema, spec, formatVersion, ImmutableMap.of(), sortOrder, null, ops);
   }
 
   public static TestTable create(
@@ -70,8 +85,10 @@ public class TestTables {
       SortOrder sortOrder,
       int formatVersion,
       MetricsReporter reporter) {
+    TestTableOperations ops = new TestTableOperations(name, temp);
+
     return createTable(
-        temp, name, schema, spec, formatVersion, ImmutableMap.of(), sortOrder, reporter);
+        temp, name, schema, spec, formatVersion, ImmutableMap.of(), sortOrder, reporter, ops);
   }
 
   public static TestTable create(
@@ -81,8 +98,10 @@ public class TestTables {
       PartitionSpec spec,
       int formatVersion,
       Map<String, String> properties) {
+    TestTableOperations ops = new TestTableOperations(name, temp);
+
     return createTable(
-        temp, name, schema, spec, formatVersion, properties, SortOrder.unsorted(), null);
+        temp, name, schema, spec, formatVersion, properties, SortOrder.unsorted(), null, ops);
   }
 
   private static TestTable createTable(
@@ -93,8 +112,8 @@ public class TestTables {
       int formatVersion,
       Map<String, String> properties,
       SortOrder sortOrder,
-      MetricsReporter reporter) {
-    TestTableOperations ops = new TestTableOperations(name, temp);
+      MetricsReporter reporter,
+      TestTableOperations ops) {
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }

--- a/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
@@ -301,11 +301,7 @@ public class TestUpdateRequirements {
 
     assertTableUUID(requirements);
 
-    assertThat(requirements)
-        .element(1)
-        .asInstanceOf(InstanceOfAssertFactories.type(UpdateRequirement.AssertCurrentSchemaID.class))
-        .extracting(UpdateRequirement.AssertCurrentSchemaID::schemaId)
-        .isEqualTo(schemaId);
+    assertCurrentSchemaId(requirements, 1, schemaId);
   }
 
   @Test
@@ -399,11 +395,7 @@ public class TestUpdateRequirements {
 
     assertTableUUID(requirements);
 
-    assertThat(requirements)
-        .element(1)
-        .asInstanceOf(InstanceOfAssertFactories.type(UpdateRequirement.AssertDefaultSpecID.class))
-        .extracting(UpdateRequirement.AssertDefaultSpecID::specId)
-        .isEqualTo(specId);
+    assertDefaultSpecId(requirements, 1, specId);
   }
 
   @Test
@@ -442,11 +434,7 @@ public class TestUpdateRequirements {
 
     assertTableUUID(requirements);
 
-    assertThat(requirements)
-        .element(1)
-        .asInstanceOf(InstanceOfAssertFactories.type(UpdateRequirement.AssertDefaultSpecID.class))
-        .extracting(UpdateRequirement.AssertDefaultSpecID::specId)
-        .isEqualTo(defaultSpecId);
+    assertDefaultSpecId(requirements, 1, defaultSpecId);
   }
 
   @Test
@@ -455,12 +443,7 @@ public class TestUpdateRequirements {
     long snapshotId = 42L;
     when(metadata.defaultSpecId()).thenReturn(defaultSpecId);
 
-    String branch = "branch";
-    SnapshotRef snapshotRef = mock(SnapshotRef.class);
-    when(snapshotRef.snapshotId()).thenReturn(snapshotId);
-    when(snapshotRef.isBranch()).thenReturn(true);
-    when(metadata.refs()).thenReturn(ImmutableMap.of(branch, snapshotRef));
-    when(metadata.ref(branch)).thenReturn(snapshotRef);
+    mockBranch("branch", snapshotId);
 
     List<UpdateRequirement> requirements =
         UpdateRequirements.forUpdateTable(
@@ -477,21 +460,13 @@ public class TestUpdateRequirements {
 
     assertTableUUID(requirements);
 
-    assertThat(requirements)
-        .element(1)
-        .asInstanceOf(InstanceOfAssertFactories.type(UpdateRequirement.AssertDefaultSpecID.class))
-        .extracting(UpdateRequirement.AssertDefaultSpecID::specId)
-        .isEqualTo(defaultSpecId);
+    assertDefaultSpecId(requirements, 1, defaultSpecId);
 
-    assertThat(requirements)
-        .element(2)
-        .asInstanceOf(InstanceOfAssertFactories.type(UpdateRequirement.AssertRefSnapshotID.class))
-        .extracting(UpdateRequirement.AssertRefSnapshotID::snapshotId)
-        .isEqualTo(snapshotId);
+    assertRefSnapshotId(requirements, 2, snapshotId);
   }
 
   @Test
-  public void testRemovePartitionSpecsFailure() {
+  public void testRemovePartitionSpecsWithSpecChangedFailure() {
     int defaultSpecId = 3;
     when(metadata.defaultSpecId()).thenReturn(defaultSpecId);
     when(updated.defaultSpecId()).thenReturn(defaultSpecId + 1);
@@ -509,28 +484,121 @@ public class TestUpdateRequirements {
   }
 
   @Test
-  public void testRemovePartitionSpecsWithBranchFailure() {
+  public void testRemovePartitionSpecsWithBranchChangedFailure() {
     int defaultSpecId = 3;
-    long snapshotId = 42L;
     when(metadata.defaultSpecId()).thenReturn(defaultSpecId);
     when(updated.defaultSpecId()).thenReturn(defaultSpecId);
 
+    long snapshotId = 42L;
     String branch = "test";
-    SnapshotRef snapshotRef = mock(SnapshotRef.class);
-    when(snapshotRef.snapshotId()).thenReturn(snapshotId);
-    when(snapshotRef.isBranch()).thenReturn(true);
-    when(metadata.refs()).thenReturn(ImmutableMap.of(branch, snapshotRef));
-    when(metadata.ref(branch)).thenReturn(snapshotRef);
-
-    SnapshotRef updatedRef = mock(SnapshotRef.class);
-    when(updatedRef.snapshotId()).thenReturn(snapshotId + 1);
-    when(updatedRef.isBranch()).thenReturn(true);
-    when(updated.ref(branch)).thenReturn(updatedRef);
+    mockBranchChanged(branch, snapshotId);
 
     List<UpdateRequirement> requirements =
         UpdateRequirements.forUpdateTable(
             metadata,
             ImmutableList.of(new MetadataUpdate.RemovePartitionSpecs(Sets.newHashSet(1, 2))));
+
+    assertThatThrownBy(() -> requirements.forEach(req -> req.validate(updated)))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage(
+            "Requirement failed: branch %s has changed: expected id %s != %s",
+            branch, snapshotId, snapshotId + 1);
+  }
+
+  private void mockBranchChanged(String branch, long snapshotId) {
+    mockBranch(branch, snapshotId);
+
+    SnapshotRef updatedRef = mock(SnapshotRef.class);
+    when(updatedRef.snapshotId()).thenReturn(snapshotId + 1);
+    when(updatedRef.isBranch()).thenReturn(true);
+    when(updated.ref(branch)).thenReturn(updatedRef);
+  }
+
+  private void mockBranch(String branch, long snapshotId) {
+    SnapshotRef snapshotRef = mock(SnapshotRef.class);
+    when(snapshotRef.snapshotId()).thenReturn(snapshotId);
+    when(snapshotRef.isBranch()).thenReturn(true);
+    when(metadata.refs()).thenReturn(ImmutableMap.of(branch, snapshotRef));
+    when(metadata.ref(branch)).thenReturn(snapshotRef);
+  }
+
+  @Test
+  public void removeSchemas() {
+    int currentSchemaId = 3;
+    when(metadata.currentSchemaId()).thenReturn(currentSchemaId);
+
+    List<UpdateRequirement> requirements =
+        UpdateRequirements.forUpdateTable(
+            metadata, ImmutableList.of(new MetadataUpdate.RemoveSchemas(Sets.newHashSet(1, 2))));
+    requirements.forEach(req -> req.validate(metadata));
+
+    assertThat(requirements)
+        .hasSize(2)
+        .hasOnlyElementsOfTypes(
+            UpdateRequirement.AssertTableUUID.class, UpdateRequirement.AssertCurrentSchemaID.class);
+
+    assertTableUUID(requirements);
+
+    assertCurrentSchemaId(requirements, 1, currentSchemaId);
+  }
+
+  @Test
+  public void testRemoveSchemasWithBranch() {
+    int currentSchemaId = 3;
+    long snapshotId = 42L;
+    when(metadata.currentSchemaId()).thenReturn(currentSchemaId);
+
+    mockBranch("branch", snapshotId);
+
+    List<UpdateRequirement> requirements =
+        UpdateRequirements.forUpdateTable(
+            metadata, ImmutableList.of(new MetadataUpdate.RemoveSchemas(Sets.newHashSet(1, 2))));
+    requirements.forEach(req -> req.validate(metadata));
+
+    assertThat(requirements)
+        .hasSize(3)
+        .hasOnlyElementsOfTypes(
+            UpdateRequirement.AssertTableUUID.class,
+            UpdateRequirement.AssertCurrentSchemaID.class,
+            UpdateRequirement.AssertRefSnapshotID.class);
+
+    assertTableUUID(requirements);
+
+    assertCurrentSchemaId(requirements, 1, currentSchemaId);
+
+    assertRefSnapshotId(requirements, 2, snapshotId);
+  }
+
+  @Test
+  public void testRemoveSchemasWithSchemaChangedFailure() {
+    int currentSchemaId = 3;
+    when(metadata.currentSchemaId()).thenReturn(currentSchemaId);
+    when(updated.currentSchemaId()).thenReturn(currentSchemaId + 1);
+
+    List<UpdateRequirement> requirements =
+        UpdateRequirements.forUpdateTable(
+            metadata, ImmutableList.of(new MetadataUpdate.RemoveSchemas(Sets.newHashSet(1, 2))));
+
+    assertThatThrownBy(() -> requirements.forEach(req -> req.validate(updated)))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage(
+            "Requirement failed: current schema changed: expected id %s != %s",
+            currentSchemaId, currentSchemaId + 1);
+  }
+
+  @Test
+  public void testRemoveSchemasWithBranchChangedFailure() {
+    int currentSchemaId = 3;
+    when(metadata.currentSchemaId()).thenReturn(currentSchemaId);
+    when(updated.currentSchemaId()).thenReturn(currentSchemaId);
+
+    long snapshotId = 42L;
+    String branch = "test";
+    mockBranchChanged(branch, snapshotId);
+
+    List<UpdateRequirement> requirements =
+        UpdateRequirements.forUpdateTable(
+            metadata, ImmutableList.of(new MetadataUpdate.RemoveSchemas(Sets.newHashSet(1, 2))));
 
     assertThatThrownBy(() -> requirements.forEach(req -> req.validate(updated)))
         .isInstanceOf(CommitFailedException.class)
@@ -901,5 +969,31 @@ public class TestUpdateRequirements {
         .asInstanceOf(InstanceOfAssertFactories.type(UpdateRequirement.AssertViewUUID.class))
         .extracting(UpdateRequirement.AssertViewUUID::uuid)
         .isEqualTo(viewMetadata.uuid());
+  }
+
+  private void assertDefaultSpecId(
+      List<UpdateRequirement> requirements, int idx, int defaultSpecId) {
+    assertThat(requirements)
+        .element(idx)
+        .asInstanceOf(InstanceOfAssertFactories.type(UpdateRequirement.AssertDefaultSpecID.class))
+        .extracting(UpdateRequirement.AssertDefaultSpecID::specId)
+        .isEqualTo(defaultSpecId);
+  }
+
+  private void assertCurrentSchemaId(
+      List<UpdateRequirement> requirements, int idx, int currentSchemaId) {
+    assertThat(requirements)
+        .element(idx)
+        .asInstanceOf(InstanceOfAssertFactories.type(UpdateRequirement.AssertCurrentSchemaID.class))
+        .extracting(UpdateRequirement.AssertCurrentSchemaID::schemaId)
+        .isEqualTo(currentSchemaId);
+  }
+
+  private void assertRefSnapshotId(List<UpdateRequirement> requirements, int idx, long snapshotId) {
+    assertThat(requirements)
+        .element(idx)
+        .asInstanceOf(InstanceOfAssertFactories.type(UpdateRequirement.AssertRefSnapshotID.class))
+        .extracting(UpdateRequirement.AssertRefSnapshotID::snapshotId)
+        .isEqualTo(snapshotId);
   }
 }


### PR DESCRIPTION
Similarly to removing partition specs, this PR improves RemoveSnapshots to also remove unused schemas.