### PR TITLE
API: Speed up Timestamps#toHumanString

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/TransformUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/TransformUtil.java
@@ -37,25 +37,30 @@ class TransformUtil {
   private static final int EPOCH_YEAR = EPOCH.getYear();
 
   static String humanYear(int yearOrdinal) {
-    return String.format(Locale.ROOT, "%04d", EPOCH_YEAR + yearOrdinal);
+    char[] result = new char[4];
+    appendNumber(result, EPOCH_YEAR + yearOrdinal, 0, 4);
+    return new String(result);
   }
 
   static String humanMonth(int monthOrdinal) {
-    return String.format(
-        Locale.ROOT,
-        "%04d-%02d",
-        EPOCH_YEAR + Math.floorDiv(monthOrdinal, 12),
-        1 + Math.floorMod(monthOrdinal, 12));
+    char[] result = new char[7];
+    int year = EPOCH_YEAR + Math.floorDiv(monthOrdinal, 12);
+    appendNumber(result, year, 0, 4);
+    result[4] = '-';
+    appendNumber(result, 1 + Math.floorMod(monthOrdinal, 12), 5, 2);
+    return new String(result);
   }
 
   static String humanDay(int dayOrdinal) {
     OffsetDateTime day = EPOCH.plusDays(dayOrdinal);
-    return String.format(
-        Locale.ROOT,
-        "%04d-%02d-%02d",
-        day.getYear(),
-        day.getMonth().getValue(),
-        day.getDayOfMonth());
+
+    char[] result = new char[10];
+    appendNumber(result, day.getYear(), 0, 4);
+    result[4] = '-';
+    appendNumber(result, day.getMonth().getValue(), 5, 2);
+    result[7] = '-';
+    appendNumber(result, day.getDayOfMonth(), 8, 2);
+    return new String(result);
   }
 
   static String humanTime(Long microsFromMidnight) {
@@ -80,13 +85,15 @@ class TransformUtil {
 
   static String humanHour(int hourOrdinal) {
     OffsetDateTime time = EPOCH.plusHours(hourOrdinal);
-    return String.format(
-        Locale.ROOT,
-        "%04d-%02d-%02d-%02d",
-        time.getYear(),
-        time.getMonth().getValue(),
-        time.getDayOfMonth(),
-        time.getHour());
+    char[] result = new char[13];
+    appendNumber(result, time.getYear(), 0, 4);
+    result[4] = '-';
+    appendNumber(result, time.getMonth().getValue(), 5, 2);
+    result[7] = '-';
+    appendNumber(result, time.getDayOfMonth(), 8, 2);
+    result[10] = '-';
+    appendNumber(result, time.getHour(), 11, 2);
+    return new String(result);
   }
 
   static String base64encode(ByteBuffer buffer) {
@@ -98,5 +105,13 @@ class TransformUtil {
     // test the granularity, in hours. hour(ts) => 1 hour, day(ts) => 24 hours, and hour satisfies
     // the order of day
     return leftGranularity.getDuration().toHours() <= rightGranularity.getDuration().toHours();
+  }
+
+  private static void appendNumber(char[] result, int number, int startIndex, int digits) {
+    int val = number;
+    for (int i = digits - 1; i >= 0; i--) {
+      result[startIndex + i] = (char) ('0' + (val % 10));
+      val /= 10;
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/transforms/TransformUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/TransformUtil.java
@@ -26,7 +26,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
-import java.util.Locale;
 import org.apache.iceberg.util.DateTimeUtil;
 
 class TransformUtil {

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTransformUtil.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTransformUtil.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.transforms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class TestTransformUtil {
+
+  @ParameterizedTest
+  @CsvSource({"0, 1970", "1, 1971", "10, 1980", "47, 2017", "100, 2070"})
+  public void test_humanYear(int yearOrdinal, String expected) {
+    String result = TransformUtil.humanYear(yearOrdinal);
+    assertThat(result).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> humanYears() {
+    return Stream.of(
+        Arguments.of(0, "1970"),
+        Arguments.of(1, "1971"),
+        Arguments.of(10, "1980"),
+        Arguments.of(47, "2017"),
+        Arguments.of(100, "2070"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0, 1970-01", "1, 1970-02", "12, 1971-01", "658, 2024-11"})
+  public void test_humanMonths(int monthOrdinal, String expected) {
+    String result = TransformUtil.humanMonth(monthOrdinal);
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0, 1970-01-01", "1, 1970-01-02", "12, 1970-01-13", "20000, 2024-10-04"})
+  public void test_humanDays(int dayOrdinal, String expected) {
+    String result = TransformUtil.humanDay(dayOrdinal);
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0, 1970-01-01-00", "1, 1970-01-01-01", "12, 1970-01-01-12", "24, 1970-01-02-00"})
+  public void test_humanHours(int hourOrdinal, String expected) {
+    String result = TransformUtil.humanHour(hourOrdinal);
+    assertThat(result).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
String#format uses regexes internally which can be expensive when used repeatedly. This PR switches out the implementation for a char array implementation that pads zeros as needed.

A simple benchmark was written to compare these 2 implementations which shows an improvement from ~ 300ns per op to 15ns per op

```
Benchmark                                    (monthOrdinal)  Mode  Cnt    Score     Error  Units
DateFormattingBenchmark.charArrayFormat               0  avgt   10   17.580 ±   5.029  ns/op
DateFormattingBenchmark.charArrayFormat               1  avgt   10   16.082 ±   0.220  ns/op
DateFormattingBenchmark.charArrayFormat              12  avgt   10   13.504 ±   0.151  ns/op
DateFormattingBenchmark.charArrayFormat              15  avgt   10   13.541 ±   0.684  ns/op
DateFormattingBenchmark.charArrayFormat             123  avgt   10   17.616 ±   5.112  ns/op
DateFormattingBenchmark.charArrayFormat            1234  avgt   10   13.350 ±   0.544  ns/op
DateFormattingBenchmark.charArrayFormat           12345  avgt   10   13.656 ±   0.128  ns/op
DateFormattingBenchmark.stringFormat                      0  avgt   10  296.576 ±   1.027  ns/op
DateFormattingBenchmark.stringFormat                      1  avgt   10  356.724 ± 277.416  ns/op
DateFormattingBenchmark.stringFormat                     12  avgt   10  320.441 ±   1.802  ns/op
DateFormattingBenchmark.stringFormat                     15  avgt   10  298.042 ±  11.098  ns/op
DateFormattingBenchmark.stringFormat                    123  avgt   10  302.227 ±  11.005  ns/op
DateFormattingBenchmark.stringFormat                   1234  avgt   10  309.586 ±  11.386  ns/op
DateFormattingBenchmark.stringFormat                  12345  avgt   10  305.583 ±   1.682  ns/op
```
