### PR TITLE
Spec: Adds in missing ChangeLog metadata columns - Reassigns Row Line…

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -337,9 +337,9 @@ The set of metadata columns is:
 | **`2147483546  file_path`**      | `string`      | Path of a file, used in position-based delete files                                                    |
 | **`2147483545  pos`**            | `long`        | Ordinal position of a row, used in position-based delete files                                         |
 | **`2147483544  row`**            | `struct<...>` | Deleted row values, used in position-based delete files                                                |
-| **`2147483543  _change_type`**                    | `string`      | Used in Changelog: The change type for this particular row:  INSERT, DELETE, UPDATE_BEFORE, or UPDATE_AFTER |
-| **`2147483542  _change_ordinal`**                 | `int`         | Used in Changelog: The order of the change                                                                  |
-| **`2147483541  _commit_snapshot_id`**             | `long`        | Used for Changelog: The snapshot id in which the change occured                                             |
+| **`2147483543  _change_type`**                    | `string`      | The record type in the changelog (INSERT, DELETE, UPDATE_BEFORE, or UPDATE_AFTER)                           |
+| **`2147483542  _change_ordinal`**                 | `int`         | The order of the change                                                                                     |
+| **`2147483541  _commit_snapshot_id`**             | `long`        | The snapshot ID in which the change occured                                                                 |
 | **`2147483540  _row_id`**                         | `long`        | A unique long assigned when row-lineage is enabled, see [Row Lineage](#row-lineage)                                  |
 | **`2147483539  _last_updated_sequence_number`**   | `long`        | The sequence number which last updated this row when row-lineage is enabled [Row Lineage](#row-lineage)              |
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -337,8 +337,11 @@ The set of metadata columns is:
 | **`2147483546  file_path`**      | `string`      | Path of a file, used in position-based delete files                                                    |
 | **`2147483545  pos`**            | `long`        | Ordinal position of a row, used in position-based delete files                                         |
 | **`2147483544  row`**            | `struct<...>` | Deleted row values, used in position-based delete files                                                |
-| **`2147483543  _row_id`**        | `long`        | A unique long assigned when row-lineage is enabled, see [Row Lineage](#row-lineage)                    |
-| **`2147483542  _last_updated_sequence_number`**   | `long`        | The sequence number which last updated this row when row-lineage is enabled [Row Lineage](#row-lineage) |
+| **`2147483543  _change_type`**                    | `string`      | Used in Changelog: The change type for this particular row:  INSERT, DELETE, UPDATE_BEFORE, or UPDATE_AFTER |
+| **`2147483542  _change_ordinal`**                 | `int`         | Used in Changelog: The order of the change                                                                  |
+| **`2147483541  _commit_snapshot_id`**             | `long`        | Used for Changelog: The snapshot id in which the change occured                                             |
+| **`2147483540  _row_id`**                         | `long`        | A unique long assigned when row-lineage is enabled, see [Row Lineage](#row-lineage)                                  |
+| **`2147483539  _last_updated_sequence_number`**   | `long`        | The sequence number which last updated this row when row-lineage is enabled [Row Lineage](#row-lineage)              |
 
 #### Row Lineage
 


### PR DESCRIPTION
…age Columns

It turns out that while our spec currently has assigned field ID's for Row Lineage fields, those ids have already been used in the reference library for ChangeLog views. I've added the missing ID's and decremented the Row Lineage fields.