### PR TITLE
Spark: Support singular form of years, months, days, and hours functions

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSystemFunctionPushDownDQL.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSystemFunctionPushDownDQL.java
@@ -84,20 +84,24 @@ public class TestSystemFunctionPushDownDQL extends ExtensionsTestBase {
   @TestTemplate
   public void testYearsFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
-    testYearsFunction(false);
+    testYearsFunction(false, false);
+    testYearsFunction(false, true);
   }
 
   @TestTemplate
   public void testYearsFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "years(ts)");
-    testYearsFunction(true);
+    testYearsFunction(true, false);
+    testYearsFunction(true, true);
   }
 
-  private void testYearsFunction(boolean partitioned) {
+  private void testYearsFunction(boolean partitioned, boolean singular) {
     int targetYears = timestampStrToYearOrdinal("2017-11-22T00:00:00.000000+00:00");
+    String functionName = singular ? "year" : "years";
     String query =
         String.format(
-            "SELECT * FROM %s WHERE system.years(ts) = %s ORDER BY id", tableName, targetYears);
+            "SELECT * FROM %s WHERE system.%s(ts) = %s ORDER BY id",
+            tableName, functionName, targetYears);
 
     Dataset<Row> df = spark.sql(query);
     LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
@@ -112,20 +116,24 @@ public class TestSystemFunctionPushDownDQL extends ExtensionsTestBase {
   @TestTemplate
   public void testMonthsFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
-    testMonthsFunction(false);
+    testMonthsFunction(false, false);
+    testMonthsFunction(false, true);
   }
 
   @TestTemplate
   public void testMonthsFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "months(ts)");
-    testMonthsFunction(true);
+    testMonthsFunction(true, false);
+    testMonthsFunction(true, true);
   }
 
-  private void testMonthsFunction(boolean partitioned) {
+  private void testMonthsFunction(boolean partitioned, boolean singular) {
     int targetMonths = timestampStrToMonthOrdinal("2017-11-22T00:00:00.000000+00:00");
+    String functionName = singular ? "month" : "months";
     String query =
         String.format(
-            "SELECT * FROM %s WHERE system.months(ts) > %s ORDER BY id", tableName, targetMonths);
+            "SELECT * FROM %s WHERE system.%s(ts) > %s ORDER BY id",
+            tableName, functionName, targetMonths);
 
     Dataset<Row> df = spark.sql(query);
     LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
@@ -140,22 +148,25 @@ public class TestSystemFunctionPushDownDQL extends ExtensionsTestBase {
   @TestTemplate
   public void testDaysFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
-    testDaysFunction(false);
+    testDaysFunction(false, false);
+    testDaysFunction(false, true);
   }
 
   @TestTemplate
   public void testDaysFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "days(ts)");
-    testDaysFunction(true);
+    testDaysFunction(true, false);
+    testDaysFunction(true, true);
   }
 
-  private void testDaysFunction(boolean partitioned) {
+  private void testDaysFunction(boolean partitioned, boolean singular) {
     String timestamp = "2018-11-20T00:00:00.000000+00:00";
     int targetDays = timestampStrToDayOrdinal(timestamp);
+    String functionName = singular ? "day" : "days";
     String query =
         String.format(
-            "SELECT * FROM %s WHERE system.days(ts) < date('%s') ORDER BY id",
-            tableName, timestamp);
+            "SELECT * FROM %s WHERE system.%s(ts) < date('%s') ORDER BY id",
+            tableName, functionName, timestamp);
 
     Dataset<Row> df = spark.sql(query);
     LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
@@ -170,20 +181,24 @@ public class TestSystemFunctionPushDownDQL extends ExtensionsTestBase {
   @TestTemplate
   public void testHoursFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
-    testHoursFunction(false);
+    testHoursFunction(false, false);
+    testHoursFunction(false, true);
   }
 
   @TestTemplate
   public void testHoursFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "hours(ts)");
-    testHoursFunction(true);
+    testHoursFunction(true, false);
+    testHoursFunction(true, true);
   }
 
-  private void testHoursFunction(boolean partitioned) {
+  private void testHoursFunction(boolean partitioned, boolean singular) {
     int targetHours = timestampStrToHourOrdinal("2017-11-22T06:02:09.243857+00:00");
+    String functionName = singular ? "hour" : "hours";
     String query =
         String.format(
-            "SELECT * FROM %s WHERE system.hours(ts) >= %s ORDER BY id", tableName, targetHours);
+            "SELECT * FROM %s WHERE system.%s(ts) >= %s ORDER BY id",
+            tableName, functionName, targetHours);
 
     Dataset<Row> df = spark.sql(query);
     LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSystemFunctionPushDownDQL.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSystemFunctionPushDownDQL.java
@@ -43,6 +43,7 @@ import java.util.List;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.expressions.ExpressionUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.source.PlanUtils;
 import org.apache.spark.sql.Dataset;
@@ -84,130 +85,126 @@ public class TestSystemFunctionPushDownDQL extends ExtensionsTestBase {
   @TestTemplate
   public void testYearsFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
-    testYearsFunction(false, false);
-    testYearsFunction(false, true);
+    testYearsFunction(false);
   }
 
   @TestTemplate
   public void testYearsFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "years(ts)");
-    testYearsFunction(true, false);
-    testYearsFunction(true, true);
+    testYearsFunction(true);
   }
 
-  private void testYearsFunction(boolean partitioned, boolean singular) {
+  private void testYearsFunction(boolean partitioned) {
     int targetYears = timestampStrToYearOrdinal("2017-11-22T00:00:00.000000+00:00");
-    String functionName = singular ? "year" : "years";
-    String query =
-        String.format(
-            "SELECT * FROM %s WHERE system.%s(ts) = %s ORDER BY id",
-            tableName, functionName, targetYears);
+    for (String functionName : ImmutableList.of("year", "years")) {
+      String query =
+          String.format(
+              "SELECT * FROM %s WHERE system.%s(ts) = %s ORDER BY id",
+              tableName, functionName, targetYears);
 
-    Dataset<Row> df = spark.sql(query);
-    LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
+      Dataset<Row> df = spark.sql(query);
+      LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
 
-    checkExpressions(optimizedPlan, partitioned, "years");
-    checkPushedFilters(optimizedPlan, equal(year("ts"), targetYears));
+      checkExpressions(optimizedPlan, partitioned, "years");
+      checkPushedFilters(optimizedPlan, equal(year("ts"), targetYears));
 
-    List<Object[]> actual = rowsToJava(df.collectAsList());
-    assertThat(actual).hasSize(5);
+      List<Object[]> actual = rowsToJava(df.collectAsList());
+      assertThat(actual).hasSize(5);
+    }
   }
 
   @TestTemplate
   public void testMonthsFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
-    testMonthsFunction(false, false);
-    testMonthsFunction(false, true);
+    testMonthsFunction(false);
   }
 
   @TestTemplate
   public void testMonthsFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "months(ts)");
