### PR TITLE
Docs: fix typo in rest-catalog-open-api.yaml.

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -4731,7 +4731,7 @@ components:
       value: "accounting%1Ftax"
 
     NamespaceAsPathVariable:
-      summary: A single part namespace, as represented in a path paremeter
+      summary: A single part namespace, as represented in a path parameter
       value: "accounting"
 
     NamespaceAlreadyExistsError:


### PR DESCRIPTION
Docs: fix typo in rest-catalog-open-api.yaml.