### PR TITLE
API: Deprecate NestedType.of in favor of builder

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -541,7 +541,9 @@ public class Types {
     }
 
     /**
-     * @deprecated will be removed in 2.0.0; use builder() instead.
+     * Create a nested field.
+     *
+     * @deprecated will be removed in 2.0.0; use {@link #builder()} instead.
      */
     @Deprecated
     public static NestedField of(int id, boolean isOptional, String name, Type type) {
@@ -549,7 +551,9 @@ public class Types {
     }
 
     /**
-     * @deprecated will be removed in 2.0.0; use builder() instead.
+     * Create a nested field.
+     *
+     * @deprecated will be removed in 2.0.0; use {@link #builder()} instead.
      */
     @Deprecated
     public static NestedField of(int id, boolean isOptional, String name, Type type, String doc) {

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -540,10 +540,18 @@ public class Types {
       return new NestedField(false, id, name, type, doc, null, null);
     }
 
+    /**
+     * @deprecated will be removed in 2.0.0; use builder() instead.
+     */
+    @Deprecated
     public static NestedField of(int id, boolean isOptional, String name, Type type) {
       return new NestedField(isOptional, id, name, type, null, null, null);
     }
 
+    /**
+     * @deprecated will be removed in 2.0.0; use builder() instead.
+     */
+    @Deprecated
     public static NestedField of(int id, boolean isOptional, String name, Type type, String doc) {
       return new NestedField(isOptional, id, name, type, doc, null, null);
     }

--- a/api/src/test/java/org/apache/iceberg/TestSchema.java
+++ b/api/src/test/java/org/apache/iceberg/TestSchema.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -50,8 +51,8 @@ public class TestSchema {
           Types.NestedField.required("has_default")
               .withId(2)
               .ofType(Types.StringType.get())
-              .withInitialDefault("--")
-              .withWriteDefault("--")
+              .withInitialDefault(Literal.of("--"))
+              .withWriteDefault(Literal.of("--"))
               .build());
 
   private static final Schema WRITE_DEFAULT_SCHEMA =
@@ -60,7 +61,7 @@ public class TestSchema {
           Types.NestedField.required("has_default")
               .withId(2)
               .ofType(Types.StringType.get())
-              .withWriteDefault("--")
+              .withWriteDefault(Literal.of("--"))
               .build());
 
   private Schema generateTypeSchema(Type type) {

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Set;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types.IntegerType;
@@ -598,8 +599,8 @@ public class TestTypeUtil {
                 Types.NestedField.required("c")
                     .withId(11)
                     .ofType(Types.IntegerType.get())
-                    .withInitialDefault(23)
-                    .withWriteDefault(34)
+                    .withInitialDefault(Literal.of(23))
+                    .withWriteDefault(Literal.of(34))
                     .build(),
                 required(12, "B", Types.IntegerType.get())),
             Sets.newHashSet(10));
@@ -617,8 +618,8 @@ public class TestTypeUtil {
                 Types.NestedField.required("c")
                     .withId(16)
                     .ofType(Types.IntegerType.get())
-                    .withInitialDefault(23)
-                    .withWriteDefault(34)
+                    .withInitialDefault(Literal.of(23))
+                    .withWriteDefault(Literal.of(34))
                     .build(),
                 required(15, "B", Types.IntegerType.get())));
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -238,9 +238,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
         // Use FixedSizeBinaryVector for binary backed decimal
         type = Types.FixedType.ofLength(primitive.getTypeLength());
       }
-      physicalType =
-          Types.NestedField.of(
-              logicalType.fieldId(), logicalType.isOptional(), logicalType.name(), type);
+      physicalType = Types.NestedField.from(logicalType).ofType(type).build();
     }
 
     return physicalType;

