### PR TITLE
support create table like in flink catalog

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -447,14 +447,14 @@ public class FlinkCatalog extends AbstractCatalog {
           location = entry.getValue();
         }
       }
+    }
 
-      try {
-        icebergCatalog.createTable(
-            toIdentifier(tablePath), icebergSchema, spec, location, properties.build());
-      } catch (AlreadyExistsException e) {
-        if (!ignoreIfExists) {
-          throw new TableAlreadyExistException(getName(), tablePath, e);
-        }
+    try {
+      icebergCatalog.createTable(
+          toIdentifier(tablePath), icebergSchema, spec, location, properties.build());
+    } catch (AlreadyExistsException e) {
+      if (!ignoreIfExists) {
+        throw new TableAlreadyExistException(getName(), tablePath, e);
       }
     }
   }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -441,8 +441,7 @@ public class FlinkCatalog extends AbstractCatalog {
         properties.put(entry.getKey(), entry.getValue());
       } else {
         // Filtering reserved properties like catalog properties(added to support CREATE TABLE LIKE
-        // in getTable()),
-        // location and not persisting on table properties.
+        // in getTable()), location and not persisting on table properties.
         if ("location".equalsIgnoreCase(entry.getKey())) {
           location = entry.getValue();
         }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -97,6 +97,7 @@ public class FlinkCatalog extends AbstractCatalog {
   private final Namespace baseNamespace;
   private final SupportsNamespaces asNamespaceCatalog;
   private final Closeable closeable;
+  private final Map<String, String> catalogProps;
   private final boolean cacheEnabled;
 
   public FlinkCatalog(
@@ -104,10 +105,12 @@ public class FlinkCatalog extends AbstractCatalog {
       String defaultDatabase,
       Namespace baseNamespace,
       CatalogLoader catalogLoader,
+      Map<String, String> catalogProps,
       boolean cacheEnabled,
       long cacheExpirationIntervalMs) {
     super(catalogName, defaultDatabase);
     this.catalogLoader = catalogLoader;
+    this.catalogProps = catalogProps;
     this.baseNamespace = baseNamespace;
     this.cacheEnabled = cacheEnabled;
 
@@ -332,7 +335,15 @@ public class FlinkCatalog extends AbstractCatalog {
   public CatalogTable getTable(ObjectPath tablePath)
       throws TableNotExistException, CatalogException {
     Table table = loadIcebergTable(tablePath);
-    return toCatalogTable(table);
+    Map<String, String> catalogAndTableProps = Maps.newHashMap(catalogProps);
+    catalogAndTableProps.put(FlinkCreateTableOptions.CATALOG_NAME.key(), getName());
+    catalogAndTableProps.put(
+        FlinkCreateTableOptions.CATALOG_DATABASE.key(), tablePath.getDatabaseName());
+    catalogAndTableProps.put(
+        FlinkCreateTableOptions.CATALOG_TABLE.key(), tablePath.getObjectName());
+    catalogAndTableProps.put("connector", FlinkDynamicTableFactory.FACTORY_IDENTIFIER);
+    catalogAndTableProps.putAll(table.properties());
+    return toCatalogTableWithProps(table, catalogAndTableProps);
   }
 
   private Table loadIcebergTable(ObjectPath tablePath) throws TableNotExistException {
@@ -384,13 +395,6 @@ public class FlinkCatalog extends AbstractCatalog {
   @Override
   public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
       throws CatalogException, TableAlreadyExistException {
-    if (Objects.equals(
-        table.getOptions().get("connector"), FlinkDynamicTableFactory.FACTORY_IDENTIFIER)) {
-      throw new IllegalArgumentException(
-          "Cannot create the table with 'connector'='iceberg' table property in "
-              + "an iceberg catalog, Please create table with 'connector'='iceberg' property in a non-iceberg catalog or "
-              + "create table without 'connector'='iceberg' related properties in an iceberg table.");
-    }
     Preconditions.checkArgument(table instanceof ResolvedCatalogTable, "table should be resolved");
     createIcebergTable(tablePath, (ResolvedCatalogTable) table, ignoreIfExists);
   }
@@ -625,7 +629,7 @@ public class FlinkCatalog extends AbstractCatalog {
     return partitionKeysBuilder.build();
   }
 
-  static CatalogTable toCatalogTable(Table table) {
+  static CatalogTable toCatalogTableWithProps(Table table, Map<String, String> props) {
     TableSchema schema = FlinkSchemaUtil.toSchema(table.schema());
     List<String> partitionKeys = toPartitionKeys(table.spec(), table.schema());
 
@@ -634,7 +638,11 @@ public class FlinkCatalog extends AbstractCatalog {
     // CatalogTableImpl to copy a new catalog table.
     // Let's re-loading table from Iceberg catalog when creating source/sink operators.
     // Iceberg does not have Table comment, so pass a null (Default comment value in Flink).
-    return new CatalogTableImpl(schema, partitionKeys, table.properties(), null);
+    return new CatalogTableImpl(schema, partitionKeys, props, null);
+  }
+
+  static CatalogTable toCatalogTable(Table table) {
+    return toCatalogTableWithProps(table, table.properties());
   }
 
   @Override

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.AbstractCatalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
@@ -91,6 +92,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
  * <p>The Iceberg table manages its partitions by itself. The partition of the Iceberg table is
  * independent of the partition of Flink.
  */
+@Internal
 public class FlinkCatalog extends AbstractCatalog {
   private final CatalogLoader catalogLoader;
   private final Catalog icebergCatalog;
@@ -350,7 +352,8 @@ public class FlinkCatalog extends AbstractCatalog {
         || tableProps.containsKey(FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY)) {
       throw new IllegalArgumentException(
           String.format(
-              "Source table %s contains one/all of the reserved property keys: %s, %s." + tablePath,
+              "Source table %s contains one/all of the reserved property keys: %s, %s.",
+              tablePath,
               FlinkCreateTableOptions.CONNECTOR_PROPS_KEY,
               FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY));
     }
@@ -442,7 +445,7 @@ public class FlinkCatalog extends AbstractCatalog {
       } else {
         // Filtering reserved properties like catalog properties(added to support CREATE TABLE LIKE
         // in getTable()), location and not persisting on table properties.
-        if ("location".equalsIgnoreCase(entry.getKey())) {
+        if (FlinkCreateTableOptions.LOCATION_KEY.equalsIgnoreCase(entry.getKey())) {
           location = entry.getValue();
         }
       }
@@ -459,7 +462,7 @@ public class FlinkCatalog extends AbstractCatalog {
   }
 
   private boolean isReservedProperty(String prop) {
-    return "location".equalsIgnoreCase(prop)
+    return FlinkCreateTableOptions.LOCATION_KEY.equalsIgnoreCase(prop)
         || FlinkCreateTableOptions.CONNECTOR_PROPS_KEY.equalsIgnoreCase(prop)
         || FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY.equalsIgnoreCase(prop);
   }
@@ -544,7 +547,7 @@ public class FlinkCatalog extends AbstractCatalog {
         continue;
       }
 
-      if ("location".equalsIgnoreCase(key)) {
+      if (FlinkCreateTableOptions.LOCATION_KEY.equalsIgnoreCase(key)) {
         setLocation = value;
       } else if ("current-snapshot-id".equalsIgnoreCase(key)) {
         setSnapshotId = value;
@@ -601,7 +604,7 @@ public class FlinkCatalog extends AbstractCatalog {
       if (change instanceof TableChange.SetOption) {
         TableChange.SetOption set = (TableChange.SetOption) change;
 
-        if ("location".equalsIgnoreCase(set.getKey())) {
+        if (FlinkCreateTableOptions.LOCATION_KEY.equalsIgnoreCase(set.getKey())) {
           setLocation = set.getValue();
         } else if ("current-snapshot-id".equalsIgnoreCase(set.getKey())) {
           setSnapshotId = set.getValue();

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -168,6 +168,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
         defaultDatabase,
         baseNamespace,
         catalogLoader,
+        properties,
         cacheEnabled,
         cacheExpirationIntervalMs);
   }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+public class FlinkCreateTableOptions {
+
+  private FlinkCreateTableOptions() {}
+
+  public static final ConfigOption<String> CATALOG_NAME =
+      ConfigOptions.key("catalog-name")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Catalog name");
+
+  public static final ConfigOption<String> CATALOG_TYPE =
+      ConfigOptions.key(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE)
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Catalog type, the optional types are: custom, hadoop, hive.");
+
+  public static final ConfigOption<String> CATALOG_DATABASE =
+      ConfigOptions.key("catalog-database")
+          .stringType()
+          .defaultValue(FlinkCatalogFactory.DEFAULT_DATABASE_NAME)
+          .withDescription("Database name managed in the iceberg catalog.");
+
+  public static final ConfigOption<String> CATALOG_TABLE =
+      ConfigOptions.key("catalog-table")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Table name managed in the underlying iceberg catalog and database.");
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -24,17 +24,17 @@ import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.util.JsonUtil;
 
 public class FlinkCreateTableOptions {
-  String catalog_name;
-  String catalog_db;
-  String catalog_table;
-  Map<String, String> catalog_props;
+  private final String catalogName;
+  private final String catalogDb;
+  private final String catalogTable;
+  private final Map<String, String> catalogProps;
 
   private FlinkCreateTableOptions(
-      String catalog_name, String catalog_db, String catalog_table, Map<String, String> props) {
-    this.catalog_name = catalog_name;
-    this.catalog_db = catalog_db;
-    this.catalog_table = catalog_table;
-    this.catalog_props = props;
+      String catalogName, String catalogDb, String catalogTable, Map<String, String> props) {
+    this.catalogName = catalogName;
+    this.catalogDb = catalogDb;
+    this.catalogTable = catalogTable;
+    this.catalogProps = props;
   }
 
   public static final ConfigOption<String> CATALOG_NAME =
@@ -70,13 +70,13 @@ public class FlinkCreateTableOptions {
   public static final String SRC_CATALOG_PROPS_KEY = "src-catalog";
 
   static String toJson(
-      String catalog_name, String catalog_db, String catalog_table, Map<String, String> props) {
+      String catalogName, String catalogDb, String catalogTable, Map<String, String> props) {
     return JsonUtil.generate(
         gen -> {
           gen.writeStartObject();
-          gen.writeStringField(CATALOG_NAME.key(), catalog_name);
-          gen.writeStringField(CATALOG_DATABASE.key(), catalog_db);
-          gen.writeStringField(CATALOG_TABLE.key(), catalog_table);
+          gen.writeStringField(CATALOG_NAME.key(), catalogName);
+          gen.writeStringField(CATALOG_DATABASE.key(), catalogDb);
+          gen.writeStringField(CATALOG_TABLE.key(), catalogTable);
           JsonUtil.writeStringMap(CATALOG_PROPS.key(), props, gen);
           gen.writeEndObject();
         },
@@ -87,13 +87,28 @@ public class FlinkCreateTableOptions {
     return JsonUtil.parse(
         createTableOptions,
         node -> {
-          String catalog_name = JsonUtil.getString(CATALOG_NAME.key(), node);
-          String catalog_db = JsonUtil.getString(CATALOG_DATABASE.key(), node);
-          String catalog_table = JsonUtil.getString(CATALOG_TABLE.key(), node);
-          Map<String, String> catalog_props = JsonUtil.getStringMap(CATALOG_PROPS.key(), node);
+          String catalogName = JsonUtil.getString(CATALOG_NAME.key(), node);
+          String catalogDb = JsonUtil.getString(CATALOG_DATABASE.key(), node);
+          String catalogTable = JsonUtil.getString(CATALOG_TABLE.key(), node);
+          Map<String, String> catalogProps = JsonUtil.getStringMap(CATALOG_PROPS.key(), node);
 
-          return new FlinkCreateTableOptions(
-              catalog_name, catalog_db, catalog_table, catalog_props);
+          return new FlinkCreateTableOptions(catalogName, catalogDb, catalogTable, catalogProps);
         });
+  }
+
+  String getCatalogName() {
+    return catalogName;
+  }
+
+  String getCatalogDb() {
+    return catalogDb;
+  }
+
+  String getCatalogTable() {
+    return catalogTable;
+  }
+
+  Map<String, String> getCatalogProps() {
+    return catalogProps;
   }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -69,6 +69,7 @@ class FlinkCreateTableOptions {
 
   public static final String SRC_CATALOG_PROPS_KEY = "src-catalog";
   public static final String CONNECTOR_PROPS_KEY = "connector";
+  public static final String LOCATION_KEY = "location";
 
   static String toJson(
       String catalogName, String catalogDb, String catalogTable, Map<String, String> catalogProps) {

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -23,7 +23,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.util.JsonUtil;
 
-public class FlinkCreateTableOptions {
+class FlinkCreateTableOptions {
   private final String catalogName;
   private final String catalogDb;
   private final String catalogTable;
@@ -68,16 +68,17 @@ public class FlinkCreateTableOptions {
           .withDescription("Properties for the underlying catalog for iceberg table.");
 
   public static final String SRC_CATALOG_PROPS_KEY = "src-catalog";
+  public static final String CONNECTOR_PROPS_KEY = "connector";
 
   static String toJson(
-      String catalogName, String catalogDb, String catalogTable, Map<String, String> props) {
+      String catalogName, String catalogDb, String catalogTable, Map<String, String> catalogProps) {
     return JsonUtil.generate(
         gen -> {
           gen.writeStartObject();
           gen.writeStringField(CATALOG_NAME.key(), catalogName);
           gen.writeStringField(CATALOG_DATABASE.key(), catalogDb);
           gen.writeStringField(CATALOG_TABLE.key(), catalogTable);
-          JsonUtil.writeStringMap(CATALOG_PROPS.key(), props, gen);
+          JsonUtil.writeStringMap(CATALOG_PROPS.key(), catalogProps, gen);
           gen.writeEndObject();
         },
         false);
@@ -96,19 +97,19 @@ public class FlinkCreateTableOptions {
         });
   }
 
-  String getCatalogName() {
+  String catalogName() {
     return catalogName;
   }
 
-  String getCatalogDb() {
+  String catalogDb() {
     return catalogDb;
   }
 
-  String getCatalogTable() {
+  String catalogTable() {
     return catalogTable;
   }
 
-  Map<String, String> getCatalogProps() {
+  Map<String, String> catalogProps() {
     return catalogProps;
   }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -198,13 +198,12 @@ public class FlinkDynamicTableFactory
       FlinkCreateTableOptions createTableOptions =
           FlinkCreateTableOptions.fromJson(srcCatalogProps);
 
+      mergedProps.put(FlinkCreateTableOptions.CATALOG_NAME.key(), createTableOptions.catalogName());
       mergedProps.put(
-          FlinkCreateTableOptions.CATALOG_NAME.key(), createTableOptions.getCatalogName());
+          FlinkCreateTableOptions.CATALOG_DATABASE.key(), createTableOptions.catalogDb());
       mergedProps.put(
-          FlinkCreateTableOptions.CATALOG_DATABASE.key(), createTableOptions.getCatalogDb());
-      mergedProps.put(
-          FlinkCreateTableOptions.CATALOG_TABLE.key(), createTableOptions.getCatalogTable());
-      mergedProps.putAll(createTableOptions.getCatalogProps());
+          FlinkCreateTableOptions.CATALOG_TABLE.key(), createTableOptions.catalogTable());
+      mergedProps.putAll(createTableOptions.catalogProps());
 
       tableProps.forEach(
           (k, v) -> {

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -189,12 +189,13 @@ public class FlinkDynamicTableFactory
       FlinkCreateTableOptions createTableOptions =
           FlinkCreateTableOptions.fromJson(srcCatalogProps);
 
-      mergedProps.put(FlinkCreateTableOptions.CATALOG_NAME.key(), createTableOptions.catalog_name);
       mergedProps.put(
-          FlinkCreateTableOptions.CATALOG_DATABASE.key(), createTableOptions.catalog_db);
+          FlinkCreateTableOptions.CATALOG_NAME.key(), createTableOptions.getCatalogName());
       mergedProps.put(
-          FlinkCreateTableOptions.CATALOG_TABLE.key(), createTableOptions.catalog_table);
-      mergedProps.putAll(createTableOptions.catalog_props);
+          FlinkCreateTableOptions.CATALOG_DATABASE.key(), createTableOptions.getCatalogDb());
+      mergedProps.put(
+          FlinkCreateTableOptions.CATALOG_TABLE.key(), createTableOptions.getCatalogTable());
+      mergedProps.putAll(createTableOptions.getCatalogProps());
 
       tableProps.forEach(
           (k, v) -> {

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.flink;
 import java.util.Map;
 import java.util.Set;
 import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
@@ -45,31 +44,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 public class FlinkDynamicTableFactory
     implements DynamicTableSinkFactory, DynamicTableSourceFactory {
   static final String FACTORY_IDENTIFIER = "iceberg";
-
-  private static final ConfigOption<String> CATALOG_NAME =
-      ConfigOptions.key("catalog-name")
-          .stringType()
-          .noDefaultValue()
-          .withDescription("Catalog name");
-
-  private static final ConfigOption<String> CATALOG_TYPE =
-      ConfigOptions.key(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE)
-          .stringType()
-          .noDefaultValue()
-          .withDescription("Catalog type, the optional types are: custom, hadoop, hive.");
-
-  private static final ConfigOption<String> CATALOG_DATABASE =
-      ConfigOptions.key("catalog-database")
-          .stringType()
-          .defaultValue(FlinkCatalogFactory.DEFAULT_DATABASE_NAME)
-          .withDescription("Database name managed in the iceberg catalog.");
-
-  private static final ConfigOption<String> CATALOG_TABLE =
-      ConfigOptions.key("catalog-table")
-          .stringType()
-          .noDefaultValue()
-          .withDescription("Table name managed in the underlying iceberg catalog and database.");
-
   private final FlinkCatalog catalog;
 
   public FlinkDynamicTableFactory() {
@@ -127,16 +101,16 @@ public class FlinkDynamicTableFactory
   @Override
   public Set<ConfigOption<?>> requiredOptions() {
     Set<ConfigOption<?>> options = Sets.newHashSet();
-    options.add(CATALOG_TYPE);
-    options.add(CATALOG_NAME);
+    options.add(FlinkCreateTableOptions.CATALOG_TYPE);
+    options.add(FlinkCreateTableOptions.CATALOG_NAME);
     return options;
   }
 
   @Override
   public Set<ConfigOption<?>> optionalOptions() {
     Set<ConfigOption<?>> options = Sets.newHashSet();
-    options.add(CATALOG_DATABASE);
-    options.add(CATALOG_TABLE);
+    options.add(FlinkCreateTableOptions.CATALOG_DATABASE);
+    options.add(FlinkCreateTableOptions.CATALOG_TABLE);
     return options;
   }
 
@@ -153,14 +127,17 @@ public class FlinkDynamicTableFactory
     Configuration flinkConf = new Configuration();
     tableProps.forEach(flinkConf::setString);
 
-    String catalogName = flinkConf.getString(CATALOG_NAME);
+    String catalogName = flinkConf.getString(FlinkCreateTableOptions.CATALOG_NAME);
     Preconditions.checkNotNull(
-        catalogName, "Table property '%s' cannot be null", CATALOG_NAME.key());
+        catalogName,
+        "Table property '%s' cannot be null",
+        FlinkCreateTableOptions.CATALOG_NAME.key());
 
-    String catalogDatabase = flinkConf.getString(CATALOG_DATABASE, databaseName);
+    String catalogDatabase =
+        flinkConf.getString(FlinkCreateTableOptions.CATALOG_DATABASE, databaseName);
     Preconditions.checkNotNull(catalogDatabase, "The iceberg database name cannot be null");
 
-    String catalogTable = flinkConf.getString(CATALOG_TABLE, tableName);
+    String catalogTable = flinkConf.getString(FlinkCreateTableOptions.CATALOG_TABLE, tableName);
     Preconditions.checkNotNull(catalogTable, "The iceberg table name cannot be null");
 
     org.apache.hadoop.conf.Configuration hadoopConf = FlinkCatalogFactory.clusterHadoopConf();

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -182,6 +182,15 @@ public class FlinkDynamicTableFactory
         flinkCatalog.getCatalogLoader(), TableIdentifier.of(catalogDatabase, catalogTable));
   }
 
+  /**
+   * Merges source catalog properties with connector properties. Iceberg Catalog properties are
+   * serialized as json in FlinkCatalog#getTable to be able to isolate catalog props from iceberg
+   * table props, Here, we flatten and merge them back to use to create catalog.
+   *
+   * @param tableProps the existing table properties
+   * @return a map of merged properties, with source catalog properties taking precedence when keys
+   *     conflict
+   */
   private static Map<String, String> mergeSrcCatalogProps(Map<String, String> tableProps) {
     String srcCatalogProps = tableProps.get(FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY);
     if (srcCatalogProps != null) {

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -189,7 +189,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testCreateTableLikeInDifferentCatalog() throws TableNotExistException {
+  public void testCreateTableLikeInDiffIcebergCatalog() throws TableNotExistException {
     sql("CREATE TABLE tl(id BIGINT)");
     sql("CREATE TABLE tl2 LIKE tl");
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -189,6 +189,23 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testCreateTableLikeInFlinkCatalog() throws TableNotExistException {
+    sql("CREATE TABLE  tl(id BIGINT)");
+
+    sql("CREATE TABLE `default_catalog`.`default_database`.tl2 LIKE tl");
+
+    CatalogTable catalogTable = catalogTable("default_catalog", "default_database", "tl2");
+    assertThat(catalogTable.getSchema())
+        .isEqualTo(TableSchema.builder().field("id", DataTypes.BIGINT()).build());
+
+    Map<String, String> options = catalogTable.getOptions();
+    assertThat(options.entrySet().containsAll(config.entrySet())).isTrue();
+    assertThat(options.get(FlinkCreateTableOptions.CATALOG_NAME.key())).isEqualTo(catalogName);
+    assertThat(options.get(FlinkCreateTableOptions.CATALOG_DATABASE.key())).isEqualTo(DATABASE);
+    assertThat(options.get(FlinkCreateTableOptions.CATALOG_TABLE.key())).isEqualTo("tl");
+  }
+
+  @TestTemplate
   public void testCreateTableLocation() {
     assumeThat(isHadoopCatalog)
         .as("HadoopCatalog does not support creating table with location")
@@ -660,10 +677,12 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
   }
 
   private CatalogTable catalogTable(String name) throws TableNotExistException {
+    return catalogTable(getTableEnv().getCurrentCatalog(), DATABASE, name);
+  }
+
+  private CatalogTable catalogTable(String catalog, String database, String table)
+      throws TableNotExistException {
     return (CatalogTable)
-        getTableEnv()
-            .getCatalog(getTableEnv().getCurrentCatalog())
-            .get()
-            .getTable(new ObjectPath(DATABASE, name));
+        getTableEnv().getCatalog(catalog).get().getTable(new ObjectPath(database, table));
   }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -256,43 +256,6 @@ public class TestIcebergConnector extends TestBase {
         .hasMessageStartingWith("Could not execute CreateTable in path");
   }
 
-  @TestTemplate
-  public void testConnectorTableInIcebergCatalog() {
-    // Create the catalog properties
-    Map<String, String> catalogProps = Maps.newHashMap();
-    catalogProps.put("type", "iceberg");
-    if (isHiveCatalog()) {
-      catalogProps.put("catalog-type", "hive");
-      catalogProps.put(CatalogProperties.URI, CatalogTestBase.getURI(hiveConf));
-    } else {
-      catalogProps.put("catalog-type", "hadoop");
-    }
-    catalogProps.put(CatalogProperties.WAREHOUSE_LOCATION, createWarehouse());
-
-    // Create the table properties
-    Map<String, String> tableProps = createTableProps();
-
-    // Create a connector table in an iceberg catalog.
-    sql("CREATE CATALOG `test_catalog` WITH %s", toWithClause(catalogProps));
-    try {
-      assertThatThrownBy(
-              () ->
-                  sql(
-                      "CREATE TABLE `test_catalog`.`%s`.`%s` (id BIGINT, data STRING) WITH %s",
-                      FlinkCatalogFactory.DEFAULT_DATABASE_NAME,
-                      TABLE_NAME,
-                      toWithClause(tableProps)))
-          .cause()
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage(
-              "Cannot create the table with 'connector'='iceberg' table property in an iceberg catalog, "
-                  + "Please create table with 'connector'='iceberg' property in a non-iceberg catalog or "
-                  + "create table without 'connector'='iceberg' related properties in an iceberg table.");
-    } finally {
-      sql("DROP CATALOG IF EXISTS `test_catalog`");
-    }
-  }
-
   private Map<String, String> createTableProps() {
     Map<String, String> tableProps = Maps.newHashMap(properties);
     tableProps.put("catalog-name", catalogName);

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceSql.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceSql.java
@@ -162,4 +162,21 @@ public class TestIcebergSourceSql extends TestSqlBase {
         expected,
         SCHEMA_TS);
   }
+
+  /** Test create table using LIKE */
+  @Test
+  public void testFlinkTableUsingLIKE() throws Exception {
+    List<Record> expected = generateExpectedRecords(false);
+    SqlHelpers.sql(
+        getTableEnv(),
+        "create table `default_catalog`.`default_database`.flink_table LIKE iceberg_catalog.`default`.%s",
+        TestFixtures.TABLE);
+
+    // Read from table in flink catalog
+    TestHelpers.assertRecords(
+        SqlHelpers.sql(
+            getTableEnv(), "select * from `default_catalog`.`default_database`.flink_table"),
+        expected,
+        SCHEMA_TS);
+  }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceSql.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceSql.java
@@ -163,9 +163,8 @@ public class TestIcebergSourceSql extends TestSqlBase {
         SCHEMA_TS);
   }
 
-  /** Test create table using LIKE */
   @Test
-  public void testFlinkTableUsingLIKE() throws Exception {
+  public void testReadFlinkDynamicTable() throws Exception {
     List<Record> expected = generateExpectedRecords(false);
     SqlHelpers.sql(
         getTableEnv(),


### PR DESCRIPTION
Creation of dynamic Iceberg table in Flink Catalog using the underlying physical Iceberg table using LIKE clause.

Currently (without the changes in PR),  create table in flink catalog works by configuring flink connector as described in,
[flink-connector](https://iceberg.apache.org/docs/nightly/flink-connector/#flink-connector )

But that needs user to provide the schema for the table. A way to tackle that is to do create table LIKE using below DDL.

```
CREATE TABLE table_wm (
      eventTS AS CAST(t1 AS TIMESTAMP(3)),
      WATERMARK FOR eventTS AS SOURCE_WATERMARK()
) WITH (
  'connector'='iceberg',
  'catalog-name'='iceberg_catalog',
  'catalog-database'='testdb',
  'catalog-table'='t'
) LIKE iceberg_catalog.testdb.t;
```

Options like connector, catalog-name, catalog-database, catalog-table need to be duplicated as Iceberg FlinkCatalog doesn't return any catalog related properties during getTable. This PR addresses the issue by including these properties when getTable is called , which will be used by Flink when creating table in Flink Catalog.


Previous discussion related to feature is in PR, https://github.com/apache/iceberg/pull/12116 . 