### PR TITLE
Wrap variant in PrimitiveHoder so serialization can result same instance

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/PrimitiveHolder.java
+++ b/api/src/main/java/org/apache/iceberg/types/PrimitiveHolder.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.types;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 
-/** Replacement for primitive types in Java Serialization. */
+/** Replacement for primitive types and Variant type in Java Serialization. */
 class PrimitiveHolder implements Serializable {
   private String typeAsString = null;
 

--- a/api/src/main/java/org/apache/iceberg/types/PrimitiveLikeHolder.java
+++ b/api/src/main/java/org/apache/iceberg/types/PrimitiveLikeHolder.java
@@ -22,13 +22,13 @@ import java.io.ObjectStreamException;
 import java.io.Serializable;
 
 /** Replacement for primitive types and Variant type in Java Serialization. */
-class PrimitiveHolder implements Serializable {
+class PrimitiveLikeHolder implements Serializable {
   private String typeAsString = null;
 
   /** Constructor for Java serialization. */
-  PrimitiveHolder() {}
+  PrimitiveLikeHolder() {}
 
-  PrimitiveHolder(String typeAsString) {
+  PrimitiveLikeHolder(String typeAsString) {
     this.typeAsString = typeAsString;
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/Type.java
+++ b/api/src/main/java/org/apache/iceberg/types/Type.java
@@ -123,7 +123,7 @@ public interface Type extends Serializable {
     }
 
     Object writeReplace() throws ObjectStreamException {
-      return new PrimitiveHolder(toString());
+      return new PrimitiveLikeHolder(toString());
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.types;
 
+import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -449,6 +450,10 @@ public class Types {
     @Override
     public VariantType asVariantType() {
       return this;
+    }
+
+    Object writeReplace() throws ObjectStreamException {
+      return new PrimitiveHolder(toString());
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -453,7 +453,7 @@ public class Types {
     }
 
     Object writeReplace() throws ObjectStreamException {
-      return new PrimitiveHolder(toString());
+      return new PrimitiveLikeHolder(toString());
     }
 
     @Override

--- a/api/src/test/java/org/apache/iceberg/types/TestSerializableTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestSerializableTypes.java
@@ -46,7 +46,8 @@ public class TestSerializableTypes {
           Types.StringType.get(),
           Types.UUIDType.get(),
           Types.BinaryType.get(),
-          Types.UnknownType.get()
+          Types.UnknownType.get(),
+          Types.VariantType.get()
         };
 
     for (Type type : identityPrimitives) {
@@ -126,15 +127,6 @@ public class TestSerializableTypes {
           .as("List serialization should preserve identity type")
           .isSameAs(Types.DoubleType.get());
     }
-  }
-
-  @Test
-  public void testVariant() throws Exception {
-    Types.VariantType variant = Types.VariantType.get();
-    Type copy = TestHelpers.roundTripSerialize(variant);
-    assertThat(copy)
-        .as("Variant serialization should be equal to starting type")
-        .isEqualTo(variant);
   }
 
   @Test


### PR DESCRIPTION
Simple change to wrap variant in PrimitiveHolder similar to primitive type so when it's deserialized, it's returning the same instance.