### PR TITLE
Add properties support for HadoopTables.load() (#12251)

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Tables.java
+++ b/api/src/main/java/org/apache/iceberg/Tables.java
@@ -51,7 +51,14 @@ public interface Tables {
         this.getClass().getName() + " does not implement create with a sort order");
   }
 
-  Table load(String tableIdentifier);
+  default Table load(String tableIdentifier) {
+    return load(tableIdentifier, null);
+  }
+
+  default Table load(String tableIdentifier, Map<String, String> properties) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement load with properties");
+  }
 
   boolean exists(String tableIdentifier);
 }


### PR DESCRIPTION
Description:
Currently, HadoopTables.load() doesn't support passing custom properties when loading tables. While HiveCatalog and HadoopCatalog support manifest caching through their initialize() method (as implemented in #4518), HadoopTables lacks this capability. This enhancement adds property support to HadoopTables.load() to enable manifest caching and other configurations.

Problem:
- HadoopTables lacks the ability to configure manifest caching during table loading
- Unlike HiveCatalog and HadoopCatalog which can enable manifest caching through initialize(), HadoopTables has no mechanism to pass these settings
- This creates inconsistency in how manifest caching can be configured across different catalog implementations