### PR TITLE
Spark 3.5: Fix job description of RewriteTablePathSparkAction

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -239,7 +239,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   private String jobDesc() {
-    if (startVersionName != null) {
+    if (startVersionName == null) {
       return String.format(
           "Replacing path prefixes '%s' with '%s' in the metadata files of table %s,"
               + "up to version '%s'.",


### PR DESCRIPTION
The original message returns "... from version 'null' to ..."