### PR TITLE
SPARK: Remove dependency on hadoop's filesystem class from remove orphan files

### DIFF
--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -306,17 +306,18 @@ Used to remove files which are not referenced in any metadata files of an Iceber
 
 #### Usage
 
-| Argument Name | Required? | Type | Description |
-|---------------|-----------|------|-------------|
-| `table`       | ✔️  | string | Name of the table to clean |
-| `older_than`  | ️   | timestamp | Remove orphan files created before this timestamp (Defaults to 3 days ago) |
-| `location`    |    | string    | Directory to look for files in (defaults to the table's location) |
-| `dry_run`     |    | boolean   | When true, don't actually remove files (defaults to false) |
-| `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used) |
-| `file_list_view` |    | string | Dataset to look for files in (skipping the directory listing) |
-| `equal_schemes` |    | map<string, string> | Mapping of file system schemes to be considered equal. Key is a comma-separated list of schemes and value is a scheme (defaults to `map('s3a,s3n','s3')`). |
-| `equal_authorities` |    | map<string, string> | Mapping of file system authorities to be considered equal. Key is a comma-separated list of authorities and value is an authority. |
-| `prefix_mismatch_mode` |    | string | Action behavior when location prefixes (schemes/authorities) mismatch: <ul><li>ERROR - throw an exception. (default) </li><li>IGNORE - no action.</li><li>DELETE - delete files.</li></ul> |  
+| Argument Name           | Required? | Type | Description                                                                                                                                                                                |
+|-------------------------|-----------|------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `table`                 | ✔️  | string | Name of the table to clean                                                                                                                                                                 |
+| `older_than`            | ️   | timestamp | Remove orphan files created before this timestamp (Defaults to 3 days ago)                                                                                                                 |
+| `location`              |    | string    | Directory to look for files in (defaults to the table's location)                                                                                                                          |
+| `dry_run`               |    | boolean   | When true, don't actually remove files (defaults to false)                                                                                                                                 |
+| `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used)                                                                                                  |
+| `file_list_view`        |    | string | Dataset to look for files in (skipping the directory listing)                                                                                                                              |
+| `equal_schemes`         |    | map<string, string> | Mapping of file system schemes to be considered equal. Key is a comma-separated list of schemes and value is a scheme (defaults to `map('s3a,s3n','s3')`).                                 |
+| `equal_authorities`     |    | map<string, string> | Mapping of file system authorities to be considered equal. Key is a comma-separated list of authorities and value is an authority.                                                         |
+| `prefix_mismatch_mode`  |    | string | Action behavior when location prefixes (schemes/authorities) mismatch: <ul><li>ERROR - throw an exception. (default) </li><li>IGNORE - no action.</li><li>DELETE - delete files.</li></ul> |  
+| `prefix_list`           |    | boolean   | When true, use prefix-based file listing via the `SupportsPrefixOperations` interface. The Table FileIO implementation must support `SupportsPrefixOperations` when this flag is enabled (defaults to false) |
 
 #### Output
 
