### PR TITLE
Nit: Remove additional 'Iceberg' in Puffin footer payload

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/BaseDVFileWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BaseDVFileWriter.java
@@ -143,8 +143,7 @@ public class BaseDVFileWriter implements DVFileWriter {
 
   private PuffinWriter newWriter() {
     EncryptedOutputFile outputFile = fileFactory.newOutputFile();
-    String ident = IcebergBuild.fullVersion();
-    return Puffin.write(outputFile).createdBy(ident).build();
+    return Puffin.write(outputFile).createdBy(IcebergBuild.fullVersion()).build();
   }
 
   private Blob toBlob(PositionDeleteIndex positions, String path) {

--- a/core/src/main/java/org/apache/iceberg/deletes/BaseDVFileWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BaseDVFileWriter.java
@@ -143,7 +143,7 @@ public class BaseDVFileWriter implements DVFileWriter {
 
   private PuffinWriter newWriter() {
     EncryptedOutputFile outputFile = fileFactory.newOutputFile();
-    String ident = "Iceberg " + IcebergBuild.fullVersion();
+    String ident = IcebergBuild.fullVersion();
     return Puffin.write(outputFile).createdBy(ident).build();
   }
 


### PR DESCRIPTION
The puffin file for DV includes the following additional `Iceberg` in its footer payload before the Iceberg full build version. I believe this is not intentional (if it's intentional, please let me know). This commit removes that additional 'Iceberg'


```
$ cat 00000-5-8c2c8943-ad1c-407a-9e73-7ff393ef06b0-00001-deletes.puffin
PFA1
"��9d:0�
PFA1
{
  "blobs": [
    {
      "type": "deletion-vector-v1",
      "fields": [
        2147483645
      ],
      "snapshot-id": -1,
      "sequence-number": -1,
      "offset": 4,
      "length": 42,
      "properties": {
        "referenced-data-file": "s3://bucket/iceberg-v3-spec/dvpuff/data/00000-3-f7da0f05-7501-4e61-b49a-10444c666cb5-0-00001.parquet",
        "cardinality": "1"
      }
    }
  ],
  "properties": {
    "created-by": "Iceberg Apache Iceberg 1.7.0-SNAPSHOT (commit d4fe23a154d4324eeb6ef4753f50834dc4804bd7)"
  }
}
�
PFA1%
```

The footer payload in the following output shows `{"created-by":"Iceberg Apache Iceberg 1.7.0-SNAPSHOT...`.