--- a/core/src/main/java/org/apache/iceberg/MetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsUtil.java
@@ -346,18 +346,21 @@ public class MetricsUtil {
         String colName = idToName.get(id);
 
         fields.add(
-            Types.NestedField.of(
-                nextId.incrementAndGet(),
-                true,
-                colName,
-                Types.StructType.of(
-                    READABLE_METRIC_COLS.stream()
-                        .map(
-                            m ->
-                                optional(
-                                    nextId.incrementAndGet(), m.name(), m.colType(field), m.doc()))
-                        .collect(Collectors.toList())),
-                String.format("Metrics for column %s", colName)));
+            Types.NestedField.optional(colName)
+                .withId(nextId.incrementAndGet())
+                .ofType(
+                    Types.StructType.of(
+                        READABLE_METRIC_COLS.stream()
+                            .map(
+                                m ->
+                                    optional(
+                                        nextId.incrementAndGet(),
+                                        m.name(),
+                                        m.colType(field),
+                                        m.doc()))
+                            .collect(Collectors.toList())))
+                .withDoc(String.format("Metrics for column %s", colName))
+                .build());
       }
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -352,7 +352,7 @@ public class TestDeleteFiles extends TestBase {
 
   @TestTemplate
   public void testDeleteWithCollision() {
-    Schema schema = new Schema(Types.NestedField.of(0, false, "x", Types.StringType.get()));
+    Schema schema = new Schema(Types.NestedField.required(0, "x", Types.StringType.get()));
     PartitionSpec spec = PartitionSpec.builderFor(schema).identity("x").build();
     Table collisionTable =
         TestTables.create(tableDir, "hashcollision", schema, spec, formatVersion);

--- a/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
@@ -28,6 +28,7 @@ import java.nio.ByteBuffer;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.iceberg.avro.AvroDataTest;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
@@ -85,30 +86,30 @@ public class TestSchemaParser extends AvroDataTest {
 
   private static Stream<Arguments> primitiveTypesAndDefaults() {
     return Stream.of(
-        Arguments.of(Types.BooleanType.get(), false),
-        Arguments.of(Types.IntegerType.get(), 34),
-        Arguments.of(Types.LongType.get(), 4900000000L),
-        Arguments.of(Types.FloatType.get(), 12.21F),
-        Arguments.of(Types.DoubleType.get(), -0.0D),
-        Arguments.of(Types.DateType.get(), DateTimeUtil.isoDateToDays("2024-12-17")),
+        Arguments.of(Types.BooleanType.get(), Literal.of(false)),
+        Arguments.of(Types.IntegerType.get(), Literal.of(34)),
+        Arguments.of(Types.LongType.get(), Literal.of(4900000000L)),
+        Arguments.of(Types.FloatType.get(), Literal.of(12.21F)),
+        Arguments.of(Types.DoubleType.get(), Literal.of(-0.0D)),
+        Arguments.of(Types.DateType.get(), Literal.of(DateTimeUtil.isoDateToDays("2024-12-17"))),
         // Arguments.of(Types.TimeType.get(), DateTimeUtil.isoTimeToMicros("23:59:59.999999")),
         Arguments.of(
             Types.TimestampType.withZone(),
-            DateTimeUtil.isoTimestamptzToMicros("2024-12-17T23:59:59.999999+00:00")),
+            Literal.of(DateTimeUtil.isoTimestamptzToMicros("2024-12-17T23:59:59.999999+00:00"))),
         Arguments.of(
             Types.TimestampType.withoutZone(),
-            DateTimeUtil.isoTimestampToMicros("2024-12-17T23:59:59.999999")),
-        Arguments.of(Types.StringType.get(), "iceberg"),
-        Arguments.of(Types.UUIDType.get(), UUID.randomUUID()),
+            Literal.of(DateTimeUtil.isoTimestampToMicros("2024-12-17T23:59:59.999999"))),
+        Arguments.of(Types.StringType.get(), Literal.of("iceberg")),
+        Arguments.of(Types.UUIDType.get(), Literal.of(UUID.randomUUID())),
         Arguments.of(
-            Types.FixedType.ofLength(4), ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),
-        Arguments.of(Types.BinaryType.get(), ByteBuffer.wrap(new byte[] {0x0a, 0x0b})),
-        Arguments.of(Types.DecimalType.of(9, 2), new BigDecimal("12.34")));
+            Types.FixedType.ofLength(4), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
+        Arguments.of(Types.BinaryType.get(), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b}))),
+        Arguments.of(Types.DecimalType.of(9, 2), Literal.of(new BigDecimal("12.34"))));
   }
 
   @ParameterizedTest
   @MethodSource("primitiveTypesAndDefaults")
-  public void testPrimitiveTypeDefaultValues(Type.PrimitiveType type, Object defaultValue) {
+  public void testPrimitiveTypeDefaultValues(Type.PrimitiveType type, Literal<?> defaultValue) {
     Schema schema =
         new Schema(
             required(1, "id", Types.LongType.get()),
@@ -120,7 +121,7 @@ public class TestSchemaParser extends AvroDataTest {
                 .build());
 
     Schema serialized = SchemaParser.fromJson(SchemaParser.toJson(schema));
-    assertThat(serialized.findField("col_with_default").initialDefault()).isEqualTo(defaultValue);
-    assertThat(serialized.findField("col_with_default").writeDefault()).isEqualTo(defaultValue);
+    assertThat(serialized.findField("col_with_default").initialDefault()).isEqualTo(defaultValue.value());
+    assertThat(serialized.findField("col_with_default").writeDefault()).isEqualTo(defaultValue.value());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
@@ -102,7 +102,8 @@ public class TestSchemaParser extends AvroDataTest {
         Arguments.of(Types.StringType.get(), Literal.of("iceberg")),
         Arguments.of(Types.UUIDType.get(), Literal.of(UUID.randomUUID())),
         Arguments.of(
-            Types.FixedType.ofLength(4), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
+            Types.FixedType.ofLength(4),
+            Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
         Arguments.of(Types.BinaryType.get(), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b}))),
         Arguments.of(Types.DecimalType.of(9, 2), Literal.of(new BigDecimal("12.34"))));
   }
