### PR TITLE
Core: Fix divide by zero when adjust split size

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
@@ -233,6 +233,9 @@ public class TableScanUtil {
   }
 
   public static long adjustSplitSize(long scanSize, int parallelism, long splitSize) {
+    Preconditions.checkArgument(parallelism > 0, "Parallelism must be > 0: %s", parallelism);
+    Preconditions.checkArgument(splitSize > 0, "Split size must be > 0: %s", splitSize);
+
     // use the configured split size if it produces at least one split per slot
     // otherwise, adjust the split size to target parallelism with a reasonable minimum
     // increasing the split size may cause expensive spills and is not done automatically

--- a/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
@@ -314,6 +314,22 @@ public class TestTableScanUtil {
 
     long adjusted2 = TableScanUtil.adjustSplitSize(scanSize, parallelism, largeDefaultSplitSize);
     assertThat(adjusted2).isEqualTo(scanSize / parallelism);
+
+    assertThatThrownBy(() -> TableScanUtil.adjustSplitSize(scanSize, parallelism, -1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Split size must be > 0: -1");
+
+    assertThatThrownBy(() -> TableScanUtil.adjustSplitSize(scanSize, parallelism, 0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Split size must be > 0: 0");
+
+    assertThatThrownBy(() -> TableScanUtil.adjustSplitSize(scanSize, -1, smallDefaultSplitSize))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Parallelism must be > 0: -1");
+
+    assertThatThrownBy(() -> TableScanUtil.adjustSplitSize(scanSize, 0, largeDefaultSplitSize))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Parallelism must be > 0: 0");
   }
 
   private PartitionScanTask taskWithPartition(


### PR DESCRIPTION
Currently, `TableScanUtil.adjustSplitSize(...)` would handle the situations where parameter `splitSize` is negative, however, it doesn't consider the situation where `splitSize` equals 0. That is to say, in a calculation engine like Spark, if we query a table after set it's property `read.split.target-size` to a negative value like `-1`, we will succeed and get  the result, since the default `read.split.adaptive-size.enabled` is true. Meanwhile, if we query a table after set it's property `read.split.target-size` to 0, we will fail with the error message `/ by zero`.

This PR add validation for the parameter `splitSize` in `TableScanUtil.adjustSplitSize(...)` to ensure that errors can be uniformly thrown when it's less than or equal to 0.