### PR TITLE
Ignore apt-get update error when building `iceberg-rest-fixture` image

### DIFF
--- a/docker/iceberg-rest-fixture/Dockerfile
+++ b/docker/iceberg-rest-fixture/Dockerfile
@@ -23,7 +23,7 @@ FROM azul/zulu-openjdk:17-jre-headless
 RUN  set -xeu && \
      groupadd iceberg --gid 1000 && \
      useradd iceberg --uid 1000 --gid 1000 --create-home && \
-     apt-get update && \
+     apt-get update || true && \
      apt-get install -y --no-install-recommends curl && \
      rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
`apt-get update` could fail to fetch updates from some archives and break the build.

```
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c set -xeu &&      groupadd iceberg --gid 1000 &&      useradd iceberg --uid 1000 --gid 1000 --create-home &&      apt-get update &&      apt-get install -y --no-install-recommends curl &&      rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```