### PR TITLE
Core: Remove `TableMetadata::Builder::resetMainBranch`

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1310,13 +1310,7 @@ public class TableMetadata implements Serializable {
     }
 
     private Builder resetMainBranch() {
-      this.currentSnapshotId = -1;
-      SnapshotRef ref = refs.remove(SnapshotRef.MAIN_BRANCH);
-      if (ref != null) {
-        changes.add(new MetadataUpdate.RemoveSnapshotRef(SnapshotRef.MAIN_BRANCH));
-      }
-
-      return this;
+      return removeRef(SnapshotRef.MAIN_BRANCH);
     }
 
     /**

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -722,7 +722,7 @@ public class TableMetadata implements Serializable {
 
     return new Builder(this)
         .upgradeFormatVersion(newFormatVersion)
-        .resetMainBranch()
+        .removeRef(SnapshotRef.MAIN_BRANCH)
         .setCurrentSchema(freshSchema, newLastColumnId.get())
         .setDefaultPartitionSpec(freshSpec)
         .setDefaultSortOrder(freshSortOrder)
@@ -1307,10 +1307,6 @@ public class TableMetadata implements Serializable {
       }
 
       return this;
-    }
-
-    private Builder resetMainBranch() {
-      return removeRef(SnapshotRef.MAIN_BRANCH);
     }
 
     /**


### PR DESCRIPTION
The private method `TableMetadata::Builder::resetMainBranch` used once is equivalent to `TableMetadata::Builder::removeRef(SnapshotRef.MAIN_BRANCH)`, so this PR removes it.