### PR TITLE
Spark 3.5: Adjust repeated INFO logs to DEBUG in SparkWrite and SparkPositionDeltaWrite

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -141,7 +141,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
   @Override
   public Distribution requiredDistribution() {
     Distribution distribution = writeRequirements.distribution();
-    LOG.info("Requesting {} as write distribution for table {}", distribution, table.name());
+    LOG.debug("Requesting {} as write distribution for table {}", distribution, table.name());
     return distribution;
   }
 
@@ -153,14 +153,14 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
   @Override
   public SortOrder[] requiredOrdering() {
     SortOrder[] ordering = writeRequirements.ordering();
-    LOG.info("Requesting {} as write ordering for table {}", ordering, table.name());
+    LOG.debug("Requesting {} as write ordering for table {}", ordering, table.name());
     return ordering;
   }
 
   @Override
   public long advisoryPartitionSizeInBytes() {
     long size = writeRequirements.advisoryPartitionSize();
-    LOG.info("Requesting {} bytes advisory partition size for table {}", size, table.name());
+    LOG.debug("Requesting {} bytes advisory partition size for table {}", size, table.name());
     return size;
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -135,7 +135,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   @Override
   public Distribution requiredDistribution() {
     Distribution distribution = writeRequirements.distribution();
-    LOG.info("Requesting {} as write distribution for table {}", distribution, table.name());
+    LOG.debug("Requesting {} as write distribution for table {}", distribution, table.name());
     return distribution;
   }
 
@@ -147,14 +147,14 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   @Override
   public SortOrder[] requiredOrdering() {
     SortOrder[] ordering = writeRequirements.ordering();
-    LOG.info("Requesting {} as write ordering for table {}", ordering, table.name());
+    LOG.debug("Requesting {} as write ordering for table {}", ordering, table.name());
     return ordering;
   }
 
   @Override
   public long advisoryPartitionSizeInBytes() {
     long size = writeRequirements.advisoryPartitionSize();
-    LOG.info("Requesting {} bytes advisory partition size for table {}", size, table.name());
+    LOG.debug("Requesting {} bytes advisory partition size for table {}", size, table.name());
     return size;
   }
 


### PR DESCRIPTION
I see repeated logs as follows from `SparkWrite` in Spark driver.

```
25/02/26 01:48:56 INFO SparkWrite: Requesting 0 bytes advisory partition size for table ***
25/02/26 01:48:56 INFO SparkWrite: Requesting 0 bytes advisory partition size for table ***
25/02/26 01:48:56 INFO SparkWrite: Requesting 0 bytes advisory partition size for table ***
25/02/26 01:48:56 INFO SparkWrite: Requesting UnspecifiedDistribution as write distribution for table ***
25/02/26 01:48:56 INFO SparkWrite: Requesting UnspecifiedDistribution as write distribution for table ***
25/02/26 01:48:56 INFO SparkWrite: Requesting [] as write ordering for table ***
25/02/26 01:48:56 INFO SparkWrite: Requesting [] as write ordering for table ***
25/02/26 01:48:56 INFO SparkWrite: Requesting [] as write ordering for table ***
```

I think they are more appropriate for debugging purpose, so this PR adjusts the corresponding log levels to DEBUG.
