### PR TITLE
Core: Apply correct metric configs in GenericAppenderFactory

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
@@ -90,11 +90,13 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
     } else {
       this.schema = schema;
     }
+
     if (table != null && spec == null) {
       this.spec = table.spec();
     } else {
       this.spec = spec;
     }
+
     this.equalityFieldIds = equalityFieldIds;
     this.eqDeleteRowSchema = eqDeleteRowSchema;
     this.posDeleteRowSchema = posDeleteRowSchema;
@@ -118,12 +120,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
   @Override
   public FileAppender<Record> newAppender(
       EncryptedOutputFile encryptedOutputFile, FileFormat fileFormat) {
-    MetricsConfig metricsConfig;
-    if (table == null) {
-      metricsConfig = MetricsConfig.fromProperties(config);
-    } else {
-      metricsConfig = MetricsConfig.forTable(table);
-    }
+    MetricsConfig metricsConfig = metricsConfig();
 
     try {
       switch (fileFormat) {
@@ -184,8 +181,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
     Preconditions.checkNotNull(
         eqDeleteRowSchema,
         "Equality delete row schema shouldn't be null when creating equality-delete writer");
-
-    MetricsConfig metricsConfig = MetricsConfig.fromProperties(config);
+    MetricsConfig metricsConfig = metricsConfig();
 
     try {
       switch (format) {
@@ -239,7 +235,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
   @Override
   public PositionDeleteWriter<Record> newPosDeleteWriter(
       EncryptedOutputFile file, FileFormat format, StructLike partition) {
-    MetricsConfig metricsConfig = MetricsConfig.fromProperties(config);
+    MetricsConfig metricsConfig = metricsConfig();
 
     try {
       switch (format) {
@@ -284,5 +280,16 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
+  }
+
+  private MetricsConfig metricsConfig() {
+    MetricsConfig metricsConfig;
+    if (table == null) {
+      metricsConfig = MetricsConfig.fromProperties(config);
+    } else {
+      metricsConfig = MetricsConfig.forTable(table);
+    }
+
+    return metricsConfig;
   }
 }

--- a/data/src/test/java/org/apache/iceberg/TestGenericAppenderFactory.java
+++ b/data/src/test/java/org/apache/iceberg/TestGenericAppenderFactory.java
@@ -18,15 +18,21 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.data.GenericAppenderFactory;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.FileAppenderFactory;
 import org.apache.iceberg.io.TestAppenderFactory;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.StructLikeSet;
+import org.junit.jupiter.api.TestTemplate;
 
 public class TestGenericAppenderFactory extends TestAppenderFactory<Record> {
 
@@ -36,8 +42,10 @@ public class TestGenericAppenderFactory extends TestAppenderFactory<Record> {
   protected FileAppenderFactory<Record> createAppenderFactory(
       List<Integer> equalityFieldIds, Schema eqDeleteSchema, Schema posDeleteRowSchema) {
     return new GenericAppenderFactory(
+        table,
         table.schema(),
         table.spec(),
+        Maps.newHashMap(),
         ArrayUtil.toIntArray(equalityFieldIds),
         eqDeleteSchema,
         posDeleteRowSchema);
@@ -53,5 +61,61 @@ public class TestGenericAppenderFactory extends TestAppenderFactory<Record> {
     StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
     records.forEach(set::add);
     return set;
+  }
+
+  @TestTemplate
+  void illegalSetConfig() {
+    GenericAppenderFactory appenderFactory =
+        (GenericAppenderFactory) createAppenderFactory(null, null, null);
+
+    assertThatThrownBy(
+            () ->
+                appenderFactory.set(
+                    TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS,
+                    MetricsModes.None.get().toString()))
+        .as("Should not allow setting metrics property if the table was provided")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot set metrics property: " + TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS);
+  }
+
+  @TestTemplate
+  void illegalSetAllConfigs() {
+    GenericAppenderFactory appenderFactory =
+        (GenericAppenderFactory) createAppenderFactory(null, null, null);
+
+    Map<String, String> properties =
+        ImmutableMap.of(
+            TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS,
+            "10",
+            TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "id",
+            MetricsModes.Full.get().toString());
+
+    assertThatThrownBy(() -> appenderFactory.setAll(properties))
+        .as("Should not allow setting metrics property if the table was provided")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot set metrics properties directly");
+  }
+
+  @TestTemplate
+  void setConfigExcludeMetrics() {
+    GenericAppenderFactory appenderFactory =
+        (GenericAppenderFactory) createAppenderFactory(null, null, null);
+    assertThatNoException().isThrownBy(() -> appenderFactory.set("key1", "value1"));
+    assertThatNoException()
+        .isThrownBy(() -> appenderFactory.setAll(ImmutableMap.of("key2", "value2")));
+  }
+
+  @TestTemplate
+  void setConfigWithoutTable() {
+    GenericAppenderFactory appenderFactory = new GenericAppenderFactory(SCHEMA);
+    assertThatNoException()
+        .isThrownBy(
+            () -> appenderFactory.set(TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS, "10"));
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                appenderFactory.setAll(
+                    ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, "full")));
   }
 }

--- a/data/src/test/java/org/apache/iceberg/TestGenericAppenderFactory.java
+++ b/data/src/test/java/org/apache/iceberg/TestGenericAppenderFactory.java
@@ -76,7 +76,7 @@ public class TestGenericAppenderFactory extends TestAppenderFactory<Record> {
         .as("Should not allow setting metrics property if the table was provided")
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Cannot set metrics property: " + TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS);
+            "Cannot set metrics properties when the table is provided, use table properties instead");
   }
 
   @TestTemplate
@@ -94,7 +94,8 @@ public class TestGenericAppenderFactory extends TestAppenderFactory<Record> {
     assertThatThrownBy(() -> appenderFactory.setAll(properties))
         .as("Should not allow setting metrics property if the table was provided")
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Cannot set metrics properties directly");
+        .hasMessageContaining(
+            "Cannot set metrics properties when the table is provided, use table properties instead");
   }
 
   @TestTemplate
@@ -133,8 +134,6 @@ public class TestGenericAppenderFactory extends TestAppenderFactory<Record> {
             () -> new GenericAppenderFactory(table, SCHEMA, SPEC, config, null, null, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            String.format(
-                "Cannot set metrics property: %s to %s, as it conflicts with the table property",
-                TableProperties.DEFAULT_WRITE_METRICS_MODE, MetricsModes.None.get().toString()));
+            "Cannot set metrics properties when the table is provided, use table properties instead");
   }
 }

--- a/data/src/test/java/org/apache/iceberg/TestGenericAppenderFactory.java
+++ b/data/src/test/java/org/apache/iceberg/TestGenericAppenderFactory.java
@@ -118,4 +118,23 @@ public class TestGenericAppenderFactory extends TestAppenderFactory<Record> {
                 appenderFactory.setAll(
                     ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, "full")));
   }
+
+  @TestTemplate
+  void createFactoryWithConflictConfig() {
+    table
+        .updateProperties()
+        .set(TableProperties.DEFAULT_WRITE_METRICS_MODE, MetricsModes.Full.get().toString())
+        .commit();
+    Map<String, String> config =
+        ImmutableMap.of(
+            TableProperties.DEFAULT_WRITE_METRICS_MODE, MetricsModes.None.get().toString());
+
+    assertThatThrownBy(
+            () -> new GenericAppenderFactory(table, SCHEMA, SPEC, config, null, null, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            String.format(
+                "Cannot set metrics property: %s to %s, as it conflicts with the table property",
+                TableProperties.DEFAULT_WRITE_METRICS_MODE, MetricsModes.None.get().toString()));
+  }
 }


### PR DESCRIPTION
The **DataWriter** created using **GenericAppenderFactory** in the application does not configure metric writing behavior according to the table's properties. 

Based on previous modifications, such as **FlinkAppenderFactory**, this class should also invoke the correct API to configure the relevant properties