### PR TITLE
Add relevant NOTICE portions from ALv2 bundled dependencies

### DIFF
--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -208,84 +208,98 @@ This binary artifact contains code from the following projects:
 --------------------------------------------------------------------------------
 
 Group: commons-codec  Name: commons-codec  Version: 1.17.1
+Copyright: Copyright 2002-2024 The Apache Software Foundation
 Project URL: https://commons.apache.org/proper/commons-codec/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: commons-logging  Name: commons-logging  Version: 1.2
+Copyright: Copyright 2003-2014 The Apache Software Foundation
 Project URL: http://commons.apache.org/proper/commons-logging/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-buffer  Version: 4.1.112.Final
+Group: io.netty  Name: netty-buffer  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec  Version: 4.1.112.Final
+Group: io.netty  Name: netty-codec  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec-http  Version: 4.1.112.Final
+Group: io.netty  Name: netty-codec-http  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec-http2  Version: 4.1.112.Final
+Group: io.netty  Name: netty-codec-http2  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-common  Version: 4.1.112.Final
+Group: io.netty  Name: netty-common  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-handler  Version: 4.1.112.Final
+Group: io.netty  Name: netty-handler  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-resolver  Version: 4.1.112.Final
+Group: io.netty  Name: netty-resolver  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport  Version: 4.1.112.Final
+Group: io.netty  Name: netty-transport  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.112.Final
+Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.112.Final
+Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.httpcomponents  Name: httpclient  Version: 4.5.13
+Copyright: Copyright 1999-2023 The Apache Software Foundation
 Project URL: http://hc.apache.org/httpcomponents-client
 License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.apache.httpcomponents  Name: httpcore  Version: 4.4.16
+Copyright: Copyright 1999-2023 The Apache Software Foundation
 Project URL: http://hc.apache.org/httpcomponents-core-ga
 License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -297,220 +311,266 @@ License: CC0 - http://creativecommons.org/publicdomain/zero/1.0/
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: annotations  Version: 2.28.5
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: apache-client  Version: 2.28.5
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: arns  Version: 2.28.5
+Group: software.amazon.awssdk  Name: annotations  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: auth  Version: 2.28.5
+Group: software.amazon.awssdk  Name: apache-client  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-core  Version: 2.28.5
+Group: software.amazon.awssdk  Name: arns  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.28.5
+Group: software.amazon.awssdk  Name: auth  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.28.5
+Group: software.amazon.awssdk  Name: aws-core  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.28.5
+Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: checksums  Version: 2.28.5
+Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.28.5
+Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: crt-core  Version: 2.28.5
+Group: software.amazon.awssdk  Name: checksums  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: dynamodb  Version: 2.28.5
+Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.28.5
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: glue  Version: 2.28.5
+Group: software.amazon.awssdk  Name: crt-core  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth  Version: 2.28.5
+Group: software.amazon.awssdk  Name: dynamodb  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.28.5
+Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.28.5
+Group: software.amazon.awssdk  Name: glue  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.28.5
+Group: software.amazon.awssdk  Name: http-auth  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.28.5
+Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.28.5
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: iam  Version: 2.28.5
+Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: identity-spi  Version: 2.28.5
+Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: json-utils  Version: 2.28.5
+Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: kms  Version: 2.28.5
+Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: lakeformation  Version: 2.28.5
+Group: software.amazon.awssdk  Name: iam  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.28.5
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.28.5
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: profiles  Version: 2.28.5
+Group: software.amazon.awssdk  Name: identity-spi  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: protocol-core  Version: 2.28.5
+Group: software.amazon.awssdk  Name: json-utils  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: regions  Version: 2.28.5
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: s3  Version: 2.28.5
+Group: software.amazon.awssdk  Name: kms  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sdk-core  Version: 2.28.5
+Group: software.amazon.awssdk  Name: lakeformation  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sso  Version: 2.28.5
+Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sts  Version: 2.28.5
+Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.28.5
+Group: software.amazon.awssdk  Name: profiles  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: utils  Version: 2.28.5
+Group: software.amazon.awssdk  Name: protocol-core  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk.crt  Name: aws-crt  Version: 0.30.6
+Group: software.amazon.awssdk  Name: regions  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Project URL: https://aws.amazon.com/sdkforjava
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: s3  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Project URL: https://aws.amazon.com/sdkforjava
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: sdk-core  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Project URL: https://aws.amazon.com/sdkforjava
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: sso  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Project URL: https://aws.amazon.com/sdkforjava
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: sts  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Project URL: https://aws.amazon.com/sdkforjava
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Project URL: https://aws.amazon.com/sdkforjava
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk  Name: utils  Version: 2.30.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Project URL: https://aws.amazon.com/sdkforjava
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk.crt  Name: aws-crt  Version: 0.33.6
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://github.com/awslabs/aws-crt-java
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: software.amazon.eventstream  Name: eventstream  Version: 1.0.1
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Project URL: https://github.com/awslabs/aws-eventstream-java
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0

--- a/aws-bundle/NOTICE
+++ b/aws-bundle/NOTICE
@@ -1,4 +1,3 @@
-
 Apache Iceberg
 Copyright 2017-2025 The Apache Software Foundation
 
@@ -7,97 +6,293 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: commons-codec  Name: commons-codec  Version: 1.17.1
+This binary artifact includes Apache HttpComponents Client 4.5.13 with the following in its NOTICE file:
 
-src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
-contains test data from http://aspell.net/test/orig/batch0.tab.
-Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
-
-===============================================================================
-
-The content of package org.apache.commons.codec.language.bm has been translated
-from the original php source code available at http://stevemorse.org/phoneticinfo.htm
-with permission from the original authors.
-Original source copyright:
-Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
+| Apache HttpComponents Client
+| Copyright 1999-2023 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: software.amazon.awssdk  Name: annotations  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: apache-client  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: arns  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: auth  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: aws-core  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: checksums  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: crt-core  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: dynamodb  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: glue  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: http-auth  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: iam  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: identity-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: json-utils  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: kms  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: lakeformation  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: profiles  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: protocol-core  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: regions  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: retries  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: retries-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: s3  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: sdk-core  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: sso  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: sts  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: utils  Version: 2.28.5
+This binary artifact includes Apache Commons Codec 1.17.1 with the following in its NOTICE file:
 