@@ -121,7 +122,9 @@ public class TestSchemaParser extends AvroDataTest {
                 .build());
 
     Schema serialized = SchemaParser.fromJson(SchemaParser.toJson(schema));
-    assertThat(serialized.findField("col_with_default").initialDefault()).isEqualTo(defaultValue.value());
-    assertThat(serialized.findField("col_with_default").writeDefault()).isEqualTo(defaultValue.value());
+    assertThat(serialized.findField("col_with_default").initialDefault())
+        .isEqualTo(defaultValue.value());
+    assertThat(serialized.findField("col_with_default").writeDefault())
+        .isEqualTo(defaultValue.value());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestReadDefaultValues.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestReadDefaultValues.java
@@ -28,6 +28,8 @@ import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SingleValueParser;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
@@ -94,7 +96,7 @@ public class TestReadDefaultValues {
               Types.NestedField.optional("defaulted")
                   .withId(1000)
                   .ofType(type)
-                  .withInitialDefault(defaultValue)
+                  .withInitialDefault(Expressions.lit(defaultValue))
                   .build());
 
       Record expectedRecord = new Record(AvroSchemaUtil.convert(readerSchema.asStruct()));
@@ -119,7 +121,7 @@ public class TestReadDefaultValues {
     for (Object[] typeAndDefault : TYPES_WITH_DEFAULTS) {
       Type type = (Type) typeAndDefault[0];
       String defaultValueJson = (String) typeAndDefault[1];
-      Object defaultValue = SingleValueParser.fromJson(type, defaultValueJson);
+      Literal<?> defaultValue = Expressions.lit(SingleValueParser.fromJson(type, defaultValueJson));
 
       Schema readerSchema =
           new Schema(

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateTableRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateTableRequest.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.SortOrderParser;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.rest.RequestResponseTestBase;
@@ -47,7 +48,11 @@ public class TestCreateTableRequest extends RequestResponseTestBase<CreateTableR
   private static final String SAMPLE_LOCATION = "file://tmp/location/";
   private static final Schema SAMPLE_SCHEMA =
       new Schema(
-          required("id").withId(1).ofType(Types.IntegerType.get()).withWriteDefault(1).build(),
+          required("id")
+              .withId(1)
+              .ofType(Types.IntegerType.get())
+              .withWriteDefault(Literal.of(1))
+              .build(),
           optional("data").withId(2).ofType(Types.StringType.get()).build());
   private static final String SAMPLE_SCHEMA_JSON = SchemaParser.toJson(SAMPLE_SCHEMA);
   private static final PartitionSpec SAMPLE_SPEC =

--- a/data/src/test/java/org/apache/iceberg/data/DataTest.java
+++ b/data/src/test/java/org/apache/iceberg/data/DataTest.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
@@ -254,7 +255,7 @@ public abstract class DataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build());
 
@@ -264,17 +265,17 @@ public abstract class DataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.required("missing_str")
                 .withId(6)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("orange")
+                .withInitialDefault(Literal.of("orange"))
                 .build(),
             Types.NestedField.optional("missing_int")
                 .withId(7)
                 .ofType(Types.IntegerType.get())
-                .withInitialDefault(34)
+                .withInitialDefault(Literal.of(34))
                 .build());
 
     writeAndValidate(writeSchema, expectedSchema);
@@ -290,7 +291,7 @@ public abstract class DataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build());
 
@@ -300,7 +301,7 @@ public abstract class DataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("missing_date")
                 .withId(3)
@@ -320,7 +321,7 @@ public abstract class DataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build(),
             Types.NestedField.optional("nested")
@@ -335,7 +336,7 @@ public abstract class DataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("nested")
                 .withId(3)
@@ -345,7 +346,7 @@ public abstract class DataTest {
                         Types.NestedField.optional("missing_inner_float")
                             .withId(5)
                             .ofType(Types.FloatType.get())
-                            .withInitialDefault(-0.0F)
+                            .withInitialDefault(Literal.of(-0.0F))
                             .build()))
                 .withDoc("Used to test nested field defaults")
                 .build());
@@ -363,7 +364,7 @@ public abstract class DataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build(),
             Types.NestedField.optional("nested_map")
@@ -383,7 +384,7 @@ public abstract class DataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("nested_map")
                 .withId(3)
@@ -397,7 +398,7 @@ public abstract class DataTest {
                             Types.NestedField.optional("value_int")
                                 .withId(7)
                                 .ofType(Types.IntegerType.get())
-                                .withInitialDefault(34)
+                                .withInitialDefault(Literal.of(34))
                                 .build())))
                 .withDoc("Used to test nested field defaults")
                 .build());
@@ -415,7 +416,7 @@ public abstract class DataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build(),
             Types.NestedField.optional("nested_list")
@@ -432,7 +433,7 @@ public abstract class DataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("nested_list")
                 .withId(3)
@@ -444,7 +445,7 @@ public abstract class DataTest {
                             Types.NestedField.optional("element_int")
                                 .withId(7)
                                 .ofType(Types.IntegerType.get())
-                                .withInitialDefault(34)
+                                .withInitialDefault(Literal.of(34))
                                 .build())))
                 .withDoc("Used to test nested field defaults")
                 .build());
