### PR TITLE
Support In and notIn operators in ParquetFilters.ConvertFilterToParquet

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -204,6 +204,10 @@ public class Schema implements Serializable {
     this(schemaId, Arrays.asList(columns));
   }
 
+  public Schema(Map<String, Integer> aliases, NestedField... columns) {
+    this(Arrays.asList(columns), aliases);
+  }
+
   private Map<Integer, NestedField> lazyIdToField() {
     if (idToField == null) {
       this.idToField = TypeUtil.indexById(struct);

--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -204,10 +204,6 @@ public class Schema implements Serializable {
     this(schemaId, Arrays.asList(columns));
   }
 
-  public Schema(Map<String, Integer> aliases, NestedField... columns) {
-    this(Arrays.asList(columns), aliases);
-  }
-
   private Map<Integer, NestedField> lazyIdToField() {
     if (idToField == null) {
       this.idToField = TypeUtil.indexById(struct);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.parquet;
 
 import java.nio.ByteBuffer;
-import java.util.HashSet;
 import java.util.Set;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.BoundPredicate;
@@ -144,21 +143,21 @@ class ParquetFilters {
           break;
         case INTEGER:
         case DATE:
-          return pred(op, FilterApi.intColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
+          return pred(op, FilterApi.intColumn(path), getParquetPrimitive(lit), litSet);
         case LONG:
         case TIME:
         case TIMESTAMP:
-          return pred(op, FilterApi.longColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
+          return pred(op, FilterApi.longColumn(path), getParquetPrimitive(lit), litSet);
         case FLOAT:
-          return pred(op, FilterApi.floatColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
+          return pred(op, FilterApi.floatColumn(path), getParquetPrimitive(lit), litSet);
         case DOUBLE:
-          return pred(op, FilterApi.doubleColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
+          return pred(op, FilterApi.doubleColumn(path), getParquetPrimitive(lit), litSet);
         case STRING:
         case UUID:
         case FIXED:
         case BINARY:
         case DECIMAL:
-          return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
+          return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit), litSet);
       }
 
       throw new UnsupportedOperationException("Cannot convert to Parquet filter: " + pred);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -126,7 +126,7 @@ class ParquetFilters {
       } else if (pred.isLiteralPredicate()) {
         lit = pred.asLiteralPredicate().literal();
       } else if (pred.isSetPredicate()) {
-        litSet = pred.asSetPredicate().asSetPredicate().literalSet();
+        litSet = pred.asSetPredicate().literalSet();
       } else {
         throw new UnsupportedOperationException("Cannot convert to Parquet filter: " + pred);
       }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.parquet;
 
 import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.BoundReference;
@@ -118,11 +120,14 @@ class ParquetFilters {
       Operation op = pred.op();
       BoundReference<T> ref = (BoundReference<T>) pred.term();
       String path = schema.idToAlias(ref.fieldId());
-      Literal<T> lit;
+      Literal<T> lit = null;
+      Set<T> litSet = null;
       if (pred.isUnaryPredicate()) {
         lit = null;
       } else if (pred.isLiteralPredicate()) {
         lit = pred.asLiteralPredicate().literal();
+      } else if (pred.isSetPredicate()) {
+        litSet = pred.asSetPredicate().asSetPredicate().literalSet();
       } else {
         throw new UnsupportedOperationException("Cannot convert to Parquet filter: " + pred);
       }
@@ -139,21 +144,21 @@ class ParquetFilters {
           break;
         case INTEGER:
         case DATE:
-          return pred(op, FilterApi.intColumn(path), getParquetPrimitive(lit));
+          return pred(op, FilterApi.intColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
         case LONG:
         case TIME:
         case TIMESTAMP:
-          return pred(op, FilterApi.longColumn(path), getParquetPrimitive(lit));
+          return pred(op, FilterApi.longColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
         case FLOAT:
-          return pred(op, FilterApi.floatColumn(path), getParquetPrimitive(lit));
+          return pred(op, FilterApi.floatColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
         case DOUBLE:
-          return pred(op, FilterApi.doubleColumn(path), getParquetPrimitive(lit));
+          return pred(op, FilterApi.doubleColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
         case STRING:
         case UUID:
         case FIXED:
         case BINARY:
         case DECIMAL:
-          return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit));
+          return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit), (HashSet) litSet);
       }
 
       throw new UnsupportedOperationException("Cannot convert to Parquet filter: " + pred);
@@ -175,7 +180,7 @@ class ParquetFilters {
 
   @SuppressWarnings("checkstyle:MethodTypeParameterName")
   private static <C extends Comparable<C>, COL extends Operators.Column<C> & Operators.SupportsLtGt>
-      FilterPredicate pred(Operation op, COL col, C value) {
+      FilterPredicate pred(Operation op, COL col, C value, Set litSet) {
     switch (op) {
       case IS_NULL:
         return FilterApi.eq(col, null);
@@ -209,6 +214,10 @@ class ParquetFilters {
         return FilterApi.lt(col, value);
       case LT_EQ:
         return FilterApi.ltEq(col, value);
+      case IN:
+        return FilterApi.in(col, litSet);
+      case NOT_IN:
+        return FilterApi.notIn(col, litSet);
       default:
         throw new UnsupportedOperationException("Unsupported predicate operation: " + op);
     }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.apache.iceberg.expressions.Expressions.in;
+import static org.apache.iceberg.expressions.Expressions.notIn;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types.DoubleType;
+import org.apache.iceberg.types.Types.IntegerType;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestParquetFilters {
+
+  private static final java.util.Map<String, Integer> ALIASES =
+      new java.util.HashMap<String, Integer>() {
+        {
+          put("id", 1);
+          put("age", 2);
+        }
+      };
+
+  private static final Schema SCHEMA =
+      new Schema(
+          ALIASES, required(1, "id", IntegerType.get()), required(2, "age", DoubleType.get()));
+
+  @Parameters(name = "writerVersion={0}")
+  public static Collection<WriterVersion> parameters() {
+    return Arrays.asList(WriterVersion.PARQUET_1_0, WriterVersion.PARQUET_2_0);
+  }
+
+  @TestTemplate
+  public void testIntegerInFilter() {
+    FilterCompat.Filter filter =
+        (FilterCompat.Filter) ParquetFilters.convert(SCHEMA, in("id", 1, 2, 3), true);
+
+    try {
+      java.lang.reflect.Field privateField = filter.getClass().getDeclaredField("filterPredicate");
+      privateField.setAccessible(true);
+      assertThat(privateField.get(filter).toString().equalsIgnoreCase("in(id, 1, 2, 3)")).isTrue();
+    } catch (Exception e) {
+      assertThat(true).isFalse();
+    }
+  }
+
+  @TestTemplate
+  public void testDoubleNotInFilter() {
+    FilterCompat.Filter filter =
+        (FilterCompat.Filter) ParquetFilters.convert(SCHEMA, notIn("age", 1.0, 2.0, 3.0), true);
+
+    try {
+      java.lang.reflect.Field privateField = filter.getClass().getDeclaredField("filterPredicate");
+      privateField.setAccessible(true);
+      assertThat(privateField.get(filter).toString().equalsIgnoreCase("notin(age, 1.0, 2.0, 3.0)"))
+          .isTrue();
+    } catch (Exception e) {
+      assertThat(true).isFalse();
+    }
+  }
+}


### PR DESCRIPTION
ParquetFilters.ConvertFilterToParquet performs conversion from an Iceberg filter (Expression) to a Parquet FilterPredicate. It currently only handles IS_NULL, NOT_NULL, IS_NAN, NOT_NAN, EQ, NOT_EQ, GT, GT_EQ, LT, LT_EQ. It does not handle, e.g., IN and NOT_IN, which would be useful to have.

This conversion can be used for setting a record filter in Parquet and then using that to filter row groups when reading Parquet files.