### PR TITLE
Bump the versions of `site/mkdocs.yml`

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -79,9 +79,9 @@ markdown_extensions:
 
 extra:
   icebergVersion: '1.6.1'
-  nessieVersion: '0.92.1'
-  flinkVersion: '1.19.0'
-  flinkVersionMajor: '1.19'
+  nessieVersion: '0.99.0'
+  flinkVersion: '1.20.0'
+  flinkVersionMajor: '1.20'
   social:
     - icon: fontawesome/regular/comments
       link: 'https://iceberg.apache.org/community/'

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -78,7 +78,7 @@ markdown_extensions:
       permalink: 🔗
 
 extra:
-  icebergVersion: '1.6.1'
+  icebergVersion: '1.7.1'
   nessieVersion: '0.99.0'
   flinkVersion: '1.20.0'
   flinkVersionMajor: '1.20'


### PR DESCRIPTION
This brings them in line with 1.7.1:

https://github.com/apache/iceberg/blob/apache-iceberg-1.7.1/gradle/libs.versions.toml