### PR TITLE
Parquet: Clean up Parquet generic and internal readers

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -214,10 +214,8 @@ public abstract class BaseParquetReaders<T> {
     @Override
     public Optional<ParquetValueReader<?>> visit(IntLogicalTypeAnnotation intLogicalType) {
       if (intLogicalType.getBitWidth() == 64) {
-        if (intLogicalType.isSigned()) {
-          // this will throw an UnsupportedOperationException
-          return Optional.empty();
-        }
+        Preconditions.checkArgument(
+            intLogicalType.isSigned(), "Cannot read UINT64 as a long value");
 
         return Optional.of(new ParquetValueReaders.UnboxedReader<>(desc));
       }

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -67,8 +67,18 @@ public abstract class BaseParquetReaders<T> {
     }
   }
 
+  /**
+   * @deprecated will be removed in 1.9.0; use {@link #createStructReader(List, Types.StructType)}
+   *     instead.
+   */
+  @Deprecated
+  protected ParquetValueReader<T> createStructReader(
+      List<Type> types, List<ParquetValueReader<?>> fieldReaders, Types.StructType structType) {
+    return createStructReader(fieldReaders, structType);
+  }
+
   protected abstract ParquetValueReader<T> createStructReader(
-      List<Type> types, List<ParquetValueReader<?>> fieldReaders, Types.StructType structType);
+      List<ParquetValueReader<?>> fieldReaders, Types.StructType structType);
 
   protected ParquetValueReader<?> fixedReader(ColumnDescriptor desc) {
     return new GenericParquetReaders.FixedReader(desc);

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -184,8 +184,7 @@ public abstract class BaseParquetReaders<T> {
     private final org.apache.iceberg.types.Type.PrimitiveType expected;
 
     LogicalTypeReadBuilder(
-        ColumnDescriptor desc,
-        org.apache.iceberg.types.Type.PrimitiveType expected) {
+        ColumnDescriptor desc, org.apache.iceberg.types.Type.PrimitiveType expected) {
       this.desc = desc;
       this.expected = expected;
     }

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -77,18 +77,8 @@ public abstract class BaseParquetReaders<T> {
     }
   }
 
-  /**
-   * @deprecated will be removed in 1.9.0; use {@link #createStructReader(List, Types.StructType)}
-   *     instead.
-   */
-  @Deprecated
-  protected ParquetValueReader<T> createStructReader(
-      List<Type> types, List<ParquetValueReader<?>> fieldReaders, Types.StructType structType) {
-    return createStructReader(fieldReaders, structType);
-  }
-
   protected abstract ParquetValueReader<T> createStructReader(
-      List<ParquetValueReader<?>> fieldReaders, Types.StructType structType);
+      List<Type> types, List<ParquetValueReader<?>> fieldReaders, Types.StructType structType);
 
   protected ParquetValueReader<?> fixedReader(ColumnDescriptor desc) {
     return new GenericParquetReaders.FixedReader(desc);

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.parquet.ParquetValueReaders;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
 
 public class GenericParquetReaders extends BaseParquetReaders<Record> {
 
@@ -57,7 +58,7 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
 
   @Override
   protected ParquetValueReader<Record> createStructReader(
-      List<ParquetValueReader<?>> fieldReaders, StructType structType) {
+      List<Type> types, List<ParquetValueReader<?>> fieldReaders, StructType structType) {
     return ParquetValueReaders.recordReader(fieldReaders, structType);
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
@@ -38,7 +38,6 @@ import org.apache.iceberg.parquet.ParquetValueReaders;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
 
 public class GenericParquetReaders extends BaseParquetReaders<Record> {
 
@@ -58,8 +57,8 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
 
   @Override
   protected ParquetValueReader<Record> createStructReader(
-      List<Type> types, List<ParquetValueReader<?>> fieldReaders, StructType structType) {
-    return ParquetValueReaders.recordReader(types, fieldReaders, structType);
+      List<ParquetValueReader<?>> fieldReaders, StructType structType) {
+    return ParquetValueReaders.recordReader(fieldReaders, structType);
   }
 
   @Override

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalReader.java
@@ -29,7 +29,6 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.apache.parquet.schema.Type;
 
 public class InternalReader<T extends StructLike> extends BaseParquetReaders<T> {
 
@@ -52,9 +51,9 @@ public class InternalReader<T extends StructLike> extends BaseParquetReaders<T> 
   @Override
   @SuppressWarnings("unchecked")
   protected ParquetValueReader<T> createStructReader(
-      List<Type> types, List<ParquetValueReader<?>> fieldReaders, StructType structType) {
+      List<ParquetValueReader<?>> fieldReaders, StructType structType) {
     return (ParquetValueReader<T>)
-        ParquetValueReaders.recordReader(types, fieldReaders, structType);
+        ParquetValueReaders.recordReader(fieldReaders, structType);
   }
 
   @Override

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalReader.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.parquet.ParquetValueReaders;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
 
 public class InternalReader<T extends StructLike> extends BaseParquetReaders<T> {
 
@@ -49,7 +50,7 @@ public class InternalReader<T extends StructLike> extends BaseParquetReaders<T> 
   @Override
   @SuppressWarnings("unchecked")
   protected ParquetValueReader<T> createStructReader(
-      List<ParquetValueReader<?>> fieldReaders, StructType structType) {
+      List<Type> types, List<ParquetValueReader<?>> fieldReaders, StructType structType) {
     return (ParquetValueReader<T>) ParquetValueReaders.recordReader(fieldReaders, structType);
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalReader.java
@@ -26,9 +26,7 @@ import org.apache.iceberg.parquet.ParquetValueReader;
 import org.apache.iceberg.parquet.ParquetValueReaders;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.column.ColumnDescriptor;
-import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.PrimitiveType;
 
 public class InternalReader<T extends StructLike> extends BaseParquetReaders<T> {
 
@@ -52,8 +50,7 @@ public class InternalReader<T extends StructLike> extends BaseParquetReaders<T> 
   @SuppressWarnings("unchecked")
   protected ParquetValueReader<T> createStructReader(
       List<ParquetValueReader<?>> fieldReaders, StructType structType) {
-    return (ParquetValueReader<T>)
-        ParquetValueReaders.recordReader(fieldReaders, structType);
+    return (ParquetValueReader<T>) ParquetValueReaders.recordReader(fieldReaders, structType);
   }
 
   @Override
@@ -67,26 +64,12 @@ public class InternalReader<T extends StructLike> extends BaseParquetReaders<T> 
   }
 
   @Override
-  protected ParquetValueReader<?> timeReader(
-      ColumnDescriptor desc, LogicalTypeAnnotation.TimeUnit unit) {
-    if (unit == LogicalTypeAnnotation.TimeUnit.MILLIS) {
-      return ParquetValueReaders.millisAsTimes(desc);
-    }
-
-    return new ParquetValueReaders.UnboxedReader<>(desc);
+  protected ParquetValueReader<?> timeReader(ColumnDescriptor desc) {
+    return ParquetValueReaders.times(desc);
   }
 
   @Override
-  protected ParquetValueReader<?> timestampReader(
-      ColumnDescriptor desc, LogicalTypeAnnotation.TimeUnit unit, boolean isAdjustedToUTC) {
-    if (desc.getPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
-      return ParquetValueReaders.int96Timestamps(desc);
-    }
-
-    if (unit == LogicalTypeAnnotation.TimeUnit.MILLIS) {
-      return ParquetValueReaders.millisAsTimestamps(desc);
-    }
-
-    return new ParquetValueReaders.UnboxedReader<>(desc);
+  protected ParquetValueReader<?> timestampReader(ColumnDescriptor desc, boolean isAdjustedToUTC) {
+    return ParquetValueReaders.timestamps(desc);
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvroValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvroValueReaders.java
@@ -100,20 +100,17 @@ public class ParquetAvroValueReaders {
           expected != null ? expected.fields() : ImmutableList.of();
       List<ParquetValueReader<?>> reorderedFields =
           Lists.newArrayListWithExpectedSize(expectedFields.size());
-      List<Type> types = Lists.newArrayListWithExpectedSize(expectedFields.size());
       for (Types.NestedField field : expectedFields) {
         int id = field.fieldId();
         ParquetValueReader<?> reader = readersById.get(id);
         if (reader != null) {
           reorderedFields.add(reader);
-          types.add(typesById.get(id));
         } else {
           reorderedFields.add(ParquetValueReaders.nulls());
-          types.add(null);
         }
       }
 
-      return new RecordReader(types, reorderedFields, avroSchema);
+      return new RecordReader(reorderedFields, avroSchema);
     }
 
     @Override
@@ -346,8 +343,8 @@ public class ParquetAvroValueReaders {
   static class RecordReader extends StructReader<Record, Record> {
     private final Schema schema;
 
-    RecordReader(List<Type> types, List<ParquetValueReader<?>> readers, Schema schema) {
-      super(types, readers);
+    RecordReader(List<ParquetValueReader<?>> readers, Schema schema) {
+      super(readers);
       this.schema = schema;
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReader.java
@@ -33,7 +33,9 @@ public interface ParquetValueReader<T> {
    *     instead.
    */
   @Deprecated
-  void setPageSource(PageReadStore pageStore, long rowPosition);
+  default void setPageSource(PageReadStore pageStore, long rowPosition) {
+    setPageSource(pageStore);
+  }
 
   default void setPageSource(PageReadStore pageStore) {
     throw new UnsupportedOperationException(

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -86,8 +86,8 @@ public class ParquetValueReaders {
   }
 
   public static ParquetValueReader<Record> recordReader(
-      List<Type> types, List<ParquetValueReader<?>> readers, Types.StructType struct) {
-    return new RecordReader(types, readers, struct);
+      List<ParquetValueReader<?>> readers, Types.StructType struct) {
+    return new RecordReader(readers, struct);
   }
 
   private static class NullReader<T> implements ParquetValueReader<T> {
@@ -826,7 +826,15 @@ public class ParquetValueReaders {
     private final TripleIterator<?> column;
     private final List<TripleIterator<?>> children;
 
+    /**
+     * @deprecated will be removed in 1.9.0; use {@link #StructReader(List)} instead.
+     */
+    @Deprecated
     protected StructReader(List<Type> types, List<ParquetValueReader<?>> readers) {
+      this(readers);
+    }
+
+    protected StructReader(List<ParquetValueReader<?>> readers) {
       this.readers =
           (ParquetValueReader<?>[]) Array.newInstance(ParquetValueReader.class, readers.size());
       TripleIterator<?>[] columns =
@@ -943,8 +951,8 @@ public class ParquetValueReaders {
   private static class RecordReader extends StructReader<Record, Record> {
     private final GenericRecord template;
 
-    RecordReader(List<Type> types, List<ParquetValueReader<?>> readers, Types.StructType struct) {
-      super(types, readers);
+    RecordReader(List<ParquetValueReader<?>> readers, Types.StructType struct) {
+      super(readers);
       this.template = struct != null ? GenericRecord.create(struct) : null;
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -152,11 +152,11 @@ public class ParquetValueReaders {
   }
 
   public static ParquetValueReader<UUID> uuids(ColumnDescriptor desc) {
-    return new ParquetValueReaders.UUIDReader(desc);
+    return new UUIDReader(desc);
   }
 
   public static ParquetValueReader<Long> int96Timestamps(ColumnDescriptor desc) {
-    return new ParquetValueReaders.TimestampInt96Reader(desc);
+    return new TimestampInt96Reader(desc);
   }
 
   public static ParquetValueReader<Record> recordReader(
@@ -497,7 +497,7 @@ public class ParquetValueReaders {
     }
   }
 
-  public static class ByteArrayReader extends ParquetValueReaders.PrimitiveReader<byte[]> {
+  public static class ByteArrayReader extends PrimitiveReader<byte[]> {
     public ByteArrayReader(ColumnDescriptor desc) {
       super(desc);
     }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -96,6 +96,7 @@ public class ParquetValueReaders {
       case INT32:
         return new IntegerAsDecimalReader(desc, scale);
     }
+
     throw new IllegalArgumentException(
         "Invalid primitive type for decimal: " + desc.getPrimitiveType());
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -213,9 +213,6 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {}
-
-    @Override
     public void setPageSource(PageReadStore pageStore) {}
   }
 
@@ -279,9 +276,6 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {}
-
-    @Override
     public void setPageSource(PageReadStore pageStore) {}
   }
 
@@ -303,11 +297,6 @@ public class ParquetValueReaders {
     @Override
     public List<TripleIterator<?>> columns() {
       return NullReader.COLUMNS;
-    }
-
-    @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {
-      setPageSource(pageStore);
     }
 
     @Override
@@ -335,11 +324,6 @@ public class ParquetValueReaders {
       this.desc = desc;
       this.column = ColumnIterator.newIterator(desc, "");
       this.children = ImmutableList.of(column);
-    }
-
-    @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {
-      setPageSource(pageStore);
     }
 
     @Override
@@ -589,11 +573,6 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {
-      setPageSource(pageStore);
-    }
-
-    @Override
     public void setPageSource(PageReadStore pageStore) {
       reader.setPageSource(pageStore);
     }
@@ -636,11 +615,6 @@ public class ParquetValueReaders {
       this.reader = reader;
       this.column = reader.column();
       this.children = reader.columns();
-    }
-
-    @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {
-      setPageSource(pageStore);
     }
 
     @Override
@@ -760,11 +734,6 @@ public class ParquetValueReaders {
               .addAll(keyReader.columns())
               .addAll(valueReader.columns())
               .build();
-    }
-
-    @Override
-    public void setPageSource(PageReadStore pageStore, long rowPosition) {
-      setPageSource(pageStore);
     }
 
     @Override
@@ -924,11 +893,6 @@ public class ParquetValueReaders {
 
       this.children = columnsBuilder.build();
       this.column = firstNonNullColumn(children);
-    }
-
-    @Override
-    public final void setPageSource(PageReadStore pageStore, long rowPosition) {
-      setPageSource(pageStore);
     }
 
     @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -106,16 +106,14 @@ public class SparkParquetReaders {
       // the expected struct is ignored because nested fields are never found when the
       List<ParquetValueReader<?>> newFields =
           Lists.newArrayListWithExpectedSize(fieldReaders.size());
-      List<Type> types = Lists.newArrayListWithExpectedSize(fieldReaders.size());
       List<Type> fields = struct.getFields();
       for (int i = 0; i < fields.size(); i += 1) {
         Type fieldType = fields.get(i);
         int fieldD = type().getMaxDefinitionLevel(path(fieldType.getName())) - 1;
         newFields.add(ParquetValueReaders.option(fieldType, fieldD, fieldReaders.get(i)));
-        types.add(fieldType);
       }
 
-      return new InternalRowReader(types, newFields);
+      return new InternalRowReader(newFields);
     }
   }
 
@@ -159,7 +157,6 @@ public class SparkParquetReaders {
           expected != null ? expected.fields() : ImmutableList.of();
       List<ParquetValueReader<?>> reorderedFields =
           Lists.newArrayListWithExpectedSize(expectedFields.size());
-      List<Type> types = Lists.newArrayListWithExpectedSize(expectedFields.size());
       // Defaulting to parent max definition level
       int defaultMaxDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
       for (Types.NestedField field : expectedFields) {
@@ -171,32 +168,26 @@ public class SparkParquetReaders {
               maxDefinitionLevelsById.getOrDefault(id, defaultMaxDefinitionLevel);
           reorderedFields.add(
               ParquetValueReaders.constant(idToConstant.get(id), fieldMaxDefinitionLevel));
-          types.add(null);
         } else if (id == MetadataColumns.ROW_POSITION.fieldId()) {
           reorderedFields.add(ParquetValueReaders.position());
-          types.add(null);
         } else if (id == MetadataColumns.IS_DELETED.fieldId()) {
           reorderedFields.add(ParquetValueReaders.constant(false));
-          types.add(null);
         } else if (reader != null) {
           reorderedFields.add(reader);
-          types.add(typesById.get(id));
         } else if (field.initialDefault() != null) {
           reorderedFields.add(
               ParquetValueReaders.constant(
                   SparkUtil.internalToSpark(field.type(), field.initialDefault()),
                   maxDefinitionLevelsById.getOrDefault(id, defaultMaxDefinitionLevel)));
-          types.add(typesById.get(id));
         } else if (field.isOptional()) {
           reorderedFields.add(ParquetValueReaders.nulls());
-          types.add(null);
         } else {
           throw new IllegalArgumentException(
               String.format("Missing required field: %s", field.name()));
         }
       }
 
-      return new InternalRowReader(types, reorderedFields);
+      return new InternalRowReader(reorderedFields);
     }
 
     @Override
@@ -518,8 +509,8 @@ public class SparkParquetReaders {
   private static class InternalRowReader extends StructReader<InternalRow, GenericInternalRow> {
     private final int numFields;
 
-    InternalRowReader(List<Type> types, List<ParquetValueReader<?>> readers) {
-      super(types, readers);
+    InternalRowReader(List<ParquetValueReader<?>> readers) {
+      super(readers);
       this.numFields = readers.size();
     }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -251,10 +251,10 @@ public class SparkParquetReaders {
             }
           case DATE:
           case INT_64:
-          case TIMESTAMP_MICROS:
             return new UnboxedReader<>(desc);
+          case TIMESTAMP_MICROS:
           case TIMESTAMP_MILLIS:
-            return ParquetValueReaders.millisAsTimestamps(desc);
+            return ParquetValueReaders.timestamps(desc);
           case DECIMAL:
             DecimalLogicalTypeAnnotation decimal =
                 (DecimalLogicalTypeAnnotation) primitive.getLogicalTypeAnnotation();


### PR DESCRIPTION
This is a refactor that cleans up a few issues I noticed while reviewing #11904 and while working on Parquet variant readers.

- Updates INT and UINT handling to reject unsupported unsigned types (like UINT64)
- Adds more factory methods to `ParquetValueReaders` to keep implementations private
- Removes unused `types` argument from `ParquetValueReader.StructReader` subclasses. Some accessible uses had to be left, but most are removed. This allowed removing types from the reader builders as well.
- Removes unnecessary `TimeUnit` param from factory methods added in #11904
- Removes unnecessary implementations of `setPageSource`
- Adds imports for `LogicalTypeAnnotation` classes to cut down on multi-line method signatures

Changes are grouped into separate commits for easier review.