### PR TITLE
Spark-3.5: Add spark action to compute partition stats

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -77,6 +77,12 @@ public interface ActionsProvider {
         this.getClass().getName() + " does not implement computeTableStats");
   }
 
+  /** Instantiates an action to compute partition stats. */
+  default ComputePartitionStats computePartitionStats(Table table) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement computePartitionStats");
+  }
+
   /** Instantiates an action to rewrite all absolute paths in table metadata. */
   default RewriteTablePath rewriteTablePath(Table table) {
     throw new UnsupportedOperationException(

--- a/api/src/main/java/org/apache/iceberg/actions/ComputePartitionStats.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ComputePartitionStats.java
@@ -20,11 +20,14 @@ package org.apache.iceberg.actions;
 
 import org.apache.iceberg.PartitionStatisticsFile;
 
-/** An action that computes and writes the partition statistics of an Iceberg table. */
+/**
+ * An action that computes and writes the partition statistics of an Iceberg table. Current snapshot
+ * is used by default.
+ */
 public interface ComputePartitionStats
     extends Action<ComputePartitionStats, ComputePartitionStats.Result> {
   /**
-   * Choose the table snapshot to compute partition stats, by default the current snapshot is used.
+   * Choose the table snapshot to compute partition stats.
    *
    * @param snapshotId long ID of the snapshot for which stats need to be computed
    * @return this for method chaining
@@ -34,7 +37,7 @@ public interface ComputePartitionStats
   /** The result of partition statistics collection. */
   interface Result {
 
-    /** Returns statistics file or none if no statistics were collected. */
+    /** Returns statistics file or null if no statistics were collected. */
     PartitionStatisticsFile statisticsFile();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/ComputePartitionStats.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ComputePartitionStats.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import org.apache.iceberg.PartitionStatisticsFile;
+
+/** An action that computes and writes the partition statistics of an Iceberg table. */
+public interface ComputePartitionStats
+    extends Action<ComputePartitionStats, ComputePartitionStats.Result> {
+  /**
+   * Choose the table snapshot to compute partition stats, by default the current snapshot is used.
+   *
+   * @param snapshotId long ID of the snapshot for which stats need to be computed
+   * @return this for method chaining
+   */
+  ComputePartitionStats snapshot(long snapshotId);
+
+  /** The result of partition statistics collection. */
+  interface Result {
+
+    /** Returns statistics file or none if no statistics were collected. */
+    PartitionStatisticsFile statisticsFile();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/PartitionStatsHandler.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStatsHandler.java
@@ -168,9 +168,7 @@ public class PartitionStatsHandler {
     } else {
       if (statisticsFile.snapshotId() == snapshotId) {
         // no-op
-        LOG.info(
-            "Snapshot {} already has statistics file computed. Returning the same file as result.",
-            snapshotId);
+        LOG.info("Returning existing statistics file for snapshot {}", snapshotId);
         return statisticsFile;
       }
 

--- a/core/src/main/java/org/apache/iceberg/PartitionStatsHandler.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStatsHandler.java
@@ -166,6 +166,14 @@ public class PartitionStatsHandler {
       stats =
           computeStats(table, snapshot.allManifests(table.io()), false /* incremental */).values();
     } else {
+      if (statisticsFile.snapshotId() == snapshotId) {
+        // no-op
+        LOG.info(
+            "Snapshot {} already has statistics file computed. Returning the same file as result.",
+            snapshotId);
+        return statisticsFile;
+      }
+
       try {
         stats = computeAndMergeStatsIncremental(table, snapshot, partitionType, statisticsFile);
       } catch (InvalidStatsFileException exception) {

--- a/core/src/main/java/org/apache/iceberg/actions/BaseComputePartitionStats.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseComputePartitionStats.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import javax.annotation.Nullable;
+import org.apache.iceberg.PartitionStatisticsFile;
+import org.immutables.value.Value;
+
+@Value.Enclosing
+@SuppressWarnings("ImmutablesStyle")
+@Value.Style(
+    typeImmutableEnclosing = "ImmutableComputePartitionStats",
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
+interface BaseComputePartitionStats extends ComputePartitionStats {
+
+  @Value.Immutable
+  interface Result extends ComputePartitionStats.Result {
+    @Override
+    @Nullable
+    PartitionStatisticsFile statisticsFile();
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ComputePartitionStatsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ComputePartitionStatsSparkAction.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ComputePartitionStats;
 import org.apache.iceberg.actions.ImmutableComputePartitionStats;
+import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.spark.sql.SparkSession;
@@ -84,7 +85,7 @@ public class ComputePartitionStatsSparkAction
     try {
       statisticsFile = PartitionStatsHandler.computeAndWriteStatsFile(table, snapshot.snapshotId());
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeIOException(e);
     }
 
     if (statisticsFile == null) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ComputePartitionStatsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ComputePartitionStatsSparkAction.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import java.io.IOException;
+import org.apache.iceberg.PartitionStatisticsFile;
+import org.apache.iceberg.PartitionStatsHandler;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.ComputePartitionStats;
+import org.apache.iceberg.actions.ImmutableComputePartitionStats;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Computes the stats incrementally after the snapshot that has partition stats file till the given
+ * snapshot (uses current snapshot if not specified) and writes the combined result into a {@link
+ * PartitionStatisticsFile} after merging the stats for a given snapshot. Does a full compute if
+ * previous statistics file does not exist. Also registers the {@link PartitionStatisticsFile} to
+ * table metadata.
+ */
+public class ComputePartitionStatsSparkAction
+    extends BaseSparkAction<ComputePartitionStatsSparkAction> implements ComputePartitionStats {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ComputePartitionStatsSparkAction.class);
+  private static final Result EMPTY_RESULT =
+      ImmutableComputePartitionStats.Result.builder().build();
+
+  private final Table table;
+  private Snapshot snapshot;
+
+  ComputePartitionStatsSparkAction(SparkSession spark, Table table) {
+    super(spark);
+    this.table = table;
+    this.snapshot = table.currentSnapshot();
+  }
+
+  @Override
+  protected ComputePartitionStatsSparkAction self() {
+    return this;
+  }
+
+  @Override
+  public ComputePartitionStats snapshot(long newSnapshotId) {
+    Snapshot newSnapshot = table.snapshot(newSnapshotId);
+    Preconditions.checkArgument(newSnapshot != null, "Snapshot not found: %s", newSnapshotId);
+    this.snapshot = newSnapshot;
+    return this;
+  }
+
+  @Override
+  public Result execute() {
+    if (snapshot == null) {
+      LOG.info("No snapshot to compute partition stats for table {}", table.name());
+      return EMPTY_RESULT;
+    }
+
+    JobGroupInfo info = newJobGroupInfo("COMPUTE-PARTITION-STATS", jobDesc());
+    return withJobGroupInfo(info, this::doExecute);
+  }
+
+  private Result doExecute() {
+    LOG.info("Computing partition stats for {} (snapshot {})", table.name(), snapshot.snapshotId());
+    PartitionStatisticsFile statisticsFile;
+    try {
+      statisticsFile = PartitionStatsHandler.computeAndWriteStatsFile(table, snapshot.snapshotId());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    if (statisticsFile == null) {
+      return EMPTY_RESULT;
+    }
+
+    table.updatePartitionStatistics().setPartitionStatistics(statisticsFile).commit();
+    return ImmutableComputePartitionStats.Result.builder().statisticsFile(statisticsFile).build();
+  }
+
+  private String jobDesc() {
+    return String.format(
+        "Computing partition stats for %s (snapshot=%s)", table.name(), snapshot.snapshotId());
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.actions;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.ComputePartitionStats;
 import org.apache.iceberg.actions.ComputeTableStats;
 import org.apache.iceberg.actions.RemoveDanglingDeleteFiles;
 import org.apache.iceberg.spark.Spark3Util;
@@ -102,6 +103,11 @@ public class SparkActions implements ActionsProvider {
   @Override
   public ComputeTableStats computeTableStats(Table table) {
     return new ComputeTableStatsSparkAction(spark, table);
+  }
+
+  @Override
+  public ComputePartitionStats computePartitionStats(Table table) {
+    return new ComputePartitionStatsSparkAction(spark, table);
   }
 
   @Override

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputePartitionStatsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputePartitionStatsAction.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionStatisticsFile;
+import org.apache.iceberg.PartitionStats;
+import org.apache.iceberg.PartitionStatsHandler;
+import org.apache.iceberg.Partitioning;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.CatalogTestBase;
+import org.apache.iceberg.types.Types;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+
+public class TestComputePartitionStatsAction extends CatalogTestBase {
+
+  @TestTemplate
+  public void testEmptyTable() {
+    createPartitionTable();
+    Table table = validationCatalog.loadTable(tableIdent);
+    SparkActions actions = SparkActions.get();
+    ComputePartitionStatsSparkAction.Result result = actions.computePartitionStats(table).execute();
+    assertThat(result.statisticsFile()).isNull();
+  }
+
+  @TestTemplate
+  public void testEmptyBranch() {
+    createPartitionTable();
+    Table table = validationCatalog.loadTable(tableIdent);
+    table.manageSnapshots().createBranch("b1").commit();
+    SparkActions actions = SparkActions.get();
+    ComputePartitionStatsSparkAction.Result result =
+        actions
+            .computePartitionStats(table)
+            .snapshot(table.refs().get("b1").snapshotId())
+            .execute();
+    assertThat(result.statisticsFile()).isNull();
+  }
+
+  @TestTemplate
+  public void testInvalidSnapshot() {
+    createPartitionTable();
+    Table table = validationCatalog.loadTable(tableIdent);
+    SparkActions actions = SparkActions.get();
+    assertThatThrownBy(() -> actions.computePartitionStats(table).snapshot(42L).execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Snapshot not found: 42");
+  }
+
+  @TestTemplate
+  public void testPartitionStatsCompute() throws IOException {
+    createPartitionTable();
+    // foo, A -> 4 records,
+    // foo, B -> 2 records,
+    // bar, A -> 2 records,
+    // bar, B -> 1 record
+    sql(
+        "INSERT into %s values (0, 'foo', 'A'), (1, 'foo', 'A'), (2, 'foo', 'B'), (3, 'foo', 'B')",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snapshot1 = table.currentSnapshot();
+    sql("INSERT into %s values(4, 'bar', 'A'), (5, 'bar', 'A'), (6, 'bar', 'B')", tableName);
+    table.refresh();
+    Snapshot snapshot2 = table.currentSnapshot();
+    sql("INSERT into %s values(7, 'foo', 'A'), (8, 'foo', 'A')", tableName);
+    // snapshot3 is unused for partition stats as the same partition is modified by snapshot4
+
+    // delete one record of foo, A
+    spark.sql("DELETE FROM " + tableName + " WHERE c1=1").show(200, false);
+    table.refresh();
+    Snapshot snapshot4 = table.currentSnapshot();
+
+    assertThat(table.partitionStatisticsFiles()).isEmpty();
+
+    SparkActions actions = SparkActions.get();
+    PartitionStatisticsFile statisticsFile =
+        actions.computePartitionStats(table).execute().statisticsFile();
+    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+    assertThat(statisticsFile.snapshotId()).isEqualTo(snapshot4.snapshotId());
+    // check table metadata registration
+    assertThat(table.partitionStatisticsFiles()).containsExactly(statisticsFile);
+
+    Types.StructType partitionType = Partitioning.partitionType(table);
+    Schema dataSchema = PartitionStatsHandler.schema(partitionType);
+    validatePartitionStats(
+        statisticsFile,
+        dataSchema,
+        Tuple.tuple(
+            partitionRecord(partitionType, "foo", "A"),
+            0,
+            4L, // total 4 records for this partition
+            2,
+            datafileSize("foo", "A"),
+            1L, // position record from delete operation
+            1, // position delete file from delete operation
+            0L,
+            0,
+            null,
+            snapshot4.timestampMillis(), // last modified by snapshot4
+            snapshot4.snapshotId()),
+        Tuple.tuple(
+            partitionRecord(partitionType, "foo", "B"),
+            0,
+            2L,
+            1,
+            datafileSize("foo", "B"),
+            0L,
+            0,
+            0L,
+            0,
+            null,
+            snapshot1.timestampMillis(), // added by snapshot1
+            snapshot1.snapshotId()),
+        Tuple.tuple(
+            partitionRecord(partitionType, "bar", "A"),
+            0,
+            2L,
+            1,
+            datafileSize("bar", "A"),
+            0L,
+            0,
+            0L,
+            0,
+            null,
+            snapshot2.timestampMillis(), // added by snapshot2
+            snapshot2.snapshotId()),
+        Tuple.tuple(
+            partitionRecord(partitionType, "bar", "B"),
+            0,
+            1L,
+            1,
+            datafileSize("bar", "B"),
+            0L,
+            0,
+            0L,
+            0,
+            null,
+            snapshot2.timestampMillis(),
+            snapshot2.snapshotId()));
+  }
+
+  @TestTemplate
+  public void testPartitionStatsComputeOnSnapshot() throws IOException {
+    createPartitionTable();
+    // foo, A -> 2 records,
+    // foo, B -> 1 record,
+    // bar, A -> 2 records,
+    sql("INSERT into %s values (0, 'foo', 'A'), (1, 'foo', 'A'), (2, 'foo', 'B')", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snapshot1 = table.currentSnapshot();
+    sql("INSERT into %s values(3, 'bar', 'A'), (4, 'bar', 'A')", tableName);
+    table.refresh();
+
+    assertThat(table.partitionStatisticsFiles()).isEmpty();
+
+    SparkActions actions = SparkActions.get();
+    PartitionStatisticsFile statisticsFile =
+        actions
+            .computePartitionStats(table)
+            .snapshot(snapshot1.snapshotId())
+            .execute()
+            .statisticsFile();
+    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+    // should be mapped to snapshot1 instead of latest snapshot
+    assertThat(statisticsFile.snapshotId()).isEqualTo(snapshot1.snapshotId());
+    // check table metadata registration
+    assertThat(table.partitionStatisticsFiles()).containsExactly(statisticsFile);
+
+    Types.StructType partitionType = Partitioning.partitionType(table);
+    Schema dataSchema = PartitionStatsHandler.schema(partitionType);
+    // should contain stats for only partitions of snapshot1 (no entry for partition bar, A)
+    validatePartitionStats(
+        statisticsFile,
+        dataSchema,
+        Tuple.tuple(
+            partitionRecord(partitionType, "foo", "A"),
+            0,
+            2L,
+            1,
+            datafileSize("foo", "A"),
+            0L,
+            0,
+            0L,
+            0,
+            null,
+            snapshot1.timestampMillis(),
+            snapshot1.snapshotId()),
+        Tuple.tuple(
+            partitionRecord(partitionType, "foo", "B"),
+            0,
+            1L,
+            1,
+            datafileSize("foo", "B"),
+            0L,
+            0,
+            0L,
+            0,
+            null,
+            snapshot1.timestampMillis(),
+            snapshot1.snapshotId()));
+  }
+
+  private long datafileSize(String col1, String col2) {
+    return (long)
+        sql(
+                "SELECT sum(file_size_in_bytes) FROM %s.data_files WHERE partition.c2 = '%s' AND partition.c3 = '%s'",
+                tableName, col1, col2)
+            .get(0)[0];
+  }
+
+  private void createPartitionTable() {
+    sql(
+        "CREATE TABLE %s (c1 int, c2 string, c3 string) USING iceberg PARTITIONED BY (c2, c3) TBLPROPERTIES('write.delete.mode'='merge-on-read')",
+        tableName);
+  }
+
+  private static void validatePartitionStats(
+      PartitionStatisticsFile result, Schema recordSchema, Tuple... expectedValues)
+      throws IOException {
+    // read the partition entries from the stats file
+    List<PartitionStats> partitionStats;
+    try (CloseableIterable<PartitionStats> recordIterator =
+        PartitionStatsHandler.readPartitionStatsFile(
+            recordSchema, Files.localInput(result.path()))) {
+      partitionStats = Lists.newArrayList(recordIterator);
+    }
+
+    assertThat(partitionStats)
+        .extracting(
+            PartitionStats::partition,
+            PartitionStats::specId,
+            PartitionStats::dataRecordCount,
+            PartitionStats::dataFileCount,
+            PartitionStats::totalDataFileSizeInBytes,
+            PartitionStats::positionDeleteRecordCount,
+            PartitionStats::positionDeleteFileCount,
+            PartitionStats::equalityDeleteRecordCount,
+            PartitionStats::equalityDeleteFileCount,
+            PartitionStats::totalRecords,
+            PartitionStats::lastUpdatedAt,
+            PartitionStats::lastUpdatedSnapshotId)
+        .containsExactlyInAnyOrder(expectedValues);
+  }
+
+  private static StructLike partitionRecord(
+      Types.StructType partitionType, String val1, String val2) {
+    GenericRecord record = GenericRecord.create(partitionType);
+    record.set(0, val1);
+    record.set(1, val2);
+    return record;
+  }
+
+  @AfterEach
+  public void removeTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+}


### PR DESCRIPTION
This is a Spark wrapper for `PartitionStatsHandler.computeAndWriteStatsFile()`. This is a foundation for spark users to compute stats using just a SQL (call procedure). 

Even though Spark may not have plans to use it for CBO at the moment[1],
Partition stats can be useful for Spark users to
a) List all the partitions of the table without reading all the manifest file 
b) To figure out which partition is affected by the latest snapshot, so users can refresh their pipelines. 

[1] IMO, Spark CBO is not matured yet.
They don't have an interface to keep partition level statistics. Only exposed interface is to keep table level statistics as can be seen here
[https://github.com/apache/iceberg/blob/6c98a9e470d44f77e1939a1a333bf197a57949a6/sp[…]rk/src/main/java/org/apache/iceberg/spark/source/SparkScan.java](https://github.com/apache/iceberg/blob/6c98a9e470d44f77e1939a1a333bf197a57949a6/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java#L183)
In future, we may need to add interface in Spark and integrate that with Iceberg.