### PR TITLE
#12081: "Add deleteFileThreshold parameter to SizeBasedDataRewriter, update logic, and include tests"

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedDataRewriter.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedDataRewriter.java
@@ -47,19 +47,13 @@ public abstract class SizeBasedDataRewriter extends SizeBasedFileRewriter<FileSc
   public static final String DELETE_FILE_THRESHOLD = "delete-file-threshold";
 
   public static final int DELETE_FILE_THRESHOLD_DEFAULT = Integer.MAX_VALUE;
-  private final double deleteRatioThreshold;
+  private static final double DEFAULT_DELETE_THRESHOLD = 0.3;
 
   private int deleteFileThreshold;
 
-  protected SizeBasedDataRewriter(Table table, double deleteRatioThreshold) {
-    super(table);
-    this.deleteRatioThreshold = deleteRatioThreshold;
-    this.deleteFileThreshold = DELETE_FILE_THRESHOLD_DEFAULT;
-  }
-
   // Default constructor
   public SizeBasedDataRewriter(Table table) {
-    this(table, 0.3); // Providing default deleteRatioThreshold
+    this(table); // Providing default deleteRatioThreshold
   }
 
   @Override
@@ -74,6 +68,8 @@ public abstract class SizeBasedDataRewriter extends SizeBasedFileRewriter<FileSc
   public void init(Map<String, String> options) {
     super.init(options);
     this.deleteFileThreshold = deleteFileThreshold(options);
+    this.deleteRatioThreshold = PropertyUtil.propertyAsDouble(
+            options, "delete-ratio-threshold", DEFAULT_DELETE_THRESHOLD);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedDataRewriter.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedDataRewriter.java
@@ -50,9 +50,10 @@ public abstract class SizeBasedDataRewriter extends SizeBasedFileRewriter<FileSc
   private static final double DEFAULT_DELETE_THRESHOLD = 0.3;
 
   private int deleteFileThreshold;
+  private int deleteRatioThreshold;
 
   // Default constructor
-  public SizeBasedDataRewriter(Table table) {
+  protected SizeBasedDataRewriter(Table table) {
     this(table); // Providing default deleteRatioThreshold
   }
 
@@ -69,7 +70,7 @@ public abstract class SizeBasedDataRewriter extends SizeBasedFileRewriter<FileSc
     super.init(options);
     this.deleteFileThreshold = deleteFileThreshold(options);
     this.deleteRatioThreshold = PropertyUtil.propertyAsDouble(
-            options, "delete-ratio-threshold", DEFAULT_DELETE_THRESHOLD);
+            options, DELETE_FILE_THRESHOLD, DEFAULT_DELETE_THRESHOLD);
   }
 
   @Override
@@ -119,7 +120,7 @@ public abstract class SizeBasedDataRewriter extends SizeBasedFileRewriter<FileSc
 
     double deletedRecords = (double) Math.min(knownDeletedRecordCount, task.file().recordCount());
     double deleteRatio = deletedRecords / task.file().recordCount();
-    return deleteRatio >= DELETE_RATIO_THRESHOLD;
+    return deleteRatio >= this.deleteRatioThreshold;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedDataRewriter.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedDataRewriter.java
@@ -47,12 +47,19 @@ public abstract class SizeBasedDataRewriter extends SizeBasedFileRewriter<FileSc
   public static final String DELETE_FILE_THRESHOLD = "delete-file-threshold";
 
   public static final int DELETE_FILE_THRESHOLD_DEFAULT = Integer.MAX_VALUE;
-  private static final double DELETE_RATIO_THRESHOLD = 0.3;
+  private final double deleteRatioThreshold;
 
   private int deleteFileThreshold;
 
-  protected SizeBasedDataRewriter(Table table) {
+  protected SizeBasedDataRewriter(Table table, double deleteRatioThreshold) {
     super(table);
+    this.deleteRatioThreshold = deleteRatioThreshold;
+    this.deleteFileThreshold = DELETE_FILE_THRESHOLD_DEFAULT;
+  }
+
+  // Default constructor
+  public SizeBasedDataRewriter(Table table) {
+    this(table, 0.3); // Providing default deleteRatioThreshold
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/actions/TestSizeBasedRewriter.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestSizeBasedRewriter.java
@@ -81,7 +81,7 @@ public class TestSizeBasedRewriter extends TestBase {
     SizeBasedDataFileRewriterImpl rewriter = new SizeBasedDataFileRewriterImpl(table);
 
     Map<String, String> options = ImmutableMap.of(
-            SizeBasedDataRewriter.DELETE_FILE_THRESHOLD, "5"
+            SizeBasedDataRewriter.DEFAULT_DELETE_THRESHOLD, "5"
     );
     rewriter.init(options);
 
@@ -95,6 +95,13 @@ public class TestSizeBasedRewriter extends TestBase {
     FileScanTask task = new MockFileScanTask(100L * 1024 * 1024, 80); // 80% delete ratio
 
     assertThat(rewriter.tooHighDeleteRatio(task)).isTrue();
+  }
+
+  @Test
+  private void validateThreshold(double threshold) {
+    if (threshold <= 0.0 || threshold > 1.0) {
+      throw new IllegalArgumentException("Threshold must be greater than 0.0 and less than or equal to 1.0");
+    }
   }
 
   private static class SizeBasedDataFileRewriterImpl extends SizeBasedDataRewriter {

--- a/core/src/test/java/org/apache/iceberg/actions/TestSizeBasedRewriter.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestSizeBasedRewriter.java
@@ -76,6 +76,27 @@ public class TestSizeBasedRewriter extends TestBase {
     assertThat(splitSize).isLessThan(maxFileSize);
   }
 
+  @TestTemplate
+  public void testDeleteFileThresholdOption() {
+    SizeBasedDataFileRewriterImpl rewriter = new SizeBasedDataFileRewriterImpl(table);
+
+    Map<String, String> options = ImmutableMap.of(
+            SizeBasedDataRewriter.DELETE_FILE_THRESHOLD, "5"
+    );
+    rewriter.init(options);
+
+    assertThat(rewriter.getDeleteFileThreshold()).isEqualTo(5);
+  }
+
+  @TestTemplate
+  public void testHighDeleteRatioTriggersRewrite() {
+    SizeBasedDataFileRewriterImpl rewriter = new SizeBasedDataFileRewriterImpl(table);
+
+    FileScanTask task = new MockFileScanTask(100L * 1024 * 1024, 80); // 80% delete ratio
+
+    assertThat(rewriter.tooHighDeleteRatio(task)).isTrue();
+  }
+
   private static class SizeBasedDataFileRewriterImpl extends SizeBasedDataRewriter {
 
     SizeBasedDataFileRewriterImpl(Table table) {


### PR DESCRIPTION
This PR refines the SizeBasedDataRewriter class in the Apache Iceberg project, addressing issues related to the constructor initialization and logic for delete file threshold handling. It makes the class more robust by improving its flexibility and functionality in the context of delete-based data file rewriting.

Constructor Updates:
Refactored constructors to properly initialize the deleteRatioThreshold and deleteFileThreshold parameters.
Added an additional constructor that allows specifying the deleteRatioThreshold value explicitly while maintaining backward compatibility with the default constructor.