### PR TITLE
Fix NOTICE and LICENSE in the aws-bundle jar

### DIFF
--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -225,55 +225,55 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec  Version: 4.1.112.Final
+Group: io.netty  Name: netty-codec  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec-http  Version: 4.1.112.Final
+Group: io.netty  Name: netty-codec-http  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec-http2  Version: 4.1.112.Final
+Group: io.netty  Name: netty-codec-http2  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-common  Version: 4.1.112.Final
+Group: io.netty  Name: netty-common  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-handler  Version: 4.1.112.Final
+Group: io.netty  Name: netty-handler  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-resolver  Version: 4.1.112.Final
+Group: io.netty  Name: netty-resolver  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport  Version: 4.1.112.Final
+Group: io.netty  Name: netty-transport  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.112.Final
+Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.112.Final
+Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
@@ -297,215 +297,215 @@ License: CC0 - http://creativecommons.org/publicdomain/zero/1.0/
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: annotations  Version: 2.28.5
+Group: software.amazon.awssdk  Name: annotations  Version: 2.30.6
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: apache-client  Version: 2.28.5
+Group: software.amazon.awssdk  Name: apache-client  Version: 2.30.6
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: arns  Version: 2.28.5
+Group: software.amazon.awssdk  Name: arns  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: auth  Version: 2.28.5
+Group: software.amazon.awssdk  Name: auth  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-core  Version: 2.28.5
+Group: software.amazon.awssdk  Name: aws-core  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.28.5
+Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.28.5
+Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.28.5
+Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: checksums  Version: 2.28.5
+Group: software.amazon.awssdk  Name: checksums  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.28.5
+Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: crt-core  Version: 2.28.5
+Group: software.amazon.awssdk  Name: crt-core  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: dynamodb  Version: 2.28.5
+Group: software.amazon.awssdk  Name: dynamodb  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.28.5
+Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.30.6
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: glue  Version: 2.28.5
+Group: software.amazon.awssdk  Name: glue  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth  Version: 2.28.5
+Group: software.amazon.awssdk  Name: http-auth  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.28.5
+Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.28.5
+Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.28.5
+Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.28.5
+Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.28.5
+Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.30.6
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: iam  Version: 2.28.5
+Group: software.amazon.awssdk  Name: iam  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: identity-spi  Version: 2.28.5
+Group: software.amazon.awssdk  Name: identity-spi  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: json-utils  Version: 2.28.5
+Group: software.amazon.awssdk  Name: json-utils  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: kms  Version: 2.28.5
+Group: software.amazon.awssdk  Name: kms  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: lakeformation  Version: 2.28.5
+Group: software.amazon.awssdk  Name: lakeformation  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.28.5
+Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.30.6
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.28.5
+Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.30.6
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: profiles  Version: 2.28.5
+Group: software.amazon.awssdk  Name: profiles  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: protocol-core  Version: 2.28.5
+Group: software.amazon.awssdk  Name: protocol-core  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: regions  Version: 2.28.5
+Group: software.amazon.awssdk  Name: regions  Version: 2.30.6
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: s3  Version: 2.28.5
+Group: software.amazon.awssdk  Name: s3  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sdk-core  Version: 2.28.5
+Group: software.amazon.awssdk  Name: sdk-core  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sso  Version: 2.28.5
+Group: software.amazon.awssdk  Name: sso  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sts  Version: 2.28.5
+Group: software.amazon.awssdk  Name: sts  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.28.5
+Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.30.6
 Project URL: https://aws.amazon.com/sdkforjava
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: utils  Version: 2.28.5
+Group: software.amazon.awssdk  Name: utils  Version: 2.30.6
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk.crt  Name: aws-crt  Version: 0.30.6
+Group: software.amazon.awssdk.crt  Name: aws-crt  Version: 0.33.6
 Project URL: https://github.com/awslabs/aws-crt-java
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/aws-bundle/NOTICE
+++ b/aws-bundle/NOTICE
@@ -7,59 +7,43 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: commons-codec  Name: commons-codec  Version: 1.17.1
-
-src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
-contains test data from http://aspell.net/test/orig/batch0.tab.
-Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
-
-===============================================================================
-
-The content of package org.apache.commons.codec.language.bm has been translated
-from the original php source code available at http://stevemorse.org/phoneticinfo.htm
-with permission from the original authors.
-Original source copyright:
-Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
-
---------------------------------------------------------------------------------
-
-NOTICE for Group: software.amazon.awssdk  Name: annotations  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: apache-client  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: arns  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: auth  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: aws-core  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: checksums  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: crt-core  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: dynamodb  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: glue  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: http-auth  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: iam  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: identity-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: json-utils  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: kms  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: lakeformation  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: profiles  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: protocol-core  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: regions  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: retries  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: retries-spi  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: s3  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: sdk-core  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: sso  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: sts  Version: 2.28.5
-NOTICE for Group: software.amazon.awssdk  Name: utils  Version: 2.28.5
+NOTICE for Group: software.amazon.awssdk  Name: annotations  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: apache-client  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: arns  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: auth  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: aws-core  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: checksums  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: crt-core  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: dynamodb  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: glue  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: http-auth  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: iam  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: identity-spi  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: json-utils  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: kms  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: lakeformation  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: profiles  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: protocol-core  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: regions  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: retries  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: retries-spi  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: s3  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: sdk-core  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: sso  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: sts  Version: 2.30.6
+NOTICE for Group: software.amazon.awssdk  Name: utils  Version: 2.30.6
 
 AWS SDK for Java 2.0
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -82,7 +66,7 @@ The licenses for these third party components are included in LICENSE.txt
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.28.5
+NOTICE for Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.30.6
 
 # Jackson JSON processor
 
