### PR TITLE
Data: open file using stats in scan

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/GenericReader.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericReader.java
@@ -92,7 +92,7 @@ class GenericReader implements Serializable {
   }
 
   private CloseableIterable<Record> openFile(FileScanTask task, Schema fileProjection) {
-    InputFile input = io.newInputFile(task.file().location());
+    InputFile input = io.newInputFile(task.file());
     Map<Integer, ?> partition =
         PartitionUtil.constantsMap(task, IdentityPartitionConverters::convertConstant);
 


### PR DESCRIPTION
When using `GenericReader`, e.g. via `IcebergGenerics`, to scan data in a table, the data file is opened using the location only. This PR passes in the `DataFile` object instead, so that the file length stat can be used. In `S3FileIO`, for example, if you don't pass in the file length then it will make an S3 head request to get the file length.