### PR TITLE
Build: Bump junit to 5.12.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,6 +200,7 @@ subprojects {
 
     testImplementation libs.junit.jupiter
     testImplementation libs.junit.jupiter.engine
+    testImplementation libs.junit.platform.launcher
     testImplementation libs.slf4j.simple
     testImplementation libs.mockito.core
     testImplementation libs.mockito.inline

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,8 +63,8 @@ jakarta-servlet-api = "6.1.0"
 jaxb-api = "2.3.1"
 jaxb-runtime = "2.3.9"
 jetty = "11.0.25"
-junit = "5.11.4"
-junit-platform = "1.11.4"
+junit = "5.12.2"
+junit-platform = "1.12.2"
 kafka = "3.9.0"
 kryo-shaded = "4.0.3"
 microprofile-openapi-api = "3.1.2"
@@ -194,6 +194,7 @@ jetty-server = { module = "org.eclipse.jetty:jetty-server", version.ref = "jetty
 jetty-servlet = { module = "org.eclipse.jetty:jetty-servlet", version.ref = "jetty" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 junit-suite-api = { module = "org.junit.platform:junit-platform-suite-api", version.ref = "junit-platform" }
 junit-suite-engine = { module = "org.junit.platform:junit-platform-suite-engine", version.ref = "junit-platform" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit" }

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -258,6 +258,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark35.get()}"
     integrationImplementation libs.junit.vintage.engine
     integrationImplementation libs.junit.jupiter
+    integrationImplementation libs.junit.platform.launcher
     integrationImplementation libs.slf4j.simple
     integrationImplementation libs.assertj.core
     integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')


### PR DESCRIPTION
Closes #12378
Closes #12381
Closes #12537
Closes #12538

As of Gradle 8, not explicitly depending upon `junit-platform-launcher` is [deprecated](https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#test_framework_implementation_dependencies) (and will be required in Gradle 9)

~~Also adds `junit-bom` as per their [recommendation](https://junit.org/junit5/docs/current/user-guide/#running-tests-build-gradle-bom)~~
