### PR TITLE
Core,Api: Add overwrite option when register external table to catalog

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1177,7 +1177,6 @@ acceptedBreaks:
       old: "class org.apache.iceberg.Metrics"
       new: "class org.apache.iceberg.Metrics"
       justification: "Java serialization across versions is not guaranteed"
-    org.apache.iceberg:iceberg-api:
     - code: "java.method.addedToInterface"
       new: "method org.apache.iceberg.Table org.apache.iceberg.catalog.SessionCatalog::registerTable(org.apache.iceberg.catalog.SessionCatalog.SessionContext,\
         \ org.apache.iceberg.catalog.TableIdentifier, java.lang.String, boolean)"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1177,7 +1177,15 @@ acceptedBreaks:
       old: "class org.apache.iceberg.Metrics"
       new: "class org.apache.iceberg.Metrics"
       justification: "Java serialization across versions is not guaranteed"
+    org.apache.iceberg:iceberg-api:
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.Table org.apache.iceberg.catalog.SessionCatalog::registerTable(org.apache.iceberg.catalog.SessionCatalog.SessionContext,\
+        \ org.apache.iceberg.catalog.TableIdentifier, java.lang.String, boolean)"
+      justification: "All subclasses implement the new method"
     org.apache.iceberg:iceberg-core:
+    - code: "java.method.addedToInterface"
+      new: "method java.lang.Boolean org.apache.iceberg.rest.requests.RegisterTableRequest::overwrite()"
+      justification: "All subclasses implement the new method"
     - code: "java.method.removed"
       old: "method java.lang.String[] org.apache.iceberg.hadoop.Util::blockLocations(org.apache.iceberg.CombinedScanTask,\
         \ org.apache.hadoop.conf.Configuration)"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1181,10 +1181,10 @@ acceptedBreaks:
     - code: "java.method.addedToInterface"
       new: "method org.apache.iceberg.Table org.apache.iceberg.catalog.SessionCatalog::registerTable(org.apache.iceberg.catalog.SessionCatalog.SessionContext,\
         \ org.apache.iceberg.catalog.TableIdentifier, java.lang.String, boolean)"
-      justification: "All subclasses implement the new method"
+      justification: "New API with default implementation provided"
     org.apache.iceberg:iceberg-core:
     - code: "java.method.addedToInterface"
-      new: "method java.lang.Boolean org.apache.iceberg.rest.requests.RegisterTableRequest::overwrite()"
+      new: "method boolean org.apache.iceberg.rest.requests.RegisterTableRequest::overwrite()"
       justification: "All subclasses implement the new method"
     - code: "java.method.removed"
       old: "method java.lang.String[] org.apache.iceberg.hadoop.Util::blockLocations(org.apache.iceberg.CombinedScanTask,\