@@ -368,6 +369,11 @@ CALL catalog_name.system.remove_orphan_files(table => 'db.sample', equal_schemes
 
 ```sql
 CALL catalog_name.system.remove_orphan_files(table => 'db.sample', equal_authorities => map('ns1', 'ns2'));
+```
+
+List all the files that are candidates for removal using prefix listing.
+```sql
+CALL catalog_name.system.remove_orphan_files(table => 'db.sample', prefix_list => true);
 ```
 
 ### `rewrite_data_files`

--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -306,18 +306,18 @@ Used to remove files which are not referenced in any metadata files of an Iceber
 
 #### Usage
 
-| Argument Name           | Required? | Type | Description                                                                                                                                                                                |
-|-------------------------|-----------|------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `table`                 | ✔️  | string | Name of the table to clean                                                                                                                                                                 |
-| `older_than`            | ️   | timestamp | Remove orphan files created before this timestamp (Defaults to 3 days ago)                                                                                                                 |
-| `location`              |    | string    | Directory to look for files in (defaults to the table's location)                                                                                                                          |
-| `dry_run`               |    | boolean   | When true, don't actually remove files (defaults to false)                                                                                                                                 |
-| `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used)                                                                                                  |
-| `file_list_view`        |    | string | Dataset to look for files in (skipping the directory listing)                                                                                                                              |
-| `equal_schemes`         |    | map<string, string> | Mapping of file system schemes to be considered equal. Key is a comma-separated list of schemes and value is a scheme (defaults to `map('s3a,s3n','s3')`).                                 |
-| `equal_authorities`     |    | map<string, string> | Mapping of file system authorities to be considered equal. Key is a comma-separated list of authorities and value is an authority.                                                         |
-| `prefix_mismatch_mode`  |    | string | Action behavior when location prefixes (schemes/authorities) mismatch: <ul><li>ERROR - throw an exception. (default) </li><li>IGNORE - no action.</li><li>DELETE - delete files.</li></ul> |  
-| `prefix_list`           |    | boolean   | When true, use prefix-based file listing via the `SupportsPrefixOperations` interface. The Table FileIO implementation must support `SupportsPrefixOperations` when this flag is enabled (defaults to false) |
+| Argument Name | Required? | Type | Description |
+|---------------|-----------|------|-------------|
+| `table`       | ✔️  | string | Name of the table to clean |
+| `older_than`  | ️   | timestamp | Remove orphan files created before this timestamp (Defaults to 3 days ago) |
+| `location`    |    | string    | Directory to look for files in (defaults to the table's location) |
+| `dry_run`     |    | boolean   | When true, don't actually remove files (defaults to false) |
+| `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used) |
+| `file_list_view` |    | string | Dataset to look for files in (skipping the directory listing) |
+| `equal_schemes` |    | map<string, string> | Mapping of file system schemes to be considered equal. Key is a comma-separated list of schemes and value is a scheme (defaults to `map('s3a,s3n','s3')`). |
+| `equal_authorities` |    | map<string, string> | Mapping of file system authorities to be considered equal. Key is a comma-separated list of authorities and value is an authority. |
+| `prefix_mismatch_mode` |    | string | Action behavior when location prefixes (schemes/authorities) mismatch: <ul><li>ERROR - throw an exception. (default) </li><li>IGNORE - no action.</li><li>DELETE - delete files.</li></ul> |  
+| `prefix_listing` |    | boolean   | When true, use prefix-based file listing via the `SupportsPrefixOperations` interface. The Table FileIO implementation must support `SupportsPrefixOperations` when this flag is enabled (defaults to false) |
 
 #### Output
 
@@ -373,7 +373,7 @@ CALL catalog_name.system.remove_orphan_files(table => 'db.sample', equal_authori
 
 List all the files that are candidates for removal using prefix listing.
 ```sql
-CALL catalog_name.system.remove_orphan_files(table => 'db.sample', prefix_list => true);
+CALL catalog_name.system.remove_orphan_files(table => 'db.sample', prefix_listing => true);
 ```
 
 ### `rewrite_data_files`

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -354,6 +354,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     if (!dir.endsWith("/")) {
       listPath = dir + "/";
     }
+
     Iterable<org.apache.iceberg.io.FileInfo> files = io.listPrefix(listPath);
     for (org.apache.iceberg.io.FileInfo file : files) {
       Path path = new Path(file.location());
@@ -371,8 +372,10 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
         isHiddenPath = true;
         break;
       }
+
       currentPath = currentPath.getParent();
     }
+
     return isHiddenPath;
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -122,7 +122,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<Row> compareToFileList;
   private Consumer<String> deleteFunc = null;
   private ExecutorService deleteExecutorService = null;
-  private boolean usePrefixList = false;
+  private boolean usePrefixListing = false;
 
   DeleteOrphanFilesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -208,8 +208,8 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     return this;
   }
 
