### PR TITLE
Kafka Connect: Add kerberos authentication option

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/CatalogUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/CatalogUtils.java
@@ -30,7 +30,9 @@ import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.common.DynMethods.BoundMethod;
+import org.apache.iceberg.common.DynMethods.StaticMethod;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.kafka.common.config.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,8 +43,15 @@ class CatalogUtils {
       ImmutableList.of("core-site.xml", "hdfs-site.xml", "hive-site.xml");
 
   static Catalog loadCatalog(IcebergSinkConfig config) {
-    return CatalogUtil.buildIcebergCatalog(
-        config.catalogName(), config.catalogProps(), loadHadoopConfig(config));
+    Object hadoopConf = loadHadoopConfig(config);
+    if (config.kerberosAuthentication()) {
+      configureKerberosAuthentication(
+          hadoopConf,
+          config.connectHdfsPrincipal(),
+          config.connectHdfsKeytab(),
+          config.kerberosTicketRenewPeriodMs());
+    }
+    return CatalogUtil.buildIcebergCatalog(config.catalogName(), config.catalogProps(), hadoopConf);
   }
 
   // use reflection here to avoid requiring Hadoop as a dependency
@@ -92,6 +101,72 @@ class CatalogUtils {
           "Hadoop found on classpath but could not create config, proceeding without config", e);
     }
     return null;
+  }
+
+  private static void configureKerberosAuthentication(
+      Object hadoopConf, String principal, String keytabPath, long renewPeriod) {
+    if (principal == null || keytabPath == null) {
+      throw new ConfigException(
+          "Hadoop is using Kerberos for authentication, you need to provide both a connect "
+              + "principal and the path to the keytab of the principal.");
+    }
+
+    Class<?> configurationClass =
+        DynClasses.builder().impl("org.apache.hadoop.conf.Configuration").build();
+    Class<?> userGroupInformationClass =
+        DynClasses.builder().impl("org.apache.hadoop.security.UserGroupInformation").build();
+    if (configurationClass == null) {
+      throw new RuntimeException("Hadoop not found on classpath, not creating Hadoop config");
+    }
+    if (userGroupInformationClass == null) {
+      throw new RuntimeException(
+          "Hadoop security not found on classpath, unable to configure Kerberos authentication");
+    }
+
+    try {
+      StaticMethod setConfigurationMethod =
+          DynMethods.builder("setConfiguration")
+              .impl(userGroupInformationClass, configurationClass)
+              .buildStatic();
+      StaticMethod loginUserFromKeytabMethod =
+          DynMethods.builder("loginUserFromKeytab")
+              .impl(userGroupInformationClass, String.class, String.class)
+              .buildStatic();
+      StaticMethod getLoginUserMethod =
+          DynMethods.builder("getLoginUser").impl(userGroupInformationClass).buildStatic();
+
+      setConfigurationMethod.invoke(hadoopConf);
+      loginUserFromKeytabMethod.invoke(principal, keytabPath);
+      final Object ugi = getLoginUserMethod.invoke();
+      BoundMethod getUserNameMethod =
+          DynMethods.builder("getUserName").impl(userGroupInformationClass).build(ugi);
+      String userName = getUserNameMethod.invoke();
+      LOG.info("login as: {}", userName);
+
+      Thread ticketRenewThread =
+          new Thread(() -> renewKerberosTicket(userGroupInformationClass, ugi, renewPeriod));
+      ticketRenewThread.setDaemon(true);
+      LOG.info("Starting the Kerberos ticket renew with period {} ms.", renewPeriod);
+      ticketRenewThread.start();
+    } catch (Exception e) {
+      throw new RuntimeException("Could not authenticate with Kerberos: " + e.getMessage());
+    }
+  }
+
+  private static void renewKerberosTicket(Class<?> ugiClass, Object ugi, long renewPeriod) {
+    BoundMethod reloginFromKeytabMethod =
+        DynMethods.builder("reloginFromKeytab").impl(ugiClass).build(ugi);
+    BoundMethod getUserNameMethod = DynMethods.builder("getUserName").impl(ugiClass).build(ugi);
+    String userName = getUserNameMethod.invoke();
+    while (true) {
+      try {
+        Thread.sleep(renewPeriod);
+        LOG.info("Attempting to re-login from keytab for user {}", userName);
+        reloginFromKeytabMethod.invoke();
+      } catch (Exception e) {
+        LOG.error("Error renewing the ticket", e);
+      }
+    }
   }
 
   private CatalogUtils() {}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -89,6 +89,17 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String CONNECT_GROUP_ID_PROP = "iceberg.connect.group-id";
   private static final String HADOOP_CONF_DIR_PROP = "iceberg.hadoop-conf-dir";
 