-AWS SDK for Java 2.0
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-This product includes software developed by
-Amazon Technologies, Inc (http://www.amazon.com/).
-
-**********************
-THIRD PARTY COMPONENTS
-**********************
-This software includes third party software subject to the following copyrights:
-- XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
-- PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
-- Apache Commons Lang - https://github.com/apache/commons-lang
-- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
-- Jackson-core - https://github.com/FasterXML/jackson-core
-- Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
-
-The licenses for these third party components are included in LICENSE.txt
+| Apache Commons Codec
+| Copyright 2002-2024 The Apache Software Foundation
+| 
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.28.5
+This binary artifact includes Apache Commons Logging 1.2 with the following in its NOTICE file:
 
-# Jackson JSON processor
+| Apache Commons Logging
+| Copyright 2003-2014 The Apache Software Foundation
+| 
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
 
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
+--------------------------------------------------------------------------------
 
-## Licensing
+This binary artifact includes AWS SDK (software.amazon.awssdk:bom:2.30.6) with the following in its NOTICE file:
 
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
+| AWS SDK for Java 2.0
+| Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+| 
+| This product includes software developed by
+| Amazon Technologies, Inc (http://www.amazon.com/).
+| 
+| **********************
+| THIRD PARTY COMPONENTS
+| **********************
+| This software includes third party software subject to the following copyrights:
+| - XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+| - PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+| - Apache Commons Lang - https://github.com/apache/commons-lang
+| - Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
+| - Jackson-core - https://github.com/FasterXML/jackson-core
+| - Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
+| 
+| The licenses for these third party components are included in LICENSE.txt
 
-## Credits
+--------------------------------------------------------------------------------
 
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
+This binary artifact includes AWS SDK Third Party Jackson Core 2.28.5 with the following in its NOTICE file:
+
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Licensing
+| 
+| Jackson 2.x core and extension components are licensed under Apache License 2.0
+| To find the details that apply to this artifact see the accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS(-2.x) file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Netty 4.1.115.Final with the following in its NOTICE file:
+
+
+|                             The Netty Project
+|                             =================
+| 
+| Please visit the Netty web site for more information:
+| 
+|   * http://netty.io/
+| 
+| Copyright 2014 The Netty Project
+| 
+| The Netty Project licenses this file to you under the Apache License,
+| version 2.0 (the "License"); you may not use this file except in compliance
+| with the License. You may obtain a copy of the License at:
+| 
+|   http://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+| WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+| License for the specific language governing permissions and limitations
+| under the License.
+| 
+| Also, please refer to each LICENSE.<component>.txt file, which is located in
+| the 'license' directory of the distribution file, for the license terms of the
+| components that this product depends on.
+| 
+| -------------------------------------------------------------------------------
+| This product contains the extensions to Java Collections Framework which has
+| been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jsr166y.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+|     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+| 
+| This product contains a modified version of Robert Harder's Public Domain
+| Base64 Encoder and Decoder, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.base64.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://iharder.sourceforge.net/current/java/base64/
+| 
+| This product contains a modified portion of 'Webbit', an event based  
+| WebSocket and HTTP server, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.webbit.txt (BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/joewalnes/webbit
+| 
+| This product contains a modified portion of 'SLF4J', a simple logging
+| facade for Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.slf4j.txt (MIT License)
+|   * HOMEPAGE:
+|     * http://www.slf4j.org/
+| 
+| This product contains a modified portion of 'Apache Harmony', an open source
+| Java SE, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.harmony.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://archive.apache.org/dist/harmony/
+| 
+| This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+| and decompression library written by Matthew J. Francis. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jbzip2.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jbzip2/
+| 
+| This product contains a modified portion of 'libdivsufsort', a C API library to construct
+| the suffix array and the Burrows-Wheeler transformed string for any input string of
+| a constant-size alphabet written by Yuta Mori. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.libdivsufsort.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/y-256/libdivsufsort
+| 
+| This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+|  which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jctools.txt (ASL2 License)
+|   * HOMEPAGE:
+|     * https://github.com/JCTools/JCTools
+| 
+| This product optionally depends on 'JZlib', a re-implementation of zlib in
+| pure Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jzlib.txt (BSD style License)
+|   * HOMEPAGE:
+|     * http://www.jcraft.com/jzlib/
+| 
+| This product optionally depends on 'Compress-LZF', a Java library for encoding and
+| decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/ning/compress
+| 
+| This product optionally depends on 'lz4', a LZ4 Java compression
+| and decompression library written by Adrien Grand. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lz4.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jpountz/lz4-java
+| 
+| This product optionally depends on 'lzma-java', a LZMA Java compression
+| and decompression library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lzma-java.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jponge/lzma-java
+| 
+| This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+| and decompression library written by William Kinney. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jfastlz.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jfastlz/
+| 
+| This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+| interchange format, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.protobuf.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/protobuf
+| 
+| This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+| a temporary self-signed X.509 certificate when the JVM does not provide the
+| equivalent functionality.  It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.bouncycastle.txt (MIT License)
+|   * HOMEPAGE:
+|     * http://www.bouncycastle.org/
+| 
+| This product optionally depends on 'Snappy', a compression library produced
+| by Google Inc, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.snappy.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/snappy
+| 
+| This product optionally depends on 'JBoss Marshalling', an alternative Java
+| serialization API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jboss-marshalling.txt (GNU LGPL 2.1)
+|   * HOMEPAGE:
+|     * http://www.jboss.org/jbossmarshalling
+| 
+| This product optionally depends on 'Caliper', Google's micro-
+| benchmarking framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.caliper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/google/caliper
+| 
+| This product optionally depends on 'Apache Commons Logging', a logging
+| framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-logging.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://commons.apache.org/logging/
+| 
+| This product optionally depends on 'Apache Log4J', a logging framework, which
+| can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.log4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://logging.apache.org/log4j/
+| 
+| This product optionally depends on 'Aalto XML', an ultra-high performance
+| non-blocking XML processor, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://wiki.fasterxml.com/AaltoHome
+| 
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.hpack.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/twitter/hpack
+| 
+| This product contains a modified portion of 'Apache Commons Lang', a Java library
+| provides utilities for the java.lang API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-lang.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/proper/commons-lang/

--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -207,80 +207,74 @@ This binary artifact contains code from the following projects:
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-core-http-netty  Version: 1.13.5
+Group: com.azure  Name: azure-core-http-netty  Version: 1.15.7
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-identity  Version: 1.9.2
+Group: com.azure  Name: azure-identity  Version: 1.14.2
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-json  Version: 1.0.1
+Group: com.azure  Name: azure-json  Version: 1.3.0
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-storage-blob  Version: 12.23.0
+Group: com.azure  Name: azure-storage-blob  Version: 12.29.0
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-storage-common  Version: 12.22.0
+Group: com.azure  Name: azure-storage-common  Version: 12.28.0
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-storage-file-datalake  Version: 12.16.0
+Group: com.azure  Name: azure-storage-file-datalake  Version: 12.22.0
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-storage-internal-avro  Version: 12.8.0
+Group: com.azure  Name: azure-storage-internal-avro  Version: 12.14.0
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.13.5
+Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.17.2
 Project URL: http://github.com/FasterXML/jackson
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.13.5
+Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.17.2
 Project URL: https://github.com/FasterXML/jackson-core
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.13.5
+Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.17.2
 Project URL: http://github.com/FasterXML/jackson
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.13.5
+Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.17.2
 Project URL: https://github.com/FasterXML/jackson-dataformat-xml
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.13.5
+Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.17.2
 Project URL: https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.woodstox  Name: woodstox-core  Version: 6.4.0
-Project URL: https://github.com/FasterXML/woodstox
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
@@ -291,181 +285,206 @@ License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.
 
 --------------------------------------------------------------------------------
 
-Group: com.microsoft.azure  Name: msal4j  Version: 1.13.8
+Group: com.microsoft.azure  Name: msal4j  Version: 1.17.2
 Project URL: https://github.com/AzureAD/microsoft-authentication-library-for-java
 License: MIT License
 
 --------------------------------------------------------------------------------
 
-Group: com.microsoft.azure  Name: msal4j-persistence-extension  Version: 1.2.0
+Group: com.microsoft.azure  Name: msal4j-persistence-extension  Version: 1.3.0
 Project URL: https://github.com/AzureAD/microsoft-authentication-extensions-for-java
 License: MIT License
 
 --------------------------------------------------------------------------------
 
-Group: com.nimbusds  Name: content-type  Version: 2.2
+Group: com.nimbusds  Name: content-type  Version: 2.3
+Copyright 2020, Connect2id Ltd.
 Project URL: https://bitbucket.org/connect2id/nimbus-content-type
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: com.nimbusds  Name: lang-tag  Version: 1.7
+Copyright 2012-2022, Connect2id Ltd.
 Project URL: https://bitbucket.org/connect2id/nimbus-language-tags
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.nimbusds  Name: nimbus-jose-jwt  Version: 9.30.2
+Group: com.nimbusds  Name: nimbus-jose-jwt  Version: 9.40
+Copyright 2012 - 2024, Connect2id Ltd.
 Project URL: https://bitbucket.org/connect2id/nimbus-jose-jwt
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.nimbusds  Name: oauth2-oidc-sdk  Version: 10.7.1
+Group: com.nimbusds  Name: oauth2-oidc-sdk  Version: 11.18
+Copyright 2012-2024, Connect2id Ltd and contributors.
 Project URL: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
 License: Apache License, version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-buffer  Version: 4.1.94.Final
+Group: io.netty  Name: netty-buffer  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec  Version: 4.1.94.Final
+Group: io.netty  Name: netty-codec  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
 Group: io.netty  Name: netty-codec-dns  Version: 4.1.93.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec-http  Version: 4.1.94.Final
+Group: io.netty  Name: netty-codec-http  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec-http2  Version: 4.1.94.Final
+Group: io.netty  Name: netty-codec-http2  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec-socks  Version: 4.1.94.Final
+Group: io.netty  Name: netty-codec-socks  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-common  Version: 4.1.94.Final
+Group: io.netty  Name: netty-common  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-handler  Version: 4.1.94.Final
+Group: io.netty  Name: netty-handler  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-handler-proxy  Version: 4.1.94.Final
+Group: io.netty  Name: netty-handler-proxy  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-resolver  Version: 4.1.94.Final
+Group: io.netty  Name: netty-resolver  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-resolver-dns  Version: 4.1.93.Final
+Group: io.netty  Name: netty-resolver-dns  Version: 4.1.112.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-resolver-dns-classes-macos  Version: 4.1.93.Final
+Group: io.netty  Name: netty-resolver-dns-classes-macos  Version: 4.1.112.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-resolver-dns-native-macos  Version: 4.1.93.Final
+Group: io.netty  Name: netty-resolver-dns-native-macos  Version: 4.1.112.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-tcnative-boringssl-static  Version: 2.0.61.Final
+Group: io.netty  Name: netty-tcnative-boringssl-static  Version: 2.0.69.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://github.com/netty/netty-tcnative/netty-tcnative-boringssl-static/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-tcnative-classes  Version: 2.0.61.Final
+Group: io.netty  Name: netty-tcnative-classes  Version: 2.0.69.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport  Version: 4.1.94.Final
+Group: io.netty  Name: netty-transport  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.94.Final
+Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-classes-kqueue  Version: 4.1.94.Final
+Group: io.netty  Name: netty-transport-classes-kqueue  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-native-epoll  Version: 4.1.94.Final
+Group: io.netty  Name: netty-transport-native-epoll  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-native-kqueue  Version: 4.1.94.Final
+Group: io.netty  Name: netty-transport-native-kqueue  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.94.Final
+Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.115.Final
+Copyright: Copyright 2014 The Netty Project
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.projectreactor  Name: reactor-core  Version: 3.4.30
+Group: io.projectreactor  Name: reactor-core  Version: 3.4.41
 Project URL: https://github.com/reactor/reactor-core
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.projectreactor.netty  Name: reactor-netty-core  Version: 1.0.33
+Group: io.projectreactor.netty  Name: reactor-netty-core  Version: 1.0.48
 Project URL: https://github.com/reactor/reactor-netty
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.projectreactor.netty  Name: reactor-netty-http  Version: 1.0.33
+Group: io.projectreactor.netty  Name: reactor-netty-http  Version: 1.0.48
 Project URL: https://github.com/reactor/reactor-netty
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -483,25 +502,19 @@ License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: net.minidev  Name: accessors-smart  Version: 2.4.9
+Group: net.minidev  Name: accessors-smart  Version: 2.5.1
 Project URL: https://urielch.github.io/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: net.minidev  Name: json-smart  Version: 2.4.10
+Group: net.minidev  Name: json-smart  Version: 2.5.1
 Project URL: https://urielch.github.io/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.codehaus.woodstox  Name: stax2-api  Version: 4.2.1
-Project URL: http://github.com/FasterXML/stax2-api
-License: The BSD License - http://www.opensource.org/licenses/bsd-license.php
-
---------------------------------------------------------------------------------
-
-Group: org.ow2.asm  Name: asm  Version: 9.3
+Group: org.ow2.asm  Name: asm  Version: 9.6
 Project URL: http://asm.ow2.io/
 License: BSD-3-Clause - https://asm.ow2.io/license.html
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/azure-bundle/NOTICE
+++ b/azure-bundle/NOTICE
@@ -1,4 +1,3 @@
-
 Apache Iceberg
 Copyright 2017-2025 The Apache Software Foundation
 
@@ -6,25 +5,219 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+This binary artifact includes Netty 4.1.115.Final with the following in its NOTICE file:
 
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.13.5
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.13.5
-NOTICE for Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.13.5
 
-# Jackson JSON processor
+|                             The Netty Project
+|                             =================
+| 
+| Please visit the Netty web site for more information:
+| 
+|   * http://netty.io/
+| 
+| Copyright 2014 The Netty Project
+| 
+| The Netty Project licenses this file to you under the Apache License,
+| version 2.0 (the "License"); you may not use this file except in compliance
+| with the License. You may obtain a copy of the License at:
+| 
+|   http://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+| WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+| License for the specific language governing permissions and limitations
+| under the License.
+| 
+| Also, please refer to each LICENSE.<component>.txt file, which is located in
+| the 'license' directory of the distribution file, for the license terms of the
+| components that this product depends on.
+| 
+| -------------------------------------------------------------------------------
+| This product contains the extensions to Java Collections Framework which has
+| been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jsr166y.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+|     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+| 
+| This product contains a modified version of Robert Harder's Public Domain
+| Base64 Encoder and Decoder, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.base64.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://iharder.sourceforge.net/current/java/base64/
+| 
+| This product contains a modified portion of 'Webbit', an event based  
+| WebSocket and HTTP server, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.webbit.txt (BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/joewalnes/webbit
+| 
+| This product contains a modified portion of 'SLF4J', a simple logging
+| facade for Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.slf4j.txt (MIT License)
+|   * HOMEPAGE:
+|     * http://www.slf4j.org/
+| 
+| This product contains a modified portion of 'Apache Harmony', an open source
+| Java SE, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.harmony.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://archive.apache.org/dist/harmony/
+| 
+| This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+| and decompression library written by Matthew J. Francis. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jbzip2.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jbzip2/
+| 
+| This product contains a modified portion of 'libdivsufsort', a C API library to construct
+| the suffix array and the Burrows-Wheeler transformed string for any input string of
+| a constant-size alphabet written by Yuta Mori. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.libdivsufsort.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/y-256/libdivsufsort
+| 
+| This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+|  which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jctools.txt (ASL2 License)
+|   * HOMEPAGE:
+|     * https://github.com/JCTools/JCTools
+| 
+| This product optionally depends on 'JZlib', a re-implementation of zlib in
+| pure Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jzlib.txt (BSD style License)
+|   * HOMEPAGE:
+|     * http://www.jcraft.com/jzlib/
+| 
+| This product optionally depends on 'Compress-LZF', a Java library for encoding and
+| decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/ning/compress
+| 
+| This product optionally depends on 'lz4', a LZ4 Java compression
+| and decompression library written by Adrien Grand. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lz4.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jpountz/lz4-java
+| 
+| This product optionally depends on 'lzma-java', a LZMA Java compression
+| and decompression library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lzma-java.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jponge/lzma-java
+| 
+| This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+| and decompression library written by William Kinney. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jfastlz.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jfastlz/
+| 
+| This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+| interchange format, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.protobuf.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/protobuf
+| 
+| This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+| a temporary self-signed X.509 certificate when the JVM does not provide the
+| equivalent functionality.  It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.bouncycastle.txt (MIT License)
+|   * HOMEPAGE:
+|     * http://www.bouncycastle.org/
+| 
+| This product optionally depends on 'Snappy', a compression library produced
+| by Google Inc, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.snappy.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/snappy
+| 
+| This product optionally depends on 'JBoss Marshalling', an alternative Java
+| serialization API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jboss-marshalling.txt (GNU LGPL 2.1)
+|   * HOMEPAGE:
+|     * http://www.jboss.org/jbossmarshalling
+| 
+| This product optionally depends on 'Caliper', Google's micro-
+| benchmarking framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.caliper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/google/caliper
+| 
+| This product optionally depends on 'Apache Commons Logging', a logging
+| framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-logging.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://commons.apache.org/logging/
+| 
+| This product optionally depends on 'Apache Log4J', a logging framework, which
+| can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.log4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://logging.apache.org/log4j/
+| 
+| This product optionally depends on 'Aalto XML', an ultra-high performance
+| non-blocking XML processor, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://wiki.fasterxml.com/AaltoHome
+| 
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.hpack.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/twitter/hpack
+| 
+| This product contains a modified portion of 'Apache Commons Lang', a Java library
+| provides utilities for the java.lang API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-lang.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/proper/commons-lang/
 
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.

--- a/flink/v1.20/flink-runtime/LICENSE
+++ b/flink/v1.20/flink-runtime/LICENSE
@@ -203,105 +203,121 @@
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache Avro.
+The binary artifact contains code from the following projects:
 
+--------------------------------------------------------------------------------
+
+Group: org.apache.avro  Name: avro  Version: 1.7.4
 Copyright: 2014-2020 The Apache Software Foundation.
-Home page: https://parquet.apache.org/
+Home page: https://avro.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains the Jackson JSON processor.
-
-Copyright: 2007-2020 Tatu Saloranta and other contributors
-Home page: http://jackson.codehaus.org/
+Group: com.fasterxml.jackson.core Name: jackson-core Version: 2.18.2
+Home page: https://github.com/FasterXML/jackson/
 License: http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache Parquet.
+Group: com.fasterxml.jackson.core Name: jackson-annotations Version: 2.18.2
+Home page: https://github.com/FasterXML/jackson/
+License: http://www.apache.org/licenses/LICENSE-2.0.txt
 
-Copyright: 2014-2020 The Apache Software Foundation.
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core Name: jackson-databind Version: 2.18.2
+Home page: https://github.com/FasterXML/jackson/
+License: http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet Name: parquet-avro Version: 1.15.0
+Copyright: Copyright 2014-2024 The Apache Software Foundation
 Home page: https://parquet.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache Thrift.
-
+Group: org.apache.thrift Name: libthrift Version: 0.9.3
 Copyright: 2006-2010 The Apache Software Foundation.
 Home page: https://thrift.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains fastutil.
+Group: org.apache.thrift Name: libfb303 Version: 0.9.3
+Copyright: 2006-2010 The Apache Software Foundation.
+Home page: https://thrift.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
 
+--------------------------------------------------------------------------------
+
+Group: org.apache.datasketches Name: datasketches-java Version: 6.2.0
+Copyright: Copyright 2024 The Apache Software Foundation
+Home page: https://datasketches.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains fastutil.
 Copyright: 2002-2014 Sebastiano Vigna
 Home page: http://fastutil.di.unimi.it/
 License: http://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache ORC.
-
+Group: org.apache.orc Name: orc-core Version: 1.9.5
 Copyright: 2013-2020 The Apache Software Foundation.
 Home page: https://orc.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache Hive's storage API via ORC.
-
-Copyright: 2013-2020 The Apache Software Foundation.
+Group: org.apache.hive Name: hive-metastore Version: 2.3.9
+Copyright: 2008-2020 The Apache Software Foundation
 Home page: https://hive.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Airlift Aircompressor.
-
+Group: io.airlift Name: aircompressor Version: 2.0.2
 Copyright: 2011-2020 Aircompressor authors.
 Home page: https://github.com/airlift/aircompressor
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Airlift Slice.
-
+Group: io.airlift Name: slice Version: 0.29
 Copyright: 2013-2020 Slice authors.
 Home page: https://github.com/airlift/slice
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains JetBrains annotations.
-
+Group: org.jetbrains Name: annotations Version: 17.0.0
 Copyright: 2000-2020 JetBrains s.r.o.
 Home page: https://github.com/JetBrains/java-annotations
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Google Guava.
-
+Group: com.google.guava Name: guava Version: 16.0.1
 Copyright: 2006-2020 The Guava Authors
 Home page: https://github.com/google/guava
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Google Error Prone Annotations.
-
+Group: com.google.errorprone Name: error_prone_annotations Version: 2.31.0
 Copyright: Copyright 2011-2019 The Error Prone Authors
 Home page: https://github.com/google/error-prone
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains checkerframework checker-qual Annotations.
-
-Copyright: 2004-2020 the Checker Framework developers
+Group: org.checkerframework Name: checker-qual Version: 3.33.0
+Copyright: 2004-present by the Checker Framework developers
 Home page: https://github.com/typetools/checker-framework
 License: https://github.com/typetools/checker-framework/blob/master/LICENSE.txt (MIT license)
 
@@ -336,55 +352,14 @@ License text:
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Animal Sniffer Annotations.
-
-Copyright: 2009-2018 codehaus.org
-Home page: https://www.mojohaus.org/animal-sniffer/animal-sniffer-annotations/
-License: https://www.mojohaus.org/animal-sniffer/animal-sniffer-annotations/license.html (MIT license)
-
-License text:
-| The MIT License
-|
-| Copyright (c) 2009 codehaus.org.
-|
-| Permission is hereby granted, free of charge, to any person obtaining a copy
-| of this software and associated documentation files (the "Software"), to deal
-| in the Software without restriction, including without limitation the rights
-| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-| copies of the Software, and to permit persons to whom the Software is
-| furnished to do so, subject to the following conditions:
-|
-| The above copyright notice and this permission notice shall be included in
-| all copies or substantial portions of the Software.
-|
-| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-| THE SOFTWARE.
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Caffeine by Ben Manes.
-
+Group: com.github.ben-names.caffeine Name: caffeine Version: 2.9.3
 Copyright: 2014-2020 Ben Manes and contributors
 Home page: https://github.com/ben-manes/caffeine
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache Yetus audience annotations.
-
-Copyright: 2008-2020 The Apache Software Foundation.
-Home page: https://yetus.apache.org/
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Google protobuf.
-
+Group: com.google.protobuf Name: protobuf-java Version: 2.5.0
 Copyright: 2008 Google Inc.
 Home page: https://developers.google.com/protocol-buffers
 License: https://github.com/protocolbuffers/protobuf/blob/master/LICENSE (BSD)
@@ -426,8 +401,7 @@ License text:
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains ThreeTen.
-
+Group: org.threeten Name: threeten-extra Version: 1.7.1
 Copyright: 2007-present, Stephen Colebourne & Michael Nascimento Santos.
 Home page: https://www.threeten.org/threeten-extra/
 License: https://github.com/ThreeTen/threeten-extra/blob/master/LICENSE.txt (BSD 3-clause)
@@ -464,47 +438,35 @@ License text:
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Project Nessie with the following in its NOTICE
-file:
-
-| Dremio
-| Copyright 2015-2017 Dremio Corporation
-|
-| This product includes software developed at
-| The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This binary includes code from Apache Commons.
-
-* Core ArrayUtil.
-
-Copyright: 2020 The Apache Software Foundation
-Home page: https://commons.apache.org/
+Group: org.projectnessie.nessie Name: nessie-client Version: 0.102.2
+Copyright: 2015-2017 Dremio Corporation
+Home page: https://projectnessie.org/
 License: https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache HttpComponents Client.
+Group: commons-codec Name: commons-codec Version: 1.9
+Copyright: 2002-2013 The Apache Software Foundation
+Home page: https://commons.apache.org/proper/commons-codec/
+License: https://www.apache.org/licenses/LICENSE-2.0
 
-Copyright: 1999-2022 The Apache Software Foundation.
+--------------------------------------------------------------------------------
+
+Group: org.apache.httpcomponents Name: httpclient Version: 4.4.1
+Copyright: 1999-2015 The Apache Software Foundation
 Home page: https://hc.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This product includes code from Apache HttpComponents Client.
-
-* retry and error handling logic in ExponentialHttpRequestRetryStrategy.java
-
-Copyright: 1999-2022 The Apache Software Foundation.
-Home page: https://hc.apache.org/
-License: https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains failsafe.
-
+Group: dev.failsafe Name: failsafe Version: 3.3.2
 Copyright: Jonathan Halterman and friends
 Home page: https://failsafe.dev/
 License: https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+Group: com.github.luben Name: zstd-jni Version: 1.5.6-6
+Copyright: 2015-present, Luben Karavelov/ All rights reserved.
+Home page: https://github.com/luben/zstd-jni
+License: BSD License

--- a/flink/v1.20/flink-runtime/NOTICE
+++ b/flink/v1.20/flink-runtime/NOTICE
@@ -1,4 +1,3 @@
-
 Apache Iceberg
 Copyright 2017-2025 The Apache Software Foundation
 
@@ -7,10 +6,94 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Apache ORC with the following in its NOTICE file:
+This binary artifact includes Apache Avro 1.12.0 with the following in its NOTICE file:
+
+| Apache Avro
+| Copyright 2010-2019 The Apache Software Foundation
+| 
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
+| 
+| NUnit license acknowledgement:
+| 
+| | Portions Copyright © 2002-2012 Charlie Poole or Copyright © 2002-2004 James
+| | W. Newkirk, Michael C. Two, Alexei A. Vorontsov or Copyright © 2000-2002
+| | Philip A. Craig 
+| 
+| Based upon the representations of upstream licensors, it is understood that
+| portions of the mapreduce API included in the Java implementation are licensed
+| from various contributors under one or more contributor license agreements to
+| Odiago, Inc. and were then contributed by Odiago to Apache Avro, which has now
+| made them available under the Apache 2.0 license. The original file header text
+| is:
+| 
+| | Licensed to Odiago, Inc. under one or more contributor license
+| | agreements.  See the NOTICE file distributed with this work for
+| | additional information regarding copyright ownership.  Odiago, Inc.
+| | licenses this file to you under the Apache License, Version 2.0
+| | (the "License"); you may not use this file except in compliance
+| | with the License.  You may obtain a copy of the License at
+| |
+| |     https://www.apache.org/licenses/LICENSE-2.0
+| |
+| | Unless required by applicable law or agreed to in writing, software
+| | distributed under the License is distributed on an "AS IS" BASIS,
+| | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+| | implied.  See the License for the specific language governing
+| | permissions and limitations under the License.
+| 
+| The Odiago NOTICE at the time of the contribution:
+| 
+| | This product includes software developed by Odiago, Inc.
+| | (https://www.wibidata.com).
+| 
+| Apache Log4Net includes the following in its NOTICE file:
+| 
+| | Apache log4net
+| | Copyright 2004-2015 The Apache Software Foundation
+| |
+| | This product includes software developed at
+| | The Apache Software Foundation (https://www.apache.org/).
+| 
+| csharp reflect serializers were contributed by Pitney Bowes Inc.
+| 
+| | Copyright 2019 Pitney Bowes Inc.
+| | Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. 
+| | You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.
+| | Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, 
+| | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| | See the License for the specific language governing permissions and limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Apache Commons Codec 1.9 with the following in its NOTICE file:
+
+| Apache Commons Codec
+| Copyright 2002-2013 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
+| contains test data from http://aspell.net/test/orig/batch0.tab.
+| Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Apache HttpComponents Client 4.4.1 with the following in its NOTICE file:
+
+| Apache HttpComponents Client
+| Copyright 1999-2015 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Apache ORC 1.9.5 with the following in its NOTICE file:
 
 | Apache ORC
-| Copyright 2013-2019 The Apache Software Foundation
+| Copyright 2013 and onwards The Apache Software Foundation.
 |
 | This product includes software developed by The Apache Software
 | Foundation (http://www.apache.org/).
@@ -20,7 +103,143 @@ This binary artifact includes Apache ORC with the following in its NOTICE file:
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Airlift Aircompressor with the following in its
+This binary artifact includes Apache Parquet 1.15.0 with the following in its NOTICE file:
+
+| Apache Parquet Java
+| Copyright 2014-2024 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| --------------------------------------------------------------------------------
+|
+| This product includes parquet-tools, initially developed at ARRIS, Inc. with
+| the following copyright notice:
+|
+|  Copyright 2013 ARRIS, Inc.
+|
+|  Licensed under the Apache License, Version 2.0 (the "License");
+|  you may not use this file except in compliance with the License.
+|  You may obtain a copy of the License at
+|
+|  http://www.apache.org/licenses/LICENSE-2.0
+|
+|  Unless required by applicable law or agreed to in writing, software
+|  distributed under the License is distributed on an "AS IS" BASIS,
+|  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|  See the License for the specific language governing permissions and
+|  limitations under the License.
+|
+|--------------------------------------------------------------------------------
+|
+| This product includes parquet-protobuf, initially developed by Lukas Nalezenc
+| with the following copyright notice:
+|
+|  Copyright 2013 Lukas Nalezenec.
+|
+|  Licensed under the Apache License, Version 2.0 (the "License");
+|  you may not use this file except in compliance with the License.
+|  You may obtain a copy of the License at
+|
+|  http://www.apache.org/licenses/LICENSE-2.0
+|
+|  Unless required by applicable law or agreed to in writing, software
+|  distributed under the License is distributed on an "AS IS" BASIS,
+|  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|  See the License for the specific language governing permissions and
+|  limitations under the License.
+|
+|--------------------------------------------------------------------------------
+|
+| This product includes code from Apache Avro, which includes the following in
+| its NOTICE file:
+|
+|  Apache Avro
+|  Copyright 2010-2015 The Apache Software Foundation
+|
+|  This product includes software developed at
+|  The Apache Software Foundation (http://www.apache.org/).
+|
+| --------------------------------------------------------------------------------
+|
+|  This project includes code from Kite, developed at Cloudera, Inc. with
+|  the following copyright notice:
+|
+| | Copyright 2013 Cloudera Inc.
+| |
+| | Licensed under the Apache License, Version 2.0 (the "License");
+| | you may not use this file except in compliance with the License.
+| | You may obtain a copy of the License at
+| |
+| |   http://www.apache.org/licenses/LICENSE-2.0
+| |
+| | Unless required by applicable law or agreed to in writing, software
+| | distributed under the License is distributed on an "AS IS" BASIS,
+| | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| | See the License for the specific language governing permissions and
+| | limitations under the License.
+|
+| --------------------------------------------------------------------------------
+|
+|  This project includes code from Netflix, Inc. with the following copyright
+|  notice:
+|
+| | Copyright 2016 Netflix, Inc.
+| |
+| | Licensed under the Apache License, Version 2.0 (the "License");
+| | you may not use this file except in compliance with the License.
+| | You may obtain a copy of the License at
+| |
+| |   http://www.apache.org/licenses/LICENSE-2.0
+| |
+| | Unless required by applicable law or agreed to in writing, software
+| | distributed under the License is distributed on an "AS IS" BASIS,
+| | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| | See the License for the specific language governing permissions and
+| | limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Apache Thrift 0.9.3 with the following in its NOTICE file:
+
+| Apache Thrift
+| Copyright 2006-2010 The Apache Software Foundation.
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Apache Datasketches 6.2.0 with the following in its NOTICE file:
+
+| Apache DataSketches Java
+| Copyright 2024 The Apache Software Foundation
+|
+| Copyright 2015-2018 Yahoo Inc.
+| Copyright 2019-2020 Verizon Media
+| Copyright 2021 Yahoo Inc.
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| Prior to moving to ASF, the software for this project was developed at
+| Yahoo Inc. (https://developer.yahoo.com).
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Apache Hive Metastore 2.3.9 with the following in its NOTICE file:
+
+| Apache Hive
+| Copyright 2008-2020 The Apache Software Foundation
+|
+| This product includes software developed by The Apache Software
+| Foundation (http://www.apache.org/).
+|
+| This project includes software licensed under the JSON license.
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Airlift Aircompressor 2.0.2 with the following in its
 NOTICE file:
 
 | Snappy Copyright Notices
@@ -63,25 +282,7 @@ NOTICE file:
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Apache Yetus with the following in its NOTICE
-file:
-
-| Apache Yetus
-| Copyright 2008-2020 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-|
-| ---
-| Additional licenses for the Apache Yetus Source/Website:
-| ---
-|
-|
-| See LICENSE for terms.
-
---------------------------------------------------------------------------------
-
-This binary artifact includes Project Nessie with the following in its NOTICE
+This binary artifact includes Project Nessie 0.102.2 with the following in its NOTICE
 file:
 
 | Dremio
@@ -89,3 +290,39 @@ file:
 |
 | This product includes software developed at
 | The Apache Software Foundation (http://www.apache.org/).
+|
+| Apache Avro
+| Copyright The Apache Software Foundation
+|
+| Apache Commons
+| Copyright The Apache Software Foundation
+|
+| Apache Curator
+| Copyright The Apache Software Foundation
+|
+| Apache Hadoop
+| Copyright The Apache Software Foundation
+|
+| Apache HTTP Components
+|Copyright The Apache Software Foundation
+|
+| Apache Iceberg
+| Copyright The Apache Software Foundation
+|
+| Apache Kerby
+| Copyright The Apache Software Foundation
+|
+| This product includes additional software licensed under the terms
+| of the following licenses, see LICENSE file:
+| * Apache Software License, Version 2.0
+| * Creative Commons 1.0 Universal
+| * Eclipse Distribution License, Version 1.0
+| * Eclipse Public License, Version 1.0
+| * Eclipse Public License, Version 2.0
+| * GNU General Public License, Version 2 with the GNU Classpath Exception
+|
+| ---
+|
+| The main docs page for a particular Nessie release under
+| https://projectnessie.org/docs/ contains an aggregated
+| license report (since Nessie version 0.83).

--- a/gcp-bundle/LICENSE
+++ b/gcp-bundle/LICENSE
@@ -207,7 +207,7 @@ This binary artifact contains code from the following projects:
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.14.2
+Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.18.2
 Project URL: https://github.com/FasterXML/jackson-core
 License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
@@ -220,100 +220,100 @@ License: Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api  Name: api-common  Version: 2.13.0
+Group: com.google.api  Name: api-common  Version: 2.42.1
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 License: BSD-3-Clause - https://github.com/googleapis/api-common-java/blob/main/LICENSE
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api  Name: gax  Version: 2.30.0
+Group: com.google.api  Name: gax  Version: 2.59.1
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 License: BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api  Name: gax-grpc  Version: 2.30.0
+Group: com.google.api  Name: gax-grpc  Version: 2.59.1
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 License: BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api  Name: gax-httpjson  Version: 2.30.0
+Group: com.google.api  Name: gax-httpjson  Version: 2.59.1
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 License: BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api-client  Name: google-api-client  Version: 2.2.0
+Group: com.google.api-client  Name: google-api-client  Version: 2.7.1
 Project URL: https://developers.google.com/api-client-library/java/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc  Name: gapic-google-cloud-storage-v2  Version: 2.22.5-alpha
+Group: com.google.api.grpc  Name: gapic-google-cloud-storage-v2  Version: 2.47.0
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc  Name: grpc-google-cloud-storage-v2  Version: 2.22.5-alpha
+Group: com.google.api.grpc  Name: grpc-google-cloud-storage-v2  Version: 2.47.0
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc  Name: proto-google-cloud-storage-v2  Version: 2.22.5-alpha
+Group: com.google.api.grpc  Name: proto-google-cloud-storage-v2  Version: 2.47.0
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc  Name: proto-google-common-protos  Version: 2.21.0
+Group: com.google.api.grpc  Name: proto-google-common-protos  Version: 2.50.1
 Project URL: https://github.com/googleapis/sdk-platform-java
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc  Name: proto-google-iam-v1  Version: 1.16.0
+Group: com.google.api.grpc  Name: proto-google-iam-v1  Version: 1.45.1
 Project URL: https://github.com/googleapis/sdk-platform-java
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.apis  Name: google-api-services-storage  Version: v1-rev20230301-2.0.0
+Group: com.google.apis  Name: google-api-services-storage  Version: v1-rev20241206-2.0.0
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.auth  Name: google-auth-library-credentials  Version: 1.18.0
+Group: com.google.auth  Name: google-auth-library-credentials  Version: 1.30.1
 License: BSD New license - http://opensource.org/licenses/BSD-3-Clause
 
 --------------------------------------------------------------------------------
 
-Group: com.google.auth  Name: google-auth-library-oauth2-http  Version: 1.18.0
+Group: com.google.auth  Name: google-auth-library-oauth2-http  Version: 1.30.1
 License: BSD New license - http://opensource.org/licenses/BSD-3-Clause
 
 --------------------------------------------------------------------------------
 
-Group: com.google.auto.value  Name: auto-value-annotations  Version: 1.10.1
+Group: com.google.auto.value  Name: auto-value-annotations  Version: 1.11.0
 Project URL: https://github.com/google/auto/tree/master/value
 License: Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.cloud  Name: google-cloud-core  Version: 2.20.0
+Group: com.google.cloud  Name: google-cloud-core  Version: 2.49.1
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.cloud  Name: google-cloud-core-grpc  Version: 2.20.0
+Group: com.google.cloud  Name: google-cloud-core-grpc  Version: 2.49.1
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.cloud  Name: google-cloud-core-http  Version: 2.20.0
+Group: com.google.cloud  Name: google-cloud-core-http  Version: 2.49.1
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.cloud  Name: google-cloud-storage  Version: 2.22.5
+Group: com.google.cloud  Name: google-cloud-storage  Version: 2.47.0
 Project URL: https://github.com/googleapis/java-storage
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -325,24 +325,24 @@ License: The Apache Software License, Version 2.0 - http://www.apache.org/licens
 
 --------------------------------------------------------------------------------
 
-Group: com.google.code.gson  Name: gson  Version: 2.10.1
+Group: com.google.code.gson  Name: gson  Version: 2.11.0
 Project URL: https://github.com/google/gson/gson
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.errorprone  Name: error_prone_annotations  Version: 2.18.0
+Group: com.google.errorprone  Name: error_prone_annotations  Version: 2.31.0
 License: Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.guava  Name: failureaccess  Version: 1.0.1
+Group: com.google.guava  Name: failureaccess  Version: 1.0.2
 Project URL: https://github.com/google/guava/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.guava  Name: guava  Version: 32.0.1-jre
+Group: com.google.guava  Name: guava  Version: 33.4.0-jre
 Project URL: https://github.com/google/guava/
 License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -353,148 +353,148 @@ License: The Apache Software License, Version 2.0 - http://www.apache.org/licens
 
 --------------------------------------------------------------------------------
 
-Group: com.google.http-client  Name: google-http-client  Version: 1.43.3
+Group: com.google.http-client  Name: google-http-client  Version: 1.45.3
 Project URL: https://www.google.com/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.http-client  Name: google-http-client-apache-v2  Version: 1.43.3
+Group: com.google.http-client  Name: google-http-client-apache-v2  Version: 1.45.3
 Project URL: https://www.google.com/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.http-client  Name: google-http-client-appengine  Version: 1.43.3
+Group: com.google.http-client  Name: google-http-client-appengine  Version: 1.45.3
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.http-client  Name: google-http-client-gson  Version: 1.43.3
+Group: com.google.http-client  Name: google-http-client-gson  Version: 1.45.3
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.http-client  Name: google-http-client-jackson2  Version: 1.43.3
+Group: com.google.http-client  Name: google-http-client-jackson2  Version: 1.45.3
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.j2objc  Name: j2objc-annotations  Version: 2.8
+Group: com.google.j2objc  Name: j2objc-annotations  Version: 3.0.0
 Project URL: https://github.com/google/j2objc/
 License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.oauth-client  Name: google-oauth-client  Version: 1.34.1
+Group: com.google.oauth-client  Name: google-oauth-client  Version: 1.37.0
 Project URL: https://www.google.com/
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.protobuf  Name: protobuf-java  Version: 3.23.2
+Group: com.google.protobuf  Name: protobuf-java  Version: 4.29.0
 Project URL: https://developers.google.com/protocol-buffers/
 License: BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
 
 --------------------------------------------------------------------------------
 
-Group: com.google.protobuf  Name: protobuf-java-util  Version: 3.23.2
+Group: com.google.protobuf  Name: protobuf-java-util  Version: 4.29.0
 Project URL: https://developers.google.com/protocol-buffers/
 License: BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
 
 --------------------------------------------------------------------------------
 
-Group: com.google.re2j  Name: re2j  Version: 1.6
+Group: com.google.re2j  Name: re2j  Version: 1.7
 Project URL: http://github.com/google/re2j
 License: Go License - https://golang.org/LICENSE
 
 --------------------------------------------------------------------------------
 
-Group: commons-codec  Name: commons-codec  Version: 1.15
+Group: commons-codec  Name: commons-codec  Version: 1.17.1
 Project URL: https://commons.apache.org/proper/commons-codec/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-alts  Version: 1.55.1
+Group: io.grpc  Name: grpc-alts  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-api  Version: 1.55.1
+Group: io.grpc  Name: grpc-api  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-auth  Version: 1.55.1
+Group: io.grpc  Name: grpc-auth  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-context  Version: 1.55.1
+Group: io.grpc  Name: grpc-context  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-core  Version: 1.55.1
+Group: io.grpc  Name: grpc-core  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-googleapis  Version: 1.55.1
+Group: io.grpc  Name: grpc-googleapis  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-grpclb  Version: 1.55.1
+Group: io.grpc  Name: grpc-grpclb  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-netty-shaded  Version: 1.55.1
+Group: io.grpc  Name: grpc-netty-shaded  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-protobuf  Version: 1.55.1
+Group: io.grpc  Name: grpc-protobuf  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-protobuf-lite  Version: 1.55.1
+Group: io.grpc  Name: grpc-protobuf-lite  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-rls  Version: 1.55.1
+Group: io.grpc  Name: grpc-rls  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-services  Version: 1.55.1
+Group: io.grpc  Name: grpc-services  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-stub  Version: 1.55.1
+Group: io.grpc  Name: grpc-stub  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-xds  Version: 1.55.1
+Group: io.grpc  Name: grpc-xds  Version: 1.69.0
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
@@ -512,13 +512,7 @@ License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENS
 
 --------------------------------------------------------------------------------
 
-Group: io.opencensus  Name: opencensus-proto  Version: 0.2.0
-Project URL: https://github.com/census-instrumentation/opencensus-proto
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.perfmark  Name: perfmark-api  Version: 0.26.0
+Group: io.perfmark  Name: perfmark-api  Version: 0.27.0
 Project URL: https://github.com/perfmark/perfmark
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
@@ -531,13 +525,13 @@ License: CDDL + GPLv2 with classpath exception - https://github.com/javaee/javax
 
 --------------------------------------------------------------------------------
 
-Group: org.checkerframework  Name: checker-qual  Version: 3.33.0
+Group: org.checkerframework  Name: checker-qual  Version: 3.48.3
 Project URL: https://checkerframework.org/
 License: The MIT License - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: org.codehaus.mojo  Name: animal-sniffer-annotations  Version: 1.23
+Group: org.codehaus.mojo  Name: animal-sniffer-annotations  Version: 1.24
 License: MIT license - https://spdx.org/licenses/MIT.txt
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -549,7 +543,7 @@ License: Apache 2 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: org.threeten  Name: threetenbp  Version: 1.6.8
+Group: org.threeten  Name: threetenbp  Version: 1.7.0
 Project URL: https://www.threeten.org
 Project URL: https://www.threeten.org/threetenbp
 License: BSD-3-Clause - https://raw.githubusercontent.com/ThreeTen/threetenbp/main/LICENSE.txt

--- a/gcp-bundle/NOTICE
+++ b/gcp-bundle/NOTICE
@@ -1,4 +1,3 @@
-
 Apache Iceberg
 Copyright 2017-2025 The Apache Software Foundation
 
@@ -7,94 +6,435 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.14.2
+This binary artifact includes FasterXML Jackson 2.18.2 with the following in its NOTICE file:
 
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
---------------------------------------------------------------------------------
-
-NOTICE for Group: commons-codec  Name: commons-codec  Version: 1.15
-
-src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
-contains test data from http://aspell.net/test/orig/batch0.tab.
-Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
-
-===============================================================================
-
-The content of package org.apache.commons.codec.language.bm has been translated
-from the original php source code available at http://stevemorse.org/phoneticinfo.htm
-with permission from the original authors.
-Original source copyright:
-Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Licensing
+| 
+| Jackson 2.x core and extension components are licensed under Apache License 2.0
+| To find the details that apply to this artifact see the accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS(-2.x) file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: io.grpc  Name: grpc-netty-shaded  Version: 1.55.1
+This binary artifact includes Apache Commons Codec 1.17.1 with the following in its NOTICE file:
 
-                          The Netty Project
-                            =================
+| Apache Commons Codec
+| Copyright 2002-2024 The Apache Software Foundation
+| 
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
 
-Please visit the Netty web site for more information:
+--------------------------------------------------------------------------------
 
-  * http://netty.io/
+This binary artifct includes gRPC 1.69.0 with the following in its NOTICE file:
 
-Copyright 2016 The Netty Project
+| Copyright 2014 The gRPC Authors
+| 
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+| 
+|     http://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+| 
+| -----------------------------------------------------------------------
+| 
+| This product contains a modified portion of 'OkHttp', an open source
+| HTTP & SPDY client for Android and Java applications, which can be obtained
+| at:
+| 
+|   * LICENSE:
+|     * okhttp/third_party/okhttp/LICENSE (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/square/okhttp
+|   * LOCATION_IN_GRPC:
+|     * okhttp/third_party/okhttp
+| 
+| This product contains a modified portion of 'Envoy', an open source
+| cloud-native high-performance edge/middle/service proxy, which can be
+| obtained at:
+| 
+|   * LICENSE:
+|     * xds/third_party/envoy/LICENSE (Apache License 2.0)
+|   * NOTICE:
+|     * xds/third_party/envoy/NOTICE
+|   * HOMEPAGE:
+|     * https://www.envoyproxy.io
+|   * LOCATION_IN_GRPC:
+|     * xds/third_party/envoy
+| 
+| This product contains a modified portion of 'protoc-gen-validate (PGV)',
+| an open source protoc plugin to generate polyglot message validators,
+| which can be obtained at:
+| 
+|   * LICENSE:
+|     * xds/third_party/protoc-gen-validate/LICENSE (Apache License 2.0)
+|   * NOTICE:
+|       * xds/third_party/protoc-gen-validate/NOTICE
+|   * HOMEPAGE:
+|     * https://github.com/envoyproxy/protoc-gen-validate
+|   * LOCATION_IN_GRPC:
+|     * xds/third_party/protoc-gen-validate
+| 
+| This product contains a modified portion of 'udpa',
+| an open source universal data plane API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * xds/third_party/udpa/LICENSE (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/cncf/udpa
+|   * LOCATION_IN_GRPC:
+|     * xds/third_party/udpa
 
-The Netty Project licenses this file to you under the Apache License,
-version 2.0 (the "License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at:
+--------------------------------------------------------------------------------
 
-  http://www.apache.org/licenses/LICENSE-2.0
+This binary artifact includes Perfmark 0.27.0 with the following in its NOTICE file:
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations
-under the License.
+| Copyright 2019 Google LLC
+| 
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+| 
+|     http://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+| 
+| -----------------------------------------------------------------------
+| 
+| This product contains a modified portion of 'Catapult', an open source
+| Trace Event viewer for Chome, Linux, and Android applications, which can 
+| be obtained at:
+| 
+|   * LICENSE:
+|     * traceviewer/src/main/resources/io/perfmark/traceviewer/third_party/catapult/LICENSE (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/catapult-project/catapult
+| 
+| This product contains a modified portion of 'Polymer', a library for Web
+| Components, which can be obtained at:
+|   * LICENSE:
+|     * traceviewer/src/main/resources/io/perfmark/traceviewer/third_party/polymer/LICENSE (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/Polymer/polymer
+| 
+| 
+| This product contains a modified portion of 'ASM', an open source
+| Java Bytecode library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * agent/src/main/resources/io/perfmark/agent/third_party/asm/LICENSE (BSD style License)
+|   * HOMEPAGE:
+|     * https://asm.ow2.io/
 
--------------------------------------------------------------------------------
-This product contains a forked and modified version of Tomcat Native
+--------------------------------------------------------------------------------
 
-  * LICENSE:
-    * license/LICENSE.tomcat-native.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://tomcat.apache.org/native-doc/
-    * https://svn.apache.org/repos/asf/tomcat/native/
+This binary artifact includes Android Annotations 4.1.1.4 with the following in its NOTICE file:
 
-This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+| Copyright 2016 The Android Open Source Project
+| 
+| This product contains a modified portion of `Netty`, a configurable network
+| stack in Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * licenses/LICENSE.netty.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * http://netty.io/
+| 
+| This product contains a modified portion of `Apache Harmony`, modular Java runtime,
+| which can be obtained at:
+| 
+|   * LICENSE:
+|     * licenses/LICENSE.harmony.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://harmony.apache.org/
 
-  * LICENSE:
-    * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * https://github.com/takari/maven-wrapper
+ --------------------------------------------------------------------------------
 
-This product contains small piece of code to support AIX, taken from netbsd.
+This binary artifct includes Netty 4.1.110.Final (shaded by gRPC 1.69.0) with the following in its NOTICE file:
 
-  * LICENSE:
-    * license/LICENSE.aix-netbsd.txt (OpenSSL License)
-  * HOMEPAGE:
-    * https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/crypto/external/bsd/openssl/dist
+|                             The Netty Project
+|                             =================
+| 
+| Please visit the Netty web site for more information:
+| 
+|   * https://netty.io/
+| 
+| Copyright 2014 The Netty Project
+| 
+| The Netty Project licenses this file to you under the Apache License,
+| version 2.0 (the "License"); you may not use this file except in compliance
+| with the License. You may obtain a copy of the License at:
+| 
+|   https://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+| WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+| License for the specific language governing permissions and limitations
+| under the License.
+| 
+| Also, please refer to each LICENSE.<component>.txt file, which is located in
+| the 'license' directory of the distribution file, for the license terms of the
+| components that this product depends on.
+| 
+| -------------------------------------------------------------------------------
+| This product contains the extensions to Java Collections Framework which has
+| been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jsr166y.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+|     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+| 
+| This product contains a modified version of Robert Harder's Public Domain
+| Base64 Encoder and Decoder, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.base64.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://iharder.sourceforge.net/current/java/base64/
+| 
+| This product contains a modified portion of 'Webbit', an event based
+| WebSocket and HTTP server, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.webbit.txt (BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/joewalnes/webbit
+| 
+| This product contains a modified portion of 'SLF4J', a simple logging
+| facade for Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.slf4j.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://www.slf4j.org/
+| 
+| This product contains a modified portion of 'Apache Harmony', an open source
+| Java SE, which can be obtained at:
+| 
+|   * NOTICE:
+|     * license/NOTICE.harmony.txt
+|   * LICENSE:
+|     * license/LICENSE.harmony.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://archive.apache.org/dist/harmony/
+| 
+| This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+| and decompression library written by Matthew J. Francis. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jbzip2.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jbzip2/
+| 
+| This product contains a modified portion of 'libdivsufsort', a C API library to construct
+| the suffix array and the Burrows-Wheeler transformed string for any input string of
+| a constant-size alphabet written by Yuta Mori. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.libdivsufsort.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/y-256/libdivsufsort
+| 
+| This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+|  which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jctools.txt (ASL2 License)
+|   * HOMEPAGE:
+|     * https://github.com/JCTools/JCTools
+| 
+| This product optionally depends on 'JZlib', a re-implementation of zlib in
+| pure Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jzlib.txt (BSD style License)
+|   * HOMEPAGE:
+|     * http://www.jcraft.com/jzlib/
+| 
+| This product optionally depends on 'Compress-LZF', a Java library for encoding and
+| decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/ning/compress
+| 
+| This product optionally depends on 'lz4', a LZ4 Java compression
+| and decompression library written by Adrien Grand. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lz4.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jpountz/lz4-java
+| 
+| This product optionally depends on 'lzma-java', a LZMA Java compression
+| and decompression library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lzma-java.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jponge/lzma-java
+| 
+| This product optionally depends on 'zstd-jni', a zstd-jni Java compression
+| and decompression library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.zstd-jni.txt (BSD)
+|   * HOMEPAGE:
+|     * https://github.com/luben/zstd-jni
+| 
+| This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+| and decompression library written by William Kinney. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jfastlz.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jfastlz/
+| 
+| This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+| interchange format, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.protobuf.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/protobuf
+| 
+| This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+| a temporary self-signed X.509 certificate when the JVM does not provide the
+| equivalent functionality.  It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.bouncycastle.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://www.bouncycastle.org/
+| 
+| This product optionally depends on 'Snappy', a compression library produced
+| by Google Inc, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.snappy.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/snappy
+| 
+| This product optionally depends on 'JBoss Marshalling', an alternative Java
+| serialization API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jboss-remoting/jboss-marshalling
+| 
+| This product optionally depends on 'Caliper', Google's micro-
+| benchmarking framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.caliper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/google/caliper
+| 
+| This product optionally depends on 'Apache Commons Logging', a logging
+| framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-logging.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/logging/
+| 
+| This product optionally depends on 'Apache Log4J', a logging framework, which
+| can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.log4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://logging.apache.org/log4j/
+| 
+| This product optionally depends on 'Aalto XML', an ultra-high performance
+| non-blocking XML processor, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://wiki.fasterxml.com/AaltoHome
+| 
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.hpack.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/twitter/hpack
+|     
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.hyper-hpack.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/python-hyper/hpack/
+| 
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.nghttp2-hpack.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/nghttp2/nghttp2/
+| 
+| This product contains a modified portion of 'Apache Commons Lang', a Java library
+| provides utilities for the java.lang API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-lang.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/proper/commons-lang/
+| 
+| 
+| This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+| 
+|   * LICENSE:
+|     * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/takari/maven-wrapper
+| 
+| This product contains the dnsinfo.h header file, that provides a way to retrieve the system DNS configuration on MacOS.
+| This private header is also used by Apple's open source
+|  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
+| 
+|  * LICENSE:
+|     * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
+|   * HOMEPAGE:
+|     * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+| 
+| This product optionally depends on 'Brotli4j', Brotli compression and
+| decompression for Java., which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.brotli4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/hyperxpro/Brotli4j
 
-
-This product contains code from boringssl.
-
-  * LICENSE (Combination ISC and OpenSSL license)
-    * license/LICENSE.boringssl.txt (Combination ISC and OpenSSL license)
-  * HOMEPAGE:
-    * https://boringssl.googlesource.com/boringssl/

--- a/spark/v3.5/spark-runtime/LICENSE
+++ b/spark/v3.5/spark-runtime/LICENSE
@@ -203,109 +203,78 @@
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache Avro.
+The binary artifact contains code from the following projects:
 
-Copyright: 2014-2017 The Apache Software Foundation.
-Home page: https://parquet.apache.org/
+--------------------------------------------------------------------------------
+
+Group: org.apache.avro Name: avro Version: 1.12.0
+Copyright: 2010-2019 The Apache Software Foundation
+Home page: https://avro.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains the Jackson JSON processor.
+Group: org.apache.datasketches Name: datasketches-java Version: 6.2.0
+Copyright: 2024 The Apache Software Foundation
+Home page: https://datasketches.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
 
-Copyright: 2007-2019 Tatu Saloranta and other contributors
+--------------------------------------------------------------------------------
+
+Group: com.fasterxml.jackson.core Name: jackson-core Version: 2.15.2
 Home page: http://jackson.codehaus.org/
 License: http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Paranamer.
-
-Copyright: 2000-2007 INRIA, France Telecom, 2006-2018 Paul Hammant & ThoughtWorks Inc
-Home page: https://github.com/paul-hammant/paranamer
-License: https://github.com/paul-hammant/paranamer/blob/master/LICENSE.txt (BSD)
-
-License text:
-| Portions copyright (c) 2006-2018 Paul Hammant & ThoughtWorks Inc
-| Portions copyright (c) 2000-2007 INRIA, France Telecom
-| All rights reserved.
-|
-| Redistribution and use in source and binary forms, with or without
-| modification, are permitted provided that the following conditions
-| are met:
-| 1. Redistributions of source code must retain the above copyright
-|    notice, this list of conditions and the following disclaimer.
-| 2. Redistributions in binary form must reproduce the above copyright
-|    notice, this list of conditions and the following disclaimer in the
-|    documentation and/or other materials provided with the distribution.
-| 3. Neither the name of the copyright holders nor the names of its
-|    contributors may be used to endorse or promote products derived from
-|    this software without specific prior written permission.
-|
-| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-| AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-| IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-| ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-| LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-| CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-| SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-| INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-| CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-| ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-| THE POSSIBILITY OF SUCH DAMAGE.
+Group: com.fasterxml.jackson.core Name: jackson-annotations Version: 2.15.2
+Home page: http://jackson.codehaus.org/
+License: http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache Parquet.
+Group: com.fasterxml.jackson.core Name: jackson-databind Version: 2.15.2
+Home page: http://jackson.codehaus.org/
+License: http://www.apache.org/licenses/LICENSE-2.0.txt
 
-Copyright: 2014-2017 The Apache Software Foundation.
+--------------------------------------------------------------------------------
+
+Group: org.apache.parquet Name: parquet-avro Version: 1.15.0
+Copyright: 2014-2024 The Apache Software Foundation
 Home page: https://parquet.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache Thrift.
-
-Copyright: 2006-2010 The Apache Software Foundation.
+Group: org.apache.thrift Name: libthrift Version: 0.12.0
+Copyright: 2006-2017 The Apache Software Foundation.
 Home page: https://thrift.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains code from Daniel Lemire's JavaFastPFOR project.
-
-Copyright: 2013 Daniel Lemire
-Home page: https://github.com/lemire/JavaFastPFOR
-License: Apache License Version 2.0 http://www.apache.org/licenses/LICENSE-2.0
+Group: org.apache.thrift Name: libfb303 Version: 0.9.3
+Copyright: 2006-2017 The Apache Software Foundation.
+Home page: https://thrift.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
 This binary artifact contains fastutil.
-
 Copyright: 2002-2014 Sebastiano Vigna
 Home page: http://fastutil.di.unimi.it/
 License: http://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache ORC.
-
-Copyright: 2013-2019 The Apache Software Foundation.
+Group: org.apache.orc Name: orc-core Version: 1.9.5
+Copyright: 2013 and onwards The Apache Software Foundation.
 Home page: https://orc.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache Hive's storage API via ORC.
-
-Copyright: 2013-2019 The Apache Software Foundation.
-Home page: https://hive.apache.org/
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Google protobuf via ORC.
-
+Group: com.google.protobuf Name: protobuf-java Version: 3.19.6
 Copyright: 2008 Google Inc.
 Home page: https://developers.google.com/protocol-buffers
 License: https://github.com/protocolbuffers/protobuf/blob/master/LICENSE (BSD)
@@ -347,80 +316,35 @@ License text:
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Airlift Aircompressor.
-
+Group: io.airlift Name: aircompressor Version: 0.27
 Copyright: 2011-2019 Aircompressor authors.
 Home page: https://github.com/airlift/aircompressor
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Airlift Slice.
-
-Copyright: 2013-2019 Slice authors.
-Home page: https://github.com/airlift/slice
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains JetBrains annotations.
-
+Group: org.jetbrains Name: annotations Version: 17.0.0
 Copyright: 2000-2020 JetBrains s.r.o.
 Home page: https://github.com/JetBrains/java-annotations
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains code from Cloudera Kite.
-
-Copyright: 2013-2017 Cloudera Inc.
-Home page: https://kitesdk.org/
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains code from Presto.
-
-Copyright: 2016 Facebook and contributors
-Home page: https://prestodb.io/
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Google Guava.
-
+Group: com.google.guava Name: guava Version: 32.1.3-jre
 Copyright: 2006-2019 The Guava Authors
 Home page: https://github.com/google/guava
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Google Error Prone Annotations.
-
+Group: com.google.errorprone Name: error_prone_annotations Version: 2.31.0
 Copyright: Copyright 2011-2019 The Error Prone Authors
 Home page: https://github.com/google/error-prone
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains findbugs-annotations by Stephen Connolly.
-
-Copyright: 2011-2016 Stephen Connolly, Greg Lucas
-Home page: https://github.com/stephenc/findbugs-annotations
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Google j2objc Annotations.
-
-Copyright: Copyright 2012-2018 Google Inc.
-Home page: https://github.com/google/j2objc/tree/master/annotations
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains checkerframework checker-qual Annotations.
-
+Group: org.checkerframework Name: checker-qual Version: 3.33.0
 Copyright: 2004-2019 the Checker Framework developers
 Home page: https://github.com/typetools/checker-framework
 License: https://github.com/typetools/checker-framework/blob/master/LICENSE.txt (MIT license)
@@ -456,95 +380,49 @@ License text:
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Animal Sniffer Annotations.
-
-Copyright: 2009-2018 codehaus.org
-Home page: https://www.mojohaus.org/animal-sniffer/animal-sniffer-annotations/
-License: https://www.mojohaus.org/animal-sniffer/animal-sniffer-annotations/license.html (MIT license)
-
-License text:
-| The MIT License
-|
-| Copyright (c) 2009 codehaus.org.
-|
-| Permission is hereby granted, free of charge, to any person obtaining a copy
-| of this software and associated documentation files (the "Software"), to deal
-| in the Software without restriction, including without limitation the rights
-| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-| copies of the Software, and to permit persons to whom the Software is
-| furnished to do so, subject to the following conditions:
-|
-| The above copyright notice and this permission notice shall be included in
-| all copies or substantial portions of the Software.
-|
-| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-| THE SOFTWARE. 
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Caffeine by Ben Manes.
-
+Group: com.github.ben-manes.caffeine Name: caffeine Version: 2.9.3
 Copyright: 2014-2019 Ben Manes and contributors
 Home page: https://github.com/ben-manes/caffeine
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Apache Arrow.
-
-Copyright: 2016-2019 The Apache Software Foundation.
+Group: org.apache.arrow Name: arrow-vector Version: 15.0.2
+Copyright: 2016-2024 The Apache Software Foundation
 Home page: https://arrow.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Netty's buffer library.
+Group: org.apache.arrow Name: arrow-format Version: 15.0.2
+Copyright: 2016-2024 The Apache Software Foundation
+Home page: https://arrow.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
 
-Copyright: 2014-2020 The Netty Project
+--------------------------------------------------------------------------------
+
+Group: org.apache.arrow Name: arrow-memory-core Version: 15.0.2
+Copyright: 2016-2024 The Apache Software Foundation
+Home page: https://arrow.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+Group: io.netty Name: netty Version: 4.1.96.Final
+Copyright: 2014 The Netty Project
 Home page: https://netty.io/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Google FlatBuffers.
-
+Group: com.google.flatbuffers Name: flatbuffers-java Version: 23.5.26
 Copyright: 2013-2020 Google Inc.
 Home page: https://google.github.io/flatbuffers/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Carrot Search Labs HPPC.
-
-Copyright: 2002-2019 Carrot Search s.c.
-Home page: http://labs.carrotsearch.com/hppc.html
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains code from Apache Lucene via Carrot Search HPPC.
-
-Copyright: 2011-2020 The Apache Software Foundation.
-Home page: https://lucene.apache.org/
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Apache Yetus audience annotations.
-
-Copyright: 2008-2020 The Apache Software Foundation.
-Home page: https://yetus.apache.org/
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains ThreeTen.
-
+Group: org.threeten Name: threeten-extra Version: 1.7.1
 Copyright: 2007-present, Stephen Colebourne & Michael Nascimento Santos.
 Home page: https://www.threeten.org/threeten-extra/
 License: https://github.com/ThreeTen/threeten-extra/blob/master/LICENSE.txt (BSD 3-clause)
@@ -582,66 +460,48 @@ License text:
 --------------------------------------------------------------------------------
 
 This binary artifact contains code from Project Nessie.
-
-Copyright: 2020 Dremio Corporation.
+Group: org.projectnessie.nessie Name: nessie-client Version: 0.102.2
+Copyright: 2015-2017 Dremio Corporation
 Home page: https://projectnessie.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This product includes code from Apache Spark.
-
-* vectorized reading of definition levels in BaseVectorizedParquetValuesReader.java
-* portions of the extensions parser
-* casting logic in AssignmentAlignmentSupport
-* implementation of SetAccumulator.
-
+Group: org.apache.spark Name: spark-sql_2.12 Version: 3.5.4
 Copyright: 2011-2018 The Apache Software Foundation
 Home page: https://spark.apache.org/
 License: https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This product includes code from Delta Lake.
-
-* AssignmentAlignmentSupport is an independent development but UpdateExpressionsSupport in Delta was used as a reference.
-
-Copyright: 2020 The Delta Lake Project Authors.
-Home page: https://delta.io/
-License: https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary includes code from Apache Commons.
-
-* Core ArrayUtil.
-
-Copyright: 2020 The Apache Software Foundation
-Home page: https://commons.apache.org/
-License: https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Apache HttpComponents Client.
-
-Copyright: 1999-2022 The Apache Software Foundation.
+Group: org.apache.httpcomponents Name: httpclient Version: 4.5.14
+Copyright: 1999-2021 The Apache Software Foundation
 Home page: https://hc.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This product includes code from Apache HttpComponents Client.
-
-* retry and error handling logic in ExponentialHttpRequestRetryStrategy.java
-
-Copyright: 1999-2022 The Apache Software Foundation.
-Home page: https://hc.apache.org/
-License: https://www.apache.org/licenses/LICENSE-2.0
+Group: dev.failsafe Name: failsafe Version: 3.3.2
+Copyright: Jonathan Halterman and friends
+Home page: https://failsafe.dev/
+License: https://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains failsafe.
+Group: org.roaringbitmap Name: RoaringBitmap Version: 1.3.0
+Home page: https://github.com/RoaringBitmap/RoaringBitmap
+License: https://www.apache.org/licenses/LICENSE-2.0.html
 
-Copyright: Jonathan Halterman and friends
-Home page: https://failsafe.dev/
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.collections Name: eclipse-collections Version: 11.1.0
+Copyright: 2007, Eclipse Foundation, Inc. and its licensors.
+Home page: https://github.com/eclipse-collections/eclipse-collections
+License: https://github.com/eclipse-collections/eclipse-collections/blob/11.1.0/LICENSE-EDL-1.0.txt
+
+--------------------------------------------------------------------------------
+
+Group: org.eclipse.microprofile.openapi Name: microprofile-openapi-api Version: 4.0.2
+Copyright: Arthur De Magalhaes arthurdm@ca.ibm.com
+Home page: https://github.com/eclipse/microprofile-open-api
 License: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/spark/v3.5/spark-runtime/NOTICE
+++ b/spark/v3.5/spark-runtime/NOTICE
@@ -1,4 +1,3 @@
-
 Apache Iceberg
 Copyright 2017-2025 The Apache Software Foundation
 
@@ -7,29 +6,87 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains code from Kite, developed at Cloudera, Inc. with
-the following copyright notice:
+This binary artifact includes Apache Avro 1.12.0 with the following in its NOTICE file:
 
-| Copyright 2013 Cloudera Inc.
+| Apache Avro
+| Copyright 2010-2019 The Apache Software Foundation
 |
-| Licensed under the Apache License, Version 2.0 (the "License");
-| you may not use this file except in compliance with the License.
-| You may obtain a copy of the License at
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
 |
-|   http://www.apache.org/licenses/LICENSE-2.0
+| NUnit license acknowledgement:
 |
-| Unless required by applicable law or agreed to in writing, software
-| distributed under the License is distributed on an "AS IS" BASIS,
-| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-| See the License for the specific language governing permissions and
-| limitations under the License.
+| | Portions Copyright © 2002-2012 Charlie Poole or Copyright © 2002-2004 James
+| | W. Newkirk, Michael C. Two, Alexei A. Vorontsov or Copyright © 2000-2002
+| | Philip A. Craig
+|
+| Based upon the representations of upstream licensors, it is understood that
+| portions of the mapreduce API included in the Java implementation are licensed
+| from various contributors under one or more contributor license agreements to
+| Odiago, Inc. and were then contributed by Odiago to Apache Avro, which has now
+| made them available under the Apache 2.0 license. The original file header text
+| is:
+|
+| | Licensed to Odiago, Inc. under one or more contributor license
+| | agreements.  See the NOTICE file distributed with this work for
+| | additional information regarding copyright ownership.  Odiago, Inc.
+| | licenses this file to you under the Apache License, Version 2.0
+| | (the "License"); you may not use this file except in compliance
+| | with the License.  You may obtain a copy of the License at
+| |
+| |     https://www.apache.org/licenses/LICENSE-2.0
+| |
+| | Unless required by applicable law or agreed to in writing, software
+| | distributed under the License is distributed on an "AS IS" BASIS,
+| | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+| | implied.  See the License for the specific language governing
+| | permissions and limitations under the License.
+|
+| The Odiago NOTICE at the time of the contribution:
+|
+| | This product includes software developed by Odiago, Inc.
+| | (https://www.wibidata.com).
+|
+| Apache Log4Net includes the following in its NOTICE file:
+|
+| | Apache log4net
+| | Copyright 2004-2015 The Apache Software Foundation
+| |
+| | This product includes software developed at
+| | The Apache Software Foundation (https://www.apache.org/).
+|
+| csharp reflect serializers were contributed by Pitney Bowes Inc.
+|
+| | Copyright 2019 Pitney Bowes Inc.
+| | Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+| | You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.
+| | Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+| | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| | See the License for the specific language governing permissions and limitations under the License.
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Apache ORC with the following in its NOTICE file:
+This binary artifact includes Apache Datasketches 6.2.0 with the following in its NOTICE file:
+
+| Apache DataSketches Java
+| Copyright 2024 The Apache Software Foundation
+|
+| Copyright 2015-2018 Yahoo Inc.
+| Copyright 2019-2020 Verizon Media
+| Copyright 2021 Yahoo Inc.
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| Prior to moving to ASF, the software for this project was developed at
+| Yahoo Inc. (https://developer.yahoo.com).
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Apache ORC 1.9.5 with the following in its NOTICE file:
 
 | Apache ORC
-| Copyright 2013-2019 The Apache Software Foundation
+| Copyright 2013 and onwards The Apache Software Foundation.
 |
 | This product includes software developed by The Apache Software
 | Foundation (http://www.apache.org/).
@@ -39,8 +96,114 @@ This binary artifact includes Apache ORC with the following in its NOTICE file:
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Airlift Aircompressor with the following in its
-NOTICE file:
+This binary artifact includes Apache Parquet 1.15.0 with the following in its NOTICE file:
+
+| Apache Parquet Java
+| Copyright 2014-2024 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| --------------------------------------------------------------------------------
+|
+| This product includes parquet-tools, initially developed at ARRIS, Inc. with
+| the following copyright notice:
+|
+|   Copyright 2013 ARRIS, Inc.
+|
+|   Licensed under the Apache License, Version 2.0 (the "License");
+|   you may not use this file except in compliance with the License.
+|   You may obtain a copy of the License at
+|
+|   http://www.apache.org/licenses/LICENSE-2.0
+|
+|   Unless required by applicable law or agreed to in writing, software
+|   distributed under the License is distributed on an "AS IS" BASIS,
+|   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|   See the License for the specific language governing permissions and
+|   limitations under the License.
+|
+| --------------------------------------------------------------------------------
+|
+| This product includes parquet-protobuf, initially developed by Lukas Nalezenc
+| with the following copyright notice:
+|
+|   Copyright 2013 Lukas Nalezenec.
+|
+|   Licensed under the Apache License, Version 2.0 (the "License");
+|   you may not use this file except in compliance with the License.
+|   You may obtain a copy of the License at
+|
+|   http://www.apache.org/licenses/LICENSE-2.0
+|
+|   Unless required by applicable law or agreed to in writing, software
+|   distributed under the License is distributed on an "AS IS" BASIS,
+|   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|   See the License for the specific language governing permissions and
+|   limitations under the License.
+|
+| --------------------------------------------------------------------------------
+|
+| This product includes code from Apache Avro, which includes the following in
+| its NOTICE file:
+|
+|   Apache Avro
+|   Copyright 2010-2015 The Apache Software Foundation
+|
+|   This product includes software developed at
+|   The Apache Software Foundation (http://www.apache.org/).
+|
+| --------------------------------------------------------------------------------
+|
+| This project includes code from Kite, developed at Cloudera, Inc. with
+| the following copyright notice:
+|
+| | Copyright 2013 Cloudera Inc.
+| |
+| | Licensed under the Apache License, Version 2.0 (the "License");
+| | you may not use this file except in compliance with the License.
+| | You may obtain a copy of the License at
+| |
+| |   http://www.apache.org/licenses/LICENSE-2.0
+| |
+| | Unless required by applicable law or agreed to in writing, software
+| | distributed under the License is distributed on an "AS IS" BASIS,
+| | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| | See the License for the specific language governing permissions and
+| | limitations under the License.
+|
+| --------------------------------------------------------------------------------
+|
+| This project includes code from Netflix, Inc. with the following copyright
+| notice:
+|
+| | Copyright 2016 Netflix, Inc.
+| |
+| | Licensed under the Apache License, Version 2.0 (the "License");
+| | you may not use this file except in compliance with the License.
+| | You may obtain a copy of the License at
+| |
+| |   http://www.apache.org/licenses/LICENSE-2.0
+| |
+| | Unless required by applicable law or agreed to in writing, software
+| | distributed under the License is distributed on an "AS IS" BASIS,
+| | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| | See the License for the specific language governing permissions and
+| | limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Apache Thrift 0.12.0 with the following in its NOTICE file:
+
+| Apache Thrift
+| Copyright 2006-2017 The Apache Software Foundation.
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Airlift Aircompressor 0.27 with the following in its NOTICE file:
 
 | Snappy Copyright Notices
 | =========================
@@ -82,42 +245,7 @@ NOTICE file:
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Carrot Search Labs HPPC with the following in its
-NOTICE file:
-
-| ACKNOWLEDGEMENT
-| ===============
-|
-| HPPC borrowed code, ideas or both from:
-|
-|  * Apache Lucene, http://lucene.apache.org/
-|    (Apache license)
-|  * Fastutil, http://fastutil.di.unimi.it/
-|    (Apache license)
-|  * Koloboke, https://github.com/OpenHFT/Koloboke
-|    (Apache license)
-
---------------------------------------------------------------------------------
-
-This binary artifact includes Apache Yetus with the following in its NOTICE
-file:
-
-| Apache Yetus
-| Copyright 2008-2020 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-|
-| ---
-| Additional licenses for the Apache Yetus Source/Website:
-| ---
-|
-|
-| See LICENSE for terms.
-
---------------------------------------------------------------------------------
-
-This binary artifact includes Google Protobuf with the following copyright
+This binary artifact includes Google Protobuf 3.19.6 with the following copyright
 notice:
 
 | Copyright 2008 Google Inc.  All rights reserved.
@@ -155,10 +283,10 @@ notice:
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Apache Arrow with the following in its NOTICE file:
+This binary artifact includes Apache Arrow 15.0.2 with the following in its NOTICE file:
 
 | Apache Arrow
-| Copyright 2016-2019 The Apache Software Foundation
+| Copyright 2016-2024 The Apache Software Foundation
 |
 | This product includes software developed at
 | The Apache Software Foundation (http://www.apache.org/).
@@ -230,8 +358,8 @@ This binary artifact includes Apache Arrow with the following in its NOTICE file
 |
 | --------------------------------------------------------------------------------
 |
-| This product includes code from Apache ORC, which includes the following in
-| its NOTICE file:
+|  This product includes code from Apache ORC, which includes the following in
+|  its NOTICE file:
 |
 |   Apache ORC
 |   Copyright 2013-2019 The Apache Software Foundation
@@ -244,8 +372,63 @@ This binary artifact includes Apache Arrow with the following in its NOTICE file
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Netty buffers with the following in its NOTICE
-file:
+This binary artifact includes Apache Spark 3.5.4 with the following in its NOTICE file:
+
+| Apache Spark
+| Copyright 2014 and onwards The Apache Software Foundation.
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+|
+| Export Control Notice
+| ---------------------
+|
+| This distribution includes cryptographic software. The country in which you currently reside may have
+| restrictions on the import, possession, use, and/or re-export to another country, of encryption software.
+| BEFORE using any encryption software, please check your country's laws, regulations and policies concerning
+| the import, possession, or use, and re-export of encryption software, to see if this is permitted. See
+| <http://www.wassenaar.org/> for more information.
+|
+| The U.S. Government Department of Commerce, Bureau of Industry and Security (BIS), has classified this
+| software as Export Commodity Control Number (ECCN) 5D002.C.1, which includes information security software
+| using or performing cryptographic functions with asymmetric algorithms. The form and manner of this Apache
+| Software Foundation distribution makes it eligible for export under the License Exception ENC Technology
+| Software Unrestricted (TSU) exception (see the BIS Export Administration Regulations, Section 740.13) for
+| both object code and source code.
+|
+| The following provides more details on the included cryptographic software:
+|
+| This software uses Apache Commons Crypto (https://commons.apache.org/proper/commons-crypto/) to
+| support authentication, and encryption and decryption of data sent across the network between
+| services.
+|
+|
+| Metrics
+| Copyright 2010-2013 Coda Hale and Yammer, Inc.
+|
+| This product includes software developed by Coda Hale and Yammer, Inc.
+|
+| This product includes code derived from the JSR-166 project (ThreadLocalRandom, Striped64,
+| LongAdder), which was released with the following comments:
+|
+|     Written by Doug Lea with assistance from members of JCP JSR-166
+|     Expert Group and released to the public domain, as explained at
+|    http://creativecommons.org/publicdomain/zero/1.0/
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Apache HttpComponents HttpClient 4.5.14 with the following in its NOTICE file:
+
+| Apache HttpComponents Client
+| Copyright 1999-2021 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Netty 4.1.96.Final with the following in its NOTICE file:
 
 |                             The Netty Project
 |                             =================
@@ -497,12 +680,46 @@ file:
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Project Nessie with the following in its NOTICE
-file:
+This binary artifact includes Project Nessie 0.102.2 with the following in its NOTICE file:
 
 | Dremio
 | Copyright 2015-2017 Dremio Corporation
 |
 | This product includes software developed at
 | The Apache Software Foundation (http://www.apache.org/).
-
+|
+| Apache Avro
+| Copyright The Apache Software Foundation
+|
+| Apache Commons
+| Copyright The Apache Software Foundation
+|
+| Apache Curator
+| Copyright The Apache Software Foundation
+|
+| Apache Hadoop
+| Copyright The Apache Software Foundation
+|
+| Apache HTTP Components
+| Copyright The Apache Software Foundation
+|
+| Apache Iceberg
+| Copyright The Apache Software Foundation
+|
+| Apache Kerby
+| Copyright The Apache Software Foundation
+|
+| This product includes additional software licensed under the terms
+| of the following licenses, see LICENSE file:
+| * Apache Software License, Version 2.0
+| * Creative Commons 1.0 Universal
+| * Eclipse Distribution License, Version 1.0
+| * Eclipse Public License, Version 1.0
+| * Eclipse Public License, Version 2.0
+| * GNU General Public License, Version 2 with the GNU Classpath Exception
+|
+| ---
+|
+| The main docs page for a particular Nessie release under
+| https://projectnessie.org/docs/ contains an aggregated
+| license report (since Nessie version 0.83).


### PR DESCRIPTION
Bundle jar files actually bundle a few ALv2 dependencies. These dependencies are correctly listed in the `LICENSE` file, but the `NOTICE` file don't contain relevant portions when the dependency provides a `NOTICE`.
I think it would be great to have both copyright and modified code from the dependencies in the `NOTICE`.

@Fokko @rdblue thoughts ?