### PR TITLE
spec: Remove `source-ids` for `V{1,2}` tables

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -1379,7 +1379,7 @@ Each partition field in `fields` is stored as a JSON object with the following p
 | V1       | V2       | V3       | Field            | JSON representation | Example      |
 |----------|----------|----------|------------------|---------------------|--------------|
 | required | required | omitted  | **`source-id`**  | `JSON int`          | 1            |
-| optional | optional | required | **`source-ids`** | `JSON list of ints` | `[1,2]`      |
+|          |          | required | **`source-ids`** | `JSON list of ints` | `[1,2]`      |
 |          | required | required | **`field-id`**   | `JSON int`          | 1000         |
 | required | required | required | **`name`**       | `JSON string`       | `id_bucket`  |
 | required | required | required | **`transform`**  | `JSON string`       | `bucket[16]` |
@@ -1400,7 +1400,7 @@ In some cases partition specs are stored using only the field list instead of th
 
 The `field-id` property was added for each partition field in v2. In v1, the reference implementation assigned field ids sequentially in each spec starting at 1,000. See Partition Evolution for more details.
 
-In v3 metadata, writers must use only `source-ids` because v3 requires reader support for multi-arg transforms. In v1 and v2 metadata, writers must always write `source-id`; for multi-arg transforms, writers must produce `source-ids` and set `source-id` to the first ID from the field ID list.
+In v3 metadata, writers must use only `source-ids` because v3 requires reader support for multi-arg transforms.
 
 Older versions of the reference implementation can read tables with transforms unknown to it, ignoring them. But other implementations may break if they encounter unknown transforms. All v3 readers are required to read tables with unknown transforms, ignoring them. Writers should not write using partition specs that use unknown transforms.
 
@@ -1423,7 +1423,7 @@ Each sort field in the fields list is stored as an object with the following pro
 | required | required | required | **`direction`**  | `JSON string`       | `asc`       |
 | required | required | required | **`null-order`** | `JSON string`       | `nulls-last`|
 
-In v3 metadata, writers must use only `source-ids` because v3 requires reader support for multi-arg transforms. In v1 and v2 metadata, writers must always write `source-id`; for multi-arg transforms, writers must produce `source-ids` and set `source-id` to the first ID from the field ID list.
+In v3 metadata, writers must use only `source-ids` because v3 requires reader support for multi-arg transforms.
 
 Older versions of the reference implementation can read tables with transforms unknown to it, ignoring them. But other implementations may break if they encounter unknown transforms. All v3 readers are required to read tables with unknown transforms, ignoring them.
 
@@ -1563,12 +1563,6 @@ Reading v1 or v2 metadata for v3:
 
 * Partition Field and Sort Field JSON:
     * `source-ids` should default to a single-value list of the value of `source-id`
-
-Writing v1 or v2 metadata:
-
-* Partition Field and Sort Field JSON:
-    * For a single-arg transform, `source-id` should be written; if `source-ids` is also written it should be a single-element list of `source-id`
-    * For multi-arg transforms, `source-ids` should be written; `source-id` should be set to the first element of `source-ids`
 
 Row-level delete changes:
 


### PR DESCRIPTION
I was looking at adding support for `source-ids` in PyIceberg, but noticed that it was also still lacking for Java.

I've noticed that `source-ids` are also backported to V1 and V2 tables, which surprised me since this might break existing V2 implementations that are unaware of the `source-ids`.

This PR reconsiders https://github.com/apache/iceberg/pull/9661
And more specifically: https://lists.apache.org/thread/9opgkrpqhzp3nl8hdohgnk1m1zxnxmq0

It would be good to only allow multi-arg transforms from V3 onwards, and avoid having some implementations support this by setting a flag. Other implementations might not be aware of this implementation and drop the 2nd argument onward:

```json
{
  "source-id": 19,
  "source-ids": [19, 25],
  "field-id": 1000,
  "name": "ts_bucket",
  "transform": "bucket"
}
```

The V2 implementation that is unaware of the `source-ids` (PyIceberg, Iceberg-Rust and others), would produce:

```json
{
  "source-id": 19,
  "field-id": 1000,
  "name": "ts_bucket",
  "transform": "bucket"
}
```

Breaking the partitioning silently 😱 

cc @rdblue @szehon-ho @advancedxy @jbonofre 