### PR TITLE
[docs] add spacing to "how to release"'s voting section

### DIFF
--- a/site/docs/how-to-release.md
+++ b/site/docs/how-to-release.md
@@ -450,8 +450,10 @@ Votes are cast by replying to the release candidate announcement email on the de
 with either `+1`, `0`, or `-1`.
 
 > [ ] +1 Release this as Apache Iceberg {{ icebergVersion }}
-[ ] +0
-[ ] -1 Do not release this because...
+>
+> [ ] +0
+>
+> [ ] -1 Do not release this because...
 
 In addition to your vote, it's customary to specify if your vote is binding or non-binding. Only members
 of the Project Management Committee have formally binding votes. If you're unsure, you can specify that your


### PR DESCRIPTION
Fix spacing issue in the "how to release" voting section, this was [already fixed in pyiceberg
](https://github.com/apache/iceberg-python/blob/985029042199d870f25b6fbec0e80907d4440f41/mkdocs/docs/verify-release.md#cast-the-vote)

Old:
https://iceberg.apache.org/how-to-release/#voting
![Screenshot 2025-01-28 at 10 58 24 AM](https://github.com/user-attachments/assets/73d3439f-ccf4-4fb7-a4b7-520723261a29)

New:
![Screenshot 2025-01-28 at 10 57 54 AM](https://github.com/user-attachments/assets/4da01ba0-5389-4f02-af33-cbc296ec785d)
