### PR TITLE
Core: Use InternalData with avro for readers.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ManifestFile.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestFile.java
@@ -27,6 +27,8 @@ import org.apache.iceberg.types.Types;
 
 /** Represents a manifest file that can be scanned to find files in a table. */
 public interface ManifestFile {
+  int PARTITION_SUMMARIES_ELEMENT_ID = 508;
+
   Types.NestedField PATH =
       required(500, "manifest_path", Types.StringType.get(), "Location URI with FS scheme");
   Types.NestedField LENGTH =
@@ -83,7 +85,7 @@ public interface ManifestFile {
       optional(
           507,
           "partitions",
-          Types.ListType.ofRequired(508, PARTITION_SUMMARY_TYPE),
+          Types.ListType.ofRequired(PARTITION_SUMMARIES_ELEMENT_ID, PARTITION_SUMMARY_TYPE),
           "Summary for each partition");
   Types.NestedField KEY_METADATA =
       optional(519, "key_metadata", Types.BinaryType.get(), "Encryption key metadata blob");

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.BoundReference;
@@ -192,13 +191,11 @@ public class AllManifestsTable extends BaseMetadataTable {
     @Override
     public CloseableIterable<StructLike> rows() {
       try (CloseableIterable<ManifestFile> manifests =
-          Avro.read(io.newInputFile(manifestListLocation))
-              .rename("manifest_file", GenericManifestFile.class.getName())
-              .rename("partitions", GenericPartitionFieldSummary.class.getName())
-              .rename("r508", GenericPartitionFieldSummary.class.getName())
+          InternalData.read(FileFormat.AVRO, io.newInputFile(manifestListLocation))
+              .setRootType(GenericManifestFile.class)
+              .setCustomType(
+                  ManifestFile.PARTITION_SUMMARIES_ELEMENT_ID, GenericPartitionFieldSummary.class)
               .project(ManifestFile.schema())
-              .classLoader(GenericManifestFile.class.getClassLoader())
-              .reuseContainers(false)
               .build()) {
 
         CloseableIterable<StructLike> rowIterable =

--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -20,7 +20,6 @@ package org.apache.iceberg;
 
 import java.io.IOException;
 import java.util.List;
-import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
@@ -33,13 +32,11 @@ class ManifestLists {
 
   static List<ManifestFile> read(InputFile manifestList) {
     try (CloseableIterable<ManifestFile> files =
-        Avro.read(manifestList)
-            .rename("manifest_file", GenericManifestFile.class.getName())
-            .rename("partitions", GenericPartitionFieldSummary.class.getName())
-            .rename("r508", GenericPartitionFieldSummary.class.getName())
-            .classLoader(GenericManifestFile.class.getClassLoader())
+        InternalData.read(FileFormat.AVRO, manifestList)
+            .setRootType(GenericManifestFile.class)
+            .setCustomType(
+                ManifestFile.PARTITION_SUMMARIES_ELEMENT_ID, GenericPartitionFieldSummary.class)
             .project(ManifestFile.schema())
-            .reuseContainers(false)
             .build()) {
 
       return Lists.newLinkedList(files);


### PR DESCRIPTION
This PR expands the use of InternalData for metadata reads to `ManifestsLists` and `AllManifestsTable` and uses a common iterable that exposes access to file metadata like Avro previously supported.  Implements the new metadata read path for both Avro and Parquet.