### PR TITLE
Fix IndexOutOfBounds exception in FileFormat#fromFileName

### DIFF
--- a/api/src/main/java/org/apache/iceberg/FileFormat.java
+++ b/api/src/main/java/org/apache/iceberg/FileFormat.java
@@ -58,6 +58,10 @@ public enum FileFormat {
   }
 
   public static FileFormat fromFileName(CharSequence filename) {
+    if (filename == null) {
+      return null;
+    }
+
     for (FileFormat format : VALUES) {
       int extStart = filename.length() - format.ext.length();
       if (extStart > 0

--- a/api/src/main/java/org/apache/iceberg/FileFormat.java
+++ b/api/src/main/java/org/apache/iceberg/FileFormat.java
@@ -60,9 +60,10 @@ public enum FileFormat {
   public static FileFormat fromFileName(CharSequence filename) {
     for (FileFormat format : VALUES) {
       int extStart = filename.length() - format.ext.length();
-      if (Comparators.charSequences()
-              .compare(format.ext, filename.subSequence(extStart, filename.length()))
-          == 0) {
+      if (extStart > 0
+          && Comparators.charSequences()
+                  .compare(format.ext, filename.subSequence(extStart, filename.length()))
+              == 0) {
         return format;
       }
     }

--- a/api/src/test/java/org/apache/iceberg/FileFormatTest.java
+++ b/api/src/test/java/org/apache/iceberg/FileFormatTest.java
@@ -24,12 +24,33 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.FieldSource;
 
 class FileFormatTest {
 
+  private static final Object[][] FILE_NAMES =
+      new Object[][] {
+        // Files with format
+        {"file.puffin", FileFormat.PUFFIN},
+        {"dir/file.puffin", FileFormat.PUFFIN},
+        {"file.orc", FileFormat.ORC},
+        {"dir/file.orc", FileFormat.ORC},
+        {"file.parquet", FileFormat.PARQUET},
+        {"dir/file.parquet", FileFormat.PARQUET},
+        {"file.avro", FileFormat.AVRO},
+        {"dir/file.avro", FileFormat.AVRO},
+        {"v1.metadata.json", FileFormat.METADATA},
+        {"dir/v1.metadata.json", FileFormat.METADATA},
+        // Unsupported formats
+        {"file.csv", null},
+        {"dir/file.csv", null},
+        // No format
+        {"file", null},
+        {"dir", null},
+      };
+
   @ParameterizedTest
-  @MethodSource
+  @FieldSource("FILE_NAMES")
   void fromFileName(String fileName, FileFormat expected) {
     FileFormat actual = FileFormat.fromFileName(fileName);
 

--- a/api/src/test/java/org/apache/iceberg/FileFormatTest.java
+++ b/api/src/test/java/org/apache/iceberg/FileFormatTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class FileFormatTest {
+
+  @ParameterizedTest
+  @MethodSource
+  void fromFileName(String fileName, FileFormat expected) {
+    FileFormat actual = FileFormat.fromFileName(fileName);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> fromFileName() {
+    return Stream.of(
+        // Files with format
+        arguments("file.puffin", FileFormat.PUFFIN),
+        arguments("dir/file.puffin", FileFormat.PUFFIN),
+        arguments("file.orc", FileFormat.ORC),
+        arguments("dir/file.orc", FileFormat.ORC),
+        arguments("file.parquet", FileFormat.PARQUET),
+        arguments("dir/file.parquet", FileFormat.PARQUET),
+        arguments("file.avro", FileFormat.AVRO),
+        arguments("dir/file.avro", FileFormat.AVRO),
+        arguments("v1.metadata.json", FileFormat.METADATA),
+        arguments("dir/v1.metadata.json", FileFormat.METADATA),
+        // Unsupported formats
+        arguments("file.csv", null),
+        arguments("dir/file.csv", null),
+        // No format
+        arguments("file", null),
+        arguments("dir", null),
+        // File names match format names but no extension
+        arguments("puffin", null),
+        arguments("orc", null),
+        arguments("parquet", null),
+        arguments("avro", null),
+        arguments("metadata.json", null));
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/TestFileFormat.java
+++ b/api/src/test/java/org/apache/iceberg/TestFileFormat.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 
+@SuppressWarnings("unused")
 class TestFileFormat {
 
   private static final Object[][] FILE_NAMES =
@@ -38,6 +39,12 @@ class TestFileFormat {
         {"dir/file.avro", FileFormat.AVRO},
         {"v1.metadata.json", FileFormat.METADATA},
         {"dir/v1.metadata.json", FileFormat.METADATA},
+        // Short file names with format
+        {"x.puffin", FileFormat.PUFFIN},
+        {"x.orc", FileFormat.ORC},
+        {"x.parquet", FileFormat.PARQUET},
+        {"x.avro", FileFormat.AVRO},
+        {"x.metadata.json", FileFormat.METADATA},
         // Unsupported formats
         {"file.csv", null},
         {"dir/file.csv", null},

--- a/api/src/test/java/org/apache/iceberg/TestFileFormat.java
+++ b/api/src/test/java/org/apache/iceberg/TestFileFormat.java
@@ -19,14 +19,11 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.FieldSource;
 
-class FileFormatTest {
+class TestFileFormat {
 
   private static final Object[][] FILE_NAMES =
       new Object[][] {
@@ -55,32 +52,5 @@ class FileFormatTest {
     FileFormat actual = FileFormat.fromFileName(fileName);
 
     assertThat(actual).isEqualTo(expected);
-  }
-
-  static Stream<Arguments> fromFileName() {
-    return Stream.of(
-        // Files with format
-        arguments("file.puffin", FileFormat.PUFFIN),
-        arguments("dir/file.puffin", FileFormat.PUFFIN),
-        arguments("file.orc", FileFormat.ORC),
-        arguments("dir/file.orc", FileFormat.ORC),
-        arguments("file.parquet", FileFormat.PARQUET),
-        arguments("dir/file.parquet", FileFormat.PARQUET),
-        arguments("file.avro", FileFormat.AVRO),
-        arguments("dir/file.avro", FileFormat.AVRO),
-        arguments("v1.metadata.json", FileFormat.METADATA),
-        arguments("dir/v1.metadata.json", FileFormat.METADATA),
-        // Unsupported formats
-        arguments("file.csv", null),
-        arguments("dir/file.csv", null),
-        // No format
-        arguments("file", null),
-        arguments("dir", null),
-        // File names match format names but no extension
-        arguments("puffin", null),
-        arguments("orc", null),
-        arguments("parquet", null),
-        arguments("avro", null),
-        arguments("metadata.json", null));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/TestFileFormat.java
+++ b/api/src/test/java/org/apache/iceberg/TestFileFormat.java
@@ -44,6 +44,10 @@ class TestFileFormat {
         // No format
         {"file", null},
         {"dir", null},
+        // Blank strings
+        {"", null},
+        {" ", null},
+        {null, null},
       };
 
   @ParameterizedTest


### PR DESCRIPTION
Closes #12300.

`FileFormat#fromFileName` should account for file names that are shorter than a file format extension.