### PR TITLE
Avro: Add variant readers and writers

### DIFF
--- a/api/src/main/java/org/apache/iceberg/variants/Serialized.java
+++ b/api/src/main/java/org/apache/iceberg/variants/Serialized.java
@@ -20,6 +20,6 @@ package org.apache.iceberg.variants;
 
 import java.nio.ByteBuffer;
 
-interface Serialized {
+public interface Serialized {
   ByteBuffer buffer();
 }

--- a/api/src/main/java/org/apache/iceberg/variants/VariantMetadata.java
+++ b/api/src/main/java/org/apache/iceberg/variants/VariantMetadata.java
@@ -54,6 +54,10 @@ public interface VariantMetadata {
     return SerializedMetadata.from(buffer);
   }
 
+  static VariantMetadata empty() {
+    return SerializedMetadata.EMPTY_V1_METADATA;
+  }
+
   static String asString(VariantMetadata metadata) {
     StringBuilder builder = new StringBuilder();
 

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -89,6 +89,7 @@ public class Avro {
     LogicalTypes.register(VariantLogicalType.NAME, schema -> VariantLogicalType.get());
     DEFAULT_MODEL.addLogicalTypeConversion(new Conversions.DecimalConversion());
     DEFAULT_MODEL.addLogicalTypeConversion(new UUIDConversion());
+    DEFAULT_MODEL.addLogicalTypeConversion(new VariantConversion());
   }
 
   public static WriteBuilder write(OutputFile file) {

--- a/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
@@ -67,7 +67,7 @@ abstract class BaseWriteBuilder extends AvroSchemaVisitor<ValueWriter<?>> {
   @Override
   public ValueWriter<?> variant(
       Schema variant, ValueWriter<?> metadataResult, ValueWriter<?> valueResult) {
-    return ValueWriters.variants(metadataResult, valueResult);
+    return ValueWriters.variants();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
@@ -65,6 +65,12 @@ abstract class BaseWriteBuilder extends AvroSchemaVisitor<ValueWriter<?>> {
   }
 
   @Override
+  public ValueWriter<?> variant(
+      Schema variant, ValueWriter<?> metadataResult, ValueWriter<?> valueResult) {
+    return ValueWriters.variants(metadataResult, valueResult);
+  }
+
+  @Override
   public ValueWriter<?> primitive(Schema primitive) {
     LogicalType logicalType = primitive.getLogicalType();
     if (logicalType != null) {

--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
@@ -166,7 +166,7 @@ public class GenericAvroReader<T>
     @Override
     public ValueReader<?> variant(
         Type partner, ValueReader<?> metadataReader, ValueReader<?> valueReader) {
-      return ValueReaders.variants(metadataReader, valueReader);
+      return ValueReaders.variants();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
@@ -164,6 +164,12 @@ public class GenericAvroReader<T>
     }
 
     @Override
+    public ValueReader<?> variant(
+        Type partner, ValueReader<?> metadataReader, ValueReader<?> valueReader) {
+      return ValueReaders.variants(metadataReader, valueReader);
+    }
+
+    @Override
     public ValueReader<?> primitive(Type partner, Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -161,6 +161,12 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, S
     }
 
     @Override
+    public ValueReader<?> variant(
+        Pair<Integer, Type> partner, ValueReader<?> metadataReader, ValueReader<?> valueReader) {
+      return ValueReaders.variants(metadataReader, valueReader);
+    }
+
+    @Override
     public ValueReader<?> primitive(Pair<Integer, Type> partner, Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -163,7 +163,7 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, S
     @Override
     public ValueReader<?> variant(
         Pair<Integer, Type> partner, ValueReader<?> metadataReader, ValueReader<?> valueReader) {
-      return ValueReaders.variants(metadataReader, valueReader);
+      return ValueReaders.variants();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -667,7 +667,7 @@ public class ValueReaders {
     private final ValueReader<ByteBuffer> metadataReader;
     private final ValueReader<ByteBuffer> valueReader;
 
-    public VariantReader(
+    private VariantReader(
         ValueReader<ByteBuffer> metadataReader, ValueReader<ByteBuffer> valueReader) {
       this.metadataReader = metadataReader;
       this.valueReader = valueReader;

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -144,11 +144,8 @@ public class ValueReaders {
     }
   }
 
-  @SuppressWarnings("unchecked")
-  public static ValueReader<Variant> variants(
-      ValueReader<?> metadataReader, ValueReader<?> valueReader) {
-    return new VariantReader(
-        (ValueReader<ByteBuffer>) metadataReader, (ValueReader<ByteBuffer>) valueReader);
+  public static ValueReader<Variant> variants() {
+    return VariantReader.INSTANCE;
   }
 
   public static ValueReader<Object> union(List<ValueReader<?>> readers) {
@@ -664,13 +661,14 @@ public class ValueReaders {
   }
 
   private static class VariantReader implements ValueReader<Variant> {
+    private static final VariantReader INSTANCE = new VariantReader();
+
     private final ValueReader<ByteBuffer> metadataReader;
     private final ValueReader<ByteBuffer> valueReader;
 
-    private VariantReader(
-        ValueReader<ByteBuffer> metadataReader, ValueReader<ByteBuffer> valueReader) {
-      this.metadataReader = metadataReader;
-      this.valueReader = valueReader;
+    private VariantReader() {
+      this.metadataReader = ByteBufferReader.INSTANCE;
+      this.valueReader = ByteBufferReader.INSTANCE;
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -144,9 +144,11 @@ public class ValueReaders {
     }
   }
 
+  @SuppressWarnings("unchecked")
   public static ValueReader<Variant> variants(
-      ValueReader<ByteBuffer> metadataReader, ValueReader<ByteBuffer> valueReader) {
-    return new VariantReader(metadataReader, valueReader);
+      ValueReader<?> metadataReader, ValueReader<?> valueReader) {
+    return new VariantReader(
+        (ValueReader<ByteBuffer>) metadataReader, (ValueReader<ByteBuffer>) valueReader);
   }
 
   public static ValueReader<Object> union(List<ValueReader<?>> readers) {
@@ -673,8 +675,11 @@ public class ValueReaders {
 
     @Override
     public Variant read(Decoder decoder, Object reuse) throws IOException {
-      VariantMetadata metadata = VariantMetadata.from(metadataReader.read(decoder, null));
-      VariantValue value = VariantValue.from(metadata, metadataReader.read(decoder, null));
+      VariantMetadata metadata =
+          VariantMetadata.from(metadataReader.read(decoder, null).order(ByteOrder.LITTLE_ENDIAN));
+      VariantValue value =
+          VariantValue.from(
+              metadata, metadataReader.read(decoder, null).order(ByteOrder.LITTLE_ENDIAN));
       return Variant.of(metadata, value);
     }
 

--- a/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
@@ -33,6 +33,7 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.io.IOUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.DecimalUtil;
@@ -113,11 +114,8 @@ public class ValueWriters {
     return new DecimalWriter(precision, scale);
   }
 
-  @SuppressWarnings("unchecked")
-  public static ValueWriter<Variant> variants(
-      ValueWriter<?> metadataWriter, ValueWriter<?> valueWriter) {
-    return new VariantWriter(
-        (ValueWriter<ByteBuffer>) metadataWriter, (ValueWriter<ByteBuffer>) valueWriter);
+  public static ValueWriter<Variant> variants() {
+    return VariantWriter.INSTANCE;
   }
 
   public static <T> ValueWriter<T> option(int nullIndex, ValueWriter<T> writer) {
@@ -384,38 +382,79 @@ public class ValueWriters {
     }
   }
 
-  private static class VariantWriter implements ValueWriter<Variant> {
-    private final ValueWriter<ByteBuffer> metadataWriter;
-    private final ValueWriter<ByteBuffer> valueWriter;
+  private abstract static class VariantBinaryWriter<T> implements ValueWriter<T> {
+    private ByteBuffer reusedBuffer = ByteBuffer.allocate(2048).order(ByteOrder.LITTLE_ENDIAN);
 
-    private VariantWriter(
-        ValueWriter<ByteBuffer> metadataWriter, ValueWriter<ByteBuffer> valueWriter) {
-      this.metadataWriter = metadataWriter;
-      this.valueWriter = valueWriter;
+    protected abstract int sizeInBytes(T value);
+
+    protected abstract int writeTo(ByteBuffer buffer, int offset, T value);
+
+    @Override
+    public void write(T datum, Encoder encoder) throws IOException {
+      if (datum instanceof Serialized) {
+        encoder.writeBytes(((Serialized) datum).buffer());
+      } else {
+        encoder.writeBytes(serialize(datum));
+      }
+    }
+
+    private void ensureCapacity(int requiredSize) {
+      if (reusedBuffer.capacity() < requiredSize) {
+        int newCapacity = IOUtil.capacityFor(requiredSize);
+        this.reusedBuffer = ByteBuffer.allocate(newCapacity).order(ByteOrder.LITTLE_ENDIAN);
+      } else {
+        reusedBuffer.limit(requiredSize);
+      }
+    }
+
+    private ByteBuffer serialize(T value) {
+      ensureCapacity(sizeInBytes(value));
+      int size = writeTo(reusedBuffer, 0, value);
+      reusedBuffer.position(0);
+      reusedBuffer.limit(size);
+      return reusedBuffer;
+    }
+  }
+
+  private static class VariantMetadataWriter extends VariantBinaryWriter<VariantMetadata> {
+    @Override
+    protected int sizeInBytes(VariantMetadata metadata) {
+      return metadata.sizeInBytes();
+    }
+
+    @Override
+    protected int writeTo(ByteBuffer buffer, int offset, VariantMetadata metadata) {
+      return metadata.writeTo(buffer, offset);
+    }
+  }
+
+  private static class VariantValueWriter extends VariantBinaryWriter<VariantValue> {
+    @Override
+    protected int sizeInBytes(VariantValue value) {
+      return value.sizeInBytes();
+    }
+
+    @Override
+    protected int writeTo(ByteBuffer buffer, int offset, VariantValue value) {
+      return value.writeTo(buffer, offset);
+    }
+  }
+
+  private static class VariantWriter implements ValueWriter<Variant> {
+    private static final VariantWriter INSTANCE = new VariantWriter();
+
+    private final VariantMetadataWriter metadataWriter;
+    private final VariantValueWriter valueWriter;
+
+    private VariantWriter() {
+      this.metadataWriter = new VariantMetadataWriter();
+      this.valueWriter = new VariantValueWriter();
     }
 
     @Override
     public void write(Variant variant, Encoder encoder) throws IOException {
-      VariantMetadata metadata = variant.metadata();
-      if (metadata instanceof Serialized) {
-        metadataWriter.write(((Serialized) metadata).buffer(), encoder);
-      } else {
-        // TODO: reuse buffers using buffer size code from Parquet
-        ByteBuffer metadataBuffer =
-            ByteBuffer.allocate(metadata.sizeInBytes()).order(ByteOrder.LITTLE_ENDIAN);
-        variant.metadata().writeTo(metadataBuffer, 0);
-        metadataWriter.write(metadataBuffer, encoder);
-      }
-
-      VariantValue value = variant.value();
-      if (value instanceof Serialized) {
-        valueWriter.write(((Serialized) value).buffer(), encoder);
-      } else {
-        ByteBuffer valueBuffer =
-            ByteBuffer.allocate(variant.value().sizeInBytes()).order(ByteOrder.LITTLE_ENDIAN);
-        variant.value().writeTo(valueBuffer, 0);
-        valueWriter.write(valueBuffer, encoder);
-      }
+      metadataWriter.write(variant.metadata(), encoder);
+      valueWriter.write(variant.value(), encoder);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/VariantConversion.java
+++ b/core/src/main/java/org/apache/iceberg/avro/VariantConversion.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.avro;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.apache.avro.Conversion;
+import org.apache.avro.LogicalType;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantValue;
+
+public class VariantConversion extends Conversion<Variant> {
+  @Override
+  public Class<Variant> getConvertedType() {
+    return Variant.class;
+  }
+
+  @Override
+  public String getLogicalTypeName() {
+    return VariantLogicalType.NAME;
+  }
+
+  @Override
+  public Variant fromRecord(IndexedRecord record, Schema schema, LogicalType type) {
+    int metadataPos = schema.getField("metadata").pos();
+    int valuePos = schema.getField("value").pos();
+    VariantMetadata metadata = VariantMetadata.from((ByteBuffer) record.get(metadataPos));
+    VariantValue value = VariantValue.from(metadata, (ByteBuffer) record.get(valuePos));
+    return Variant.of(metadata, value);
+  }
+
+  @Override
+  public IndexedRecord toRecord(Variant variant, Schema schema, LogicalType type) {
+    int metadataPos = schema.getField("metadata").pos();
+    int valuePos = schema.getField("value").pos();
+    GenericRecord record = new GenericData.Record(schema);
+    ByteBuffer metadataBuffer =
+        ByteBuffer.allocate(variant.metadata().sizeInBytes()).order(ByteOrder.LITTLE_ENDIAN);
+    variant.metadata().writeTo(metadataBuffer, 0);
+    record.put(metadataPos, metadataBuffer);
+    ByteBuffer valueBuffer =
+        ByteBuffer.allocate(variant.value().sizeInBytes()).order(ByteOrder.LITTLE_ENDIAN);
+    variant.value().writeTo(valueBuffer, 0);
+    record.put(valuePos, valueBuffer);
+    return record;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
@@ -104,7 +104,7 @@ public class DataWriter<T> implements MetricsAwareDatumWriter<T> {
     @Override
     public ValueWriter<?> variant(
         Schema variant, ValueWriter<?> metadataResult, ValueWriter<?> valueResult) {
-      return ValueWriters.variants(metadataResult, valueResult);
+      return ValueWriters.variants();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
@@ -103,7 +103,7 @@ public class DataWriter<T> implements MetricsAwareDatumWriter<T> {
 
     @Override
     public ValueWriter<?> variant(
-        Schema variant, ValueWriter<?> metadataResult, ValueWriter<?> valueResult) {
+        Schema variant, ValueWriter<?> metadataWriter, ValueWriter<?> valueWriter) {
       return ValueWriters.variants();
     }
 

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
@@ -102,6 +102,12 @@ public class DataWriter<T> implements MetricsAwareDatumWriter<T> {
     }
 
     @Override
+    public ValueWriter<?> variant(
+        Schema variant, ValueWriter<?> metadataResult, ValueWriter<?> valueResult) {
+      return ValueWriters.variants(metadataResult, valueResult);
+    }
+
+    @Override
     public ValueWriter<?> primitive(Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {

--- a/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
@@ -128,7 +128,7 @@ public class PlannedDataReader<T> implements DatumReader<T>, SupportsRowPosition
     @Override
     public ValueReader<?> variant(
         Type partner, ValueReader<?> metadataReader, ValueReader<?> valueReader) {
-      return ValueReaders.variants(metadataReader, valueReader);
+      return ValueReaders.variants();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
@@ -126,6 +126,12 @@ public class PlannedDataReader<T> implements DatumReader<T>, SupportsRowPosition
     }
 
     @Override
+    public ValueReader<?> variant(
+        Type partner, ValueReader<?> metadataReader, ValueReader<?> valueReader) {
+      return ValueReaders.variants(metadataReader, valueReader);
+    }
+
+    @Override
     public ValueReader<?> primitive(Type partner, Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {

--- a/core/src/main/java/org/apache/iceberg/io/IOUtil.java
+++ b/core/src/main/java/org/apache/iceberg/io/IOUtil.java
@@ -90,7 +90,6 @@ public class IOUtil {
     return length - remaining;
   }
 
-
   private static final double LN2 = Math.log(2);
 
   /**

--- a/core/src/main/java/org/apache/iceberg/io/IOUtil.java
+++ b/core/src/main/java/org/apache/iceberg/io/IOUtil.java
@@ -89,4 +89,20 @@ public class IOUtil {
 
     return length - remaining;
   }
+
+
+  private static final double LN2 = Math.log(2);
+
+  /**
+   * Returns a capacity that is the next power of 2 larger than the size.
+   *
+   * @param size an object size
+   * @return a capacity that is larger than the size for reused buffers
+   */
+  public static int capacityFor(int size) {
+    // find the power of 2 size that fits the value
+    int nextPow2 = (int) Math.ceil(Math.log(size) / LN2);
+    // return a capacity that is 2 the next power of 2 size up to the max
+    return Math.min(1 << (nextPow2 + 1), Integer.MAX_VALUE - 1);
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/InternalTestHelpers.java
+++ b/core/src/test/java/org/apache/iceberg/InternalTestHelpers.java
@@ -93,6 +93,14 @@ public class InternalTestHelpers {
       case DECIMAL:
         assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
+      case VARIANT:
+        assertThat(expected).as("Expected should be a Variant").isInstanceOf(Variant.class);
+        assertThat(actual).as("Actual should be a Variant").isInstanceOf(Variant.class);
+        Variant expectedVariant = (Variant) expected;
+        Variant actualVariant = (Variant) actual;
+        VariantTestUtil.assertEqual(expectedVariant.metadata(), actualVariant.metadata());
+        VariantTestUtil.assertEqual(expectedVariant.value(), actualVariant.value());
+        break;
       case STRUCT:
         assertThat(expected).as("Expected should be a StructLike").isInstanceOf(StructLike.class);
         assertThat(actual).as("Actual should be a StructLike").isInstanceOf(StructLike.class);

--- a/core/src/test/java/org/apache/iceberg/InternalTestHelpers.java
+++ b/core/src/test/java/org/apache/iceberg/InternalTestHelpers.java
@@ -93,14 +93,6 @@ public class InternalTestHelpers {
       case DECIMAL:
         assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
-      case VARIANT:
-        assertThat(expected).as("Expected should be a Variant").isInstanceOf(Variant.class);
-        assertThat(actual).as("Actual should be a Variant").isInstanceOf(Variant.class);
-        Variant expectedVariant = (Variant) expected;
-        Variant actualVariant = (Variant) actual;
-        VariantTestUtil.assertEqual(expectedVariant.metadata(), actualVariant.metadata());
-        VariantTestUtil.assertEqual(expectedVariant.value(), actualVariant.value());
-        break;
       case STRUCT:
         assertThat(expected).as("Expected should be a StructLike").isInstanceOf(StructLike.class);
         assertThat(actual).as("Actual should be a StructLike").isInstanceOf(StructLike.class);

--- a/core/src/test/java/org/apache/iceberg/RandomInternalData.java
+++ b/core/src/test/java/org/apache/iceberg/RandomInternalData.java
@@ -88,6 +88,11 @@ public class RandomInternalData {
     }
 
     @Override
+    public Object variant(Types.VariantType variant) {
+      return RandomVariants.randomVariant(random);
+    }
+
+    @Override
     public Object primitive(Type.PrimitiveType primitive) {
       Object result = RandomUtil.generatePrimitive(primitive, random);
 

--- a/core/src/test/java/org/apache/iceberg/RandomVariants.java
+++ b/core/src/test/java/org/apache/iceberg/RandomVariants.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Random;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.RandomUtil;
+import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.ShreddedObject;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantTestUtil;
+import org.apache.iceberg.variants.VariantValue;
+import org.apache.iceberg.variants.Variants;
+
+public class RandomVariants {
+  private RandomVariants() {}
+
+  public static Variant randomVariant(Random random) {
+    PhysicalType type = randomType(random);
+    VariantMetadata metadata;
+    if (type == PhysicalType.OBJECT || type == PhysicalType.ARRAY) {
+      int numFields = random.nextInt(25) + 5; // at least 5 keys
+      List<String> randomNames = Lists.newArrayList();
+      for (int i = 0; i < numFields; i += 1) {
+        randomNames.add(RandomUtil.generateString(10, random));
+      }
+      metadata =
+          VariantMetadata.from(VariantTestUtil.createMetadata(randomNames, random.nextBoolean()));
+    } else {
+      metadata = VariantMetadata.empty();
+    }
+
+    return Variant.of(metadata, randomVariant(random, metadata, randomType(random)));
+  }
+
+  private static PhysicalType randomType(Random random) {
+    PhysicalType[] types = PhysicalType.values();
+    return types[random.nextInt(types.length)];
+  }
+
+  private static VariantValue randomVariant(
+      Random random, VariantMetadata metadata, PhysicalType type) {
+    switch (type) {
+      case NULL:
+        return Variants.ofNull();
+      case BOOLEAN_TRUE:
+        return Variants.of(true);
+      case BOOLEAN_FALSE:
+        return Variants.of(false);
+      case INT8:
+        return Variants.of(
+            type,
+            ((Integer) RandomUtil.generatePrimitive(Types.IntegerType.get(), random)).byteValue());
+      case INT16:
+        return Variants.of(
+            type,
+            ((Integer) RandomUtil.generatePrimitive(Types.IntegerType.get(), random)).shortValue());
+      case INT32:
+        return Variants.of(type, RandomUtil.generatePrimitive(Types.IntegerType.get(), random));
+      case INT64:
+        return Variants.of(type, RandomUtil.generatePrimitive(Types.LongType.get(), random));
+      case DOUBLE:
+        return Variants.of(type, RandomUtil.generatePrimitive(Types.DoubleType.get(), random));
+      case DECIMAL4:
+        return Variants.of(
+            type, RandomUtil.generatePrimitive(Types.DecimalType.of(9, random.nextInt(9)), random));
+      case DECIMAL8:
+        return Variants.of(
+            type,
+            RandomUtil.generatePrimitive(Types.DecimalType.of(18, random.nextInt(18)), random));
+      case DECIMAL16:
+        return Variants.of(
+            type,
+            RandomUtil.generatePrimitive(Types.DecimalType.of(38, random.nextInt(38)), random));
+      case DATE:
+        return Variants.of(type, RandomUtil.generatePrimitive(Types.DateType.get(), random));
+      case TIMESTAMPTZ:
+        return Variants.of(
+            type, RandomUtil.generatePrimitive(Types.TimestampType.withZone(), random));
+      case TIMESTAMPNTZ:
+        return Variants.of(
+            type, RandomUtil.generatePrimitive(Types.TimestampType.withoutZone(), random));
+      case FLOAT:
+        return Variants.of(type, RandomUtil.generatePrimitive(Types.FloatType.get(), random));
+      case BINARY:
+        byte[] randomBytes = (byte[]) RandomUtil.generatePrimitive(Types.BinaryType.get(), random);
+        return Variants.of(type, ByteBuffer.wrap(randomBytes));
+      case STRING:
+        return Variants.of(type, RandomUtil.generatePrimitive(Types.StringType.get(), random));
+      case ARRAY:
+        // for now, generate an object instead of an array
+      case OBJECT:
+        ShreddedObject object = Variants.object(metadata);
+        if (metadata.dictionarySize() > 0) {
+          int numFields = random.nextInt(10);
+          for (int i = 0; i < numFields; i += 1) {
+            String field = metadata.get(random.nextInt(metadata.dictionarySize()));
+            object.put(field, randomVariant(random, metadata, randomType(random)));
+          }
+        }
+
+        return object;
+    }
+
+    throw new UnsupportedOperationException("Unsupported variant type: " + type);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/avro/AvroTestHelpers.java
+++ b/core/src/test/java/org/apache/iceberg/avro/AvroTestHelpers.java
@@ -29,6 +29,8 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantTestUtil;
 
 class AvroTestHelpers {
 
@@ -134,6 +136,14 @@ class AvroTestHelpers {
       case BINARY:
       case DECIMAL:
         assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
+        break;
+      case VARIANT:
+        assertThat(expected).as("Expected should be a Variant").isInstanceOf(Variant.class);
+        assertThat(actual).as("Actual should be a Variant").isInstanceOf(Variant.class);
+        Variant expectedVariant = (Variant) expected;
+        Variant actualVariant = (Variant) actual;
+        VariantTestUtil.assertEqual(expectedVariant.metadata(), actualVariant.metadata());
+        VariantTestUtil.assertEqual(expectedVariant.value(), actualVariant.value());
         break;
       case STRUCT:
         assertThat(expected).as("Expected should be a Record").isInstanceOf(Record.class);

--- a/core/src/test/java/org/apache/iceberg/avro/RandomAvroData.java
+++ b/core/src/test/java/org/apache/iceberg/avro/RandomAvroData.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.util.Utf8;
+import org.apache.iceberg.RandomVariants;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
@@ -91,6 +92,11 @@ public class RandomAvroData {
     @Override
     public Object map(Types.MapType map, Supplier<Object> keyResult, Supplier<Object> valueResult) {
       return RandomUtil.generateMap(random, map, keyResult, valueResult);
+    }
+
+    @Override
+    public Object variant(Types.VariantType variant) {
+      return RandomVariants.randomVariant(random);
     }
 
     @Override

--- a/core/src/test/java/org/apache/iceberg/avro/TestGenericAvro.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestGenericAvro.java
@@ -40,6 +40,11 @@ public class TestGenericAvro extends DataTest {
   }
 
   @Override
+  protected boolean supportsVariant() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expected = RandomAvroData.generate(schema, 100, 0L);
 

--- a/core/src/test/java/org/apache/iceberg/avro/TestInternalAvro.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestInternalAvro.java
@@ -48,6 +48,11 @@ public class TestInternalAvro extends DataTest {
   }
 
   @Override
+  protected boolean supportsVariant() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expected = RandomInternalData.generate(schema, 100, 42L);
     writeAndValidate(schema, expected);

--- a/data/src/test/java/org/apache/iceberg/data/DataTestHelpers.java
+++ b/data/src/test/java/org/apache/iceberg/data/DataTestHelpers.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantTestUtil;
 
 public class DataTestHelpers {
   private DataTestHelpers() {}
@@ -93,6 +95,12 @@ public class DataTestHelpers {
         assertThat(actual)
             .as("Primitive value should be equal to expected for type " + type)
             .isEqualTo(expected);
+        break;
+      case VARIANT:
+        assertThat(expected).as("Expected should be a Variant").isInstanceOf(Variant.class);
+        assertThat(actual).as("Actual should be a Variant").isInstanceOf(Variant.class);
+        VariantTestUtil.assertEqual(((Variant) expected).metadata(), ((Variant) actual).metadata());
+        VariantTestUtil.assertEqual(((Variant) expected).value(), ((Variant) actual).value());
         break;
       case FIXED:
         assertThat(expected).as("Expected should be a byte[]").isInstanceOf(byte[].class);

--- a/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
@@ -35,6 +35,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
+import org.apache.iceberg.RandomVariants;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -228,6 +229,11 @@ public class RandomGenericData {
       }
 
       return result;
+    }
+
+    @Override
+    public Object variant(Types.VariantType variant) {
+      return RandomVariants.randomVariant(random);
     }
 
     @Override

--- a/data/src/test/java/org/apache/iceberg/data/avro/TestGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/avro/TestGenericData.java
@@ -98,4 +98,9 @@ public class TestGenericData extends DataTest {
   protected boolean supportsTimestampNanos() {
     return true;
   }
+
+  @Override
+  protected boolean supportsVariant() {
+    return true;
+  }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -19,18 +19,14 @@
 package org.apache.iceberg.parquet;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import org.apache.curator.shaded.com.google.common.collect.Maps;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.Pair;
-import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.io.InvalidRecordException;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
@@ -279,66 +275,5 @@ public class ParquetSchemaUtil {
         //    }
         //
         repeatedType.getName().equals(parentName + "_tuple");
-  }
-
-  private static Map<ColumnPath, Pair<Integer, String>> indexVariantFields(Type type) {
-    IndexVariantFields indexer = new IndexVariantFields();
-    TypeWithSchemaVisitor.visit(null, type, indexer);
-    return indexer.result();
-  }
-
-  private static class IndexVariantFields extends TypeWithSchemaVisitor<Void> {
-    private final Map<ColumnPath, Pair<Integer, String>> result = Maps.newHashMap();
-
-    Map<ColumnPath, Pair<Integer, String>> result() {
-      return result;
-    }
-
-    @Override
-    public Void variant(Types.VariantType iVariant, Void result) {
-      return super.variant(iVariant, result);
-    }
-
-    @Override
-    public ParquetVariantVisitor<Void> variantVisitor() {
-      return new VariantFieldIndexer();
-    }
-
-    private class VariantFieldIndexer extends ParquetVariantVisitor<Void> {
-      @Override
-      public Void array(GroupType array, Void valueResult, Void elementResult) {
-        return super.array(array, valueResult, elementResult);
-      }
-
-      @Override
-      public Void object(GroupType object, Void valueResult, List<Void> fieldResults) {
-        return super.object(object, valueResult, fieldResults);
-      }
-
-      @Override
-      public Void value(GroupType value, Void valueResult, Void typedResult) {
-        return super.value(value, valueResult, typedResult);
-      }
-
-      @Override
-      public Void primitive(PrimitiveType primitive) {
-        return super.primitive(primitive);
-      }
-
-      @Override
-      public Void serialized(PrimitiveType value) {
-        return super.serialized(value);
-      }
-
-      @Override
-      public Void metadata(PrimitiveType metadata) {
-        return super.metadata(metadata);
-      }
-
-      @Override
-      public Void variant(GroupType variant, Void metadataResult, Void valueResult) {
-        return super.variant(variant, metadataResult, valueResult);
-      }
-    }
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantWriters.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.iceberg.io.IOUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -157,7 +158,7 @@ class ParquetVariantWriters {
 
     private void ensureCapacity(int requiredSize) {
       if (reusedBuffer.capacity() < requiredSize) {
-        int newCapacity = capacityFor(requiredSize);
+        int newCapacity = IOUtil.capacityFor(requiredSize);
         this.reusedBuffer = ByteBuffer.allocate(newCapacity).order(ByteOrder.LITTLE_ENDIAN);
       } else {
         reusedBuffer.limit(requiredSize);
@@ -373,14 +374,5 @@ class ParquetVariantWriters {
   private static List<TripleWriter<?>> children(Iterable<ParquetValueWriter<?>> writers) {
     return ImmutableList.copyOf(
         Iterables.concat(Iterables.transform(writers, ParquetValueWriter::columns)));
-  }
-
-  private static final double LN2 = Math.log(2);
-
-  private static int capacityFor(int valueSize) {
-    // find the power of 2 size that fits the value
-    int nextPow2 = (int) Math.ceil(Math.log(valueSize) / LN2);
-    // return a capacity that is 2 the next power of 2 size up to the max
-    return Math.min(1 << (nextPow2 + 1), Integer.MAX_VALUE - 1);
   }
 }


### PR DESCRIPTION
This adds readers and writers for Variants in Avro. Avro generics, Iceberg generics, and the internal data model are supported.

Variant values are tested using `RandomVariants` to extend random data generation.