@@ -454,30 +455,30 @@ public abstract class DataTest {
 
   private static Stream<Arguments> primitiveTypesAndDefaults() {
     return Stream.of(
-        Arguments.of(Types.BooleanType.get(), false),
-        Arguments.of(Types.IntegerType.get(), 34),
-        Arguments.of(Types.LongType.get(), 4900000000L),
-        Arguments.of(Types.FloatType.get(), 12.21F),
-        Arguments.of(Types.DoubleType.get(), -0.0D),
-        Arguments.of(Types.DateType.get(), DateTimeUtil.isoDateToDays("2024-12-17")),
-        Arguments.of(Types.TimeType.get(), DateTimeUtil.isoTimeToMicros("23:59:59.999999")),
+        Arguments.of(Types.BooleanType.get(), Literal.of(false)),
+        Arguments.of(Types.IntegerType.get(), Literal.of(34)),
+        Arguments.of(Types.LongType.get(), Literal.of(4900000000L)),
+        Arguments.of(Types.FloatType.get(), Literal.of(12.21F)),
+        Arguments.of(Types.DoubleType.get(), Literal.of(-0.0D)),
+        Arguments.of(Types.DateType.get(), Literal.of(DateTimeUtil.isoDateToDays("2024-12-17"))),
+        // Arguments.of(Types.TimeType.get(), DateTimeUtil.isoTimeToMicros("23:59:59.999999")),
         Arguments.of(
             Types.TimestampType.withZone(),
-            DateTimeUtil.isoTimestamptzToMicros("2024-12-17T23:59:59.999999+00:00")),
+            Literal.of(DateTimeUtil.isoTimestamptzToMicros("2024-12-17T23:59:59.999999+00:00"))),
         Arguments.of(
             Types.TimestampType.withoutZone(),
-            DateTimeUtil.isoTimestampToMicros("2024-12-17T23:59:59.999999")),
-        Arguments.of(Types.StringType.get(), "iceberg"),
-        Arguments.of(Types.UUIDType.get(), UUID.randomUUID()),
+            Literal.of(DateTimeUtil.isoTimestampToMicros("2024-12-17T23:59:59.999999"))),
+        Arguments.of(Types.StringType.get(), Literal.of("iceberg")),
+        Arguments.of(Types.UUIDType.get(), Literal.of(UUID.randomUUID())),
         Arguments.of(
-            Types.FixedType.ofLength(4), ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),
-        Arguments.of(Types.BinaryType.get(), ByteBuffer.wrap(new byte[] {0x0a, 0x0b})),
-        Arguments.of(Types.DecimalType.of(9, 2), new BigDecimal("12.34")));
+            Types.FixedType.ofLength(4), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
+        Arguments.of(Types.BinaryType.get(), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b}))),
+        Arguments.of(Types.DecimalType.of(9, 2), Literal.of(new BigDecimal("12.34"))));
   }
 
   @ParameterizedTest
   @MethodSource("primitiveTypesAndDefaults")
-  public void testPrimitiveTypeDefaultValues(Type.PrimitiveType type, Object defaultValue)
+  public void testPrimitiveTypeDefaultValues(Type.PrimitiveType type, Literal<?> defaultValue)
       throws IOException {
     Assumptions.assumeThat(supportsDefaultValues()).isTrue();
 

--- a/data/src/test/java/org/apache/iceberg/data/DataTest.java
+++ b/data/src/test/java/org/apache/iceberg/data/DataTest.java
@@ -471,7 +471,8 @@ public abstract class DataTest {
         Arguments.of(Types.StringType.get(), Literal.of("iceberg")),
         Arguments.of(Types.UUIDType.get(), Literal.of(UUID.randomUUID())),
         Arguments.of(
-            Types.FixedType.ofLength(4), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
+            Types.FixedType.ofLength(4),
+            Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
         Arguments.of(Types.BinaryType.get(), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b}))),
         Arguments.of(Types.DecimalType.of(9, 2), Literal.of(new BigDecimal("12.34"))));
   }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeySerializer.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeySerializer.java
@@ -68,12 +68,7 @@ class SortKeySerializer extends TypeSerializer<SortKey> {
       Types.NestedField sourceField = schema.findField(sortField.sourceId());
       Type resultType = sortField.transform().getResultType(sourceField.type());
       Types.NestedField transformedField =
-          Types.NestedField.of(
-              sourceField.fieldId(),
-              sourceField.isOptional(),
-              sourceField.name(),
-              resultType,
-              sourceField.doc());
+          Types.NestedField.from(sourceField).ofType(resultType).build();
       transformedFields[i] = transformedField;
     }
   }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeyUtil.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SortKeyUtil.java
