### PR TITLE
List data and metadata directories instead of table root

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -166,7 +166,7 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
     Table table = validationCatalog.loadTable(tableIdent);
 
     // produce orphan files in the table location using parquet
-    sql("CREATE TABLE p (id bigint) USING parquet LOCATION '%s'", table.location());
+    sql("CREATE TABLE p (id bigint) USING parquet LOCATION '%s'", table.location() + "/data");
     sql("INSERT INTO TABLE p VALUES (1)");
 
     // wait to ensure files are old enough

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -26,7 +26,6 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -330,7 +329,8 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
                 subDirs,
                 pathFilter,
                 matchingFiles));
-    JavaRDD<String> matchingFileRDD = sparkContext().parallelize(new ArrayList<>(matchingFiles), 1);
+    JavaRDD<String> matchingFileRDD =
+        sparkContext().parallelize(Lists.newArrayList(matchingFiles), 1);
 
     if (subDirs.isEmpty()) {
       return spark().createDataset(matchingFileRDD.rdd(), Encoders.STRING());


### PR DESCRIPTION
### Issue
Tables t1 and t2 use a common prefix for their table location `/path/to/shared_root`.
 t1 has it data and metadata dir  ->  `/path/to/shared_root/t1`
t2 has its data a and metadata dir -> `/path/to/shared_root` (Intentional or misconfigured table).
When cleaning up t2 of orphan files, iceberg lists all files in `/path/to/shared_root`, including those in `/path/to/shared_root/t1`.
This creates the risk of accidentally deleting t1's data.

This change lists the data and metadata directory instead of table root.


