### PR TITLE
Spark: Infer partition spec in ADD_FILES procedure for FileTables than taking latest table spec

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -791,7 +791,8 @@ public class TestAddFilesProcedure extends ExtensionsTestBase {
                     "CALL %s.system.add_files('%s', '`parquet`.`%s`', map('id', 1))",
                     catalogName, tableName, fileTableDir.getAbsolutePath()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Cannot use partition filter with an unpartitioned table");
+        .hasMessageStartingWith("Cannot find a partition spec in Iceberg table")
+        .hasMessageContaining("that matches the partition columns");
 
     assertThatThrownBy(
             () ->
@@ -799,7 +800,8 @@ public class TestAddFilesProcedure extends ExtensionsTestBase {
                     "CALL %s.system.add_files('%s', '`parquet`.`%s`')",
                     catalogName, tableName, fileTableDir.getAbsolutePath()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Cannot add partitioned files to an unpartitioned table");
+        .hasMessageStartingWith("Cannot find a partition spec in Iceberg table")
+        .hasMessageContaining("that matches the partition columns");
   }
 
   @TestTemplate
@@ -815,8 +817,8 @@ public class TestAddFilesProcedure extends ExtensionsTestBase {
                     "CALL %s.system.add_files('%s', '`parquet`.`%s`', map('x', '1', 'y', '2'))",
                     catalogName, tableName, fileTableDir.getAbsolutePath()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Cannot add data files to target table")
-        .hasMessageContaining("is greater than the number of partitioned columns");
+        .hasMessageStartingWith("Cannot find a partition spec in Iceberg table")
+        .hasMessageContaining("that matches the partition columns");
 
     assertThatThrownBy(
             () ->
@@ -824,9 +826,8 @@ public class TestAddFilesProcedure extends ExtensionsTestBase {
                     "CALL %s.system.add_files('%s', '`parquet`.`%s`', map('dept', '2'))",
                     catalogName, tableName, fileTableDir.getAbsolutePath()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Cannot add files to target table")
-        .hasMessageContaining(
-            "specified partition filter refers to columns that are not partitioned");
+        .hasMessageStartingWith("Cannot find a partition spec in Iceberg table")
+        .hasMessageContaining("that matches the partition columns");
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -863,6 +863,23 @@ public class Spark3Util {
         .quoted();
   }
 
+  public static org.apache.spark.sql.execution.datasources.PartitionSpec getInferredSpec(
+      SparkSession spark, Path rootPath) {
+    FileStatusCache fileStatusCache = FileStatusCache.getOrCreate(spark);
+    InMemoryFileIndex fileIndex =
+        new InMemoryFileIndex(
+            spark,
+            JavaConverters.collectionAsScalaIterableConverter(ImmutableList.of(rootPath))
+                .asScala()
+                .toSeq(),
+            scala.collection.immutable.Map$.MODULE$.empty(),
+            Option.empty(), // Pass empty so that automatic schema inference is used
+            fileStatusCache,
+            Option.empty(),
+            Option.empty());
+    return fileIndex.partitionSpec();
+  }
+
   /**
    * Use Spark to list all partitions in the table.
    *

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -1133,7 +1133,6 @@ public class SparkTableUtil {
         spark.catalog().listColumns(db, table).collectAsList().stream()
             .filter(org.apache.spark.sql.catalog.Column::isPartition)
             .map(org.apache.spark.sql.catalog.Column::name)
-            .map(name -> name.toLowerCase(Locale.ROOT))
             .collect(Collectors.toList());
     return findCompatibleSpec(sparkPartNames, icebergTable);
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -1097,6 +1097,10 @@ public class SparkTableUtil {
    * the partition columns provided. Throws an error if not found
    */
   public static PartitionSpec findCompatibleSpec(List<String> partitionNames, Table icebergTable) {
+    List<String> partitionNamesLower =
+        partitionNames.stream()
+            .map(name -> name.toLowerCase(Locale.ROOT))
+            .collect(Collectors.toList());
     for (PartitionSpec icebergSpec : icebergTable.specs().values()) {
       boolean allIdentity =
           icebergSpec.fields().stream().allMatch(field -> field.transform().isIdentity());
@@ -1106,7 +1110,7 @@ public class SparkTableUtil {
                 .map(PartitionField::name)
                 .map(name -> name.toLowerCase(Locale.ROOT))
                 .collect(Collectors.toList());
-        if (icebergPartNames.equals(partitionNames)) {
+        if (icebergPartNames.equals(partitionNamesLower)) {
           return icebergSpec;
         }
       }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -544,6 +545,8 @@ public class SparkTableUtil {
     try {
       PartitionSpec spec =
           findCompatibleSpec(targetTable, spark, sourceTableIdentWithDB.unquotedString());
+
+      validatePartitionFilter(spec, partitionFilter, targetTable.name());
 
       if (Objects.equal(spec, PartitionSpec.unpartitioned())) {
         importUnpartitionedSparkTable(
@@ -1091,6 +1094,33 @@ public class SparkTableUtil {
 
   /**
    * Returns the first partition spec in an IcebergTable that shares the same names and ordering as
+   * the partition columns provided. Throws an error if not found
+   */
+  public static PartitionSpec findCompatibleSpec(List<String> partitionNames, Table icebergTable) {
+    for (PartitionSpec icebergSpec : icebergTable.specs().values()) {
+      boolean allIdentity =
+          icebergSpec.fields().stream().allMatch(field -> field.transform().isIdentity());
+      if (allIdentity) {
+        List<String> icebergPartNames =
+            icebergSpec.fields().stream()
+                .map(PartitionField::name)
+                .map(name -> name.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toList());
+        if (icebergPartNames.equals(partitionNames)) {
+          return icebergSpec;
+        }
+      }
+    }
+
+    throw new IllegalArgumentException(
+        String.format(
+            "Cannot find a partition spec in Iceberg table %s that matches the partition"
+                + " columns (%s) in input table",
+            icebergTable, partitionNames));
+  }
+
+  /**
+   * Returns the first partition spec in an IcebergTable that shares the same names and ordering as
    * the partition columns in a given Spark Table. Throws an error if not found
    */
   private static PartitionSpec findCompatibleSpec(
@@ -1105,26 +1135,47 @@ public class SparkTableUtil {
             .map(org.apache.spark.sql.catalog.Column::name)
             .map(name -> name.toLowerCase(Locale.ROOT))
             .collect(Collectors.toList());
+    return findCompatibleSpec(sparkPartNames, icebergTable);
+  }
 
-    for (PartitionSpec icebergSpec : icebergTable.specs().values()) {
-      boolean allIdentity =
-          icebergSpec.fields().stream().allMatch(field -> field.transform().isIdentity());
-      if (allIdentity) {
-        List<String> icebergPartNames =
-            icebergSpec.fields().stream()
-                .map(PartitionField::name)
-                .map(name -> name.toLowerCase(Locale.ROOT))
-                .collect(Collectors.toList());
-        if (icebergPartNames.equals(sparkPartNames)) {
-          return icebergSpec;
-        }
-      }
+  public static void validatePartitionFilter(
+      PartitionSpec spec, Map<String, String> partitionFilter, String tableName) {
+    List<PartitionField> partitionFields = spec.fields();
+    Set<String> partitionNames =
+        spec.fields().stream().map(PartitionField::name).collect(Collectors.toSet());
+
+    boolean tablePartitioned = !partitionFields.isEmpty();
+    boolean partitionFilterPassed = !partitionFilter.isEmpty();
+
+    if (tablePartitioned && partitionFilterPassed) {
+      // Check to see there are sufficient partition columns to satisfy the filter
+      Preconditions.checkArgument(
+          partitionFields.size() >= partitionFilter.size(),
+          "Cannot add data files to target table %s because that table is partitioned, "
+              + "but the number of columns in the provided partition filter (%s) "
+              + "is greater than the number of partitioned columns in table (%s)",
+          tableName,
+          partitionFilter.size(),
+          partitionFields.size());
+
+      // Check for any filters of non-existent columns
+      List<String> unMatchedFilters =
+          partitionFilter.keySet().stream()
+              .filter(filterName -> !partitionNames.contains(filterName))
+              .collect(Collectors.toList());
+      Preconditions.checkArgument(
+          unMatchedFilters.isEmpty(),
+          "Cannot add files to target table %s. %s is partitioned but the specified partition filter "
+              + "refers to columns that are not partitioned: '%s' . Valid partition columns %s",
+          tableName,
+          tableName,
+          unMatchedFilters,
+          String.join(",", partitionNames));
+    } else {
+      Preconditions.checkArgument(
+          !partitionFilterPassed,
+          "Cannot use partition filter with an unpartitioned table %s",
+          tableName);
     }
-
-    throw new IllegalArgumentException(
-        String.format(
-            "Cannot find a partition spec in Iceberg table %s that matches the partition"
-                + " columns (%s) in Spark table %s",
-            icebergTable, sparkPartNames, sparkTable));
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -18,10 +18,6 @@
  */
 package org.apache.iceberg.spark.procedures;
 
-import static org.apache.iceberg.spark.Spark3Util.getInferredSpec;
-import static org.apache.iceberg.spark.SparkTableUtil.findCompatibleSpec;
-import static org.apache.iceberg.spark.SparkTableUtil.validatePartitionFilter;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -194,15 +190,15 @@ class AddFilesProcedure extends BaseProcedure {
       int parallelism) {
 
     org.apache.spark.sql.execution.datasources.PartitionSpec inferredSpec =
-        getInferredSpec(spark(), tableLocation);
+        Spark3Util.getInferredSpec(spark(), tableLocation);
 
     List<String> sparkPartNames =
         JavaConverters.seqAsJavaList(inferredSpec.partitionColumns()).stream()
             .map(StructField::name)
             .collect(Collectors.toList());
-    PartitionSpec compatibleSpec = findCompatibleSpec(sparkPartNames, table);
+    PartitionSpec compatibleSpec = SparkTableUtil.findCompatibleSpec(sparkPartNames, table);
 
-    validatePartitionFilter(compatibleSpec, partitionFilter, table.name());
+    SparkTableUtil.validatePartitionFilter(compatibleSpec, partitionFilter, table.name());
 
     // List Partitions via Spark InMemory file search interface
     List<SparkPartition> partitions =


### PR DESCRIPTION
Also renaming `validatePartitionSpec` method to `validatePartitionFilter` as it's actually validating the filters

Closes #12325