@@ -101,3 +85,280 @@ To find the details that apply to this artifact see the accompanying LICENSE fil
 A list of contributors may be found from CREDITS(-2.x) file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
+
+--------------------------------------------------------------------------------
+
+NOTICE for Group: io.netty  Name: netty-buffer                          Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-codec                           Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-codec-http                      Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-codec-http2                     Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-common                          Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-handler                         Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-resolver                        Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-transport                       Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-transport-classes-epoll         Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-transport-native-unix-common    Version: 4.1.115.Final
+
+|                             The Netty Project
+|                             =================
+| 
+| Please visit the Netty web site for more information:
+| 
+|   * https://netty.io/
+| 
+| Copyright 2014 The Netty Project
+| 
+| The Netty Project licenses this file to you under the Apache License,
+| version 2.0 (the "License"); you may not use this file except in compliance
+| with the License. You may obtain a copy of the License at:
+| 
+|   https://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+| WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+| License for the specific language governing permissions and limitations
+| under the License.
+| 
+| Also, please refer to each LICENSE.<component>.txt file, which is located in
+| the 'license' directory of the distribution file, for the license terms of the
+| components that this product depends on.
+| 
+| -------------------------------------------------------------------------------
+| This product contains the extensions to Java Collections Framework which has
+| been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jsr166y.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+|     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+| 
+| This product contains a modified version of Robert Harder's Public Domain
+| Base64 Encoder and Decoder, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.base64.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://iharder.sourceforge.net/current/java/base64/
+| 
+| This product contains a modified portion of 'Webbit', an event based
+| WebSocket and HTTP server, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.webbit.txt (BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/joewalnes/webbit
+| 
+| This product contains a modified portion of 'SLF4J', a simple logging
+| facade for Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.slf4j.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://www.slf4j.org/
+| 
+| This product contains a modified portion of 'Apache Harmony', an open source
+| Java SE, which can be obtained at:
+| 
+|   * NOTICE:
+|     * license/NOTICE.harmony.txt
+|   * LICENSE:
+|     * license/LICENSE.harmony.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://archive.apache.org/dist/harmony/
+| 
+| This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+| and decompression library written by Matthew J. Francis. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jbzip2.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jbzip2/
+| 
+| This product contains a modified portion of 'libdivsufsort', a C API library to construct
+| the suffix array and the Burrows-Wheeler transformed string for any input string of
+| a constant-size alphabet written by Yuta Mori. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.libdivsufsort.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/y-256/libdivsufsort
+| 
+| This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+|  which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jctools.txt (ASL2 License)
+|   * HOMEPAGE:
+|     * https://github.com/JCTools/JCTools
+| 
+| This product optionally depends on 'JZlib', a re-implementation of zlib in
+| pure Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jzlib.txt (BSD style License)
+|   * HOMEPAGE:
+|     * http://www.jcraft.com/jzlib/
+| 
+| This product optionally depends on 'Compress-LZF', a Java library for encoding and
+| decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/ning/compress
+| 
+| This product optionally depends on 'lz4', a LZ4 Java compression
+| and decompression library written by Adrien Grand. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lz4.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jpountz/lz4-java
+| 
+| This product optionally depends on 'lzma-java', a LZMA Java compression
+| and decompression library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lzma-java.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jponge/lzma-java
+| 
+| This product optionally depends on 'zstd-jni', a zstd-jni Java compression
+| and decompression library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.zstd-jni.txt (BSD)
+|   * HOMEPAGE:
+|     * https://github.com/luben/zstd-jni
+| 
+| This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+| and decompression library written by William Kinney. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jfastlz.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jfastlz/
+| 
+| This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+| interchange format, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.protobuf.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/protobuf
+| 
+| This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+| a temporary self-signed X.509 certificate when the JVM does not provide the
+| equivalent functionality.  It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.bouncycastle.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://www.bouncycastle.org/
+| 
+| This product optionally depends on 'Snappy', a compression library produced
+| by Google Inc, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.snappy.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/snappy
+| 
+| This product optionally depends on 'JBoss Marshalling', an alternative Java
+| serialization API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jboss-remoting/jboss-marshalling
+| 
+| This product optionally depends on 'Caliper', Google's micro-
+| benchmarking framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.caliper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/google/caliper
+| 
+| This product optionally depends on 'Apache Commons Logging', a logging
+| framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-logging.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/logging/
+| 
+| This product optionally depends on 'Apache Log4J', a logging framework, which
+| can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.log4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://logging.apache.org/log4j/
+| 
+| This product optionally depends on 'Aalto XML', an ultra-high performance
+| non-blocking XML processor, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://wiki.fasterxml.com/AaltoHome
+| 
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.hpack.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/twitter/hpack
+|     
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.hyper-hpack.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/python-hyper/hpack/
+| 
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.nghttp2-hpack.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/nghttp2/nghttp2/
+| 
+| This product contains a modified portion of 'Apache Commons Lang', a Java library
+| provides utilities for the java.lang API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-lang.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/proper/commons-lang/
+| 
+| 
+| This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+| 
+|   * LICENSE:
+|     * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/takari/maven-wrapper
+| 
+| This product contains the dnsinfo.h header file, that provides a way to retrieve the system DNS configuration on MacOS.
+| This private header is also used by Apple's open source
+|  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
+| 
+|  * LICENSE:
+|     * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
+|   * HOMEPAGE:
+|     * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+| 
+| This product optionally depends on 'Brotli4j', Brotli compression and
+| decompression for Java., which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.brotli4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/hyperxpro/Brotli4j


### PR DESCRIPTION
This fixes:
- Update versions in both `LICENSE` and `NOTICE`
- Add/update `NOTICE` with `netty`