### PR TITLE
Build: skip scheduled docker image publish workflows on forks

### DIFF
--- a/.github/workflows/publish-iceberg-rest-fixture-docker.yml
+++ b/.github/workflows/publish-iceberg-rest-fixture-docker.yml
@@ -34,6 +34,7 @@ env:
 
 jobs:
   build:
+    if: github.repository_owner == 'apache'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Only enable workflow #11632 in apache and avoid failure like https://github.com/dramaticlly/iceberg/actions/runs/13127287689/job/36625899396

@nastra @Fokko @sungwy can you help review?