### PR TITLE
OpenAPI: Use more clear language in recommending error responses

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -4458,7 +4458,9 @@ components:
     #  The fields `message` and `type` as indicated here are not presently prescriptive.
     UnauthorizedResponse:
       description:
-        Unauthorized. Authentication is required and has failed or has not yet been provided.
+        Unauthorized. The REST Catalog SHOULD respond with the 401 (UnauthorizedResponse) when
+        the access token provided is expired, revoked, malformed, or invalid for other reasons.
+        The client MAY request a new access token and retry the request.
       content:
         application/json:
           schema:
@@ -4566,7 +4568,9 @@ components:
 
     AuthenticationTimeoutResponse:
       description:
-        Credentials have timed out. If possible, the client should refresh credentials and retry.
+        This is an optional status response type that the REST Catalog can issue when the
+        token has expired. The client MAY request a new access token and retry the request.
+        401 UnauthorizedResponse SHOULD be preferred over this response type upon token expiration.
       content:
         application/json:
           schema:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -4458,7 +4458,7 @@ components:
     #  The fields `message` and `type` as indicated here are not presently prescriptive.
     UnauthorizedResponse:
       description:
-        Unauthorized. The REST Catalog SHOULD respond with the 401 (UnauthorizedResponse) when
+        Unauthorized. The REST Catalog SHOULD respond with the 401 UnauthorizedResponse when
         the access token provided is expired, revoked, malformed, or invalid for other reasons.
         The client MAY request a new access token and retry the request.
       content:
@@ -4570,7 +4570,7 @@ components:
       description:
         This is an optional status response type that the REST Catalog can issue when the
         token has expired. The client MAY request a new access token and retry the request.
-        401 UnauthorizedResponse SHOULD be preferred over this response type upon token expiration.
+        401 UnauthorizedResponse SHOULD be preferred over this response type on token expiry.
       content:
         application/json:
           schema:


### PR DESCRIPTION
The existence of the 419 AuthenticationTimeoutResponse status code caused confusion in the Iceberg community on the following two questions:
- whether the error response should be issued by a REST catalog on token expiry over 401 UnauthorizedResponse
- and how the client should respond on 419 response (vs a 401 response)

The updated description follows the RFC language of using SHOULD and MAY to be make these more clear for the REST catalog as well as the client responding to the status response.