### PR TITLE
Core: don't override `LoggingMetricsReporter`

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableScanContext.java
+++ b/core/src/main/java/org/apache/iceberg/TableScanContext.java
@@ -182,10 +182,7 @@ abstract class TableScanContext {
   TableScanContext reportWith(MetricsReporter reporter) {
     return ImmutableTableScanContext.builder()
         .from(this)
-        .metricsReporter(
-            metricsReporter() instanceof LoggingMetricsReporter
-                ? reporter
-                : MetricsReporters.combine(metricsReporter(), reporter))
+        .metricsReporter(MetricsReporters.combine(metricsReporter(), reporter))
         .build();
   }
 


### PR DESCRIPTION
the current metrics reporter is overwritten if it's a `LoggingMetricsReporter`. If it's not `LoggingMetricsReporter`, metrics reporters are combined.

Imho, the only reason to do this is to prevent multiple `LoggingMetricsReporters`. However, `MetricsReporters::combine` takes care of this case already as `LoggingMetricsReporter` is a singleton and the `combine` method uses an IdentityHasMap.