### PR TITLE
REST: Expose endpoints in RESTSessionCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -362,6 +362,10 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     return session(context)::headers;
   }
 
+  public Set<Endpoint> endpoints() {
+    return endpoints;
+  }
+
   @Override
   public void setConf(Object newConf) {
     this.conf = newConf;


### PR DESCRIPTION
Trino wants to use this field to avoid exception-driven logic. 