### PR TITLE
Core: Lazy init workerPool in RemoveSnapshots and SnapshotProducer

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -157,6 +157,7 @@ class RemoveSnapshots implements ExpireSnapshots {
     if (planExecutorService == null) {
       this.planExecutorService = ThreadPools.getWorkerPool();
     }
+
     return planExecutorService;
   }
 

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -38,7 +38,6 @@ import static org.apache.iceberg.TableProperties.MIN_SNAPSHOTS_TO_KEEP_DEFAULT;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
@@ -155,7 +154,10 @@ class RemoveSnapshots implements ExpireSnapshots {
   }
 
   protected ExecutorService planExecutorService() {
-    return Optional.ofNullable(planExecutorService).orElseGet(ThreadPools::getWorkerPool);
+    if (planExecutorService == null) {
+      this.planExecutorService = ThreadPools.getWorkerPool();
+    }
+    return planExecutorService;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
@@ -198,7 +197,10 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   }
 
   protected ExecutorService workerPool() {
-    return Optional.ofNullable(workerPool).orElseGet(ThreadPools::getWorkerPool);
+    if (workerPool == null) {
+      this.workerPool = ThreadPools.getWorkerPool();
+    }
+    return workerPool;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -276,7 +276,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       Tasks.range(manifestFiles.length)
           .stopOnFailure()
           .throwFailureWhenFinished()
-          .executeWith(workerPool)
+          .executeWith(workerPool())
           .run(index -> manifestFiles[index] = manifestsWithMetadata.get(manifests.get(index)));
 
       writer.addAll(Arrays.asList(manifestFiles));

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
@@ -119,7 +120,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   private boolean stageOnly = false;
   private Consumer<String> deleteFunc = defaultDelete;
 
-  private ExecutorService workerPool = ThreadPools.getWorkerPool();
+  private ExecutorService workerPool;
   private String targetBranch = SnapshotRef.MAIN_BRANCH;
   private CommitMetrics commitMetrics;
 
@@ -197,7 +198,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   }
 
   protected ExecutorService workerPool() {
-    return this.workerPool;
+    return Optional.ofNullable(workerPool).orElseGet(ThreadPools::getWorkerPool);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -200,6 +200,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     if (workerPool == null) {
       this.workerPool = ThreadPools.getWorkerPool();
     }
+
     return workerPool;
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -35,9 +35,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.iceberg.ManifestEntry.Status;
@@ -1777,16 +1775,18 @@ public class TestRemoveSnapshots extends TestBase {
   @TestTemplate
   public void testExpireSnapshotsWithExecutor() {
     AtomicInteger scanThreadsIndex = new AtomicInteger(0);
-    RemoveSnapshots removeSnapshots = (RemoveSnapshots) removeSnapshots(table)
-      .planWith(
-        Executors.newFixedThreadPool(
-            1,
-            runnable -> {
-              Thread thread = new Thread(runnable);
-              thread.setName("scan-" + scanThreadsIndex.getAndIncrement());
-              thread.setDaemon(true);
-              return thread;
-            }));
+    RemoveSnapshots removeSnapshots =
+        (RemoveSnapshots)
+            removeSnapshots(table)
+                .planWith(
+                    Executors.newFixedThreadPool(
+                        1,
+                        runnable -> {
+                          Thread thread = new Thread(runnable);
+                          thread.setName("scan-" + scanThreadsIndex.getAndIncrement());
+                          thread.setDaemon(true);
+                          return thread;
+                        }));
 
     table.newAppend().appendFile(FILE_A).commit();
     table.newAppend().appendFile(FILE_A).commit();


### PR DESCRIPTION
For code paths where an ExecutorService can be provided, the default call to ThreadPools.getWorkerPool() can be deferred until the point of actual usage.