### PR TITLE
Fix NOTICE and LICENSE in the azure-bundle jar

### DIFF
--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -207,80 +207,68 @@ This binary artifact contains code from the following projects:
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-core-http-netty  Version: 1.13.5
+Group: com.azure  Name: azure-core-http-netty  Version: 1.15.7
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-identity  Version: 1.9.2
+Group: com.azure  Name: azure-identity  Version: 1.14.2
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-json  Version: 1.0.1
+Group: com.azure  Name: azure-json  Version: 1.3.0
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-storage-blob  Version: 12.23.0
+Group: com.azure  Name: azure-storage-blob  Version: 12.29.0
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-storage-common  Version: 12.22.0
+Group: com.azure  Name: azure-storage-common  Version: 12.28.0
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-storage-file-datalake  Version: 12.16.0
+Group: com.azure  Name: azure-storage-file-datalake  Version: 12.22.0
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-storage-internal-avro  Version: 12.8.0
+Group: com.azure  Name: azure-storage-internal-avro  Version: 12.14.0
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.13.5
+Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.17.2
 Project URL: http://github.com/FasterXML/jackson
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.13.5
+Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.17.2
 Project URL: https://github.com/FasterXML/jackson-core
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.13.5
+Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.17.2
 Project URL: http://github.com/FasterXML/jackson
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.13.5
-Project URL: https://github.com/FasterXML/jackson-dataformat-xml
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.13.5
+Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.17.2
 Project URL: https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.woodstox  Name: woodstox-core  Version: 6.4.0
-Project URL: https://github.com/FasterXML/woodstox
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
@@ -291,19 +279,19 @@ License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.
 
 --------------------------------------------------------------------------------
 
-Group: com.microsoft.azure  Name: msal4j  Version: 1.13.8
+Group: com.microsoft.azure  Name: msal4j  Version: 1.17.2
 Project URL: https://github.com/AzureAD/microsoft-authentication-library-for-java
 License: MIT License
 
 --------------------------------------------------------------------------------
 
-Group: com.microsoft.azure  Name: msal4j-persistence-extension  Version: 1.2.0
+Group: com.microsoft.azure  Name: msal4j-persistence-extension  Version: 1.3.0
 Project URL: https://github.com/AzureAD/microsoft-authentication-extensions-for-java
 License: MIT License
 
 --------------------------------------------------------------------------------
 
-Group: com.nimbusds  Name: content-type  Version: 2.2
+Group: com.nimbusds  Name: content-type  Version: 2.3
 Project URL: https://bitbucket.org/connect2id/nimbus-content-type
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -315,157 +303,157 @@ License: The Apache Software License, Version 2.0 - https://www.apache.org/licen
 
 --------------------------------------------------------------------------------
 
-Group: com.nimbusds  Name: nimbus-jose-jwt  Version: 9.30.2
+Group: com.nimbusds  Name: nimbus-jose-jwt  Version: 9.40
 Project URL: https://bitbucket.org/connect2id/nimbus-jose-jwt
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.nimbusds  Name: oauth2-oidc-sdk  Version: 10.7.1
+Group: com.nimbusds  Name: oauth2-oidc-sdk  Version: 11.18
 Project URL: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
 License: Apache License, version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-buffer  Version: 4.1.94.Final
+Group: io.netty  Name: netty-buffer  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec  Version: 4.1.94.Final
+Group: io.netty  Name: netty-codec  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec-dns  Version: 4.1.93.Final
+Group: io.netty  Name: netty-codec-dns  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec-http  Version: 4.1.94.Final
+Group: io.netty  Name: netty-codec-http  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec-http2  Version: 4.1.94.Final
+Group: io.netty  Name: netty-codec-http2  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec-socks  Version: 4.1.94.Final
+Group: io.netty  Name: netty-codec-socks  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-common  Version: 4.1.94.Final
+Group: io.netty  Name: netty-common  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-handler  Version: 4.1.94.Final
+Group: io.netty  Name: netty-handler  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-handler-proxy  Version: 4.1.94.Final
+Group: io.netty  Name: netty-handler-proxy  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-resolver  Version: 4.1.94.Final
+Group: io.netty  Name: netty-resolver  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-resolver-dns  Version: 4.1.93.Final
+Group: io.netty  Name: netty-resolver-dns  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-resolver-dns-classes-macos  Version: 4.1.93.Final
+Group: io.netty  Name: netty-resolver-dns-classes-macos  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-resolver-dns-native-macos  Version: 4.1.93.Final
+Group: io.netty  Name: netty-resolver-dns-native-macos  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-tcnative-boringssl-static  Version: 2.0.61.Final
+Group: io.netty  Name: netty-tcnative-boringssl-static  Version: 2.0.69.Final
 Project URL: https://github.com/netty/netty-tcnative/netty-tcnative-boringssl-static/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-tcnative-classes  Version: 2.0.61.Final