+  private static final String HDFS_AUTHENTICATION_KERBEROS_PROP =
+      "iceberg.hdfs.authentication.kerberos";
+  private static final Boolean HDFS_AUTHENTICATION_KERBEROS_DEFAULT = false;
+  private static final String CONNECT_HDFS_PRINCIPAL_PROP = "iceberg.connect.hdfs.principal";
+  private static final String CONNECT_HDFS_PRINCIPAL_DEFAULT = "";
+  private static final String CONNECT_HDFS_KEYTAB_PROP = "iceberg.connect.hdfs.keytab";
+  private static final String CONNECT_HDFS_KEYTAB_DEFAULT = "";
+  private static final String KERBEROS_TICKET_RENEW_PERIOD_MS_PROP =
+      "kerberos.ticket.renew.period.ms";
+  private static final long KERBEROS_TICKET_RENEW_PERIOD_MS_DEFAULT = 60000 * 60;
+
   private static final String NAME_PROP = "name";
   private static final String BOOTSTRAP_SERVERS_PROP = "bootstrap.servers";
 
@@ -193,6 +204,30 @@ public class IcebergSinkConfig extends AbstractConfig {
         null,
         Importance.LOW,
         "Name of the Connect consumer group, should not be set under normal conditions");
+    configDef.define(
+        HDFS_AUTHENTICATION_KERBEROS_PROP,
+        ConfigDef.Type.BOOLEAN,
+        HDFS_AUTHENTICATION_KERBEROS_DEFAULT,
+        Importance.HIGH,
+        "Configuration indicating whether HDFS is using Kerberos for authentication");
+    configDef.define(
+        CONNECT_HDFS_PRINCIPAL_PROP,
+        ConfigDef.Type.STRING,
+        CONNECT_HDFS_PRINCIPAL_DEFAULT,
+        Importance.HIGH,
+        "The principal name to load from the keytab for Kerberos authentication");
+    configDef.define(
+        CONNECT_HDFS_KEYTAB_PROP,
+        ConfigDef.Type.STRING,
+        CONNECT_HDFS_KEYTAB_DEFAULT,
+        Importance.HIGH,
+        "The path to the keytab file for the HDFS connector principal. This keytab file should only be readable by the connector user");
+    configDef.define(
+        KERBEROS_TICKET_RENEW_PERIOD_MS_PROP,
+        ConfigDef.Type.LONG,
+        KERBEROS_TICKET_RENEW_PERIOD_MS_DEFAULT,
+        Importance.LOW,
+        "The period in milliseconds to renew the Kerberos ticket");
     configDef.define(
         COMMIT_INTERVAL_MS_PROP,
         ConfigDef.Type.INT,
@@ -379,6 +414,22 @@ public class IcebergSinkConfig extends AbstractConfig {
     String connectorName = connectorName();
     Preconditions.checkNotNull(connectorName, "Connector name cannot be null");
     return "connect-" + connectorName;
+  }
+
+  public boolean kerberosAuthentication() {
+    return getBoolean(HDFS_AUTHENTICATION_KERBEROS_PROP);
+  }
+
+  public String connectHdfsPrincipal() {
+    return getString(CONNECT_HDFS_PRINCIPAL_PROP);
+  }
+
+  public String connectHdfsKeytab() {
+    return getString(CONNECT_HDFS_KEYTAB_PROP);
+  }
+
+  public long kerberosTicketRenewPeriodMs() {
+    return getLong(KERBEROS_TICKET_RENEW_PERIOD_MS_PROP);
   }
 
   public int commitIntervalMs() {


### PR DESCRIPTION
Hi, I previously submitted a PR for the same feature, but I’m reposting it since the previous one was closed for some reason. You can find the full history in the [original PR](https://github.com/apache/iceberg/pull/10173).
To explain the background again, I wanted to use the Iceberg connector in an HDFS environment that requires Kerberos authentication, but I couldn’t because it doesn’t support it now. I’ve made some changes to the connect part to have an option for Kerberos authentication, referring to the HDFS sink connector which already supports it.

An example config would look like:
```
iceberg.hdfs.authentication.kerberos: true,
iceberg.connect.hdfs.principal: "user@EXAMPLE.COM",
iceberg.connect.hdfs.keytab: "/tmp/user.keytab",
kerberos.ticket.renew.period.ms: 3600000
```

One more thing, as you can see in the original PR, it wasn't accepted for quite a long time. I think I gave pretty convincing reasons why the connector itself should have this option since there's no way to inject it through the Hadoop configuration.

If you still think something is missing or have any concerns about this feature, please feel free to share. Thank you.