-    testMonthsFunction(true, false);
-    testMonthsFunction(true, true);
+    testMonthsFunction(true);
   }
 
-  private void testMonthsFunction(boolean partitioned, boolean singular) {
+  private void testMonthsFunction(boolean partitioned) {
     int targetMonths = timestampStrToMonthOrdinal("2017-11-22T00:00:00.000000+00:00");
-    String functionName = singular ? "month" : "months";
-    String query =
-        String.format(
-            "SELECT * FROM %s WHERE system.%s(ts) > %s ORDER BY id",
-            tableName, functionName, targetMonths);
+    for (String functionName : ImmutableList.of("month", "months")) {
+      String query =
+          String.format(
+              "SELECT * FROM %s WHERE system.%s(ts) > %s ORDER BY id",
+              tableName, functionName, targetMonths);
 
-    Dataset<Row> df = spark.sql(query);
-    LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
+      Dataset<Row> df = spark.sql(query);
+      LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
 
-    checkExpressions(optimizedPlan, partitioned, "months");
-    checkPushedFilters(optimizedPlan, greaterThan(month("ts"), targetMonths));
+      checkExpressions(optimizedPlan, partitioned, "months");
+      checkPushedFilters(optimizedPlan, greaterThan(month("ts"), targetMonths));
 
-    List<Object[]> actual = rowsToJava(df.collectAsList());
-    assertThat(actual).hasSize(5);
+      List<Object[]> actual = rowsToJava(df.collectAsList());
+      assertThat(actual).hasSize(5);
+    }
   }
 
   @TestTemplate
   public void testDaysFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
-    testDaysFunction(false, false);
-    testDaysFunction(false, true);
+    testDaysFunction(false);
   }
 
   @TestTemplate
   public void testDaysFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "days(ts)");
-    testDaysFunction(true, false);
-    testDaysFunction(true, true);
+    testDaysFunction(true);
   }
 
-  private void testDaysFunction(boolean partitioned, boolean singular) {
+  private void testDaysFunction(boolean partitioned) {
     String timestamp = "2018-11-20T00:00:00.000000+00:00";
     int targetDays = timestampStrToDayOrdinal(timestamp);
-    String functionName = singular ? "day" : "days";
-    String query =
-        String.format(
-            "SELECT * FROM %s WHERE system.%s(ts) < date('%s') ORDER BY id",
-            tableName, functionName, timestamp);
+    for (String functionName : ImmutableList.of("day", "days")) {
+      String query =
+          String.format(
+              "SELECT * FROM %s WHERE system.%s(ts) < date('%s') ORDER BY id",
+              tableName, functionName, timestamp);
 
-    Dataset<Row> df = spark.sql(query);
-    LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
+      Dataset<Row> df = spark.sql(query);
+      LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
 
-    checkExpressions(optimizedPlan, partitioned, "days");
-    checkPushedFilters(optimizedPlan, lessThan(day("ts"), targetDays));
+      checkExpressions(optimizedPlan, partitioned, "days");
+      checkPushedFilters(optimizedPlan, lessThan(day("ts"), targetDays));
 
-    List<Object[]> actual = rowsToJava(df.collectAsList());
-    assertThat(actual).hasSize(5);
+      List<Object[]> actual = rowsToJava(df.collectAsList());
+      assertThat(actual).hasSize(5);
+    }
   }
 
   @TestTemplate
   public void testHoursFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
-    testHoursFunction(false, false);
-    testHoursFunction(false, true);
+    testHoursFunction(false);
   }
 
   @TestTemplate
   public void testHoursFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "hours(ts)");
-    testHoursFunction(true, false);
-    testHoursFunction(true, true);
+    testHoursFunction(true);
   }
 
