### PR TITLE
Core: Refactor variants to enable moving interfaces to API module

### DIFF
--- a/core/src/main/java/org/apache/iceberg/variants/LogicalType.java
+++ b/core/src/main/java/org/apache/iceberg/variants/LogicalType.java
@@ -18,21 +18,17 @@
  */
 package org.apache.iceberg.variants;
 
-/** An variant array value. */
-public interface VariantArray extends VariantValue {
-  /** Returns the {@link VariantValue} at {@code index} in this array. */
-  VariantValue get(int index);
-
-  /** Returns the number of fields stored in this array. */
-  int numElements();
-
-  @Override
-  default PhysicalType type() {
-    return PhysicalType.ARRAY;
-  }
-
-  @Override
-  default VariantArray asArray() {
-    return this;
-  }
+enum LogicalType {
+  NULL,
+  BOOLEAN,
+  EXACT_NUMERIC,
+  FLOAT,
+  DOUBLE,
+  DATE,
+  TIMESTAMPTZ,
+  TIMESTAMPNTZ,
+  BINARY,
+  STRING,
+  ARRAY,
+  OBJECT
 }

--- a/core/src/main/java/org/apache/iceberg/variants/PhysicalType.java
+++ b/core/src/main/java/org/apache/iceberg/variants/PhysicalType.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.variants;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+public enum PhysicalType {
+  NULL(LogicalType.NULL, Void.class),
+  BOOLEAN_TRUE(LogicalType.BOOLEAN, Boolean.class),
+  BOOLEAN_FALSE(LogicalType.BOOLEAN, Boolean.class),
+  INT8(LogicalType.EXACT_NUMERIC, Byte.class),
+  INT16(LogicalType.EXACT_NUMERIC, Short.class),
+  INT32(LogicalType.EXACT_NUMERIC, Integer.class),
+  INT64(LogicalType.EXACT_NUMERIC, Long.class),
+  DOUBLE(LogicalType.DOUBLE, Double.class),
+  DECIMAL4(LogicalType.EXACT_NUMERIC, BigDecimal.class),
+  DECIMAL8(LogicalType.EXACT_NUMERIC, BigDecimal.class),
+  DECIMAL16(LogicalType.EXACT_NUMERIC, BigDecimal.class),
+  DATE(LogicalType.DATE, Integer.class),
+  TIMESTAMPTZ(LogicalType.TIMESTAMPTZ, Long.class),
+  TIMESTAMPNTZ(LogicalType.TIMESTAMPNTZ, Long.class),
+  FLOAT(LogicalType.FLOAT, Float.class),
+  BINARY(LogicalType.BINARY, ByteBuffer.class),
+  STRING(LogicalType.STRING, String.class),
+  ARRAY(LogicalType.ARRAY, List.class),
+  OBJECT(LogicalType.OBJECT, Map.class);
+
+  private final LogicalType logicalType;
+  private final Class<?> javaClass;
+
+  PhysicalType(LogicalType logicalType, Class<?> javaClass) {
+    this.logicalType = logicalType;
+    this.javaClass = javaClass;
+  }
+
+  LogicalType toLogicalType() {
+    return logicalType;
+  }
+
+  public Class<?> javaClass() {
+    return javaClass;
+  }
+
+  public static PhysicalType from(int primitiveType) {
+    switch (primitiveType) {
+      case Primitives.TYPE_NULL:
+        return NULL;
+      case Primitives.TYPE_TRUE:
+        return BOOLEAN_TRUE;
+      case Primitives.TYPE_FALSE:
+        return BOOLEAN_FALSE;
+      case Primitives.TYPE_INT8:
+        return INT8;
+      case Primitives.TYPE_INT16:
+        return INT16;
+      case Primitives.TYPE_INT32:
+        return INT32;
+      case Primitives.TYPE_INT64:
+        return INT64;
+      case Primitives.TYPE_DATE:
+        return DATE;
+      case Primitives.TYPE_TIMESTAMPTZ:
+        return TIMESTAMPTZ;
+      case Primitives.TYPE_TIMESTAMPNTZ:
+        return TIMESTAMPNTZ;
+      case Primitives.TYPE_FLOAT:
+        return FLOAT;
+      case Primitives.TYPE_DOUBLE:
+        return DOUBLE;
+      case Primitives.TYPE_DECIMAL4:
+        return DECIMAL4;
+      case Primitives.TYPE_DECIMAL8:
+        return DECIMAL8;
+      case Primitives.TYPE_DECIMAL16:
+        return DECIMAL16;
+      case Primitives.TYPE_BINARY:
+        return BINARY;
+      case Primitives.TYPE_STRING:
+        return STRING;
+    }
+
+    throw new UnsupportedOperationException("Unknown primitive physical type: " + primitiveType);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
@@ -23,8 +23,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.variants.Variants.PhysicalType;
-import org.apache.iceberg.variants.Variants.Primitives;
 
 class PrimitiveWrapper<T> implements VariantPrimitive<T> {
   private static final byte NULL_HEADER = VariantUtil.primitiveHeader(Primitives.TYPE_NULL);

--- a/core/src/main/java/org/apache/iceberg/variants/Primitives.java
+++ b/core/src/main/java/org/apache/iceberg/variants/Primitives.java
@@ -18,21 +18,26 @@
  */
 package org.apache.iceberg.variants;
 
-/** An variant array value. */
-public interface VariantArray extends VariantValue {
-  /** Returns the {@link VariantValue} at {@code index} in this array. */
-  VariantValue get(int index);
+class Primitives {
+  static final int TYPE_NULL = 0;
+  static final int TYPE_TRUE = 1;
+  static final int TYPE_FALSE = 2;
+  static final int TYPE_INT8 = 3;
+  static final int TYPE_INT16 = 4;
+  static final int TYPE_INT32 = 5;
+  static final int TYPE_INT64 = 6;
+  static final int TYPE_DOUBLE = 7;
+  static final int TYPE_DECIMAL4 = 8;
+  static final int TYPE_DECIMAL8 = 9;
+  static final int TYPE_DECIMAL16 = 10;
+  static final int TYPE_DATE = 11;
+  static final int TYPE_TIMESTAMPTZ = 12; // equivalent to timestamptz
+  static final int TYPE_TIMESTAMPNTZ = 13; // equivalent to timestamp
+  static final int TYPE_FLOAT = 14;
+  static final int TYPE_BINARY = 15;
+  static final int TYPE_STRING = 16;
 
-  /** Returns the number of fields stored in this array. */
-  int numElements();
+  static final int PRIMITIVE_TYPE_SHIFT = 2;
 
-  @Override
-  default PhysicalType type() {
-    return PhysicalType.ARRAY;
-  }
-
-  @Override
-  default VariantArray asArray() {
-    return this;
-  }
+  private Primitives() {}
 }

--- a/core/src/main/java/org/apache/iceberg/variants/SerializedMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/variants/SerializedMetadata.java
@@ -113,6 +113,18 @@ class SerializedMetadata implements VariantMetadata, Variants.Serialized {
   }
 
   @Override
+  public int sizeInBytes() {
+    return buffer().remaining();
+  }
+
+  @Override
+  public int writeTo(ByteBuffer buffer, int offset) {
+    ByteBuffer value = buffer();
+    VariantUtil.writeBufferAbsolute(buffer, offset, value);
+    return value.remaining();
+  }
+
+  @Override
   public String toString() {
     return VariantMetadata.asString(this);
   }

--- a/core/src/main/java/org/apache/iceberg/variants/SerializedPrimitive.java
+++ b/core/src/main/java/org/apache/iceberg/variants/SerializedPrimitive.java
@@ -43,12 +43,12 @@ class SerializedPrimitive extends Variants.SerializedValue implements VariantPri
   }
 
   private final ByteBuffer value;
-  private final Variants.PhysicalType type;
+  private final PhysicalType type;
   private Object primitive = null;
 
   private SerializedPrimitive(ByteBuffer value, int header) {
     this.value = value;
-    this.type = Variants.PhysicalType.from(header >> PRIMITIVE_TYPE_SHIFT);
+    this.type = PhysicalType.from(header >> PRIMITIVE_TYPE_SHIFT);
   }
 
   private Object read() {
@@ -111,7 +111,7 @@ class SerializedPrimitive extends Variants.SerializedValue implements VariantPri
   }
 
   @Override
-  public Variants.PhysicalType type() {
+  public PhysicalType type() {
     return type;
   }
 

--- a/core/src/main/java/org/apache/iceberg/variants/SerializedShortString.java
+++ b/core/src/main/java/org/apache/iceberg/variants/SerializedShortString.java
@@ -50,8 +50,8 @@ class SerializedShortString extends Variants.SerializedValue implements VariantP
   }
 
   @Override
-  public Variants.PhysicalType type() {
-    return Variants.PhysicalType.STRING;
+  public PhysicalType type() {
+    return PhysicalType.STRING;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/variants/VariantMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/variants/VariantMetadata.java
@@ -18,10 +18,11 @@
  */
 package org.apache.iceberg.variants;
 
+import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
 
 /** A variant metadata dictionary. */
-public interface VariantMetadata extends Variants.Serialized {
+public interface VariantMetadata {
   /** Returns the ID for a {@code name} in the dictionary, or -1 if not present. */
   int id(String name);
 
@@ -34,6 +35,20 @@ public interface VariantMetadata extends Variants.Serialized {
 
   /** Returns the size of the metadata dictionary. */
   int dictionarySize();
+
+  /** Returns the serialized size in bytes of this value. */
+  int sizeInBytes();
+
+  /**
+   * Writes this value to the buffer at the given offset, ignoring the buffer's position and limit.
+   *
+   * <p>{@link #sizeInBytes()} bytes will be written to the buffer.
+   *
+   * @param buffer a ByteBuffer to write serialized metadata into
+   * @param offset starting offset to write serialized metadata
+   * @return the number of bytes written
+   */
+  int writeTo(ByteBuffer buffer, int offset);
 
   static String asString(VariantMetadata metadata) {
     StringBuilder builder = new StringBuilder();

--- a/core/src/main/java/org/apache/iceberg/variants/VariantObject.java
+++ b/core/src/main/java/org/apache/iceberg/variants/VariantObject.java
@@ -30,8 +30,8 @@ public interface VariantObject extends VariantValue {
   int numFields();
 
   @Override
-  default Variants.PhysicalType type() {
-    return Variants.PhysicalType.OBJECT;
+  default PhysicalType type() {
+    return PhysicalType.OBJECT;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/variants/VariantUtil.java
+++ b/core/src/main/java/org/apache/iceberg/variants/VariantUtil.java
@@ -165,7 +165,7 @@ class VariantUtil {
   }
 
   static byte primitiveHeader(int primitiveType) {
-    return (byte) (primitiveType << Variants.Primitives.PRIMITIVE_TYPE_SHIFT);
+    return (byte) (primitiveType << Primitives.PRIMITIVE_TYPE_SHIFT);
   }
 
   static byte objectHeader(boolean isLarge, int fieldIdSize, int offsetSize) {

--- a/core/src/main/java/org/apache/iceberg/variants/VariantValue.java
+++ b/core/src/main/java/org/apache/iceberg/variants/VariantValue.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.variants;
 
 import java.nio.ByteBuffer;
-import org.apache.iceberg.variants.Variants.PhysicalType;
 
 /** A variant value. */
 public interface VariantValue {

--- a/core/src/main/java/org/apache/iceberg/variants/Variants.java
+++ b/core/src/main/java/org/apache/iceberg/variants/Variants.java
@@ -20,106 +20,10 @@ package org.apache.iceberg.variants;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import java.util.List;
-import java.util.Map;
 import org.apache.iceberg.util.DateTimeUtil;
 
 public class Variants {
   private Variants() {}
-
-  enum LogicalType {
-    NULL,
-    BOOLEAN,
-    EXACT_NUMERIC,
-    FLOAT,
-    DOUBLE,
-    DATE,
-    TIMESTAMPTZ,
-    TIMESTAMPNTZ,
-    BINARY,
-    STRING,
-    ARRAY,
-    OBJECT
-  }
-
-  public enum PhysicalType {
-    NULL(LogicalType.NULL, Void.class),
-    BOOLEAN_TRUE(LogicalType.BOOLEAN, Boolean.class),
-    BOOLEAN_FALSE(LogicalType.BOOLEAN, Boolean.class),
-    INT8(LogicalType.EXACT_NUMERIC, Byte.class),
-    INT16(LogicalType.EXACT_NUMERIC, Short.class),
-    INT32(LogicalType.EXACT_NUMERIC, Integer.class),
-    INT64(LogicalType.EXACT_NUMERIC, Long.class),
-    DOUBLE(LogicalType.DOUBLE, Double.class),
-    DECIMAL4(LogicalType.EXACT_NUMERIC, BigDecimal.class),
-    DECIMAL8(LogicalType.EXACT_NUMERIC, BigDecimal.class),
-    DECIMAL16(LogicalType.EXACT_NUMERIC, BigDecimal.class),
-    DATE(LogicalType.DATE, Integer.class),
-    TIMESTAMPTZ(LogicalType.TIMESTAMPTZ, Long.class),
-    TIMESTAMPNTZ(LogicalType.TIMESTAMPNTZ, Long.class),
-    FLOAT(LogicalType.FLOAT, Float.class),
-    BINARY(LogicalType.BINARY, ByteBuffer.class),
-    STRING(LogicalType.STRING, String.class),
-    ARRAY(LogicalType.ARRAY, List.class),
-    OBJECT(LogicalType.OBJECT, Map.class);
-
-    private final LogicalType logicalType;
-    private final Class<?> javaClass;
-
-    PhysicalType(LogicalType logicalType, Class<?> javaClass) {
-      this.logicalType = logicalType;
-      this.javaClass = javaClass;
-    }
-
-    LogicalType toLogicalType() {
-      return logicalType;
-    }
-
-    public Class<?> javaClass() {
-      return javaClass;
-    }
-
-    public static PhysicalType from(int primitiveType) {
-      switch (primitiveType) {
-        case Primitives.TYPE_NULL:
-          return NULL;
-        case Primitives.TYPE_TRUE:
-          return BOOLEAN_TRUE;
-        case Primitives.TYPE_FALSE:
-          return BOOLEAN_FALSE;
-        case Primitives.TYPE_INT8:
-          return INT8;
-        case Primitives.TYPE_INT16:
-          return INT16;
-        case Primitives.TYPE_INT32:
-          return INT32;
-        case Primitives.TYPE_INT64:
-          return INT64;
-        case Primitives.TYPE_DATE:
-          return DATE;
-        case Primitives.TYPE_TIMESTAMPTZ:
-          return TIMESTAMPTZ;
-        case Primitives.TYPE_TIMESTAMPNTZ:
-          return TIMESTAMPNTZ;
-        case Primitives.TYPE_FLOAT:
-          return FLOAT;
-        case Primitives.TYPE_DOUBLE:
-          return DOUBLE;
-        case Primitives.TYPE_DECIMAL4:
-          return DECIMAL4;
-        case Primitives.TYPE_DECIMAL8:
-          return DECIMAL8;
-        case Primitives.TYPE_DECIMAL16:
-          return DECIMAL16;
-        case Primitives.TYPE_BINARY:
-          return BINARY;
-        case Primitives.TYPE_STRING:
-          return STRING;
-      }
-
-      throw new UnsupportedOperationException("Unknown primitive physical type: " + primitiveType);
-    }
-  }
 
   interface Serialized {
     ByteBuffer buffer();
@@ -137,30 +41,6 @@ public class Variants {
       VariantUtil.writeBufferAbsolute(buffer, offset, value);
       return value.remaining();
     }
-  }
-
-  static class Primitives {
-    static final int TYPE_NULL = 0;
-    static final int TYPE_TRUE = 1;
-    static final int TYPE_FALSE = 2;
-    static final int TYPE_INT8 = 3;
-    static final int TYPE_INT16 = 4;
-    static final int TYPE_INT32 = 5;
-    static final int TYPE_INT64 = 6;
-    static final int TYPE_DOUBLE = 7;
-    static final int TYPE_DECIMAL4 = 8;
-    static final int TYPE_DECIMAL8 = 9;
-    static final int TYPE_DECIMAL16 = 10;
-    static final int TYPE_DATE = 11;
-    static final int TYPE_TIMESTAMPTZ = 12; // equivalent to timestamptz
-    static final int TYPE_TIMESTAMPNTZ = 13; // equivalent to timestamp
-    static final int TYPE_FLOAT = 14;
-    static final int TYPE_BINARY = 15;
-    static final int TYPE_STRING = 16;
-
-    static final int PRIMITIVE_TYPE_SHIFT = 2;
-
-    private Primitives() {}
   }
 
   static final int HEADER_SIZE = 1;

--- a/core/src/test/java/org/apache/iceberg/variants/TestSerializedArray.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestSerializedArray.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.ByteBuffer;
 import java.util.Random;
 import org.apache.iceberg.util.RandomUtil;
-import org.apache.iceberg.variants.Variants.PhysicalType;
 import org.junit.jupiter.api.Test;
 
 public class TestSerializedArray {

--- a/core/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
@@ -29,7 +29,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.RandomUtil;
-import org.apache.iceberg.variants.Variants.PhysicalType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -255,12 +254,12 @@ public class TestSerializedObject {
     VariantMetadata metadata = Variants.metadata(meta);
     SerializedObject object = SerializedObject.from(metadata, value, value.get(0));
 
-    assertThat(object.type()).isEqualTo(Variants.PhysicalType.OBJECT);
+    assertThat(object.type()).isEqualTo(PhysicalType.OBJECT);
     assertThat(object.numFields()).isEqualTo(10_000);
 
     for (Map.Entry<String, VariantPrimitive<String>> entry : fields.entrySet()) {
       VariantValue fieldValue = object.get(entry.getKey());
-      assertThat(fieldValue.type()).isEqualTo(Variants.PhysicalType.STRING);
+      assertThat(fieldValue.type()).isEqualTo(PhysicalType.STRING);
       assertThat(fieldValue.asPrimitive().get()).isEqualTo(entry.getValue().get());
     }
   }

--- a/core/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import org.apache.iceberg.util.DateTimeUtil;
-import org.apache.iceberg.variants.Variants.PhysicalType;
 import org.junit.jupiter.api.Test;
 
 public class TestSerializedPrimitives {

--- a/core/src/test/java/org/apache/iceberg/variants/TestShreddedObject.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestShreddedObject.java
@@ -150,7 +150,7 @@ public class TestShreddedObject {
     assertThat(partial.get("a")).isInstanceOf(VariantPrimitive.class);
     assertThat(partial.get("a").asPrimitive().get()).isEqualTo(34);
     assertThat(partial.get("c")).isInstanceOf(VariantPrimitive.class);
-    assertThat(partial.get("c").type()).isEqualTo(Variants.PhysicalType.DATE);
+    assertThat(partial.get("c").type()).isEqualTo(PhysicalType.DATE);
     assertThat(partial.get("c").asPrimitive().get())
         .isEqualTo(DateTimeUtil.isoDateToDays("2024-10-12"));
   }
@@ -190,7 +190,7 @@ public class TestShreddedObject {
     assertThat(actual.get("a")).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get("a").asPrimitive().get()).isEqualTo(34);
     assertThat(actual.get("c")).isInstanceOf(VariantPrimitive.class);
-    assertThat(actual.get("c").type()).isEqualTo(Variants.PhysicalType.DATE);
+    assertThat(actual.get("c").type()).isEqualTo(PhysicalType.DATE);
     assertThat(actual.get("c").asPrimitive().get())
         .isEqualTo(DateTimeUtil.isoDateToDays("2024-10-12"));
   }
@@ -212,7 +212,7 @@ public class TestShreddedObject {
     assertThat(actual.get("a")).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get("a").asPrimitive().get()).isEqualTo(34);
     assertThat(actual.get("c")).isInstanceOf(VariantPrimitive.class);
-    assertThat(actual.get("c").type()).isEqualTo(Variants.PhysicalType.DATE);
+    assertThat(actual.get("c").type()).isEqualTo(PhysicalType.DATE);
     assertThat(actual.get("c").asPrimitive().get())
         .isEqualTo(DateTimeUtil.isoDateToDays("2024-10-12"));
   }
@@ -230,17 +230,17 @@ public class TestShreddedObject {
     ShreddedObject shredded = createShreddedObject(data);
     VariantValue value = roundTripLargeBuffer(shredded, shredded.metadata());
 
-    assertThat(value.type()).isEqualTo(Variants.PhysicalType.OBJECT);
+    assertThat(value.type()).isEqualTo(PhysicalType.OBJECT);
     SerializedObject object = (SerializedObject) value;
     assertThat(object.numFields()).isEqualTo(4);
 
-    assertThat(object.get("a").type()).isEqualTo(Variants.PhysicalType.INT32);
+    assertThat(object.get("a").type()).isEqualTo(PhysicalType.INT32);
     assertThat(object.get("a").asPrimitive().get()).isEqualTo(34);
-    assertThat(object.get("b").type()).isEqualTo(Variants.PhysicalType.STRING);
+    assertThat(object.get("b").type()).isEqualTo(PhysicalType.STRING);
     assertThat(object.get("b").asPrimitive().get()).isEqualTo("iceberg");
-    assertThat(object.get("c").type()).isEqualTo(Variants.PhysicalType.DECIMAL4);
+    assertThat(object.get("c").type()).isEqualTo(PhysicalType.DECIMAL4);
     assertThat(object.get("c").asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
-    assertThat(object.get("big").type()).isEqualTo(Variants.PhysicalType.STRING);
+    assertThat(object.get("big").type()).isEqualTo(PhysicalType.STRING);
     assertThat(object.get("big").asPrimitive().get()).isEqualTo(randomString);
   }
 
@@ -257,17 +257,17 @@ public class TestShreddedObject {
     ShreddedObject shredded = createShreddedObject(data);
     VariantValue value = roundTripLargeBuffer(shredded, shredded.metadata());
 
-    assertThat(value.type()).isEqualTo(Variants.PhysicalType.OBJECT);
+    assertThat(value.type()).isEqualTo(PhysicalType.OBJECT);
     SerializedObject object = (SerializedObject) value;
     assertThat(object.numFields()).isEqualTo(4);
 
-    assertThat(object.get("a").type()).isEqualTo(Variants.PhysicalType.INT32);
+    assertThat(object.get("a").type()).isEqualTo(PhysicalType.INT32);
     assertThat(object.get("a").asPrimitive().get()).isEqualTo(34);
-    assertThat(object.get("b").type()).isEqualTo(Variants.PhysicalType.STRING);
+    assertThat(object.get("b").type()).isEqualTo(PhysicalType.STRING);
     assertThat(object.get("b").asPrimitive().get()).isEqualTo("iceberg");
-    assertThat(object.get("c").type()).isEqualTo(Variants.PhysicalType.DECIMAL4);
+    assertThat(object.get("c").type()).isEqualTo(PhysicalType.DECIMAL4);
     assertThat(object.get("c").asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
-    assertThat(object.get("really-big").type()).isEqualTo(Variants.PhysicalType.STRING);
+    assertThat(object.get("really-big").type()).isEqualTo(PhysicalType.STRING);
     assertThat(object.get("really-big").asPrimitive().get()).isEqualTo(randomString);
   }
 
@@ -284,17 +284,17 @@ public class TestShreddedObject {
     ShreddedObject shredded = createShreddedObject(data);
     VariantValue value = roundTripLargeBuffer(shredded, shredded.metadata());
 
-    assertThat(value.type()).isEqualTo(Variants.PhysicalType.OBJECT);
+    assertThat(value.type()).isEqualTo(PhysicalType.OBJECT);
     SerializedObject object = (SerializedObject) value;
     assertThat(object.numFields()).isEqualTo(4);
 
-    assertThat(object.get("a").type()).isEqualTo(Variants.PhysicalType.INT32);
+    assertThat(object.get("a").type()).isEqualTo(PhysicalType.INT32);
     assertThat(object.get("a").asPrimitive().get()).isEqualTo(34);
-    assertThat(object.get("b").type()).isEqualTo(Variants.PhysicalType.STRING);
+    assertThat(object.get("b").type()).isEqualTo(PhysicalType.STRING);
     assertThat(object.get("b").asPrimitive().get()).isEqualTo("iceberg");
-    assertThat(object.get("c").type()).isEqualTo(Variants.PhysicalType.DECIMAL4);
+    assertThat(object.get("c").type()).isEqualTo(PhysicalType.DECIMAL4);
     assertThat(object.get("c").asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
-    assertThat(object.get("really-big").type()).isEqualTo(Variants.PhysicalType.STRING);
+    assertThat(object.get("really-big").type()).isEqualTo(PhysicalType.STRING);
     assertThat(object.get("really-big").asPrimitive().get()).isEqualTo(randomString);
   }
 
@@ -315,13 +315,13 @@ public class TestShreddedObject {
     ShreddedObject shredded = createShreddedObject(metadata, (Map) fields);
     VariantValue value = roundTripLargeBuffer(shredded, metadata);
 
-    assertThat(value.type()).isEqualTo(Variants.PhysicalType.OBJECT);
+    assertThat(value.type()).isEqualTo(PhysicalType.OBJECT);
     SerializedObject object = (SerializedObject) value;
     assertThat(object.numFields()).isEqualTo(10_000);
 
     for (Map.Entry<String, VariantPrimitive<String>> entry : fields.entrySet()) {
       VariantValue fieldValue = object.get(entry.getKey());
-      assertThat(fieldValue.type()).isEqualTo(Variants.PhysicalType.STRING);
+      assertThat(fieldValue.type()).isEqualTo(PhysicalType.STRING);
       assertThat(fieldValue.asPrimitive().get()).isEqualTo(entry.getValue().get());
     }
   }
@@ -345,15 +345,15 @@ public class TestShreddedObject {
     ShreddedObject shredded = createShreddedObject(metadata, data);
     VariantValue value = roundTripLargeBuffer(shredded, metadata);
 
-    assertThat(value.type()).isEqualTo(Variants.PhysicalType.OBJECT);
+    assertThat(value.type()).isEqualTo(PhysicalType.OBJECT);
     SerializedObject object = (SerializedObject) value;
     assertThat(object.numFields()).isEqualTo(3);
 
-    assertThat(object.get("aa").type()).isEqualTo(Variants.PhysicalType.INT32);
+    assertThat(object.get("aa").type()).isEqualTo(PhysicalType.INT32);
     assertThat(object.get("aa").asPrimitive().get()).isEqualTo(34);
-    assertThat(object.get("AA").type()).isEqualTo(Variants.PhysicalType.STRING);
+    assertThat(object.get("AA").type()).isEqualTo(PhysicalType.STRING);
     assertThat(object.get("AA").asPrimitive().get()).isEqualTo("iceberg");
-    assertThat(object.get("ZZ").type()).isEqualTo(Variants.PhysicalType.DECIMAL4);
+    assertThat(object.get("ZZ").type()).isEqualTo(PhysicalType.DECIMAL4);
     assertThat(object.get("ZZ").asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
   }
 
@@ -376,15 +376,15 @@ public class TestShreddedObject {
     ShreddedObject shredded = createShreddedObject(metadata, data);
     VariantValue value = roundTripLargeBuffer(shredded, metadata);
 
-    assertThat(value.type()).isEqualTo(Variants.PhysicalType.OBJECT);
+    assertThat(value.type()).isEqualTo(PhysicalType.OBJECT);
     SerializedObject object = (SerializedObject) value;
     assertThat(object.numFields()).isEqualTo(3);
 
-    assertThat(object.get("aa").type()).isEqualTo(Variants.PhysicalType.INT32);
+    assertThat(object.get("aa").type()).isEqualTo(PhysicalType.INT32);
     assertThat(object.get("aa").asPrimitive().get()).isEqualTo(34);
-    assertThat(object.get("AA").type()).isEqualTo(Variants.PhysicalType.STRING);
+    assertThat(object.get("AA").type()).isEqualTo(PhysicalType.STRING);
     assertThat(object.get("AA").asPrimitive().get()).isEqualTo("iceberg");
-    assertThat(object.get("ZZ").type()).isEqualTo(Variants.PhysicalType.DECIMAL4);
+    assertThat(object.get("ZZ").type()).isEqualTo(PhysicalType.DECIMAL4);
     assertThat(object.get("ZZ").asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
   }
 


### PR DESCRIPTION
This refactors the existing Variant class structure to avoid breaking changes when the Variant interfaces are moved to `iceberg-api`. This requires:

* `PhysicalType` should not be a static class in `Variants`, which will not move
* `VariantMetadata` should not extend `Variants.Serialized`, which should not be exposed


This also adds `writeTo` and `sizeInBytes` to `VariantMetadata` to be able to serialize back to a `ByteBuffer` without `Serialized`.