@@ -45,12 +45,11 @@ class SortKeyUtil {
       // case. To resolve the collision, field id is set to transform index and field name is set to
       // sourceFieldName_transformIndex
       Types.NestedField transformedField =
-          Types.NestedField.of(
-              i,
-              sourceField.isOptional(),
-              sourceField.name() + '_' + i,
-              transformedType,
-              sourceField.doc());
+          Types.NestedField.from(sourceField)
+              .withId(i)
+              .withName(sourceField.name() + '_' + i)
+              .ofType(transformedType)
+              .build();
       transformedFields.add(transformedField);
     }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
@@ -276,11 +276,13 @@ class SchemaUtils {
               valueSchema.fields().stream()
                   .map(
                       field ->
-                          NestedField.of(
-                              nextId(),
-                              config.schemaForceOptional() || field.schema().isOptional(),
-                              field.name(),
-                              toIcebergType(field.schema())))
+                          NestedField.builder()
+                              .isOptional(
+                                  config.schemaForceOptional() || field.schema().isOptional())
+                              .withId(nextId())
+                              .ofType(toIcebergType(field.schema()))
+                              .withName(field.name())
+                              .build())
                   .collect(Collectors.toList());
           return StructType.of(structFields);
         case STRING:

--- a/orc/src/test/java/org/apache/iceberg/orc/TestBuildOrcProjection.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestBuildOrcProjection.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
 import org.junit.jupiter.api.Test;
@@ -184,7 +185,7 @@ public class TestBuildOrcProjection {
                     Types.NestedField.required("d")
                         .withId(4)
                         .ofType(Types.LongType.get())
-                        .withInitialDefault(34L)
+                        .withInitialDefault(Literal.of(34L))
                         .build())));
 
     assertThatThrownBy(() -> ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema))

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -321,7 +321,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build());
 
@@ -331,17 +331,17 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.required("missing_str")
                 .withId(6)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("orange")
+                .withInitialDefault(Literal.of("orange"))
                 .build(),
             Types.NestedField.optional("missing_int")
                 .withId(7)
                 .ofType(Types.IntegerType.get())
-                .withInitialDefault(34)
+                .withInitialDefault(Literal.of(34))
                 .build());
 
     writeAndValidate(writeSchema, expectedSchema);
@@ -357,7 +357,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build());
 
@@ -367,7 +367,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("missing_date")
                 .withId(3)
@@ -388,7 +388,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build(),
             Types.NestedField.optional("nested")
@@ -403,7 +403,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("nested")
                 .withId(3)
@@ -413,7 +413,7 @@ public abstract class AvroDataTest {
                         Types.NestedField.optional("missing_inner_float")
                             .withId(5)
                             .ofType(Types.FloatType.get())
-                            .withInitialDefault(-0.0F)
+                            .withInitialDefault(Literal.of(-0.0F))
                             .build()))
                 .withDoc("Used to test nested field defaults")
                 .build());
@@ -432,7 +432,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build(),
             Types.NestedField.optional("nested_map")
@@ -452,7 +452,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("nested_map")
                 .withId(3)
@@ -466,7 +466,7 @@ public abstract class AvroDataTest {
                             Types.NestedField.optional("value_int")
                                 .withId(7)
                                 .ofType(Types.IntegerType.get())
-                                .withInitialDefault(34)
+                                .withInitialDefault(Literal.of(34))
                                 .build())))
                 .withDoc("Used to test nested field defaults")
                 .build());
@@ -485,7 +485,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build(),
             Types.NestedField.optional("nested_list")
@@ -502,7 +502,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("nested_list")
                 .withId(3)
@@ -514,7 +514,7 @@ public abstract class AvroDataTest {
                             Types.NestedField.optional("element_int")
                                 .withId(7)
                                 .ofType(Types.IntegerType.get())
-                                .withInitialDefault(34)
+                                .withInitialDefault(Literal.of(34))
                                 .build())))
                 .withDoc("Used to test nested field defaults")
                 .build());
