### PR TITLE
AWS: Integrate S3 analytics accelerator library 

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
@@ -24,17 +24,24 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
 
 abstract class BaseS3File {
   private final S3Client client;
+  private final S3SeekableInputStreamFactory streamFactory;
   private final S3URI uri;
   private final S3FileIOProperties s3FileIOProperties;
   private HeadObjectResponse metadata;
   private final MetricsContext metrics;
 
   BaseS3File(
-      S3Client client, S3URI uri, S3FileIOProperties s3FileIOProperties, MetricsContext metrics) {
+      S3Client client,
+      S3SeekableInputStreamFactory streamFactory,
+      S3URI uri,
+      S3FileIOProperties s3FileIOProperties,
+      MetricsContext metrics) {
     this.client = client;
+    this.streamFactory = streamFactory;
     this.uri = uri;
     this.s3FileIOProperties = s3FileIOProperties;
     this.metrics = metrics;
@@ -46,6 +53,10 @@ abstract class BaseS3File {
 
   S3Client client() {
     return client;
+  }
+
+  S3SeekableInputStreamFactory streamFactory() {
+    return streamFactory;
   }
 
   S3URI uri() {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.apache.iceberg.aws.AwsClientFactory;
 import org.apache.iceberg.aws.S3FileIOAwsClientFactories;
+import org.apache.iceberg.aws.s3.analyticsaccelerator.S3SeekableInputStreamFactorySupplier;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.CredentialSupplier;
@@ -71,6 +72,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
 import software.amazon.awssdk.services.s3.paginators.ListObjectVersionsIterable;
+import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
 
 /**
  * FileIO implementation backed by S3.
@@ -87,9 +89,11 @@ public class S3FileIO implements CredentialSupplier, DelegateFileIO, SupportsRec
 
   private String credential = null;
   private SerializableSupplier<S3Client> s3;
+  private S3SeekableInputStreamFactorySupplier streamFactorySupplier;
   private S3FileIOProperties s3FileIOProperties;
   private SerializableMap<String, String> properties = null;
   private transient volatile S3Client client;
+  private transient volatile S3SeekableInputStreamFactory streamFactory;
   private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
   private transient StackTraceElement[] createStack;
@@ -122,23 +126,25 @@ public class S3FileIO implements CredentialSupplier, DelegateFileIO, SupportsRec
    */
   public S3FileIO(SerializableSupplier<S3Client> s3, S3FileIOProperties s3FileIOProperties) {
     this.s3 = s3;
+    this.streamFactorySupplier = new S3SeekableInputStreamFactorySupplier(s3FileIOProperties);
     this.s3FileIOProperties = s3FileIOProperties;
     this.createStack = Thread.currentThread().getStackTrace();
   }
 
   @Override
   public InputFile newInputFile(String path) {
-    return S3InputFile.fromLocation(path, client(), s3FileIOProperties, metrics);
+    return S3InputFile.fromLocation(path, client(), streamFactory(), s3FileIOProperties, metrics);
   }
 
   @Override
   public InputFile newInputFile(String path, long length) {
-    return S3InputFile.fromLocation(path, length, client(), s3FileIOProperties, metrics);
+    return S3InputFile.fromLocation(
+        path, length, client(), streamFactory(), s3FileIOProperties, metrics);
   }
 
   @Override
   public OutputFile newOutputFile(String path) {
-    return S3OutputFile.fromLocation(path, client(), s3FileIOProperties, metrics);
+    return S3OutputFile.fromLocation(path, client(), streamFactory(), s3FileIOProperties, metrics);
   }
 
   @Override
@@ -343,6 +349,18 @@ public class S3FileIO implements CredentialSupplier, DelegateFileIO, SupportsRec
     return client;
   }
 
+  public S3SeekableInputStreamFactory streamFactory() {
+    if (streamFactory == null) {
+      synchronized (this) {
+        if (streamFactory == null) {
+          streamFactory = streamFactorySupplier.get();
+        }
+      }
+    }
+
+    return streamFactory;
+  }
+
   private ExecutorService executorService() {
     if (executorService == null) {
       synchronized (S3FileIO.class) {
@@ -387,6 +405,8 @@ public class S3FileIO implements CredentialSupplier, DelegateFileIO, SupportsRec
         client();
       }
     }
+
+    this.streamFactorySupplier = new S3SeekableInputStreamFactorySupplier(s3FileIOProperties);
 
     initMetrics(properties);
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -73,6 +73,16 @@ public class S3FileIOProperties implements Serializable {
   public static final boolean S3_ACCESS_GRANTS_ENABLED_DEFAULT = false;
 
   /**
+   * This property is used to enable using the S3 Analytics Accelerator library to accelerate data
+   * access from client applications to Amazon S3.
+   *
+   * <p>For more details, see: https://github.com/awslabs/analytics-accelerator-s3
+   */
+  public static final String S3_ANALYTICS_ACCELERATOR_ENABLED = "s3.analyticsaccelerator.enabled";
+
+  public static final boolean S3_ANALYTICS_ACCELERATOR_ENABLED_DEFAULT = false;
+
+  /**
    * The fallback-to-iam property allows users to customize whether or not they would like their
    * jobs fall back to the Job Execution IAM role in case they get an Access Denied from the S3
    * Access Grants call. Further documentation regarding this flag can be found in the S3 Access
@@ -484,6 +494,8 @@ public class S3FileIOProperties implements Serializable {
   private final boolean isAccelerationEnabled;
   private final String endpoint;
   private final boolean isRemoteSigningEnabled;
+  private final boolean isS3AnalyticsAcceleratorEnabled;
+  private final Map<String, String> s3AnalyticsacceleratorConfiguration;
   private String writeStorageClass;
   private int s3RetryNumRetries;
   private long s3RetryMinWaitMs;
@@ -528,6 +540,8 @@ public class S3FileIOProperties implements Serializable {
     this.s3RetryMaxWaitMs = S3_RETRY_MAX_WAIT_MS_DEFAULT;
     this.s3DirectoryBucketListPrefixAsDirectory =
         S3_DIRECTORY_BUCKET_LIST_PREFIX_AS_DIRECTORY_DEFAULT;
+    this.isS3AnalyticsAcceleratorEnabled = S3_ANALYTICS_ACCELERATOR_ENABLED_DEFAULT;
+    this.s3AnalyticsacceleratorConfiguration = Maps.newHashMap();
     this.allProperties = Maps.newHashMap();
 
     ValidationException.check(
@@ -640,6 +654,11 @@ public class S3FileIOProperties implements Serializable {
             properties,
             S3_DIRECTORY_BUCKET_LIST_PREFIX_AS_DIRECTORY,
             S3_DIRECTORY_BUCKET_LIST_PREFIX_AS_DIRECTORY_DEFAULT);
+    this.isS3AnalyticsAcceleratorEnabled =
+        PropertyUtil.propertyAsBoolean(
+            properties, S3_ANALYTICS_ACCELERATOR_ENABLED, S3_ANALYTICS_ACCELERATOR_ENABLED_DEFAULT);
+    this.s3AnalyticsacceleratorConfiguration =
+        PropertyUtil.propertiesWithPrefix(properties, "s3.analyticsaccelerator.");
 
     ValidationException.check(
         keyIdAccessKeyBothConfigured(),
@@ -752,6 +771,14 @@ public class S3FileIOProperties implements Serializable {
 
   public boolean isRemoteSigningEnabled() {
     return this.isRemoteSigningEnabled;
+  }
+
+  public boolean isS3AnalyticsAcceleratorEnabled() {
+    return isS3AnalyticsAcceleratorEnabled;
+  }
+
+  public Map<String, String> getS3AnalyticsacceleratorConfiguration() {
+    return s3AnalyticsacceleratorConfiguration;
   }
 
   public String endpoint() {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
@@ -18,24 +18,36 @@
  */
 package org.apache.iceberg.aws.s3;
 
+import java.io.IOException;
+import org.apache.iceberg.aws.s3.analyticsaccelerator.AnalyticsAcceleratorInputStream;
 import org.apache.iceberg.encryption.NativeFileCryptoParameters;
 import org.apache.iceberg.encryption.NativelyEncryptedFile;
+import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.MetricsContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
+import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 
 public class S3InputFile extends BaseS3File implements InputFile, NativelyEncryptedFile {
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3InputFile.class);
+
   private NativeFileCryptoParameters nativeDecryptionParameters;
   private Long length;
 
   public static S3InputFile fromLocation(
       String location,
       S3Client client,
+      S3SeekableInputStreamFactory streamFactory,
       S3FileIOProperties s3FileIOProperties,
       MetricsContext metrics) {
     return new S3InputFile(
         client,
+        streamFactory,
         new S3URI(location, s3FileIOProperties.bucketToAccessPointMapping()),
         null,
         s3FileIOProperties,
@@ -46,10 +58,12 @@ public class S3InputFile extends BaseS3File implements InputFile, NativelyEncryp
       String location,
       long length,
       S3Client client,
+      S3SeekableInputStreamFactory streamFactory,
       S3FileIOProperties s3FileIOProperties,
       MetricsContext metrics) {
     return new S3InputFile(
         client,
+        streamFactory,
         new S3URI(location, s3FileIOProperties.bucketToAccessPointMapping()),
         length > 0 ? length : null,
         s3FileIOProperties,
@@ -58,11 +72,12 @@ public class S3InputFile extends BaseS3File implements InputFile, NativelyEncryp
 
   S3InputFile(
       S3Client client,
+      S3SeekableInputStreamFactory streamFactory,
       S3URI uri,
       Long length,
       S3FileIOProperties s3FileIOProperties,
       MetricsContext metrics) {
-    super(client, uri, s3FileIOProperties, metrics);
+    super(client, streamFactory, uri, s3FileIOProperties, metrics);
     this.length = length;
   }
 
@@ -82,6 +97,27 @@ public class S3InputFile extends BaseS3File implements InputFile, NativelyEncryp
 
   @Override
   public SeekableInputStream newStream() {
+    if (s3FileIOProperties().isS3AnalyticsAcceleratorEnabled()) {
+      LOG.info("Using S3 analytics accelerator stream");
+      LOG.info("S3 analytics accelerator configuration: {}", streamFactory().getConfiguration());
+      try {
+        final ObjectMetadata metadata =
+            ObjectMetadata.builder()
+                .contentLength(getObjectMetadata().contentLength())
+                .etag(getObjectMetadata().eTag())
+                .build();
+        return new AnalyticsAcceleratorInputStream(
+            streamFactory()
+                .createStream(
+                    software.amazon.s3.analyticsaccelerator.util.S3URI.of(
+                        uri().bucket(), uri().key()),
+                    metadata));
+      } catch (IOException e) {
+        throw new RuntimeIOException(
+            "Failed to create analytics accelerator input stream for bucket: %s, key: %s - %s",
+            uri().bucket(), uri().key(), e);
+      }
+    }
     return new S3InputStream(client(), uri(), s3FileIOProperties(), metrics());
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.metrics.MetricsContext;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
 
 public class S3OutputFile extends BaseS3File implements OutputFile, NativelyEncryptedFile {
   private NativeFileCryptoParameters nativeEncryptionParameters;
@@ -35,18 +36,24 @@ public class S3OutputFile extends BaseS3File implements OutputFile, NativelyEncr
   public static S3OutputFile fromLocation(
       String location,
       S3Client client,
+      S3SeekableInputStreamFactory streamFactory,
       S3FileIOProperties s3FileIOProperties,
       MetricsContext metrics) {
     return new S3OutputFile(
         client,
+        streamFactory,
         new S3URI(location, s3FileIOProperties.bucketToAccessPointMapping()),
         s3FileIOProperties,
         metrics);
   }
 
   S3OutputFile(
-      S3Client client, S3URI uri, S3FileIOProperties s3FileIOProperties, MetricsContext metrics) {
-    super(client, uri, s3FileIOProperties, metrics);
+      S3Client client,
+      S3SeekableInputStreamFactory streamFactory,
+      S3URI uri,
+      S3FileIOProperties s3FileIOProperties,
+      MetricsContext metrics) {
+    super(client, streamFactory, uri, s3FileIOProperties, metrics);
   }
 
   /**
@@ -75,7 +82,7 @@ public class S3OutputFile extends BaseS3File implements OutputFile, NativelyEncr
 
   @Override
   public InputFile toInputFile() {
-    return new S3InputFile(client(), uri(), null, s3FileIOProperties(), metrics());
+    return new S3InputFile(client(), streamFactory(), uri(), null, s3FileIOProperties(), metrics());
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/analyticsaccelerator/AnalyticsAcceleratorInputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/analyticsaccelerator/AnalyticsAcceleratorInputStream.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3.analyticsaccelerator;
+
+import java.io.IOException;
+import org.apache.iceberg.io.SeekableInputStream;
+import software.amazon.s3.analyticsaccelerator.S3SeekableInputStream;
+
+public class AnalyticsAcceleratorInputStream extends SeekableInputStream {
+
+  private final S3SeekableInputStream delegate;
+
+  public AnalyticsAcceleratorInputStream(S3SeekableInputStream stream) {
+    this.delegate = stream;
+  }
+
+  @Override
+  public int read() throws IOException {
+    return this.delegate.read();
+  }
+
+  @Override
+  public int read(byte[] b) throws IOException {
+    return this.delegate.read(b, 0, b.length);
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    return this.delegate.read(b, off, len);
+  }
+
+  @Override
+  public void seek(long l) throws IOException {
+    this.delegate.seek(l);
+  }
+
+  @Override
+  public long getPos() {
+    return this.delegate.getPos();
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.delegate.close();
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/analyticsaccelerator/S3SeekableInputStreamFactorySupplier.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/analyticsaccelerator/S3SeekableInputStreamFactorySupplier.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3.analyticsaccelerator;
+
+import java.util.Map;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.util.SerializableSupplier;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.s3.analyticsaccelerator.ObjectClientConfiguration;
+import software.amazon.s3.analyticsaccelerator.S3SdkObjectClient;
+import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
+import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
+import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;
+import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
+
+public class S3SeekableInputStreamFactorySupplier
+    implements SerializableSupplier<S3SeekableInputStreamFactory> {
+
+  private final Map<String, String> s3AnalyticsAccelaratorProperties;
+
+  public S3SeekableInputStreamFactorySupplier(S3FileIOProperties s3FileIOProperties) {
+    this.s3AnalyticsAccelaratorProperties =
+        s3FileIOProperties.getS3AnalyticsacceleratorConfiguration();
+  }
+
+  @Override
+  public S3SeekableInputStreamFactory get() {
+    ConnectorConfiguration connectorConfiguration =
+        new ConnectorConfiguration(s3AnalyticsAccelaratorProperties);
+    S3SeekableInputStreamConfiguration streamConfiguration =
+        S3SeekableInputStreamConfiguration.fromConfiguration(connectorConfiguration);
+    ObjectClientConfiguration objectClientConfiguration =
+        ObjectClientConfiguration.fromConfiguration(connectorConfiguration);
+
+    ObjectClient objectClient =
+        new S3SdkObjectClient(
+            S3AsyncClient.crtBuilder().maxConcurrency(500).build(), objectClientConfiguration);
+    return new S3SeekableInputStreamFactory(objectClient, streamConfiguration);
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -470,6 +470,8 @@ project(':iceberg-aws') {
     compileOnly("software.amazon.awssdk:dynamodb")
     compileOnly("software.amazon.awssdk:lakeformation")
 
+    compileOnly("software.amazon.s3.analyticsaccelerator:analyticsaccelerator-s3:0.0.3")
+
     compileOnly(libs.hadoop2.common) {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'


### PR DESCRIPTION
#### Description

- This is an initial PR for integrating [analytics-accelerator-s3](https://github.com/awslabs/analytics-accelerator-s3) into `iceberg/aws`
- In short, our library accelerates read performance of objects stored in Amazon S3 by integrating AWS Common Run Time (CRT) libraries and implementing optimisations specific to Apache Parquet files.

#### Testing
- In progress, We would really appreciate any initial feedback from the community meanwhile.

**PS:** We are also integrating this library into [hadoop-aws](https://github.com/apache/hadoop/pull/7334).
