### PR TITLE
Core: HadoopCatalog root level warehouse path bug: missing slash

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -191,7 +191,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog
     Preconditions.checkArgument(
         namespace.levels().length >= 1, "Missing database in table identifier: %s", namespace);
 
-    Path nsPath = new Path(warehouseLocation, SLASH.join(namespace.levels()));
+    Path nsPath = new Path(warehouseLocation + "/", SLASH.join(namespace.levels()));
     Set<TableIdentifier> tblIdents = Sets.newHashSet();
 
     try {
@@ -284,7 +284,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog
           "Cannot create namespace " + namespace + ": metadata is not supported");
     }
 
-    Path nsPath = new Path(warehouseLocation, SLASH.join(namespace.levels()));
+    Path nsPath = new Path(warehouseLocation + "/", SLASH.join(namespace.levels()));
 
     if (isNamespace(nsPath)) {
       throw new AlreadyExistsException("Namespace already exists: %s", namespace);
@@ -303,7 +303,8 @@ public class HadoopCatalog extends BaseMetastoreCatalog
     Path nsPath =
         namespace.isEmpty()
             ? new Path(warehouseLocation)
-            : new Path(warehouseLocation, SLASH.join(namespace.levels()));
+            : new Path(warehouseLocation + "/", SLASH.join(namespace.levels()));
+
     if (!isNamespace(nsPath)) {
       throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
     }
@@ -333,7 +334,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog
 
   @Override
   public boolean dropNamespace(Namespace namespace) {
-    Path nsPath = new Path(warehouseLocation, SLASH.join(namespace.levels()));
+    Path nsPath = new Path(warehouseLocation + "/", SLASH.join(namespace.levels()));
 
     if (!isNamespace(nsPath) || namespace.isEmpty()) {
       return false;
@@ -364,7 +365,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog
 
   @Override
   public Map<String, String> loadNamespaceMetadata(Namespace namespace) {
-    Path nsPath = new Path(warehouseLocation, SLASH.join(namespace.levels()));
+    Path nsPath = new Path(warehouseLocation + "/", SLASH.join(namespace.levels()));
 
     if (!isNamespace(nsPath) || namespace.isEmpty()) {
       throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);


### PR DESCRIPTION
Path concatenation in HadoopCatalog at e.g. [this line](https://github.com/apache/iceberg/blob/31e9dc768cef47df5eb007577f25ef3bbff86f61/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java#L194) is buggy for root level path URI resolving for some JVMs. 

e.g. Calling `sparkSession.catalog().listTables("namespace");` with warehouse path `s3a://test-bucket` will wrongly concatenate to `s3a://test-bucketnamespace` (missing the slash) and throw!

Seems to only happen for some JVMs. I've tested the following JVMs for the bad concatenation behavior:

**confirmed broken (bug occurs):**
* 11.0.19-zulu
* 11.0.26-zulu
* 17.0.12-oracle
* 11.0.26-tem
* 11.0.26-amzn

**confirmed OK (bug doesn't occur):**
* 17.0.12-zulu
* 21.0.6-oracle
* 17.0.14-tem
* 17.0.14-amzn

See the first commit for a green test that showcases the broken concatenation/bug: https://github.com/apache/iceberg/commit/a066b0fe00769760a48eb1b1191c4f97f2a385f0

The fix in this PR (2nd commit) is simple, suffix the warehouse path with `/` before using it as a parent in a Path join, from my testing that seems to solve the issue.

Not sure how to properly test this though, since all the other tests rely on using a local tmp storage that will never have that kind of root level path.

I've left in the updated version of the original test for now, it's a bit ugly but in theory it should show that the root level path concatenation issue doesn't occur, since the error message contains the correctly resolved URI.

Issue for more discussion https://github.com/apache/iceberg/issues/12232