### PR TITLE
Core: Adjust Jackson settings to handle large metadata json

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTObjectMapper.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTObjectMapper.java
@@ -21,12 +21,17 @@ package org.apache.iceberg.rest;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 class RESTObjectMapper {
-  private static final JsonFactory FACTORY = new JsonFactory();
+  private static final JsonFactory FACTORY =
+      new JsonFactoryBuilder()
+          .configure(JsonFactory.Feature.INTERN_FIELD_NAMES, false)
+          .configure(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false)
+          .build();
   private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
   private static volatile boolean isInitialized = false;
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTObjectMapper.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTObjectMapper.java
@@ -29,7 +29,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 class RESTObjectMapper {
   private static final JsonFactory FACTORY =
       new JsonFactoryBuilder()
-          .configure(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES, false)
+          .configure(JsonFactory.Feature.INTERN_FIELD_NAMES, false)
+          .configure(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false)
           .build();
   private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
   private static volatile boolean isInitialized = false;

--- a/core/src/main/java/org/apache/iceberg/rest/RESTObjectMapper.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTObjectMapper.java
@@ -29,8 +29,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 class RESTObjectMapper {
   private static final JsonFactory FACTORY =
       new JsonFactoryBuilder()
-          .configure(JsonFactory.Feature.INTERN_FIELD_NAMES, false)
-          .configure(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false)
+          .configure(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES, false)
           .build();
   private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
   private static volatile boolean isInitialized = false;

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -46,8 +46,7 @@ public class JsonUtil {
 
   private static final JsonFactory FACTORY =
       new JsonFactoryBuilder()
-          .configure(JsonFactory.Feature.INTERN_FIELD_NAMES, false)
-          .configure(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false)
+          .configure(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES, false)
           .build();
   private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
 

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.util;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,7 +44,11 @@ public class JsonUtil {
 
   private JsonUtil() {}
 
-  private static final JsonFactory FACTORY = new JsonFactory();
+  private static final JsonFactory FACTORY =
+      new JsonFactoryBuilder()
+          .configure(JsonFactory.Feature.INTERN_FIELD_NAMES, false)
+          .configure(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false)
+          .build();
   private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
 
   public static JsonFactory factory() {

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -46,7 +46,8 @@ public class JsonUtil {
 
   private static final JsonFactory FACTORY =
       new JsonFactoryBuilder()
-          .configure(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES, false)
+          .configure(JsonFactory.Feature.INTERN_FIELD_NAMES, false)
+          .configure(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false)
           .build();
   private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
 

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -51,8 +51,12 @@ project(':iceberg-mr') {
       exclude group: 'org.apache.hive', module: 'hive-storage-api'
     }
 
-    testImplementation libs.calcite.core
-    testImplementation libs.calcite.druid
+    testImplementation(libs.calcite.core) {
+      exclude group: 'org.apache.calcite.avatica', module: 'avatica'
+    }
+    testImplementation(libs.calcite.druid) {
+      exclude group: 'org.apache.calcite.avatica', module: 'avatica'
+    }
 
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
@@ -60,7 +64,6 @@ project(':iceberg-mr') {
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
 
     testImplementation libs.avro.avro
-    testImplementation libs.calcite.core
     testImplementation libs.kryo.shaded
     testImplementation platform(libs.jackson.bom)
     testImplementation libs.jackson.annotations


### PR DESCRIPTION
With very large table metadata json, for example, those with many snapshots with partition summaries, we sometimes encounter errors involving hash collisions when loading the metadata. This PR disables that hash collision check so the metadata can be parsed without error. We have had this set in our internal fork for a while.

In addition, this PR disable string interning of field names which has lead to performance problems for us when parsing metadata. Given partition summary field names and other snapshot properties are often not reused across different metadata, the interning causes more harm than good. This is especially true when using Iceberg in a server which is loading metadata for many tables.

This also fixes a test classpath issue. The Avatica driver is a shadow jar that bundles an old unshaded version of Jackson.