### PR TITLE
Enable HTTP proxy support for the client used by REST Catalog 

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -174,6 +174,65 @@ public class TestHTTPClient {
   }
 
   @Test
+  public void testClientWithProxyProps() throws IOException {
+    int proxyPort = 1070;
+    try (ClientAndServer proxyServer = startClientAndServer(proxyPort);
+        RESTClient clientWithProxy =
+            HTTPClient.builder(
+                    ImmutableMap.of(
+                        HTTPClient.REST_PROXY_HOSTNAME,
+                        "localhost",
+                        HTTPClient.REST_PROXY_PORT,
+                        String.valueOf(proxyPort)))
+                .uri(URI)
+                .withAuthSession(AuthSession.EMPTY)
+                .build()) {
+      String path = "v1/config";
+      HttpRequest mockRequest =
+          request("/" + path).withMethod(HttpMethod.HEAD.name().toUpperCase(Locale.ROOT));
+      HttpResponse mockResponse = response().withStatusCode(200);
+      proxyServer.when(mockRequest).respond(mockResponse);
+      clientWithProxy.head(path, ImmutableMap.of(), (onError) -> {});
+      proxyServer.verify(mockRequest, VerificationTimes.exactly(1));
+    }
+  }
+
+  @Test
+  public void testClientWithAuthProxyProps() throws IOException {
+    int proxyPort = 1070;
+    String authorizedUsername = "test-username";
+    String authorizedPassword = "test-password";
+    try (ClientAndServer proxyServer =
+            startClientAndServer(
+                new Configuration()
+                    .proxyAuthenticationUsername(authorizedUsername)
+                    .proxyAuthenticationPassword(authorizedPassword),
+                proxyPort);
+        RESTClient clientWithProxy =
+            HTTPClient.builder(
+                    ImmutableMap.of(
+                        HTTPClient.REST_PROXY_HOSTNAME,
+                        "localhost",
+                        HTTPClient.REST_PROXY_PORT,
+                        String.valueOf(proxyPort),
+                        HTTPClient.REST_PROXY_USERNAME,
+                        authorizedUsername,
+                        HTTPClient.REST_PROXY_PASSWORD,
+                        authorizedPassword))
+                .uri(URI)
+                .withAuthSession(AuthSession.EMPTY)
+                .build()) {
+      String path = "v1/config";
+      HttpRequest mockRequest =
+          request("/" + path).withMethod(HttpMethod.HEAD.name().toUpperCase(Locale.ROOT));
+      HttpResponse mockResponse = response().withStatusCode(200);
+      proxyServer.when(mockRequest).respond(mockResponse);
+      clientWithProxy.head(path, ImmutableMap.of(), (onError) -> {});
+      proxyServer.verify(mockRequest, VerificationTimes.exactly(1));
+    }
+  }
+
+  @Test
   public void testProxyAuthenticationFailure() throws IOException {
     int proxyPort = 1050;
     String proxyHostName = "localhost";


### PR DESCRIPTION
This PR Fixes the following issues

https://github.com/apache/iceberg/issues/12059
https://github.com/apache/iceberg/issues/9174

```
# extra configs needed to connect via proxy
conf.set("spark.sql.catalog.demo.rest.client.proxy.hostname", "127.0.0.1")
conf.set("spark.sql.catalog.demo.rest.client.proxy.port", "8080")

# below configs are needed only if the proxy require credentials
conf.set("spark.sql.catalog.demo.rest.client.proxy.username", "admin")
conf.set("spark.sql.catalog.demo.rest.client.proxy.password", "admin")
```

Notes:
* Changes are tested using [mitmproxy](https://mitmproxy.org/)