### PR TITLE
[hive]:Fix Hive table creation syntax errors

### DIFF
--- a/docs/docs/hive.md
+++ b/docs/docs/hive.md
@@ -284,7 +284,7 @@ You can create Iceberg partitions using the following Iceberg partition specific
 (supported only from Hive 4.0.0-alpha-1):
 
 ```sql
-CREATE TABLE x (i int, ts timestamp) PARTITIONED BY SPEC (month(ts), bucket(2, i)) STORED AS ICEBERG;
+CREATE TABLE x (i int, ts timestamp) PARTITIONED BY SPEC (month(ts), bucket(2, i)) STORED BY ICEBERG;
 DESCRIBE x;
 ```
 The result is:


### PR DESCRIPTION
iceberg/docs/docs/hive.md In the document Hive table creation statement word error, 
STORED BY written as STORED AS.

**Incorrect  statement**

![e1](https://github.com/user-attachments/assets/580099a5-79ab-4d76-83bf-f3a94a57b09f)

**Correct statement**

![e2](https://github.com/user-attachments/assets/bf59669b-883f-4140-9899-7fe3ec38428e)