-  public DeleteOrphanFilesSparkAction usePrefixList(boolean newUsePrefixList) {
-    this.usePrefixList = newUsePrefixList;
+  public DeleteOrphanFilesSparkAction usePrefixListing(boolean newUsePrefixListing) {
+    this.usePrefixListing = newUsePrefixListing;
     return this;
   }
 
@@ -312,7 +312,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
 
     PathFilter pathFilter = PartitionAwareHiddenPathFilter.forSpecs(table.specs());
 
-    if (usePrefixList) {
+    if (usePrefixListing) {
       Preconditions.checkArgument(
           table.io() instanceof SupportsPrefixOperations,
           "Table file io should prefix operations when using prefix list.");

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -315,7 +315,8 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     if (usePrefixListing) {
       Preconditions.checkArgument(
           table.io() instanceof SupportsPrefixOperations,
-          "Table file io should prefix operations when using prefix list.");
+          "Cannot use prefix listing with FileIO {} which does not support prefix operations.",
+          table.io());
 
       Predicate<org.apache.iceberg.io.FileInfo> predicate =
           fileInfo -> fileInfo.createdAtMillis() < olderThanTimestamp;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -391,7 +391,8 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     return isHiddenPath;
   }
 
-  private static void listDirRecursivelyWithHadoop(
+  @VisibleForTesting
+  static void listDirRecursivelyWithHadoop(
       String dir,
       Predicate<FileStatus> predicate,
       Configuration conf,

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -63,6 +63,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         ProcedureParameter.optional("equal_schemes", STRING_MAP),
         ProcedureParameter.optional("equal_authorities", STRING_MAP),
         ProcedureParameter.optional("prefix_mismatch_mode", DataTypes.StringType),
+        // List files with prefix operations. Default is false.
+        ProcedureParameter.optional("prefix_list", DataTypes.BooleanType)
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -136,6 +138,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
     PrefixMismatchMode prefixMismatchMode =
         args.isNullAt(8) ? null : PrefixMismatchMode.fromString(args.getString(8));
 
+    boolean prefixList = args.isNullAt(9) ? false : args.getBoolean(9);
+
     return withIcebergTable(
         tableIdent,
         table -> {
@@ -181,6 +185,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
           if (prefixMismatchMode != null) {
             action.prefixMismatchMode(prefixMismatchMode);
           }
+
+          action.usePrefixList(prefixList);
 
           DeleteOrphanFiles.Result result = action.execute();
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -64,7 +64,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         ProcedureParameter.optional("equal_authorities", STRING_MAP),
         ProcedureParameter.optional("prefix_mismatch_mode", DataTypes.StringType),
         // List files with prefix operations. Default is false.
-        ProcedureParameter.optional("prefix_list", DataTypes.BooleanType)
+        ProcedureParameter.optional("prefix_listing", DataTypes.BooleanType)
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -138,7 +138,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
     PrefixMismatchMode prefixMismatchMode =
         args.isNullAt(8) ? null : PrefixMismatchMode.fromString(args.getString(8));
 
-    boolean prefixList = args.isNullAt(9) ? false : args.getBoolean(9);
+    boolean prefixListing = args.isNullAt(9) ? false : args.getBoolean(9);
 
     return withIcebergTable(
         tableIdent,
@@ -186,7 +186,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
             action.prefixMismatchMode(prefixMismatchMode);
           }
 
-          action.usePrefixListing(prefixList);
+          action.usePrefixListing(prefixListing);
 
           DeleteOrphanFiles.Result result = action.execute();
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -186,7 +186,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
             action.prefixMismatchMode(prefixMismatchMode);
           }
 
-          action.usePrefixList(prefixList);
+          action.usePrefixListing(prefixList);
 
           DeleteOrphanFiles.Result result = action.execute();
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -117,7 +117,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   @Parameters(name = "formatVersion = {0}, usePrefixListing = {1}")
   protected static List<Object> parameters() {
-    return Arrays.asList(new Object[] {2, true}, new Object[] {2, false}, new Object[] {3, false});
+    return Arrays.asList(
+        new Object[] {2, true},
+        new Object[] {2, false},
+        new Object[] {3, true},
+        new Object[] {3, false});
   }
 
   @BeforeEach
@@ -1141,7 +1145,8 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   @TestTemplate
   public void testDefaultToHadoopListing() {
     assumeThat(usePrefixListing)
-        .as("Should not test both prefix listing and Hadoop file listing (redundant)")
+        .as(
+            "This test verifies default listing behavior and does not require prefix listing to be enabled.")
         .isEqualTo(false);
     Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -18,15 +18,6 @@
  */
 package org.apache.iceberg.spark.actions;
 
-import static org.apache.iceberg.types.Types.NestedField.optional;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assumptions.assumeThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -97,6 +88,15 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+
 @ExtendWith(ParameterizedTestExtension.class)
 public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
@@ -119,9 +119,8 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   @Parameters(name = "formatVersion = {0}, usePrefixListing = {1}")
   protected static List<Object> parameters() {
-    return Arrays.stream(TestHelpers.ALL_VERSIONS)
+    return TestHelpers.ALL_VERSIONS.stream()
         .filter(version -> version > 1)
-        .boxed()
         .flatMap(version -> Stream.of(new Object[] {version, true}, new Object[] {version, false}))
         .collect(Collectors.toList());
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -109,11 +109,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   @Parameters(name = "formatVersion = {0}, usePrefixListing = {1}")
   protected static List<Object> parameters() {
-    return Arrays.asList(
-        new Object[] {2, true},
-        new Object[] {3, true},
-        new Object[] {2, false},
-        new Object[] {3, false});
+    return Arrays.asList(new Object[] {2, true}, new Object[] {2, false}, new Object[] {3, false});
   }
 
   @BeforeEach

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -104,9 +104,16 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   protected Map<String, String> properties;
   @Parameter private int formatVersion;
 
-  @Parameters(name = "formatVersion = {0}")
+  @Parameter(index = 1)
+  private boolean usePrefixList;
+
+  @Parameters(name = "formatVersion = {0}, usePrefixList = {1}")
   protected static List<Object> parameters() {
-    return Arrays.asList(2, 3);
+    return Arrays.asList(
+        new Object[] {2, true},
+        new Object[] {3, true},
+        new Object[] {2, false},
+        new Object[] {3, false});
   }
 
   @BeforeEach
@@ -158,7 +165,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result1 =
-        actions.deleteOrphanFiles(table).deleteWith(s -> {}).execute();
+        actions.deleteOrphanFiles(table).usePrefixList(usePrefixList).deleteWith(s -> {}).execute();
     assertThat(result1.orphanFileLocations())
         .as("Default olderThan interval should be safe")
         .isEmpty();
@@ -166,6 +173,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result2 =
         actions
             .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
             .olderThan(System.currentTimeMillis())
             .deleteWith(s -> {})
             .execute();
@@ -177,7 +185,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
         .isTrue();
 
     DeleteOrphanFiles.Result result3 =
-        actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
+        actions
+            .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
+            .olderThan(System.currentTimeMillis())
+            .execute();
     assertThat(result3.orphanFileLocations())
         .as("Action should delete 1 file")
         .isEqualTo(invalidFiles);
@@ -237,7 +249,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
-        actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
+        actions
+            .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
+            .olderThan(System.currentTimeMillis())
+            .execute();
 
     assertThat(result.orphanFileLocations()).as("Should delete 4 files").hasSize(4);
 
@@ -302,6 +318,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         SparkActions.get()
             .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
             .executeDeleteWith(executorService)
             .olderThan(System.currentTimeMillis() + 5000) // Ensure all orphan files are selected
             .deleteWith(
@@ -339,6 +356,8 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     // wap write
     df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
 
+    spark.conf().unset(SparkSQLProperties.WAP_ID);
+
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
         resultDF.as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
@@ -353,7 +372,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
-        actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
+        actions
+            .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
+            .olderThan(System.currentTimeMillis())
+            .execute();
 
     assertThat(result.orphanFileLocations()).as("Should not delete any files").isEmpty();
   }
@@ -379,7 +402,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
-        actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
+        actions
+            .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
+            .olderThan(System.currentTimeMillis())
+            .execute();
 
     assertThat(result.orphanFileLocations()).as("Should delete 1 file").hasSize(1);
 
@@ -413,7 +440,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
-        actions.deleteOrphanFiles(table).olderThan(timestamp).execute();
+        actions
+            .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
+            .olderThan(timestamp)
+            .execute();
 
     assertThat(result.orphanFileLocations()).as("Should delete only 2 files").hasSize(2);
   }
@@ -439,7 +470,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
-        actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
+        actions
+            .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
+            .olderThan(System.currentTimeMillis())
+            .execute();
 
     assertThat(result.orphanFileLocations())
         .containsExactly(tableLocation + "metadata/v1.metadata.json");
@@ -472,7 +507,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
-        actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
+        actions
+            .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
+            .olderThan(System.currentTimeMillis())
+            .execute();
 
     assertThat(result.orphanFileLocations()).as("Should not delete any files").isEmpty();
 
@@ -498,7 +537,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
-        actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
+        actions
+            .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
+            .olderThan(System.currentTimeMillis())
+            .execute();
 
     assertThat(result.orphanFileLocations()).as("Should not delete any files").isEmpty();
 
@@ -534,7 +577,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
-        actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
+        actions
+            .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
+            .olderThan(System.currentTimeMillis())
+            .execute();
 
     assertThat(result.orphanFileLocations()).as("Should delete 2 files").hasSize(2);
   }
@@ -570,7 +617,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
-        actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
+        actions
+            .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
+            .olderThan(System.currentTimeMillis())
+            .execute();
 
     assertThat(result.orphanFileLocations()).as("Should delete 2 files").hasSize(2);
   }
@@ -605,7 +656,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
-        actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
+        actions
+            .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
+            .olderThan(System.currentTimeMillis())
+            .execute();
 
     assertThat(result.orphanFileLocations()).as("Should delete 0 files").isEmpty();
     assertThat(fs.exists(pathToFileInHiddenFolder)).isTrue();
@@ -671,6 +726,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions
             .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
             .olderThan(System.currentTimeMillis())
             .deleteWith(s -> {})
             .execute();
@@ -707,7 +763,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     table.refresh();
 
     DeleteOrphanFiles.Result result =
-        SparkActions.get().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
+        SparkActions.get()
+            .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
+            .olderThan(System.currentTimeMillis())
+            .execute();
 
     assertThat(result.orphanFileLocations()).as("Should delete only 1 file").hasSize(1);
 
@@ -739,6 +799,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         SparkActions.get()
             .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
     assertThat(result.orphanFileLocations())
@@ -759,7 +820,9 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
     table.updateProperties().set(TableProperties.GC_ENABLED, "false").commit();
 
-    assertThatThrownBy(() -> SparkActions.get().deleteOrphanFiles(table).execute())
+    assertThatThrownBy(
+            () ->
+                SparkActions.get().deleteOrphanFiles(table).usePrefixList(usePrefixList).execute())
         .isInstanceOf(ValidationException.class)
         .hasMessage(
             "Cannot delete orphan files: GC is disabled (deleting files may corrupt other tables)");
@@ -826,6 +889,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result1 =
         actions
             .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
             .compareToFileList(compareToFileList)
             .deleteWith(s -> {})
             .execute();
@@ -836,6 +900,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result2 =
         actions
             .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
             .compareToFileList(compareToFileList)
             .olderThan(System.currentTimeMillis())
             .deleteWith(s -> {})
@@ -850,6 +915,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result3 =
         actions
             .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
             .compareToFileList(compareToFileList)
             .olderThan(System.currentTimeMillis())
             .execute();
@@ -881,6 +947,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result4 =
         actions
             .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
             .compareToFileList(compareToFileListWithOutsideLocation)
             .deleteWith(s -> {})
             .execute();
@@ -942,6 +1009,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
     SparkActions.get()
         .deleteOrphanFiles(table)
+        .usePrefixList(usePrefixList)
         .olderThan(System.currentTimeMillis() + 1000)
         .execute();
 
@@ -957,6 +1025,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         SparkActions.get()
             .deleteOrphanFiles(table)
+            .usePrefixList(usePrefixList)
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
     Iterable<String> orphanFileLocations = result.orphanFileLocations();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -105,9 +105,9 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   @Parameter private int formatVersion;
 
   @Parameter(index = 1)
-  private boolean usePrefixList;
+  private boolean usePrefixListing;
 
-  @Parameters(name = "formatVersion = {0}, usePrefixList = {1}")
+  @Parameters(name = "formatVersion = {0}, usePrefixListing = {1}")
   protected static List<Object> parameters() {
     return Arrays.asList(
         new Object[] {2, true},
@@ -165,7 +165,11 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result1 =
-        actions.deleteOrphanFiles(table).usePrefixList(usePrefixList).deleteWith(s -> {}).execute();
+        actions
+            .deleteOrphanFiles(table)
+            .usePrefixListing(usePrefixListing)
+            .deleteWith(s -> {})
+            .execute();
     assertThat(result1.orphanFileLocations())
         .as("Default olderThan interval should be safe")
         .isEmpty();
@@ -173,7 +177,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result2 =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(System.currentTimeMillis())
             .deleteWith(s -> {})
             .execute();
@@ -187,7 +191,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result3 =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(System.currentTimeMillis())
             .execute();
     assertThat(result3.orphanFileLocations())
@@ -251,7 +255,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(System.currentTimeMillis())
             .execute();
 
@@ -275,6 +279,9 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   @TestTemplate
   public void orphanedFileRemovedWithParallelTasks() {
+    assumeThat(usePrefixListing)
+        .as("Should not test both prefix listing and Hadoop file listing (redundant)")
+        .isEqualTo(false);
     Table table = TABLES.create(SCHEMA, SPEC, properties, tableLocation);
 
     List<ThreeColumnRecord> records1 =
@@ -318,7 +325,6 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         SparkActions.get()
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
             .executeDeleteWith(executorService)
             .olderThan(System.currentTimeMillis() + 5000) // Ensure all orphan files are selected
             .deleteWith(
@@ -338,6 +344,9 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   @TestTemplate
   public void testWapFilesAreKept() {
+    assumeThat(usePrefixListing)
+        .as("Should not test both prefix listing and Hadoop file listing (redundant)")
+        .isEqualTo(false);
     assumeThat(formatVersion).as("currently fails with DVs").isEqualTo(2);
     Map<String, String> props = Maps.newHashMap();
     props.put(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED, "true");
@@ -372,11 +381,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
-        actions
-            .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
-            .olderThan(System.currentTimeMillis())
-            .execute();
+        actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
     assertThat(result.orphanFileLocations()).as("Should not delete any files").isEmpty();
   }
@@ -404,7 +409,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(System.currentTimeMillis())
             .execute();
 
@@ -442,7 +447,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(timestamp)
             .execute();
 
@@ -472,7 +477,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(System.currentTimeMillis())
             .execute();
 
@@ -509,7 +514,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(System.currentTimeMillis())
             .execute();
 
@@ -539,7 +544,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(System.currentTimeMillis())
             .execute();
 
@@ -579,7 +584,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(System.currentTimeMillis())
             .execute();
 
@@ -619,7 +624,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(System.currentTimeMillis())
             .execute();
 
@@ -658,7 +663,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(System.currentTimeMillis())
             .execute();
 
@@ -679,6 +684,9 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   @TestTemplate
   public void testRemoveOrphanFilesWithRelativeFilePath() throws IOException {
+    assumeThat(usePrefixListing)
+        .as("Should not test both prefix listing and Hadoop file listing (redundant)")
+        .isEqualTo(false);
     Table table =
         TABLES.create(
             SCHEMA, PartitionSpec.unpartitioned(), properties, tableDir.getAbsolutePath());
@@ -726,7 +734,6 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
             .olderThan(System.currentTimeMillis())
             .deleteWith(s -> {})
             .execute();
@@ -765,7 +772,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         SparkActions.get()
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(System.currentTimeMillis())
             .execute();
 
@@ -799,7 +806,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         SparkActions.get()
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
+            .usePrefixListing(usePrefixListing)
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
     assertThat(result.orphanFileLocations())
@@ -809,6 +816,9 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   @TestTemplate
   public void testGarbageCollectionDisabled() {
+    assumeThat(usePrefixListing)
+        .as("Should not test both prefix listing and Hadoop file listing (redundant)")
+        .isEqualTo(false);
     Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
 
     List<ThreeColumnRecord> records =
@@ -820,9 +830,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
     table.updateProperties().set(TableProperties.GC_ENABLED, "false").commit();
 
-    assertThatThrownBy(
-            () ->
-                SparkActions.get().deleteOrphanFiles(table).usePrefixList(usePrefixList).execute())
+    assertThatThrownBy(() -> SparkActions.get().deleteOrphanFiles(table).execute())
         .isInstanceOf(ValidationException.class)
         .hasMessage(
             "Cannot delete orphan files: GC is disabled (deleting files may corrupt other tables)");
@@ -830,6 +838,9 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   @TestTemplate
   public void testCompareToFileList() throws IOException {
+    assumeThat(usePrefixListing)
+        .as("Should not test both prefix listing and Hadoop file listing (redundant)")
+        .isEqualTo(false);
     Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
 
     List<ThreeColumnRecord> records =
@@ -889,7 +900,6 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result1 =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
             .compareToFileList(compareToFileList)
             .deleteWith(s -> {})
             .execute();
@@ -900,7 +910,6 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result2 =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
             .compareToFileList(compareToFileList)
             .olderThan(System.currentTimeMillis())
             .deleteWith(s -> {})
@@ -915,7 +924,6 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result3 =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
             .compareToFileList(compareToFileList)
             .olderThan(System.currentTimeMillis())
             .execute();
@@ -947,7 +955,6 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result4 =
         actions
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
             .compareToFileList(compareToFileListWithOutsideLocation)
             .deleteWith(s -> {})
             .execute();
@@ -964,6 +971,9 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   @TestTemplate
   public void testRemoveOrphanFilesWithStatisticFiles() throws Exception {
+    assumeThat(usePrefixListing)
+        .as("Should not test both prefix listing and Hadoop file listing (redundant)")
+        .isEqualTo(false);
     assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
 
@@ -1009,7 +1019,6 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
     SparkActions.get()
         .deleteOrphanFiles(table)
-        .usePrefixList(usePrefixList)
         .olderThan(System.currentTimeMillis() + 1000)
         .execute();
 
@@ -1025,7 +1034,6 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFiles.Result result =
         SparkActions.get()
             .deleteOrphanFiles(table)
-            .usePrefixList(usePrefixList)
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
     Iterable<String> orphanFileLocations = result.orphanFileLocations();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -18,6 +18,15 @@
  */
 package org.apache.iceberg.spark.actions;
 
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -87,15 +96,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-
-import static org.apache.iceberg.types.Types.NestedField.optional;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assumptions.assumeThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public abstract class TestRemoveOrphanFilesAction extends TestBase {


### PR DESCRIPTION
Closes #11541  
RemoveOrphanFiles Using FileIO when it implements SupportPrefixOperations to list files. And it will fall back using Hadoop Class when it does not.

Some concerns:
1. All list file operations are performed on the driver, which may cause performance pressure in scenarios involving massive files.
2. Currently, it has only been implemented in Spark 3.5. Should it be implemented in other Spark versions as well?
3. Tests are running on this FileIO branch. Should tests be added for the original Hadoop Class based branch?