+Group: io.netty  Name: netty-tcnative-classes  Version: 2.0.69.Final
 Project URL: https://netty.io/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport  Version: 4.1.94.Final
+Group: io.netty  Name: netty-transport  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.94.Final
+Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-classes-kqueue  Version: 4.1.94.Final
+Group: io.netty  Name: netty-transport-classes-kqueue  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-native-epoll  Version: 4.1.94.Final
+Group: io.netty  Name: netty-transport-native-epoll  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-native-kqueue  Version: 4.1.94.Final
+Group: io.netty  Name: netty-transport-native-kqueue  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.94.Final
+Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.115.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.projectreactor  Name: reactor-core  Version: 3.4.30
+Group: io.projectreactor  Name: reactor-core  Version: 3.4.41
 Project URL: https://github.com/reactor/reactor-core
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.projectreactor.netty  Name: reactor-netty-core  Version: 1.0.33
+Group: io.projectreactor.netty  Name: reactor-netty-core  Version: 1.0.48
 Project URL: https://github.com/reactor/reactor-netty
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.projectreactor.netty  Name: reactor-netty-http  Version: 1.0.33
+Group: io.projectreactor.netty  Name: reactor-netty-http  Version: 1.0.48
 Project URL: https://github.com/reactor/reactor-netty
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -483,25 +471,19 @@ License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: net.minidev  Name: accessors-smart  Version: 2.4.9
+Group: net.minidev  Name: accessors-smart  Version: 2.5.1
 Project URL: https://urielch.github.io/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: net.minidev  Name: json-smart  Version: 2.4.10
+Group: net.minidev  Name: json-smart  Version: 2.5.1
 Project URL: https://urielch.github.io/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.codehaus.woodstox  Name: stax2-api  Version: 4.2.1
-Project URL: http://github.com/FasterXML/stax2-api
-License: The BSD License - http://www.opensource.org/licenses/bsd-license.php
-
---------------------------------------------------------------------------------
-
-Group: org.ow2.asm  Name: asm  Version: 9.3
+Group: org.ow2.asm  Name: asm  Version: 9.6
 Project URL: http://asm.ow2.io/
 License: BSD-3-Clause - https://asm.ow2.io/license.html
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/azure-bundle/NOTICE
+++ b/azure-bundle/NOTICE
@@ -7,24 +7,311 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.13.5
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.13.5
-NOTICE for Group: com.fasterxml.jackson.dataformat  Name: jackson-dataformat-xml  Version: 2.13.5
+NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.17.2
+NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.17.2
 
-# Jackson JSON processor
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Licensing
+| 
+| Jackson 2.x core and extension components are licensed under Apache License 2.0
+| To find the details that apply to this artifact see the accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS(-2.x) file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
 
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
+--------------------------------------------------------------------------------
 
