### PR TITLE
update site to include iceberg summit link

### DIFF
--- a/site/overrides/home.html
+++ b/site/overrides/home.html
@@ -38,7 +38,7 @@
             <h3>The open table format for analytic datasets.</h3>
             <a class="btn btn-default btn-lg" href="https://www.icebergsummit2025.com/" target="_blank">
               <span>
-                Iceberg Summit 2025: Register Now!
+                Iceberg Summit 2025 (8-9 Apr): Register Now!
               </span>
             </a>
             <hr class="intro-divider" />

--- a/site/overrides/home.html
+++ b/site/overrides/home.html
@@ -36,9 +36,9 @@
           <div class="intro-message">
             <h1>Apache Iceberg™</h1>
             <h3>The open table format for analytic datasets.</h3>
-            <a class="btn btn-default btn-lg" href="https://sessionize.com/iceberg-summit-2025" target="_blank">
+            <a class="btn btn-default btn-lg" href="https://www.icebergsummit2025.com/" target="_blank">
               <span>
-                Iceberg Summit 2025: Call For Proposals - Open Until Feb 9
+                Iceberg Summit 2025: Register Now!
               </span>
             </a>
             <hr class="intro-divider" />


### PR DESCRIPTION
Removed Call for Papers CTA and added link to icebergsummit2025.com with 'Register Now!' CTA.

<img width="915" alt="Screenshot 2025-02-13 at 11 00 08 AM" src="https://github.com/user-attachments/assets/82f39d0f-a5d1-4fe9-b53e-10176a5c1cb7" />