### PR TITLE
Docs: Fix formatting of 1.8.0 release notes

### DIFF
--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -77,6 +77,7 @@ To add a dependency on Iceberg in Maven, add the following to your `pom.xml`:
 Apache Iceberg 1.8.0 was released on February 13, 2025.
 
 The 1.8.0 release contains bug fixes and new features. For full release notes visit [Github](https://github.com/apache/iceberg/releases/tag/apache-iceberg-1.8.0)
+
 * Deprecation / End of Support
     - Spark 3.3
     - Removed Hive Runtime


### PR DESCRIPTION
Fix formatting for 1.8.0 release notes, was missing a newline and it messed up the list structure below.

Before:
<img width="1562" alt="Screenshot 2025-02-13 at 2 58 33 PM" src="https://github.com/user-attachments/assets/00d5f9f8-eebf-417a-a48f-bc1fd0710778" />

After:
<img width="1296" alt="Screenshot 2025-02-13 at 2 52 11 PM" src="https://github.com/user-attachments/assets/e9a26e40-e289-40dc-810d-e3139964d9b5" />
