### PR TITLE
Core: use ReachableFileCleanup when table has discontinuous snapshots

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -36,7 +36,6 @@ import static org.apache.iceberg.TableProperties.MIN_SNAPSHOTS_TO_KEEP;
 import static org.apache.iceberg.TableProperties.MIN_SNAPSHOTS_TO_KEEP_DEFAULT;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -36,6 +36,7 @@ import static org.apache.iceberg.TableProperties.MIN_SNAPSHOTS_TO_KEEP;
 import static org.apache.iceberg.TableProperties.MIN_SNAPSHOTS_TO_KEEP_DEFAULT;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -374,6 +375,10 @@ class RemoveSnapshots implements ExpireSnapshots {
 
     if (incrementalCleanup == null) {
       incrementalCleanup = current.refs().size() == 1;
+    }
+
+    if (SnapshotUtil.hasDiscontinuousSnapshots(base)) {
+      incrementalCleanup = false;
     }
 
     LOG.info(

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -506,17 +506,18 @@ public class SnapshotUtil {
   /**
    * Checks if the table metadata has discontinuous snapshots.
    *
-   * This method counts the number of ancestor snapshots starting from the current snapshot
-   * and compares it with the total number of snapshots in the metadata. If the counts are
-   * not equal, it indicates that there are discontinuous snapshots in the given metadata.
+   * <p>This method counts the number of ancestor snapshots starting from the current snapshot and
+   * compares it with the total number of snapshots in the metadata. If the counts are not equal, it
+   * indicates that there are discontinuous snapshots in the given metadata.
    *
    * @param metadata a {@link TableMetadata}
    * @return true if there are discontinuous snapshots, false otherwise
    */
-  public static boolean hasDiscontinuousSnapshots(TableMetadata metadata){
-    Iterator<Snapshot> ancestorsIterator= ancestorsOf(metadata.currentSnapshot().snapshotId(), metadata::snapshot).iterator();
+  public static boolean hasDiscontinuousSnapshots(TableMetadata metadata) {
+    Iterator<Snapshot> ancestorsIterator =
+        ancestorsOf(metadata.currentSnapshot().snapshotId(), metadata::snapshot).iterator();
     int ancestorCount = 0;
-    while(ancestorsIterator.hasNext()) {
+    while (ancestorsIterator.hasNext()) {
       ancestorCount++;
       ancestorsIterator.next();
     }

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -502,4 +502,24 @@ public class SnapshotUtil {
 
     return metadata.snapshot(ref.snapshotId());
   }
+
+  /**
+   * Checks if the table metadata has discontinuous snapshots.
+   *
+   * This method counts the number of ancestor snapshots starting from the current snapshot
+   * and compares it with the total number of snapshots in the metadata. If the counts are
+   * not equal, it indicates that there are discontinuous snapshots in the given metadata.
+   *
+   * @param metadata a {@link TableMetadata}
+   * @return true if there are discontinuous snapshots, false otherwise
+   */
+  public static boolean hasDiscontinuousSnapshots(TableMetadata metadata){
+    Iterator<Snapshot> ancestorsIterator= ancestorsOf(metadata.currentSnapshot().snapshotId(), metadata::snapshot).iterator();
+    int ancestorCount = 0;
+    while(ancestorsIterator.hasNext()) {
+      ancestorCount++;
+      ancestorsIterator.next();
+    }
+    return ancestorCount != metadata.snapshots().size();
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -31,7 +31,6 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -1142,19 +1141,21 @@ public class TestRemoveSnapshots extends TestBase {
     // set longer ref age ensure it not get expired by the test
     long tagRefMaxAgeMs = 3600000;
     // tagA -> S3-> ML3-> MF2, MF3 -> File_B, File_C(added)
-    table.manageSnapshots()
-            .createTag(tagName, table.currentSnapshot().snapshotId())
-            .setMaxRefAgeMs(tagName, tagRefMaxAgeMs)
-            .commit();
+    table
+        .manageSnapshots()
+        .createTag(tagName, table.currentSnapshot().snapshotId())
+        .setMaxRefAgeMs(tagName, tagRefMaxAgeMs)
+        .commit();
     // S4-> ML4 -> MF3, MF4 -> File_B(deleted), File_C
     table.newDelete().deleteFile(FILE_B).commit();
     Snapshot fourthSnapshot = table.currentSnapshot();
     // branchB -> S4-> ML4-> MF3, MF4 -> File_C, File_B(deleted)
     long branchRefMaxAgeMs = 10;
-    table.manageSnapshots()
-            .createBranch(branchName, table.currentSnapshot().snapshotId())
-            .setMaxRefAgeMs(branchName, branchRefMaxAgeMs)
-            .commit();
+    table
+        .manageSnapshots()
+        .createBranch(branchName, table.currentSnapshot().snapshotId())
+        .setMaxRefAgeMs(branchName, branchRefMaxAgeMs)
+        .commit();
     // S5-> ML5 -> MF3, MF5 -> File_C, File_D(added)
     table.newAppend().appendFile(FILE_D).commit();
     long snapshotId = table.currentSnapshot().snapshotId();


### PR DESCRIPTION
This change is to fix fixes issue: #12200 . 
by updating `RemoveSnapshots.cleanExpiredSnapshots()` to use `ReachableFileCleanup` strategy to clean up expired files when table has discontinuous snapshots. Pls check above issue for details. 

Added util method `hasDiscontinuousSnapshots` in `SnapshotUtil`
Added UT