### PR TITLE
Core: Fix move/update/makeRequire/makeOptional fail after rename schema (#10830)

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -2193,4 +2193,52 @@ public class TestSchemaUpdate {
 
     assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
   }
+
+  @Test
+  public void testUpdateDocAfterRename() {
+    Schema schema =
+        new Schema(
+            required(1, "b", Types.IntegerType.get()), required(2, "c", Types.IntegerType.get()));
+
+    Schema actual =
+        new SchemaUpdate(schema, 2).renameColumn("c", "a").updateColumnDoc("a", "doc of a").apply();
+
+    Schema expected =
+        new Schema(
+            required(1, "b", Types.IntegerType.get()),
+            required(2, "a", Types.IntegerType.get(), "doc of a"));
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testUpdateAfterRename() {
+    Schema schema =
+        new Schema(
+            required(1, "b", Types.IntegerType.get()), required(2, "c", Types.IntegerType.get()));
+
+    Schema actual =
+        new SchemaUpdate(schema, 2)
+            .renameColumn("c", "a")
+            .updateColumn("a", Types.LongType.get())
+            .apply();
+
+    Schema expected =
+        new Schema(
+            required(1, "b", Types.IntegerType.get()), required(2, "a", Types.LongType.get()));
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testMoveAfterRename() {
+    Schema schema =
+        new Schema(
+            required(1, "b", Types.IntegerType.get()), required(2, "c", Types.IntegerType.get()));
+
+    Schema actual = new SchemaUpdate(schema, 2).renameColumn("c", "a").moveBefore("a", "b").apply();
+
+    Schema expected =
+        new Schema(
+            required(2, "a", Types.IntegerType.get()), required(1, "b", Types.IntegerType.get()));
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
+  }
 }


### PR DESCRIPTION
Some SchemaUpdate API will fail after renameColumn including updateColumn, updateColumnDoc, requireColumn, makeColumnOptional, moveFirst, moveBefore and moveAfter. We don't fix every api after rename because some can be avoid by appropriate API restructuring, for example, renameColumn after renameColumn can be simplified to one rename, deleteColumn after renameColumn can be simplified to delete only because the field no need any more