### PR TITLE
Flink: Support source watermark for flink sql windows

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
@@ -180,10 +180,9 @@ public class IcebergTableSource
 
   @Override
   public void applySourceWatermark() {
-    if (!readableConfig.get(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_FLIP27_SOURCE)) {
-      throw new UnsupportedOperationException(
-          "Source watermarks are supported only in flip-27 iceberg source implementation");
-    }
+    Preconditions.checkArgument(
+        readableConfig.get(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_FLIP27_SOURCE),
+        "Source watermarks are supported only in flip-27 iceberg source implementation");
 
     Preconditions.checkNotNull(
         properties.get(FlinkReadOptions.WATERMARK_COLUMN),

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
@@ -35,12 +35,14 @@ import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsSourceWatermark;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.types.DataType;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkConfigOptions;
 import org.apache.iceberg.flink.FlinkFilters;
+import org.apache.iceberg.flink.FlinkReadOptions;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.source.assigner.SplitAssignerType;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -53,7 +55,8 @@ public class IcebergTableSource
     implements ScanTableSource,
         SupportsProjectionPushDown,
         SupportsFilterPushDown,
-        SupportsLimitPushDown {
+        SupportsLimitPushDown,
+        SupportsSourceWatermark {
 
   private int[] projectedFields;
   private Long limit;
@@ -173,6 +176,18 @@ public class IcebergTableSource
 
     this.filters = expressions;
     return Result.of(acceptedFilters, flinkFilters);
+  }
+
+  @Override
+  public void applySourceWatermark() {
+    if (!readableConfig.get(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_FLIP27_SOURCE)) {
+      throw new UnsupportedOperationException(
+          "Source watermarks are supported only in flip-27 iceberg source implementation");
+    }
+
+    Preconditions.checkNotNull(
+        properties.get(FlinkReadOptions.WATERMARK_COLUMN),
+        "watermark-column needs to be configured to use source watermark.");
   }
 
   @Override

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/SqlBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/SqlBase.java
@@ -86,7 +86,7 @@ public abstract class SqlBase {
     sql("DROP DATABASE %s %s", ifExists ? "IF EXISTS" : "", database);
   }
 
-  public static String toWithClause(Map<String, String> props) {
+  protected static String toWithClause(Map<String, String> props) {
     StringBuilder builder = new StringBuilder();
     builder.append("(");
     int propCount = 0;

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/SqlBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/SqlBase.java
@@ -86,7 +86,7 @@ public abstract class SqlBase {
     sql("DROP DATABASE %s %s", ifExists ? "IF EXISTS" : "", database);
   }
 
-  protected static String toWithClause(Map<String, String> props) {
+  public static String toWithClause(Map<String, String> props) {
     StringBuilder builder = new StringBuilder();
     builder.append("(");
     int propCount = 0;

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestSqlBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestSqlBase.java
@@ -86,6 +86,7 @@ public abstract class TestSqlBase {
         }
       }
     }
+
     return streamingTEnv;
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestSqlBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestSqlBase.java
@@ -63,6 +63,8 @@ public abstract class TestSqlBase {
 
   private volatile TableEnvironment tEnv;
 
+  private volatile TableEnvironment streamingTEnv;
+
   protected TableEnvironment getTableEnv() {
     if (tEnv == null) {
       synchronized (this) {
@@ -73,6 +75,18 @@ public abstract class TestSqlBase {
       }
     }
     return tEnv;
+  }
+
+  protected TableEnvironment getStreamingTableEnv() {
+    if (streamingTEnv == null) {
+      synchronized (this) {
+        if (streamingTEnv == null) {
+          this.streamingTEnv =
+              TableEnvironment.create(EnvironmentSettings.newInstance().inStreamingMode().build());
+        }
+      }
+    }
+    return streamingTEnv;
   }
 
   @BeforeEach


### PR DESCRIPTION
 Iceberg Source to support Source Watermark, so it can be used in Flink WINDOW functions. https://github.com/apache/flink/blob/release-1.18/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsSourceWatermark.java enables Flink to rely on the watermark strategy provided by the ScanTableSource itself.

```
CREATE TABLE table_wm (
      eventTS AS CAST(t1 AS TIMESTAMP(3)),
      WATERMARK FOR eventTS AS SOURCE_WATERMARK()
) WITH (
  'watermark-column'='t1'
) LIKE iceberg_catalog.db.table;
```

**Reference:**
https://github.com/apache/iceberg/issues/10219
https://github.com/apache/iceberg/pull/9346


Previous discussion in PR, https://github.com/apache/iceberg/pull/12116 . Split into separate PR for easy review.