### PR TITLE
Core: Support removing keys from EnvironmentContext

### DIFF
--- a/core/src/main/java/org/apache/iceberg/EnvironmentContext.java
+++ b/core/src/main/java/org/apache/iceberg/EnvironmentContext.java
@@ -52,4 +52,13 @@ public class EnvironmentContext {
   public static void put(String key, String value) {
     PROPERTIES.put(key, value);
   }
+
+  /**
+   * Remove the key from the global properties map.
+   *
+   * @param key The key whose value to remove
+   */
+  public static void remove(String key) {
+    PROPERTIES.remove(key);
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/EnvironmentContext.java
+++ b/core/src/main/java/org/apache/iceberg/EnvironmentContext.java
@@ -57,8 +57,9 @@ public class EnvironmentContext {
    * Remove the key from the global properties map.
    *
    * @param key The key whose value to remove
+   * @return The previous value associated with the key or null
    */
-  public static void remove(String key) {
-    PROPERTIES.remove(key);
+  public static String remove(String key) {
+    return PROPERTIES.remove(key);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestEnvironmentContext.java
+++ b/core/src/test/java/org/apache/iceberg/TestEnvironmentContext.java
@@ -36,9 +36,9 @@ public class TestEnvironmentContext {
     EnvironmentContext.put("test-key", "test-value");
     assertThat(EnvironmentContext.get()).containsEntry("test-key", "test-value");
 
-    EnvironmentContext.remove("test-key");
+    assertThat(EnvironmentContext.remove("test-key")).isEqualTo("test-value");
     assertThat(EnvironmentContext.get()).doesNotContainKey("test-key");
 
-    assertThatNoException().isThrownBy(() -> EnvironmentContext.remove("test-key"));
+    assertThat(EnvironmentContext.remove("test-key")).isNull();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestEnvironmentContext.java
+++ b/core/src/test/java/org/apache/iceberg/TestEnvironmentContext.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,5 +29,16 @@ public class TestEnvironmentContext {
   public void testDefaultValue() {
     assertThat(EnvironmentContext.get().get("iceberg-version"))
         .isEqualTo(IcebergBuild.fullVersion());
+  }
+
+  @Test
+  public void testPutAndRemove() {
+    EnvironmentContext.put("test-key", "test-value");
+    assertThat(EnvironmentContext.get()).containsEntry("test-key", "test-value");
+
+    EnvironmentContext.remove("test-key");
+    assertThat(EnvironmentContext.get()).doesNotContainKey("test-key");
+
+    assertThatNoException().isThrownBy(() -> EnvironmentContext.remove("test-key"));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestEnvironmentContext.java
+++ b/core/src/test/java/org/apache/iceberg/TestEnvironmentContext.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Tiny change to support removing keys from `EnvironmentContext`.

Useful when a JVM is shared by multiple jobs and jobs want to express different environment properties.