@@ -524,30 +524,30 @@ public abstract class AvroDataTest {
 
   private static Stream<Arguments> primitiveTypesAndDefaults() {
     return Stream.of(
-        Arguments.of(Types.BooleanType.get(), false),
-        Arguments.of(Types.IntegerType.get(), 34),
-        Arguments.of(Types.LongType.get(), 4900000000L),
-        Arguments.of(Types.FloatType.get(), 12.21F),
-        Arguments.of(Types.DoubleType.get(), -0.0D),
-        Arguments.of(Types.DateType.get(), DateTimeUtil.isoDateToDays("2024-12-17")),
+        Arguments.of(Types.BooleanType.get(), Literal.of(false)),
+        Arguments.of(Types.IntegerType.get(), Literal.of(34)),
+        Arguments.of(Types.LongType.get(), Literal.of(4900000000L)),
+        Arguments.of(Types.FloatType.get(), Literal.of(12.21F)),
+        Arguments.of(Types.DoubleType.get(), Literal.of(-0.0D)),
+        Arguments.of(Types.DateType.get(), Literal.of(DateTimeUtil.isoDateToDays("2024-12-17"))),
         // Arguments.of(Types.TimeType.get(), DateTimeUtil.isoTimeToMicros("23:59:59.999999")),
         Arguments.of(
             Types.TimestampType.withZone(),
-            DateTimeUtil.isoTimestamptzToMicros("2024-12-17T23:59:59.999999+00:00")),
+            Literal.of(DateTimeUtil.isoTimestamptzToMicros("2024-12-17T23:59:59.999999+00:00"))),
         // Arguments.of(
         //     Types.TimestampType.withoutZone(),
-        //     DateTimeUtil.isoTimestampToMicros("2024-12-17T23:59:59.999999")),
-        Arguments.of(Types.StringType.get(), "iceberg"),
-        Arguments.of(Types.UUIDType.get(), UUID.randomUUID()),
+        //     Literal.of(DateTimeUtil.isoTimestampToMicros("2024-12-17T23:59:59.999999"))),
+        Arguments.of(Types.StringType.get(), Literal.of("iceberg")),
+        Arguments.of(Types.UUIDType.get(), Literal.of(UUID.randomUUID())),
         Arguments.of(
-            Types.FixedType.ofLength(4), ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),
-        Arguments.of(Types.BinaryType.get(), ByteBuffer.wrap(new byte[] {0x0a, 0x0b})),
-        Arguments.of(Types.DecimalType.of(9, 2), new BigDecimal("12.34")));
+            Types.FixedType.ofLength(4), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
+        Arguments.of(Types.BinaryType.get(), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b}))),
+        Arguments.of(Types.DecimalType.of(9, 2), Literal.of(new BigDecimal("12.34"))));
   }
 
   @ParameterizedTest
   @MethodSource("primitiveTypesAndDefaults")
-  public void testPrimitiveTypeDefaultValues(Type.PrimitiveType type, Object defaultValue)
+  public void testPrimitiveTypeDefaultValues(Type.PrimitiveType type, Literal<?> defaultValue)
       throws IOException {
     Assumptions.assumeThat(supportsDefaultValues()).isTrue();
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -540,7 +540,8 @@ public abstract class AvroDataTest {
         Arguments.of(Types.StringType.get(), Literal.of("iceberg")),
         Arguments.of(Types.UUIDType.get(), Literal.of(UUID.randomUUID())),
         Arguments.of(
-            Types.FixedType.ofLength(4), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
+            Types.FixedType.ofLength(4),
+            Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
         Arguments.of(Types.BinaryType.get(), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b}))),
         Arguments.of(Types.DecimalType.of(9, 2), Literal.of(new BigDecimal("12.34"))));
   }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -522,7 +522,8 @@ public abstract class AvroDataTest {
         Arguments.of(Types.StringType.get(), Literal.of("iceberg")),
         Arguments.of(Types.UUIDType.get(), Literal.of(UUID.randomUUID())),
         Arguments.of(
-            Types.FixedType.ofLength(4), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
+            Types.FixedType.ofLength(4),
+            Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
         Arguments.of(Types.BinaryType.get(), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b}))),
         Arguments.of(Types.DecimalType.of(9, 2), Literal.of(new BigDecimal("12.34"))));
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
@@ -302,7 +303,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build());
 
@@ -312,17 +313,17 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.required("missing_str")
                 .withId(6)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("orange")
+                .withInitialDefault(Literal.of("orange"))
                 .build(),
             Types.NestedField.optional("missing_int")
                 .withId(7)
                 .ofType(Types.IntegerType.get())
-                .withInitialDefault(34)
+                .withInitialDefault(Literal.of(34))
                 .build());
 
     writeAndValidate(writeSchema, expectedSchema);
@@ -338,7 +339,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build());
 
@@ -348,7 +349,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("missing_date")
                 .withId(3)
@@ -369,7 +370,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build(),
             Types.NestedField.optional("nested")
@@ -384,7 +385,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("nested")
                 .withId(3)
@@ -394,7 +395,7 @@ public abstract class AvroDataTest {
                         Types.NestedField.optional("missing_inner_float")
                             .withId(5)
                             .ofType(Types.FloatType.get())
-                            .withInitialDefault(-0.0F)
+                            .withInitialDefault(Literal.of(-0.0F))
                             .build()))
                 .withDoc("Used to test nested field defaults")
                 .build());
@@ -413,7 +414,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build(),
             Types.NestedField.optional("nested_map")
@@ -433,7 +434,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("nested_map")
                 .withId(3)
@@ -447,7 +448,7 @@ public abstract class AvroDataTest {
                             Types.NestedField.optional("value_int")
                                 .withId(7)
                                 .ofType(Types.IntegerType.get())
-                                .withInitialDefault(34)
+                                .withInitialDefault(Literal.of(34))
                                 .build())))
                 .withDoc("Used to test nested field defaults")
                 .build());
@@ -466,7 +467,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build(),
             Types.NestedField.optional("nested_list")
@@ -483,7 +484,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("nested_list")
                 .withId(3)
