### PR TITLE
API: Reject unknown type for required fields and validate defaults

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -680,6 +680,10 @@ public class Types {
         Literal<?> writeDefault) {
       Preconditions.checkNotNull(name, "Name cannot be null");
       Preconditions.checkNotNull(type, "Type cannot be null");
+      Preconditions.checkArgument(
+          isOptional || !type.equals(UnknownType.get()),
+          "Cannot create required field with unknown type: %s",
+          name);
       this.isOptional = isOptional;
       this.id = id;
       this.name = name;
@@ -694,7 +698,10 @@ public class Types {
         throw new IllegalArgumentException(
             String.format("Invalid default value for %s: %s (must be null)", type, defaultValue));
       } else if (defaultValue != null) {
-        return defaultValue.to(type);
+        Literal<?> typedDefault = defaultValue.to(type);
+        Preconditions.checkArgument(
+            typedDefault != null, "Cannot cast default value to %s: %s", type, defaultValue);
+        return typedDefault;
       }
 
       return null;

--- a/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
+++ b/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
@@ -37,7 +37,7 @@ public class TestPartitionSpecValidation {
           NestedField.required(5, "another_d", Types.TimestampType.withZone()),
           NestedField.required(6, "s", Types.StringType.get()),
           NestedField.required(7, "v", Types.VariantType.get()),
-          NestedField.required(8, "u", Types.UnknownType.get()));
+          NestedField.optional(8, "u", Types.UnknownType.get()));
 
   @Test
   public void testMultipleTimestampPartitions() {

--- a/api/src/test/java/org/apache/iceberg/TestSchema.java
+++ b/api/src/test/java/org/apache/iceberg/TestSchema.java
@@ -124,7 +124,7 @@ public class TestSchema {
 
   @Test
   public void testUnknownSupport() {
-    // this needs a different schema becuase it cannot be used in required fields
+    // this needs a different schema because it cannot be used in required fields
     Schema schemaWithUnknown =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),

--- a/api/src/test/java/org/apache/iceberg/TestSchema.java
+++ b/api/src/test/java/org/apache/iceberg/TestSchema.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.FieldSource;
@@ -41,8 +42,7 @@ public class TestSchema {
       ImmutableList.of(
           Types.TimestampNanoType.withoutZone(),
           Types.TimestampNanoType.withZone(),
-          Types.VariantType.get(),
-          Types.UnknownType.get());
+          Types.VariantType.get());
 
   private static final Schema INITIAL_DEFAULT_SCHEMA =
       new Schema(
@@ -120,6 +120,56 @@ public class TestSchema {
             type ->
                 IntStream.rangeClosed(MIN_FORMAT_VERSIONS.get(type.typeId()), MAX_FORMAT_VERSION)
                     .mapToObj(supportedVersion -> Arguments.of(type, supportedVersion)));
+  }
+
+  @Test
+  public void testUnknownSupport() {
+    // this needs a different schema becuase it cannot be used in required fields
+    Schema schemaWithUnknown =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "top", Types.UnknownType.get()),
+            Types.NestedField.optional(
+                3, "arr", Types.ListType.ofOptional(4, Types.UnknownType.get())),
+            Types.NestedField.required(
+                5,
+                "struct",
+                Types.StructType.of(
+                    Types.NestedField.optional(6, "inner_op", Types.UnknownType.get()),
+                    Types.NestedField.optional(
+                        7,
+                        "inner_map",
+                        Types.MapType.ofOptional(
+                            8, 9, Types.StringType.get(), Types.UnknownType.get())),
+                    Types.NestedField.optional(
+                        10,
+                        "struct_arr",
+                        Types.StructType.of(
+                            Types.NestedField.optional(11, "deep", Types.UnknownType.get()))))));
+
+    assertThatThrownBy(() -> Schema.checkCompatibility(schemaWithUnknown, 2))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Invalid schema for v%s:\n"
+                + "- Invalid type for top: %s is not supported until v%s\n"
+                + "- Invalid type for arr.element: %s is not supported until v%s\n"
+                + "- Invalid type for struct.inner_op: %s is not supported until v%s\n"
+                + "- Invalid type for struct.inner_map.value: %s is not supported until v%s\n"
+                + "- Invalid type for struct.struct_arr.deep: %s is not supported until v%s",
+            2,
+            Types.UnknownType.get(),
+            MIN_FORMAT_VERSIONS.get(Type.TypeID.UNKNOWN),
+            Types.UnknownType.get(),
+            MIN_FORMAT_VERSIONS.get(Type.TypeID.UNKNOWN),
+            Types.UnknownType.get(),
+            MIN_FORMAT_VERSIONS.get(Type.TypeID.UNKNOWN),
+            Types.UnknownType.get(),
+            MIN_FORMAT_VERSIONS.get(Type.TypeID.UNKNOWN),
+            Types.UnknownType.get(),
+            MIN_FORMAT_VERSIONS.get(Type.TypeID.UNKNOWN));
+
+    assertThatCode(() -> Schema.checkCompatibility(schemaWithUnknown, 3))
+        .doesNotThrowAnyException();
   }
 
   @ParameterizedTest


### PR DESCRIPTION
This updates `NestedField` to check that `UnknownType` is not used in a required field, which is [not permitted by the spec](https://github.com/apache/iceberg/blob/main/format/spec.md#primitive-types). It also checks that default values are cast to the correct type or are rejected.