### PR TITLE
Parquet: Support unknown and timestamp(9) in generics and internal model

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
@@ -46,6 +46,20 @@ import org.apache.parquet.hadoop.ParquetWriter;
 import org.junit.jupiter.api.Test;
 
 public class TestGenericData extends DataTest {
+  @Override
+  protected boolean supportsDefaultValues() {
+    return true;
+  }
+
+  @Override
+  protected boolean supportsUnknown() {
+    return true;
+  }
+
+  @Override
+  protected boolean supportsTimestampNanos() {
+    return true;
+  }
 
   @Override
   protected void writeAndValidate(Schema schema) throws IOException {
@@ -105,11 +119,6 @@ public class TestGenericData extends DataTest {
         index += 1;
       }
     }
-  }
-
-  @Override
-  protected boolean supportsDefaultValues() {
-    return true;
   }
 
   @Test

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -79,54 +79,14 @@ abstract class BaseParquetReaders<T> {
   protected abstract ParquetValueReader<T> createStructReader(
       List<Type> types, List<ParquetValueReader<?>> fieldReaders, Types.StructType structType);
 
-  protected ParquetValueReader<?> fixedReader(ColumnDescriptor desc) {
-    return new GenericParquetReaders.FixedReader(desc);
-  }
+  protected abstract ParquetValueReader<?> fixedReader(ColumnDescriptor desc);
 
-  protected ParquetValueReader<?> dateReader(ColumnDescriptor desc) {
-    return new GenericParquetReaders.DateReader(desc);
-  }
+  protected abstract ParquetValueReader<?> dateReader(ColumnDescriptor desc);
 
-  protected ParquetValueReader<?> timeReader(ColumnDescriptor desc) {
-    LogicalTypeAnnotation time = desc.getPrimitiveType().getLogicalTypeAnnotation();
-    Preconditions.checkArgument(
-        time instanceof TimeLogicalTypeAnnotation, "Invalid time logical type: " + time);
+  protected abstract ParquetValueReader<?> timeReader(ColumnDescriptor desc);
 
-    LogicalTypeAnnotation.TimeUnit unit = ((TimeLogicalTypeAnnotation) time).getUnit();
-    switch (unit) {
-      case MICROS:
-        return new GenericParquetReaders.TimeReader(desc);
-      case MILLIS:
-        return new GenericParquetReaders.TimeMillisReader(desc);
-      default:
-        throw new UnsupportedOperationException("Unsupported unit for time: " + unit);
-    }
-  }
-
-  protected ParquetValueReader<?> timestampReader(ColumnDescriptor desc, boolean isAdjustedToUTC) {
-    if (desc.getPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
-      return new GenericParquetReaders.TimestampInt96Reader(desc);
-    }
-
-    LogicalTypeAnnotation timestamp = desc.getPrimitiveType().getLogicalTypeAnnotation();
-    Preconditions.checkArgument(
-        timestamp instanceof TimestampLogicalTypeAnnotation,
-        "Invalid timestamp logical type: " + timestamp);
-
-    LogicalTypeAnnotation.TimeUnit unit = ((TimestampLogicalTypeAnnotation) timestamp).getUnit();
-    switch (unit) {
-      case MICROS:
-        return isAdjustedToUTC
-            ? new GenericParquetReaders.TimestamptzReader(desc)
-            : new GenericParquetReaders.TimestampReader(desc);
-      case MILLIS:
-        return isAdjustedToUTC
-            ? new GenericParquetReaders.TimestamptzMillisReader(desc)
-            : new GenericParquetReaders.TimestampMillisReader(desc);
-      default:
-        throw new UnsupportedOperationException("Unsupported unit for timestamp: " + unit);
-    }
-  }
+  protected abstract ParquetValueReader<?> timestampReader(
+      ColumnDescriptor desc, boolean isAdjustedToUTC);
 
   protected Object convertConstant(org.apache.iceberg.types.Type type, Object value) {
     return value;
@@ -206,8 +166,7 @@ abstract class BaseParquetReaders<T> {
     @Override
     public Optional<ParquetValueReader<?>> visit(
         TimestampLogicalTypeAnnotation timestampLogicalType) {
-      return Optional.of(
-          timestampReader(desc, ((Types.TimestampType) expected).shouldAdjustToUTC()));
+      return Optional.of(timestampReader(desc, timestampLogicalType.isAdjustedToUTC()));
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
@@ -51,25 +51,14 @@ abstract class BaseParquetWriter<T> {
   protected abstract ParquetValueWriters.StructWriter<T> createStructWriter(
       List<ParquetValueWriter<?>> writers);
 
-  protected ParquetValueWriter<?> fixedWriter(ColumnDescriptor desc) {
-    return new GenericParquetWriter.FixedWriter(desc);
-  }
+  protected abstract ParquetValueWriter<?> fixedWriter(ColumnDescriptor desc);
 
-  protected ParquetValueWriter<?> dateWriter(ColumnDescriptor desc) {
-    return new GenericParquetWriter.DateWriter(desc);
-  }
+  protected abstract ParquetValueWriter<?> dateWriter(ColumnDescriptor desc);
 
-  protected ParquetValueWriter<?> timeWriter(ColumnDescriptor desc) {
-    return new GenericParquetWriter.TimeWriter(desc);
-  }
+  protected abstract ParquetValueWriter<?> timeWriter(ColumnDescriptor desc);
 
-  protected ParquetValueWriter<?> timestampWriter(ColumnDescriptor desc, boolean isAdjustedToUTC) {
-    if (isAdjustedToUTC) {
-      return new GenericParquetWriter.TimestamptzWriter(desc);
-    } else {
-      return new GenericParquetWriter.TimestampWriter(desc);
-    }
-  }
+  protected abstract ParquetValueWriter<?> timestampWriter(
+      ColumnDescriptor desc, boolean isAdjustedToUTC);
 
   private class WriteBuilder extends TypeWithSchemaVisitor<ParquetValueWriter<?>> {
     private final MessageType type;
@@ -244,8 +233,8 @@ abstract class BaseParquetWriter<T> {
     public Optional<ParquetValueWriter<?>> visit(
         LogicalTypeAnnotation.TimestampLogicalTypeAnnotation timestampType) {
       Preconditions.checkArgument(
-          LogicalTypeAnnotation.TimeUnit.MICROS.equals(timestampType.getUnit()),
-          "Cannot write timestamp in %s, only MICROS is supported",
+          !LogicalTypeAnnotation.TimeUnit.MILLIS.equals(timestampType.getUnit()),
+          "Cannot write timestamp in %s, only MICROS and NANOS are supported",
           timestampType.getUnit());
       return Optional.of(timestampWriter(desc, timestampType.isAdjustedToUTC()));
     }

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
@@ -35,9 +35,12 @@ import org.apache.iceberg.data.GenericDataUtil;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.parquet.ParquetValueReader;
 import org.apache.iceberg.parquet.ParquetValueReaders;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 
 public class GenericParquetReaders extends BaseParquetReaders<Record> {
@@ -63,6 +66,66 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
   }
 
   @Override
+  protected ParquetValueReader<?> fixedReader(ColumnDescriptor desc) {
+    return new GenericParquetReaders.FixedReader(desc);
+  }
+
+  @Override
+  protected ParquetValueReader<?> dateReader(ColumnDescriptor desc) {
+    return new GenericParquetReaders.DateReader(desc);
+  }
+
+  @Override
+  protected ParquetValueReader<?> timeReader(ColumnDescriptor desc) {
+    LogicalTypeAnnotation time = desc.getPrimitiveType().getLogicalTypeAnnotation();
+    Preconditions.checkArgument(
+        time instanceof LogicalTypeAnnotation.TimeLogicalTypeAnnotation,
+        "Invalid time logical type: " + time);
+
+    LogicalTypeAnnotation.TimeUnit unit =
+        ((LogicalTypeAnnotation.TimeLogicalTypeAnnotation) time).getUnit();
+    switch (unit) {
+      case MICROS:
+        return new GenericParquetReaders.TimeReader(desc);
+      case MILLIS:
+        return new GenericParquetReaders.TimeMillisReader(desc);
+      default:
+        throw new UnsupportedOperationException("Unsupported unit for time: " + unit);
+    }
+  }
+
+  @Override
+  protected ParquetValueReader<?> timestampReader(ColumnDescriptor desc, boolean isAdjustedToUTC) {
+    if (desc.getPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
+      return new GenericParquetReaders.TimestampInt96Reader(desc);
+    }
+
+    LogicalTypeAnnotation timestamp = desc.getPrimitiveType().getLogicalTypeAnnotation();
+    Preconditions.checkArgument(
+        timestamp instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation,
+        "Invalid timestamp logical type: " + timestamp);
+
+    LogicalTypeAnnotation.TimeUnit unit =
+        ((LogicalTypeAnnotation.TimestampLogicalTypeAnnotation) timestamp).getUnit();
+    switch (unit) {
+      case NANOS:
+        return isAdjustedToUTC
+            ? new GenericParquetReaders.TimestamptzReader(desc, ChronoUnit.NANOS)
+            : new GenericParquetReaders.TimestampReader(desc, ChronoUnit.NANOS);
+      case MICROS:
+        return isAdjustedToUTC
+            ? new GenericParquetReaders.TimestamptzReader(desc, ChronoUnit.MICROS)
+            : new GenericParquetReaders.TimestampReader(desc, ChronoUnit.MICROS);
+      case MILLIS:
+        return isAdjustedToUTC
+            ? new GenericParquetReaders.TimestamptzMillisReader(desc)
+            : new GenericParquetReaders.TimestampMillisReader(desc);
+      default:
+        throw new UnsupportedOperationException("Unsupported unit for timestamp: " + unit);
+    }
+  }
+
+  @Override
   protected Object convertConstant(org.apache.iceberg.types.Type type, Object value) {
     return GenericDataUtil.internalToGeneric(type, value);
   }
@@ -70,7 +133,7 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
   private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
   private static final LocalDate EPOCH_DAY = EPOCH.toLocalDate();
 
-  static class DateReader extends ParquetValueReaders.PrimitiveReader<LocalDate> {
+  private static class DateReader extends ParquetValueReaders.PrimitiveReader<LocalDate> {
     DateReader(ColumnDescriptor desc) {
       super(desc);
     }
@@ -81,18 +144,22 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
     }
   }
 
-  static class TimestampReader extends ParquetValueReaders.PrimitiveReader<LocalDateTime> {
-    TimestampReader(ColumnDescriptor desc) {
+  private static class TimestampReader extends ParquetValueReaders.PrimitiveReader<LocalDateTime> {
+    private final ChronoUnit unit;
+
+    TimestampReader(ColumnDescriptor desc, ChronoUnit unit) {
       super(desc);
+      this.unit = unit;
     }
 
     @Override
     public LocalDateTime read(LocalDateTime reuse) {
-      return EPOCH.plus(column.nextLong(), ChronoUnit.MICROS).toLocalDateTime();
+      return EPOCH.plus(column.nextLong(), unit).toLocalDateTime();
     }
   }
 
-  static class TimestampMillisReader extends ParquetValueReaders.PrimitiveReader<LocalDateTime> {
+  private static class TimestampMillisReader
+      extends ParquetValueReaders.PrimitiveReader<LocalDateTime> {
     TimestampMillisReader(ColumnDescriptor desc) {
       super(desc);
     }
@@ -103,7 +170,8 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
     }
   }
 
-  static class TimestampInt96Reader extends ParquetValueReaders.PrimitiveReader<OffsetDateTime> {
+  private static class TimestampInt96Reader
+      extends ParquetValueReaders.PrimitiveReader<OffsetDateTime> {
     private static final long UNIX_EPOCH_JULIAN = 2_440_588L;
 
     TimestampInt96Reader(ColumnDescriptor desc) {
@@ -123,18 +191,23 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
     }
   }
 
-  static class TimestamptzReader extends ParquetValueReaders.PrimitiveReader<OffsetDateTime> {
-    TimestamptzReader(ColumnDescriptor desc) {
+  private static class TimestamptzReader
+      extends ParquetValueReaders.PrimitiveReader<OffsetDateTime> {
+    private final ChronoUnit unit;
+
+    TimestamptzReader(ColumnDescriptor desc, ChronoUnit unit) {
       super(desc);
+      this.unit = unit;
     }
 
     @Override
     public OffsetDateTime read(OffsetDateTime reuse) {
-      return EPOCH.plus(column.nextLong(), ChronoUnit.MICROS);
+      return EPOCH.plus(column.nextLong(), unit);
     }
   }
 
-  static class TimestamptzMillisReader extends ParquetValueReaders.PrimitiveReader<OffsetDateTime> {
+  private static class TimestamptzMillisReader
+      extends ParquetValueReaders.PrimitiveReader<OffsetDateTime> {
     TimestamptzMillisReader(ColumnDescriptor desc) {
       super(desc);
     }
@@ -145,7 +218,7 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
     }
   }
 
-  static class TimeMillisReader extends ParquetValueReaders.PrimitiveReader<LocalTime> {
+  private static class TimeMillisReader extends ParquetValueReaders.PrimitiveReader<LocalTime> {
     TimeMillisReader(ColumnDescriptor desc) {
       super(desc);
     }
@@ -156,7 +229,7 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
     }
   }
 
-  static class TimeReader extends ParquetValueReaders.PrimitiveReader<LocalTime> {
+  private static class TimeReader extends ParquetValueReaders.PrimitiveReader<LocalTime> {
     TimeReader(ColumnDescriptor desc) {
       super(desc);
     }
@@ -167,7 +240,7 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
     }
   }
 
-  static class FixedReader extends ParquetValueReaders.PrimitiveReader<byte[]> {
+  private static class FixedReader extends ParquetValueReaders.PrimitiveReader<byte[]> {
     FixedReader(ColumnDescriptor desc) {
       super(desc);
     }

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
@@ -33,6 +33,8 @@ import org.apache.iceberg.parquet.ParquetValueWriters.StructWriter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 
 public class GenericParquetWriter extends BaseParquetWriter<Record> {
@@ -49,10 +51,41 @@ public class GenericParquetWriter extends BaseParquetWriter<Record> {
     return ParquetValueWriters.recordWriter(writers);
   }
 
+  @Override
+  protected ParquetValueWriter<?> fixedWriter(ColumnDescriptor desc) {
+    return new GenericParquetWriter.FixedWriter(desc);
+  }
+
+  @Override
+  protected ParquetValueWriter<?> dateWriter(ColumnDescriptor desc) {
+    return new GenericParquetWriter.DateWriter(desc);
+  }
+
+  @Override
+  protected ParquetValueWriter<?> timeWriter(ColumnDescriptor desc) {
+    return new GenericParquetWriter.TimeWriter(desc);
+  }
+
+  @Override
+  protected ParquetValueWriter<?> timestampWriter(ColumnDescriptor desc, boolean isAdjustedToUTC) {
+    LogicalTypeAnnotation timestamp = desc.getPrimitiveType().getLogicalTypeAnnotation();
+    Preconditions.checkArgument(
+        timestamp instanceof TimestampLogicalTypeAnnotation,
+        "Invalid timestamp logical type: " + timestamp);
+
+    LogicalTypeAnnotation.TimeUnit unit = ((TimestampLogicalTypeAnnotation) timestamp).getUnit();
+
+    if (isAdjustedToUTC) {
+      return new GenericParquetWriter.TimestamptzWriter(desc, fromParquet(unit));
+    } else {
+      return new GenericParquetWriter.TimestampWriter(desc, fromParquet(unit));
+    }
+  }
+
   private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
   private static final LocalDate EPOCH_DAY = EPOCH.toLocalDate();
 
-  static class DateWriter extends ParquetValueWriters.PrimitiveWriter<LocalDate> {
+  private static class DateWriter extends ParquetValueWriters.PrimitiveWriter<LocalDate> {
     DateWriter(ColumnDescriptor desc) {
       super(desc);
     }
@@ -63,7 +96,7 @@ public class GenericParquetWriter extends BaseParquetWriter<Record> {
     }
   }
 
-  static class TimeWriter extends ParquetValueWriters.PrimitiveWriter<LocalTime> {
+  private static class TimeWriter extends ParquetValueWriters.PrimitiveWriter<LocalTime> {
     TimeWriter(ColumnDescriptor desc) {
       super(desc);
     }
@@ -74,30 +107,36 @@ public class GenericParquetWriter extends BaseParquetWriter<Record> {
     }
   }
 
-  static class TimestampWriter extends ParquetValueWriters.PrimitiveWriter<LocalDateTime> {
-    TimestampWriter(ColumnDescriptor desc) {
+  private static class TimestampWriter extends ParquetValueWriters.PrimitiveWriter<LocalDateTime> {
+    private final ChronoUnit unit;
+
+    TimestampWriter(ColumnDescriptor desc, ChronoUnit unit) {
       super(desc);
+      this.unit = unit;
     }
 
     @Override
     public void write(int repetitionLevel, LocalDateTime value) {
-      column.writeLong(
-          repetitionLevel, ChronoUnit.MICROS.between(EPOCH, value.atOffset(ZoneOffset.UTC)));
+      column.writeLong(repetitionLevel, unit.between(EPOCH, value.atOffset(ZoneOffset.UTC)));
     }
   }
 
-  static class TimestamptzWriter extends ParquetValueWriters.PrimitiveWriter<OffsetDateTime> {
-    TimestamptzWriter(ColumnDescriptor desc) {
+  private static class TimestamptzWriter
+      extends ParquetValueWriters.PrimitiveWriter<OffsetDateTime> {
+    private final ChronoUnit unit;
+
+    TimestamptzWriter(ColumnDescriptor desc, ChronoUnit unit) {
       super(desc);
+      this.unit = unit;
     }
 
     @Override
     public void write(int repetitionLevel, OffsetDateTime value) {
-      column.writeLong(repetitionLevel, ChronoUnit.MICROS.between(EPOCH, value));
+      column.writeLong(repetitionLevel, unit.between(EPOCH, value));
     }
   }
 
-  static class FixedWriter extends ParquetValueWriters.PrimitiveWriter<byte[]> {
+  private static class FixedWriter extends ParquetValueWriters.PrimitiveWriter<byte[]> {
     private final int length;
 
     FixedWriter(ColumnDescriptor desc) {
@@ -113,6 +152,17 @@ public class GenericParquetWriter extends BaseParquetWriter<Record> {
           value.length,
           length);
       column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(value));
+    }
+  }
+
+  private static ChronoUnit fromParquet(LogicalTypeAnnotation.TimeUnit unit) {
+    switch (unit) {
+      case MICROS:
+        return ChronoUnit.MICROS;
+      case NANOS:
+        return ChronoUnit.NANOS;
+      default:
+        throw new UnsupportedOperationException("Unsupported unit for timestamp: " + unit);
     }
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -137,6 +137,7 @@ public class ParquetValueReaders {
       case MILLIS:
         return new TimestampMillisReader(desc);
       case MICROS:
+      case NANOS:
         return new UnboxedReader<>(desc);
     }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestInternalParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestInternalParquet.java
@@ -42,6 +42,16 @@ public class TestInternalParquet extends DataTest {
   }
 
   @Override
+  protected boolean supportsUnknown() {
+    return true;
+  }
+
+  @Override
+  protected boolean supportsTimestampNanos() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expected = RandomInternalData.generate(schema, 100, 1376L);
     writeAndValidate(schema, expected);


### PR DESCRIPTION
This adds Parquet readers and writers for unknown and nanosecond timestamp types. It supports Iceberg generics and the internal object model. Spark and Flink support will be added in following PRs.