### PR TITLE
OpenAPI: add initial/write defaults to schema

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateTableRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateTableRequest.java
@@ -47,7 +47,8 @@ public class TestCreateTableRequest extends RequestResponseTestBase<CreateTableR
   private static final String SAMPLE_LOCATION = "file://tmp/location/";
   private static final Schema SAMPLE_SCHEMA =
       new Schema(
-          required(1, "id", Types.IntegerType.get()), optional(2, "data", Types.StringType.get()));
+          required("id").withId(1).ofType(Types.IntegerType.get()).withWriteDefault(1).build(),
+          optional("data").withId(2).ofType(Types.StringType.get()).build());
   private static final String SAMPLE_SCHEMA_JSON = SchemaParser.toJson(SAMPLE_SCHEMA);
   private static final PartitionSpec SAMPLE_SPEC =
       PartitionSpec.builderFor(SAMPLE_SCHEMA).bucket("id", 16).build();
@@ -59,7 +60,7 @@ public class TestCreateTableRequest extends RequestResponseTestBase<CreateTableR
   public void testRoundTripSerDe() throws JsonProcessingException {
     String fullJsonRaw =
         "{\"name\":\"test_tbl\",\"location\":\"file://tmp/location/\",\"schema\":{\"type\":\"struct\","
-            + "\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"int\"},"
+            + "\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"int\",\"write-default\":1},"
             + "{\"id\":2,\"name\":\"data\",\"required\":false,\"type\":\"string\"}]},\"partition-spec\":{\"spec-id\":0,"
             + "\"fields\":[{\"name\":\"id_bucket\",\"transform\":\"bucket[16]\",\"source-id\":1,\"field-id\":1000}]},"
             + "\"write-order\":{\"order-id\":1,\"fields\":"

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponse.java
@@ -148,6 +148,23 @@ public class TestLoadTableResponse extends RequestResponseTestBase<LoadTableResp
   }
 
   @Test
+  public void testRoundTripSerdeWithV3TableMetadata() throws Exception {
+    String tableMetadataJson = readTableMetadataInputFile("TableMetadataV3ValidMinimal.json");
+    TableMetadata v3Metadata =
+        TableMetadataParser.fromJson(TEST_METADATA_LOCATION, tableMetadataJson);
+    // Convert the TableMetadata JSON from the file to an object and then back to JSON so that
+    // missing fields
+    // are filled in with their default values.
+    String json =
+        String.format(
+            "{\"metadata-location\":\"%s\",\"metadata\":%s,\"config\":{\"foo\":\"bar\"}}",
+            TEST_METADATA_LOCATION, TableMetadataParser.toJson(v3Metadata));
+    LoadTableResponse resp =
+        LoadTableResponse.builder().withTableMetadata(v3Metadata).addAllConfig(CONFIG).build();
+    assertRoundTripSerializesEquallyFrom(json, resp);
+  }
+
+  @Test
   public void testCanDeserializeWithoutDefaultValues() throws Exception {
     String metadataJson = readTableMetadataInputFile("TableMetadataV1Valid.json");
     // `config` is missing in the JSON

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponse.java
@@ -136,8 +136,7 @@ public class TestLoadTableResponse extends RequestResponseTestBase<LoadTableResp
     TableMetadata v2Metadata =
         TableMetadataParser.fromJson(TEST_METADATA_LOCATION, tableMetadataJson);
     // Convert the TableMetadata JSON from the file to an object and then back to JSON so that
-    // missing fields
-    // are filled in with their default values.
+    // missing fields are filled in with their default values.
     String json =
         String.format(
             "{\"metadata-location\":\"%s\",\"metadata\":%s,\"config\":{\"foo\":\"bar\"}}",
@@ -153,8 +152,7 @@ public class TestLoadTableResponse extends RequestResponseTestBase<LoadTableResp
     TableMetadata v3Metadata =
         TableMetadataParser.fromJson(TEST_METADATA_LOCATION, tableMetadataJson);
     // Convert the TableMetadata JSON from the file to an object and then back to JSON so that
-    // missing fields
-    // are filled in with their default values.
+    // missing fields are filled in with their default values.
     String json =
         String.format(
             "{\"metadata-location\":\"%s\",\"metadata\":%s,\"config\":{\"foo\":\"bar\"}}",

--- a/core/src/test/resources/TableMetadataV3ValidMinimal.json
+++ b/core/src/test/resources/TableMetadataV3ValidMinimal.json
@@ -1,0 +1,73 @@
+{
+  "format-version": 2,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "current-schema-id": 0,
+  "schemas": [
+    {
+      "type": "struct",
+      "schema-id": 0,
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long",
+          "initial-default": 1,
+          "write-default": 1
+        },
+        {
+          "id": 2,
+          "name": "y",
+          "required": true,
+          "type": "long",
+          "doc": "comment"
+        },
+        {
+          "id": 3,
+          "name": "z",
+          "required": true,
+          "type": "long"
+        }
+      ]
+    }
+  ],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "last-partition-id": 1000,
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ]
+}

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1052,8 +1052,8 @@ class StructField(BaseModel):
     type: Type
     required: bool
     doc: Optional[str] = None
-    initial_default: Optional[str] = Field(None, alias='initial-default')
-    write_default: Optional[str] = Field(None, alias='write-default')
+    initial_default: Optional[PrimitiveTypeValue] = Field(None, alias='initial-default')
+    write_default: Optional[PrimitiveTypeValue] = Field(None, alias='write-default')
 
 
 class StructType(BaseModel):

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1052,6 +1052,8 @@ class StructField(BaseModel):
     type: Type
     required: bool
     doc: Optional[str] = None
+    initial_default: Optional[str] = Field(None, alias='initial-default')
+    write_default: Optional[str] = Field(None, alias='write-default')
 
 
 class StructType(BaseModel):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2052,6 +2052,10 @@ components:
           type: boolean
         doc:
           type: string
+        initial-default:
+          type: string
+        write-default:
+          type: string
 
     StructType:
       type: object

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2053,9 +2053,9 @@ components:
         doc:
           type: string
         initial-default:
-          type: string
+          $ref: "#/components/schemas/PrimitiveTypeValue"
         write-default:
-          type: string
+          $ref: "#/components/schemas/PrimitiveTypeValue"
 
     StructType:
       type: object


### PR DESCRIPTION
Adds `inital-default` and `write-default` to the REST API spec.

Includes updates to a couple small round-trip request/response serde tests.