### PR TITLE
[1.8.x] Parquet: Fix performance regression in reader init (#12305)

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -106,6 +106,7 @@ import org.apache.parquet.avro.AvroReadSupport;
 import org.apache.parquet.avro.AvroWriteSupport;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.ParquetProperties.WriterVersion;
+import org.apache.parquet.conf.PlainParquetConfiguration;
 import org.apache.parquet.crypto.FileDecryptionProperties;
 import org.apache.parquet.crypto.FileEncryptionProperties;
 import org.apache.parquet.hadoop.ParquetFileReader;
@@ -1206,7 +1207,7 @@ public class Parquet {
           }
           optionsBuilder = HadoopReadOptions.builder(conf);
         } else {
-          optionsBuilder = ParquetReadOptions.builder();
+          optionsBuilder = ParquetReadOptions.builder(new PlainParquetConfiguration());
         }
 
         for (Map.Entry<String, String> entry : properties.entrySet()) {
@@ -1275,7 +1276,9 @@ public class Parquet {
         // TODO: should not need to get the schema to push down before opening the file.
         // Parquet should allow setting a filter inside its read support
         ParquetReadOptions decryptOptions =
-            ParquetReadOptions.builder().withDecryption(fileDecryptionProperties).build();
+            ParquetReadOptions.builder(new PlainParquetConfiguration())
+                .withDecryption(fileDecryptionProperties)
+                .build();
         MessageType type;
         try (ParquetFileReader schemaReader =
             ParquetFileReader.open(ParquetIO.file(file), decryptOptions)) {


### PR DESCRIPTION
This backports #12305 to 1.8.x