### PR TITLE
[1.8.x] Core: Remove namespace/table/view HEAD endpoints from defaults (#12351)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -135,17 +135,17 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
           .addAll(TOKEN_PREFERENCE_ORDER)
           .build();
 
+  // these default endpoints must not be updated in order to maintain backwards compatibility with
+  // legacy servers
   private static final Set<Endpoint> DEFAULT_ENDPOINTS =
       ImmutableSet.<Endpoint>builder()
           .add(Endpoint.V1_LIST_NAMESPACES)
           .add(Endpoint.V1_LOAD_NAMESPACE)
-          .add(Endpoint.V1_NAMESPACE_EXISTS)
           .add(Endpoint.V1_CREATE_NAMESPACE)
           .add(Endpoint.V1_UPDATE_NAMESPACE)
           .add(Endpoint.V1_DELETE_NAMESPACE)
           .add(Endpoint.V1_LIST_TABLES)
           .add(Endpoint.V1_LOAD_TABLE)
-          .add(Endpoint.V1_TABLE_EXISTS)
           .add(Endpoint.V1_CREATE_TABLE)
           .add(Endpoint.V1_UPDATE_TABLE)
           .add(Endpoint.V1_DELETE_TABLE)
@@ -155,11 +155,12 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
           .add(Endpoint.V1_COMMIT_TRANSACTION)
           .build();
 
+  // these view endpoints must not be updated in order to maintain backwards compatibility with
+  // legacy servers
   private static final Set<Endpoint> VIEW_ENDPOINTS =
       ImmutableSet.<Endpoint>builder()
           .add(Endpoint.V1_LIST_VIEWS)
           .add(Endpoint.V1_LOAD_VIEW)
-          .add(Endpoint.V1_VIEW_EXISTS)
           .add(Endpoint.V1_CREATE_VIEW)
           .add(Endpoint.V1_UPDATE_VIEW)
           .add(Endpoint.V1_DELETE_VIEW)

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -2508,6 +2508,15 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
   @Test
   public void testNamespaceExistsFallbackToGETRequest() {
+    // server indicates support of loading a namespace only via GET, which is
+    // what older REST servers would send back too
+    verifyNamespaceExistsFallbackToGETRequest(
+        ConfigResponse.builder()
+            .withEndpoints(ImmutableList.of(Endpoint.V1_LOAD_NAMESPACE))
+            .build());
+  }
+
+  private void verifyNamespaceExistsFallbackToGETRequest(ConfigResponse configResponse) {
     RESTCatalogAdapter adapter =
         Mockito.spy(
             new RESTCatalogAdapter(backendCatalog) {
@@ -2518,13 +2527,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                   Consumer<ErrorResponse> errorHandler,
                   Consumer<Map<String, String>> responseHeaders) {
                 if ("v1/config".equals(request.path())) {
-                  return castResponse(
-                      responseType,
-                      ConfigResponse.builder()
-                          // server indicates support of loading a namespace only via GET, which is
-                          // what older REST servers would send back too
-                          .withEndpoints(ImmutableList.of(Endpoint.V1_LOAD_NAMESPACE))
-                          .build());
+                  return castResponse(responseType, configResponse);
                 }
 
                 return super.execute(request, responseType, errorHandler, responseHeaders);
@@ -2554,6 +2557,13 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   }
 
   @Test
+  public void testNamespaceExistsFallbackToGETRequestWithLegacyServer() {
+    // simulate a legacy server that doesn't send back supported endpoints, thus the
+    // client relies on the default endpoints
+    verifyNamespaceExistsFallbackToGETRequest(ConfigResponse.builder().build());
+  }
+
+  @Test
   public void testTableExistsViaHEADRequest() {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog =
@@ -2578,6 +2588,13 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
   @Test
   public void testTableExistsFallbackToGETRequest() {
+    // server indicates support of loading a table only via GET, which is
+    // what older REST servers would send back too
+    verifyTableExistsFallbackToGETRequest(
+        ConfigResponse.builder().withEndpoints(ImmutableList.of(Endpoint.V1_LOAD_TABLE)).build());
+  }
+
+  private void verifyTableExistsFallbackToGETRequest(ConfigResponse configResponse) {
     RESTCatalogAdapter adapter =
         Mockito.spy(
             new RESTCatalogAdapter(backendCatalog) {
@@ -2588,13 +2605,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                   Consumer<ErrorResponse> errorHandler,
                   Consumer<Map<String, String>> responseHeaders) {
                 if ("v1/config".equals(request.path())) {
-                  return castResponse(
-                      responseType,
-                      ConfigResponse.builder()
-                          // server indicates support of loading a table only via GET, which is
-                          // what older REST servers would send back too
-                          .withEndpoints(ImmutableList.of(Endpoint.V1_LOAD_TABLE))
-                          .build());
+                  return castResponse(responseType, configResponse);
                 }
 
                 return super.execute(request, responseType, errorHandler, responseHeaders);
@@ -2625,6 +2636,13 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             any(),
             any(),
             any());
+  }
+
+  @Test
+  public void testTableExistsFallbackToGETRequestWithLegacyServer() {
+    // simulate a legacy server that doesn't send back supported endpoints, thus the
+    // client relies on the default endpoints
+    verifyTableExistsFallbackToGETRequest(ConfigResponse.builder().build());
   }
 
   private RESTCatalog catalog(RESTCatalogAdapter adapter) {

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -111,8 +111,6 @@ paths:
 
           - GET /v1/{prefix}/namespaces/{namespace}
 
-          - HEAD /v1/{prefix}/namespaces/{namespace}
-
           - DELETE /v1/{prefix}/namespaces/{namespace}
 
           - POST /v1/{prefix}/namespaces/{namespace}/properties
@@ -122,8 +120,6 @@ paths:
           - POST /v1/{prefix}/namespaces/{namespace}/tables
 
           - GET /v1/{prefix}/namespaces/{namespace}/tables/{table}
-
-          - HEAD /v1/{prefix}/namespaces/{namespace}/tables/{table}
 
           - POST /v1/{prefix}/namespaces/{namespace}/tables/{table}
 


### PR DESCRIPTION
this backports #12351 to 1.8.x