### PR TITLE
Update LICENSE/NOTICE in flink-runtime jar files

### DIFF
--- a/flink/v1.18/flink-runtime/LICENSE
+++ b/flink/v1.18/flink-runtime/LICENSE
@@ -267,14 +267,6 @@ License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Airlift Slice.
-
-Copyright: 2013-2020 Slice authors.
-Home page: https://github.com/airlift/slice
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 This binary artifact contains JetBrains annotations.
 
 Copyright: 2000-2020 JetBrains s.r.o.
@@ -336,49 +328,10 @@ License text:
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Animal Sniffer Annotations.
-
-Copyright: 2009-2018 codehaus.org
-Home page: https://www.mojohaus.org/animal-sniffer/animal-sniffer-annotations/
-License: https://www.mojohaus.org/animal-sniffer/animal-sniffer-annotations/license.html (MIT license)
-
-License text:
-| The MIT License
-|
-| Copyright (c) 2009 codehaus.org.
-|
-| Permission is hereby granted, free of charge, to any person obtaining a copy
-| of this software and associated documentation files (the "Software"), to deal
-| in the Software without restriction, including without limitation the rights
-| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-| copies of the Software, and to permit persons to whom the Software is
-| furnished to do so, subject to the following conditions:
-|
-| The above copyright notice and this permission notice shall be included in
-| all copies or substantial portions of the Software.
-|
-| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-| THE SOFTWARE.
-
---------------------------------------------------------------------------------
-
 This binary artifact contains Caffeine by Ben Manes.
 
 Copyright: 2014-2020 Ben Manes and contributors
 Home page: https://github.com/ben-manes/caffeine
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Apache Yetus audience annotations.
-
-Copyright: 2008-2020 The Apache Software Foundation.
-Home page: https://yetus.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
@@ -464,14 +417,11 @@ License text:
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Project Nessie with the following in its NOTICE
-file:
+This binary artifact contains Project Nessie.
 
