### PR TITLE
Parquet: Implement Variant writers

### DIFF
--- a/api/src/main/java/org/apache/iceberg/variants/VariantData.java
+++ b/api/src/main/java/org/apache/iceberg/variants/VariantData.java
@@ -18,26 +18,26 @@
  */
 package org.apache.iceberg.variants;
 
-import java.nio.ByteBuffer;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-/** A variant metadata and value pair. */
-public interface Variant {
-  /** Returns the metadata for all values in the variant. */
-  VariantMetadata metadata();
+class VariantData implements Variant {
+  private final VariantMetadata metadata;
+  private final VariantValue value;
 
-  /** Returns the variant value. */
-  VariantValue value();
-
-  static Variant of(VariantMetadata metadata, VariantValue value) {
-    return new VariantData(metadata, value);
+  VariantData(VariantMetadata metadata, VariantValue value) {
+    Preconditions.checkArgument(metadata != null, "Invalid variant metadata: null");
+    Preconditions.checkArgument(value != null, "Invalid variant value: null");
+    this.metadata = metadata;
+    this.value = value;
   }
 
-  static Variant from(ByteBuffer buffer) {
-    VariantMetadata metadata = VariantMetadata.from(buffer);
-    ByteBuffer valueBuffer =
-        VariantUtil.slice(
-            buffer, metadata.sizeInBytes(), buffer.remaining() - metadata.sizeInBytes());
-    VariantValue value = VariantValue.from(metadata, valueBuffer);
-    return of(metadata, value);
+  @Override
+  public VariantMetadata metadata() {
+    return metadata;
+  }
+
+  @Override
+  public VariantValue value() {
+    return value;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
+++ b/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
@@ -46,11 +46,11 @@ public class ShreddedObject implements VariantObject {
   private SerializationState serializationState = null;
 
   ShreddedObject(VariantMetadata metadata) {
-    this.metadata = metadata;
-    this.unshredded = null;
+    this(metadata, null);
   }
 
   ShreddedObject(VariantMetadata metadata, VariantObject unshredded) {
+    Preconditions.checkArgument(metadata != null, "Invalid metadata: null");
     this.metadata = metadata;
     this.unshredded = unshredded;
   }

--- a/core/src/main/java/org/apache/iceberg/variants/VariantVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/variants/VariantVisitor.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.variants;
+
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+public class VariantVisitor<R> {
+  public R object(VariantObject object, List<R> fieldResults) {
+    return null;
+  }
+
+  public R array(VariantArray array, List<R> elementResults) {
+    return null;
+  }
+
+  public R primitive(VariantPrimitive<?> primitive) {
+    return null;
+  }
+
+  public void beforeArrayElement(int index) {}
+
+  public void afterArrayElement(int index) {}
+
+  public void beforeObjectField(String fieldName) {}
+
+  public void afterObjectField(String fieldName) {}
+
+  public static <R> R visit(Variant variant, VariantVisitor<R> visitor) {
+    return visit(variant.value(), visitor);
+  }
+
+  public static <R> R visit(VariantValue value, VariantVisitor<R> visitor) {
+    switch (value.type()) {
+      case ARRAY:
+        VariantArray array = value.asArray();
+        List<R> elementResults = Lists.newArrayList();
+        for (int index = 0; index < array.numElements(); index += 1) {
+          visitor.beforeArrayElement(index);
+          try {
+            elementResults.add(visit(array.get(index), visitor));
+          } finally {
+            visitor.afterArrayElement(index);
+          }
+        }
+
+        return visitor.array(array, elementResults);
+
+      case OBJECT:
+        VariantObject object = value.asObject();
+        List<R> fieldResults = Lists.newArrayList();
+        for (String fieldName : object.fieldNames()) {
+          visitor.beforeObjectField(fieldName);
+          try {
+            fieldResults.add(visit(object.get(fieldName), visitor));
+          } finally {
+            visitor.afterObjectField(fieldName);
+          }
+        }
+
+        return visitor.object(object, fieldResults);
+
+      default:
+        return visitor.primitive(value.asPrimitive());
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/variants/VariantVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/variants/VariantVisitor.java
@@ -22,7 +22,7 @@ import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 public class VariantVisitor<R> {
-  public R object(VariantObject object, List<R> fieldResults) {
+  public R object(VariantObject object, List<String> fieldNames, List<R> fieldResults) {
     return null;
   }
 
@@ -64,8 +64,10 @@ public class VariantVisitor<R> {
 
       case OBJECT:
         VariantObject object = value.asObject();
+        List<String> fieldNames = Lists.newArrayList();
         List<R> fieldResults = Lists.newArrayList();
         for (String fieldName : object.fieldNames()) {
+          fieldNames.add(fieldName);
           visitor.beforeObjectField(fieldName);
           try {
             fieldResults.add(visit(object.get(fieldName), visitor));
@@ -74,7 +76,7 @@ public class VariantVisitor<R> {
           }
         }
 
-        return visitor.object(object, fieldResults);
+        return visitor.object(object, fieldNames, fieldResults);
 
       default:
         return visitor.primitive(value.asPrimitive());

--- a/core/src/main/java/org/apache/iceberg/variants/Variants.java
+++ b/core/src/main/java/org/apache/iceberg/variants/Variants.java
@@ -45,6 +45,16 @@ public class Variants {
     return new ShreddedObject(metadata);
   }
 
+  public static ShreddedObject object(VariantObject object) {
+    if (object instanceof ShreddedObject) {
+      return new ShreddedObject(((ShreddedObject) object).metadata(), object);
+    } else if (object instanceof SerializedObject) {
+      return new ShreddedObject(((SerializedObject) object).metadata(), object);
+    }
+
+    throw new UnsupportedOperationException("Metadata is required for object: " + object);
+  }
+
   public static <T> VariantPrimitive<T> of(PhysicalType type, T value) {
     return new PrimitiveWrapper<>(type, value);
   }

--- a/core/src/test/java/org/apache/iceberg/InternalTestHelpers.java
+++ b/core/src/test/java/org/apache/iceberg/InternalTestHelpers.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantTestUtil;
 
 public class InternalTestHelpers {
 
@@ -105,6 +107,12 @@ public class InternalTestHelpers {
         assertThat(expected).as("Expected should be a Map").isInstanceOf(Map.class);
         assertThat(actual).as("Actual should be a Map").isInstanceOf(Map.class);
         assertEquals(type.asMapType(), (Map<?, ?>) expected, (Map<?, ?>) actual);
+        break;
+      case VARIANT:
+        assertThat(expected).as("Expected should be a Variant").isInstanceOf(Variant.class);
+        assertThat(actual).as("Actual should be a Variant").isInstanceOf(Variant.class);
+        VariantTestUtil.assertEqual(((Variant) expected).metadata(), ((Variant) actual).metadata());
+        VariantTestUtil.assertEqual(((Variant) expected).value(), ((Variant) actual).value());
         break;
       default:
         throw new IllegalArgumentException("Not a supported type: " + type);

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalWriter.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.parquet.ParquetValueWriter;
 import org.apache.iceberg.parquet.ParquetValueWriters;
 import org.apache.iceberg.parquet.ParquetValueWriters.StructWriter;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.MessageType;
 
@@ -38,9 +39,14 @@ public class InternalWriter<T extends StructLike> extends BaseParquetWriter<T> {
 
   private InternalWriter() {}
 
-  @SuppressWarnings("unchecked")
   public static <T extends StructLike> ParquetValueWriter<T> create(MessageType type) {
-    return (ParquetValueWriter<T>) INSTANCE.createWriter(type);
+    return create(null, type);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T extends StructLike> ParquetValueWriter<T> create(
+      Types.StructType struct, MessageType type) {
+    return (ParquetValueWriter<T>) INSTANCE.createWriter(struct, type);
   }
 
   @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -120,7 +120,6 @@ import org.apache.parquet.hadoop.api.ReadSupport;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -161,7 +160,7 @@ public class Parquet {
     private final Map<String, String> metadata = Maps.newLinkedHashMap();
     private final Map<String, String> config = Maps.newLinkedHashMap();
     private Schema schema = null;
-    private BiFunction<Integer, String, Type> variantShreddingFunc = null;
+    private VariantShreddingFunction variantShreddingFunc = null;
     private String name = "table";
     private WriteSupport<?> writeSupport = null;
     private BiFunction<Schema, MessageType, ParquetValueWriter<?>> createWriterFunc = null;
@@ -195,14 +194,14 @@ public class Parquet {
     }
 
     /**
-     * Set a {@link BiFunction} that is called with each variant field's name and field ID to
-     * produce the shredding type as a {@code typed_value} field. This field is added to the result
-     * variant struct alongside the {@code metadata} and {@code value} fields.
+     * Set a {@link VariantShreddingFunction} that is called with each variant field's name and
+     * field ID to produce the shredding type as a {@code typed_value} field. This field is added to
+     * the result variant struct alongside the {@code metadata} and {@code value} fields.
      *
-     * @param func {@link BiFunction} that produces a shredded {@code typed_value}
+     * @param func {@link VariantShreddingFunction} that produces a shredded {@code typed_value}
      * @return this for method chaining
      */
-    public WriteBuilder variantShreddingFunc(BiFunction<Integer, String, Type> func) {
+    public WriteBuilder variantShreddingFunc(VariantShreddingFunction func) {
       this.variantShreddingFunc = func;
       return this;
     }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -194,6 +194,14 @@ public class Parquet {
       return this;
     }
 
+    /**
+     * Set a {@link BiFunction} that is called with each variant field's name and field ID to
+     * produce the shredding type as a {@code typed_value} field. This field is added to the result
+     * variant struct alongside the {@code metadata} and {@code value} fields.
+     *
+     * @param func {@link BiFunction} that produces a shredded {@code typed_value}
+     * @return this for method chaining
+     */
     public WriteBuilder variantShreddingFunc(BiFunction<Integer, String, Type> func) {
       this.variantShreddingFunc = func;
       return this;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.parquet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.NameMapping;
@@ -40,6 +41,11 @@ public class ParquetSchemaUtil {
 
   public static MessageType convert(Schema schema, String name) {
     return new TypeToMessageType().convert(schema, name);
+  }
+
+  public static MessageType convert(
+      Schema schema, String name, BiFunction<Integer, String, Type> variantShreddingFunc) {
+    return new TypeToMessageType(variantShreddingFunc).convert(schema, name);
   }
 
   /**

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -39,10 +39,29 @@ public class ParquetSchemaUtil {
 
   private ParquetSchemaUtil() {}
 
+  /**
+   * Convert an Iceberg schema to Parquet.
+   *
+   * @param schema an Iceberg {@link Schema}
+   * @param name name for the Parquet schema
+   * @return the schema converted to a Parquet {@link MessageType}
+   */
   public static MessageType convert(Schema schema, String name) {
     return new TypeToMessageType().convert(schema, name);
   }
 
+  /**
+   * Convert an Iceberg schema to Parquet.
+   *
+   * <p>Variant fields are converted by calling the function with the variant's name and field ID to
+   * produce the shredding type as a {@code typed_value} field. This field is added to the variant
+   * struct alongside the {@code metadata} and {@code value} fields.
+   *
+   * @param schema an Iceberg {@link Schema}
+   * @param name name for the Parquet schema
+   * @param variantShreddingFunc {@link BiFunction} that produces a shredded {@code typed_value}
+   * @return the schema converted to a Parquet {@link MessageType}
+   */
   public static MessageType convert(
       Schema schema, String name, BiFunction<Integer, String, Type> variantShreddingFunc) {
     return new TypeToMessageType(variantShreddingFunc).convert(schema, name);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.parquet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.NameMapping;
@@ -53,17 +52,18 @@ public class ParquetSchemaUtil {
   /**
    * Convert an Iceberg schema to Parquet.
    *
-   * <p>Variant fields are converted by calling the function with the variant's name and field ID to
-   * produce the shredding type as a {@code typed_value} field. This field is added to the variant
-   * struct alongside the {@code metadata} and {@code value} fields.
+   * <p>Variant fields are converted by calling the {@link VariantShreddingFunction} with the
+   * variant's and field ID and name to produce the shredding type as a {@code typed_value} field.
+   * This field is added to the variant struct alongside the {@code metadata} and {@code value}
+   * fields.
    *
    * @param schema an Iceberg {@link Schema}
    * @param name name for the Parquet schema
-   * @param variantShreddingFunc {@link BiFunction} that produces a shredded {@code typed_value}
+   * @param variantShreddingFunc {@link VariantShreddingFunction} that produces a shredded type
    * @return the schema converted to a Parquet {@link MessageType}
    */
   public static MessageType convert(
-      Schema schema, String name, BiFunction<Integer, String, Type> variantShreddingFunc) {
+      Schema schema, String name, VariantShreddingFunction variantShreddingFunc) {
     return new TypeToMessageType(variantShreddingFunc).convert(schema, name);
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
@@ -71,6 +71,10 @@ public class ParquetValueWriters {
     return new ShortWriter(desc);
   }
 
+  public static <T> ParquetValueWriter<T> unboxed(ColumnDescriptor desc) {
+    return new UnboxedWriter<>(desc);
+  }
+
   public static UnboxedWriter<Integer> ints(ColumnDescriptor desc) {
     return new UnboxedWriter<>(desc);
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantReaders.java
@@ -351,31 +351,7 @@ public class ParquetVariantReaders {
     public Variant read(Variant ignored) {
       VariantMetadata metadata = metadataReader.read(null);
       VariantValue value = valueReader.read(metadata);
-      if (value == MISSING) {
-        return new Variant() {
-          @Override
-          public VariantMetadata metadata() {
-            return metadata;
-          }
-
-          @Override
-          public VariantValue value() {
-            return Variants.ofNull();
-          }
-        };
-      }
-
-      return new Variant() {
-        @Override
-        public VariantMetadata metadata() {
-          return metadata;
-        }
-
-        @Override
-        public VariantValue value() {
-          return value;
-        }
-      };
+      return Variant.of(metadata, value != MISSING ? value : Variants.ofNull());
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantWriters.java
@@ -1,0 +1,379 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.ShreddedObject;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantObject;
+import org.apache.iceberg.variants.VariantValue;
+import org.apache.iceberg.variants.Variants;
+import org.apache.parquet.column.ColumnWriteStore;
+
+class ParquetVariantWriters {
+  private ParquetVariantWriters() {}
+
+  @SuppressWarnings("unchecked")
+  static ParquetValueWriter<Variant> variant(
+      ParquetValueWriter<?> metadataWriter, ParquetValueWriter<?> valueWriter) {
+    return new VariantWriter(
+        (ParquetValueWriter<VariantMetadata>) metadataWriter,
+        (ParquetValueWriter<VariantValue>) valueWriter);
+  }
+
+  @SuppressWarnings("unchecked")
+  static ParquetValueWriter<VariantMetadata> metadata(ParquetValueWriter<?> bytesWriter) {
+    return new VariantMetadataWriter((ParquetValueWriter<ByteBuffer>) bytesWriter);
+  }
+
+  @SuppressWarnings("unchecked")
+  static ParquetValueWriter<VariantValue> value(ParquetValueWriter<?> bytesWriter) {
+    return new VariantValueWriter((ParquetValueWriter<ByteBuffer>) bytesWriter);
+  }
+
+  static ParquetValueWriter<VariantValue> primitive(
+      ParquetValueWriter<?> writer, PhysicalType... types) {
+    return new PrimitiveWriter<>(writer, Sets.immutableEnumSet(Arrays.asList(types)));
+  }
+
+  @SuppressWarnings("unchecked")
+  static ParquetValueWriter<VariantValue> shredded(
+      int valueDefinitionLevel,
+      ParquetValueWriter<?> valueWriter,
+      int typedDefinitionLevel,
+      ParquetValueWriter<?> typedWriter) {
+    return new ShreddedVariantWriter(
+        valueDefinitionLevel,
+        (ParquetValueWriter<VariantValue>) valueWriter,
+        typedDefinitionLevel,
+        (TypedWriter) typedWriter);
+  }
+
+  @SuppressWarnings("unchecked")
+  static ParquetValueWriter<VariantValue> objects(
+      int valueDefinitionLevel,
+      ParquetValueWriter<?> valueWriter,
+      int typedDefinitionLevel,
+      List<String> fieldNames,
+      List<ParquetValueWriter<?>> fieldWriters) {
+    ImmutableMap.Builder<String, ParquetValueWriter<VariantValue>> builder = ImmutableMap.builder();
+    for (int i = 0; i < fieldNames.size(); i += 1) {
+      builder.put(fieldNames.get(i), (ParquetValueWriter<VariantValue>) fieldWriters.get(i));
+    }
+
+    return new ShreddedObjectWriter(
+        valueDefinitionLevel,
+        (ParquetValueWriter<VariantValue>) valueWriter,
+        typedDefinitionLevel,
+        builder.build());
+  }
+
+  private static class VariantWriter implements ParquetValueWriter<Variant> {
+    private final ParquetValueWriter<VariantMetadata> metadataWriter;
+    private final ParquetValueWriter<VariantValue> valueWriter;
+    private final List<TripleWriter<?>> children;
+
+    private VariantWriter(
+        ParquetValueWriter<VariantMetadata> metadataWriter,
+        ParquetValueWriter<VariantValue> valueWriter) {
+      this.metadataWriter = metadataWriter;
+      this.valueWriter = valueWriter;
+      this.children = children(metadataWriter, valueWriter);
+    }
+
+    @Override
+    public void write(int repetitionLevel, Variant variant) {
+      metadataWriter.write(repetitionLevel, variant.metadata());
+      valueWriter.write(repetitionLevel, variant.value());
+    }
+
+    @Override
+    public List<TripleWriter<?>> columns() {
+      return children;
+    }
+
+    @Override
+    public void setColumnStore(ColumnWriteStore columnStore) {
+      metadataWriter.setColumnStore(columnStore);
+      valueWriter.setColumnStore(columnStore);
+    }
+  }
+
+  private abstract static class VariantBinaryWriter<T> implements ParquetValueWriter<T> {
+    private final ParquetValueWriter<ByteBuffer> bytesWriter;
+    private ByteBuffer reusedBuffer = ByteBuffer.allocate(2048);
+
+    private VariantBinaryWriter(ParquetValueWriter<ByteBuffer> bytesWriter) {
+      this.bytesWriter = bytesWriter;
+    }
+
+    protected abstract int sizeInBytes(T value);
+
+    protected abstract int writeTo(ByteBuffer buffer, int offset, T value);
+
+    @Override
+    public void write(int repetitionLevel, T value) {
+      bytesWriter.write(repetitionLevel, serialize(value));
+    }
+
+    @Override
+    public List<TripleWriter<?>> columns() {
+      return bytesWriter.columns();
+    }
+
+    @Override
+    public void setColumnStore(ColumnWriteStore columnStore) {
+      bytesWriter.setColumnStore(columnStore);
+    }
+
+    private void ensureCapacity(int requiredSize) {
+      if (reusedBuffer.capacity() < requiredSize) {
+        int newCapacity = capacityFor(requiredSize);
+        this.reusedBuffer = ByteBuffer.allocate(newCapacity).order(ByteOrder.LITTLE_ENDIAN);
+      }
+    }
+
+    private ByteBuffer serialize(T value) {
+      ensureCapacity(sizeInBytes(value));
+      int size = writeTo(reusedBuffer, 0, value);
+      reusedBuffer.position(0);
+      reusedBuffer.limit(size);
+      return reusedBuffer;
+    }
+  }
+
+  private static class VariantMetadataWriter extends VariantBinaryWriter<VariantMetadata> {
+    private VariantMetadataWriter(ParquetValueWriter<ByteBuffer> bytesWriter) {
+      super(bytesWriter);
+    }
+
+    @Override
+    protected int sizeInBytes(VariantMetadata metadata) {
+      return metadata.sizeInBytes();
+    }
+
+    @Override
+    protected int writeTo(ByteBuffer buffer, int offset, VariantMetadata metadata) {
+      return metadata.writeTo(buffer, offset);
+    }
+  }
+
+  private static class VariantValueWriter extends VariantBinaryWriter<VariantValue> {
+    private VariantValueWriter(ParquetValueWriter<ByteBuffer> bytesWriter) {
+      super(bytesWriter);
+    }
+
+    @Override
+    protected int sizeInBytes(VariantValue value) {
+      return value.sizeInBytes();
+    }
+
+    @Override
+    protected int writeTo(ByteBuffer buffer, int offset, VariantValue value) {
+      return value.writeTo(buffer, offset);
+    }
+  }
+
+  private interface TypedWriter extends ParquetValueWriter<VariantValue> {
+    Set<PhysicalType> types();
+  }
+
+  private static class PrimitiveWriter<T> implements TypedWriter {
+    private final Set<PhysicalType> types;
+    private final ParquetValueWriter<T> writer;
+
+    private PrimitiveWriter(ParquetValueWriter<T> writer, Set<PhysicalType> types) {
+      this.types = types;
+      this.writer = writer;
+    }
+
+    @Override
+    public Set<PhysicalType> types() {
+      return types;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void write(int repetitionLevel, VariantValue value) {
+      writer.write(repetitionLevel, (T) value.asPrimitive().get());
+    }
+
+    @Override
+    public List<TripleWriter<?>> columns() {
+      return writer.columns();
+    }
+
+    @Override
+    public void setColumnStore(ColumnWriteStore columnStore) {
+      writer.setColumnStore(columnStore);
+    }
+  }
+
+  private static class ShreddedVariantWriter implements ParquetValueWriter<VariantValue> {
+    private final int valueDefinitionLevel;
+    private final ParquetValueWriter<VariantValue> valueWriter;
+    private final int typedDefinitionLevel;
+    private final TypedWriter typedWriter;
+    private final List<TripleWriter<?>> children;
+
+    private ShreddedVariantWriter(
+        int valueDefinitionLevel,
+        ParquetValueWriter<VariantValue> valueWriter,
+        int typedDefinitionLevel,
+        TypedWriter typedWriter) {
+      this.valueDefinitionLevel = valueDefinitionLevel;
+      this.valueWriter = valueWriter;
+      this.typedDefinitionLevel = typedDefinitionLevel;
+      this.typedWriter = typedWriter;
+      this.children = children(valueWriter, typedWriter);
+    }
+
+    @Override
+    public void write(int repetitionLevel, VariantValue value) {
+      if (typedWriter.types().contains(value.type())) {
+        typedWriter.write(repetitionLevel, value);
+        writeNull(valueWriter, repetitionLevel, valueDefinitionLevel);
+      } else {
+        valueWriter.write(repetitionLevel, value);
+        writeNull(typedWriter, repetitionLevel, typedDefinitionLevel);
+      }
+    }
+
+    @Override
+    public List<TripleWriter<?>> columns() {
+      return children;
+    }
+
+    @Override
+    public void setColumnStore(ColumnWriteStore columnStore) {
+      valueWriter.setColumnStore(columnStore);
+      typedWriter.setColumnStore(columnStore);
+    }
+  }
+
+  private static class ShreddedObjectWriter implements ParquetValueWriter<VariantValue> {
+    private final int valueDefinitionLevel;
+    private final ParquetValueWriter<VariantValue> valueWriter;
+    private final int typedDefinitionLevel;
+    private final Map<String, ParquetValueWriter<VariantValue>> typedWriters;
+    private final List<TripleWriter<?>> children;
+
+    private ShreddedObjectWriter(
+        int valueDefinitionLevel,
+        ParquetValueWriter<VariantValue> valueWriter,
+        int typedDefinitionLevel,
+        Map<String, ParquetValueWriter<VariantValue>> typedWriters) {
+      this.valueDefinitionLevel = valueDefinitionLevel;
+      this.valueWriter = valueWriter;
+      this.typedDefinitionLevel = typedDefinitionLevel;
+      this.typedWriters = typedWriters;
+      this.children =
+          children(
+              Iterables.concat(
+                  ImmutableList.of(valueWriter), ImmutableList.copyOf(typedWriters.values())));
+    }
+
+    @Override
+    public void write(int repetitionLevel, VariantValue value) {
+      if (value.type() != PhysicalType.OBJECT) {
+        valueWriter.write(repetitionLevel, value);
+
+        // write null for all fields
+        for (ParquetValueWriter<?> writer : typedWriters.values()) {
+          writeNull(writer, repetitionLevel, typedDefinitionLevel);
+        }
+
+      } else {
+        VariantObject object = value.asObject();
+        ShreddedObject shredded = Variants.object(null, object);
+        for (Map.Entry<String, ParquetValueWriter<VariantValue>> entry : typedWriters.entrySet()) {
+          String fieldName = entry.getKey();
+          ParquetValueWriter<VariantValue> writer = entry.getValue();
+
+          VariantValue fieldValue = object.get(fieldName);
+          if (fieldValue != null) {
+            // shredded: suppress the field in the object and write it to the value pair
+            shredded.remove(fieldName);
+            writer.write(repetitionLevel, fieldValue);
+          } else {
+            // missing: write null to both value and typed_value
+            writeNull(writer, repetitionLevel, typedDefinitionLevel);
+          }
+        }
+
+        if (shredded.numFields() > 0) {
+          // partially shredded: write the unshredded fields
+          valueWriter.write(repetitionLevel, shredded);
+        } else {
+          // completely shredded: omit the empty value
+          writeNull(valueWriter, repetitionLevel, valueDefinitionLevel);
+        }
+      }
+    }
+
+    @Override
+    public List<TripleWriter<?>> columns() {
+      return children;
+    }
+
+    @Override
+    public void setColumnStore(ColumnWriteStore columnStore) {
+      valueWriter.setColumnStore(columnStore);
+      for (ParquetValueWriter<?> fieldWriter : typedWriters.values()) {
+        fieldWriter.setColumnStore(columnStore);
+      }
+    }
+  }
+
+  private static void writeNull(
+      ParquetValueWriter<?> writer, int repetitionLevel, int definitionLevel) {
+    for (TripleWriter<?> column : writer.columns()) {
+      column.writeNull(repetitionLevel, definitionLevel - 1);
+    }
+  }
+
+  private static List<TripleWriter<?>> children(ParquetValueWriter<?>... writers) {
+    return children(Arrays.asList(writers));
+  }
+
+  private static List<TripleWriter<?>> children(Iterable<ParquetValueWriter<?>> writers) {
+    return ImmutableList.copyOf(
+        Iterables.concat(Iterables.transform(writers, ParquetValueWriter::columns)));
+  }
+
+  private static final double LN2 = Math.log(2);
+
+  private static int capacityFor(int valueSize) {
+    // find the power of 2 size that fits the value
+    int nextPow2 = (int) Math.ceil(Math.log(valueSize) / LN2);
+    // return a capacity that is 2 the next power of 2 size up to the max
+    return Math.min(1 << (nextPow2 + 1), Integer.MAX_VALUE - 1);
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
@@ -75,9 +75,10 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
       Configuration conf,
       OutputFile output,
       Schema schema,
+      MessageType parquetSchema,
       long rowGroupSize,
       Map<String, String> metadata,
-      Function<MessageType, ParquetValueWriter<?>> createWriterFunc,
+      BiFunction<Schema, MessageType, ParquetValueWriter<?>> createWriterFunc,
       CompressionCodecName codec,
       ParquetProperties properties,
       MetricsConfig metricsConfig,
@@ -88,8 +89,8 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
     this.metadata = ImmutableMap.copyOf(metadata);
     this.compressor =
         new ParquetCodecFactory(conf, props.getPageSizeThreshold()).getCompressor(codec);
-    this.parquetSchema = ParquetSchemaUtil.convert(schema, "table");
-    this.model = (ParquetValueWriter<T>) createWriterFunc.apply(parquetSchema);
+    this.parquetSchema = parquetSchema;
+    this.model = (ParquetValueWriter<T>) createWriterFunc.apply(schema, parquetSchema);
     this.metricsConfig = metricsConfig;
     this.columnIndexTruncateLength =
         conf.getInt(COLUMN_INDEX_TRUNCATE_LENGTH, DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
@@ -68,7 +68,7 @@ public class TypeToMessageType {
     this.variantShreddingFunc = null;
   }
 
-  public TypeToMessageType(BiFunction<Integer, String, Type> variantShreddingFunc) {
+  TypeToMessageType(BiFunction<Integer, String, Type> variantShreddingFunc) {
     this.variantShreddingFunc = variantShreddingFunc;
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VariantShreddingFunction.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VariantShreddingFunction.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.parquet;
+
+import java.util.function.BiFunction;
+import org.apache.parquet.schema.Type;
+
+public interface VariantShreddingFunction extends BiFunction<Integer, String, Type> {
+  /**
+   * A function to produce the shredded type for a variant field. This function is called with the
+   * ID and name of a variant field to produce the shredded type as a {@code typed_value} field.
+   * This field is added to the result variant struct alongside the {@code metadata} and {@code
+   * value} fields.
+   *
+   * @param fieldId field ID of the variant field to shred
+   * @param name name of the variant field to shred
+   * @return a Parquet {@link Type} to use as the Variant's {@code typed_value} field
+   */
+  @Override
+  Type apply(Integer fieldId, String name);
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VariantShreddingFunction.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VariantShreddingFunction.java
@@ -1,24 +1,21 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg.parquet;
 
 import java.util.function.BiFunction;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VariantWriterBuilder.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VariantWriterBuilder.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.VariantValue;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.IntLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.LogicalTypeAnnotationVisitor;
+import org.apache.parquet.schema.LogicalTypeAnnotation.StringLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+public class VariantWriterBuilder extends ParquetVariantVisitor<ParquetValueWriter<?>> {
+  private final MessageType schema;
+  private final Iterable<String> basePath;
+  private final Deque<String> fieldNames = Lists.newLinkedList();
+
+  public VariantWriterBuilder(MessageType schema, Iterable<String> basePath) {
+    this.schema = schema;
+    this.basePath = basePath;
+  }
+
+  @Override
+  public void beforeField(Type type) {
+    fieldNames.addLast(type.getName());
+  }
+
+  @Override
+  public void afterField(Type type) {
+    fieldNames.removeLast();
+  }
+
+  private String[] currentPath() {
+    return Streams.concat(Streams.stream(basePath), fieldNames.stream()).toArray(String[]::new);
+  }
+
+  private String[] path(String name) {
+    return Streams.concat(Streams.stream(basePath), fieldNames.stream(), Stream.of(name))
+        .toArray(String[]::new);
+  }
+
+  @Override
+  public ParquetValueWriter<?> variant(
+      GroupType variant, ParquetValueWriter<?> metadataWriter, ParquetValueWriter<?> valueWriter) {
+    return ParquetVariantWriters.variant(metadataWriter, valueWriter);
+  }
+
+  @Override
+  public ParquetValueWriter<?> metadata(PrimitiveType metadata) {
+    ColumnDescriptor desc = schema.getColumnDescription(currentPath());
+    return ParquetVariantWriters.metadata(ParquetValueWriters.byteBuffers(desc));
+  }
+
+  @Override
+  public ParquetValueWriter<?> serialized(PrimitiveType value) {
+    ColumnDescriptor desc = schema.getColumnDescription(currentPath());
+    return ParquetVariantWriters.value(ParquetValueWriters.byteBuffers(desc));
+  }
+
+  @Override
+  public ParquetValueWriter<?> primitive(PrimitiveType primitive) {
+    ColumnDescriptor desc = schema.getColumnDescription(currentPath());
+    LogicalTypeAnnotation annotation = primitive.getLogicalTypeAnnotation();
+    if (annotation != null) {
+      Optional<ParquetValueWriter<?>> writer =
+          annotation.accept(new LogicalTypeToVariantWriter(desc));
+      if (writer.isPresent()) {
+        return writer.get();
+      }
+
+    } else {
+      switch (primitive.getPrimitiveTypeName()) {
+        case BINARY:
+          return ParquetVariantWriters.primitive(
+              ParquetValueWriters.byteBuffers(desc), PhysicalType.BINARY);
+        case BOOLEAN:
+          return ParquetVariantWriters.primitive(
+              ParquetValueWriters.booleans(desc),
+              PhysicalType.BOOLEAN_TRUE,
+              PhysicalType.BOOLEAN_FALSE);
+        case INT32:
+          return ParquetVariantWriters.primitive(
+              ParquetValueWriters.ints(desc), PhysicalType.INT32);
+        case INT64:
+          return ParquetVariantWriters.primitive(
+              ParquetValueWriters.longs(desc), PhysicalType.INT64);
+        case FLOAT:
+          return ParquetVariantWriters.primitive(
+              ParquetValueWriters.floats(desc), PhysicalType.FLOAT);
+        case DOUBLE:
+          return ParquetVariantWriters.primitive(
+              ParquetValueWriters.doubles(desc), PhysicalType.DOUBLE);
+      }
+    }
+
+    throw new UnsupportedOperationException("Unsupported shredded value type: " + primitive);
+  }
+
+  @Override
+  public ParquetValueWriter<?> value(
+      GroupType value, ParquetValueWriter<?> valueWriter, ParquetValueWriter<?> typedWriter) {
+    int valueDL = schema.getMaxDefinitionLevel(path(VALUE));
+    if (typedWriter != null) {
+      int typedValueDL = schema.getMaxDefinitionLevel(path(TYPED_VALUE));
+      return ParquetVariantWriters.shredded(valueDL, valueWriter, typedValueDL, typedWriter);
+    } else if (value.getType(VALUE).isRepetition(Type.Repetition.OPTIONAL)) {
+      return ParquetValueWriters.option(value.getType(VALUE), valueDL, valueWriter);
+    } else {
+      return valueWriter;
+    }
+  }
+
+  @Override
+  public ParquetValueWriter<?> object(
+      GroupType object,
+      ParquetValueWriter<?> valueWriter,
+      List<ParquetValueWriter<?>> fieldWriters) {
+    int valueDL = schema.getMaxDefinitionLevel(path(VALUE));
+    int fieldsDL = schema.getMaxDefinitionLevel(path(TYPED_VALUE));
+
+    List<String> names =
+        object.getType(TYPED_VALUE).asGroupType().getFields().stream()
+            .map(Type::getName)
+            .collect(Collectors.toList());
+
+    return ParquetVariantWriters.objects(valueDL, valueWriter, fieldsDL, names, fieldWriters);
+  }
+
+  @Override
+  public ParquetValueWriter<?> array(
+      GroupType array, ParquetValueWriter<?> valueWriter, ParquetValueWriter<?> elementWriter) {
+    throw new UnsupportedOperationException("Array is not yet supported");
+  }
+
+  private static class LogicalTypeToVariantWriter
+      implements LogicalTypeAnnotationVisitor<ParquetValueWriter<?>> {
+    private final ColumnDescriptor desc;
+
+    private LogicalTypeToVariantWriter(ColumnDescriptor desc) {
+      this.desc = desc;
+    }
+
+    @Override
+    public Optional<ParquetValueWriter<?>> visit(StringLogicalTypeAnnotation ignored) {
+      ParquetValueWriter<VariantValue> writer =
+          ParquetVariantWriters.primitive(ParquetValueWriters.strings(desc), PhysicalType.STRING);
+      return Optional.of(writer);
+    }
+
+    @Override
+    public Optional<ParquetValueWriter<?>> visit(DecimalLogicalTypeAnnotation decimal) {
+      ParquetValueWriter<VariantValue> writer;
+      switch (desc.getPrimitiveType().getPrimitiveTypeName()) {
+        case FIXED_LEN_BYTE_ARRAY:
+        case BINARY:
+          writer =
+              ParquetVariantWriters.primitive(
+                  ParquetValueWriters.decimalAsFixed(
+                      desc, decimal.getPrecision(), decimal.getScale()),
+                  PhysicalType.DECIMAL16);
+          return Optional.of(writer);
+        case INT64:
+          writer =
+              ParquetVariantWriters.primitive(
+                  ParquetValueWriters.decimalAsLong(
+                      desc, decimal.getPrecision(), decimal.getScale()),
+                  PhysicalType.DECIMAL8);
+          return Optional.of(writer);
+        case INT32:
+          writer =
+              ParquetVariantWriters.primitive(
+                  ParquetValueWriters.decimalAsInteger(
+                      desc, decimal.getPrecision(), decimal.getScale()),
+                  PhysicalType.DECIMAL4);
+          return Optional.of(writer);
+      }
+
+      throw new IllegalArgumentException(
+          "Invalid primitive type for decimal: " + desc.getPrimitiveType());
+    }
+
+    @Override
+    public Optional<ParquetValueWriter<?>> visit(DateLogicalTypeAnnotation ignored) {
+      ParquetValueWriter<VariantValue> writer =
+          ParquetVariantWriters.primitive(ParquetValueWriters.ints(desc), PhysicalType.DATE);
+      return Optional.of(writer);
+    }
+
+    @Override
+    public Optional<ParquetValueWriter<?>> visit(TimeLogicalTypeAnnotation time) {
+      // ParquetValueWriter<VariantValue> writer =
+      //     ParquetVariantWriters.primitive(ParquetValueWriters.longs(desc), PhysicalType.TIME);
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<ParquetValueWriter<?>> visit(TimestampLogicalTypeAnnotation timestamp) {
+      if (timestamp.getUnit() == TimeUnit.MICROS) {
+        PhysicalType type =
+            timestamp.isAdjustedToUTC() ? PhysicalType.TIMESTAMPTZ : PhysicalType.TIMESTAMPNTZ;
+        ParquetValueWriter<?> writer =
+            ParquetVariantWriters.primitive(ParquetValueWriters.longs(desc), type);
+        return Optional.of(writer);
+      }
+
+      throw new IllegalArgumentException(
+          "Invalid unit for shredded timestamp: " + timestamp.getUnit());
+    }
+
+    @Override
+    public Optional<ParquetValueWriter<?>> visit(IntLogicalTypeAnnotation logical) {
+      Preconditions.checkArgument(
+          logical.isSigned(), "Invalid logical type for variant, unsigned: %s", logical);
+      ParquetValueWriter<?> writer;
+      switch (logical.getBitWidth()) {
+        case 8:
+          writer =
+              ParquetVariantWriters.primitive(
+                  ParquetValueWriters.tinyints(desc), PhysicalType.INT8);
+          return Optional.of(writer);
+        case 16:
+          writer =
+              ParquetVariantWriters.primitive(ParquetValueWriters.shorts(desc), PhysicalType.INT16);
+          return Optional.of(writer);
+        case 32:
+          writer =
+              ParquetVariantWriters.primitive(ParquetValueWriters.ints(desc), PhysicalType.INT32);
+          return Optional.of(writer);
+        case 64:
+          writer =
+              ParquetVariantWriters.primitive(ParquetValueWriters.longs(desc), PhysicalType.INT64);
+          return Optional.of(writer);
+      }
+
+      throw new IllegalArgumentException("Invalid bit width for int: " + logical.getBitWidth());
+    }
+
+    @Override
+    public Optional<ParquetValueWriter<?>> visit(UUIDLogicalTypeAnnotation uuidLogicalType) {
+      // ParquetValueWriter<VariantValue> writer =
+      //     ParquetVariantWriters.primitive(ParquetValueWriters.uuids(desc), PhysicalType.UUID);
+      return Optional.empty();
+    }
+  }
+}

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
@@ -97,40 +97,41 @@ public class TestVariantWriters {
 
   private static final Variant[] VARIANTS =
       new Variant[] {
-        variantOf(EMPTY_METADATA, Variants.ofNull()),
-        variantOf(EMPTY_METADATA, Variants.of(true)),
-        variantOf(EMPTY_METADATA, Variants.of(false)),
-        variantOf(EMPTY_METADATA, Variants.of((byte) 34)),
-        variantOf(EMPTY_METADATA, Variants.of((byte) -34)),
-        variantOf(EMPTY_METADATA, Variants.of((short) 1234)),
-        variantOf(EMPTY_METADATA, Variants.of((short) -1234)),
-        variantOf(EMPTY_METADATA, Variants.of(12345)),
-        variantOf(EMPTY_METADATA, Variants.of(-12345)),
-        variantOf(EMPTY_METADATA, Variants.of(9876543210L)),
-        variantOf(EMPTY_METADATA, Variants.of(-9876543210L)),
-        variantOf(EMPTY_METADATA, Variants.of(10.11F)),
-        variantOf(EMPTY_METADATA, Variants.of(-10.11F)),
-        variantOf(EMPTY_METADATA, Variants.of(14.3D)),
-        variantOf(EMPTY_METADATA, Variants.of(-14.3D)),
-        variantOf(EMPTY_METADATA, EMPTY_OBJECT),
-        variantOf(TEST_METADATA, TEST_OBJECT),
-        variantOf(TEST_METADATA, SIMILAR_OBJECT),
-        variantOf(EMPTY_METADATA, Variants.ofIsoDate("2024-11-07")),
-        variantOf(EMPTY_METADATA, Variants.ofIsoDate("1957-11-07")),
-        variantOf(EMPTY_METADATA, Variants.ofIsoTimestamptz("2024-11-07T12:33:54.123456+00:00")),
-        variantOf(EMPTY_METADATA, Variants.ofIsoTimestamptz("1957-11-07T12:33:54.123456+00:00")),
-        variantOf(EMPTY_METADATA, Variants.ofIsoTimestampntz("2024-11-07T12:33:54.123456")),
-        variantOf(EMPTY_METADATA, Variants.ofIsoTimestampntz("1957-11-07T12:33:54.123456")),
-        variantOf(EMPTY_METADATA, Variants.of(new BigDecimal("123456.789"))), // decimal4
-        variantOf(EMPTY_METADATA, Variants.of(new BigDecimal("-123456.789"))), // decimal4
-        variantOf(EMPTY_METADATA, Variants.of(new BigDecimal("123456789.987654321"))), // decimal8
-        variantOf(EMPTY_METADATA, Variants.of(new BigDecimal("-123456789.987654321"))), // decimal8
-        variantOf(EMPTY_METADATA, Variants.of(new BigDecimal("9876543210.123456789"))), // decimal16
-        variantOf(
+        Variant.of(EMPTY_METADATA, Variants.ofNull()),
+        Variant.of(EMPTY_METADATA, Variants.of(true)),
+        Variant.of(EMPTY_METADATA, Variants.of(false)),
+        Variant.of(EMPTY_METADATA, Variants.of((byte) 34)),
+        Variant.of(EMPTY_METADATA, Variants.of((byte) -34)),
+        Variant.of(EMPTY_METADATA, Variants.of((short) 1234)),
+        Variant.of(EMPTY_METADATA, Variants.of((short) -1234)),
+        Variant.of(EMPTY_METADATA, Variants.of(12345)),
+        Variant.of(EMPTY_METADATA, Variants.of(-12345)),
+        Variant.of(EMPTY_METADATA, Variants.of(9876543210L)),
+        Variant.of(EMPTY_METADATA, Variants.of(-9876543210L)),
+        Variant.of(EMPTY_METADATA, Variants.of(10.11F)),
+        Variant.of(EMPTY_METADATA, Variants.of(-10.11F)),
+        Variant.of(EMPTY_METADATA, Variants.of(14.3D)),
+        Variant.of(EMPTY_METADATA, Variants.of(-14.3D)),
+        Variant.of(EMPTY_METADATA, EMPTY_OBJECT),
+        Variant.of(TEST_METADATA, TEST_OBJECT),
+        Variant.of(TEST_METADATA, SIMILAR_OBJECT),
+        Variant.of(EMPTY_METADATA, Variants.ofIsoDate("2024-11-07")),
+        Variant.of(EMPTY_METADATA, Variants.ofIsoDate("1957-11-07")),
+        Variant.of(EMPTY_METADATA, Variants.ofIsoTimestamptz("2024-11-07T12:33:54.123456+00:00")),
+        Variant.of(EMPTY_METADATA, Variants.ofIsoTimestamptz("1957-11-07T12:33:54.123456+00:00")),
+        Variant.of(EMPTY_METADATA, Variants.ofIsoTimestampntz("2024-11-07T12:33:54.123456")),
+        Variant.of(EMPTY_METADATA, Variants.ofIsoTimestampntz("1957-11-07T12:33:54.123456")),
+        Variant.of(EMPTY_METADATA, Variants.of(new BigDecimal("123456.789"))), // decimal4
+        Variant.of(EMPTY_METADATA, Variants.of(new BigDecimal("-123456.789"))), // decimal4
+        Variant.of(EMPTY_METADATA, Variants.of(new BigDecimal("123456789.987654321"))), // decimal8
+        Variant.of(EMPTY_METADATA, Variants.of(new BigDecimal("-123456789.987654321"))), // decimal8
+        Variant.of(
+            EMPTY_METADATA, Variants.of(new BigDecimal("9876543210.123456789"))), // decimal16
+        Variant.of(
             EMPTY_METADATA, Variants.of(new BigDecimal("-9876543210.123456789"))), // decimal16
-        variantOf(
+        Variant.of(
             EMPTY_METADATA, Variants.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
-        variantOf(EMPTY_METADATA, Variants.of("iceberg")),
+        Variant.of(EMPTY_METADATA, Variants.of("iceberg")),
       };
 
   @ParameterizedTest
@@ -197,25 +198,6 @@ public class TestVariantWriters {
             .build()) {
       return Lists.newArrayList(reader);
     }
-  }
-
-  private static Variant variantOf(VariantMetadata metadata, VariantValue value) {
-    return new Variant() {
-      @Override
-      public VariantMetadata metadata() {
-        return metadata;
-      }
-
-      @Override
-      public VariantValue value() {
-        return value;
-      }
-
-      @Override
-      public String toString() {
-        return "Variant(metadata=" + metadata + ", value=" + value + ")";
-      }
-    };
   }
 
   private Type toParquetSchema(VariantValue value) {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
@@ -206,7 +206,7 @@ public class TestVariantWriters {
 
   private static class ParquetSchemaProducer extends VariantVisitor<Type> {
     @Override
-    public Type object(VariantObject object, List<Type> typedValues) {
+    public Type object(VariantObject object, List<String> names, List<Type> typedValues) {
       if (object.numFields() < 1) {
         // Parquet cannot write  typed_value group with no fields
         return null;
@@ -214,7 +214,7 @@ public class TestVariantWriters {
 
       List<GroupType> fields = Lists.newArrayList();
       int index = 0;
-      for (String name : object.fieldNames()) {
+      for (String name : names) {
         Type typedValue = typedValues.get(index);
         fields.add(field(name, typedValue));
         index += 1;

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.iceberg.InternalTestHelpers;
@@ -171,13 +170,13 @@ public class TestVariantWriters {
     }
   }
 
-  private static Record writeAndRead(BiFunction<Integer, String, Type> shreddingFunc, Record record)
+  private static Record writeAndRead(VariantShreddingFunction shreddingFunc, Record record)
       throws IOException {
     return Iterables.getOnlyElement(writeAndRead(shreddingFunc, List.of(record)));
   }
 
   private static List<Record> writeAndRead(
-      BiFunction<Integer, String, Type> shreddingFunc, List<Record> records) throws IOException {
+      VariantShreddingFunction shreddingFunc, List<Record> records) throws IOException {
     OutputFile outputFile = new InMemoryOutputFile();
 
     try (FileAppender<Record> writer =

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.iceberg.InternalTestHelpers;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.InternalReader;
+import org.apache.iceberg.data.parquet.InternalWriter;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantArray;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantObject;
+import org.apache.iceberg.variants.VariantPrimitive;
+import org.apache.iceberg.variants.VariantTestUtil;
+import org.apache.iceberg.variants.VariantValue;
+import org.apache.iceberg.variants.VariantVisitor;
+import org.apache.iceberg.variants.Variants;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types.GroupBuilder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+
+public class TestVariantWriters {
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.required(2, "var", Types.VariantType.get()));
+
+  private static final GenericRecord RECORD = GenericRecord.create(SCHEMA);
+
+  private static final ByteBuffer TEST_METADATA_BUFFER =
+      VariantTestUtil.createMetadata(ImmutableList.of("a", "b", "c", "d", "e"), true);
+  private static final ByteBuffer TEST_OBJECT_BUFFER =
+      VariantTestUtil.createObject(
+          TEST_METADATA_BUFFER,
+          ImmutableMap.of(
+              "a", Variants.ofNull(),
+              "d", Variants.of("iceberg")));
+  private static final ByteBuffer SIMILAR_OBJECT_BUFFER =
+      VariantTestUtil.createObject(
+          TEST_METADATA_BUFFER,
+          ImmutableMap.of(
+              "a", Variants.of(123456789),
+              "c", Variants.of("string")));
+  private static final ByteBuffer EMPTY_OBJECT_BUFFER =
+      VariantTestUtil.createObject(TEST_METADATA_BUFFER, ImmutableMap.of());
+
+  private static final VariantMetadata EMPTY_METADATA =
+      Variants.metadata(VariantTestUtil.emptyMetadata());
+  private static final VariantMetadata TEST_METADATA = Variants.metadata(TEST_METADATA_BUFFER);
+  private static final VariantObject TEST_OBJECT =
+      (VariantObject) Variants.value(TEST_METADATA, TEST_OBJECT_BUFFER);
+  private static final VariantObject SIMILAR_OBJECT =
+      (VariantObject) Variants.value(TEST_METADATA, SIMILAR_OBJECT_BUFFER);
+  private static final VariantObject EMPTY_OBJECT =
+      (VariantObject) Variants.value(TEST_METADATA, EMPTY_OBJECT_BUFFER);
+
+  private static final Variant[] VARIANTS =
+      new Variant[] {
+        variantOf(EMPTY_METADATA, Variants.ofNull()),
+        variantOf(EMPTY_METADATA, Variants.of(true)),
+        variantOf(EMPTY_METADATA, Variants.of(false)),
+        variantOf(EMPTY_METADATA, Variants.of((byte) 34)),
+        variantOf(EMPTY_METADATA, Variants.of((byte) -34)),
+        variantOf(EMPTY_METADATA, Variants.of((short) 1234)),
+        variantOf(EMPTY_METADATA, Variants.of((short) -1234)),
+        variantOf(EMPTY_METADATA, Variants.of(12345)),
+        variantOf(EMPTY_METADATA, Variants.of(-12345)),
+        variantOf(EMPTY_METADATA, Variants.of(9876543210L)),
+        variantOf(EMPTY_METADATA, Variants.of(-9876543210L)),
+        variantOf(EMPTY_METADATA, Variants.of(10.11F)),
+        variantOf(EMPTY_METADATA, Variants.of(-10.11F)),
+        variantOf(EMPTY_METADATA, Variants.of(14.3D)),
+        variantOf(EMPTY_METADATA, Variants.of(-14.3D)),
+        variantOf(EMPTY_METADATA, EMPTY_OBJECT),
+        variantOf(TEST_METADATA, TEST_OBJECT),
+        variantOf(TEST_METADATA, SIMILAR_OBJECT),
+        variantOf(EMPTY_METADATA, Variants.ofIsoDate("2024-11-07")),
+        variantOf(EMPTY_METADATA, Variants.ofIsoDate("1957-11-07")),
+        variantOf(EMPTY_METADATA, Variants.ofIsoTimestamptz("2024-11-07T12:33:54.123456+00:00")),
+        variantOf(EMPTY_METADATA, Variants.ofIsoTimestamptz("1957-11-07T12:33:54.123456+00:00")),
+        variantOf(EMPTY_METADATA, Variants.ofIsoTimestampntz("2024-11-07T12:33:54.123456")),
+        variantOf(EMPTY_METADATA, Variants.ofIsoTimestampntz("1957-11-07T12:33:54.123456")),
+        variantOf(EMPTY_METADATA, Variants.of(new BigDecimal("123456.789"))), // decimal4
+        variantOf(EMPTY_METADATA, Variants.of(new BigDecimal("-123456.789"))), // decimal4
+        variantOf(EMPTY_METADATA, Variants.of(new BigDecimal("123456789.987654321"))), // decimal8
+        variantOf(EMPTY_METADATA, Variants.of(new BigDecimal("-123456789.987654321"))), // decimal8
+        variantOf(EMPTY_METADATA, Variants.of(new BigDecimal("9876543210.123456789"))), // decimal16
+        variantOf(
+            EMPTY_METADATA, Variants.of(new BigDecimal("-9876543210.123456789"))), // decimal16
+        variantOf(
+            EMPTY_METADATA, Variants.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
+        variantOf(EMPTY_METADATA, Variants.of("iceberg")),
+      };
+
+  @ParameterizedTest
+  @FieldSource("VARIANTS")
+  public void testUnshreddedValues(Variant variant) throws IOException {
+    Record record = RECORD.copy("id", 1, "var", variant);
+
+    Record actual = writeAndRead((id, name) -> null, record);
+
+    InternalTestHelpers.assertEquals(SCHEMA.asStruct(), record, actual);
+  }
+
+  @ParameterizedTest
+  @FieldSource("VARIANTS")
+  public void testShreddedValues(Variant variant) throws IOException {
+    Record record = RECORD.copy("id", 1, "var", variant);
+
+    Record actual = writeAndRead((id, name) -> toParquetSchema(variant.value()), record);
+
+    InternalTestHelpers.assertEquals(SCHEMA.asStruct(), record, actual);
+  }
+
+  @ParameterizedTest
+  @FieldSource("VARIANTS")
+  public void testMixedShredding(Variant variant) throws IOException {
+    List<Record> expected =
+        IntStream.range(0, VARIANTS.length)
+            .mapToObj(i -> RECORD.copy("id", i, "var", VARIANTS[i]))
+            .collect(Collectors.toList());
+
+    List<Record> actual = writeAndRead((id, name) -> toParquetSchema(variant.value()), expected);
+
+    assertThat(actual.size()).isEqualTo(expected.size());
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      InternalTestHelpers.assertEquals(SCHEMA.asStruct(), expected.get(i), actual.get(i));
+    }
+  }
+
+  private static Record writeAndRead(BiFunction<Integer, String, Type> shreddingFunc, Record record)
+      throws IOException {
+    return Iterables.getOnlyElement(writeAndRead(shreddingFunc, List.of(record)));
+  }
+
+  private static List<Record> writeAndRead(
+      BiFunction<Integer, String, Type> shreddingFunc, List<Record> records) throws IOException {
+    OutputFile outputFile = new InMemoryOutputFile();
+
+    try (FileAppender<Record> writer =
+        Parquet.write(outputFile)
+            .schema(SCHEMA)
+            .variantShreddingFunc(shreddingFunc)
+            .createWriterFunc(fileSchema -> InternalWriter.create(SCHEMA.asStruct(), fileSchema))
+            .build()) {
+      for (Record record : records) {
+        writer.add(record);
+      }
+    }
+
+    try (CloseableIterable<Record> reader =
+        Parquet.read(outputFile.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(fileSchema -> InternalReader.create(SCHEMA, fileSchema))
+            .build()) {
+      return Lists.newArrayList(reader);
+    }
+  }
+
+  private static Variant variantOf(VariantMetadata metadata, VariantValue value) {
+    return new Variant() {
+      @Override
+      public VariantMetadata metadata() {
+        return metadata;
+      }
+
+      @Override
+      public VariantValue value() {
+        return value;
+      }
+
+      @Override
+      public String toString() {
+        return "Variant(metadata=" + metadata + ", value=" + value + ")";
+      }
+    };
+  }
+
+  private Type toParquetSchema(VariantValue value) {
+    return VariantVisitor.visit(value, new ParquetSchemaProducer());
+  }
+
+  private static class ParquetSchemaProducer extends VariantVisitor<Type> {
+    @Override
+    public Type object(VariantObject object, List<Type> typedValues) {
+      if (object.numFields() < 1) {
+        // Parquet cannot write  typed_value group with no fields
+        return null;
+      }
+
+      List<GroupType> fields = Lists.newArrayList();
+      int index = 0;
+      for (String name : object.fieldNames()) {
+        Type typedValue = typedValues.get(index);
+        fields.add(field(name, typedValue));
+        index += 1;
+      }
+
+      return objectFields(fields);
+    }
+
+    @Override
+    public Type array(VariantArray array, List<Type> elementResults) {
+      throw null;
+    }
+
+    @Override
+    public Type primitive(VariantPrimitive<?> primitive) {
+      switch (primitive.type()) {
+        case NULL:
+          return null;
+        case BOOLEAN_TRUE:
+        case BOOLEAN_FALSE:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.BOOLEAN);
+        case INT8:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT32, LogicalTypeAnnotation.intType(8));
+        case INT16:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT32, LogicalTypeAnnotation.intType(16));
+        case INT32:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.INT32);
+        case INT64:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.INT64);
+        case FLOAT:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.FLOAT);
+        case DOUBLE:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.DOUBLE);
+        case DECIMAL4:
+          BigDecimal decimal4 = (BigDecimal) primitive.get();
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT32,
+              LogicalTypeAnnotation.decimalType(decimal4.scale(), 9));
+        case DECIMAL8:
+          BigDecimal decimal8 = (BigDecimal) primitive.get();
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT64,
+              LogicalTypeAnnotation.decimalType(decimal8.scale(), 18));
+        case DECIMAL16:
+          BigDecimal decimal16 = (BigDecimal) primitive.get();
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.BINARY,
+              LogicalTypeAnnotation.decimalType(decimal16.scale(), 38));
+        case DATE:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT32, LogicalTypeAnnotation.dateType());
+        case TIMESTAMPTZ:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT64,
+              LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS));
+        case TIMESTAMPNTZ:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT64,
+              LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.MICROS));
+        case BINARY:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.BINARY);
+        case STRING:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.BINARY, LogicalTypeAnnotation.stringType());
+      }
+
+      throw new UnsupportedOperationException("Unsupported shredding type: " + primitive.type());
+    }
+
+    private static GroupType objectFields(List<GroupType> fields) {
+      GroupBuilder<GroupType> builder =
+          org.apache.parquet.schema.Types.buildGroup(Type.Repetition.OPTIONAL);
+      for (GroupType field : fields) {
+        checkField(field);
+        builder.addField(field);
+      }
+
+      return builder.named("typed_value");
+    }
+
+    private static void checkField(GroupType fieldType) {
+      Preconditions.checkArgument(
+          fieldType.isRepetition(Type.Repetition.REQUIRED),
+          "Invalid field type repetition: %s should be REQUIRED",
+          fieldType.getRepetition());
+    }
+
+    private static GroupType field(String name, Type shreddedType) {
+      GroupBuilder<GroupType> builder =
+          org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+              .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+              .named("value");
+
+      if (shreddedType != null) {
+        checkShreddedType(shreddedType);
+        builder.addField(shreddedType);
+      }
+
+      return builder.named(name);
+    }
+
+    private static void checkShreddedType(Type shreddedType) {
+      Preconditions.checkArgument(
+          shreddedType.getName().equals("typed_value"),
+          "Invalid shredded type name: %s should be typed_value",
+          shreddedType.getName());
+      Preconditions.checkArgument(
+          shreddedType.isRepetition(Type.Repetition.OPTIONAL),
+          "Invalid shredded type repetition: %s should be OPTIONAL",
+          shreddedType.getRepetition());
+    }
+
+    private static Type shreddedPrimitive(PrimitiveType.PrimitiveTypeName primitive) {
+      return org.apache.parquet.schema.Types.optional(primitive).named("typed_value");
+    }
+
+    private static Type shreddedPrimitive(
+        PrimitiveType.PrimitiveTypeName primitive, LogicalTypeAnnotation annotation) {
+      return org.apache.parquet.schema.Types.optional(primitive)
+          .as(annotation)
+          .named("typed_value");
+    }
+  }
+}


### PR DESCRIPTION
This PR implements Variant writers for Parquet based on a Parquet schema passed into the writer builder. It works basically the same as #12139.