### PR TITLE
S3: Add LegacyMd5Plugin to S3 client builder

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -115,9 +115,10 @@ import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
 
 @Testcontainers
 public class TestS3FileIO {
-  @Container private static final MinIOContainer MINIO = MinioUtil.createContainer();
+  @Container private final MinIOContainer minio = createMinIOContainer();
 
-  private final SerializableSupplier<S3Client> s3 = () -> MinioUtil.createS3Client(MINIO);
+  private final SerializableSupplier<S3Client> s3 =
+      () -> MinioUtil.createS3Client(minio, legacyMd5PluginEnabled());
   private final S3Client s3mock = mock(S3Client.class, delegatesTo(s3.get()));
   private final Random random = new Random(1);
   private final int numBucketsForBatchDeletion = 3;
@@ -134,6 +135,16 @@ public class TestS3FileIO {
           "TagValue1",
           "s3.delete.batch-size",
           Integer.toString(batchDeletionSize));
+
+  protected MinIOContainer createMinIOContainer() {
+    MinIOContainer container = MinioUtil.createContainer();
+    container.start();
+    return container;
+  }
+
+  protected boolean legacyMd5PluginEnabled() {
+    return false;
+  }
 
   @BeforeEach
   public void before() {

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOWithLegacyMinIO.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOWithLegacyMinIO.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import org.testcontainers.containers.MinIOContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class TestS3FileIOWithLegacyMinIO extends TestS3FileIO {
+  @Override
+  protected MinIOContainer createMinIOContainer() {
+    MinIOContainer container = MinioUtil.createContainer(MinioUtil.LEGACY_TAG, null);
+    container.start();
+    return container;
+  }
+
+  @Override
+  protected boolean legacyMd5PluginEnabled() {
+    return true;
+  }
+}

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
@@ -86,7 +86,7 @@ public class TestS3RestSigner {
 
   @Container
   private static final MinIOContainer MINIO_CONTAINER =
-      MinioUtil.createContainer(CREDENTIALS_PROVIDER.resolveCredentials());
+      MinioUtil.createContainer(MinioUtil.LATEST_TAG, CREDENTIALS_PROVIDER.resolveCredentials());
 
   private static Server httpServer;
   private static ValidatingSigner validatingSigner;

--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -47,6 +47,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   public S3Client s3() {
     return S3Client.builder()
         .applyMutation(this::applyAssumeRoleConfigurations)
+        .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .applyMutation(s3FileIOProperties::applyServiceConfigurations)
@@ -70,6 +71,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
         .applyMutation(this::applyAssumeRoleConfigurations)
         .applyMutation(awsClientProperties::applyClientRegionConfiguration)
         .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+        .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .build();
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -106,6 +106,7 @@ public class AwsClientFactories {
     @Override
     public S3Client s3() {
       return S3Client.builder()
+          .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
           .applyMutation(httpClientProperties::applyHttpClientConfigurations)
           .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
@@ -131,6 +132,7 @@ public class AwsClientFactories {
             .build();
       }
       return S3AsyncClient.builder()
+          .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
           .applyMutation(
               b -> s3FileIOProperties.applyCredentialConfigurations(awsClientProperties, b))

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -106,8 +106,8 @@ public class AwsClientFactories {
     @Override
     public S3Client s3() {
       return S3Client.builder()
-          .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+          .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
           .applyMutation(httpClientProperties::applyHttpClientConfigurations)
           .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
           .applyMutation(s3FileIOProperties::applyServiceConfigurations)
@@ -132,8 +132,8 @@ public class AwsClientFactories {
             .build();
       }
       return S3AsyncClient.builder()
-          .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+          .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
           .applyMutation(
               b -> s3FileIOProperties.applyCredentialConfigurations(awsClientProperties, b))
           .applyMutation(s3FileIOProperties::applyEndpointConfigurations)

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -83,7 +83,12 @@ public class AwsClientProperties implements Serializable {
   /** Controls whether vended credentials should be refreshed or not. Defaults to true. */
   public static final String REFRESH_CREDENTIALS_ENABLED = "client.refresh-credentials-enabled";
 
-  /** Controls whether legacy md5 plugin should be added or not. Defaults to false. */
+  /**
+   * Controls whether legacy MD5 plugin should be added or not. Defaults to false. AWS SDK version
+   * 2.30.0 introduced integrity protections that are not backward compatible. Enable this property
+   * only when you need to access older S3-compatible object storages that depend on the legacy MD5
+   * checksum.
+   */
   public static final String LEGACY_MD5_PLUGIN_ENABLED = "client.legacy-md5-plugin-enabled";
 
   private String clientRegion;

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -38,6 +38,7 @@ import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.LegacyMd5Plugin;
 import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
 
 public class AwsClientProperties implements Serializable {
@@ -82,11 +83,15 @@ public class AwsClientProperties implements Serializable {
   /** Controls whether vended credentials should be refreshed or not. Defaults to true. */
   public static final String REFRESH_CREDENTIALS_ENABLED = "client.refresh-credentials-enabled";
 
+  /** Controls whether legacy md5 plugin should be added or not. Defaults to false. */
+  public static final String LEGACY_MD5_PLUGIN_ENABLED = "client.legacy-md5-plugin-enabled";
+
   private String clientRegion;
   private final String clientCredentialsProvider;
   private final Map<String, String> clientCredentialsProviderProperties;
   private final String refreshCredentialsEndpoint;
   private final boolean refreshCredentialsEnabled;
+  private final boolean legacyMd5pluginEnabled;
   private final Map<String, String> allProperties;
 
   public AwsClientProperties() {
@@ -95,6 +100,7 @@ public class AwsClientProperties implements Serializable {
     this.clientCredentialsProviderProperties = null;
     this.refreshCredentialsEndpoint = null;
     this.refreshCredentialsEnabled = true;
+    this.legacyMd5pluginEnabled = false;
     this.allProperties = null;
   }
 
@@ -109,6 +115,8 @@ public class AwsClientProperties implements Serializable {
             properties.get(CatalogProperties.URI), properties.get(REFRESH_CREDENTIALS_ENDPOINT));
     this.refreshCredentialsEnabled =
         PropertyUtil.propertyAsBoolean(properties, REFRESH_CREDENTIALS_ENABLED, true);
+    this.legacyMd5pluginEnabled =
+        PropertyUtil.propertyAsBoolean(properties, LEGACY_MD5_PLUGIN_ENABLED, false);
   }
 
   public String clientRegion() {
@@ -128,7 +136,8 @@ public class AwsClientProperties implements Serializable {
    *     S3Client.builder().applyMutation(awsClientProperties::applyClientRegionConfiguration)
    * </pre>
    */
-  public <T extends AwsClientBuilder> void applyClientRegionConfiguration(T builder) {
+  public <BuilderT extends AwsClientBuilder<BuilderT, ClientT>, ClientT>
+      void applyClientRegionConfiguration(BuilderT builder) {
     if (clientRegion != null) {
       builder.region(Region.of(clientRegion));
     }
@@ -158,7 +167,8 @@ public class AwsClientProperties implements Serializable {
    *     DynamoDbClient.builder().applyMutation(awsClientProperties::applyClientCredentialConfigurations)
    * </pre>
    */
-  public <T extends AwsClientBuilder> void applyClientCredentialConfigurations(T builder) {
+  public <BuilderT extends AwsClientBuilder<BuilderT, ClientT>, ClientT>
+      void applyClientCredentialConfigurations(BuilderT builder) {
     if (!Strings.isNullOrEmpty(this.clientCredentialsProvider)) {
       builder.credentialsProvider(credentialsProvider(this.clientCredentialsProvider));
     }
@@ -231,13 +241,30 @@ public class AwsClientProperties implements Serializable {
    *   KmsClient.builder().applyMutation(awsClientProperties::applyRetryConfigurations)
    * </pre>
    */
-  public <T extends AwsClientBuilder> void applyRetryConfigurations(T builder) {
+  public <BuilderT extends AwsClientBuilder<BuilderT, ClientT>, ClientT>
+      void applyRetryConfigurations(BuilderT builder) {
     ClientOverrideConfiguration.Builder configBuilder =
         null != builder.overrideConfiguration()
             ? builder.overrideConfiguration().toBuilder()
             : ClientOverrideConfiguration.builder();
 
     builder.overrideConfiguration(configBuilder.retryStrategy(RetryMode.ADAPTIVE_V2).build());
+  }
+
+  /**
+   * Add a legacy md5 plugin if it is enabled.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3Client.builder().applyMutation(awsClientProperties::applyLegacyMd5Plugin)
+   * </pre>
+   */
+  public <BuilderT extends AwsClientBuilder<BuilderT, ClientT>, ClientT> void applyLegacyMd5Plugin(
+      BuilderT builder) {
+    if (legacyMd5pluginEnabled) {
+      builder.addPlugin(LegacyMd5Plugin.create());
+    }
   }
 
   private AwsCredentialsProvider credentialsProvider(String credentialsProviderClass) {

--- a/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
@@ -78,6 +78,7 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
   public S3Client s3() {
     if (isTableRegisteredWithLakeFormation()) {
       return S3Client.builder()
+          .applyMutation(awsClientProperties()::applyLegacyMd5Plugin)
           .applyMutation(httpClientProperties()::applyHttpClientConfigurations)
           .applyMutation(s3FileIOProperties()::applyEndpointConfigurations)
           .applyMutation(s3FileIOProperties()::applyServiceConfigurations)

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -46,6 +46,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
   public S3Client s3() {
     return S3Client.builder()
         .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+        .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .applyMutation(s3FileIOProperties::applyServiceConfigurations)

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -74,6 +74,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
     return S3AsyncClient.builder()
         .applyMutation(awsClientProperties::applyClientRegionConfiguration)
         .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+        .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .build();
   }


### PR DESCRIPTION
The recent AWS SDK bump introduced strong integrity checksums, and broke compatibility with many S3-compatible object storages (pre-2025 Minio, Vast, Dell EC etc). 

In Trino project, we received the error report (Missing required header for this request: Content-Md5) from several users and had to disable the check temporarily. We recommend disabling it in Iceberg as well. I faced this issue when I tried upgrading Iceberg library to 1.8.0 in Trino. 

Relates to https://github.com/trinodb/trino/pull/24954 & https://github.com/trinodb/trino/pull/24713