### PR TITLE
HTTPRequest: don't remove trailing slash from absolute paths [1.8.x]

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPRequest.java
@@ -53,13 +53,17 @@ public interface HTTPRequest {
    */
   @Value.Lazy
   default URI requestUri() {
-    // if full path is provided, use the input path as path
-    String fullPath =
-        (path().startsWith("https://") || path().startsWith("http://"))
-            ? path()
-            : String.format("%s/%s", baseUri(), path());
+    String fullPath;
+    if (path().startsWith("https://") || path().startsWith("http://")) {
+      // if path is an absolute URI, use it as is
+      fullPath = path();
+    } else {
+      String baseUri = RESTUtil.stripTrailingSlash(baseUri().toString());
+      fullPath = RESTUtil.stripTrailingSlash(String.format("%s/%s", baseUri, path()));
+    }
+
     try {
-      URIBuilder builder = new URIBuilder(RESTUtil.stripTrailingSlash(fullPath));
+      URIBuilder builder = new URIBuilder(fullPath);
       queryParameters().forEach(builder::addParameter);
       return builder.build();
     } catch (URISyntaxException e) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPRequest.java
@@ -60,6 +60,17 @@ class TestHTTPRequest {
                 "http://localhost:8080/foo/v1/namespaces/ns/tables?pageToken=1234&pageSize=10")),
         Arguments.of(
             ImmutableHTTPRequest.builder()
+                .baseUri(
+                    URI.create("http://localhost:8080/foo/")) // trailing slash should be removed
+                .method(HTTPRequest.HTTPMethod.GET)
+                .path("v1/namespaces/ns/tables/") // trailing slash should be removed
+                .putQueryParameter("pageToken", "1234")
+                .putQueryParameter("pageSize", "10")
+                .build(),
+            URI.create(
+                "http://localhost:8080/foo/v1/namespaces/ns/tables?pageToken=1234&pageSize=10")),
+        Arguments.of(
+            ImmutableHTTPRequest.builder()
                 .baseUri(URI.create("http://localhost:8080/foo"))
                 .method(HTTPRequest.HTTPMethod.GET)
                 .path("https://authserver.com/token") // absolute path HTTPS
@@ -71,7 +82,15 @@ class TestHTTPRequest {
                 .method(HTTPRequest.HTTPMethod.GET)
                 .path("http://authserver.com/token") // absolute path HTTP
                 .build(),
-            URI.create("http://authserver.com/token")));
+            URI.create("http://authserver.com/token")),
+        Arguments.of(
+            ImmutableHTTPRequest.builder()
+                .baseUri(URI.create("http://localhost:8080/foo"))
+                .method(HTTPRequest.HTTPMethod.GET)
+                // absolute path with trailing slash: should be preserved
+                .path("http://authserver.com/token/")
+                .build(),
+            URI.create("http://authserver.com/token/")));
   }
 
   @Test


### PR DESCRIPTION
Fixes #12373