### PR TITLE
Core: Handle partition evolution case in PartitionStatsUtil#computeStats

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionStatsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStatsUtil.java
@@ -96,7 +96,10 @@ public class PartitionStatsUtil {
         StructLike key = keyTemplate.copyFor(coercedPartition);
         Snapshot snapshot = table.snapshot(entry.snapshotId());
         PartitionStats stats =
-            statsMap.computeIfAbsent(specId, key, () -> new PartitionStats(key, specId));
+            statsMap.computeIfAbsent(
+                specId,
+                ((PartitionData) file.partition()).copy(),
+                () -> new PartitionStats(key, specId));
         if (entry.isLive()) {
           stats.liveEntry(file, snapshot);
         } else {


### PR DESCRIPTION
**Description**:
`PartitionMap` creates internal wrappers based on table specs `partitionType`, however, we are passing coercedPartition with `unified partition type` considering all specs as a `KEY`, leading to wrong evaluation. 

https://github.com/apache/iceberg/issues/12168
 
**Repro**:
https://github.com/apache/hive/blob/master/iceberg/iceberg-handler/src/test/queries/positive/iceberg_bucket_map_join_4.q

**Testing**:
- TestPartitionStatsUtil#testPartitionStatsWithSchemaEvolution2