-  private void testHoursFunction(boolean partitioned, boolean singular) {
+  private void testHoursFunction(boolean partitioned) {
     int targetHours = timestampStrToHourOrdinal("2017-11-22T06:02:09.243857+00:00");
-    String functionName = singular ? "hour" : "hours";
-    String query =
-        String.format(
-            "SELECT * FROM %s WHERE system.%s(ts) >= %s ORDER BY id",
-            tableName, functionName, targetHours);
+    for (String functionName : ImmutableList.of("hour", "hours")) {
+      String query =
+          String.format(
+              "SELECT * FROM %s WHERE system.%s(ts) >= %s ORDER BY id",
+              tableName, functionName, targetHours);
 
-    Dataset<Row> df = spark.sql(query);
-    LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
+      Dataset<Row> df = spark.sql(query);
+      LogicalPlan optimizedPlan = df.queryExecution().optimizedPlan();
 
-    checkExpressions(optimizedPlan, partitioned, "hours");
-    checkPushedFilters(optimizedPlan, greaterThanOrEqual(hour("ts"), targetHours));
+      checkExpressions(optimizedPlan, partitioned, "hours");
+      checkPushedFilters(optimizedPlan, greaterThanOrEqual(hour("ts"), targetHours));
 
-    List<Object[]> actual = rowsToJava(df.collectAsList());
-    assertThat(actual).hasSize(8);
+      List<Object[]> actual = rowsToJava(df.collectAsList());
+      assertThat(actual).hasSize(8);
+    }
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -70,7 +70,8 @@ import org.apache.spark.unsafe.types.UTF8String;
 public class SparkV2Filters {
 
   public static final Set<String> SUPPORTED_FUNCTIONS =
-      ImmutableSet.of("years", "months", "days", "hours", "bucket", "truncate");
+      ImmutableSet.of(
+          "year", "years", "month", "months", "day", "days", "hour", "hours", "bucket", "truncate");
 
   private static final String TRUE = "ALWAYS_TRUE";
   private static final String FALSE = "ALWAYS_FALSE";
@@ -455,12 +456,16 @@ public class SparkV2Filters {
       if (isRef(child)) {
         String column = SparkUtil.toColumnName((NamedReference) child);
         switch (udfName) {
+          case "year":
           case "years":
             return year(column);
+          case "month":
           case "months":
             return month(column);
+          case "day":
           case "days":
             return day(column);
+          case "hour":
           case "hours":
             return hour(column);
         }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/DaysFunction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/DaysFunction.java
@@ -31,6 +31,8 @@ import org.apache.spark.sql.types.TimestampType;
  * A Spark function implementation for the Iceberg day transform.
  *
  * <p>Example usage: {@code SELECT system.days('source_col')}.
+ *
+ * <p>Alternate form: {@code SELECT system.day('source_col')}.
  */
 public class DaysFunction extends UnaryUnboundFunction {
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/DaysFunction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/DaysFunction.java
@@ -30,16 +30,16 @@ import org.apache.spark.sql.types.TimestampType;
 /**
  * A Spark function implementation for the Iceberg day transform.
  *
- * <p>Example usage: {@code SELECT system.day('source_col')}.
+ * <p>Example usage: {@code SELECT system.days('source_col')}.
  *
- * <p>Alternate form: {@code SELECT system.days('source_col')}.
+ * <p>Alternate form: {@code SELECT system.day('source_col')}.
  */
 public class DaysFunction extends UnaryUnboundFunction {
 
   private boolean singular;
 
   public DaysFunction() {
-    this(true);
+    this(false);
   }
 
   DaysFunction(boolean singular) {
@@ -93,7 +93,7 @@ public class DaysFunction extends UnaryUnboundFunction {
   // Spark and Iceberg internal representations of dates match so no transformation is required
   public static class DateToDaysFunction extends BaseToDaysFunction {
     public DateToDaysFunction() {
-      this(true);
+      this(false);
     }
 
     DateToDaysFunction(boolean singular) {
@@ -124,7 +124,7 @@ public class DaysFunction extends UnaryUnboundFunction {
 
   public static class TimestampToDaysFunction extends BaseToDaysFunction {
     public TimestampToDaysFunction() {
-      this(true);
+      this(false);
     }
 
     TimestampToDaysFunction(boolean singular) {
@@ -155,7 +155,7 @@ public class DaysFunction extends UnaryUnboundFunction {
 
   public static class TimestampNtzToDaysFunction extends BaseToDaysFunction {
     public TimestampNtzToDaysFunction() {
-      this(true);
+      this(false);
     }
 
     TimestampNtzToDaysFunction(boolean singular) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/HoursFunction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/HoursFunction.java
@@ -29,16 +29,16 @@ import org.apache.spark.sql.types.TimestampType;
 /**
  * A Spark function implementation for the Iceberg hour transform.
  *
- * <p>Example usage: {@code SELECT system.hour('source_col')}.
+ * <p>Example usage: {@code SELECT system.hours('source_col')}.
  *
- * <p>Alternate form: {@code SELECT system.hours('source_col')}.
+ * <p>Alternate form: {@code SELECT system.hour('source_col')}.
  */
 public class HoursFunction extends UnaryUnboundFunction {
 
   private boolean singular;
 
   public HoursFunction() {
-    this(true);
+    this(false);
   }
 
   HoursFunction(boolean singular) {
@@ -73,7 +73,7 @@ public class HoursFunction extends UnaryUnboundFunction {
     private boolean singular;
 
     public TimestampToHoursFunction() {
-      this(true);
+      this(false);
     }
 
     TimestampToHoursFunction(boolean singular) {
@@ -116,7 +116,7 @@ public class HoursFunction extends UnaryUnboundFunction {
     private boolean singular;
 
     public TimestampNtzToHoursFunction() {
-      this(true);
+      this(false);
     }
 
     TimestampNtzToHoursFunction(boolean singular) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/HoursFunction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/HoursFunction.java
@@ -29,18 +29,28 @@ import org.apache.spark.sql.types.TimestampType;
 /**
  * A Spark function implementation for the Iceberg hour transform.
  *
- * <p>Example usage: {@code SELECT system.hours('source_col')}.
+ * <p>Example usage: {@code SELECT system.hour('source_col')}.
  *
- * <p>Alternate form: {@code SELECT system.hour('source_col')}.
+ * <p>Alternate form: {@code SELECT system.hours('source_col')}.
  */
 public class HoursFunction extends UnaryUnboundFunction {
+
+  private boolean singular;
+
+  public HoursFunction() {
+    this(true);
+  }
+
+  HoursFunction(boolean singular) {
+    this.singular = singular;
+  }
 
   @Override
   protected BoundFunction doBind(DataType valueType) {
     if (valueType instanceof TimestampType) {
-      return new TimestampToHoursFunction();
+      return new TimestampToHoursFunction(singular);
     } else if (valueType instanceof TimestampNTZType) {
-      return new TimestampNtzToHoursFunction();
+      return new TimestampNtzToHoursFunction(singular);
     } else {
       throw new UnsupportedOperationException(
           "Expected value to be timestamp: " + valueType.catalogString());
@@ -56,10 +66,20 @@ public class HoursFunction extends UnaryUnboundFunction {
 
   @Override
   public String name() {
-    return "hours";
+    return singular ? "hour" : "hours";
   }
 
   public static class TimestampToHoursFunction extends BaseScalarFunction<Integer> {
+    private boolean singular;
+
+    public TimestampToHoursFunction() {
+      this(true);
+    }
+
+    TimestampToHoursFunction(boolean singular) {
+      this.singular = singular;
+    }
+
     // magic method used in codegen
     public static int invoke(long micros) {
       return DateTimeUtil.microsToHours(micros);
@@ -67,7 +87,7 @@ public class HoursFunction extends UnaryUnboundFunction {
 
     @Override
     public String name() {
-      return "hours";
+      return singular ? "hour" : "hours";
     }
 
     @Override
@@ -82,7 +102,7 @@ public class HoursFunction extends UnaryUnboundFunction {
 
     @Override
     public String canonicalName() {
-      return "iceberg.hours(timestamp)";
+      return "iceberg." + name() + "(timestamp)";
     }
 
     @Override
@@ -93,6 +113,16 @@ public class HoursFunction extends UnaryUnboundFunction {
   }
 
   public static class TimestampNtzToHoursFunction extends BaseScalarFunction<Integer> {
+    private boolean singular;
+
+    public TimestampNtzToHoursFunction() {
+      this(true);
+    }
+
+    TimestampNtzToHoursFunction(boolean singular) {
+      this.singular = singular;
+    }
+
     // magic method used in codegen
     public static int invoke(long micros) {
       return DateTimeUtil.microsToHours(micros);
@@ -100,7 +130,7 @@ public class HoursFunction extends UnaryUnboundFunction {
 
     @Override
     public String name() {
-      return "hours";
+      return singular ? "hour" : "hours";
     }
 
     @Override
@@ -115,7 +145,7 @@ public class HoursFunction extends UnaryUnboundFunction {
 
     @Override
     public String canonicalName() {
-      return "iceberg.hours(timestamp_ntz)";
+      return "iceberg." + name() + "(timestamp_ntz)";
     }
 
     @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/HoursFunction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/HoursFunction.java
@@ -30,6 +30,8 @@ import org.apache.spark.sql.types.TimestampType;
  * A Spark function implementation for the Iceberg hour transform.
  *
  * <p>Example usage: {@code SELECT system.hours('source_col')}.
+ *
+ * <p>Alternate form: {@code SELECT system.hour('source_col')}.
  */
 public class HoursFunction extends UnaryUnboundFunction {
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/MonthsFunction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/MonthsFunction.java
@@ -30,16 +30,16 @@ import org.apache.spark.sql.types.TimestampType;
 /**
  * A Spark function implementation for the Iceberg month transform.
  *
- * <p>Example usage: {@code SELECT system.month('source_col')}.
+ * <p>Example usage: {@code SELECT system.months('source_col')}.
  *
- * <p>Alternate form: {@code SELECT system.months('source_col')}.
+ * <p>Alternate form: {@code SELECT system.month('source_col')}.
  */
 public class MonthsFunction extends UnaryUnboundFunction {
 
   private boolean singular;
 
   public MonthsFunction() {
-    this(true);
+    this(false);
   }
 
   MonthsFunction(boolean singular) {
@@ -92,7 +92,7 @@ public class MonthsFunction extends UnaryUnboundFunction {
 
   public static class DateToMonthsFunction extends BaseToMonthsFunction {
     public DateToMonthsFunction() {
-      this(true);
+      this(false);
     }
 
     DateToMonthsFunction(boolean singular) {
@@ -123,7 +123,7 @@ public class MonthsFunction extends UnaryUnboundFunction {
 
   public static class TimestampToMonthsFunction extends BaseToMonthsFunction {
     public TimestampToMonthsFunction() {
-      this(true);
+      this(false);
     }
 
     TimestampToMonthsFunction(boolean singular) {
@@ -154,7 +154,7 @@ public class MonthsFunction extends UnaryUnboundFunction {
 
   public static class TimestampNtzToMonthsFunction extends BaseToMonthsFunction {
     public TimestampNtzToMonthsFunction() {
-      this(true);
+      this(false);
     }
 
     TimestampNtzToMonthsFunction(boolean singular) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/MonthsFunction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/MonthsFunction.java
@@ -31,6 +31,8 @@ import org.apache.spark.sql.types.TimestampType;
  * A Spark function implementation for the Iceberg month transform.
  *
  * <p>Example usage: {@code SELECT system.months('source_col')}.
+ *
+ * <p>Alternate form: {@code SELECT system.month('source_col')}.
  */
 public class MonthsFunction extends UnaryUnboundFunction {
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
@@ -30,14 +30,19 @@ public class SparkFunctions {
   private SparkFunctions() {}
 
   private static final Map<String, UnboundFunction> FUNCTIONS =
-      ImmutableMap.of(
-          "iceberg_version", new IcebergVersionFunction(),
-          "years", new YearsFunction(),
-          "months", new MonthsFunction(),
-          "days", new DaysFunction(),
-          "hours", new HoursFunction(),
-          "bucket", new BucketFunction(),
-          "truncate", new TruncateFunction());
+      new ImmutableMap.Builder<String, UnboundFunction>()
+          .put("iceberg_version", new IcebergVersionFunction())
+          .put("years", new YearsFunction())
+          .put("year", new YearsFunction())
+          .put("months", new MonthsFunction())
+          .put("month", new MonthsFunction())
+          .put("days", new DaysFunction())
+          .put("day", new DaysFunction())
+          .put("hours", new HoursFunction())
+          .put("hour", new HoursFunction())
+          .put("bucket", new BucketFunction())
+          .put("truncate", new TruncateFunction())
+          .build();
 
   private static final Map<Class<?>, UnboundFunction> CLASS_TO_FUNCTIONS =
       ImmutableMap.of(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
@@ -29,29 +29,37 @@ public class SparkFunctions {
 
   private SparkFunctions() {}
 
+  private static final UnboundFunction VERSION_FUNCTION = new IcebergVersionFunction();
+  private static final UnboundFunction YEAR_FUNCTION = new YearsFunction();
+  private static final UnboundFunction MONTH_FUNCTION = new MonthsFunction();
+  private static final UnboundFunction DAY_FUNCTION = new DaysFunction();
+  private static final UnboundFunction HOUR_FUNCTION = new HoursFunction();
+  private static final UnboundFunction BUCKET_FUNCTION = new BucketFunction();
+  private static final UnboundFunction TRUNCATE_FUNCTION = new TruncateFunction();
+
   private static final Map<String, UnboundFunction> FUNCTIONS =
       new ImmutableMap.Builder<String, UnboundFunction>()
-          .put("iceberg_version", new IcebergVersionFunction())
-          .put("years", new YearsFunction())
-          .put("year", new YearsFunction())
-          .put("months", new MonthsFunction())
-          .put("month", new MonthsFunction())
-          .put("days", new DaysFunction())
-          .put("day", new DaysFunction())
-          .put("hours", new HoursFunction())
-          .put("hour", new HoursFunction())
-          .put("bucket", new BucketFunction())
-          .put("truncate", new TruncateFunction())
+          .put("iceberg_version", VERSION_FUNCTION)
+          .put("years", YEAR_FUNCTION)
+          .put("year", YEAR_FUNCTION)
+          .put("months", MONTH_FUNCTION)
+          .put("month", MONTH_FUNCTION)
+          .put("days", DAY_FUNCTION)
+          .put("day", DAY_FUNCTION)
+          .put("hours", HOUR_FUNCTION)
+          .put("hour", HOUR_FUNCTION)
+          .put("bucket", BUCKET_FUNCTION)
+          .put("truncate", TRUNCATE_FUNCTION)
           .build();
 
   private static final Map<Class<?>, UnboundFunction> CLASS_TO_FUNCTIONS =
       ImmutableMap.of(
-          YearsFunction.class, new YearsFunction(),
-          MonthsFunction.class, new MonthsFunction(),
-          DaysFunction.class, new DaysFunction(),
-          HoursFunction.class, new HoursFunction(),
-          BucketFunction.class, new BucketFunction(),
-          TruncateFunction.class, new TruncateFunction());
+          YearsFunction.class, YEAR_FUNCTION,
+          MonthsFunction.class, MONTH_FUNCTION,
+          DaysFunction.class, DAY_FUNCTION,
+          HoursFunction.class, HOUR_FUNCTION,
+          BucketFunction.class, BUCKET_FUNCTION,
+          TruncateFunction.class, TRUNCATE_FUNCTION);
 
   private static final List<String> FUNCTION_NAMES = ImmutableList.copyOf(FUNCTIONS.keySet());
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
@@ -30,14 +30,14 @@ public class SparkFunctions {
   private SparkFunctions() {}
 
   private static final UnboundFunction VERSION_FUNCTION = new IcebergVersionFunction();
-  private static final UnboundFunction YEAR_FUNCTION = new YearsFunction();
-  private static final UnboundFunction YEARS_FUNCTION = new YearsFunction(false);
-  private static final UnboundFunction MONTH_FUNCTION = new MonthsFunction();
-  private static final UnboundFunction MONTHS_FUNCTION = new MonthsFunction(false);
-  private static final UnboundFunction DAY_FUNCTION = new DaysFunction();
-  private static final UnboundFunction DAYS_FUNCTION = new DaysFunction(false);
-  private static final UnboundFunction HOUR_FUNCTION = new HoursFunction();
-  private static final UnboundFunction HOURS_FUNCTION = new HoursFunction(false);
+  private static final UnboundFunction YEAR_FUNCTION = new YearsFunction(true);
+  private static final UnboundFunction YEARS_FUNCTION = new YearsFunction();
+  private static final UnboundFunction MONTH_FUNCTION = new MonthsFunction(true);
+  private static final UnboundFunction MONTHS_FUNCTION = new MonthsFunction();
+  private static final UnboundFunction DAY_FUNCTION = new DaysFunction(true);
+  private static final UnboundFunction DAYS_FUNCTION = new DaysFunction();
+  private static final UnboundFunction HOUR_FUNCTION = new HoursFunction(true);
+  private static final UnboundFunction HOURS_FUNCTION = new HoursFunction();
   private static final UnboundFunction BUCKET_FUNCTION = new BucketFunction();
   private static final UnboundFunction TRUNCATE_FUNCTION = new TruncateFunction();
 
@@ -58,10 +58,10 @@ public class SparkFunctions {
 
   private static final Map<Class<?>, UnboundFunction> CLASS_TO_FUNCTIONS =
       ImmutableMap.of(
-          YearsFunction.class, YEAR_FUNCTION,
-          MonthsFunction.class, MONTH_FUNCTION,
-          DaysFunction.class, DAY_FUNCTION,
-          HoursFunction.class, HOUR_FUNCTION,
+          YearsFunction.class, YEARS_FUNCTION,
+          MonthsFunction.class, MONTHS_FUNCTION,
+          DaysFunction.class, DAYS_FUNCTION,
+          HoursFunction.class, HOURS_FUNCTION,
           BucketFunction.class, BUCKET_FUNCTION,
           TruncateFunction.class, TRUNCATE_FUNCTION);
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
@@ -31,13 +31,13 @@ public class SparkFunctions {
 
   private static final UnboundFunction VERSION_FUNCTION = new IcebergVersionFunction();
   private static final UnboundFunction YEAR_FUNCTION = new YearsFunction(true);
-  private static final UnboundFunction YEARS_FUNCTION = new YearsFunction();
+  private static final UnboundFunction YEARS_FUNCTION = new YearsFunction(false);
   private static final UnboundFunction MONTH_FUNCTION = new MonthsFunction(true);
-  private static final UnboundFunction MONTHS_FUNCTION = new MonthsFunction();
+  private static final UnboundFunction MONTHS_FUNCTION = new MonthsFunction(false);
   private static final UnboundFunction DAY_FUNCTION = new DaysFunction(true);
-  private static final UnboundFunction DAYS_FUNCTION = new DaysFunction();
+  private static final UnboundFunction DAYS_FUNCTION = new DaysFunction(false);
   private static final UnboundFunction HOUR_FUNCTION = new HoursFunction(true);
-  private static final UnboundFunction HOURS_FUNCTION = new HoursFunction();
+  private static final UnboundFunction HOURS_FUNCTION = new HoursFunction(false);
   private static final UnboundFunction BUCKET_FUNCTION = new BucketFunction();
   private static final UnboundFunction TRUNCATE_FUNCTION = new TruncateFunction();
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
@@ -31,23 +31,27 @@ public class SparkFunctions {
 
   private static final UnboundFunction VERSION_FUNCTION = new IcebergVersionFunction();
   private static final UnboundFunction YEAR_FUNCTION = new YearsFunction();
+  private static final UnboundFunction YEARS_FUNCTION = new YearsFunction(false);
   private static final UnboundFunction MONTH_FUNCTION = new MonthsFunction();
+  private static final UnboundFunction MONTHS_FUNCTION = new MonthsFunction(false);
   private static final UnboundFunction DAY_FUNCTION = new DaysFunction();
+  private static final UnboundFunction DAYS_FUNCTION = new DaysFunction(false);
   private static final UnboundFunction HOUR_FUNCTION = new HoursFunction();
+  private static final UnboundFunction HOURS_FUNCTION = new HoursFunction(false);
   private static final UnboundFunction BUCKET_FUNCTION = new BucketFunction();
   private static final UnboundFunction TRUNCATE_FUNCTION = new TruncateFunction();
 
   private static final Map<String, UnboundFunction> FUNCTIONS =
       new ImmutableMap.Builder<String, UnboundFunction>()
           .put("iceberg_version", VERSION_FUNCTION)
-          .put("years", YEAR_FUNCTION)
           .put("year", YEAR_FUNCTION)
-          .put("months", MONTH_FUNCTION)
+          .put("years", YEARS_FUNCTION)
           .put("month", MONTH_FUNCTION)
-          .put("days", DAY_FUNCTION)
+          .put("months", MONTHS_FUNCTION)
           .put("day", DAY_FUNCTION)
-          .put("hours", HOUR_FUNCTION)
+          .put("days", DAYS_FUNCTION)
           .put("hour", HOUR_FUNCTION)
+          .put("hours", HOURS_FUNCTION)
           .put("bucket", BUCKET_FUNCTION)
           .put("truncate", TRUNCATE_FUNCTION)
           .build();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/YearsFunction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/YearsFunction.java
@@ -30,16 +30,16 @@ import org.apache.spark.sql.types.TimestampType;
 /**
  * A Spark function implementation for the Iceberg year transform.
  *
- * <p>Example usage: {@code SELECT system.year('source_col')}.
+ * <p>Example usage: {@code SELECT system.years('source_col')}.
  *
- * <p>Alternate form: {@code SELECT system.years('source_col')}.
+ * <p>Alternate form: {@code SELECT system.year('source_col')}.
  */
 public class YearsFunction extends UnaryUnboundFunction {
 
   private boolean singular;
 
   public YearsFunction() {
-    this(true);
+    this(false);
   }
 
   YearsFunction(boolean singular) {
@@ -92,7 +92,7 @@ public class YearsFunction extends UnaryUnboundFunction {
 
   public static class DateToYearsFunction extends BaseToYearsFunction {
     public DateToYearsFunction() {
-      this(true);
+      this(false);
     }
 
     DateToYearsFunction(boolean singular) {
@@ -123,7 +123,7 @@ public class YearsFunction extends UnaryUnboundFunction {
 
   public static class TimestampToYearsFunction extends BaseToYearsFunction {
     public TimestampToYearsFunction() {
-      this(true);
+      this(false);
     }
 
     TimestampToYearsFunction(boolean singular) {
@@ -154,7 +154,7 @@ public class YearsFunction extends UnaryUnboundFunction {
 
   public static class TimestampNtzToYearsFunction extends BaseToYearsFunction {
     public TimestampNtzToYearsFunction() {
-      this(true);
+      this(false);
     }
 
     TimestampNtzToYearsFunction(boolean singular) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/YearsFunction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/YearsFunction.java
@@ -31,6 +31,8 @@ import org.apache.spark.sql.types.TimestampType;
  * A Spark function implementation for the Iceberg year transform.
  *
  * <p>Example usage: {@code SELECT system.years('source_col')}.
+ *
+ * <p>Alternate form: {@code SELECT system.year('source_col')}.
  */
 public class YearsFunction extends UnaryUnboundFunction {
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDaysFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDaysFunction.java
@@ -86,6 +86,22 @@ public class TestSparkDaysFunction extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void testBuiltInDayFunction() {
+    assertThat(scalarSql("SELECT day(date('2017-12-01'))"))
+        .as("Expected to produce 1")
+        .isEqualTo(1);
+    assertThat(scalarSql("SELECT day(date('1969-12-31'))"))
+        .as("Expected to produce 31")
+        .isEqualTo(31);
+    assertThat(scalarSql("SELECT day(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+        .as("Expected to produce 1")
+        .isEqualTo(1);
+    assertThat(scalarSql("SELECT day(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999')"))
+        .as("Expected to produce 31")
+        .isEqualTo(31);
+  }
+
+  @TestTemplate
   public void testWrongNumberOfArguments() {
     assertThatThrownBy(() -> scalarSql("SELECT system.days()"))
         .isInstanceOf(AnalysisException.class)

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDaysFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDaysFunction.java
@@ -39,6 +39,9 @@ public class TestSparkDaysFunction extends TestBaseWithCatalog {
     assertThat(scalarSql("SELECT system.days(date('2017-12-01'))"))
         .as("Expected to produce 2017-12-01")
         .isEqualTo(Date.valueOf("2017-12-01"));
+    assertThat(scalarSql("SELECT system.day(date('2017-12-01'))"))
+        .as("Expected to produce 2017-12-01")
+        .isEqualTo(Date.valueOf("2017-12-01"));
     assertThat(scalarSql("SELECT system.days(date('1970-01-01'))"))
         .as("Expected to produce 1970-01-01")
         .isEqualTo(Date.valueOf("1970-01-01"));
@@ -53,6 +56,9 @@ public class TestSparkDaysFunction extends TestBaseWithCatalog {
     assertThat(scalarSql("SELECT system.days(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
         .as("Expected to produce 2017-12-01")
         .isEqualTo(Date.valueOf("2017-12-01"));
+    assertThat(scalarSql("SELECT system.day(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+        .as("Expected to produce 2017-12-01")
+        .isEqualTo(Date.valueOf("2017-12-01"));
     assertThat(scalarSql("SELECT system.days(TIMESTAMP '1970-01-01 00:00:01.000001 UTC+00:00')"))
         .as("Expected to produce 1970-01-01")
         .isEqualTo(Date.valueOf("1970-01-01"));
@@ -65,6 +71,9 @@ public class TestSparkDaysFunction extends TestBaseWithCatalog {
   @TestTemplate
   public void testTimestampNtz() {
     assertThat(scalarSql("SELECT system.days(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"))
+        .as("Expected to produce 2017-12-01")
+        .isEqualTo(Date.valueOf("2017-12-01"));
+    assertThat(scalarSql("SELECT system.day(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"))
         .as("Expected to produce 2017-12-01")
         .isEqualTo(Date.valueOf("2017-12-01"));
     assertThat(scalarSql("SELECT system.days(TIMESTAMP_NTZ '1970-01-01 00:00:01.000001 UTC')"))

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDaysFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDaysFunction.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.Date;
+import java.util.TimeZone;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.AnalysisException;
 import org.junit.jupiter.api.BeforeEach;
@@ -93,7 +94,8 @@ public class TestSparkDaysFunction extends TestBaseWithCatalog {
     assertThat(scalarSql("SELECT day(date('1969-12-31'))"))
         .as("Expected to produce 31")
         .isEqualTo(31);
-    assertThat(scalarSql("SELECT day(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+    String tz = TimeZone.getDefault().getID();
+    assertThat(scalarSql(String.format("SELECT day(TIMESTAMP '2017-12-01 10:12:55 %s')", tz)))
         .as("Expected to produce 1")
         .isEqualTo(1);
     assertThat(scalarSql("SELECT day(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999')"))

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDaysFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDaysFunction.java
@@ -91,6 +91,10 @@ public class TestSparkDaysFunction extends TestBaseWithCatalog {
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith("Function 'days' cannot process input: (): Wrong number of inputs");
 
+    assertThatThrownBy(() -> scalarSql("SELECT system.day()"))
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageStartingWith("Function 'day' cannot process input: (): Wrong number of inputs");
+
     assertThatThrownBy(
             () -> scalarSql("SELECT system.days(date('1969-12-31'), date('1969-12-31'))"))
         .isInstanceOf(AnalysisException.class)

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkHoursFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkHoursFunction.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.sql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.TimeZone;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.AnalysisException;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,6 +66,17 @@ public class TestSparkHoursFunction extends TestBaseWithCatalog {
         .as("Expected to produce -1")
         .isEqualTo(-1);
     assertThat(scalarSql("SELECT system.hours(CAST(null AS TIMESTAMP_NTZ))")).isNull();
+  }
+
+  @TestTemplate
+  public void testBuiltInHourFunction() {
+    String tz = TimeZone.getDefault().getID();
+    assertThat(scalarSql(String.format("SELECT hour(TIMESTAMP '2017-12-01 10:12:55 %s')", tz)))
+        .as("Expected to produce 10")
+        .isEqualTo(10);
+    assertThat(scalarSql("SELECT hour(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999')"))
+        .as("Expected to produce 23")
+        .isEqualTo(23);
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkHoursFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkHoursFunction.java
@@ -38,6 +38,9 @@ public class TestSparkHoursFunction extends TestBaseWithCatalog {
     assertThat(scalarSql("SELECT system.hours(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
         .as("Expected to produce 17501 * 24 + 10")
         .isEqualTo(420034);
+    assertThat(scalarSql("SELECT system.hour(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+        .as("Expected to produce 17501 * 24 + 10")
+        .isEqualTo(420034);
     assertThat(scalarSql("SELECT system.hours(TIMESTAMP '1970-01-01 00:00:01.000001 UTC+00:00')"))
         .as("Expected to produce 0 * 24 + 0 = 0")
         .isEqualTo(0);
@@ -50,6 +53,9 @@ public class TestSparkHoursFunction extends TestBaseWithCatalog {
   @TestTemplate
   public void testTimestampsNtz() {
     assertThat(scalarSql("SELECT system.hours(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"))
+        .as("Expected to produce 17501 * 24 + 10")
+        .isEqualTo(420034);
+    assertThat(scalarSql("SELECT system.hour(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"))
         .as("Expected to produce 17501 * 24 + 10")
         .isEqualTo(420034);
     assertThat(scalarSql("SELECT system.hours(TIMESTAMP_NTZ '1970-01-01 00:00:01.000001 UTC')"))

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkHoursFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkHoursFunction.java
@@ -74,6 +74,10 @@ public class TestSparkHoursFunction extends TestBaseWithCatalog {
         .hasMessageStartingWith(
             "Function 'hours' cannot process input: (): Wrong number of inputs");
 
+    assertThatThrownBy(() -> scalarSql("SELECT system.hour()"))
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageStartingWith("Function 'hour' cannot process input: (): Wrong number of inputs");
+
     assertThatThrownBy(
             () -> scalarSql("SELECT system.hours(date('1969-12-31'), date('1969-12-31'))"))
         .isInstanceOf(AnalysisException.class)

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkMonthsFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkMonthsFunction.java
@@ -93,7 +93,7 @@ public class TestSparkMonthsFunction extends TestBaseWithCatalog {
     assertThat(scalarSql("SELECT month(date('1969-12-31'))"))
         .as("Expected to produce 12")
         .isEqualTo(12);
-    assertThat(scalarSql("SELECT month(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+    assertThat(scalarSql("SELECT month(TIMESTAMP '2017-12-11 10:12:55.038194 UTC+00:00')"))
         .as("Expected to produce 12")
         .isEqualTo(12);
     assertThat(scalarSql("SELECT month(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999')"))

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkMonthsFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkMonthsFunction.java
@@ -39,6 +39,9 @@ public class TestSparkMonthsFunction extends TestBaseWithCatalog {
     assertThat(scalarSql("SELECT system.months(date('2017-12-01'))"))
         .as("Expected to produce 47 * 12 + 11 = 575")
         .isEqualTo(575);
+    assertThat(scalarSql("SELECT system.month(date('2017-12-01'))"))
+        .as("Expected to produce 47 * 12 + 11 = 575")
+        .isEqualTo(575);
     assertThat(scalarSql("SELECT system.months(date('1970-01-01'))"))
         .as("Expected to produce 0 * 12 + 0 = 0")
         .isEqualTo(0);
@@ -53,6 +56,9 @@ public class TestSparkMonthsFunction extends TestBaseWithCatalog {
     assertThat(scalarSql("SELECT system.months(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
         .as("Expected to produce 47 * 12 + 11 = 575")
         .isEqualTo(575);
+    assertThat(scalarSql("SELECT system.month(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+        .as("Expected to produce 47 * 12 + 11 = 575")
+        .isEqualTo(575);
     assertThat(scalarSql("SELECT system.months(TIMESTAMP '1970-01-01 00:00:01.000001 UTC+00:00')"))
         .as("Expected to produce 0 * 12 + 0 = 0")
         .isEqualTo(0);
@@ -65,6 +71,9 @@ public class TestSparkMonthsFunction extends TestBaseWithCatalog {
   @TestTemplate
   public void testTimestampNtz() {
     assertThat(scalarSql("SELECT system.months(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"))
+        .as("Expected to produce 47 * 12 + 11 = 575")
+        .isEqualTo(575);
+    assertThat(scalarSql("SELECT system.month(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"))
         .as("Expected to produce 47 * 12 + 11 = 575")
         .isEqualTo(575);
     assertThat(scalarSql("SELECT system.months(TIMESTAMP_NTZ '1970-01-01 00:00:01.000001 UTC')"))

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkMonthsFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkMonthsFunction.java
@@ -92,6 +92,11 @@ public class TestSparkMonthsFunction extends TestBaseWithCatalog {
         .hasMessageStartingWith(
             "Function 'months' cannot process input: (): Wrong number of inputs");
 
+    assertThatThrownBy(() -> scalarSql("SELECT system.month()"))
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageStartingWith(
+            "Function 'month' cannot process input: (): Wrong number of inputs");
+
     assertThatThrownBy(
             () -> scalarSql("SELECT system.months(date('1969-12-31'), date('1969-12-31'))"))
         .isInstanceOf(AnalysisException.class)
@@ -120,10 +125,18 @@ public class TestSparkMonthsFunction extends TestBaseWithCatalog {
         .asString()
         .isNotNull()
         .contains("staticinvoke(class " + dateTransformClass);
+    assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.month(%s)", dateValue))
+        .asString()
+        .isNotNull()
+        .contains("staticinvoke(class " + dateTransformClass);
 
     String timestampValue = "TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00'";
     String timestampTransformClass = MonthsFunction.TimestampToMonthsFunction.class.getName();
     assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.months(%s)", timestampValue))
+        .asString()
+        .isNotNull()
+        .contains("staticinvoke(class " + timestampTransformClass);
+    assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.month(%s)", timestampValue))
         .asString()
         .isNotNull()
         .contains("staticinvoke(class " + timestampTransformClass);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkMonthsFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkMonthsFunction.java
@@ -86,6 +86,22 @@ public class TestSparkMonthsFunction extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void testBuiltInMonthFunction() {
+    assertThat(scalarSql("SELECT month(date('2017-12-01'))"))
+        .as("Expected to produce 12")
+        .isEqualTo(12);
+    assertThat(scalarSql("SELECT month(date('1969-12-31'))"))
+        .as("Expected to produce 12")
+        .isEqualTo(12);
+    assertThat(scalarSql("SELECT month(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+        .as("Expected to produce 12")
+        .isEqualTo(12);
+    assertThat(scalarSql("SELECT month(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999')"))
+        .as("Expected to produce 12")
+        .isEqualTo(12);
+  }
+
+  @TestTemplate
   public void testWrongNumberOfArguments() {
     assertThatThrownBy(() -> scalarSql("SELECT system.months()"))
         .isInstanceOf(AnalysisException.class)

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkYearsFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkYearsFunction.java
@@ -86,6 +86,22 @@ public class TestSparkYearsFunction extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void testBuiltInYearFunction() {
+    assertThat(scalarSql("SELECT year(date('2017-12-01'))"))
+        .as("Expected to produce 2017")
+        .isEqualTo(2017);
+    assertThat(scalarSql("SELECT year(date('1969-12-31'))"))
+        .as("Expected to produce 1969")
+        .isEqualTo(1969);
+    assertThat(scalarSql("SELECT year(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+        .as("Expected to produce 2017")
+        .isEqualTo(2017);
+    assertThat(scalarSql("SELECT year(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999')"))
+        .as("Expected to produce 1969")
+        .isEqualTo(1969);
+  }
+
+  @TestTemplate
   public void testWrongNumberOfArguments() {
     assertThatThrownBy(() -> scalarSql("SELECT system.years()"))
         .isInstanceOf(AnalysisException.class)

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkYearsFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkYearsFunction.java
@@ -39,6 +39,9 @@ public class TestSparkYearsFunction extends TestBaseWithCatalog {
     assertThat(scalarSql("SELECT system.years(date('2017-12-01'))"))
         .as("Expected to produce 2017 - 1970 = 47")
         .isEqualTo(47);
+    assertThat(scalarSql("SELECT system.year(date('2017-12-01'))"))
+        .as("Expected to produce 2017 - 1970 = 47")
+        .isEqualTo(47);
     assertThat(scalarSql("SELECT system.years(date('1970-01-01'))"))
         .as("Expected to produce 1970 - 1970 = 0")
         .isEqualTo(0);
@@ -53,6 +56,9 @@ public class TestSparkYearsFunction extends TestBaseWithCatalog {
     assertThat(scalarSql("SELECT system.years(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
         .as("Expected to produce 2017 - 1970 = 47")
         .isEqualTo(47);
+    assertThat(scalarSql("SELECT system.year(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+        .as("Expected to produce 2017 - 1970 = 47")
+        .isEqualTo(47);
     assertThat(scalarSql("SELECT system.years(TIMESTAMP '1970-01-01 00:00:01.000001 UTC+00:00')"))
         .as("Expected to produce 1970 - 1970 = 0")
         .isEqualTo(0);
@@ -65,6 +71,9 @@ public class TestSparkYearsFunction extends TestBaseWithCatalog {
   @TestTemplate
   public void testTimestampNtz() {
     assertThat(scalarSql("SELECT system.years(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"))
+        .as("Expected to produce 2017 - 1970 = 47")
+        .isEqualTo(47);
+    assertThat(scalarSql("SELECT system.year(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"))
         .as("Expected to produce 2017 - 1970 = 47")
         .isEqualTo(47);
     assertThat(scalarSql("SELECT system.years(TIMESTAMP_NTZ '1970-01-01 00:00:01.000001 UTC')"))

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkYearsFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkYearsFunction.java
@@ -92,6 +92,10 @@ public class TestSparkYearsFunction extends TestBaseWithCatalog {
         .hasMessageStartingWith(
             "Function 'years' cannot process input: (): Wrong number of inputs");
 
+    assertThatThrownBy(() -> scalarSql("SELECT system.year()"))
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageStartingWith("Function 'year' cannot process input: (): Wrong number of inputs");
+
     assertThatThrownBy(
             () -> scalarSql("SELECT system.years(date('1969-12-31'), date('1969-12-31'))"))
         .isInstanceOf(AnalysisException.class)
@@ -120,10 +124,18 @@ public class TestSparkYearsFunction extends TestBaseWithCatalog {
         .asString()
         .isNotNull()
         .contains("staticinvoke(class " + dateTransformClass);
+    assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.year(%s)", dateValue))
+        .asString()
+        .isNotNull()
+        .contains("staticinvoke(class " + dateTransformClass);
 
     String timestampValue = "TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00'";
     String timestampTransformClass = YearsFunction.TimestampToYearsFunction.class.getName();
     assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.years(%s)", timestampValue))
+        .asString()
+        .isNotNull()
+        .contains("staticinvoke(class " + timestampTransformClass);
+    assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.year(%s)", timestampValue))
         .asString()
         .isNotNull()
         .contains("staticinvoke(class " + timestampTransformClass);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
@@ -189,8 +189,18 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void testJoinsWithYearOnDateColumn() throws NoSuchTableException {
+    checkJoin("date_col", "DATE", "year(date_col)");
+  }
+
+  @TestTemplate
   public void testJoinsWithMonthsOnTimestampColumn() throws NoSuchTableException {
     checkJoin("timestamp_col", "TIMESTAMP", "months(timestamp_col)");
+  }
+
+  @TestTemplate
+  public void testJoinsWithMonthOnTimestampColumn() throws NoSuchTableException {
+    checkJoin("timestamp_col", "TIMESTAMP", "month(timestamp_col)");
   }
 
   @TestTemplate
@@ -214,6 +224,11 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void testJoinsWithDayOnTimestampNtzColumn() throws NoSuchTableException {
+    checkJoin("timestamp_col", "TIMESTAMP_NTZ", "day(timestamp_col)");
+  }
+
+  @TestTemplate
   public void testJoinsWithDaysOnDateColumn() throws NoSuchTableException {
     checkJoin("date_col", "DATE", "days(date_col)");
   }
@@ -224,8 +239,18 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void testJoinsWithHourOnTimestampColumn() throws NoSuchTableException {
+    checkJoin("timestamp_col", "TIMESTAMP", "hour(timestamp_col)");
+  }
+
+  @TestTemplate
   public void testJoinsWithHoursOnTimestampNtzColumn() throws NoSuchTableException {
     checkJoin("timestamp_col", "TIMESTAMP_NTZ", "hours(timestamp_col)");
+  }
+
+  @TestTemplate
+  public void testJoinsWithHourOnTimestampNtzColumn() throws NoSuchTableException {
+    checkJoin("timestamp_col", "TIMESTAMP_NTZ", "hour(timestamp_col)");
   }
 
   @TestTemplate


### PR DESCRIPTION
Since Iceberg 1.4 ([#8192](https://github.com/apache/iceberg/pull/8192)), Spark has supported using the singular form (`year`, `month`, `day`, `hour`) of partition transforms to be consistent with the spec, while still supporting the plural form of those transforms for backward compatibility.
However, `SparkFunctions` still supported only the plural form (`years`, `months`, `days`, `hours`) for functions that can be used in queries.
For consistency, we add the singular form of those functions so the singular form can be used in queries as well.