@@ -495,7 +496,7 @@ public abstract class AvroDataTest {
                             Types.NestedField.optional("element_int")
                                 .withId(7)
                                 .ofType(Types.IntegerType.get())
-                                .withInitialDefault(34)
+                                .withInitialDefault(Literal.of(34))
                                 .build())))
                 .withDoc("Used to test nested field defaults")
                 .build());
@@ -505,30 +506,30 @@ public abstract class AvroDataTest {
 
   private static Stream<Arguments> primitiveTypesAndDefaults() {
     return Stream.of(
-        Arguments.of(Types.BooleanType.get(), false),
-        Arguments.of(Types.IntegerType.get(), 34),
-        Arguments.of(Types.LongType.get(), 4900000000L),
-        Arguments.of(Types.FloatType.get(), 12.21F),
-        Arguments.of(Types.DoubleType.get(), -0.0D),
-        Arguments.of(Types.DateType.get(), DateTimeUtil.isoDateToDays("2024-12-17")),
+        Arguments.of(Types.BooleanType.get(), Literal.of(false)),
+        Arguments.of(Types.IntegerType.get(), Literal.of(34)),
+        Arguments.of(Types.LongType.get(), Literal.of(4900000000L)),
+        Arguments.of(Types.FloatType.get(), Literal.of(12.21F)),
+        Arguments.of(Types.DoubleType.get(), Literal.of(-0.0D)),
+        Arguments.of(Types.DateType.get(), Literal.of(DateTimeUtil.isoDateToDays("2024-12-17"))),
         // Arguments.of(Types.TimeType.get(), DateTimeUtil.isoTimeToMicros("23:59:59.999999")),
         Arguments.of(
             Types.TimestampType.withZone(),
-            DateTimeUtil.isoTimestamptzToMicros("2024-12-17T23:59:59.999999+00:00")),
+            Literal.of(DateTimeUtil.isoTimestamptzToMicros("2024-12-17T23:59:59.999999+00:00"))),
         Arguments.of(
             Types.TimestampType.withoutZone(),
-            DateTimeUtil.isoTimestampToMicros("2024-12-17T23:59:59.999999")),
-        Arguments.of(Types.StringType.get(), "iceberg"),
-        Arguments.of(Types.UUIDType.get(), UUID.randomUUID()),
+            Literal.of(DateTimeUtil.isoTimestampToMicros("2024-12-17T23:59:59.999999"))),
+        Arguments.of(Types.StringType.get(), Literal.of("iceberg")),
+        Arguments.of(Types.UUIDType.get(), Literal.of(UUID.randomUUID())),
         Arguments.of(
-            Types.FixedType.ofLength(4), ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),
-        Arguments.of(Types.BinaryType.get(), ByteBuffer.wrap(new byte[] {0x0a, 0x0b})),
-        Arguments.of(Types.DecimalType.of(9, 2), new BigDecimal("12.34")));
+            Types.FixedType.ofLength(4), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
+        Arguments.of(Types.BinaryType.get(), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b}))),
+        Arguments.of(Types.DecimalType.of(9, 2), Literal.of(new BigDecimal("12.34"))));
   }
 
   @ParameterizedTest
   @MethodSource("primitiveTypesAndDefaults")
-  public void testPrimitiveTypeDefaultValues(Type.PrimitiveType type, Object defaultValue)
+  public void testPrimitiveTypeDefaultValues(Type.PrimitiveType type, Literal<?> defaultValue)
       throws IOException {
     Assumptions.assumeThat(supportsDefaultValues()).isTrue();
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -522,7 +522,8 @@ public abstract class AvroDataTest {
         Arguments.of(Types.StringType.get(), Literal.of("iceberg")),
         Arguments.of(Types.UUIDType.get(), Literal.of(UUID.randomUUID())),
         Arguments.of(
-            Types.FixedType.ofLength(4), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
+            Types.FixedType.ofLength(4),
+            Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
         Arguments.of(Types.BinaryType.get(), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b}))),
         Arguments.of(Types.DecimalType.of(9, 2), Literal.of(new BigDecimal("12.34"))));
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
@@ -302,7 +303,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build());
 
@@ -312,17 +313,17 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.required("missing_str")
                 .withId(6)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("orange")
+                .withInitialDefault(Literal.of("orange"))
                 .build(),
             Types.NestedField.optional("missing_int")
                 .withId(7)
                 .ofType(Types.IntegerType.get())
-                .withInitialDefault(34)
+                .withInitialDefault(Literal.of(34))
                 .build());
 
     writeAndValidate(writeSchema, expectedSchema);
@@ -338,7 +339,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build());
 
@@ -348,7 +349,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("missing_date")
                 .withId(3)
@@ -369,7 +370,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build(),
             Types.NestedField.optional("nested")
@@ -384,7 +385,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("nested")
                 .withId(3)
@@ -394,7 +395,7 @@ public abstract class AvroDataTest {
                         Types.NestedField.optional("missing_inner_float")
                             .withId(5)
                             .ofType(Types.FloatType.get())
-                            .withInitialDefault(-0.0F)
+                            .withInitialDefault(Literal.of(-0.0F))
                             .build()))
                 .withDoc("Used to test nested field defaults")
                 .build());
