### PR TITLE
Flink: Fix the comment error in SketchDataStatistics

### DIFF
--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SketchDataStatistics.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SketchDataStatistics.java
@@ -24,7 +24,7 @@ import org.apache.iceberg.SortKey;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 
-/** MapDataStatistics uses map to count key frequency */
+/** SketchDataStatistics uses reservoir sampling algorithm to count key frequency */
 class SketchDataStatistics implements DataStatistics {
 
   private final ReservoirItemsSketch<SortKey> sketch;

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SketchDataStatistics.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SketchDataStatistics.java
@@ -24,7 +24,7 @@ import org.apache.iceberg.SortKey;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 
-/** MapDataStatistics uses map to count key frequency */
+/** SketchDataStatistics uses reservoir sampling algorithm to count key frequency */
 class SketchDataStatistics implements DataStatistics {
 
   private final ReservoirItemsSketch<SortKey> sketch;

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SketchDataStatistics.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SketchDataStatistics.java
@@ -24,7 +24,7 @@ import org.apache.iceberg.SortKey;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 
-/** MapDataStatistics uses map to count key frequency */
+/** SketchDataStatistics uses reservoir sampling algorithm to count key frequency */
 class SketchDataStatistics implements DataStatistics {
 
   private final ReservoirItemsSketch<SortKey> sketch;


### PR DESCRIPTION
The comment for SketchDataStatistics is incorrectly written as the comment information for MapDataStatistics. This PR mainly aims to correct the comments for SketchDataStatistics.