### PR TITLE
Variants: Implement toString

### DIFF
--- a/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
@@ -210,4 +210,9 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
 
     throw new UnsupportedOperationException("Unsupported primitive type: " + type());
   }
+
+  @Override
+  public String toString() {
+    return VariantPrimitive.asString(this);
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/variants/SerializedMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/variants/SerializedMetadata.java
@@ -111,4 +111,9 @@ class SerializedMetadata implements VariantMetadata, Variants.Serialized {
   public ByteBuffer buffer() {
     return metadata;
   }
+
+  @Override
+  public String toString() {
+    return VariantMetadata.asString(this);
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/variants/SerializedObject.java
+++ b/core/src/main/java/org/apache/iceberg/variants/SerializedObject.java
@@ -228,4 +228,9 @@ class SerializedObject extends Variants.SerializedValue implements VariantObject
   public int sizeInBytes() {
     return value.remaining();
   }
+
+  @Override
+  public String toString() {
+    return VariantObject.asString(this);
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/variants/SerializedPrimitive.java
+++ b/core/src/main/java/org/apache/iceberg/variants/SerializedPrimitive.java
@@ -127,4 +127,9 @@ class SerializedPrimitive extends Variants.SerializedValue implements VariantPri
   public ByteBuffer buffer() {
     return value;
   }
+
+  @Override
+  public String toString() {
+    return VariantPrimitive.asString(this);
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/variants/SerializedShortString.java
+++ b/core/src/main/java/org/apache/iceberg/variants/SerializedShortString.java
@@ -66,4 +66,9 @@ class SerializedShortString extends Variants.SerializedValue implements VariantP
   public ByteBuffer buffer() {
     return value;
   }
+
+  @Override
+  public String toString() {
+    return VariantPrimitive.asString(this);
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
+++ b/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
@@ -261,4 +261,9 @@ public class ShreddedObject implements VariantObject {
       return (dataOffset - offset) + dataSize;
     }
   }
+
+  @Override
+  public String toString() {
+    return VariantObject.asString(this);
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/variants/VariantMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/variants/VariantMetadata.java
@@ -34,4 +34,20 @@ public interface VariantMetadata extends Variants.Serialized {
 
   /** Returns the size of the metadata dictionary. */
   int dictionarySize();
+
+  static String asString(VariantMetadata metadata) {
+    StringBuilder builder = new StringBuilder();
+
+    builder.append("VariantMetadata(dict={");
+    for (int i = 0; i < metadata.dictionarySize(); i += 1) {
+      if (i > 0) {
+        builder.append(", ");
+      }
+
+      builder.append(i).append(" => ").append(metadata.get(i));
+    }
+    builder.append("})");
+
+    return builder.toString();
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/variants/VariantObject.java
+++ b/core/src/main/java/org/apache/iceberg/variants/VariantObject.java
@@ -38,4 +38,23 @@ public interface VariantObject extends VariantValue {
   default VariantObject asObject() {
     return this;
   }
+
+  static String asString(VariantObject object) {
+    StringBuilder builder = new StringBuilder();
+
+    builder.append("VariantObject(fields={");
+    boolean first = true;
+    for (String field : object.fieldNames()) {
+      if (first) {
+        first = false;
+      } else {
+        builder.append(", ");
+      }
+
+      builder.append(field).append(": ").append(object.get(field));
+    }
+    builder.append("})");
+
+    return builder.toString();
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/variants/VariantPrimitive.java
+++ b/core/src/main/java/org/apache/iceberg/variants/VariantPrimitive.java
@@ -18,6 +18,11 @@
  */
 package org.apache.iceberg.variants;
 
+import java.nio.ByteBuffer;
+import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
+import org.apache.iceberg.util.ByteBuffers;
+import org.apache.iceberg.util.DateTimeUtil;
+
 /** A primitive variant value. */
 public interface VariantPrimitive<T> extends VariantValue {
   T get();
@@ -25,5 +30,24 @@ public interface VariantPrimitive<T> extends VariantValue {
   @Override
   default VariantPrimitive<?> asPrimitive() {
     return this;
+  }
+
+  private String valueAsString() {
+    switch (type()) {
+      case DATE:
+        return DateTimeUtil.daysToIsoDate((Integer) get());
+      case TIMESTAMPTZ:
+        return DateTimeUtil.microsToIsoTimestamptz((Long) get());
+      case TIMESTAMPNTZ:
+        return DateTimeUtil.microsToIsoTimestamp((Long) get());
+      case BINARY:
+        return BaseEncoding.base16().encode(ByteBuffers.toByteArray((ByteBuffer) get()));
+      default:
+        return String.valueOf(get());
+    }
+  }
+
+  static String asString(VariantPrimitive<?> primitive) {
+    return "Variant(type=" + primitive.type() + ", value=" + primitive.valueAsString() + ")";
   }
 }


### PR DESCRIPTION
This implements `toString` for Variant classes, which is more friendly when reading parameterized test cases.