-## Licensing
+NOTICE for Group: io.netty  Name: netty-buffer  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-codec  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-codec-dns  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-codec-http  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-codec-http2  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-codec-socks  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-common  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-handler  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-handler-proxy  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-resolver  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-resolver-dns  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-resolver-dns-classes-macos  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-resolver-dns-native-macos  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-tcnative-boringssl-static  Version: 2.0.69.Final
+NOTICE for Group: io.netty  Name: netty-tcnative-classes  Version: 2.0.69.Final
+NOTICE for Group: io.netty  Name: netty-transport  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-transport-classes-kqueue  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-transport-native-epoll  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-transport-native-kqueue  Version: 4.1.115.Final
+NOTICE for Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.115.Final
 
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
+|                             The Netty Project
+|                             =================
+| 
+| Please visit the Netty web site for more information:
+| 
+|   * https://netty.io/
+| 
+| Copyright 2014 The Netty Project
+| 
+| The Netty Project licenses this file to you under the Apache License,
+| version 2.0 (the "License"); you may not use this file except in compliance
+| with the License. You may obtain a copy of the License at:
+| 
+|   https://www.apache.org/licenses/LICENSE-2.0
+| 
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+| WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+| License for the specific language governing permissions and limitations
+| under the License.
+| 
+| Also, please refer to each LICENSE.<component>.txt file, which is located in
+| the 'license' directory of the distribution file, for the license terms of the
+| components that this product depends on.
+| 
+| -------------------------------------------------------------------------------
+| This product contains the extensions to Java Collections Framework which has
+| been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jsr166y.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+|     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+| 
+| This product contains a modified version of Robert Harder's Public Domain
+| Base64 Encoder and Decoder, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.base64.txt (Public Domain)
+|   * HOMEPAGE:
+|     * http://iharder.sourceforge.net/current/java/base64/
+| 
+| This product contains a modified portion of 'Webbit', an event based
+| WebSocket and HTTP server, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.webbit.txt (BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/joewalnes/webbit
+| 
+| This product contains a modified portion of 'SLF4J', a simple logging
+| facade for Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.slf4j.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://www.slf4j.org/
+| 
+| This product contains a modified portion of 'Apache Harmony', an open source
+| Java SE, which can be obtained at:
+| 
+|   * NOTICE:
+|     * license/NOTICE.harmony.txt
+|   * LICENSE:
+|     * license/LICENSE.harmony.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://archive.apache.org/dist/harmony/
+| 
+| This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+| and decompression library written by Matthew J. Francis. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jbzip2.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jbzip2/
+| 
+| This product contains a modified portion of 'libdivsufsort', a C API library to construct
+| the suffix array and the Burrows-Wheeler transformed string for any input string of
+| a constant-size alphabet written by Yuta Mori. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.libdivsufsort.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/y-256/libdivsufsort
+| 
+| This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+|  which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jctools.txt (ASL2 License)
+|   * HOMEPAGE:
+|     * https://github.com/JCTools/JCTools
+| 
+| This product optionally depends on 'JZlib', a re-implementation of zlib in
+| pure Java, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jzlib.txt (BSD style License)
+|   * HOMEPAGE:
+|     * http://www.jcraft.com/jzlib/
+| 
+| This product optionally depends on 'Compress-LZF', a Java library for encoding and
+| decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/ning/compress
+| 
+| This product optionally depends on 'lz4', a LZ4 Java compression
+| and decompression library written by Adrien Grand. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lz4.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jpountz/lz4-java
+| 
+| This product optionally depends on 'lzma-java', a LZMA Java compression
+| and decompression library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.lzma-java.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jponge/lzma-java
+| 
+| This product optionally depends on 'zstd-jni', a zstd-jni Java compression
+| and decompression library, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.zstd-jni.txt (BSD)
+|   * HOMEPAGE:
+|     * https://github.com/luben/zstd-jni
+| 
+| This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+| and decompression library written by William Kinney. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jfastlz.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://code.google.com/p/jfastlz/
+| 
+| This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+| interchange format, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.protobuf.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/protobuf
+| 
+| This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+| a temporary self-signed X.509 certificate when the JVM does not provide the
+| equivalent functionality.  It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.bouncycastle.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://www.bouncycastle.org/
+| 
+| This product optionally depends on 'Snappy', a compression library produced
+| by Google Inc, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.snappy.txt (New BSD License)
+|   * HOMEPAGE:
+|     * https://github.com/google/snappy
+| 
+| This product optionally depends on 'JBoss Marshalling', an alternative Java
+| serialization API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/jboss-remoting/jboss-marshalling
+| 
+| This product optionally depends on 'Caliper', Google's micro-
+| benchmarking framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.caliper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/google/caliper
+| 
+| This product optionally depends on 'Apache Commons Logging', a logging
+| framework, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-logging.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/logging/
+| 
+| This product optionally depends on 'Apache Log4J', a logging framework, which
+| can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.log4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://logging.apache.org/log4j/
+| 
+| This product optionally depends on 'Aalto XML', an ultra-high performance
+| non-blocking XML processor, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://wiki.fasterxml.com/AaltoHome
+| 
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.hpack.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/twitter/hpack
+|     
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.hyper-hpack.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/python-hyper/hpack/
+| 
+| This product contains a modified version of 'HPACK', a Java implementation of
+| the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.nghttp2-hpack.txt (MIT License)
+|   * HOMEPAGE:
+|     * https://github.com/nghttp2/nghttp2/
+| 
+| This product contains a modified portion of 'Apache Commons Lang', a Java library
+| provides utilities for the java.lang API, which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.commons-lang.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://commons.apache.org/proper/commons-lang/
+| 
+| 
+| This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+| 
+|   * LICENSE:
+|     * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/takari/maven-wrapper
+| 
+| This product contains the dnsinfo.h header file, that provides a way to retrieve the system DNS configuration on MacOS.
+| This private header is also used by Apple's open source
+|  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
+| 
+|  * LICENSE:
+|     * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
+|   * HOMEPAGE:
+|     * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+| 
+| This product optionally depends on 'Brotli4j', Brotli compression and
+| decompression for Java., which can be obtained at:
+| 
+|   * LICENSE:
+|     * license/LICENSE.brotli4j.txt (Apache License 2.0)
+|   * HOMEPAGE:
+|     * https://github.com/hyperxpro/Brotli4j


### PR DESCRIPTION
This fixes `LICENSE` and `NOTICE` in the azure-bundle jar with:
- Update the versions
- Remove `jackson-dataformat-xml` as it's not in the runtime classpath and the jar
- Remove `woodstox-core` as it's not in the runtime classpath and the jar
- Add Netty `NOTICE` content in azure-bundle `NOTICE`