### PR TITLE
Core: Add "volatile" to HadoopFileIO#hadoopConf

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -54,7 +54,7 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
   private static final int DEFAULT_DELETE_CORE_MULTIPLE = 4;
   private static volatile ExecutorService executorService;
 
-  private SerializableSupplier<Configuration> hadoopConf;
+  private volatile SerializableSupplier<Configuration> hadoopConf;
   private SerializableMap<String, String> properties = SerializableMap.copyOf(ImmutableMap.of());
 
   /**


### PR DESCRIPTION
This PR follows a warning message on a compilation.
https://errorprone.info/bugpattern/DoubleCheckedLocking

```
/.../iceberg/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java:125: warning: [DoubleCheckedLocking] Double-checked locking on non-volatile fields is unsafe
    if (hadoopConf == null) {
    ^
    (see https://errorprone.info/bugpattern/DoubleCheckedLocking)
  Did you mean 'private volatile SerializableSupplier<Configuration> hadoopConf;'?
```