-| Dremio
-| Copyright 2015-2017 Dremio Corporation
-|
-| This product includes software developed at
-| The Apache Software Foundation (http://www.apache.org/).
+Copyright: Copyright 2015-2025 Dremio Corporation
+Home page: https://projectnessie.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
@@ -507,4 +457,64 @@ This binary artifact contains failsafe.
 
 Copyright: Jonathan Halterman and friends
 Home page: https://failsafe.dev/
-License: http://www.apache.org/licenses/LICENSE-2.0.html
+License: https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Codehale Metrics.
+
+Copyright: (c) 2010-2013 Coda Hale, Yammer.com, 2014-2021 Dropwizard Team
+Home page: https://github.com/dropwizard/metrics
+License: https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains RoaringBitmap.
+
+Copyright: (c) 2013-... the RoaringBitmap authors
+Home page: https://github.com/RoaringBitmap/RoaringBitmap
+License: https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Eclipse Microprofile OpenAPI.
+
+Copyright: Copyright (c) 2017 Contributors to the Eclipse Foundation
+Home page: https://github.com/microprofile/microprofile-open-api
+License: https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Luben Zstd.
+
+Copyright: Copyright (c) 2015-present, Luben Karavelov/ All rights reserved.
+Home page: https://github.com/luben/zstd-jni/
+License: BSD-2 License
+License text:
+
+| Zstd-jni: JNI bindings to Zstd Library
+| 
+| Copyright (c) 2015-present, Luben Karavelov/ All rights reserved.
+| 
+| BSD License
+| 
+| Redistribution and use in source and binary forms, with or without modification,
+| are permitted provided that the following conditions are met:
+| 
+| * Redistributions of source code must retain the above copyright notice, this
+|   list of conditions and the following disclaimer.
+| 
+| * Redistributions in binary form must reproduce the above copyright notice, this
+|   list of conditions and the following disclaimer in the documentation and/or
+|   other materials provided with the distribution.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+| ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+| WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+| DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+| ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+| (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+| LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+| ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/flink/v1.18/flink-runtime/NOTICE
+++ b/flink/v1.18/flink-runtime/NOTICE
@@ -7,19 +7,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Apache ORC with the following in its NOTICE file:
-
-| Apache ORC
-| Copyright 2013-2019 The Apache Software Foundation
-|
-| This product includes software developed by The Apache Software
-| Foundation (http://www.apache.org/).
-|
-| This product includes software developed by Hewlett-Packard:
-| (c) Copyright [2014-2015] Hewlett-Packard Development Company, L.P
-
---------------------------------------------------------------------------------
-
 This binary artifact includes Airlift Aircompressor with the following in its
 NOTICE file:
 
@@ -63,29 +50,311 @@ NOTICE file:
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Apache Yetus with the following in its NOTICE
-file:
-
-| Apache Yetus
-| Copyright 2008-2020 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-|
-| ---
-| Additional licenses for the Apache Yetus Source/Website:
-| ---
-|
-|
-| See LICENSE for terms.
-
---------------------------------------------------------------------------------
-
 This binary artifact includes Project Nessie with the following in its NOTICE
 file:
 
-| Dremio
-| Copyright 2015-2017 Dremio Corporation
-|
-| This product includes software developed at
-| The Apache Software Foundation (http://www.apache.org/).
+| Nessie
+| Copyright 2015-2025 Dremio Corporation
+| 
+| ---------------------------------------
+| This project includes code from Apache Polaris (incubating), with the following in its NOTICE file:
+| 
+| | Apache Polaris (incubating)
+| | Copyright 2024 The Apache Software Foundation
+| |
+| | This product includes software developed at
+| | The Apache Software Foundation (http://www.apache.org/).
+| |
+| | The initial code for the Polaris project was donated
+| | to the ASF by Snowflake Inc. (https://www.snowflake.com/) copyright 2024.
+| 
+| ---------------------------------------
+| This project includes code from Netty, with the following in its NOTICE file:
+| 
+| |                             The Netty Project
+| |                             =================
+| |
+| | Please visit the Netty web site for more information:
+| |
+| |   * https://netty.io/
+| |
+| | Copyright 2014 The Netty Project
+| |
+| | The Netty Project licenses this file to you under the Apache License,
+| | version 2.0 (the "License"); you may not use this file except in compliance
+| | with the License. You may obtain a copy of the License at:
+| |
+| |   https://www.apache.org/licenses/LICENSE-2.0
+| |
+| | Unless required by applicable law or agreed to in writing, software
+| | distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+| | WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+| | License for the specific language governing permissions and limitations
+| | under the License.
+| |
+| | Also, please refer to each LICENSE.<component>.txt file, which is located in
+| | the 'license' directory of the distribution file, for the license terms of the
+| | components that this product depends on.
+| |
+| | -------------------------------------------------------------------------------
+| | This product contains the extensions to Java Collections Framework which has
+| | been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.jsr166y.txt (Public Domain)
+| |   * HOMEPAGE:
+| |     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+| |     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+| |
+| | This product contains a modified version of Robert Harder's Public Domain
+| | Base64 Encoder and Decoder, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.base64.txt (Public Domain)
+| |   * HOMEPAGE:
+| |     * http://iharder.sourceforge.net/current/java/base64/
+| |
+| | This product contains a modified portion of 'Webbit', an event based
+| | WebSocket and HTTP server, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.webbit.txt (BSD License)
+| |   * HOMEPAGE:
+| |     * https://github.com/joewalnes/webbit
+| |
+| | This product contains a modified portion of 'SLF4J', a simple logging
+| | facade for Java, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.slf4j.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://www.slf4j.org/
+| |
+| | This product contains a modified portion of 'Apache Harmony', an open source
+| | Java SE, which can be obtained at:
+| |
+| |   * NOTICE:
+| |     * license/NOTICE.harmony.txt
+| |   * LICENSE:
+| |     * license/LICENSE.harmony.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://archive.apache.org/dist/harmony/
+| |
+| | This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+| | and decompression library written by Matthew J. Francis. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.jbzip2.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://code.google.com/p/jbzip2/
+| |
+| | This product contains a modified portion of 'libdivsufsort', a C API library to construct
+| | the suffix array and the Burrows-Wheeler transformed string for any input string of
+| | a constant-size alphabet written by Yuta Mori. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.libdivsufsort.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://github.com/y-256/libdivsufsort
+| |
+| | This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+| |  which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.jctools.txt (ASL2 License)
+| |   * HOMEPAGE:
+| |     * https://github.com/JCTools/JCTools
+| |
+| | This product optionally depends on 'JZlib', a re-implementation of zlib in
+| | pure Java, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.jzlib.txt (BSD style License)
+| |   * HOMEPAGE:
+| |     * http://www.jcraft.com/jzlib/
+| |
+| | This product optionally depends on 'Compress-LZF', a Java library for encoding and
+| | decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/ning/compress
+| |
+| | This product optionally depends on 'lz4', a LZ4 Java compression
+| | and decompression library written by Adrien Grand. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.lz4.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/jpountz/lz4-java
+| |
+| | This product optionally depends on 'lzma-java', a LZMA Java compression
+| | and decompression library, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.lzma-java.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/jponge/lzma-java
+| |
+| | This product optionally depends on 'zstd-jni', a zstd-jni Java compression
+| | and decompression library, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.zstd-jni.txt (BSD)
+| |   * HOMEPAGE:
+| |     * https://github.com/luben/zstd-jni
+| |
+| | This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+| | and decompression library written by William Kinney. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.jfastlz.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://code.google.com/p/jfastlz/
+| |
+| | This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+| | interchange format, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.protobuf.txt (New BSD License)
+| |   * HOMEPAGE:
+| |     * https://github.com/google/protobuf
+| |
+| | This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+| | a temporary self-signed X.509 certificate when the JVM does not provide the
+| | equivalent functionality.  It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.bouncycastle.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://www.bouncycastle.org/
+| |
+| | This product optionally depends on 'Snappy', a compression library produced
+| | by Google Inc, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.snappy.txt (New BSD License)
+| |   * HOMEPAGE:
+| |     * https://github.com/google/snappy
+| |
+| | This product optionally depends on 'JBoss Marshalling', an alternative Java
+| | serialization API, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/jboss-remoting/jboss-marshalling
+| |
+| | This product optionally depends on 'Caliper', Google's micro-
+| | benchmarking framework, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.caliper.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/google/caliper
+| |
+| | This product optionally depends on 'Apache Commons Logging', a logging
+| | framework, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.commons-logging.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://commons.apache.org/logging/
+| |
+| | This product optionally depends on 'Apache Log4J', a logging framework, which
+| | can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.log4j.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://logging.apache.org/log4j/
+| |
+| | This product optionally depends on 'Aalto XML', an ultra-high performance
+| | non-blocking XML processor, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://wiki.fasterxml.com/AaltoHome
+| |
+| | This product contains a modified version of 'HPACK', a Java implementation of
+| | the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.hpack.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/twitter/hpack
+| |
+| | This product contains a modified version of 'HPACK', a Java implementation of
+| | the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.hyper-hpack.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://github.com/python-hyper/hpack/
+| |
+| | This product contains a modified version of 'HPACK', a Java implementation of
+| | the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.nghttp2-hpack.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://github.com/nghttp2/nghttp2/
+| |
+| | This product contains a modified portion of 'Apache Commons Lang', a Java library
+| | provides utilities for the java.lang API, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.commons-lang.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://commons.apache.org/proper/commons-lang/
+| |
+| |
+| | This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/takari/maven-wrapper
+| |
+| | This product contains the dnsinfo.h header file, that provides a way to retrieve the system DNS configuration on MacOS.
+| | This private header is also used by Apple's open source
+| |  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
+| |
+| |  * LICENSE:
+| |     * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
+| |   * HOMEPAGE:
+| |     * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+| |
+| | This product optionally depends on 'Brotli4j', Brotli compression and
+| | decompression for Java., which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.brotli4j.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/hyperxpro/Brotli4j
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Eclipse Microprofile OpenAPI with the following in its NOTICE file:
+
+| =========================================================================
+| ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+| ==  Version 2.0, in this case for MicroProfile OpenAPI                 ==
+| =========================================================================
+| 
+| The majority of this software were originally based on the following:
+| * Swagger Core
+|   https://github.com/swagger-api/swagger-core
+|   under Apache License, v2.0
+| 
+| 
+| SPDXVersion: SPDX-2.1
+| PackageName: Eclipse MicroProfile
+| PackageHomePage: http://www.eclipse.org/microprofile
+| PackageLicenseDeclared: Apache-2.0
+| 
+| PackageCopyrightText: <text>
+| Arthur De Magalhaes arthurdm@ca.ibm.com
+| </text>

--- a/flink/v1.19/flink-runtime/LICENSE
+++ b/flink/v1.19/flink-runtime/LICENSE
@@ -267,14 +267,6 @@ License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Airlift Slice.
-
-Copyright: 2013-2020 Slice authors.
-Home page: https://github.com/airlift/slice
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 This binary artifact contains JetBrains annotations.
 
 Copyright: 2000-2020 JetBrains s.r.o.
@@ -336,49 +328,10 @@ License text:
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Animal Sniffer Annotations.
-
-Copyright: 2009-2018 codehaus.org
-Home page: https://www.mojohaus.org/animal-sniffer/animal-sniffer-annotations/
-License: https://www.mojohaus.org/animal-sniffer/animal-sniffer-annotations/license.html (MIT license)
-
-License text:
-| The MIT License
-|
-| Copyright (c) 2009 codehaus.org.
-|
-| Permission is hereby granted, free of charge, to any person obtaining a copy
-| of this software and associated documentation files (the "Software"), to deal
-| in the Software without restriction, including without limitation the rights
-| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-| copies of the Software, and to permit persons to whom the Software is
-| furnished to do so, subject to the following conditions:
-|
-| The above copyright notice and this permission notice shall be included in
-| all copies or substantial portions of the Software.
-|
-| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-| THE SOFTWARE.
-
---------------------------------------------------------------------------------
-
 This binary artifact contains Caffeine by Ben Manes.
 
 Copyright: 2014-2020 Ben Manes and contributors
 Home page: https://github.com/ben-manes/caffeine
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This binary artifact contains Apache Yetus audience annotations.
-
-Copyright: 2008-2020 The Apache Software Foundation.
-Home page: https://yetus.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
@@ -464,14 +417,11 @@ License text:
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Project Nessie with the following in its NOTICE
-file:
+This binary artifact contains Project Nessie.
 
-| Dremio
-| Copyright 2015-2017 Dremio Corporation
-|
-| This product includes software developed at
-| The Apache Software Foundation (http://www.apache.org/).
+Copyright: Copyright 2015-2025 Dremio Corporation
+Home page: https://projectnessie.org/
+License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
@@ -508,3 +458,63 @@ This binary artifact contains failsafe.
 Copyright: Jonathan Halterman and friends
 Home page: https://failsafe.dev/
 License: https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Codehale Metrics.
+
+Copyright: (c) 2010-2013 Coda Hale, Yammer.com, 2014-2021 Dropwizard Team
+Home page: https://github.com/dropwizard/metrics
+License: https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains RoaringBitmap.
+
+Copyright: (c) 2013-... the RoaringBitmap authors
+Home page: https://github.com/RoaringBitmap/RoaringBitmap
+License: https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Eclipse Microprofile OpenAPI.
+
+Copyright: Copyright (c) 2017 Contributors to the Eclipse Foundation
+Home page: https://github.com/microprofile/microprofile-open-api
+License: https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Luben Zstd.
+
+Copyright: Copyright (c) 2015-present, Luben Karavelov/ All rights reserved.
+Home page: https://github.com/luben/zstd-jni/
+License: BSD-2 License
+License text:
+
+| Zstd-jni: JNI bindings to Zstd Library
+| 
+| Copyright (c) 2015-present, Luben Karavelov/ All rights reserved.
+| 
+| BSD License
+| 
+| Redistribution and use in source and binary forms, with or without modification,
+| are permitted provided that the following conditions are met:
+| 
+| * Redistributions of source code must retain the above copyright notice, this
+|   list of conditions and the following disclaimer.
+| 
+| * Redistributions in binary form must reproduce the above copyright notice, this
+|   list of conditions and the following disclaimer in the documentation and/or
+|   other materials provided with the distribution.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+| ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+| WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+| DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+| ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+| (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+| LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+| ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/flink/v1.19/flink-runtime/NOTICE
+++ b/flink/v1.19/flink-runtime/NOTICE
@@ -7,19 +7,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Apache ORC with the following in its NOTICE file:
-
-| Apache ORC
-| Copyright 2013-2019 The Apache Software Foundation
-|
-| This product includes software developed by The Apache Software
-| Foundation (http://www.apache.org/).
-|
-| This product includes software developed by Hewlett-Packard:
-| (c) Copyright [2014-2015] Hewlett-Packard Development Company, L.P
-
---------------------------------------------------------------------------------
-
 This binary artifact includes Airlift Aircompressor with the following in its
 NOTICE file:
 
@@ -63,29 +50,311 @@ NOTICE file:
 
 --------------------------------------------------------------------------------
 
-This binary artifact includes Apache Yetus with the following in its NOTICE
-file:
-
-| Apache Yetus
-| Copyright 2008-2020 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-|
-| ---
-| Additional licenses for the Apache Yetus Source/Website:
-| ---
-|
-|
-| See LICENSE for terms.
-
---------------------------------------------------------------------------------
-
 This binary artifact includes Project Nessie with the following in its NOTICE
 file:
 
-| Dremio
-| Copyright 2015-2017 Dremio Corporation
-|
-| This product includes software developed at
-| The Apache Software Foundation (http://www.apache.org/).
+| Nessie
+| Copyright 2015-2025 Dremio Corporation
+| 
+| ---------------------------------------
+| This project includes code from Apache Polaris (incubating), with the following in its NOTICE file:
+| 
+| | Apache Polaris (incubating)
+| | Copyright 2024 The Apache Software Foundation
+| |
+| | This product includes software developed at
+| | The Apache Software Foundation (http://www.apache.org/).
+| |
+| | The initial code for the Polaris project was donated
+| | to the ASF by Snowflake Inc. (https://www.snowflake.com/) copyright 2024.
+| 
+| ---------------------------------------
+| This project includes code from Netty, with the following in its NOTICE file:
+| 
+| |                             The Netty Project
+| |                             =================
+| |
+| | Please visit the Netty web site for more information:
+| |
+| |   * https://netty.io/
+| |
+| | Copyright 2014 The Netty Project
+| |
+| | The Netty Project licenses this file to you under the Apache License,
+| | version 2.0 (the "License"); you may not use this file except in compliance
+| | with the License. You may obtain a copy of the License at:
+| |
+| |   https://www.apache.org/licenses/LICENSE-2.0
+| |
+| | Unless required by applicable law or agreed to in writing, software
+| | distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+| | WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+| | License for the specific language governing permissions and limitations
+| | under the License.
+| |
+| | Also, please refer to each LICENSE.<component>.txt file, which is located in
+| | the 'license' directory of the distribution file, for the license terms of the
+| | components that this product depends on.
+| |
+| | -------------------------------------------------------------------------------
+| | This product contains the extensions to Java Collections Framework which has
+| | been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.jsr166y.txt (Public Domain)
+| |   * HOMEPAGE:
+| |     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+| |     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+| |
+| | This product contains a modified version of Robert Harder's Public Domain
+| | Base64 Encoder and Decoder, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.base64.txt (Public Domain)
+| |   * HOMEPAGE:
+| |     * http://iharder.sourceforge.net/current/java/base64/
+| |
+| | This product contains a modified portion of 'Webbit', an event based
+| | WebSocket and HTTP server, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.webbit.txt (BSD License)
+| |   * HOMEPAGE:
+| |     * https://github.com/joewalnes/webbit
+| |
+| | This product contains a modified portion of 'SLF4J', a simple logging
+| | facade for Java, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.slf4j.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://www.slf4j.org/
+| |
+| | This product contains a modified portion of 'Apache Harmony', an open source
+| | Java SE, which can be obtained at:
+| |
+| |   * NOTICE:
+| |     * license/NOTICE.harmony.txt
+| |   * LICENSE:
+| |     * license/LICENSE.harmony.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://archive.apache.org/dist/harmony/
+| |
+| | This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+| | and decompression library written by Matthew J. Francis. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.jbzip2.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://code.google.com/p/jbzip2/
+| |
+| | This product contains a modified portion of 'libdivsufsort', a C API library to construct
+| | the suffix array and the Burrows-Wheeler transformed string for any input string of
+| | a constant-size alphabet written by Yuta Mori. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.libdivsufsort.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://github.com/y-256/libdivsufsort
+| |
+| | This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+| |  which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.jctools.txt (ASL2 License)
+| |   * HOMEPAGE:
+| |     * https://github.com/JCTools/JCTools
+| |
+| | This product optionally depends on 'JZlib', a re-implementation of zlib in
+| | pure Java, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.jzlib.txt (BSD style License)
+| |   * HOMEPAGE:
+| |     * http://www.jcraft.com/jzlib/
+| |
+| | This product optionally depends on 'Compress-LZF', a Java library for encoding and
+| | decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/ning/compress
+| |
+| | This product optionally depends on 'lz4', a LZ4 Java compression
+| | and decompression library written by Adrien Grand. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.lz4.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/jpountz/lz4-java
+| |
+| | This product optionally depends on 'lzma-java', a LZMA Java compression
+| | and decompression library, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.lzma-java.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/jponge/lzma-java
+| |
+| | This product optionally depends on 'zstd-jni', a zstd-jni Java compression
+| | and decompression library, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.zstd-jni.txt (BSD)
+| |   * HOMEPAGE:
+| |     * https://github.com/luben/zstd-jni
+| |
+| | This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+| | and decompression library written by William Kinney. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.jfastlz.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://code.google.com/p/jfastlz/
+| |
+| | This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+| | interchange format, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.protobuf.txt (New BSD License)
+| |   * HOMEPAGE:
+| |     * https://github.com/google/protobuf
+| |
+| | This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+| | a temporary self-signed X.509 certificate when the JVM does not provide the
+| | equivalent functionality.  It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.bouncycastle.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://www.bouncycastle.org/
+| |
+| | This product optionally depends on 'Snappy', a compression library produced
+| | by Google Inc, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.snappy.txt (New BSD License)
+| |   * HOMEPAGE:
+| |     * https://github.com/google/snappy
+| |
+| | This product optionally depends on 'JBoss Marshalling', an alternative Java
+| | serialization API, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/jboss-remoting/jboss-marshalling
+| |
+| | This product optionally depends on 'Caliper', Google's micro-
+| | benchmarking framework, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.caliper.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/google/caliper
+| |
+| | This product optionally depends on 'Apache Commons Logging', a logging
+| | framework, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.commons-logging.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://commons.apache.org/logging/
+| |
+| | This product optionally depends on 'Apache Log4J', a logging framework, which
+| | can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.log4j.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://logging.apache.org/log4j/
+| |
+| | This product optionally depends on 'Aalto XML', an ultra-high performance
+| | non-blocking XML processor, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://wiki.fasterxml.com/AaltoHome
+| |
+| | This product contains a modified version of 'HPACK', a Java implementation of
+| | the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.hpack.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/twitter/hpack
+| |
+| | This product contains a modified version of 'HPACK', a Java implementation of
+| | the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.hyper-hpack.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://github.com/python-hyper/hpack/
+| |
+| | This product contains a modified version of 'HPACK', a Java implementation of
+| | the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.nghttp2-hpack.txt (MIT License)
+| |   * HOMEPAGE:
+| |     * https://github.com/nghttp2/nghttp2/
+| |
+| | This product contains a modified portion of 'Apache Commons Lang', a Java library
+| | provides utilities for the java.lang API, which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.commons-lang.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://commons.apache.org/proper/commons-lang/
+| |
+| |
+| | This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/takari/maven-wrapper
+| |
+| | This product contains the dnsinfo.h header file, that provides a way to retrieve the system DNS configuration on MacOS.
+| | This private header is also used by Apple's open source
+| |  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
+| |
+| |  * LICENSE:
+| |     * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
+| |   * HOMEPAGE:
+| |     * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+| |
+| | This product optionally depends on 'Brotli4j', Brotli compression and
+| | decompression for Java., which can be obtained at:
+| |
+| |   * LICENSE:
+| |     * license/LICENSE.brotli4j.txt (Apache License 2.0)
+| |   * HOMEPAGE:
+| |     * https://github.com/hyperxpro/Brotli4j
+
+--------------------------------------------------------------------------------
+
+This binary artifact includes Eclipse Microprofile OpenAPI with the following in its NOTICE file:
+
+| =========================================================================
+| ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+| ==  Version 2.0, in this case for MicroProfile OpenAPI                 ==
+| =========================================================================
+| 
+| The majority of this software were originally based on the following:
+| * Swagger Core
+|   https://github.com/swagger-api/swagger-core
+|   under Apache License, v2.0
+| 
+| 
+| SPDXVersion: SPDX-2.1
+| PackageName: Eclipse MicroProfile
+| PackageHomePage: http://www.eclipse.org/microprofile
+| PackageLicenseDeclared: Apache-2.0
+| 
+| PackageCopyrightText: <text>
+| Arthur De Magalhaes arthurdm@ca.ibm.com
+| </text>

--- a/flink/v1.20/flink-runtime/LICENSE
+++ b/flink/v1.20/flink-runtime/LICENSE
@@ -267,14 +267,6 @@ License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Airlift Slice.
-
-Copyright: 2013-2020 Slice authors.
-Home page: https://github.com/airlift/slice
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 This binary artifact contains JetBrains annotations.
 
 Copyright: 2000-2020 JetBrains s.r.o.
@@ -465,6 +457,14 @@ This binary artifact contains failsafe.
 
 Copyright: Jonathan Halterman and friends
 Home page: https://failsafe.dev/
+License: https://www.apache.org/licenses/LICENSE-2.0.html
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Codehale Metrics.
+
+Copyright: (c) 2010-2013 Coda Hale, Yammer.com, 2014-2021 Dropwizard Team
+Home page: https://github.com/dropwizard/metrics
 License: https://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR:
- remove airlift slice from `LICENSE` (I don't see it in any flink-runtime jar)
- add Codahale Metrics (present in all flink-runtime jars)
- I check flink-runtime 1.18 and 1.19 and the `LICENSE` and `NOTICE` from 1.20 also apply 