### PR TITLE
Spec: Fix current-version-id in View Spec example

### DIFF
--- a/format/view-spec.md
+++ b/format/view-spec.md
@@ -263,7 +263,7 @@ s3://bucket/warehouse/default.db/event_agg/metadata/00002-(uuid).metadata.json
   "view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",
   "format-version" : 1,
   "location" : "s3://bucket/warehouse/default.db/event_agg",
-  "current-version-id" : 1,
+  "current-version-id" : 2,
   "properties" : {
     "comment" : "Daily event counts"
   },


### PR DESCRIPTION
The example given [in the View Spec](https://iceberg.apache.org/view-spec/#appendix-a-an-example) demonstrates creation of a new version of a View. The new metadata file should list the `current-version-id` as `2` but currently lists `1`. This PR is intended to fix that discrepancy and prevent potential confusion around the behavior of `current-version-id` in View metadata files.