### PR TITLE
Spark: Use correct statistics file in SparkScan::estimateStatistics(Snapshot)

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.source;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.iceberg.BlobMetadata;
@@ -195,8 +196,10 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     if (readConf.reportColumnStats() && cboEnabled) {
       colStatsMap = Maps.newHashMap();
       List<StatisticsFile> files = table.statisticsFiles();
-      if (!files.isEmpty()) {
-        List<BlobMetadata> metadataList = (files.get(0)).blobMetadata();
+      Optional<StatisticsFile> file =
+          files.stream().filter(f -> f.snapshotId() == snapshot.snapshotId()).findFirst();
+      if (file.isPresent()) {
+        List<BlobMetadata> metadataList = file.get().blobMetadata();
 
         Map<Integer, List<BlobMetadata>> groupedByField =
             metadataList.stream()


### PR DESCRIPTION
This fixes a bug in `SparkScan::estimateStatistics(Snapshot)`.
`Table::statisticsFiles()` returns a `List<StatisticsFile>`. We need to get the `StatisticsFile` with the `snapshotId` of the `Snapshot` for use in estimating the statistics.
I modified an existing test so that it fails without the fix and passes with it.
