### PR TITLE
Minor: update Learn More to point to spark quickstart

### DIFF
--- a/site/docs/about.md
+++ b/site/docs/about.md
@@ -22,7 +22,7 @@ Iceberg is a high-performance format for huge analytic tables. Iceberg brings th
 <div class="button-box">
 <ul class="list-inline intro-social-buttons">
     <li>
-        <a href="/getting-started" class="btn btn-default btn-lg">
+        <a href="/spark-quickstart" class="btn btn-default btn-lg">
             <span class="network-name">Learn More</span>
         </a>
     </li>


### PR DESCRIPTION
Fixes #12265 

Button now points to /spark-quickstart (same as 'Learn More' on the homepage).

<img width="742" alt="Screenshot 2025-02-14 at 9 06 02 AM" src="https://github.com/user-attachments/assets/f1448df0-7890-4689-875d-b40d0e68a7e4" />
