### PR TITLE
API: Null check for auto-unboxed field id in builder

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -609,7 +609,7 @@ public class Types {
       }
 
       public NestedField build() {
-        Preconditions.checkNotNull(id, "id cannot be null");
+        Preconditions.checkNotNull(id, "Id cannot be null");
         // the constructor validates the other fields
         return new NestedField(isOptional, id, name, type, doc, initialDefault, writeDefault);
       }

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -609,7 +609,8 @@ public class Types {
       }
 
       public NestedField build() {
-        // the constructor validates the fields
+        Preconditions.checkNotNull(id, "id cannot be null");
+        // the constructor validates the other fields
         return new NestedField(isOptional, id, name, type, doc, initialDefault, writeDefault);
       }
     }

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.types;
 
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -46,5 +48,16 @@ public class TestTypes {
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> Types.fromPrimitiveString("abcdefghij"))
         .withMessage("Cannot parse type string to primitive: abcdefghij");
+  }
+
+  @Test
+  public void testNestedFieldBuilderIdCheck() {
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> optional("field").ofType(Types.StringType.get()).build())
+        .withMessage("id cannot be null");
+
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> required("field").ofType(Types.StringType.get()).build())
+        .withMessage("id cannot be null");
   }
 }

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -54,7 +54,7 @@ public class TestTypes {
   public void testNestedFieldBuilderIdCheck() {
     assertThatExceptionOfType(NullPointerException.class)
         .isThrownBy(() -> optional("field").ofType(Types.StringType.get()).build())
-        .withMessage("id cannot be null");
+        .withMessage("Id cannot be null");
 
     assertThatExceptionOfType(NullPointerException.class)
         .isThrownBy(() -> required("field").ofType(Types.StringType.get()).build())

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -58,6 +58,6 @@ public class TestTypes {
 
     assertThatExceptionOfType(NullPointerException.class)
         .isThrownBy(() -> required("field").ofType(Types.StringType.get()).build())
-        .withMessage("id cannot be null");
+        .withMessage("Id cannot be null");
   }
 }


### PR DESCRIPTION
The NestedField builder relies on the NestedField constructor to validate values, but the builder uses `Integer` for the id value whereas the constructor uses `int`.  

This results in a confusing auto-unboxing related NPE if a field id is not provided to the builder.  This PR adds a check prior to the auto-unboxing to provide a reasonable message that the field id is required.