--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -344,6 +344,22 @@ public interface Catalog {
    * @throws AlreadyExistsException if the table already exists in the catalog.
    */
   default Table registerTable(TableIdentifier identifier, String metadataFileLocation) {
+    return registerTable(
+        identifier, metadataFileLocation, false /* register only if it does not exist */);
+  }
+
+  /**
+   * Register a table with the catalog, optionally overwrite existing table metadata
+   *
+   * @param identifier a table identifier
+   * @param metadataFileLocation the location of a metadata file
+   * @param overwrite if true, overwrite existing table with provided metadata
+   * @return a Table instance
+   * @throws AlreadyExistsException if the table already exists in the catalog and overwrite is
+   *     false.
+   */
+  default Table registerTable(
+      TableIdentifier identifier, String metadataFileLocation, boolean overwrite) {
     throw new UnsupportedOperationException("Registering tables is not supported");
   }
 

--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -349,11 +349,13 @@ public interface Catalog {
   }
 
   /**
-   * Register a table with the catalog, optionally overwrite existing table metadata
+   * Register a table with the catalog, optionally overwrite existing table metadata.
+   *
+   * <p><strong>Note:</strong> Overwriting an existing table may result in a new table UUID.
    *
    * @param identifier a table identifier
    * @param metadataFileLocation the location of a metadata file
-   * @param overwrite if true, overwrite existing table with provided metadata
+   * @param overwrite if true, overwrite the existing table with provided metadata
    * @return a Table instance
    * @throws AlreadyExistsException if the table already exists in the catalog and overwrite is
    *     false.

--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -351,7 +351,8 @@ public interface Catalog {
   /**
    * Register a table with the catalog, optionally overwrite existing table metadata.
    *
-   * <p><strong>Note:</strong> Overwriting an existing table may result in a new table UUID.
+   * <p><strong>Note:</strong> Overwriting an existing table may result in the change of table UUID,
+   * to match the one in the metadata file.
    *
    * @param identifier a table identifier
    * @param metadataFileLocation the location of a metadata file

--- a/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java
@@ -168,7 +168,27 @@ public interface SessionCatalog {
    * @return a Table instance
    * @throws AlreadyExistsException if the table already exists in the catalog.
    */
-  Table registerTable(SessionContext context, TableIdentifier ident, String metadataFileLocation);
+  default Table registerTable(
+      SessionContext context, TableIdentifier ident, String metadataFileLocation) {
+    return registerTable(context, ident, metadataFileLocation, false);
+  }
+
+  /**
+   * Register a table with the catalog, optionally overwrite existing table metadata
+   *
+   * @param context session context
+   * @param ident a table identifier
+   * @param metadataFileLocation the location of a metadata file
+   * @param overwrite if true, overwrite existing table with provided metadata
+   * @return a Table instance
+   * @throws AlreadyExistsException if the table already exists in the catalog and overwrite is
+   *     false.
+   */
+  Table registerTable(
+      SessionContext context,
+      TableIdentifier ident,
+      String metadataFileLocation,
+      boolean overwrite);
 
   /**
    * Check whether table exists.

--- a/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java
@@ -176,7 +176,8 @@ public interface SessionCatalog {
   /**
    * Register a table with the catalog, optionally overwrite existing table metadata.
    *
-   * <p><strong>Note:</strong> Overwriting an existing table may result in a new table UUID.
+   * <p><strong>Note:</strong> Overwriting an existing table may result in the change of table UUID,
+   * to match the one in the metadata file.
    *
    * @param context session context
    * @param ident a table identifier

--- a/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java
@@ -174,12 +174,14 @@ public interface SessionCatalog {
   }
 
   /**
-   * Register a table with the catalog, optionally overwrite existing table metadata
+   * Register a table with the catalog, optionally overwrite existing table metadata.
+   *
+   * <p><strong>Note:</strong> Overwriting an existing table may result in a new table UUID.
    *
    * @param context session context
    * @param ident a table identifier
    * @param metadataFileLocation the location of a metadata file
-   * @param overwrite if true, overwrite existing table with provided metadata
+   * @param overwrite if true, overwrite the existing table with provided metadata
    * @return a Table instance
    * @throws AlreadyExistsException if the table already exists in the catalog and overwrite is
    *     false.

--- a/aws/src/integration/java/org/apache/iceberg/aws/dynamodb/TestDynamoDbCatalog.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/dynamodb/TestDynamoDbCatalog.java
@@ -392,6 +392,9 @@ public class TestDynamoDbCatalog {
     assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessageContaining("already exists");
+    assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation, false))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("already exists");
     assertThat(catalog.dropTable(identifier, true)).isTrue();
     assertThat(catalog.dropNamespace(namespace)).isTrue();
   }
@@ -417,6 +420,7 @@ public class TestDynamoDbCatalog {
 
     registeringTable.refresh();
     assertThat(registeringTable.spec().isPartitioned()).isFalse();
+    assertThat(ops.current().metadataFileLocation()).isEqualTo(unpartitionedMetadataLocation);
     assertThat(catalog.dropTable(identifier, true)).isTrue();
     assertThat(catalog.dropNamespace(namespace)).isTrue();
   }

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -85,7 +85,8 @@ public abstract class BaseMetastoreCatalog implements Catalog, Closeable {
         metadataFileLocation != null && !metadataFileLocation.isEmpty(),
         "Cannot register an empty metadata file location as a table");
 
-    // Throw an exception if this table already exists in the catalog and not overwrite is requested
+    // Throw an exception if the table already exists in the catalog and overwriting is not
+    // requested.
     if (tableExists(identifier) && !overwrite) {
       throw new AlreadyExistsException("Table already exists: %s", identifier);
     }

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -191,8 +191,9 @@ public class CachingCatalog implements Catalog {
   }
 
   @Override
-  public Table registerTable(TableIdentifier identifier, String metadataFileLocation) {
-    Table table = catalog.registerTable(identifier, metadataFileLocation);
+  public Table registerTable(
+      TableIdentifier identifier, String metadataFileLocation, boolean overwrite) {
+    Table table = catalog.registerTable(identifier, metadataFileLocation, overwrite);
     invalidateTable(identifier);
     return table;
   }

--- a/core/src/main/java/org/apache/iceberg/catalog/BaseSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/catalog/BaseSessionCatalog.java
@@ -85,8 +85,9 @@ public abstract class BaseSessionCatalog implements SessionCatalog {
     }
 
     @Override
-    public Table registerTable(TableIdentifier ident, String metadataFileLocation) {
-      return BaseSessionCatalog.this.registerTable(context, ident, metadataFileLocation);
+    public Table registerTable(
+        TableIdentifier ident, String metadataFileLocation, boolean overwrite) {
+      return BaseSessionCatalog.this.registerTable(context, ident, metadataFileLocation, overwrite);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.LockManager;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Namespace;
@@ -273,6 +274,15 @@ public class HadoopCatalog extends BaseMetastoreCatalog
   @Override
   public void renameTable(TableIdentifier from, TableIdentifier to) {
     throw new UnsupportedOperationException("Cannot rename Hadoop tables");
+  }
+
+  @Override
+  public Table registerTable(
+      TableIdentifier identifier, String metadataFileLocation, boolean overwrite) {
+    if (!overwrite) {
+      return super.registerTable(identifier, metadataFileLocation, false);
+    }
+    throw new UnsupportedOperationException("Cannot register and overwrite Hadoop tables");
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -293,7 +293,9 @@ public class CatalogHandlers {
     request.validate();
 
     TableIdentifier identifier = TableIdentifier.of(namespace, request.name());
-    Table table = catalog.registerTable(identifier, request.metadataLocation());
+    Table table =
+        catalog.registerTable(
+            identifier, request.metadataLocation(), Boolean.TRUE.equals(request.overwrite()));
     if (table instanceof BaseTable) {
       return LoadTableResponse.builder()
           .withTableMetadata(((BaseTable) table).operations().current())

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -219,6 +219,12 @@ public class RESTCatalog
   }
 
   @Override
+  public Table registerTable(
+      TableIdentifier ident, String metadataFileLocation, boolean overwrite) {
+    return delegate.registerTable(ident, metadataFileLocation, overwrite);
+  }
+
+  @Override
   public void createNamespace(Namespace ns, Map<String, String> props) {
     nsDelegate.createNamespace(ns, props);
   }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -481,7 +481,10 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
   @Override
   public Table registerTable(
-      SessionContext context, TableIdentifier ident, String metadataFileLocation) {
+      SessionContext context,
+      TableIdentifier ident,
+      String metadataFileLocation,
+      boolean overwrite) {
     Endpoint.check(endpoints, Endpoint.V1_REGISTER_TABLE);
     checkIdentifierIsValid(ident);
 
@@ -494,6 +497,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
         ImmutableRegisterTableRequest.builder()
             .name(ident.name())
             .metadataLocation(metadataFileLocation)
+            .overwrite(overwrite)
             .build();
 
     AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);

--- a/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequest.java
@@ -28,7 +28,7 @@ public interface RegisterTableRequest extends RESTRequest {
 
   String metadataLocation();
 
-  Boolean overwrite();
+  boolean overwrite();
 
   @Override
   default void validate() {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequest.java
@@ -28,6 +28,8 @@ public interface RegisterTableRequest extends RESTRequest {
 
   String metadataLocation();
 
+  Boolean overwrite();
+
   @Override
   default void validate() {
     // nothing to validate as it's not possible to create an invalid instance

--- a/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequestParser.java
@@ -47,10 +47,7 @@ public class RegisterTableRequestParser {
 
     gen.writeStringField(NAME, request.name());
     gen.writeStringField(METADATA_LOCATION, request.metadataLocation());
-
-    if (null != request.overwrite()) {
-      gen.writeBooleanField(OVERWRITE, request.overwrite());
-    }
+    gen.writeBooleanField(OVERWRITE, request.overwrite());
 
     gen.writeEndObject();
   }

--- a/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequestParser.java
@@ -28,6 +28,7 @@ public class RegisterTableRequestParser {
 
   private static final String NAME = "name";
   private static final String METADATA_LOCATION = "metadata-location";
+  private static final String OVERWRITE = "overwrite";
 
   private RegisterTableRequestParser() {}
 
@@ -47,6 +48,9 @@ public class RegisterTableRequestParser {
     gen.writeStringField(NAME, request.name());
     gen.writeStringField(METADATA_LOCATION, request.metadataLocation());
 
+    if (null != request.overwrite()) {
+      gen.writeBooleanField(OVERWRITE, request.overwrite());
+    }
     gen.writeEndObject();
   }
 
@@ -60,10 +64,12 @@ public class RegisterTableRequestParser {
 
     String name = JsonUtil.getString(NAME, json);
     String metadataLocation = JsonUtil.getString(METADATA_LOCATION, json);
+    boolean overwrite = Boolean.TRUE.equals(JsonUtil.getBoolOrNull(OVERWRITE, json));
 
     return ImmutableRegisterTableRequest.builder()
         .name(name)
         .metadataLocation(metadataLocation)
+        .overwrite(overwrite)
         .build();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequestParser.java
@@ -51,6 +51,7 @@ public class RegisterTableRequestParser {
     if (null != request.overwrite()) {
       gen.writeBooleanField(OVERWRITE, request.overwrite());
     }
+
     gen.writeEndObject();
   }
 

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -3141,6 +3141,10 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     TestHelpers.assertSameSchemaMap(registeredTable.schemas(), originalTable.schemas());
     assertFiles(registeredTable, FILE_B, FILE_C);
 
+    assertThat(ops.refresh().metadataFileLocation())
+        .as("metadataFileLocation must match")
+        .isEqualTo(metadataLocation);
+
     registeredTable.newFastAppend().appendFile(FILE_A).commit();
     assertFiles(registeredTable, FILE_B, FILE_C, FILE_A);
 
@@ -3166,58 +3170,105 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessageStartingWith("Table already exists: a.t1");
+    assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation, false))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageStartingWith("Table already exists: a.t1");
     assertThat(catalog.dropTable(identifier)).isTrue();
+  }
+
+  @Test
+  public void testRegisterAndOverwriteForeignTable() {
+    C catalog = catalog();
+
+    TableIdentifier identT1 = TableIdentifier.of("a", "t1");
+    TableIdentifier identT2 = TableIdentifier.of("a", "t2");
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(identT1.namespace());
+    }
+
+    Table t1 = catalog.createTable(identT1, SCHEMA);
+    UUID t1UUID = t1.uuid();
+    Table t2 =
+        catalog.createTable(
+            identT2, SCHEMA, PartitionSpec.builderFor(SCHEMA).bucket("id", 16).build());
+    assertThat(t1.spec().isPartitioned()).isFalse();
+    assertThat(t2.spec().isPartitioned()).isTrue();
+
+    TableOperations opsT2 = operation(t2);
+
+    // register table t1 with metadata from table t2
+    Table registered = catalog.registerTable(identT1, opsT2.current().metadataFileLocation(), true);
+
+    assertThat(registered.uuid())
+        .as("table UUID should differ when registering with foreign metadata")
+        .isNotEqualTo(t1UUID);
+    assertThat(registered.spec().isPartitioned())
+        .as("table is expected to be partitioned after registration with t2’s metadata")
+        .isEqualTo(t2.spec().isPartitioned())
+        .isTrue();
+    assertThat(operation(registered).refresh())
+        .usingRecursiveComparison()
+        // Nessie catalog holds different Nessie commit-ID from which the metadata has been loaded.
+        .ignoringFields("properties.nessie.commit.id")
+        .as("TableMetadata fields must match")
+        .isEqualTo(opsT2.current());
+
+    // Both tables now point to the same metadata location, so we only need to purge once.
+    assertThat(catalog.dropTable(identT1, true)).isTrue();
+    assertThat(catalog.dropTable(identT2, false)).isTrue();
+  }
+
+  private TableOperations operation(Table table) {
+    return ((BaseTable) table).operations();
   }
 
   @Test
   public void testRegisterAndOverwriteExistingTable() {
     C catalog = catalog();
 
-    TableIdentifier ident1 = TableIdentifier.of("a", "t1");
-    TableIdentifier ident2 = TableIdentifier.of("a", "t2");
+    TableIdentifier ident = TableIdentifier.of("a", "e1");
 
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident1.namespace());
+      catalog.createNamespace(ident.namespace());
     }
 
-    Table table1 = catalog.createTable(ident1, SCHEMA);
-    Table table2 =
-        catalog.createTable(
-            ident2, SCHEMA, PartitionSpec.builderFor(SCHEMA).bucket("id", 16).build());
-    assertThat(table1.spec().isPartitioned()).isFalse();
-
-    TableOperations ops1 = ((BaseTable) table1).operations();
-    TableOperations ops2 = ((BaseTable) table2).operations();
-    TableMetadata metadata1 = ops1.current();
-    String unpartitionedMetadataLocation = metadata1.metadataFileLocation();
-    String metadata1AsJson = TableMetadataParser.toJson(metadata1);
-
-    String metadata2 = ops2.current().metadataFileLocation();
-
-    // register and overwrite metadata of foreign table
-    assertThatThrownBy(() -> catalog.registerTable(ident1, metadata2, true))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Table UUID does not match");
+    Table table = catalog.createTable(ident, SCHEMA);
+    UUID tableUUID = table.uuid();
+    TableMetadata metadata = operation(table).current();
+    String originalMetadataLocation = metadata.metadataFileLocation();
+    // Serialize the table’s current (unpartitioned) metadata to JSON for later comparison.
+    String metadataAsJson = TableMetadataParser.toJson(metadata);
 
     // update table spec
-    table1.updateSpec().addField(bucket("id", 16)).commit();
-    assertThat(table1.spec().isPartitioned()).isTrue();
+    table.updateSpec().addField(bucket("id", 16)).commit();
+    assertThat(table.spec().isPartitioned()).isTrue();
 
-    // register and overwrite metadata of same table
-    catalog.registerTable(ident1, unpartitionedMetadataLocation, true);
-    table1.refresh();
+    // overwrite the table’s metadata with its original unpartitioned version.
+    Table overwritten = catalog.registerTable(ident, originalMetadataLocation, true);
 
-    assertThat(table1.spec().isPartitioned()).isFalse();
-    TableMetadata actual = ((BaseTable) table1).operations().current();
-    TableMetadata expected = TableMetadataParser.fromJson(metadata1AsJson);
+    assertThat(overwritten.uuid())
+        .as("UUID should remain the same when overwriting an existing table's own metadata")
+        .isEqualTo(tableUUID);
+    assertThat(overwritten.spec().isPartitioned())
+        .as("table is expected to be unpartitioned")
+        .isFalse();
 
+    TableMetadata actual = operation(overwritten).refresh();
+    TableMetadata expected = TableMetadataParser.fromJson(metadataAsJson);
+    assertThat(actual.metadataFileLocation())
+        .as("metadataFileLocation must match")
+        .isEqualTo(originalMetadataLocation);
     assertThat(actual)
         .usingRecursiveComparison()
-        .ignoringFields("metadataFileLocation", "properties")
+        // reason to ignore:
+        // TableMetadataParser to/fromJson skips recording of metadataFileLocation in TableMetadata
+        // Nessie catalog holds different Nessie commit-ID from which the metadata has been loaded.
+        .ignoringFields("metadataFileLocation", "properties.nessie.commit.id")
+        .as("tableMetadata fields must match")
         .isEqualTo(expected);
 
-    assertThat(catalog.dropTable(ident1)).isTrue();
-    assertThat(catalog.dropTable(ident2)).isTrue();
+    assertThat(catalog.dropTable(ident)).isTrue();
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.catalog;
 
+import static org.apache.iceberg.expressions.Expressions.bucket;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -50,6 +51,8 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableUtil;
@@ -3164,6 +3167,57 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessageStartingWith("Table already exists: a.t1");
     assertThat(catalog.dropTable(identifier)).isTrue();
+  }
+
+  @Test
+  public void testRegisterAndOverwriteExistingTable() {
+    C catalog = catalog();
+
+    TableIdentifier ident1 = TableIdentifier.of("a", "t1");
+    TableIdentifier ident2 = TableIdentifier.of("a", "t2");
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(ident1.namespace());
+    }
+
+    Table table1 = catalog.createTable(ident1, SCHEMA);
+    Table table2 =
+        catalog.createTable(
+            ident2, SCHEMA, PartitionSpec.builderFor(SCHEMA).bucket("id", 16).build());
+    assertThat(table1.spec().isPartitioned()).isFalse();
+
+    TableOperations ops1 = ((BaseTable) table1).operations();
+    TableOperations ops2 = ((BaseTable) table2).operations();
+    TableMetadata metadata1 = ops1.current();
+    String unpartitionedMetadataLocation = metadata1.metadataFileLocation();
+    String metadata1AsJson = TableMetadataParser.toJson(metadata1);
+
+    String metadata2 = ops2.current().metadataFileLocation();
+
+    // register and overwrite metadata of foreign table
+    assertThatThrownBy(() -> catalog.registerTable(ident1, metadata2, true))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Table UUID does not match");
+
+    // update table spec
+    table1.updateSpec().addField(bucket("id", 16)).commit();
+    assertThat(table1.spec().isPartitioned()).isTrue();
+
+    // register and overwrite metadata of same table
+    catalog.registerTable(ident1, unpartitionedMetadataLocation, true);
+    table1.refresh();
+
+    assertThat(table1.spec().isPartitioned()).isFalse();
+    TableMetadata actual = ((BaseTable) table1).operations().current();
+    TableMetadata expected = TableMetadataParser.fromJson(metadata1AsJson);
+
+    assertThat(actual)
+        .usingRecursiveComparison()
+        .ignoringFields("metadataFileLocation")
+        .isEqualTo(expected);
+
+    assertThat(catalog.dropTable(ident1)).isTrue();
+    assertThat(catalog.dropTable(ident2)).isTrue();
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -3213,7 +3213,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     assertThat(actual)
         .usingRecursiveComparison()
-        .ignoringFields("metadataFileLocation")
+        .ignoringFields("metadataFileLocation", "properties")
         .isEqualTo(expected);
 
     assertThat(catalog.dropTable(ident1)).isTrue();

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -677,6 +677,9 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessage("Table already exists: a.t1");
+    assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation, false))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessage("Table already exists: a.t1");
     assertThat(catalog.dropTable(identifier)).isTrue();
   }
 
@@ -692,8 +695,9 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     registeringTable.updateSpec().addField(bucket("id", 16)).commit();
     assertThat(registeringTable.spec().isPartitioned()).isTrue();
     // register with overwrite
-    catalog.registerTable(identifier, unpartitionedMetadataLocation, true);
-    assertThat(catalog.loadTable(identifier).spec().isPartitioned()).isFalse();
+    Table registered = catalog.registerTable(identifier, unpartitionedMetadataLocation, true);
+    assertThat(registered.spec().isPartitioned()).isFalse();
+
     assertThat(catalog.dropTable(identifier)).isTrue();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.hadoop;
 
 import static org.apache.iceberg.NullOrder.NULLS_FIRST;
 import static org.apache.iceberg.SortDirection.ASC;
+import static org.apache.iceberg.expressions.Expressions.bucket;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -676,6 +677,23 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessage("Table already exists: a.t1");
+    assertThat(catalog.dropTable(identifier)).isTrue();
+  }
+
+  @Test
+  public void testRegisterAndOverwriteExistingTable() throws IOException {
+    TableIdentifier identifier = TableIdentifier.of("a", "t1");
+    HadoopCatalog catalog = hadoopCatalog();
+    catalog.createTable(identifier, SCHEMA);
+    Table registeringTable = catalog.loadTable(identifier);
+    TableOperations ops = ((HasTableOperations) registeringTable).operations();
+    String unpartitionedMetadataLocation = ops.current().metadataFileLocation();
+    // update table spec
+    registeringTable.updateSpec().addField(bucket("id", 16)).commit();
+    assertThat(registeringTable.spec().isPartitioned()).isTrue();
+    // register with overwrite
+    catalog.registerTable(identifier, unpartitionedMetadataLocation, true);
+    assertThat(catalog.loadTable(identifier).spec().isPartitioned()).isFalse();
     assertThat(catalog.dropTable(identifier)).isTrue();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -695,8 +695,9 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     registeringTable.updateSpec().addField(bucket("id", 16)).commit();
     assertThat(registeringTable.spec().isPartitioned()).isTrue();
     // register with overwrite
-    Table registered = catalog.registerTable(identifier, unpartitionedMetadataLocation, true);
-    assertThat(registered.spec().isPartitioned()).isFalse();
+    assertThatThrownBy(() -> catalog.registerTable(identifier, unpartitionedMetadataLocation, true))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot register and overwrite Hadoop tables");
 
     assertThat(catalog.dropTable(identifier)).isTrue();
   }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestRegisterTableRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestRegisterTableRequestParser.java
@@ -62,12 +62,14 @@ public class TestRegisterTableRequestParser {
             .name("table_1")
             .metadataLocation(
                 "file://tmp/NS/test_tbl/metadata/00000-d4f60d2f-2ad2-408b-8832-0ed7fbd851ee.metadata.json")
+            .overwrite(true)
             .build();
 
     String expectedJson =
         "{\n"
             + "  \"name\" : \"table_1\",\n"
-            + "  \"metadata-location\" : \"file://tmp/NS/test_tbl/metadata/00000-d4f60d2f-2ad2-408b-8832-0ed7fbd851ee.metadata.json\"\n"
+            + "  \"metadata-location\" : \"file://tmp/NS/test_tbl/metadata/00000-d4f60d2f-2ad2-408b-8832-0ed7fbd851ee.metadata.json\",\n"
+            + "  \"overwrite\" : true\n"
             + "}";
 
     String json = RegisterTableRequestParser.toJson(request, true);
@@ -75,5 +77,16 @@ public class TestRegisterTableRequestParser {
 
     assertThat(RegisterTableRequestParser.toJson(RegisterTableRequestParser.fromJson(json), true))
         .isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void missingOptionalOverwriteField() {
+    String json =
+        "{\n"
+            + "  \"name\" : \"table_1\",\n"
+            + "  \"metadata-location\" : \"file://tmp/NS/test_tbl/metadata/00000-d4f60d2f-2ad2-408b-8832-0ed7fbd851ee.metadata.json\"\n"
+            + "}";
+    RegisterTableRequest request = RegisterTableRequestParser.fromJson(json);
+    assertThat(request.overwrite()).isFalse();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestRegisterTableRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestRegisterTableRequestParser.java
@@ -80,13 +80,21 @@ public class TestRegisterTableRequestParser {
   }
 
   @Test
-  public void missingOptionalOverwriteField() {
-    String json =
+  public void serdeOnDefaultAndExplicitOverwriteField() {
+    String defaultJson =
         "{\n"
             + "  \"name\" : \"table_1\",\n"
             + "  \"metadata-location\" : \"file://tmp/NS/test_tbl/metadata/00000-d4f60d2f-2ad2-408b-8832-0ed7fbd851ee.metadata.json\"\n"
             + "}";
-    RegisterTableRequest request = RegisterTableRequestParser.fromJson(json);
-    assertThat(request.overwrite()).isFalse();
+    RegisterTableRequest defaultRequest = RegisterTableRequestParser.fromJson(defaultJson);
+    assertThat(defaultRequest.overwrite()).isFalse();
+    String explicitJson =
+        "{\n"
+            + "  \"name\" : \"table_1\",\n"
+            + "  \"metadata-location\" : \"file://tmp/NS/test_tbl/metadata/00000-d4f60d2f-2ad2-408b-8832-0ed7fbd851ee.metadata.json\",\n"
+            + "  \"overwrite\" :false\n"
+            + "}";
+    RegisterTableRequest explicitRequest = RegisterTableRequestParser.fromJson(explicitJson);
+    assertThat(explicitRequest.overwrite()).isFalse();
   }
 }

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsCatalog.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsCatalog.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.dell.ecs;
 
+import static org.apache.iceberg.expressions.Expressions.bucket;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -199,6 +200,22 @@ public class TestEcsCatalog {
     assertThatThrownBy(() -> ecsCatalog.registerTable(identifier, metadataLocation))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessage("Table already exists: a.t1");
+    assertThat(ecsCatalog.dropTable(identifier, true)).isTrue();
+  }
+
+  @Test
+  public void testRegisterAndOverwriteExistingTable() {
+    TableIdentifier identifier = TableIdentifier.of("a", "t1");
+    ecsCatalog.createTable(identifier, SCHEMA);
+    Table registeringTable = ecsCatalog.loadTable(identifier);
+    TableOperations ops = ((HasTableOperations) registeringTable).operations();
+    String unpartitionedMetadataLocation = ops.current().metadataFileLocation();
+    // update table spec
+    registeringTable.updateSpec().addField(bucket("id", 16)).commit();
+    assertThat(registeringTable.spec().isPartitioned()).isTrue();
+    // register with overwrite
+    ecsCatalog.registerTable(identifier, unpartitionedMetadataLocation, true);
+    assertThat(ecsCatalog.loadTable(identifier).spec().isPartitioned()).isFalse();
     assertThat(ecsCatalog.dropTable(identifier, true)).isTrue();
   }
 }

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsCatalog.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsCatalog.java
@@ -200,6 +200,9 @@ public class TestEcsCatalog {
     assertThatThrownBy(() -> ecsCatalog.registerTable(identifier, metadataLocation))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessage("Table already exists: a.t1");
+    assertThatThrownBy(() -> ecsCatalog.registerTable(identifier, metadataLocation, false))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessage("Table already exists: a.t1");
     assertThat(ecsCatalog.dropTable(identifier, true)).isTrue();
   }
 
@@ -216,6 +219,7 @@ public class TestEcsCatalog {
     // register with overwrite
     ecsCatalog.registerTable(identifier, unpartitionedMetadataLocation, true);
     assertThat(ecsCatalog.loadTable(identifier).spec().isPartitioned()).isFalse();
+    assertThat(ops.refresh().metadataFileLocation()).isEqualTo(unpartitionedMetadataLocation);
     assertThat(ecsCatalog.dropTable(identifier, true)).isTrue();
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -623,8 +623,10 @@ public class HiveTableTest extends HiveTableBaseTest {
     assertThat(metadataVersionFiles).hasSize(1);
 
     // Try to register an existing table
-    assertThatThrownBy(
-            () -> catalog.registerTable(TABLE_IDENTIFIER, "file:" + metadataVersionFiles.get(0)))
+    String metadataLocation = "file:" + metadataVersionFiles.get(0);
+    assertThatThrownBy(() -> catalog.registerTable(TABLE_IDENTIFIER, metadataLocation))
+        .hasMessage("Table already exists: hivedb.tbl");
+    assertThatThrownBy(() -> catalog.registerTable(TABLE_IDENTIFIER, metadataLocation, false))
         .hasMessage("Table already exists: hivedb.tbl");
   }
 
@@ -647,8 +649,9 @@ public class HiveTableTest extends HiveTableBaseTest {
     org.apache.hadoop.hive.metastore.api.Table overwritten =
         HIVE_METASTORE_EXTENSION.metastoreClient().getTable(DB_NAME, TABLE_NAME);
     assertThat(overwritten.getParameters())
+        .doesNotContainKey(PREVIOUS_METADATA_LOCATION_PROP)
         .containsEntry(TABLE_TYPE_PROP, originalParams.get(TABLE_TYPE_PROP))
-        .containsEntry(PREVIOUS_METADATA_LOCATION_PROP, originalParams.get(METADATA_LOCATION_PROP));
+        .containsEntry(METADATA_LOCATION_PROP, originalParams.get(METADATA_LOCATION_PROP));
     assertThat(overwritten.getSd()).isEqualTo(originalTable.getSd());
   }
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -36,7 +36,6 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -128,52 +127,6 @@ public class TestHiveCommits extends HiveTableBaseTest {
             "New metadata files should still exist, new location not in history but"
                 + " the commit may still succeed")
         .isEqualTo(3);
-  }
-
-  /**
-   * Pretends we throw a concurrent commit to allow for retry when register and overwrite an iceberg
-   * table
-   */
-  @Test
-  public void testCommitFailedExceptionOnRegisterOverwrite() {
-    Table table = catalog.loadTable(TABLE_IDENTIFIER);
-    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
-
-    TableMetadata metadataV1 = ops.current();
-    String metadataV1Location = metadataV1.metadataFileLocation();
-    String metadataV1AsJson = TableMetadataParser.toJson(metadataV1);
-
-    table.updateSchema().addColumn("n", Types.IntegerType.get()).commit();
-
-    ops.refresh();
-
-    TableMetadata metadataV2 = ops.current();
-
-    assertThat(ops.current().schema().columns()).hasSize(2);
-
-    HiveTableOperations spyOps = spy(ops);
-
-    HiveCatalog spyCatalog = spy(catalog);
-    when(spyCatalog.newTableOps(TABLE_IDENTIFIER)).thenReturn(spyOps);
-    // Simulate a CommitFailedException and then allow the commit to be retried
-    doThrow(new CommitFailedException("Cannot commit: stale table metadata"))
-        .doCallRealMethod()
-        .when(spyOps)
-        .commit(any(), any());
-    spyCatalog.registerTable(TABLE_IDENTIFIER, metadataV1Location, true);
-
-    TableMetadata actual = ops.refresh();
-    assertThat(actual).as("Current metadata should have changed").isNotEqualTo(metadataV2);
-    assertThat(metadataFileExists(actual)).as("Current metadata file should still exist").isTrue();
-    assertThat(metadataFileCount(actual))
-        .as("Commit should have been successful and new metadata file should be made")
-        .isEqualTo(3);
-
-    TableMetadata expected = TableMetadataParser.fromJson(metadataV1AsJson);
-    assertThat(actual)
-        .usingRecursiveComparison()
-        .ignoringFields("metadataFileLocation")
-        .isEqualTo(expected);
   }
 
   /** Pretends we throw an error while persisting that actually does commit serverside */


### PR DESCRIPTION
This PR adds a new register-table with overwrite option on Catalog interface to allow overwrite table metadata of an existing Iceberg table. The overwrite is achieved via `TableOperations.commit(base, new)` for catalogs extends BaseMetastoreCatalog. 

- Relate to #12134 
- openAPI REST spec change merged in #12239 