@@ -413,7 +414,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build(),
             Types.NestedField.optional("nested_map")
@@ -433,7 +434,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("nested_map")
                 .withId(3)
@@ -447,7 +448,7 @@ public abstract class AvroDataTest {
                             Types.NestedField.optional("value_int")
                                 .withId(7)
                                 .ofType(Types.IntegerType.get())
-                                .withInitialDefault(34)
+                                .withInitialDefault(Literal.of(34))
                                 .build())))
                 .withDoc("Used to test nested field defaults")
                 .build());
@@ -466,7 +467,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .withDoc("Should not produce default value")
                 .build(),
             Types.NestedField.optional("nested_list")
@@ -483,7 +484,7 @@ public abstract class AvroDataTest {
             Types.NestedField.optional("data")
                 .withId(2)
                 .ofType(Types.StringType.get())
-                .withInitialDefault("wrong!")
+                .withInitialDefault(Literal.of("wrong!"))
                 .build(),
             Types.NestedField.optional("nested_list")
                 .withId(3)
@@ -495,7 +496,7 @@ public abstract class AvroDataTest {
                             Types.NestedField.optional("element_int")
                                 .withId(7)
                                 .ofType(Types.IntegerType.get())
-                                .withInitialDefault(34)
+                                .withInitialDefault(Literal.of(34))
                                 .build())))
                 .withDoc("Used to test nested field defaults")
                 .build());
@@ -505,30 +506,30 @@ public abstract class AvroDataTest {
 
   private static Stream<Arguments> primitiveTypesAndDefaults() {
     return Stream.of(
-        Arguments.of(Types.BooleanType.get(), false),
-        Arguments.of(Types.IntegerType.get(), 34),
-        Arguments.of(Types.LongType.get(), 4900000000L),
-        Arguments.of(Types.FloatType.get(), 12.21F),
-        Arguments.of(Types.DoubleType.get(), -0.0D),
-        Arguments.of(Types.DateType.get(), DateTimeUtil.isoDateToDays("2024-12-17")),
+        Arguments.of(Types.BooleanType.get(), Literal.of(false)),
+        Arguments.of(Types.IntegerType.get(), Literal.of(34)),
+        Arguments.of(Types.LongType.get(), Literal.of(4900000000L)),
+        Arguments.of(Types.FloatType.get(), Literal.of(12.21F)),
+        Arguments.of(Types.DoubleType.get(), Literal.of(-0.0D)),
+        Arguments.of(Types.DateType.get(), Literal.of(DateTimeUtil.isoDateToDays("2024-12-17"))),
         // Arguments.of(Types.TimeType.get(), DateTimeUtil.isoTimeToMicros("23:59:59.999999")),
         Arguments.of(
             Types.TimestampType.withZone(),
-            DateTimeUtil.isoTimestamptzToMicros("2024-12-17T23:59:59.999999+00:00")),
+            Literal.of(DateTimeUtil.isoTimestamptzToMicros("2024-12-17T23:59:59.999999+00:00"))),
         Arguments.of(
             Types.TimestampType.withoutZone(),
-            DateTimeUtil.isoTimestampToMicros("2024-12-17T23:59:59.999999")),
-        Arguments.of(Types.StringType.get(), "iceberg"),
-        Arguments.of(Types.UUIDType.get(), UUID.randomUUID()),
+            Literal.of(DateTimeUtil.isoTimestampToMicros("2024-12-17T23:59:59.999999"))),
+        Arguments.of(Types.StringType.get(), Literal.of("iceberg")),
+        Arguments.of(Types.UUIDType.get(), Literal.of(UUID.randomUUID())),
         Arguments.of(
-            Types.FixedType.ofLength(4), ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),
-        Arguments.of(Types.BinaryType.get(), ByteBuffer.wrap(new byte[] {0x0a, 0x0b})),
-        Arguments.of(Types.DecimalType.of(9, 2), new BigDecimal("12.34")));
+            Types.FixedType.ofLength(4), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
+        Arguments.of(Types.BinaryType.get(), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b}))),
+        Arguments.of(Types.DecimalType.of(9, 2), Literal.of(new BigDecimal("12.34"))));
   }
 
   @ParameterizedTest
   @MethodSource("primitiveTypesAndDefaults")
-  public void testPrimitiveTypeDefaultValues(Type.PrimitiveType type, Object defaultValue)
+  public void testPrimitiveTypeDefaultValues(Type.PrimitiveType type, Literal<?> defaultValue)
       throws IOException {
     Assumptions.assumeThat(supportsDefaultValues()).isTrue();
 


### PR DESCRIPTION
This is a follow up to #12211. While adding support for default values in `UpdateSchema`, many of the changes were to use the `NestedField` builder's copy constructor, `from(NestedField)`, so that field defaults are not dropped. Dropping defaults is easy to do when using the `of` factory method that was previously used to copy fields.

This PR deprecates that factory method and removes deprecated uses of `NestedField` methods.