### PR TITLE
API, Core: Support default values in UpdateSchema

### DIFF
--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -196,9 +196,9 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    *
    * <p>Adding a required column without a default is an incompatible change that can break reading
    * older data. To make this a compatible change, add a default value by calling {@link
-   * #updateColumnDefault(String, Object)} or use {@link #addRequiredColumn(String, Type,
-   * String, Object)} instead. To suppress exceptions thrown when an incompatible change is
-   * detected, call {@link #allowIncompatibleChanges()}.
+   * #updateColumnDefault(String, Object)} or use {@link #addRequiredColumn(String, Type, String,
+   * Object)} instead. To suppress exceptions thrown when an incompatible change is detected, call
+   * {@link #allowIncompatibleChanges()}.
    *
    * <p>Because "." may be interpreted as a column path separator or may be used in field names, it
    * is not allowed in names passed to this method. To add to nested structures or to add fields
@@ -220,9 +220,9 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    *
    * <p>Adding a required column without a default is an incompatible change that can break reading
    * older data. To make this a compatible change, add a default value by calling {@link
-   * #updateColumnDefault(String, Object)} or use {@link #addRequiredColumn(String, Type,
-   * String, Object)} instead. To suppress exceptions thrown when an incompatible change is
-   * detected, call {@link #allowIncompatibleChanges()}.
+   * #updateColumnDefault(String, Object)} or use {@link #addRequiredColumn(String, Type, String,
+   * Object)} instead. To suppress exceptions thrown when an incompatible change is detected, call
+   * {@link #allowIncompatibleChanges()}.
    *
    * <p>Because "." may be interpreted as a column path separator or may be used in field names, it
    * is not allowed in names passed to this method. To add to nested structures or to add fields

--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import java.util.Collection;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
 
@@ -49,13 +50,15 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   UpdateSchema allowIncompatibleChanges();
 
   /**
-   * Add a new top-level column.
+   * Add a new optional top-level column.
    *
    * <p>Because "." may be interpreted as a column path separator or may be used in field names, it
    * is not allowed in names passed to this method. To add to nested structures or to add fields
    * with names that contain ".", use {@link #addColumn(String, String, Type)}.
    *
    * <p>If type is a nested type, its field IDs are reassigned when added to the existing schema.
+   *
+   * <p>The added column will be optional with a null default value.
    *
    * @param name name for the new column
    * @param type type for the new column
@@ -67,7 +70,28 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   }
 
   /**
-   * Add a new top-level column.
+   * Add a new optional top-level column.
+   *
+   * <p>Because "." may be interpreted as a column path separator or may be used in field names, it
+   * is not allowed in names passed to this method. To add to nested structures or to add fields
+   * with names that contain ".", use {@link #addColumn(String, String, Type)}.
+   *
+   * <p>If type is a nested type, its field IDs are reassigned when added to the existing schema.
+   *
+   * <p>The added column will be optional with a null default value.
+   *
+   * @param name name for the new column
+   * @param type type for the new column
+   * @param doc documentation string for the new column
+   * @return this for method chaining
+   * @throws IllegalArgumentException If name contains "."
+   */
+  default UpdateSchema addColumn(String name, Type type, String doc) {
+    return addColumn(name, type, doc, null);
+  }
+
+  /**
+   * Add a new optional top-level column.
    *
    * <p>Because "." may be interpreted as a column path separator or may be used in field names, it
    * is not allowed in names passed to this method. To add to nested structures or to add fields
@@ -78,13 +102,20 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    * @param name name for the new column
    * @param type type for the new column
    * @param doc documentation string for the new column
+   * @param defaultValue a default value for the column in existing rows
    * @return this for method chaining
    * @throws IllegalArgumentException If name contains "."
    */
-  UpdateSchema addColumn(String name, Type type, String doc);
+  default UpdateSchema addColumn(String name, Type type, String doc, Object defaultValue) {
+    Preconditions.checkArgument(
+        !name.contains("."),
+        "Cannot add column with ambiguous name: %s, use addColumn(parent, name, type)",
+        name);
+    return addColumn(null, name, type, doc, defaultValue);
+  }
 
   /**
-   * Add a new column to a nested struct.
+   * Add a new optional column to a nested struct.
    *
    * <p>The parent name is used to find the parent using {@link Schema#findField(String)}. If the
    * parent name is null, the new column will be added to the root as a top-level column. If parent
@@ -96,6 +127,8 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    * differently.
    *
    * <p>If type is a nested type, its field IDs are reassigned when added to the existing schema.
+   *
+   * <p>The added column will be optional with a null default value.
    *
    * @param parent name of the parent struct to the column will be added to
    * @param name name for the new column
@@ -108,7 +141,34 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   }
 
   /**
-   * Add a new column to a nested struct.
+   * Add a new optional column to a nested struct.
+   *
+   * <p>The parent name is used to find the parent using {@link Schema#findField(String)}. If the
+   * parent name is null, the new column will be added to the root as a top-level column. If parent
+   * identifies a struct, a new column is added to that struct. If it identifies a list, the column
+   * is added to the list element struct, and if it identifies a map, the new column is added to the
+   * map's value struct.
+   *
+   * <p>The given name is used to name the new column and names containing "." are not handled
+   * differently.
+   *
+   * <p>If type is a nested type, its field IDs are reassigned when added to the existing schema.
+   *
+   * <p>The added column will be optional with a null default value.
+   *
+   * @param parent name of the parent struct to the column will be added to
+   * @param name name for the new column
+   * @param type type for the new column
+   * @param doc documentation string for the new column
+   * @return this for method chaining
+   * @throws IllegalArgumentException If parent doesn't identify a struct
+   */
+  default UpdateSchema addColumn(String parent, String name, Type type, String doc) {
+    return addColumn(parent, name, type, doc, null);
+  }
+
+  /**
+   * Add a new optional column to a nested struct.
    *
    * <p>The parent name is used to find the parent using {@link Schema#findField(String)}. If the
    * parent name is null, the new column will be added to the root as a top-level column. If parent
@@ -125,16 +185,20 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    * @param name name for the new column
    * @param type type for the new column
    * @param doc documentation string for the new column
+   * @param defaultValue a default value for the column in existing rows
    * @return this for method chaining
    * @throws IllegalArgumentException If parent doesn't identify a struct
    */
-  UpdateSchema addColumn(String parent, String name, Type type, String doc);
+  UpdateSchema addColumn(String parent, String name, Type type, String doc, Object defaultValue);
 
   /**
    * Add a new required top-level column.
    *
-   * <p>This is an incompatible change that can break reading older data. This method will result in
-   * an exception unless {@link #allowIncompatibleChanges()} has been called.
+   * <p>Adding a required column without a default is an incompatible change that can break reading
+   * older data. To make this a compatible change, add a default value by calling {@link
+   * #updateColumnDefault(String, Object)} or use {@link #addRequiredColumn(String, Type,
+   * String, Object)} instead. To suppress exceptions thrown when an incompatible change is
+   * detected, call {@link #allowIncompatibleChanges()}.
    *
    * <p>Because "." may be interpreted as a column path separator or may be used in field names, it
    * is not allowed in names passed to this method. To add to nested structures or to add fields
@@ -154,8 +218,11 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   /**
    * Add a new required top-level column.
    *
-   * <p>This is an incompatible change that can break reading older data. This method will result in
-   * an exception unless {@link #allowIncompatibleChanges()} has been called.
+   * <p>Adding a required column without a default is an incompatible change that can break reading
+   * older data. To make this a compatible change, add a default value by calling {@link
+   * #updateColumnDefault(String, Object)} or use {@link #addRequiredColumn(String, Type,
+   * String, Object)} instead. To suppress exceptions thrown when an incompatible change is
+   * detected, call {@link #allowIncompatibleChanges()}.
    *
    * <p>Because "." may be interpreted as a column path separator or may be used in field names, it
    * is not allowed in names passed to this method. To add to nested structures or to add fields
@@ -169,13 +236,41 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    * @return this for method chaining
    * @throws IllegalArgumentException If name contains "."
    */
-  UpdateSchema addRequiredColumn(String name, Type type, String doc);
+  default UpdateSchema addRequiredColumn(String name, Type type, String doc) {
+    return addRequiredColumn(name, type, doc, null);
+  }
 
   /**
    * Add a new required top-level column.
    *
-   * <p>This is an incompatible change that can break reading older data. This method will result in
-   * an exception unless {@link #allowIncompatibleChanges()} has been called.
+   * <p>Because "." may be interpreted as a column path separator or may be used in field names, it
+   * is not allowed in names passed to this method. To add to nested structures or to add fields
+   * with names that contain ".", use {@link #addRequiredColumn(String, String, Type)}.
+   *
+   * <p>If type is a nested type, its field IDs are reassigned when added to the existing schema.
+   *
+   * @param name name for the new column
+   * @param type type for the new column
+   * @param doc documentation string for the new column
+   * @return this for method chaining
+   * @throws IllegalArgumentException If name contains "."
+   */
+  default UpdateSchema addRequiredColumn(String name, Type type, String doc, Object defaultValue) {
+    Preconditions.checkArgument(
+        !name.contains("."),
+        "Cannot add column with ambiguous name: %s, use addColumn(parent, name, type)",
+        name);
+    return addRequiredColumn(null, name, type, doc, defaultValue);
+  }
+
+  /**
+   * Add a new required column to a nested struct.
+   *
+   * <p>Adding a required column without a default is an incompatible change that can break reading
+   * older data. To make this a compatible change, add a default value by calling {@link
+   * #updateColumnDefault(String, Object)} or use {@link #addRequiredColumn(String, String, Type,
+   * String, Object)} instead. To suppress exceptions thrown when an incompatible change is
+   * detected, call {@link #allowIncompatibleChanges()}.
    *
    * <p>The parent name is used to find the parent using {@link Schema#findField(String)}. If the
    * parent name is null, the new column will be added to the root as a top-level column. If parent
@@ -199,10 +294,13 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   }
 
   /**
-   * Add a new required top-level column.
+   * Add a new required column to a nested struct.
    *
-   * <p>This is an incompatible change that can break reading older data. This method will result in
-   * an exception unless {@link #allowIncompatibleChanges()} has been called.
+   * <p>Adding a required column without a default is an incompatible change that can break reading
+   * older data. To make this a compatible change, add a default value by calling {@link
+   * #updateColumnDefault(String, Object)} or use {@link #addRequiredColumn(String, String, Type,
+   * String, Object)} instead. To suppress exceptions thrown when an incompatible change is
+   * detected, call {@link #allowIncompatibleChanges()}.
    *
    * <p>The parent name is used to find the parent using {@link Schema#findField(String)}. If the
    * parent name is null, the new column will be added to the root as a top-level column. If parent
@@ -222,7 +320,34 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    * @return this for method chaining
    * @throws IllegalArgumentException If parent doesn't identify a struct
    */
-  UpdateSchema addRequiredColumn(String parent, String name, Type type, String doc);
+  default UpdateSchema addRequiredColumn(String parent, String name, Type type, String doc) {
+    return addRequiredColumn(parent, name, type, doc, null);
+  }
+
+  /**
+   * Add a new required top-level column.
+   *
+   * <p>The parent name is used to find the parent using {@link Schema#findField(String)}. If the
+   * parent name is null, the new column will be added to the root as a top-level column. If parent
+   * identifies a struct, a new column is added to that struct. If it identifies a list, the column
+   * is added to the list element struct, and if it identifies a map, the new column is added to the
+   * map's value struct.
+   *
+   * <p>The given name is used to name the new column and names containing "." are not handled
+   * differently.
+   *
+   * <p>If type is a nested type, its field IDs are reassigned when added to the existing schema.
+   *
+   * @param parent name of the parent struct to the column will be added to
+   * @param name name for the new column
+   * @param type type for the new column
+   * @param doc documentation string for the new column
+   * @param defaultValue a default value for the column in existing rows
+   * @return this for method chaining
+   * @throws IllegalArgumentException If parent doesn't identify a struct
+   */
+  UpdateSchema addRequiredColumn(
+      String parent, String name, Type type, String doc, Object defaultValue);
 
   /**
    * Rename a column in the schema.
@@ -281,6 +406,30 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   }
 
   /**
+   * Update a column in the schema to a new primitive type.
+   *
+   * <p>The name is used to find the column to update using {@link Schema#findField(String)}.
+   *
+   * <p>Only updates that widen types are allowed.
+   *
+   * <p>Columns may be updated and renamed in the same schema update.
+   *
+   * @param name name of the column to rename
+   * @param newType replacement type for the column
+   * @param newDoc replacement documentation string for the column
+   * @return this for method chaining
+   * @throws IllegalArgumentException If name doesn't identify a column in the schema or if this
+   *     change introduces a type incompatibility or if it conflicts with other additions, renames,
+   *     or updates.
+   */
+  default UpdateSchema updateColumn(
+      String name, Type.PrimitiveType newType, String newDoc, Object newDefaultValue) {
+    return updateColumn(name, newType)
+        .updateColumnDoc(name, newDoc)
+        .updateColumnDefault(name, newDefaultValue);
+  }
+
+  /**
    * Update the documentation string for a column.
    *
    * <p>The name is used to find the column to update using {@link Schema#findField(String)}.
@@ -294,7 +443,22 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   UpdateSchema updateColumnDoc(String name, String newDoc);
 
   /**
-   * Update a column to optional.
+   * Update the default value for a column.
+   *
+   * <p>The name is used to find the column to update using {@link Schema#findField(String)}.
+   *
+   * <p>Note: Changing the default value for a column does not alter existing rows.
+   *
+   * @param name name of the column to update the default value for
+   * @param newDefault replacement default value for the column
+   * @return this for method chaining
+   * @throws IllegalArgumentException If name doesn't identify a column in the schema or if the
+   *     column will be deleted
+   */
+  UpdateSchema updateColumnDefault(String name, Object newDefault);
+
+  /**
+   * Update a column to be optional.
    *
    * @param name name of the column to mark optional
    * @return this for method chaining
@@ -302,7 +466,7 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   UpdateSchema makeColumnOptional(String name);
 
   /**
-   * Update a column to required.
+   * Update a column to be required.
    *
    * <p>This is an incompatible change that can break reading older data. This method will result in
    * an exception unless {@link #allowIncompatibleChanges()} has been called.

--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -189,7 +189,10 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    * @return this for method chaining
    * @throws IllegalArgumentException If parent doesn't identify a struct
    */
-  UpdateSchema addColumn(String parent, String name, Type type, String doc, Object defaultValue);
+  default UpdateSchema addColumn(
+      String parent, String name, Type type, String doc, Object defaultValue) {
+    throw new UnsupportedOperationException("Default values are not supported");
+  }
 
   /**
    * Add a new required top-level column.
@@ -346,8 +349,10 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    * @return this for method chaining
    * @throws IllegalArgumentException If parent doesn't identify a struct
    */
-  UpdateSchema addRequiredColumn(
-      String parent, String name, Type type, String doc, Object defaultValue);
+  default UpdateSchema addRequiredColumn(
+      String parent, String name, Type type, String doc, Object defaultValue) {
+    throw new UnsupportedOperationException("Default values are not supported");
+  }
 
   /**
    * Rename a column in the schema.
@@ -455,7 +460,9 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    * @throws IllegalArgumentException If name doesn't identify a column in the schema or if the
    *     column will be deleted
    */
-  UpdateSchema updateColumnDefault(String name, Object newDefault);
+  default UpdateSchema updateColumnDefault(String name, Object newDefault) {
+    throw new UnsupportedOperationException("Default values are not supported");
+  }
 
   /**
    * Update a column to be optional.

--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -255,6 +255,7 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    * @param name name for the new column
    * @param type type for the new column
    * @param doc documentation string for the new column
+   * @param defaultValue a default value for the column in existing rows
    * @return this for method chaining
    * @throws IllegalArgumentException If name contains "."
    */
@@ -408,30 +409,6 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    */
   default UpdateSchema updateColumn(String name, Type.PrimitiveType newType, String newDoc) {
     return updateColumn(name, newType).updateColumnDoc(name, newDoc);
-  }
-
-  /**
-   * Update a column in the schema to a new primitive type.
-   *
-   * <p>The name is used to find the column to update using {@link Schema#findField(String)}.
-   *
-   * <p>Only updates that widen types are allowed.
-   *
-   * <p>Columns may be updated and renamed in the same schema update.
-   *
-   * @param name name of the column to rename
-   * @param newType replacement type for the column
-   * @param newDoc replacement documentation string for the column
-   * @return this for method chaining
-   * @throws IllegalArgumentException If name doesn't identify a column in the schema or if this
-   *     change introduces a type incompatibility or if it conflicts with other additions, renames,
-   *     or updates.
-   */
-  default UpdateSchema updateColumn(
-      String name, Type.PrimitiveType newType, String newDoc, Object newDefaultValue) {
-    return updateColumn(name, newType)
-        .updateColumnDoc(name, newDoc)
-        .updateColumnDefault(name, newDefaultValue);
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.util.NaNUtil;
 
 /** Factory methods for creating {@link Expression expressions}. */
 public class Expressions {
@@ -245,6 +246,9 @@ public class Expressions {
             && op != Operation.NOT_NAN,
         "Cannot create %s predicate inclusive a value",
         op);
+    Preconditions.checkArgument(
+        !NaNUtil.isNaN(lit.value()),
+        "Invalid expression literal: NaN, use isNaN or notNaN instead");
     return new UnboundPredicate<T>(op, ref(name), lit);
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -626,8 +626,11 @@ public class Types {
       }
 
       /**
+       * Set the initial default using an Object.
+       *
        * @deprecated will be removed in 2.0.0; use {@link #withInitialDefault(Literal)} instead.
        */
+      @Deprecated
       public Builder withInitialDefault(Object fieldInitialDefault) {
         return withInitialDefault(Expressions.lit(fieldInitialDefault));
       }
@@ -638,6 +641,8 @@ public class Types {
       }
 
       /**
+       * Set the write default using an Object.
+       *
        * @deprecated will be removed in 2.0.0; use {@link #withWriteDefault(Literal)} instead.
        */
       @Deprecated

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -625,7 +625,9 @@ public class Types {
         return this;
       }
 
-      /** @deprecated will be removed in 2.0.0; use {@link #withInitialDefault(Literal)} instead. */
+      /**
+       * @deprecated will be removed in 2.0.0; use {@link #withInitialDefault(Literal)} instead.
+       */
       public Builder withInitialDefault(Object fieldInitialDefault) {
         return withInitialDefault(Expressions.lit(fieldInitialDefault));
       }
@@ -635,7 +637,9 @@ public class Types {
         return this;
       }
 
-      /** @deprecated will be removed in 2.0.0; use {@link #withWriteDefault(Literal)} instead. */
+      /**
+       * @deprecated will be removed in 2.0.0; use {@link #withWriteDefault(Literal)} instead.
+       */
       @Deprecated
       public Builder withWriteDefault(Object fieldWriteDefault) {
         return withWriteDefault(Expressions.lit(fieldWriteDefault));

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -559,14 +559,21 @@ public class Types {
       return new Builder(true, name);
     }
 
+    public static Builder builder() {
+      return new Builder();
+    }
+
     public static class Builder {
-      private final boolean isOptional;
-      private final String name;
+      private boolean isOptional = true;
+      private String name = null;
       private Integer id = null;
       private Type type = null;
       private String doc = null;
       private Object initialDefault = null;
       private Object writeDefault = null;
+
+      private Builder() {
+      }
 
       private Builder(boolean isFieldOptional, String fieldName) {
         isOptional = isFieldOptional;
@@ -581,6 +588,26 @@ public class Types {
         this.doc = toCopy.doc;
         this.initialDefault = toCopy.initialDefault;
         this.writeDefault = toCopy.writeDefault;
+      }
+
+      public Builder asRequired() {
+        this.isOptional = false;
+        return this;
+      }
+
+      public Builder asOptional() {
+        this.isOptional = true;
+        return this;
+      }
+
+      public Builder isOptional(boolean fieldIsOptional) {
+        this.isOptional = fieldIsOptional;
+        return this;
+      }
+
+      public Builder withName(String fieldName) {
+        this.name = fieldName;
+        return this;
       }
 
       public Builder withId(int fieldId) {

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -572,8 +572,7 @@ public class Types {
       private Object initialDefault = null;
       private Object writeDefault = null;
 
-      private Builder() {
-      }
+      private Builder() {}
 
       private Builder(boolean isFieldOptional, String fieldName) {
         isOptional = isFieldOptional;

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
@@ -197,9 +199,9 @@ public class SchemaParser {
     throw new IllegalArgumentException("Cannot parse type from json: " + json);
   }
 
-  private static Object defaultFromJson(String defaultField, Type type, JsonNode json) {
+  private static Literal<?> defaultFromJson(String defaultField, Type type, JsonNode json) {
     if (json.has(defaultField)) {
-      return SingleValueParser.fromJson(type, json.get(defaultField));
+      return Expressions.lit(SingleValueParser.fromJson(type, json.get(defaultField)));
     }
 
     return null;
@@ -229,8 +231,8 @@ public class SchemaParser {
       String name = JsonUtil.getString(NAME, field);
       Type type = typeFromJson(JsonUtil.get(TYPE, field));
 
-      Object initialDefault = defaultFromJson(INITIAL_DEFAULT, type, field);
-      Object writeDefault = defaultFromJson(WRITE_DEFAULT, type, field);
+      Literal<?> initialDefault = defaultFromJson(INITIAL_DEFAULT, type, field);
+      Literal<?> writeDefault = defaultFromJson(WRITE_DEFAULT, type, field);
 
       String doc = JsonUtil.getStringOrNull(DOC, field);
       boolean isRequired = JsonUtil.getBool(REQUIRED, field);

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
@@ -55,7 +56,7 @@ class SchemaUpdate implements UpdateSchema {
   private final Map<Integer, Integer> idToParent;
   private final List<Integer> deletes = Lists.newArrayList();
   private final Map<Integer, Types.NestedField> updates = Maps.newHashMap();
-  private final Multimap<Integer, Types.NestedField> adds =
+  private final Multimap<Integer, Integer> parentToAddedIds =
       Multimaps.newListMultimap(Maps.newHashMap(), Lists::newArrayList);
   private final Map<String, Integer> addedNameToId = Maps.newHashMap();
   private final Multimap<Integer, Move> moves =
@@ -94,40 +95,24 @@ class SchemaUpdate implements UpdateSchema {
   }
 
   @Override
-  public UpdateSchema addColumn(String name, Type type, String doc) {
-    Preconditions.checkArgument(
-        !name.contains("."),
-        "Cannot add column with ambiguous name: %s, use addColumn(parent, name, type)",
-        name);
-    return addColumn(null, name, type, doc);
-  }
-
-  @Override
-  public UpdateSchema addColumn(String parent, String name, Type type, String doc) {
-    internalAddColumn(parent, name, true, type, doc);
+  public UpdateSchema addColumn(
+      String parent, String name, Type type, String doc, Object defaultValue) {
+    internalAddColumn(parent, name, true, type, doc, defaultValue);
     return this;
   }
 
   @Override
-  public UpdateSchema addRequiredColumn(String name, Type type, String doc) {
-    Preconditions.checkArgument(
-        !name.contains("."),
-        "Cannot add column with ambiguous name: %s, use addColumn(parent, name, type)",
-        name);
-    addRequiredColumn(null, name, type, doc);
-    return this;
-  }
-
-  @Override
-  public UpdateSchema addRequiredColumn(String parent, String name, Type type, String doc) {
-    Preconditions.checkArgument(
-        allowIncompatibleChanges, "Incompatible change: cannot add required column: %s", name);
-    internalAddColumn(parent, name, false, type, doc);
+  public UpdateSchema addRequiredColumn(
+      String parent, String name, Type type, String doc, Object defaultValue) {
+    // checking whether the initial default is set for a required field is done in apply, so that
+    // the updateColumnDefault method can be used in the style of a builder. this allows chaining
+    // calls to set the initial default using updateColumnDefault.
+    internalAddColumn(parent, name, false, type, doc, defaultValue);
     return this;
   }
 
   private void internalAddColumn(
-      String parent, String name, boolean isOptional, Type type, String doc) {
+      String parent, String name, boolean isOptional, Type type, String doc, Object defaultValue) {
     int parentId = TABLE_ROOT_ID;
     String fullName;
     if (parent != null) {
@@ -177,10 +162,19 @@ class SchemaUpdate implements UpdateSchema {
       idToParent.put(newId, parentId);
     }
 
-    adds.put(
-        parentId,
-        Types.NestedField.of(
-            newId, isOptional, name, TypeUtil.assignFreshIds(type, this::assignNewColumnId), doc));
+    Types.NestedField newField =
+        Types.NestedField.builder()
+            .withName(name)
+            .isOptional(isOptional)
+            .withId(newId)
+            .ofType(TypeUtil.assignFreshIds(type, this::assignNewColumnId))
+            .withDoc(doc)
+            .withInitialDefault(defaultValue)
+            .withWriteDefault(defaultValue)
+            .build();
+
+    updates.put(newId, newField);
+    parentToAddedIds.put(parentId, newId);
   }
 
   @Override
@@ -188,7 +182,9 @@ class SchemaUpdate implements UpdateSchema {
     Types.NestedField field = findField(name);
     Preconditions.checkArgument(field != null, "Cannot delete missing column: %s", name);
     Preconditions.checkArgument(
-        !adds.containsKey(field.fieldId()), "Cannot delete a column that has additions: %s", name);
+        !parentToAddedIds.containsKey(field.fieldId()),
+        "Cannot delete a column that has additions: %s",
+        name);
     Preconditions.checkArgument(
         !updates.containsKey(field.fieldId()), "Cannot delete a column that has updates: %s", name);
     deletes.add(field.fieldId());
@@ -209,15 +205,9 @@ class SchemaUpdate implements UpdateSchema {
     // merge with an update, if present
     int fieldId = field.fieldId();
     Types.NestedField update = updates.get(fieldId);
-    if (update != null) {
-      updates.put(
-          fieldId,
-          Types.NestedField.of(fieldId, update.isOptional(), newName, update.type(), update.doc()));
-    } else {
-      updates.put(
-          fieldId,
-          Types.NestedField.of(fieldId, field.isOptional(), newName, field.type(), field.doc()));
-    }
+    Types.NestedField newField =
+        Types.NestedField.from(update != null ? update : field).withName(newName).build();
+    updates.put(fieldId, newField);
 
     if (identifierFieldNames.contains(name)) {
       identifierFieldNames.remove(name);
@@ -240,7 +230,7 @@ class SchemaUpdate implements UpdateSchema {
   }
 
   private void internalUpdateColumnRequirement(String name, boolean isOptional) {
-    Types.NestedField field = findField(name);
+    Types.NestedField field = findForUpdate(name);
     Preconditions.checkArgument(field != null, "Cannot update missing column: %s", name);
 
     if ((!isOptional && field.isRequired()) || (isOptional && field.isOptional())) {
@@ -248,8 +238,10 @@ class SchemaUpdate implements UpdateSchema {
       return;
     }
 
+    boolean isDefaultedAdd = isAdded(name) && field.initialDefault() != null;
+
     Preconditions.checkArgument(
-        isOptional || allowIncompatibleChanges,
+        isOptional || isDefaultedAdd || allowIncompatibleChanges,
         "Cannot change column nullability: %s: optional -> required",
         name);
     Preconditions.checkArgument(
@@ -258,22 +250,19 @@ class SchemaUpdate implements UpdateSchema {
         field.name());
 
     int fieldId = field.fieldId();
-    Types.NestedField update = updates.get(fieldId);
-
-    if (update != null) {
-      updates.put(
-          fieldId,
-          Types.NestedField.of(fieldId, isOptional, update.name(), update.type(), update.doc()));
+    Types.NestedField.Builder builder = Types.NestedField.from(field);
+    if (isOptional) {
+      builder.asOptional();
     } else {
-      updates.put(
-          fieldId,
-          Types.NestedField.of(fieldId, isOptional, field.name(), field.type(), field.doc()));
+      builder.asRequired();
     }
+
+    updates.put(fieldId, builder.build());
   }
 
   @Override
   public UpdateSchema updateColumn(String name, Type.PrimitiveType newType) {
-    Types.NestedField field = findField(name);
+    Types.NestedField field = findForUpdate(name);
     Preconditions.checkArgument(field != null, "Cannot update missing column: %s", name);
     Preconditions.checkArgument(
         !deletes.contains(field.fieldId()),
@@ -293,23 +282,15 @@ class SchemaUpdate implements UpdateSchema {
 
     // merge with a rename, if present
     int fieldId = field.fieldId();
-    Types.NestedField update = updates.get(fieldId);
-    if (update != null) {
-      updates.put(
-          fieldId,
-          Types.NestedField.of(fieldId, update.isOptional(), update.name(), newType, update.doc()));
-    } else {
-      updates.put(
-          fieldId,
-          Types.NestedField.of(fieldId, field.isOptional(), field.name(), newType, field.doc()));
-    }
+    Types.NestedField newField = Types.NestedField.from(field).ofType(newType).build();
+    updates.put(fieldId, newField);
 
     return this;
   }
 
   @Override
   public UpdateSchema updateColumnDoc(String name, String doc) {
-    Types.NestedField field = findField(name);
+    Types.NestedField field = findForUpdate(name);
     Preconditions.checkArgument(field != null, "Cannot update missing column: %s", name);
     Preconditions.checkArgument(
         !deletes.contains(field.fieldId()),
@@ -322,16 +303,44 @@ class SchemaUpdate implements UpdateSchema {
 
     // merge with a rename or update, if present
     int fieldId = field.fieldId();
-    Types.NestedField update = updates.get(fieldId);
-    if (update != null) {
-      updates.put(
-          fieldId,
-          Types.NestedField.of(fieldId, update.isOptional(), update.name(), update.type(), doc));
-    } else {
-      updates.put(
-          fieldId,
-          Types.NestedField.of(fieldId, field.isOptional(), field.name(), field.type(), doc));
+    Types.NestedField newField = Types.NestedField.from(field).withDoc(doc).build();
+    updates.put(fieldId, newField);
+
+    return this;
+  }
+
+  @Override
+  public UpdateSchema updateColumnDefault(String name, Object newDefault) {
+    Types.NestedField field = findForUpdate(name);
+    Preconditions.checkArgument(field != null, "Cannot update missing column: %s", name);
+    Preconditions.checkArgument(
+        !deletes.contains(field.fieldId()),
+        "Cannot update a column that will be deleted: %s",
+        field.name());
+
+    boolean isAdded = isAdded(name);
+
+    try {
+      if (!isAdded
+          && Objects.equals(
+              field.writeDefault(), Expressions.lit(newDefault).to(field.type()).value())) {
+        return this;
+      }
+    } catch (RuntimeException ignored) {
+      // if the comparison failed, try to set the new default
     }
+
+    // write default is always set and initial default is only set if the field requires one
+    int fieldId = field.fieldId();
+    Types.NestedField.Builder builder = Types.NestedField.from(field).withWriteDefault(newDefault);
+
+    if (isAdded && field.isRequired() && null == field.initialDefault()) {
+      // if this update is used in the style of a builder, update the initial default.
+      // for instance, addRequiredColumn("name", LongType.get()).updateColumnDefault("name", 0);
+      builder.withInitialDefault(newDefault);
+    }
+
+    updates.put(fieldId, builder.build());
 
     return this;
   }
@@ -386,6 +395,29 @@ class SchemaUpdate implements UpdateSchema {
     return this;
   }
 
+  private boolean isAdded(String name) {
+    return addedNameToId.containsKey(name);
+  }
+
+  private Types.NestedField findForUpdate(String name) {
+    Types.NestedField existing = findField(name);
+    if (existing != null) {
+      Types.NestedField pendingUpdate = updates.get(existing.fieldId());
+      if (pendingUpdate != null) {
+        return pendingUpdate;
+      }
+
+      return existing;
+    }
+
+    Integer addedId = addedNameToId.get(name);
+    if (addedId != null) {
+      return updates.get(addedId);
+    }
+
+    return null;
+  }
+
   private Integer findForMove(String name) {
     Integer addedId = addedNameToId.get(name);
     if (addedId != null) {
@@ -436,10 +468,19 @@ class SchemaUpdate implements UpdateSchema {
    */
   @Override
   public Schema apply() {
-    Schema newSchema =
-        applyChanges(schema, deletes, updates, adds, moves, identifierFieldNames, caseSensitive);
+    // validate that new required fields have initial defaults
+    if (!allowIncompatibleChanges) {
+      for (Map.Entry<String, Integer> added : addedNameToId.entrySet()) {
+        Types.NestedField newField = updates.get(added.getValue());
+        Preconditions.checkArgument(
+            newField.isOptional() || newField.initialDefault() != null,
+            "Incompatible change: cannot add required column without a default value: %s",
+            added.getKey());
+      }
+    }
 
-    return newSchema;
+    return applyChanges(
+        schema, deletes, updates, parentToAddedIds, moves, identifierFieldNames, caseSensitive);
   }
 
   @Override
@@ -461,7 +502,7 @@ class SchemaUpdate implements UpdateSchema {
       try {
         // parse and update the mapping
         NameMapping mapping = NameMappingParser.fromJson(mappingJson);
-        NameMapping updated = MappingUtil.update(mapping, updates, adds);
+        NameMapping updated = MappingUtil.update(mapping, updates, parentToAddedIds);
 
         // replace the table property
         Map<String, String> updatedProperties = Maps.newHashMap();
@@ -505,7 +546,7 @@ class SchemaUpdate implements UpdateSchema {
       Schema schema,
       List<Integer> deletes,
       Map<Integer, Types.NestedField> updates,
-      Multimap<Integer, Types.NestedField> adds,
+      Multimap<Integer, Integer> parentToAddedIds,
       Multimap<Integer, Move> moves,
       Set<String> identifierFieldNames,
       boolean caseSensitive) {
@@ -535,7 +576,7 @@ class SchemaUpdate implements UpdateSchema {
 
     // apply schema changes
     Types.StructType struct =
-        TypeUtil.visit(schema, new ApplyChanges(deletes, updates, adds, moves))
+        TypeUtil.visit(schema, new ApplyChanges(deletes, updates, parentToAddedIds, moves))
             .asNestedType()
             .asStructType();
 
@@ -560,27 +601,29 @@ class SchemaUpdate implements UpdateSchema {
   private static class ApplyChanges extends TypeUtil.SchemaVisitor<Type> {
     private final List<Integer> deletes;
     private final Map<Integer, Types.NestedField> updates;
-    private final Multimap<Integer, Types.NestedField> adds;
+    private final Multimap<Integer, Integer> parentToAddedIds;
     private final Multimap<Integer, Move> moves;
 
     private ApplyChanges(
         List<Integer> deletes,
         Map<Integer, Types.NestedField> updates,
-        Multimap<Integer, Types.NestedField> adds,
+        Multimap<Integer, Integer> parentToAddedIds,
         Multimap<Integer, Move> moves) {
       this.deletes = deletes;
       this.updates = updates;
-      this.adds = adds;
+      this.parentToAddedIds = parentToAddedIds;
       this.moves = moves;
     }
 
     @Override
     public Type schema(Schema schema, Type structResult) {
+      List<Types.NestedField> addedFields =
+          parentToAddedIds.get(TABLE_ROOT_ID).stream()
+              .map(updates::get)
+              .collect(Collectors.toList());
       List<Types.NestedField> fields =
           addAndMoveFields(
-              structResult.asStructType().fields(),
-              adds.get(TABLE_ROOT_ID),
-              moves.get(TABLE_ROOT_ID));
+              structResult.asStructType().fields(), addedFields, moves.get(TABLE_ROOT_ID));
 
       if (fields != null) {
         return Types.StructType.of(fields);
@@ -601,24 +644,15 @@ class SchemaUpdate implements UpdateSchema {
         }
 
         Types.NestedField field = struct.fields().get(i);
-        String name = field.name();
-        String doc = field.doc();
-        boolean isOptional = field.isOptional();
         Types.NestedField update = updates.get(field.fieldId());
-        if (update != null) {
-          name = update.name();
-          doc = update.doc();
-          isOptional = update.isOptional();
-        }
+        Types.NestedField updated =
+            Types.NestedField.from(update != null ? update : field).ofType(resultType).build();
 
-        if (name.equals(field.name())
-            && isOptional == field.isOptional()
-            && field.type() == resultType
-            && Objects.equals(doc, field.doc())) {
+        if (field.equals(updated)) {
           newFields.add(field);
         } else {
           hasChange = true;
-          newFields.add(Types.NestedField.of(field.fieldId(), isOptional, name, resultType, doc));
+          newFields.add(updated);
         }
       }
 
@@ -647,7 +681,8 @@ class SchemaUpdate implements UpdateSchema {
       }
 
       // handle adds
-      Collection<Types.NestedField> newFields = adds.get(fieldId);
+      Collection<Types.NestedField> newFields =
+          parentToAddedIds.get(fieldId).stream().map(updates::get).collect(Collectors.toList());
       Collection<Move> columnsToMove = moves.get(fieldId);
       if (!newFields.isEmpty() || !columnsToMove.isEmpty()) {
         // if either collection is non-null, then this must be a struct type. try to apply the
@@ -694,7 +729,7 @@ class SchemaUpdate implements UpdateSchema {
         throw new IllegalArgumentException("Cannot delete map keys: " + map);
       } else if (updates.containsKey(keyId)) {
         throw new IllegalArgumentException("Cannot update map keys: " + map);
-      } else if (adds.containsKey(keyId)) {
+      } else if (parentToAddedIds.containsKey(keyId)) {
         throw new IllegalArgumentException("Cannot add fields to map keys: " + map);
       } else if (!map.keyType().equals(kResult)) {
         throw new IllegalArgumentException("Cannot alter map keys: " + map);

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -525,6 +525,7 @@ class SchemaUpdate implements UpdateSchema {
           deletes.stream().map(schema::findColumnName).collect(Collectors.toList());
       Map<String, String> renamedColumns =
           updates.keySet().stream()
+              .filter(id -> !addedNameToId.containsValue(id)) // remove added columns
               .filter(id -> !schema.findColumnName(id).equals(newSchema.findColumnName(id)))
               .collect(Collectors.toMap(schema::findColumnName, newSchema::findColumnName));
       if (!deletedColumns.isEmpty() || !renamedColumns.isEmpty()) {

--- a/core/src/main/java/org/apache/iceberg/mapping/MappingUtil.java
+++ b/core/src/main/java/org/apache/iceberg/mapping/MappingUtil.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -64,7 +65,7 @@ public class MappingUtil {
   public static NameMapping update(
       NameMapping mapping,
       Map<Integer, Types.NestedField> updates,
-      Multimap<Integer, Types.NestedField> adds) {
+      Multimap<Integer, Integer> adds) {
     return new NameMapping(visit(mapping, new UpdateMapping(updates, adds)));
   }
 
@@ -78,10 +79,10 @@ public class MappingUtil {
 
   private static class UpdateMapping implements Visitor<MappedFields, MappedField> {
     private final Map<Integer, Types.NestedField> updates;
-    private final Multimap<Integer, Types.NestedField> adds;
+    private final Multimap<Integer, Integer> adds;
 
     private UpdateMapping(
-        Map<Integer, Types.NestedField> updates, Multimap<Integer, Types.NestedField> adds) {
+        Map<Integer, Types.NestedField> updates, Multimap<Integer, Integer> adds) {
       this.updates = updates;
       this.adds = adds;
     }
@@ -121,8 +122,9 @@ public class MappingUtil {
     }
 
     private MappedFields addNewFields(MappedFields mapping, int parentId) {
-      Collection<Types.NestedField> fieldsToAdd = adds.get(parentId);
-      if (fieldsToAdd == null || fieldsToAdd.isEmpty()) {
+      Collection<Types.NestedField> fieldsToAdd =
+          adds.get(parentId).stream().map(updates::get).collect(Collectors.toList());
+      if (fieldsToAdd.isEmpty()) {
         return mapping;
       }
 

--- a/core/src/main/java/org/apache/iceberg/schema/UnionByNameVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/schema/UnionByNameVisitor.java
@@ -157,7 +157,9 @@ public class UnionByNameVisitor extends SchemaWithPartnerVisitor<Integer, Boolea
 
   private void addColumn(int parentId, Types.NestedField field) {
     String parentName = partnerSchema.findColumnName(parentId);
-    api.addColumn(parentName, field.name(), field.type(), field.doc());
+    String fullName = (parentName != null ? parentName + "." : "") + field.name();
+    api.addColumn(parentName, field.name(), field.type(), field.doc(), field.initialDefault())
+        .updateColumnDefault(fullName, field.writeDefault());
   }
 
   private void updateColumn(Types.NestedField field, Types.NestedField existingField) {
@@ -166,6 +168,8 @@ public class UnionByNameVisitor extends SchemaWithPartnerVisitor<Integer, Boolea
     boolean needsOptionalUpdate = field.isOptional() && existingField.isRequired();
     boolean needsTypeUpdate = !isIgnorableTypeUpdate(existingField.type(), field.type());
     boolean needsDocUpdate = field.doc() != null && !field.doc().equals(existingField.doc());
+    boolean needsDefaultUpdate =
+        field.writeDefault() != null && !field.writeDefault().equals(existingField.writeDefault());
 
     if (needsOptionalUpdate) {
       api.makeColumnOptional(fullName);
@@ -177,6 +181,10 @@ public class UnionByNameVisitor extends SchemaWithPartnerVisitor<Integer, Boolea
 
     if (needsDocUpdate) {
       api.updateColumnDoc(fullName, field.doc());
+    }
+
+    if (needsDefaultUpdate) {
+      api.updateColumnDefault(fullName, field.writeDefault());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/schema/UnionByNameVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/schema/UnionByNameVisitor.java
@@ -158,8 +158,13 @@ public class UnionByNameVisitor extends SchemaWithPartnerVisitor<Integer, Boolea
   private void addColumn(int parentId, Types.NestedField field) {
     String parentName = partnerSchema.findColumnName(parentId);
     String fullName = (parentName != null ? parentName + "." : "") + field.name();
-    api.addColumn(parentName, field.name(), field.type(), field.doc(), field.initialDefault())
-        .updateColumnDefault(fullName, field.writeDefault());
+    api.addColumn(
+            parentName,
+            field.name(),
+            field.type(),
+            field.doc(),
+            field.initialDefaultLiteral())
+        .updateColumnDefault(fullName, field.writeDefaultLiteral());
   }
 
   private void updateColumn(Types.NestedField field, Types.NestedField existingField) {
@@ -184,7 +189,7 @@ public class UnionByNameVisitor extends SchemaWithPartnerVisitor<Integer, Boolea
     }
 
     if (needsDefaultUpdate) {
-      api.updateColumnDefault(fullName, field.writeDefault());
+      api.updateColumnDefault(fullName, field.writeDefaultLiteral());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/schema/UnionByNameVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/schema/UnionByNameVisitor.java
@@ -159,11 +159,7 @@ public class UnionByNameVisitor extends SchemaWithPartnerVisitor<Integer, Boolea
     String parentName = partnerSchema.findColumnName(parentId);
     String fullName = (parentName != null ? parentName + "." : "") + field.name();
     api.addColumn(
-            parentName,
-            field.name(),
-            field.type(),
-            field.doc(),
-            field.initialDefaultLiteral())
+            parentName, field.name(), field.type(), field.doc(), field.initialDefaultLiteral())
         .updateColumnDefault(fullName, field.writeDefaultLiteral());
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.Types;
@@ -94,8 +95,8 @@ public class TestSchemaUnionByFieldName {
                 .withId(1)
                 .ofType(LongType.get())
                 .withDoc("description")
-                .withInitialDefault(34)
-                .withWriteDefault(35)
+                .withInitialDefault(Literal.of(34))
+                .withWriteDefault(Literal.of(35))
                 .build());
     Schema applied = new SchemaUpdate(new Schema(), 0).unionByNameWith(newSchema).apply();
     assertThat(applied.asStruct()).isEqualTo(newSchema.asStruct());
@@ -311,14 +312,18 @@ public class TestSchemaUnionByFieldName {
             required("aCol")
                 .withId(1)
                 .ofType(IntegerType.get())
-                .withInitialDefault(34)
-                .withWriteDefault(35)
+                .withInitialDefault(Literal.of(34))
+                .withWriteDefault(Literal.of(35))
                 .build());
 
     // the initial default is not modified for existing columns
     Schema expected =
         new Schema(
-            required("aCol").withId(1).ofType(IntegerType.get()).withWriteDefault(35).build());
+            required("aCol")
+                .withId(1)
+                .ofType(IntegerType.get())
+                .withWriteDefault(Literal.of(35))
+                .build());
 
     Schema applied = new SchemaUpdate(currentSchema, 1).unionByNameWith(newSchema).apply();
     assertThat(applied.asStruct()).isEqualTo(expected.asStruct());

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -204,6 +204,84 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testUpdateTypePreservesOtherMetadata() {
+    Schema schema =
+        new Schema(
+            required("i")
+                .withId(1)
+                .ofType(Types.IntegerType.get())
+                .withDoc("description")
+                .withInitialDefault(34)
+                .withWriteDefault(35)
+                .build());
+    Schema expected =
+        new Schema(
+            required("i")
+                .withId(1)
+                .withDoc("description")
+                .ofType(Types.LongType.get())
+                .withInitialDefault(34)
+                .withWriteDefault(35)
+                .build());
+
+    Schema updated = new SchemaUpdate(schema, 1).updateColumn("i", Types.LongType.get()).apply();
+
+    assertThat(updated.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testUpdateDocPreservesOtherMetadata() {
+    Schema schema =
+        new Schema(
+            required("i")
+                .withId(1)
+                .ofType(Types.IntegerType.get())
+                .withDoc("description")
+                .withInitialDefault(34)
+                .withWriteDefault(35)
+                .build());
+    Schema expected =
+        new Schema(
+            required("i")
+                .withId(1)
+                .ofType(Types.IntegerType.get())
+                .withDoc("longer description")
+                .withInitialDefault(34)
+                .withWriteDefault(35)
+                .build());
+
+    Schema updated = new SchemaUpdate(schema, 1).updateColumnDoc("i", "longer description").apply();
+
+    assertThat(updated.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testUpdateDefaultPreservesOtherMetadata() {
+    Schema schema =
+        new Schema(
+            required("i")
+                .withId(1)
+                .ofType(Types.IntegerType.get())
+                .withDoc("description")
+                .withInitialDefault(34)
+                .withWriteDefault(35)
+                .build());
+    Schema expected =
+        new Schema(
+            required("i")
+                .withId(1)
+                .ofType(Types.IntegerType.get())
+                .withDoc("description")
+                .withInitialDefault(34)
+                .withWriteDefault(123456)
+                .build());
+
+    Schema updated = new SchemaUpdate(schema, 1).updateColumnDefault("i", 123456).apply();
+
+    assertThat(updated.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
   public void testUpdateTypesCaseInsensitive() {
     Types.StructType expected =
         Types.StructType.of(
@@ -480,6 +558,53 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testAddColumnWithDefault() {
+    Schema schema = new Schema(optional(1, "id", Types.IntegerType.get()));
+    Schema expected =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional("data")
+                .withId(2)
+                .ofType(Types.StringType.get())
+                .withDoc("description")
+                .withInitialDefault("unknown")
+                .withWriteDefault("unknown")
+                .build());
+
+    // when default value is passed to add column, both initial and write defaults are set
+    Schema result =
+        new SchemaUpdate(schema, 1)
+            .addColumn("data", Types.StringType.get(), "description", "unknown")
+            .apply();
+
+    assertThat(result.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testAddColumnWithUpdateColumnDefault() {
+    Schema schema = new Schema(optional(1, "id", Types.IntegerType.get()));
+    Schema expected =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional("data")
+                .withId(2)
+                .ofType(Types.StringType.get())
+                .withInitialDefault(null)
+                .withWriteDefault("unknown")
+                .build());
+
+    // changes only the write default because the initial default is null when adding an optional
+    // column, unless the default value is given in the addColumn call
+    Schema result =
+        new SchemaUpdate(schema, 1)
+            .addColumn("data", Types.StringType.get())
+            .updateColumnDefault("data", "unknown")
+            .apply();
+
+    assertThat(result.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
   public void testAddNestedStruct() {
     Schema schema = new Schema(required(1, "id", Types.IntegerType.get()));
     Types.StructType struct =
@@ -569,7 +694,7 @@ public class TestSchemaUpdate {
   }
 
   @Test
-  public void testAddRequiredColumn() {
+  public void testAddRequiredColumnWithoutDefault() {
     Schema schema = new Schema(required(1, "id", Types.IntegerType.get()));
     Schema expected =
         new Schema(
@@ -577,14 +702,65 @@ public class TestSchemaUpdate {
             required(2, "data", Types.StringType.get()));
 
     assertThatThrownBy(
-            () -> new SchemaUpdate(schema, 1).addRequiredColumn("data", Types.StringType.get()))
+            () ->
+                new SchemaUpdate(schema, 1)
+                    .addRequiredColumn("data", Types.StringType.get())
+                    .apply())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Incompatible change: cannot add required column: data");
+        .hasMessage(
+            "Incompatible change: cannot add required column without a default value: data");
 
     Schema result =
         new SchemaUpdate(schema, 1)
             .allowIncompatibleChanges()
             .addRequiredColumn("data", Types.StringType.get())
+            .apply();
+
+    assertThat(result.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testAddRequiredColumnWithDefault() {
+    Schema schema = new Schema(optional(1, "id", Types.IntegerType.get()));
+    Schema expected =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required("data")
+                .withId(2)
+                .ofType(Types.StringType.get())
+                .withDoc("description")
+                .withInitialDefault("unknown")
+                .withWriteDefault("unknown")
+                .build());
+
+    // when default value is passed to add column, both initial and write defaults are set
+    Schema result =
+        new SchemaUpdate(schema, 1)
+            .addRequiredColumn("data", Types.StringType.get(), "description", "unknown")
+            .apply();
+
+    assertThat(result.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testAddRequiredColumnWithUpdateColumnDefault() {
+    Schema schema = new Schema(optional(1, "id", Types.IntegerType.get()));
+    Schema expected =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required("data")
+                .withId(2)
+                .ofType(Types.StringType.get())
+                .withInitialDefault("unknown")
+                .withWriteDefault("unknown")
+                .build());
+
+    // changes the initial default, which has not been set and is needed or else this is an
+    // incompatible change. also sets the write default.
+    Schema result =
+        new SchemaUpdate(schema, 1)
+            .addRequiredColumn("data", Types.StringType.get())
+            .updateColumnDefault("data", "unknown")
             .apply();
 
     assertThat(result.asStruct()).isEqualTo(expected.asStruct());
@@ -631,6 +807,44 @@ public class TestSchemaUpdate {
         new SchemaUpdate(schema, 1).allowIncompatibleChanges().requireColumn("id").apply();
 
     assertThat(result.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testAddColumnWithDefaultToRequiredColumn() {
+    Schema schema = new Schema(optional(1, "id", Types.IntegerType.get()));
+    Schema expected =
+        new Schema(
+            optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required("data")
+                .withId(2)
+                .ofType(Types.StringType.get())
+                .withInitialDefault("unknown")
+                .withWriteDefault("unknown")
+                .build());
+
+    Schema result =
+        new SchemaUpdate(schema, 1)
+            .addColumn("data", Types.StringType.get(), null, "unknown")
+            .requireColumn("data")
+            .apply();
+
+    assertThat(result.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
+  public void testAddColumnWithUpdateColumnDefaultToRequiredColumn() {
+    Schema schema = new Schema(optional(1, "id", Types.IntegerType.get()));
+
+    // updateColumnDefault with an optional column does not set the initial default so the column
+    // cannot be set to required
+    assertThatThrownBy(
+            () ->
+                new SchemaUpdate(schema, 1)
+                    .addColumn("data", Types.StringType.get())
+                    .updateColumnDefault("data", "unknown")
+                    .requireColumn("data"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot change column nullability: data: optional -> required");
   }
 
   @Test
@@ -902,6 +1116,24 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testUpdateMissingColumnDoc() {
+    assertThatThrownBy(
+            () ->
+                new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+                    .updateColumnDoc("col", "description"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot update missing column: col");
+  }
+
+  @Test
+  public void testUpdateMissingColumnDefaultValue() {
+    assertThatThrownBy(
+            () -> new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID).updateColumnDefault("col", 34))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot update missing column: col");
+  }
+
+  @Test
   public void testUpdateDeleteConflict() {
     assertThatThrownBy(
             () -> {
@@ -971,16 +1203,36 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testUpdateAddedColumnType() {
+    Schema schema = new Schema(required(1, "i", Types.IntegerType.get()));
+    Schema expected =
+        new Schema(
+            required(1, "i", Types.IntegerType.get()), optional(2, "value", Types.LongType.get()));
+
+    Schema updated =
+        new SchemaUpdate(schema, 1)
+            .addColumn("value", Types.IntegerType.get())
+            .updateColumn("value", Types.LongType.get())
+            .apply();
+
+    assertThat(updated.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
   public void testUpdateAddedColumnDoc() {
     Schema schema = new Schema(required(1, "i", Types.IntegerType.get()));
-    assertThatThrownBy(
-            () ->
-                new SchemaUpdate(schema, 3)
-                    .addColumn("value", Types.LongType.get())
-                    .updateColumnDoc("value", "a value")
-                    .apply())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot update missing column: value");
+    Schema expected =
+        new Schema(
+            required(1, "i", Types.IntegerType.get()),
+            optional(2, "value", Types.LongType.get(), "a value"));
+
+    Schema updated =
+        new SchemaUpdate(schema, 1)
+            .addColumn("value", Types.LongType.get())
+            .updateColumnDoc("value", "a value")
+            .apply();
+
+    assertThat(updated.asStruct()).isEqualTo(expected.asStruct());
   }
 
   @Test

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -339,11 +339,6 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
                         3, "col1", Types.StringType.get(), "comment for col1"),
                     Types.NestedField.optional(4, "col2", Types.LongType.get()))
                 .asStruct());
-    // Adding a required field should fail because Iceberg's SchemaUpdate does not allow
-    // incompatible changes.
-    assertThatThrownBy(() -> sql("ALTER TABLE tl ADD (pk STRING NOT NULL)"))
-        .hasRootCauseInstanceOf(IllegalArgumentException.class)
-        .hasRootCauseMessage("Incompatible change: cannot add required column: pk");
 
     // Adding an existing field should fail due to Flink's internal validation.
     assertThatThrownBy(() -> sql("ALTER TABLE tl ADD (id STRING)"))
@@ -446,12 +441,6 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
                     Types.NestedField.required(1, "id", Types.IntegerType.get()),
                     Types.NestedField.optional(2, "dt", Types.StringType.get()))
                 .asStruct());
-    // Changing nullability from optional to required should fail
-    // because Iceberg's SchemaUpdate does not allow incompatible changes.
-    assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (dt STRING NOT NULL)"))
-        .isInstanceOf(TableException.class)
-        .hasRootCauseInstanceOf(IllegalArgumentException.class)
-        .hasRootCauseMessage("Cannot change column nullability: dt: optional -> required");
 
     // Set nullability from required to optional
     sql("ALTER TABLE tl MODIFY (id INTEGER)");

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -339,11 +339,6 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
                         3, "col1", Types.StringType.get(), "comment for col1"),
                     Types.NestedField.optional(4, "col2", Types.LongType.get()))
                 .asStruct());
-    // Adding a required field should fail because Iceberg's SchemaUpdate does not allow
-    // incompatible changes.
-    assertThatThrownBy(() -> sql("ALTER TABLE tl ADD (pk STRING NOT NULL)"))
-        .hasRootCauseInstanceOf(IllegalArgumentException.class)
-        .hasRootCauseMessage("Incompatible change: cannot add required column: pk");
 
     // Adding an existing field should fail due to Flink's internal validation.
     assertThatThrownBy(() -> sql("ALTER TABLE tl ADD (id STRING)"))
@@ -446,12 +441,6 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
                     Types.NestedField.required(1, "id", Types.IntegerType.get()),
                     Types.NestedField.optional(2, "dt", Types.StringType.get()))
                 .asStruct());
-    // Changing nullability from optional to required should fail
-    // because Iceberg's SchemaUpdate does not allow incompatible changes.
-    assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (dt STRING NOT NULL)"))
-        .isInstanceOf(TableException.class)
-        .hasRootCauseInstanceOf(IllegalArgumentException.class)
-        .hasRootCauseMessage("Cannot change column nullability: dt: optional -> required");
 
     // Set nullability from required to optional
     sql("ALTER TABLE tl MODIFY (id INTEGER)");

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -339,11 +339,6 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
                         3, "col1", Types.StringType.get(), "comment for col1"),
                     Types.NestedField.optional(4, "col2", Types.LongType.get()))
                 .asStruct());
-    // Adding a required field should fail because Iceberg's SchemaUpdate does not allow
-    // incompatible changes.
-    assertThatThrownBy(() -> sql("ALTER TABLE tl ADD (pk STRING NOT NULL)"))
-        .hasRootCauseInstanceOf(IllegalArgumentException.class)
-        .hasRootCauseMessage("Incompatible change: cannot add required column: pk");
 
     // Adding an existing field should fail due to Flink's internal validation.
     assertThatThrownBy(() -> sql("ALTER TABLE tl ADD (id STRING)"))
@@ -446,12 +441,6 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
                     Types.NestedField.required(1, "id", Types.IntegerType.get()),
                     Types.NestedField.optional(2, "dt", Types.StringType.get()))
                 .asStruct());
-    // Changing nullability from optional to required should fail
-    // because Iceberg's SchemaUpdate does not allow incompatible changes.
-    assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (dt STRING NOT NULL)"))
-        .isInstanceOf(TableException.class)
-        .hasRootCauseInstanceOf(IllegalArgumentException.class)
-        .hasRootCauseMessage("Cannot change column nullability: dt: optional -> required");
 
     // Set nullability from required to optional
     sql("ALTER TABLE tl MODIFY (id INTEGER)");


### PR DESCRIPTION
This adds default value support to `UpdateSchema` and the implementation of it in core.

The API has new methods that accept a default value:
* `addColumn(String name, Type type, String doc, Object defaultValue)`
* `addRequiredColumn(String name, Type type, String doc, Object defaultValue)`
* `updateColumnDefault(String name, Object defaultValue)`
* `updateColumn(String name, Type type, String doc, Object defaultValue)`

The new methods always require supplying a doc string, which can be `null`. However, callers should not need to know to pass `null` when there is no doc string. Because the type of a default value is `Object`, adding additional method signatures that omit the doc string would conflict (for instance `addColumn("a", StringType.get(), "default or description?")`).

To make the API easier to use without adding conflicting signatures or new method names, this updates the implementation to allow combining `addRequiredColumn` with `updateColumnDefault`. Previously, modifications to added columns were not supported, but adding support makes the API behave like a builder:

```java
table.updateSchema()
    .addRequiredColumn("a", StringType.get())
    .updateColumnDefault("a", "unknown")
    .commit();
```

The API allows setting a field's default and does not expose the internal concepts of initial default and write default. When a column is added, its initial default can be set. Subsequent updates will only modify the write default. The only exception to this is that `updateColumnDefault` will change the initial default for a newly added required column if it is not set to enable the builder-like pattern.