### PR TITLE
Build: Bump datamodel-code-generator from 0.27.2 to 0.28.1

### DIFF
--- a/open-api/Makefile
+++ b/open-api/Makefile
@@ -24,7 +24,7 @@ lint:
 generate:
 	datamodel-codegen \
                 --enum-field-as-literal all \
-	        --target-python-version 3.8 \
+	        --target-python-version 3.9 \
 	        --use-schema-description \
 	        --field-constraints \
 	        --input rest-catalog-open-api.yaml \

--- a/open-api/requirements.txt
+++ b/open-api/requirements.txt
@@ -16,4 +16,4 @@
 # under the License.
 
 openapi-spec-validator==0.7.1
-datamodel-code-generator==0.27.2
+datamodel-code-generator==0.28.1


### PR DESCRIPTION
This supersedes #12285 