### PR TITLE
Docs: Add documentation for Rate limiting in Spark Structured Streaming

### DIFF
--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -166,7 +166,13 @@ spark.read
 | batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
 | stream-from-timestamp | (none) | A timestamp in milliseconds to stream from; if before the oldest known ancestor snapshot, the oldest will be used |
 | streaming-max-files-per-micro-batch | INT_MAX | Maximum number of files per microbatch |
-| streaming-max-rows-per-micro-batch  | INT_MAX | Maximum number of rows per microbatch. This number should be greater than the number of records in any data file in the table. The smallest unit that will be streamed is a single file, so if a data file contains more records than this limit, the stream will get stuck at this file.|
+| streaming-max-rows-per-micro-batch  | INT_MAX | Maximum number of rows per microbatch |
+
+!!! warning
+    streaming-max-rows-per-micro-batch should always be greater than the number of records in any data file in the table.
+    The smallest unit that will be streamed is a single file, so if a data file contains more records than this limit, the stream will get stuck at this file.
+
+
 
 ### Write options
 

--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -155,18 +155,18 @@ spark.read
     .table("catalog.db.table")
 ```
 
-| Spark option                        | Default               | Description                                                                                                                                                                                                                                               |
-|-------------------------------------| --------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| snapshot-id                         | (latest)              | Snapshot ID of the table snapshot to read                                                                                                                                                                                                                 |
-| as-of-timestamp                     | (latest)              | A timestamp in milliseconds; the snapshot used will be the snapshot current at this time.                                                                                                                                                                 |
-| split-size                          | As per table property | Overrides this table's read.split.target-size and read.split.metadata-target-size                                                                                                                                                                         |
-| lookback                            | As per table property | Overrides this table's read.split.planning-lookback                                                                                                                                                                                                       |
-| file-open-cost                      | As per table property | Overrides this table's read.split.open-file-cost                                                                                                                                                                                                          |
-| vectorization-enabled               | As per table property | Overrides this table's read.parquet.vectorization.enabled                                                                                                                                                                                                 |
-| batch-size                          | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                                                                                                                                                                              |
-| stream-from-timestamp               | (none) | A timestamp in milliseconds to stream from; if before the oldest known ancestor snapshot, the oldest will be used                                                                                                                                         |
-| streaming-max-files-per-micro-batch | INT_MAX | Maximum number of files per microbatch                                                                                                                                                                                                                    | 
-| streaming-max-rows-per-micro-batch  | INT_MAX | Maximum number of rows per microbatch. Note : smallest granuality supported is 1 file, please make sure number of records per file is always greater than the number of records in the largest file possible, otherwise it can lead to stream being stuck | 
+| Spark option    | Default               | Description                                                                               |
+| --------------- | --------------------- | ----------------------------------------------------------------------------------------- |
+| snapshot-id     | (latest)              | Snapshot ID of the table snapshot to read                                                 |
+| as-of-timestamp | (latest)              | A timestamp in milliseconds; the snapshot used will be the snapshot current at this time. |
+| split-size      | As per table property | Overrides this table's read.split.target-size and read.split.metadata-target-size         |
+| lookback        | As per table property | Overrides this table's read.split.planning-lookback                                       |
+| file-open-cost  | As per table property | Overrides this table's read.split.open-file-cost                                          |
+| vectorization-enabled  | As per table property | Overrides this table's read.parquet.vectorization.enabled                                          |
+| batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
+| stream-from-timestamp | (none) | A timestamp in milliseconds to stream from; if before the oldest known ancestor snapshot, the oldest will be used |
+| streaming-max-files-per-micro-batch | INT_MAX | Maximum number of files per microbatch |
+| streaming-max-rows-per-micro-batch  | INT_MAX | Maximum number of rows per microbatch. This number should be greater than the number of records in any data file in the table. The smallest unit that will be streamed is a single file, so if a data file contains more records than this limit, the stream will get stuck at this file.|
 
 ### Write options
 

--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -155,16 +155,18 @@ spark.read
     .table("catalog.db.table")
 ```
 
-| Spark option    | Default               | Description                                                                               |
-| --------------- | --------------------- | ----------------------------------------------------------------------------------------- |
-| snapshot-id     | (latest)              | Snapshot ID of the table snapshot to read                                                 |
-| as-of-timestamp | (latest)              | A timestamp in milliseconds; the snapshot used will be the snapshot current at this time. |
-| split-size      | As per table property | Overrides this table's read.split.target-size and read.split.metadata-target-size         |
-| lookback        | As per table property | Overrides this table's read.split.planning-lookback                                       |
-| file-open-cost  | As per table property | Overrides this table's read.split.open-file-cost                                          |
-| vectorization-enabled  | As per table property | Overrides this table's read.parquet.vectorization.enabled                                          |
-| batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
-| stream-from-timestamp | (none) | A timestamp in milliseconds to stream from; if before the oldest known ancestor snapshot, the oldest will be used |
+| Spark option                        | Default               | Description                                                                                                                                                                                                                                               |
+|-------------------------------------| --------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| snapshot-id                         | (latest)              | Snapshot ID of the table snapshot to read                                                                                                                                                                                                                 |
+| as-of-timestamp                     | (latest)              | A timestamp in milliseconds; the snapshot used will be the snapshot current at this time.                                                                                                                                                                 |
+| split-size                          | As per table property | Overrides this table's read.split.target-size and read.split.metadata-target-size                                                                                                                                                                         |
+| lookback                            | As per table property | Overrides this table's read.split.planning-lookback                                                                                                                                                                                                       |
+| file-open-cost                      | As per table property | Overrides this table's read.split.open-file-cost                                                                                                                                                                                                          |
+| vectorization-enabled               | As per table property | Overrides this table's read.parquet.vectorization.enabled                                                                                                                                                                                                 |
+| batch-size                          | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                                                                                                                                                                              |
+| stream-from-timestamp               | (none) | A timestamp in milliseconds to stream from; if before the oldest known ancestor snapshot, the oldest will be used                                                                                                                                         |
+| streaming-max-files-per-micro-batch | INT_MAX | Maximum number of files per microbatch                                                                                                                                                                                                                    | 
+| streaming-max-rows-per-micro-batch  | INT_MAX | Maximum number of rows per microbatch. Note : smallest granuality supported is 1 file, please make sure number of records per file is always greater than the number of records in the largest file possible, otherwise it can lead to stream being stuck | 
 
 ### Write options
 


### PR DESCRIPTION
revives PR: https://github.com/apache/iceberg/pull/8044

Request for adding this in docs : 
Past occurrence : 
[1] https://apache-iceberg.slack.com/archives/C025PH0G1D4/p1716740209929429
[2] https://apache-iceberg.slack.com/archives/C03LG1D563F/p1689071538157539?thread_ts=1688648903.712169&cid=C03LG1D563F

Recent occurrence (2/10): 
[1] https://apache-iceberg.slack.com/archives/C025PH0G1D4/p1739229168225159?thread_ts=1739220861.061949&cid=C025PH0G1D4