### PR TITLE
Spark-3.5: Add unit tests for ColumnarBatchUtil

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnarBatchUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnarBatchUtil.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data.vectorized;
+
+import static java.util.Collections.nCopies;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.DeleteFilter;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestColumnarBatchUtil {
+
+  private ColumnVector[] columnVectors;
+  private DeleteFilter deleteFilter;
+
+  @BeforeEach
+  public void setup() {
+    columnVectors = new ColumnVector[2];
+    columnVectors[0] = mock(ColumnVector.class);
+    columnVectors[1] = mock(ColumnVector.class);
+    deleteFilter = mock(DeleteFilter.class);
+  }
+
+  @Test
+  public void testBuildRowIdMappingNoDeletes() {
+    when(deleteFilter.hasPosDeletes()).thenReturn(true);
+    PositionDeleteIndex deletedRowPos = mock(PositionDeleteIndex.class);
+
+    for (long i = 0; i <= 10; i++) {
+      when(deletedRowPos.isDeleted(i)).thenReturn(false);
+    }
+
+    when(deleteFilter.deletedRowPositions()).thenReturn(deletedRowPos);
+    var rowIdMapping = ColumnarBatchUtil.buildRowIdMapping(columnVectors, deleteFilter, 0, 10);
+    assertThat(rowIdMapping).isNull();
+  }
+
+  @Test
+  public void testBuildRowIdMapping() {
+    when(deleteFilter.hasPosDeletes()).thenReturn(true);
+    PositionDeleteIndex deletedRowPos = mock(PositionDeleteIndex.class);
+
+    // 5 position deletes
+    for (long i = 98; i < 103; i++) {
+      when(deletedRowPos.isDeleted(i)).thenReturn(true);
+    }
+
+    when(deleteFilter.deletedRowPositions()).thenReturn(deletedRowPos);
+
+    var rowIdMapping = ColumnarBatchUtil.buildRowIdMapping(columnVectors, deleteFilter, 0, 200);
+    assertThat(rowIdMapping).isNotNull();
+
+    int[] rowIds = (int[]) rowIdMapping.first();
+    int liveRows = (int) rowIdMapping.second();
+
+    for (int id : rowIds) {
+      assertThat(id < 98 || id > 102).isTrue();
+    }
+
+    assertThat(rowIds.length).isEqualTo(200);
+    assertThat(liveRows).isEqualTo(195);
+  }
+
+  @Test
+  void testBuildIsDeletedWithDeletedRange() {
+    PositionDeleteIndex deletedRowPos = mock(PositionDeleteIndex.class);
+    when(deleteFilter.deletedRowPositions()).thenReturn(deletedRowPos);
+
+    for (long i = 98; i < 100; i++) {
+      when(deletedRowPos.isDeleted(i)).thenReturn(true);
+    }
+
+    var isDeleted = ColumnarBatchUtil.buildIsDeleted(columnVectors, deleteFilter, 0, 100);
+
+    assertThat(isDeleted).isNotNull();
+    assertThat(isDeleted.length).isEqualTo(100);
+
+    for (int i = 98; i < 100; i++) {
+      assertThat(isDeleted[i]).isTrue();
+    }
+    assertThat(isDeleted[97]).isFalse();
+  }
+
+    @Test
+    void testBuildIsDeletedNoDeletes() {
+        var result = ColumnarBatchUtil.buildIsDeleted(columnVectors, null, 0, 5);
+        assertThat(result).isNotNull();
+        for (int i = 0; i < 5; i++) {
+            assertThat(result[i]).isFalse();
+        }
+    }
+
+    @Test
+    void testRemoveExtraColumns() {
+        ColumnVector[] vectors = new ColumnVector[5];
+        for (int i = 0; i < 5; i++) {
+            vectors[i] = mock(ColumnVector.class);
+        }
+        when(deleteFilter.expectedSchema()).thenReturn(mock(Schema.class));
+        when(deleteFilter.expectedSchema().columns()).thenReturn(nCopies(3, null));
+
+        ColumnVector[] result = ColumnarBatchUtil.removeExtraColumns(deleteFilter, vectors);
+        assertThat(result.length).isEqualTo(3);
+    }
+
+    @Test
+    void testRemoveExtraColumnsNotNeeded() {
+        ColumnVector[] vectors = new ColumnVector[3];
+        for (int i = 0; i < 3; i++) {
+            vectors[i] = mock(ColumnVector.class);
+        }
+        when(deleteFilter.expectedSchema()).thenReturn(mock(Schema.class));
+        when(deleteFilter.expectedSchema().columns()).thenReturn(nCopies(3, null));
+
+        ColumnVector[] result = ColumnarBatchUtil.removeExtraColumns(deleteFilter, vectors);
+        assertThat( result.length).isEqualTo(3);
+    }
+}

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnarBatchUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnarBatchUtil.java
@@ -36,7 +36,7 @@ public class TestColumnarBatchUtil {
   private DeleteFilter deleteFilter;
 
   @BeforeEach
-  public void setup() {
+  public void before() {
     columnVectors = new ColumnVector[2];
     columnVectors[0] = mock(ColumnVector.class);
     columnVectors[1] = mock(ColumnVector.class);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnarBatchUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnarBatchUtil.java
@@ -103,38 +103,38 @@ public class TestColumnarBatchUtil {
     assertThat(isDeleted[97]).isFalse();
   }
 
-    @Test
-    void testBuildIsDeletedNoDeletes() {
-        var result = ColumnarBatchUtil.buildIsDeleted(columnVectors, null, 0, 5);
-        assertThat(result).isNotNull();
-        for (int i = 0; i < 5; i++) {
-            assertThat(result[i]).isFalse();
-        }
+  @Test
+  void testBuildIsDeletedNoDeletes() {
+    var result = ColumnarBatchUtil.buildIsDeleted(columnVectors, null, 0, 5);
+    assertThat(result).isNotNull();
+    for (int i = 0; i < 5; i++) {
+      assertThat(result[i]).isFalse();
     }
+  }
 
-    @Test
-    void testRemoveExtraColumns() {
-        ColumnVector[] vectors = new ColumnVector[5];
-        for (int i = 0; i < 5; i++) {
-            vectors[i] = mock(ColumnVector.class);
-        }
-        when(deleteFilter.expectedSchema()).thenReturn(mock(Schema.class));
-        when(deleteFilter.expectedSchema().columns()).thenReturn(nCopies(3, null));
-
-        ColumnVector[] result = ColumnarBatchUtil.removeExtraColumns(deleteFilter, vectors);
-        assertThat(result.length).isEqualTo(3);
+  @Test
+  void testRemoveExtraColumns() {
+    ColumnVector[] vectors = new ColumnVector[5];
+    for (int i = 0; i < 5; i++) {
+      vectors[i] = mock(ColumnVector.class);
     }
+    when(deleteFilter.expectedSchema()).thenReturn(mock(Schema.class));
+    when(deleteFilter.expectedSchema().columns()).thenReturn(nCopies(3, null));
 
-    @Test
-    void testRemoveExtraColumnsNotNeeded() {
-        ColumnVector[] vectors = new ColumnVector[3];
-        for (int i = 0; i < 3; i++) {
-            vectors[i] = mock(ColumnVector.class);
-        }
-        when(deleteFilter.expectedSchema()).thenReturn(mock(Schema.class));
-        when(deleteFilter.expectedSchema().columns()).thenReturn(nCopies(3, null));
+    ColumnVector[] result = ColumnarBatchUtil.removeExtraColumns(deleteFilter, vectors);
+    assertThat(result.length).isEqualTo(3);
+  }
 
-        ColumnVector[] result = ColumnarBatchUtil.removeExtraColumns(deleteFilter, vectors);
-        assertThat( result.length).isEqualTo(3);
+  @Test
+  void testRemoveExtraColumnsNotNeeded() {
+    ColumnVector[] vectors = new ColumnVector[3];
+    for (int i = 0; i < 3; i++) {
+      vectors[i] = mock(ColumnVector.class);
     }
+    when(deleteFilter.expectedSchema()).thenReturn(mock(Schema.class));
+    when(deleteFilter.expectedSchema().columns()).thenReturn(nCopies(3, null));
+
+    ColumnVector[] result = ColumnarBatchUtil.removeExtraColumns(deleteFilter, vectors);
+    assertThat(result.length).isEqualTo(3);
+  }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryEncodedVectorizedReads.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.spark.data.parquet.vectorized;
+package org.apache.iceberg.spark.data.vectorized.parquet;
 
 import static org.apache.iceberg.TableProperties.PARQUET_DICT_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.PARQUET_PAGE_ROW_LIMIT;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryFallbackToPlainEncodingVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryFallbackToPlainEncodingVectorizedReads.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.spark.data.parquet.vectorized;
+package org.apache.iceberg.spark.data.vectorized.parquet;
 
 import java.io.File;
 import java.io.IOException;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.spark.data.parquet.vectorized;
+package org.apache.iceberg.spark.data.vectorized.parquet;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;


### PR DESCRIPTION
Fixes: https://github.com/apache/iceberg/issues/12054

`ColumnarBatchUtil` class was added as part of delete logic refactor https://github.com/apache/iceberg/pull/11933. This PR adds unit tests for this class and minor refactor of test packages to match with the class.