### PR TITLE
Core, Spark 3.5: Apply Ignore Residuals to Delete Filtering

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -549,6 +549,16 @@ class DeleteFileIndex {
     private Iterable<CloseableIterable<ManifestEntry<DeleteFile>>> deleteManifestReaders() {
       Expression entryFilter = ignoreResiduals ? Expressions.alwaysTrue() : dataFilter;
 
+      LoadingCache<Integer, Expression> partExprCache =
+          specsById == null
+              ? null
+              : Caffeine.newBuilder()
+                  .build(
+                      specId -> {
+                        PartitionSpec spec = specsById.get(specId);
+                        return Projections.inclusive(spec, caseSensitive).project(dataFilter);
+                      });
+
       LoadingCache<Integer, ManifestEvaluator> evalCache =
           specsById == null
               ? null
@@ -557,9 +567,7 @@ class DeleteFileIndex {
                       specId -> {
                         PartitionSpec spec = specsById.get(specId);
                         return ManifestEvaluator.forPartitionFilter(
-                            Expressions.and(
-                                partitionFilter,
-                                Projections.inclusive(spec, caseSensitive).project(dataFilter)),
+                            Expressions.and(partitionFilter, partExprCache.get(specId)),
                             spec,
                             caseSensitive);
                       });
@@ -584,7 +592,12 @@ class DeleteFileIndex {
           manifest ->
               ManifestFiles.readDeleteManifest(manifest, io, specsById)
                   .filterRows(entryFilter)
-                  .filterPartitions(Expressions.and(partitionFilter, dataFilter))
+                  .filterPartitions(
+                      Expressions.and(
+                          partitionFilter,
+                          Projections.inclusive(
+                                  specsById.get(manifest.partitionSpecId()), caseSensitive)
+                              .project(dataFilter)))
                   .filterPartitions(partitionSet)
                   .caseSensitive(caseSensitive)
                   .scanMetrics(scanMetrics)

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -547,7 +547,7 @@ class DeleteFileIndex {
     }
 
     private Iterable<CloseableIterable<ManifestEntry<DeleteFile>>> deleteManifestReaders() {
-      Expression deleteFilter = ignoreResiduals ? Expressions.alwaysTrue() : dataFilter;
+      Expression entryFilter = ignoreResiduals ? Expressions.alwaysTrue() : dataFilter;
 
       LoadingCache<Integer, ManifestEvaluator> evalCache =
           specsById == null
@@ -559,7 +559,7 @@ class DeleteFileIndex {
                         return ManifestEvaluator.forPartitionFilter(
                             Expressions.and(
                                 partitionFilter,
-                                Projections.inclusive(spec, caseSensitive).project(deleteFilter)),
+                                Projections.inclusive(spec, caseSensitive).project(dataFilter)),
                             spec,
                             caseSensitive);
                       });
@@ -583,8 +583,8 @@ class DeleteFileIndex {
           matchingManifests,
           manifest ->
               ManifestFiles.readDeleteManifest(manifest, io, specsById)
-                  .filterRows(deleteFilter)
-                  .filterPartitions(partitionFilter)
+                  .filterRows(entryFilter)
+                  .filterPartitions(Expressions.and(partitionFilter, dataFilter))
                   .filterPartitions(partitionSet)
                   .caseSensitive(caseSensitive)
                   .scanMetrics(scanMetrics)

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -547,9 +547,7 @@ class DeleteFileIndex {
     }
 
     private Iterable<CloseableIterable<ManifestEntry<DeleteFile>>> deleteManifestReaders() {
-      if (ignoreResiduals) {
-        dataFilter = Expressions.alwaysTrue();
-      }
+      Expression deleteFilter = ignoreResiduals ? Expressions.alwaysTrue() : dataFilter;
 
       LoadingCache<Integer, ManifestEvaluator> evalCache =
           specsById == null
@@ -561,7 +559,7 @@ class DeleteFileIndex {
                         return ManifestEvaluator.forPartitionFilter(
                             Expressions.and(
                                 partitionFilter,
-                                Projections.inclusive(spec, caseSensitive).project(dataFilter)),
+                                Projections.inclusive(spec, caseSensitive).project(deleteFilter)),
                             spec,
                             caseSensitive);
                       });
@@ -585,7 +583,7 @@ class DeleteFileIndex {
           matchingManifests,
           manifest ->
               ManifestFiles.readDeleteManifest(manifest, io, specsById)
-                  .filterRows(dataFilter)
+                  .filterRows(deleteFilter)
                   .filterPartitions(partitionFilter)
                   .filterPartitions(partitionSet)
                   .caseSensitive(caseSensitive)

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -594,10 +594,7 @@ class DeleteFileIndex {
                   .filterRows(entryFilter)
                   .filterPartitions(
                       Expressions.and(
-                          partitionFilter,
-                          Projections.inclusive(
-                                  specsById.get(manifest.partitionSpecId()), caseSensitive)
-                              .project(dataFilter)))
+                          partitionFilter, partExprCache.get(manifest.partitionSpecId())))
                   .filterPartitions(partitionSet)
                   .caseSensitive(caseSensitive)
                   .scanMetrics(scanMetrics)

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -372,6 +372,7 @@ class DeleteFileIndex {
     private boolean caseSensitive = true;
     private ExecutorService executorService = null;
     private ScanMetrics scanMetrics = ScanMetrics.noop();
+    private boolean ignoreResiduals = false;
 
     Builder(FileIO io, Set<ManifestFile> deleteManifests) {
       this.io = io;
@@ -431,6 +432,11 @@ class DeleteFileIndex {
       return this;
     }
 
+    Builder ignoreResiduals() {
+      this.ignoreResiduals = true;
+      return this;
+    }
+
     private Iterable<DeleteFile> filterDeleteFiles() {
       return Iterables.filter(deleteFiles, file -> file.dataSequenceNumber() > minSequenceNumber);
     }
@@ -460,6 +466,10 @@ class DeleteFileIndex {
     }
 
     DeleteFileIndex build() {
+      if (ignoreResiduals) {
+        dataFilter = Expressions.alwaysTrue();
+      }
+
       Iterable<DeleteFile> files = deleteFiles != null ? filterDeleteFiles() : loadDeleteFiles();
 
       EqualityDeletes globalDeletes = new EqualityDeletes();

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -466,10 +466,6 @@ class DeleteFileIndex {
     }
 
     DeleteFileIndex build() {
-      if (ignoreResiduals) {
-        dataFilter = Expressions.alwaysTrue();
-      }
-
       Iterable<DeleteFile> files = deleteFiles != null ? filterDeleteFiles() : loadDeleteFiles();
 
       EqualityDeletes globalDeletes = new EqualityDeletes();
@@ -551,6 +547,10 @@ class DeleteFileIndex {
     }
 
     private Iterable<CloseableIterable<ManifestEntry<DeleteFile>>> deleteManifestReaders() {
+      if (ignoreResiduals) {
+        dataFilter = Expressions.alwaysTrue();
+      }
+
       LoadingCache<Integer, ManifestEvaluator> evalCache =
           specsById == null
               ? null

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -135,6 +135,7 @@ class ManifestGroup {
 
   ManifestGroup ignoreResiduals() {
     this.ignoreResiduals = true;
+    this.deleteIndexBuilder.ignoreResiduals();
     return this;
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -135,7 +135,7 @@ class ManifestGroup {
 
   ManifestGroup ignoreResiduals() {
     this.ignoreResiduals = true;
-    this.deleteIndexBuilder.ignoreResiduals();
+    deleteIndexBuilder.ignoreResiduals();
     return this;
   }
 

--- a/data/src/test/java/org/apache/iceberg/data/FileHelpers.java
+++ b/data/src/test/java/org/apache/iceberg/data/FileHelpers.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
@@ -133,9 +134,14 @@ public class FileHelpers {
 
   public static DataFile writeDataFile(Table table, OutputFile out, List<Record> rows)
       throws IOException {
+    return writeDataFile(table, out, rows, null);
+  }
+
+  public static DataFile writeDataFile(
+      Table table, OutputFile out, List<Record> rows, PartitionData partition) throws IOException {
     FileWriterFactory<Record> factory = GenericFileWriterFactory.builderFor(table).build();
 
-    DataWriter<Record> writer = factory.newDataWriter(encrypt(out), table.spec(), null);
+    DataWriter<Record> writer = factory.newDataWriter(encrypt(out), table.spec(), partition);
     try (Closeable toClose = writer) {
       writer.write(rows);
     }

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -171,6 +171,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
     testImplementation project(path: ':iceberg-hive-metastore')
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
+    testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
     testImplementation (project(path: ':iceberg-open-api', configuration: 'testFixturesRuntimeElements')) {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -194,7 +195,7 @@ public class TestCopyOnWriteDelete extends TestDelete {
     append(tableName, new Employee(1, "hr"), new Employee(2, "hr"), new Employee(3, "hr"));
 
     Table table = validationCatalog.loadTable(tableIdent);
-    OutputFile out = Files.localOutput(File.createTempFile("equality_delete",".parquet"));
+    OutputFile out = Files.localOutput(File.createTempFile("junit", null, temp.toFile()));
     Schema deleteSchema = table.schema().select("id");
     GenericRecord deleteRecord = GenericRecord.create(deleteSchema);
     DeleteFile eqDelete = FileHelpers.writeDeleteFile(
@@ -216,10 +217,8 @@ public class TestCopyOnWriteDelete extends TestDelete {
     sql("DELETE FROM %s WHERE id = 3", tableName);
 
     assertEquals(
-      "COW Delete should remove row with id 3",
-      ImmutableList.of(row(1, "hr")),
+      "COW Delete should remove row with id 3", ImmutableList.of(row(1, "hr")),
       sql("SELECT * FROM %s ORDER BY id, dep", tableName));
   }
-
 
 }

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -23,7 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -35,12 +38,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileGenerationUtil;
+import org.apache.iceberg.Files;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
@@ -177,4 +187,39 @@ public class TestCopyOnWriteDelete extends TestDelete {
         ImmutableList.of(row(1, "hardware"), row(1, "hr"), row(3, "hr")),
         sql("SELECT * FROM %s ORDER BY id, dep", selectTarget()));
   }
+
+  @TestTemplate
+  public void testEqualityDeletePreservation() throws NoSuchTableException, IOException {
+    createAndInitPartitionedTable();
+    append(tableName, new Employee(1, "hr"), new Employee(2, "hr"), new Employee(3, "hr"));
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    OutputFile out = Files.localOutput(File.createTempFile("equality_delete",".parquet"));
+    Schema deleteSchema = table.schema().select("id");
+    GenericRecord deleteRecord = GenericRecord.create(deleteSchema);
+    DeleteFile eqDelete = FileHelpers.writeDeleteFile(
+      table,
+      out,
+      TestHelpers.Row.of("hr"),
+      List.of(deleteRecord.copy("id", 2)),
+      deleteSchema);
+
+    table.newRowDelta().addDeletes(eqDelete).commit();
+
+    sql("REFRESH TABLE %s", tableName);
+
+    assertEquals(
+      "Equality delete should remove row with id 2",
+      ImmutableList.of(row(1, "hr"), row(3, "hr")),
+      sql("SELECT * FROM %s ORDER BY id, dep", tableName));
+
+    sql("DELETE FROM %s WHERE id = 3", tableName);
+
+    assertEquals(
+      "COW Delete should remove row with id 3",
+      ImmutableList.of(row(1, "hr")),
+      sql("SELECT * FROM %s ORDER BY id, dep", tableName));
+  }
+
+
 }


### PR DESCRIPTION
The original issue here is that a user noted that Equality deletes were essentially being ignored on COW operations. I tracked this down to the fact that the data filter being used during COW was essentially being used to remove Equality Deletes that don't fit the COW operation.

This shouldn't have been an issue because "ignoreResiduals" essentially tells ManifestGroups to throw out data file level filters when it gets applied *BUT* this doesn't get passed through to the DeleteFileIndex. _This means while the filter won't be used to ignore data files, it will be used to ignore delete files for those data files_.|

To fix this I add an interface to the DeleteFileIndex Builder to actually take in the arg for ignoringResiduals and pass that through from the Manifest Group. Then within the DeleteFileIndex we null out the data filter if ignoreResiduals is set much like in the ManifestGroup itself.