### PR TITLE
Parquet: Implement Variant metrics

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1172,6 +1172,11 @@ acceptedBreaks:
         \ java.util.function.Consumer<T>)"
       justification: "Removing deprecated code"
   "1.8.0":
+    org.apache.iceberg:iceberg-api:
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.Metrics"
+      new: "class org.apache.iceberg.Metrics"
+      justification: "Java serialization across versions is not guaranteed"
     org.apache.iceberg:iceberg-core:
     - code: "java.method.removed"
       old: "method java.lang.String[] org.apache.iceberg.hadoop.Util::blockLocations(org.apache.iceberg.CombinedScanTask,\

--- a/api/src/main/java/org/apache/iceberg/Metrics.java
+++ b/api/src/main/java/org/apache/iceberg/Metrics.java
@@ -40,6 +40,10 @@ public class Metrics implements Serializable {
 
   public Metrics() {}
 
+  public Metrics(long rowCount) {
+    this.rowCount = rowCount;
+  }
+
   public Metrics(
       Long rowCount,
       Map<Integer, Long> columnSizes,

--- a/api/src/main/java/org/apache/iceberg/util/BinaryUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BinaryUtil.java
@@ -77,13 +77,29 @@ public class BinaryUtil {
   }
 
   /**
+   * Returns a byte buffer whose length is lesser than or equal to truncateLength and is lower than
+   * the given input
+   */
+  public static ByteBuffer truncateBinaryMin(ByteBuffer input, int length) {
+    return truncateBinary(input, length);
+  }
+
+  /**
    * Returns a byte buffer whose length is lesser than or equal to truncateLength and is greater
    * than the given input
    */
   public static Literal<ByteBuffer> truncateBinaryMax(Literal<ByteBuffer> input, int length) {
-    ByteBuffer inputBuffer = input.value();
+    ByteBuffer truncated = truncateBinaryMax(input.value(), length);
+    return truncated != null ? Literal.of(truncated) : null;
+  }
+
+  /**
+   * Returns a byte buffer whose length is lesser than or equal to truncateLength and is greater
+   * than the given input
+   */
+  public static ByteBuffer truncateBinaryMax(ByteBuffer inputBuffer, int length) {
     if (length >= inputBuffer.remaining()) {
-      return input;
+      return inputBuffer;
     }
 
     // Truncate the input to the specified truncate length.
@@ -99,7 +115,7 @@ public class BinaryUtil {
         // Return a byte buffer whose position is zero and limit is i + 1
         truncatedInput.position(0);
         truncatedInput.limit(i + 1);
-        return Literal.of(truncatedInput);
+        return truncatedInput;
       }
     }
     return null; // Cannot find a valid upper bound

--- a/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
@@ -65,8 +65,8 @@ public class UnicodeUtil {
   }
 
   /**
-   * Returns a valid String that is lower than the given input such that the number of
-   * unicode characters in the truncated String is lesser than or equal to length
+   * Returns a valid String that is lower than the given input such that the number of unicode
+   * characters in the truncated String is lesser than or equal to length
    */
   public static String truncateStringMin(String input, int length) {
     return truncateString(input, length).toString();
@@ -82,8 +82,8 @@ public class UnicodeUtil {
   }
 
   /**
-   * Returns a valid String that is greater than the given input such that the number
-   * of unicode characters in the truncated String is lesser than or equal to length
+   * Returns a valid String that is greater than the given input such that the number of unicode
+   * characters in the truncated String is lesser than or equal to length
    */
   public static String truncateStringMax(String input, int length) {
     CharSequence truncated = internalTruncateMax(input, length);

--- a/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
@@ -65,17 +65,38 @@ public class UnicodeUtil {
   }
 
   /**
+   * Returns a valid String that is lower than the given input such that the number of
+   * unicode characters in the truncated String is lesser than or equal to length
+   */
+  public static String truncateStringMin(String input, int length) {
+    return truncateString(input, length).toString();
+  }
+
+  /**
    * Returns a valid unicode charsequence that is greater than the given input such that the number
    * of unicode characters in the truncated charSequence is lesser than or equal to length
    */
   public static Literal<CharSequence> truncateStringMax(Literal<CharSequence> input, int length) {
-    CharSequence inputCharSeq = input.value();
+    CharSequence truncated = internalTruncateMax(input.value(), length);
+    return truncated != null ? Literal.of(truncated) : null;
+  }
+
+  /**
+   * Returns a valid String that is greater than the given input such that the number
+   * of unicode characters in the truncated String is lesser than or equal to length
+   */
+  public static String truncateStringMax(String input, int length) {
+    CharSequence truncated = internalTruncateMax(input, length);
+    return truncated != null ? truncated.toString() : null;
+  }
+
+  private static CharSequence internalTruncateMax(CharSequence inputCharSeq, int length) {
     // Truncate the input to the specified truncate length.
     StringBuilder truncatedStringBuilder = new StringBuilder(truncateString(inputCharSeq, length));
 
     // No need to increment if the input length is under the truncate length
     if (inputCharSeq.length() == truncatedStringBuilder.length()) {
-      return input;
+      return inputCharSeq;
     }
 
     // Try incrementing the code points from the end
@@ -88,7 +109,7 @@ public class UnicodeUtil {
         truncatedStringBuilder.setLength(offsetByCodePoint);
         // Append next code point to the truncated substring
         truncatedStringBuilder.appendCodePoint(nextCodePoint);
-        return Literal.of(truncatedStringBuilder.toString());
+        return truncatedStringBuilder.toString();
       }
     }
     return null; // Cannot find a valid upper bound

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedObject.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedObject.java
@@ -224,6 +224,16 @@ class SerializedObject implements VariantObject, SerializedValue {
   }
 
   @Override
+  public int hashCode() {
+    return VariantObject.hash(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return VariantObject.equals(this, obj);
+  }
+
+  @Override
   public String toString() {
     return VariantObject.asString(this);
   }

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedPrimitive.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedPrimitive.java
@@ -129,6 +129,16 @@ class SerializedPrimitive implements VariantPrimitive<Object>, SerializedValue {
   }
 
   @Override
+  public int hashCode() {
+    return VariantPrimitive.hash(this);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return VariantPrimitive.equals(this, other);
+  }
+
+  @Override
   public String toString() {
     return VariantPrimitive.asString(this);
   }

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedShortString.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedShortString.java
@@ -68,6 +68,16 @@ class SerializedShortString implements VariantPrimitive<String>, SerializedValue
   }
 
   @Override
+  public int hashCode() {
+    return VariantPrimitive.hash(this);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return VariantPrimitive.equals(this, other);
+  }
+
+  @Override
   public String toString() {
     return VariantPrimitive.asString(this);
   }

--- a/api/src/main/java/org/apache/iceberg/variants/VariantObject.java
+++ b/api/src/main/java/org/apache/iceberg/variants/VariantObject.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.variants;
 
+import java.util.Objects;
+
 /** An variant object value. */
 public interface VariantObject extends VariantValue {
   /** Returns the {@link VariantValue} for the field named {@code name} in this object. */
@@ -56,5 +58,38 @@ public interface VariantObject extends VariantValue {
     builder.append("})");
 
     return builder.toString();
+  }
+
+  static int hash(VariantObject self) {
+    int hash = 17;
+    for (String field : self.fieldNames()) {
+      hash = 59 * hash + field.hashCode();
+      hash = 59 * hash + self.get(field).hashCode();
+    }
+
+    return hash;
+  }
+
+  static boolean equals(VariantObject self, Object obj) {
+    if (self == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof VariantObject)) {
+      return false;
+    }
+
+    VariantObject other = (VariantObject) obj;
+    if (self.numFields() != other.numFields()) {
+      return false;
+    }
+
+    for (String field : self.fieldNames()) {
+      if (!Objects.equals(self.get(field), other.get(field))) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/api/src/main/java/org/apache/iceberg/variants/VariantPrimitive.java
+++ b/api/src/main/java/org/apache/iceberg/variants/VariantPrimitive.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.variants;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.DateTimeUtil;
@@ -49,5 +50,22 @@ public interface VariantPrimitive<T> extends VariantValue {
 
   static String asString(VariantPrimitive<?> primitive) {
     return "Variant(type=" + primitive.type() + ", value=" + primitive.valueAsString() + ")";
+  }
+
+  static int hash(VariantPrimitive<?> self) {
+    return Objects.hash(self.type(), self.get());
+  }
+
+  static boolean equals(VariantPrimitive<?> self, Object obj) {
+    if (self == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof VariantPrimitive)) {
+      return false;
+    }
+
+    VariantPrimitive<?> other = (VariantPrimitive<?>) obj;
+    return Objects.equals(self.type(), other.type()) && Objects.equals(self.get(), other.get());
   }
 }

--- a/api/src/main/java/org/apache/iceberg/variants/VariantUtil.java
+++ b/api/src/main/java/org/apache/iceberg/variants/VariantUtil.java
@@ -164,6 +164,10 @@ class VariantUtil {
     }
   }
 
+  static byte metadataHeader(boolean isSorted, int offsetSize) {
+    return (byte) (((offsetSize - 1) << 6) | (isSorted ? 0b10000 : 0) | 0b0001);
+  }
+
   static byte primitiveHeader(int primitiveType) {
     return (byte) (primitiveType << Primitives.PRIMITIVE_TYPE_SHIFT);
   }

--- a/core/src/main/java/org/apache/iceberg/FieldMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/FieldMetrics.java
@@ -27,6 +27,18 @@ public class FieldMetrics<T> {
   private final T lowerBound;
   private final T upperBound;
 
+  public FieldMetrics(int id, long valueCount, long nullValueCount) {
+    this(id, valueCount, nullValueCount, -1L, null, null);
+  }
+
+  public FieldMetrics(int id, long valueCount, long nullValueCount, T lowerBound, T upperBound) {
+    this(id, valueCount, nullValueCount, -1L, lowerBound, upperBound);
+  }
+
+  public FieldMetrics(int id, long valueCount, long nullValueCount, long nanValueCount) {
+    this(id, valueCount, nullValueCount, nanValueCount, null, null);
+  }
+
   public FieldMetrics(
       int id,
       long valueCount,

--- a/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
@@ -210,6 +210,16 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
   }
 
   @Override
+  public int hashCode() {
+    return VariantPrimitive.hash(this);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return VariantPrimitive.equals(this, other);
+  }
+
+  @Override
   public String toString() {
     return VariantPrimitive.asString(this);
   }

--- a/core/src/main/java/org/apache/iceberg/variants/Variants.java
+++ b/core/src/main/java/org/apache/iceberg/variants/Variants.java
@@ -20,6 +20,9 @@ package org.apache.iceberg.variants;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import org.apache.iceberg.util.DateTimeUtil;
 
 public class Variants {
@@ -31,6 +34,62 @@ public class Variants {
 
   public static VariantMetadata metadata(ByteBuffer metadata) {
     return SerializedMetadata.from(metadata);
+  }
+
+  public static VariantMetadata metadata(Collection<String> fieldNames) {
+    if (fieldNames.isEmpty()) {
+      return emptyMetadata();
+    }
+
+    int numElements = fieldNames.size();
+    ByteBuffer[] nameBuffers = new ByteBuffer[numElements];
+    boolean sorted = true;
+    String last = null;
+    int i = 0;
+    for (String name : fieldNames) {
+      nameBuffers[i] = ByteBuffer.wrap(name.getBytes(StandardCharsets.UTF_8));
+      if (last != null && last.compareTo(name) >= 0) {
+        sorted = false;
+      }
+
+      last = name;
+      i += 1;
+    }
+
+    int dataSize = 0;
+    for (ByteBuffer nameBuffer : nameBuffers) {
+      dataSize += nameBuffer.remaining();
+    }
+
+    int offsetSize = VariantUtil.sizeOf(dataSize);
+    int offsetListOffset = 1 /* header size */ + offsetSize /* dictionary size */;
+    int dataOffset = offsetListOffset + ((1 + numElements) * offsetSize);
+    int totalSize = dataOffset + dataSize;
+
+    byte header = VariantUtil.metadataHeader(sorted, offsetSize);
+    ByteBuffer buffer = ByteBuffer.allocate(totalSize).order(ByteOrder.LITTLE_ENDIAN);
+
+    buffer.put(0, header);
+    VariantUtil.writeLittleEndianUnsigned(buffer, numElements, 1, offsetSize);
+
+    // write offsets and strings
+    int nextOffset = 0;
+    int index = 0;
+    for (ByteBuffer nameBuffer : nameBuffers) {
+      // write the offset and the string
+      VariantUtil.writeLittleEndianUnsigned(
+          buffer, nextOffset, offsetListOffset + (index * offsetSize), offsetSize);
+      int nameSize = VariantUtil.writeBufferAbsolute(buffer, dataOffset + nextOffset, nameBuffer);
+      // update the offset and index
+      nextOffset += nameSize;
+      index += 1;
+    }
+
+    // write the final size of the data section
+    VariantUtil.writeLittleEndianUnsigned(
+        buffer, nextOffset, offsetListOffset + (index * offsetSize), offsetSize);
+
+    return SerializedMetadata.from(buffer);
   }
 
   public static VariantValue value(VariantMetadata metadata, ByteBuffer value) {
@@ -53,6 +112,10 @@ public class Variants {
     }
 
     throw new UnsupportedOperationException("Metadata is required for object: " + object);
+  }
+
+  public static boolean isNull(ByteBuffer valueBuffer) {
+    return VariantUtil.readByte(valueBuffer, 0) == 0;
   }
 
   public static <T> VariantPrimitive<T> of(PhysicalType type, T value) {

--- a/core/src/main/java/org/apache/iceberg/variants/Variants.java
+++ b/core/src/main/java/org/apache/iceberg/variants/Variants.java
@@ -45,15 +45,15 @@ public class Variants {
     ByteBuffer[] nameBuffers = new ByteBuffer[numElements];
     boolean sorted = true;
     String last = null;
-    int i = 0;
+    int pos = 0;
     for (String name : fieldNames) {
-      nameBuffers[i] = ByteBuffer.wrap(name.getBytes(StandardCharsets.UTF_8));
+      nameBuffers[pos] = ByteBuffer.wrap(name.getBytes(StandardCharsets.UTF_8));
       if (last != null && last.compareTo(name) >= 0) {
         sorted = false;
       }
 
       last = name;
-      i += 1;
+      pos += 1;
     }
 
     int dataSize = 0;

--- a/core/src/main/java/org/apache/iceberg/variants/Variants.java
+++ b/core/src/main/java/org/apache/iceberg/variants/Variants.java
@@ -51,19 +51,16 @@ public class Variants {
     boolean sorted = true;
     String last = null;
     int pos = 0;
+    int dataSize = 0;
     for (String name : fieldNames) {
       nameBuffers[pos] = ByteBuffer.wrap(name.getBytes(StandardCharsets.UTF_8));
+      dataSize += nameBuffers[pos].remaining();
       if (last != null && last.compareTo(name) >= 0) {
         sorted = false;
       }
 
       last = name;
       pos += 1;
-    }
-
-    int dataSize = 0;
-    for (ByteBuffer nameBuffer : nameBuffers) {
-      dataSize += nameBuffer.remaining();
     }
 
     int offsetSize = VariantUtil.sizeOf(dataSize);

--- a/core/src/main/java/org/apache/iceberg/variants/Variants.java
+++ b/core/src/main/java/org/apache/iceberg/variants/Variants.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collection;
 import org.apache.iceberg.util.DateTimeUtil;
 
@@ -34,6 +35,10 @@ public class Variants {
 
   public static VariantMetadata metadata(ByteBuffer metadata) {
     return SerializedMetadata.from(metadata);
+  }
+
+  public static VariantMetadata metadata(String... fieldNames) {
+    return metadata(Arrays.asList(fieldNames));
   }
 
   public static VariantMetadata metadata(Collection<String> fieldNames) {

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -355,17 +355,10 @@ public abstract class TestMetrics {
 
     Metrics metrics = getMetrics(schema, record);
     assertThat(metrics.recordCount()).isEqualTo(1L);
-    if (fileFormat() != FileFormat.ORC) {
-      assertCounts(1, 1L, 0L, metrics);
-      assertCounts(2, 1L, 0L, metrics);
-      assertCounts(4, 3L, 0L, metrics);
-      assertCounts(6, 1L, 0L, metrics);
-    } else {
-      assertCounts(1, null, null, metrics);
-      assertCounts(2, null, null, metrics);
-      assertCounts(4, null, null, metrics);
-      assertCounts(6, null, null, metrics);
-    }
+    assertCounts(1, null, null, metrics);
+    assertCounts(2, null, null, metrics);
+    assertCounts(4, null, null, metrics);
+    assertCounts(6, null, null, metrics);
     assertBounds(1, IntegerType.get(), null, null, metrics);
     assertBounds(2, StringType.get(), null, null, metrics);
     assertBounds(4, IntegerType.get(), null, null, metrics);

--- a/data/src/test/java/org/apache/iceberg/TestMergingMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/TestMergingMetrics.java
@@ -25,14 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
@@ -91,8 +87,7 @@ public abstract class TestMergingMetrics<T> {
               optional(27, "timestamp", Types.TimestampType.withZone())));
 
   private static final Map<Types.NestedField, Integer> FIELDS_WITH_NAN_COUNT_TO_ID =
-      ImmutableMap.of(
-          FLOAT_FIELD, 3, DOUBLE_FIELD, 4, FLOAT_LIST, 10, MAP_FIELD_1, 18, MAP_FIELD_2, 22);
+      ImmutableMap.of(FLOAT_FIELD, 3, DOUBLE_FIELD, 4);
 
   // create a schema with all supported fields
   protected static final Schema SCHEMA =
@@ -142,23 +137,15 @@ public abstract class TestMergingMetrics<T> {
     Map<Integer, ByteBuffer> upperBounds = metrics.upperBounds();
     Map<Integer, ByteBuffer> lowerBounds = metrics.lowerBounds();
 
+    assertThat(nanValueCount.size()).isEqualTo(2);
     assertNaNCountMatch(1L, nanValueCount, FLOAT_FIELD);
     assertNaNCountMatch(1L, nanValueCount, DOUBLE_FIELD);
-    assertNaNCountMatch(2L, nanValueCount, FLOAT_LIST);
-    assertNaNCountMatch(1L, nanValueCount, MAP_FIELD_1);
-    assertNaNCountMatch(3L, nanValueCount, MAP_FIELD_2);
 
-    assertBoundValueMatch(null, upperBounds, FLOAT_FIELD);
-    assertBoundValueMatch(null, upperBounds, DOUBLE_FIELD);
-    assertBoundValueMatch(3.3F, upperBounds, FLOAT_LIST);
-    assertBoundValueMatch(0F, upperBounds, MAP_FIELD_1);
-    assertBoundValueMatch(2D, upperBounds, MAP_FIELD_2);
+    assertThat(upperBounds.size()).isEqualTo(1);
+    assertBoundValueMatch(3, upperBounds, ID_FIELD);
 
-    assertBoundValueMatch(null, lowerBounds, FLOAT_FIELD);
-    assertBoundValueMatch(null, lowerBounds, DOUBLE_FIELD);
-    assertBoundValueMatch(-25.1F, lowerBounds, FLOAT_LIST);
-    assertBoundValueMatch(0F, lowerBounds, MAP_FIELD_1);
-    assertBoundValueMatch(0D, lowerBounds, MAP_FIELD_2);
+    assertThat(lowerBounds.size()).isEqualTo(1);
+    assertBoundValueMatch(3, lowerBounds, ID_FIELD);
   }
 
   @TestTemplate
@@ -196,19 +183,13 @@ public abstract class TestMergingMetrics<T> {
       Long expected, Map<Integer, Long> nanValueCount, Types.NestedField field) {
     assertThat(nanValueCount)
         .as(String.format("NaN count for field %s does not match expected", field.name()))
-        .containsEntry(FIELDS_WITH_NAN_COUNT_TO_ID.get(field), expected);
+        .containsEntry(field.fieldId(), expected);
   }
 
   private void assertBoundValueMatch(
       Number expected, Map<Integer, ByteBuffer> boundMap, Types.NestedField field) {
-    if (field.type().isNestedType() && fileFormat == FileFormat.ORC) {
-      // we don't update floating column bounds values within ORC nested columns
-      return;
-    }
-
-    int actualFieldId = FIELDS_WITH_NAN_COUNT_TO_ID.get(field);
-    ByteBuffer byteBuffer = boundMap.get(actualFieldId);
-    Type type = SCHEMA.findType(actualFieldId);
+    ByteBuffer byteBuffer = boundMap.get(field.fieldId());
+    Type type = SCHEMA.findType(field.fieldId());
     assertThat(byteBuffer == null ? null : Conversions.<T>fromByteBuffer(type, byteBuffer))
         .as(String.format("Bound value for field %s must match", field.name()))
         .isEqualTo(expected);
@@ -236,47 +217,7 @@ public abstract class TestMergingMetrics<T> {
           expectedNaNCount,
           DOUBLE_FIELD,
           (Double) record.getField(DOUBLE_FIELD.name()));
-
-      List<Float> floatList = (List<Float>) record.getField(FLOAT_LIST.name());
-      if (floatList != null) {
-        updateExpectedValueFromRecords(
-            upperBounds, lowerBounds, expectedNaNCount, FLOAT_LIST, floatList);
-      }
-
-      Map<Float, ?> map1 = (Map<Float, ?>) record.getField(MAP_FIELD_1.name());
-      if (map1 != null) {
-        updateExpectedValueFromRecords(
-            upperBounds, lowerBounds, expectedNaNCount, MAP_FIELD_1, map1.keySet());
-      }
-
-      Map<?, Double> map2 = (Map<?, Double>) record.getField(MAP_FIELD_2.name());
-      if (map2 != null) {
-        updateExpectedValueFromRecords(
-            upperBounds, lowerBounds, expectedNaNCount, MAP_FIELD_2, map2.values());
-      }
     }
-  }
-
-  private <T1 extends Number> void updateExpectedValueFromRecords(
-      Map<Types.NestedField, AtomicReference<Number>> upperBounds,
-      Map<Types.NestedField, AtomicReference<Number>> lowerBounds,
-      Map<Types.NestedField, AtomicLong> expectedNaNCount,
-      Types.NestedField key,
-      Collection<T1> vals) {
-    List<Number> nonNullNumbers =
-        vals.stream().filter(v -> !NaNUtil.isNaN(v)).collect(Collectors.toList());
-    Optional<Number> maxOptional =
-        nonNullNumbers.stream()
-            .filter(Objects::nonNull)
-            .reduce((v1, v2) -> getMinOrMax(v1, v2, true));
-    Optional<Number> minOptional =
-        nonNullNumbers.stream()
-            .filter(Objects::nonNull)
-            .reduce((v1, v2) -> getMinOrMax(v1, v2, false));
-
-    expectedNaNCount.get(key).addAndGet(vals.size() - nonNullNumbers.size());
-    maxOptional.ifPresent(max -> updateBound(key, max, upperBounds, true));
-    minOptional.ifPresent(min -> updateBound(key, min, lowerBounds, false));
   }
 
   private void updateExpectedValuePerRecord(

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -390,7 +390,7 @@ abstract class BaseParquetReaders<T> {
     }
 
     @Override
-    public ParquetValueReader<?> variant(Types.VariantType iVariant, ParquetValueReader<?> reader) {
+    public ParquetValueReader<?> variant(Types.VariantType iVariant, GroupType variant, ParquetValueReader<?> reader) {
       return reader;
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -390,7 +390,8 @@ abstract class BaseParquetReaders<T> {
     }
 
     @Override
-    public ParquetValueReader<?> variant(Types.VariantType iVariant, GroupType variant, ParquetValueReader<?> reader) {
+    public ParquetValueReader<?> variant(
+        Types.VariantType iVariant, GroupType variant, ParquetValueReader<?> reader) {
       return reader;
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
@@ -162,7 +162,8 @@ abstract class BaseParquetWriter<T> {
     }
 
     @Override
-    public ParquetValueWriter<?> variant(Types.VariantType iVariant, GroupType variant, ParquetValueWriter<?> result) {
+    public ParquetValueWriter<?> variant(
+        Types.VariantType iVariant, GroupType variant, ParquetValueWriter<?> result) {
       return result;
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
@@ -162,7 +162,7 @@ abstract class BaseParquetWriter<T> {
     }
 
     @Override
-    public ParquetValueWriter<?> variant(Types.VariantType iVariant, ParquetValueWriter<?> result) {
+    public ParquetValueWriter<?> variant(Types.VariantType iVariant, GroupType variant, ParquetValueWriter<?> result) {
       return result;
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetConversions.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetConversions.java
@@ -25,7 +25,6 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.function.Function;
-import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.UUIDUtil;
 import org.apache.parquet.io.api.Binary;
@@ -43,6 +42,7 @@ class ParquetConversions {
       case DATE:
       case TIME:
       case TIMESTAMP:
+      case TIMESTAMP_NANO:
       case LONG:
       case FLOAT:
       case DOUBLE:
@@ -68,40 +68,6 @@ class ParquetConversions {
             throw new IllegalArgumentException(
                 "Unsupported primitive type for decimal: " + parquetType.getPrimitiveTypeName());
         }
-      default:
-        throw new IllegalArgumentException("Unsupported primitive type: " + type);
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  static <T> Literal<T> fromParquetPrimitive(Type type, PrimitiveType parquetType, Object value) {
-    switch (type.typeId()) {
-      case BOOLEAN:
-        return (Literal<T>) Literal.of((Boolean) value);
-      case INTEGER:
-      case DATE:
-        return (Literal<T>) Literal.of((Integer) value);
-      case LONG:
-      case TIME:
-      case TIMESTAMP:
-        return (Literal<T>) Literal.of((Long) value);
-      case FLOAT:
-        return (Literal<T>) Literal.of((Float) value);
-      case DOUBLE:
-        return (Literal<T>) Literal.of((Double) value);
-      case STRING:
-        Function<Object, Object> stringConversion = converterFromParquet(parquetType);
-        return (Literal<T>) Literal.of((CharSequence) stringConversion.apply(value));
-      case UUID:
-        Function<Object, Object> uuidConversion = converterFromParquet(parquetType);
-        return (Literal<T>) Literal.of((UUID) uuidConversion.apply(value));
-      case FIXED:
-      case BINARY:
-        Function<Object, Object> binaryConversion = converterFromParquet(parquetType);
-        return (Literal<T>) Literal.of((ByteBuffer) binaryConversion.apply(value));
-      case DECIMAL:
-        Function<Object, Object> decimalConversion = converterFromParquet(parquetType);
-        return (Literal<T>) Literal.of((BigDecimal) decimalConversion.apply(value));
       default:
         throw new IllegalArgumentException("Unsupported primitive type: " + type);
     }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
@@ -521,6 +521,7 @@ class ParquetMetrics {
         return new ParquetVariantUtil.VariantMetrics(valueCount, nullCount);
       }
 
+      @SuppressWarnings("CyclomaticComplexity")
       private <T> ParquetVariantUtil.VariantMetrics metrics(PrimitiveType primitive) {
         PhysicalType variantType = ParquetVariantUtil.convert(primitive);
         if (null == variantType) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
@@ -336,6 +336,7 @@ class ParquetMetrics {
     }
 
     @Override
+    @SuppressWarnings("CyclomaticComplexity")
     public Iterable<FieldMetrics<ByteBuffer>> variant(
         Types.VariantType iVariant, GroupType variant, Iterable<FieldMetrics<ByteBuffer>> ignored) {
       Type.ID id = variant.getId();

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
@@ -1,0 +1,613 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import java.nio.ByteBuffer;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.iceberg.FieldMetrics;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.MetricsModes;
+import org.apache.iceberg.MetricsUtil;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Multimap;
+import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.BinaryUtil;
+import org.apache.iceberg.util.NaNUtil;
+import org.apache.iceberg.util.UnicodeUtil;
+import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.ShreddedObject;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantValue;
+import org.apache.iceberg.variants.Variants;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+class ParquetMetrics {
+  private ParquetMetrics() {}
+
+  static Metrics metrics(
+      Schema schema,
+      MessageType type,
+      MetricsConfig metricsConfig,
+      ParquetMetadata metadata,
+      Stream<FieldMetrics<?>> fields) {
+    long rowCount = 0L;
+    Map<Integer, Long> columnSizes = Maps.newHashMap();
+    Multimap<ColumnPath, ColumnChunkMetaData> columns =
+        Multimaps.newMultimap(Maps.newHashMap(), Lists::newArrayList);
+    for (BlockMetaData block : metadata.getBlocks()) {
+      rowCount += block.getRowCount();
+      for (ColumnChunkMetaData column : block.getColumns()) {
+        Type.ID id =
+            type.getColumnDescription(column.getPath().toArray()).getPrimitiveType().getId();
+        if (null == id) {
+          continue;
+        }
+
+        int fieldId = id.intValue();
+        MetricsModes.MetricsMode mode = MetricsUtil.metricsMode(schema, metricsConfig, fieldId);
+        if (mode != MetricsModes.None.get()) {
+          columns.put(column.getPath(), column);
+          columnSizes.put(fieldId, columnSizes.getOrDefault(fieldId, 0L) + column.getTotalSize());
+        }
+      }
+    }
+
+    Map<Integer, FieldMetrics<?>> metricsById =
+        fields.collect(Collectors.toMap(FieldMetrics::id, Function.identity()));
+
+    Iterable<FieldMetrics<ByteBuffer>> results =
+        TypeWithSchemaVisitor.visit(
+            schema.asStruct(),
+            type,
+            new MetricsVisitor(schema, metricsConfig, metricsById, columns));
+
+    Map<Integer, Long> valueCounts = Maps.newHashMap();
+    Map<Integer, Long> nullValueCounts = Maps.newHashMap();
+    Map<Integer, Long> nanValueCounts = Maps.newHashMap();
+    Map<Integer, ByteBuffer> lowerBounds = Maps.newHashMap();
+    Map<Integer, ByteBuffer> upperBounds = Maps.newHashMap();
+
+    for (FieldMetrics<ByteBuffer> metrics : results) {
+      int id = metrics.id();
+      if (metrics.valueCount() >= 0) {
+        valueCounts.put(id, metrics.valueCount());
+      }
+
+      if (metrics.nullValueCount() >= 0) {
+        nullValueCounts.put(id, metrics.nullValueCount());
+      }
+
+      if (metrics.nanValueCount() >= 0) {
+        nanValueCounts.put(id, metrics.nanValueCount());
+      }
+
+      if (metrics.hasBounds()) {
+        lowerBounds.put(id, metrics.lowerBound());
+        upperBounds.put(id, metrics.upperBound());
+      }
+    }
+
+    return new Metrics(
+        rowCount,
+        columnSizes,
+        valueCounts,
+        nullValueCounts,
+        nanValueCounts,
+        lowerBounds,
+        upperBounds);
+  }
+
+  private static class MetricsVisitor
+      extends TypeWithSchemaVisitor<Iterable<FieldMetrics<ByteBuffer>>> {
+    private final Schema schema;
+    private final MetricsConfig metricsConfig;
+    private final Map<Integer, FieldMetrics<?>> metricsById;
+    private final Multimap<ColumnPath, ColumnChunkMetaData> columns;
+
+    private MetricsVisitor(
+        Schema schema,
+        MetricsConfig metricsConfig,
+        Map<Integer, FieldMetrics<?>> metricsById,
+        Multimap<ColumnPath, ColumnChunkMetaData> columns) {
+      this.schema = schema;
+      this.metricsConfig = metricsConfig;
+      this.metricsById = metricsById;
+      this.columns = columns;
+    }
+
+    @Override
+    public Iterable<FieldMetrics<ByteBuffer>> message(
+        Types.StructType iStruct,
+        MessageType message,
+        List<Iterable<FieldMetrics<ByteBuffer>>> fieldResults) {
+      return Iterables.concat(fieldResults);
+    }
+
+    @Override
+    public Iterable<FieldMetrics<ByteBuffer>> struct(
+        Types.StructType iStruct,
+        GroupType struct,
+        List<Iterable<FieldMetrics<ByteBuffer>>> fieldResults) {
+      return Iterables.concat(fieldResults);
+    }
+
+    @Override
+    public Iterable<FieldMetrics<ByteBuffer>> list(
+        Types.ListType iList, GroupType array, Iterable<FieldMetrics<ByteBuffer>> elementResults) {
+      // remove lower and upper bounds for repeated fields
+      return ImmutableList.of();
+    }
+
+    @Override
+    public Iterable<FieldMetrics<ByteBuffer>> map(
+        Types.MapType iMap,
+        GroupType map,
+        Iterable<FieldMetrics<ByteBuffer>> keyResults,
+        Iterable<FieldMetrics<ByteBuffer>> valueResults) {
+      // repeated fields are not currently supported
+      return ImmutableList.of();
+    }
+
+    @Override
+    public Iterable<FieldMetrics<ByteBuffer>> primitive(
+        org.apache.iceberg.types.Type.PrimitiveType iPrimitive, PrimitiveType primitive) {
+      Type.ID id = primitive.getId();
+      if (null == id) {
+        return ImmutableList.of();
+      }
+      int fieldId = id.intValue();
+
+      MetricsModes.MetricsMode mode = MetricsUtil.metricsMode(schema, metricsConfig, fieldId);
+      if (mode == MetricsModes.None.get()) {
+        return ImmutableList.of();
+      }
+
+      int length = truncateLength(mode);
+
+      FieldMetrics<ByteBuffer> metrics = metricsFromFieldMetrics(fieldId, iPrimitive, length);
+      if (metrics != null) {
+        return ImmutableList.of(metrics);
+      }
+
+      metrics = metricsFromFooter(fieldId, iPrimitive, primitive, length);
+      if (metrics != null) {
+        return ImmutableList.of(metrics);
+      }
+
+      return ImmutableList.of();
+    }
+
+    private FieldMetrics<ByteBuffer> metricsFromFieldMetrics(
+        int fieldId, org.apache.iceberg.types.Type.PrimitiveType icebergType, int truncateLength) {
+      FieldMetrics<?> fieldMetrics = metricsById.get(fieldId);
+      if (null == fieldMetrics) {
+        return null;
+      } else if (truncateLength <= 0) {
+        return new FieldMetrics<>(
+            fieldMetrics.id(),
+            fieldMetrics.valueCount(),
+            fieldMetrics.nullValueCount(),
+            fieldMetrics.nanValueCount());
+      } else {
+        Object lowerBound =
+            truncateLowerBound(icebergType, fieldMetrics.lowerBound(), truncateLength);
+        Object upperBound =
+            truncateUpperBound(icebergType, fieldMetrics.upperBound(), truncateLength);
+        ByteBuffer lower = Conversions.toByteBuffer(icebergType, lowerBound);
+        ByteBuffer upper = Conversions.toByteBuffer(icebergType, upperBound);
+        return new FieldMetrics<>(
+            fieldMetrics.id(),
+            fieldMetrics.valueCount(),
+            fieldMetrics.nullValueCount(),
+            fieldMetrics.nanValueCount(),
+            lower,
+            upper);
+      }
+    }
+
+    private FieldMetrics<ByteBuffer> metricsFromFooter(
+        int fieldId,
+        org.apache.iceberg.types.Type.PrimitiveType icebergType,
+        PrimitiveType primitive,
+        int truncateLength) {
+      if (primitive.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
+        return null;
+      } else if (truncateLength <= 0) {
+        return counts(fieldId);
+      } else {
+        return bounds(fieldId, icebergType, primitive, truncateLength);
+      }
+    }
+
+    private FieldMetrics<ByteBuffer> counts(int fieldId) {
+      ColumnPath path = ColumnPath.get(currentPath());
+      long valueCount = 0;
+      long nullCount = 0;
+
+      for (ColumnChunkMetaData column : columns.get(path)) {
+        Statistics<?> stats = column.getStatistics();
+        if (stats == null || stats.isEmpty()) {
+          return null;
+        }
+
+        nullCount += stats.getNumNulls();
+        valueCount += column.getValueCount();
+      }
+
+      return new FieldMetrics<>(fieldId, valueCount, nullCount);
+    }
+
+    private <T> FieldMetrics<ByteBuffer> bounds(
+        int fieldId,
+        org.apache.iceberg.types.Type.PrimitiveType icebergType,
+        PrimitiveType primitive,
+        int truncateLength) {
+      if (icebergType == null) {
+        return null;
+      }
+
+      ColumnPath path = ColumnPath.get(currentPath());
+      Comparator<T> comparator = Comparators.forType(icebergType);
+      long valueCount = 0;
+      long nullCount = 0;
+      T lowerBound = null;
+      T upperBound = null;
+
+      for (ColumnChunkMetaData column : columns.get(path)) {
+        Statistics<?> stats = column.getStatistics();
+        if (stats == null || stats.isEmpty()) {
+          return null;
+        }
+
+        nullCount += stats.getNumNulls();
+        valueCount += column.getValueCount();
+
+        if (stats.hasNonNullValue()) {
+          T chunkMin =
+              ParquetConversions.convertValue(icebergType, primitive, stats.genericGetMin());
+          if (lowerBound == null || comparator.compare(chunkMin, lowerBound) < 0) {
+            lowerBound = chunkMin;
+          }
+
+          T chunkMax =
+              ParquetConversions.convertValue(icebergType, primitive, stats.genericGetMax());
+          if (upperBound == null || comparator.compare(chunkMax, upperBound) > 0) {
+            upperBound = chunkMax;
+          }
+        }
+      }
+
+      if (NaNUtil.isNaN(lowerBound) || NaNUtil.isNaN(upperBound)) {
+        return new FieldMetrics<>(fieldId, valueCount, nullCount);
+      }
+
+      lowerBound = truncateLowerBound(icebergType, lowerBound, truncateLength);
+      upperBound = truncateUpperBound(icebergType, upperBound, truncateLength);
+
+      ByteBuffer lower = Conversions.toByteBuffer(icebergType, lowerBound);
+      ByteBuffer upper = Conversions.toByteBuffer(icebergType, upperBound);
+
+      return new FieldMetrics<>(fieldId, valueCount, nullCount, lower, upper);
+    }
+
+    @Override
+    public Iterable<FieldMetrics<ByteBuffer>> variant(
+        Types.VariantType iVariant, GroupType variant, Iterable<FieldMetrics<ByteBuffer>> ignored) {
+      Type.ID id = variant.getId();
+      if (null == id) {
+        return ImmutableList.of();
+      }
+      int fieldId = id.intValue();
+
+      MetricsModes.MetricsMode mode = MetricsUtil.metricsMode(schema, metricsConfig, fieldId);
+      if (mode == MetricsModes.None.get()) {
+        return ImmutableList.of();
+      }
+
+      List<ParquetVariantUtil.VariantMetrics> results =
+          Lists.newArrayList(
+              ParquetVariantVisitor.visit(variant, new MetricsVariantVisitor(currentPath())));
+
+      if (results.size() <= 1) {
+        return ImmutableList.of();
+      }
+
+      ParquetVariantUtil.VariantMetrics metadataCounts = results.get(0);
+      if (mode == MetricsModes.Counts.get()) {
+        return ImmutableList.of(
+            new FieldMetrics<>(fieldId, metadataCounts.valueCount(), metadataCounts.nullCount()));
+      }
+
+      Set<String> fieldNames = Sets.newTreeSet();
+      for (ParquetVariantUtil.VariantMetrics result : results.subList(1, results.size())) {
+        fieldNames.add(result.fieldName());
+      }
+
+      VariantMetadata metadata = Variants.metadata(fieldNames);
+      ShreddedObject lowerBounds = Variants.object(metadata);
+      ShreddedObject upperBounds = Variants.object(metadata);
+      for (ParquetVariantUtil.VariantMetrics result : results.subList(1, results.size())) {
+        String fieldName = result.fieldName();
+        lowerBounds.put(fieldName, result.lowerBound());
+        upperBounds.put(fieldName, result.upperBound());
+      }
+
+      return ImmutableList.of(
+          new FieldMetrics<>(
+              fieldId,
+              metadataCounts.valueCount(),
+              metadataCounts.nullCount(),
+              ParquetVariantUtil.toByteBuffer(metadata, lowerBounds),
+              ParquetVariantUtil.toByteBuffer(metadata, upperBounds)));
+    }
+
+    private class MetricsVariantVisitor
+        extends ParquetVariantVisitor<Iterable<ParquetVariantUtil.VariantMetrics>> {
+      private final Deque<String> fieldNames = Lists.newLinkedList();
+      private final String[] basePath;
+
+      private MetricsVariantVisitor(String[] basePath) {
+        this.basePath = basePath;
+      }
+
+      @Override
+      public void beforeField(Type type) {
+        fieldNames.addLast(type.getName());
+      }
+
+      @Override
+      public void afterField(Type type) {
+        fieldNames.removeLast();
+      }
+
+      private Stream<String> currentPath() {
+        return Streams.concat(Stream.of(basePath), fieldNames.stream());
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> variant(
+          GroupType variant,
+          Iterable<ParquetVariantUtil.VariantMetrics> metadataResults,
+          Iterable<ParquetVariantUtil.VariantMetrics> valueResults) {
+        return Iterables.concat(metadataResults, valueResults);
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> object(
+          GroupType object,
+          Iterable<ParquetVariantUtil.VariantMetrics> valueResult,
+          List<Iterable<ParquetVariantUtil.VariantMetrics>> fieldResults) {
+        // shredded fields are not allowed in the variant-encoded value so the stats are trusted
+        // even if value result has non-null values
+        GroupType shreddedFields = object.getType(TYPED_VALUE).asGroupType();
+        List<Iterable<ParquetVariantUtil.VariantMetrics>> results = Lists.newArrayList();
+
+        // for each field, prepend the field name
+        for (int i = 0; i < fieldResults.size(); i += 1) {
+          String name = shreddedFields.getFieldName(i);
+          results.add(
+              Iterables.transform(fieldResults.get(i), result -> result.prependFieldName(name)));
+        }
+
+        // return metrics for all sub-fields
+        return Iterables.concat(results);
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> array(
+          GroupType array,
+          Iterable<ParquetVariantUtil.VariantMetrics> valueResult,
+          Iterable<ParquetVariantUtil.VariantMetrics> elementResult) {
+        return ImmutableList.of();
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> value(
+          GroupType value,
+          Iterable<ParquetVariantUtil.VariantMetrics> valueResult,
+          Iterable<ParquetVariantUtil.VariantMetrics> typedResult) {
+        if (null == valueResult) {
+          // a value field was not present so the typed metrics can be used
+          return typedResult;
+        }
+
+        ParquetVariantUtil.VariantMetrics valueMetrics = Iterables.getOnlyElement(valueResult);
+        if (typedResult != null && valueMetrics.valueCount() == valueMetrics.nullCount()) {
+          // all the variant-encoded values are null, so the typed stats can be used
+          return typedResult;
+        } else {
+          // any non-null encoded variant invalidates the typed lower and upper bounds
+          return ImmutableList.of();
+        }
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> metadata(PrimitiveType metadata) {
+        ParquetVariantUtil.VariantMetrics counts = counts();
+        if (counts != null) {
+          return ImmutableList.of(counts);
+        } else {
+          return ImmutableList.of();
+        }
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> serialized(PrimitiveType value) {
+        ParquetVariantUtil.VariantMetrics counts = counts();
+        if (counts != null) {
+          return ImmutableList.of(counts);
+        } else {
+          return ImmutableList.of();
+        }
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> primitive(PrimitiveType primitive) {
+        ParquetVariantUtil.VariantMetrics result = metrics(primitive);
+        if (result != null) {
+          return ImmutableList.of(result);
+        } else {
+          return ImmutableList.of();
+        }
+      }
+
+      private ParquetVariantUtil.VariantMetrics counts() {
+        ColumnPath path = ColumnPath.get(currentPath().toArray(String[]::new));
+        long valueCount = 0;
+        long nullCount = 0;
+
+        for (ColumnChunkMetaData column : columns.get(path)) {
+          Statistics<?> stats = column.getStatistics();
+          if (stats == null || stats.isEmpty()) {
+            // the null count is unknown
+            return null;
+          }
+
+          boolean hasOnlyNullVariants;
+          if (stats.hasNonNullValue()) {
+            hasOnlyNullVariants =
+                Variants.isNull(ByteBuffer.wrap(stats.getMinBytes()))
+                    && Variants.isNull(ByteBuffer.wrap(stats.getMaxBytes()));
+          } else {
+            // use the null count because the min/max were not defined
+            hasOnlyNullVariants = false;
+          }
+
+          valueCount += column.getValueCount();
+          nullCount += hasOnlyNullVariants ? column.getValueCount() : stats.getNumNulls();
+        }
+
+        return new ParquetVariantUtil.VariantMetrics(valueCount, nullCount);
+      }
+
+      private <T> ParquetVariantUtil.VariantMetrics metrics(PrimitiveType primitive) {
+        PhysicalType variantType = ParquetVariantUtil.convert(primitive);
+        if (null == variantType) {
+          // the type could not be converted and is either invalid or unsupported
+          return null;
+        }
+
+        ColumnPath path = ColumnPath.get(currentPath().toArray(String[]::new));
+        Comparator<T> comparator = ParquetVariantUtil.comparator(variantType);
+        int scale = ParquetVariantUtil.scale(primitive);
+        long valueCount = 0;
+        long nullCount = 0;
+        T lowerBound = null;
+        T upperBound = null;
+
+        for (ColumnChunkMetaData column : columns.get(path)) {
+          Statistics<?> stats = column.getStatistics();
+          if (stats == null || stats.isEmpty()) {
+            return null;
+          }
+
+          nullCount += stats.getNumNulls();
+          valueCount += column.getValueCount();
+
+          if (stats.hasNonNullValue()) {
+            T chunkMin = ParquetVariantUtil.convertValue(variantType, scale, stats.genericGetMin());
+            if (lowerBound == null || comparator.compare(chunkMin, lowerBound) < 0) {
+              lowerBound = chunkMin;
+            }
+
+            T chunkMax = ParquetVariantUtil.convertValue(variantType, scale, stats.genericGetMax());
+            if (upperBound == null || comparator.compare(chunkMax, upperBound) > 0) {
+              upperBound = chunkMax;
+            }
+          }
+        }
+
+        if (NaNUtil.isNaN(lowerBound) || NaNUtil.isNaN(upperBound)) {
+          return null;
+        }
+
+        if (lowerBound != null && upperBound != null) {
+          VariantValue lower = Variants.of(variantType, lowerBound);
+          VariantValue upper = Variants.of(variantType, upperBound);
+          return new ParquetVariantUtil.VariantMetrics(valueCount, nullCount, lower, upper);
+        } else {
+          return new ParquetVariantUtil.VariantMetrics(valueCount, nullCount);
+        }
+      }
+    }
+  }
+
+  private static int truncateLength(MetricsModes.MetricsMode mode) {
+    if (mode == MetricsModes.None.get()) {
+      return 0;
+    } else if (mode == MetricsModes.Counts.get()) {
+      return 0;
+    } else if (mode instanceof MetricsModes.Truncate) {
+      return ((MetricsModes.Truncate) mode).length();
+    } else {
+      return Integer.MAX_VALUE;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T truncateLowerBound(
+      org.apache.iceberg.types.Type.PrimitiveType type, T value, int length) {
+    switch (type.typeId()) {
+      case STRING:
+        return (T) UnicodeUtil.truncateStringMin((String) value, length);
+      case BINARY:
+        return (T) BinaryUtil.truncateBinaryMin((ByteBuffer) value, length);
+      default:
+        return value;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T truncateUpperBound(
+      org.apache.iceberg.types.Type.PrimitiveType type, T value, int length) {
+    switch (type.typeId()) {
+      case STRING:
+        return (T) UnicodeUtil.truncateStringMax((String) value, length);
+      case BINARY:
+        return (T) BinaryUtil.truncateBinaryMax((ByteBuffer) value, length);
+      default:
+        return value;
+    }
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
@@ -588,6 +588,10 @@ class ParquetMetrics {
   @SuppressWarnings("unchecked")
   private static <T> T truncateLowerBound(
       org.apache.iceberg.types.Type.PrimitiveType type, T value, int length) {
+    if (null == value) {
+      return null;
+    }
+
     switch (type.typeId()) {
       case STRING:
         return (T) UnicodeUtil.truncateStringMin((String) value, length);
@@ -601,6 +605,10 @@ class ParquetMetrics {
   @SuppressWarnings("unchecked")
   private static <T> T truncateUpperBound(
       org.apache.iceberg.types.Type.PrimitiveType type, T value, int length) {
+    if (null == value) {
+      return null;
+    }
+
     switch (type.typeId()) {
       case STRING:
         return (T) UnicodeUtil.truncateStringMax((String) value, length);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
@@ -122,8 +122,11 @@ class ParquetMetrics {
         nanValueCounts.put(id, metrics.nanValueCount());
       }
 
-      if (metrics.hasBounds()) {
+      if (metrics.lowerBound() != null) {
         lowerBounds.put(id, metrics.lowerBound());
+      }
+
+      if (metrics.upperBound() != null) {
         upperBounds.put(id, metrics.upperBound());
       }
     }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -21,45 +21,29 @@ package org.apache.iceberg.parquet;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.FieldMetrics;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
-import org.apache.iceberg.MetricsModes;
-import org.apache.iceberg.MetricsModes.MetricsMode;
-import org.apache.iceberg.MetricsUtil;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.RuntimeIOException;
-import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.types.Conversions;
-import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.BinaryUtil;
-import org.apache.iceberg.util.UnicodeUtil;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.EncodingStats;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReader;
-import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
-import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.MessageType;
@@ -89,125 +73,16 @@ public class ParquetUtil {
     return footerMetrics(metadata, fieldMetrics, metricsConfig, null);
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public static Metrics footerMetrics(
       ParquetMetadata metadata,
       Stream<FieldMetrics<?>> fieldMetrics,
       MetricsConfig metricsConfig,
       NameMapping nameMapping) {
     Preconditions.checkNotNull(fieldMetrics, "fieldMetrics should not be null");
-
-    long rowCount = 0;
-    Map<Integer, Long> columnSizes = Maps.newHashMap();
-    Map<Integer, Long> valueCounts = Maps.newHashMap();
-    Map<Integer, Long> nullValueCounts = Maps.newHashMap();
-    Map<Integer, Literal<?>> lowerBounds = Maps.newHashMap();
-    Map<Integer, Literal<?>> upperBounds = Maps.newHashMap();
-    Set<Integer> missingStats = Sets.newHashSet();
-
-    // ignore metrics for fields we failed to determine reliable IDs
+    MessageType messageType = metadata.getFileMetaData().getSchema();
     MessageType parquetTypeWithIds = getParquetTypeWithIds(metadata, nameMapping);
     Schema fileSchema = ParquetSchemaUtil.convertAndPrune(parquetTypeWithIds);
-
-    Map<Integer, FieldMetrics<?>> fieldMetricsMap =
-        fieldMetrics.collect(Collectors.toMap(FieldMetrics::id, Function.identity()));
-
-    List<BlockMetaData> blocks = metadata.getBlocks();
-    for (BlockMetaData block : blocks) {
-      rowCount += block.getRowCount();
-      for (ColumnChunkMetaData column : block.getColumns()) {
-
-        Integer fieldId = fileSchema.aliasToId(column.getPath().toDotString());
-        if (fieldId == null) {
-          // fileSchema may contain a subset of columns present in the file
-          // as we prune columns we could not assign ids
-          continue;
-        }
-
-        MetricsMode metricsMode = MetricsUtil.metricsMode(fileSchema, metricsConfig, fieldId);
-        if (metricsMode == MetricsModes.None.get()) {
-          continue;
-        }
-
-        increment(columnSizes, fieldId, column.getTotalSize());
-        increment(valueCounts, fieldId, column.getValueCount());
-
-        Statistics stats = column.getStatistics();
-        if (stats != null && !stats.isEmpty()) {
-          increment(nullValueCounts, fieldId, stats.getNumNulls());
-
-          // when there are metrics gathered by Iceberg for a column, we should use those instead
-          // of the ones from Parquet
-          if (metricsMode != MetricsModes.Counts.get() && !fieldMetricsMap.containsKey(fieldId)) {
-            Types.NestedField field = fileSchema.findField(fieldId);
-            if (field != null && stats.hasNonNullValue() && shouldStoreBounds(column, fileSchema)) {
-              Literal<?> min =
-                  ParquetConversions.fromParquetPrimitive(
-                      field.type(), column.getPrimitiveType(), stats.genericGetMin());
-              updateMin(lowerBounds, fieldId, field.type(), min, metricsMode);
-              Literal<?> max =
-                  ParquetConversions.fromParquetPrimitive(
-                      field.type(), column.getPrimitiveType(), stats.genericGetMax());
-              updateMax(upperBounds, fieldId, field.type(), max, metricsMode);
-            }
-          }
-        } else {
-          missingStats.add(fieldId);
-        }
-      }
-    }
-
-    // discard accumulated values if any stats were missing
-    for (Integer fieldId : missingStats) {
-      nullValueCounts.remove(fieldId);
-      lowerBounds.remove(fieldId);
-      upperBounds.remove(fieldId);
-    }
-
-    updateFromFieldMetrics(fieldMetricsMap, metricsConfig, fileSchema, lowerBounds, upperBounds);
-
-    return new Metrics(
-        rowCount,
-        columnSizes,
-        valueCounts,
-        nullValueCounts,
-        MetricsUtil.createNanValueCounts(
-            fieldMetricsMap.values().stream(), metricsConfig, fileSchema),
-        toBufferMap(fileSchema, lowerBounds),
-        toBufferMap(fileSchema, upperBounds));
-  }
-
-  private static void updateFromFieldMetrics(
-      Map<Integer, FieldMetrics<?>> idToFieldMetricsMap,
-      MetricsConfig metricsConfig,
-      Schema schema,
-      Map<Integer, Literal<?>> lowerBounds,
-      Map<Integer, Literal<?>> upperBounds) {
-    idToFieldMetricsMap
-        .entrySet()
-        .forEach(
-            entry -> {
-              int fieldId = entry.getKey();
-              FieldMetrics<?> metrics = entry.getValue();
-              MetricsMode metricsMode = MetricsUtil.metricsMode(schema, metricsConfig, fieldId);
-
-              // only check for MetricsModes.None, since we don't truncate float/double values.
-              if (metricsMode != MetricsModes.None.get()) {
-                if (!metrics.hasBounds()) {
-                  lowerBounds.remove(fieldId);
-                  upperBounds.remove(fieldId);
-                } else if (metrics.upperBound() instanceof Float) {
-                  lowerBounds.put(fieldId, Literal.of((Float) metrics.lowerBound()));
-                  upperBounds.put(fieldId, Literal.of((Float) metrics.upperBound()));
-                } else if (metrics.upperBound() instanceof Double) {
-                  lowerBounds.put(fieldId, Literal.of((Double) metrics.lowerBound()));
-                  upperBounds.put(fieldId, Literal.of((Double) metrics.upperBound()));
-                } else {
-                  throw new UnsupportedOperationException(
-                      "Expected only float or double column metrics");
-                }
-              }
-            });
+    return ParquetMetrics.metrics(fileSchema, messageType, metricsConfig, metadata, fieldMetrics);
   }
 
   private static MessageType getParquetTypeWithIds(
@@ -236,116 +111,6 @@ public class ParquetUtil {
     }
     Collections.sort(splitOffsets);
     return splitOffsets;
-  }
-
-  // we allow struct nesting, but not maps or arrays
-  private static boolean shouldStoreBounds(ColumnChunkMetaData column, Schema schema) {
-    if (column.getPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
-      // stats for INT96 are not reliable
-      return false;
-    }
-
-    ColumnPath columnPath = column.getPath();
-    Iterator<String> pathIterator = columnPath.iterator();
-    Type currentType = schema.asStruct();
-
-    while (pathIterator.hasNext()) {
-      if (currentType == null || !currentType.isStructType()) {
-        return false;
-      }
-      String fieldName = pathIterator.next();
-      currentType = currentType.asStructType().fieldType(fieldName);
-    }
-
-    return currentType != null && currentType.isPrimitiveType();
-  }
-
-  private static void increment(Map<Integer, Long> columns, int fieldId, long amount) {
-    if (columns != null) {
-      if (columns.containsKey(fieldId)) {
-        columns.put(fieldId, columns.get(fieldId) + amount);
-      } else {
-        columns.put(fieldId, amount);
-      }
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T> void updateMin(
-      Map<Integer, Literal<?>> lowerBounds,
-      int id,
-      Type type,
-      Literal<T> min,
-      MetricsMode metricsMode) {
-    Literal<T> currentMin = (Literal<T>) lowerBounds.get(id);
-    if (currentMin == null || min.comparator().compare(min.value(), currentMin.value()) < 0) {
-      if (metricsMode == MetricsModes.Full.get()) {
-        lowerBounds.put(id, min);
-      } else {
-        MetricsModes.Truncate truncateMode = (MetricsModes.Truncate) metricsMode;
-        int truncateLength = truncateMode.length();
-        switch (type.typeId()) {
-          case STRING:
-            lowerBounds.put(
-                id, UnicodeUtil.truncateStringMin((Literal<CharSequence>) min, truncateLength));
-            break;
-          case FIXED:
-          case BINARY:
-            lowerBounds.put(
-                id, BinaryUtil.truncateBinaryMin((Literal<ByteBuffer>) min, truncateLength));
-            break;
-          default:
-            lowerBounds.put(id, min);
-        }
-      }
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T> void updateMax(
-      Map<Integer, Literal<?>> upperBounds,
-      int id,
-      Type type,
-      Literal<T> max,
-      MetricsMode metricsMode) {
-    Literal<T> currentMax = (Literal<T>) upperBounds.get(id);
-    if (currentMax == null || max.comparator().compare(max.value(), currentMax.value()) > 0) {
-      if (metricsMode == MetricsModes.Full.get()) {
-        upperBounds.put(id, max);
-      } else {
-        MetricsModes.Truncate truncateMode = (MetricsModes.Truncate) metricsMode;
-        int truncateLength = truncateMode.length();
-        switch (type.typeId()) {
-          case STRING:
-            Literal<CharSequence> truncatedMaxString =
-                UnicodeUtil.truncateStringMax((Literal<CharSequence>) max, truncateLength);
-            if (truncatedMaxString != null) {
-              upperBounds.put(id, truncatedMaxString);
-            }
-            break;
-          case FIXED:
-          case BINARY:
-            Literal<ByteBuffer> truncatedMaxBinary =
-                BinaryUtil.truncateBinaryMax((Literal<ByteBuffer>) max, truncateLength);
-            if (truncatedMaxBinary != null) {
-              upperBounds.put(id, truncatedMaxBinary);
-            }
-            break;
-          default:
-            upperBounds.put(id, max);
-        }
-      }
-    }
-  }
-
-  private static Map<Integer, ByteBuffer> toBufferMap(Schema schema, Map<Integer, Literal<?>> map) {
-    Map<Integer, ByteBuffer> bufferMap = Maps.newHashMap();
-    for (Map.Entry<Integer, Literal<?>> entry : map.entrySet()) {
-      bufferMap.put(
-          entry.getKey(),
-          Conversions.toByteBuffer(schema.findType(entry.getKey()), entry.getValue().value()));
-    }
-    return bufferMap;
   }
 
   @SuppressWarnings("deprecation")

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
@@ -24,16 +24,23 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Comparator;
 import java.util.Deque;
+import java.util.List;
 import java.util.Optional;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.util.BinaryUtil;
 import org.apache.iceberg.util.UnicodeUtil;
 import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.VariantArray;
 import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantObject;
+import org.apache.iceberg.variants.VariantPrimitive;
 import org.apache.iceberg.variants.VariantValue;
+import org.apache.iceberg.variants.VariantVisitor;
 import org.apache.iceberg.variants.Variants;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
@@ -44,6 +51,8 @@ import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
 
 class ParquetVariantUtil {
   private ParquetVariantUtil() {}
@@ -165,6 +174,16 @@ class ParquetVariantUtil {
     }
 
     return 0;
+  }
+
+  /**
+   * Creates a Parquet schema to fully shred the {@link VariantValue}.
+   *
+   * @param value a variant value
+   * @return a Parquet schema that can fully shred the value
+   */
+  static Type toParquetSchema(VariantValue value) {
+    return VariantVisitor.visit(value, new ParquetSchemaProducer());
   }
 
   private static class PhysicalTypeConverter implements LogicalTypeAnnotationVisitor<PhysicalType> {
@@ -318,6 +337,140 @@ class ParquetVariantUtil {
         default:
           return value;
       }
+    }
+  }
+
+  private static class ParquetSchemaProducer extends VariantVisitor<Type> {
+    @Override
+    public Type object(VariantObject object, List<String> names, List<Type> typedValues) {
+      if (object.numFields() < 1) {
+        // Parquet cannot write  typed_value group with no fields
+        return null;
+      }
+
+      List<GroupType> fields = Lists.newArrayList();
+      int index = 0;
+      for (String name : names) {
+        Type typedValue = typedValues.get(index);
+        fields.add(field(name, typedValue));
+        index += 1;
+      }
+
+      return objectFields(fields);
+    }
+
+    @Override
+    public Type array(VariantArray array, List<Type> elementResults) {
+      throw null;
+    }
+
+    @Override
+    public Type primitive(VariantPrimitive<?> primitive) {
+      switch (primitive.type()) {
+        case NULL:
+          return null;
+        case BOOLEAN_TRUE:
+        case BOOLEAN_FALSE:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.BOOLEAN);
+        case INT8:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT32, LogicalTypeAnnotation.intType(8));
+        case INT16:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT32, LogicalTypeAnnotation.intType(16));
+        case INT32:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.INT32);
+        case INT64:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.INT64);
+        case FLOAT:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.FLOAT);
+        case DOUBLE:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.DOUBLE);
+        case DECIMAL4:
+          BigDecimal decimal4 = (BigDecimal) primitive.get();
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT32,
+              LogicalTypeAnnotation.decimalType(decimal4.scale(), 9));
+        case DECIMAL8:
+          BigDecimal decimal8 = (BigDecimal) primitive.get();
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT64,
+              LogicalTypeAnnotation.decimalType(decimal8.scale(), 18));
+        case DECIMAL16:
+          BigDecimal decimal16 = (BigDecimal) primitive.get();
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.BINARY,
+              LogicalTypeAnnotation.decimalType(decimal16.scale(), 38));
+        case DATE:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT32, LogicalTypeAnnotation.dateType());
+        case TIMESTAMPTZ:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT64,
+              LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS));
+        case TIMESTAMPNTZ:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT64,
+              LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.MICROS));
+        case BINARY:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.BINARY);
+        case STRING:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.BINARY, LogicalTypeAnnotation.stringType());
+      }
+
+      throw new UnsupportedOperationException("Unsupported shredding type: " + primitive.type());
+    }
+
+    private static GroupType objectFields(List<GroupType> fields) {
+      Types.GroupBuilder<GroupType> builder = Types.buildGroup(Type.Repetition.OPTIONAL);
+      for (GroupType field : fields) {
+        checkField(field);
+        builder.addField(field);
+      }
+
+      return builder.named("typed_value");
+    }
+
+    private static void checkField(GroupType fieldType) {
+      Preconditions.checkArgument(
+          fieldType.isRepetition(Type.Repetition.REQUIRED),
+          "Invalid field type repetition: %s should be REQUIRED",
+          fieldType.getRepetition());
+    }
+
+    private static GroupType field(String name, Type shreddedType) {
+      Types.GroupBuilder<GroupType> builder =
+          Types.buildGroup(Type.Repetition.REQUIRED)
+              .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+              .named("value");
+
+      if (shreddedType != null) {
+        checkShreddedType(shreddedType);
+        builder.addField(shreddedType);
+      }
+
+      return builder.named(name);
+    }
+
+    private static void checkShreddedType(Type shreddedType) {
+      Preconditions.checkArgument(
+          shreddedType.getName().equals("typed_value"),
+          "Invalid shredded type name: %s should be typed_value",
+          shreddedType.getName());
+      Preconditions.checkArgument(
+          shreddedType.isRepetition(Type.Repetition.OPTIONAL),
+          "Invalid shredded type repetition: %s should be OPTIONAL",
+          shreddedType.getRepetition());
+    }
+
+    private static Type shreddedPrimitive(PrimitiveType.PrimitiveTypeName primitive) {
+      return Types.optional(primitive).named("typed_value");
+    }
+
+    private static Type shreddedPrimitive(
+        PrimitiveType.PrimitiveTypeName primitive, LogicalTypeAnnotation annotation) {
+      return Types.optional(primitive).as(annotation).named("typed_value");
     }
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
@@ -102,8 +102,8 @@ class ParquetVariantUtil {
    * @param primitive a primitive variant {@link PhysicalType}
    * @param scale decimal scale used when the value is a decimal
    * @param value a value from Parquet value to convert
-   * @return the primitive value
    * @param <T> Java type used for values of the given Variant physical type
+   * @return the primitive value
    */
   @SuppressWarnings("unchecked")
   static <T> T convertValue(PhysicalType primitive, int scale, Object value) {
@@ -140,8 +140,8 @@ class ParquetVariantUtil {
    * Returns a comparator for values of the given primitive {@link PhysicalType type}.
    *
    * @param primitive a primitive variant {@link PhysicalType}
-   * @return a comparator for in-memory values of the given type
    * @param <T> Java type used for values of the given Variant physical type
+   * @return a comparator for in-memory values of the given type
    */
   @SuppressWarnings("unchecked")
   static <T> Comparator<T> comparator(PhysicalType primitive) {
@@ -245,14 +245,14 @@ class ParquetVariantUtil {
     private final Deque<String> fieldNames = Lists.newLinkedList();
     private String lazyFieldName = null;
 
-    public VariantMetrics(long valueCount, long nullCount) {
+    VariantMetrics(long valueCount, long nullCount) {
       this.valueCount = valueCount;
       this.nullCount = nullCount;
       this.lowerBound = null;
       this.upperBound = null;
     }
 
-    public VariantMetrics(
+    VariantMetrics(
         long valueCount, long nullCount, VariantValue lowerBound, VariantValue upperBound) {
       this.valueCount = valueCount;
       this.nullCount = nullCount;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
@@ -361,7 +361,7 @@ class ParquetVariantUtil {
 
     @Override
     public Type array(VariantArray array, List<Type> elementResults) {
-      throw null;
+      return null;
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.Optional;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.util.BinaryUtil;
+import org.apache.iceberg.util.UnicodeUtil;
+import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantValue;
+import org.apache.iceberg.variants.Variants;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.IntLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.LogicalTypeAnnotationVisitor;
+import org.apache.parquet.schema.LogicalTypeAnnotation.StringLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+
+class ParquetVariantUtil {
+  private ParquetVariantUtil() {}
+
+  /**
+   * Convert a Parquet {@link PrimitiveType} to the equivalent Variant {@link PhysicalType}.
+   *
+   * @param primitive a Parquet {@link PrimitiveType}
+   * @return a Variant {@link PhysicalType}
+   * @throws UnsupportedOperationException if the Parquet type is not equivalent to a variant type
+   */
+  static PhysicalType convert(PrimitiveType primitive) {
+    LogicalTypeAnnotation annotation = primitive.getLogicalTypeAnnotation();
+    if (annotation != null) {
+      return annotation.accept(PhysicalTypeConverter.INSTANCE).orElse(null);
+    }
+
+    switch (primitive.getPrimitiveTypeName()) {
+      case BOOLEAN:
+        return PhysicalType.BOOLEAN_TRUE;
+      case INT32:
+        return PhysicalType.INT32;
+      case INT64:
+        return PhysicalType.INT64;
+      case FLOAT:
+        return PhysicalType.FLOAT;
+      case DOUBLE:
+        return PhysicalType.DOUBLE;
+      case BINARY:
+        return PhysicalType.BINARY;
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Serialize Variant metadata and value in a single concatenated buffer.
+   *
+   * @param metadata a {VariantMetadata}
+   * @param value a {VariantValue}
+   * @return a buffer containing the metadata and value serialized and concatenated
+   */
+  static ByteBuffer toByteBuffer(VariantMetadata metadata, VariantValue value) {
+    ByteBuffer buffer =
+        ByteBuffer.allocate(metadata.sizeInBytes() + value.sizeInBytes())
+            .order(ByteOrder.LITTLE_ENDIAN);
+    metadata.writeTo(buffer, 0);
+    value.writeTo(buffer, metadata.sizeInBytes());
+    return buffer;
+  }
+
+  /**
+   * Converts a Parquet primitive value to a Variant in-memory value for the given {@link
+   * PhysicalType type}.
+   *
+   * @param primitive a primitive variant {@link PhysicalType}
+   * @param scale decimal scale used when the value is a decimal
+   * @param value a value from Parquet value to convert
+   * @return the primitive value
+   * @param <T> Java type used for values of the given Variant physical type
+   */
+  @SuppressWarnings("unchecked")
+  static <T> T convertValue(PhysicalType primitive, int scale, Object value) {
+    switch (primitive) {
+      case BOOLEAN_FALSE:
+      case BOOLEAN_TRUE:
+      case INT32:
+      case INT64:
+      case DATE:
+      case TIMESTAMPTZ:
+      case TIMESTAMPNTZ:
+      case FLOAT:
+      case DOUBLE:
+        return (T) value;
+      case INT8:
+        return (T) (Byte) ((Number) value).byteValue();
+      case INT16:
+        return (T) (Short) ((Number) value).shortValue();
+      case DECIMAL4:
+      case DECIMAL8:
+        return (T) BigDecimal.valueOf(((Number) value).longValue(), scale);
+      case DECIMAL16:
+        return (T) new BigDecimal(new BigInteger(((Binary) value).getBytes()), scale);
+      case BINARY:
+        return (T) ((Binary) value).toByteBuffer();
+      case STRING:
+        return (T) ((Binary) value).toStringUsingUTF8();
+      default:
+        throw new IllegalStateException("Invalid bound type: " + primitive);
+    }
+  }
+
+  /**
+   * Returns a comparator for values of the given primitive {@link PhysicalType type}.
+   *
+   * @param primitive a primitive variant {@link PhysicalType}
+   * @return a comparator for in-memory values of the given type
+   * @param <T> Java type used for values of the given Variant physical type
+   */
+  @SuppressWarnings("unchecked")
+  static <T> Comparator<T> comparator(PhysicalType primitive) {
+    if (primitive == PhysicalType.BINARY) {
+      return (Comparator<T>) Comparators.unsignedBytes();
+    } else {
+      return (Comparator<T>) Comparator.naturalOrder();
+    }
+  }
+
+  /**
+   * Returns a decimal scale if the primitive is a decimal, or 0 otherwise.
+   *
+   * @param primitive a primitive type
+   * @return decimal scale if the primitive is a decimal, 0 otherwise
+   */
+  static int scale(PrimitiveType primitive) {
+    LogicalTypeAnnotation annotation = primitive.getLogicalTypeAnnotation();
+    if (annotation instanceof DecimalLogicalTypeAnnotation) {
+      return ((DecimalLogicalTypeAnnotation) annotation).getScale();
+    }
+
+    return 0;
+  }
+
+  private static class PhysicalTypeConverter implements LogicalTypeAnnotationVisitor<PhysicalType> {
+    private static final PhysicalTypeConverter INSTANCE = new PhysicalTypeConverter();
+
+    @Override
+    public Optional<PhysicalType> visit(StringLogicalTypeAnnotation ignored) {
+      return Optional.of(PhysicalType.STRING);
+    }
+
+    @Override
+    public Optional<PhysicalType> visit(DecimalLogicalTypeAnnotation decimal) {
+      if (decimal.getPrecision() <= 9) {
+        return Optional.of(PhysicalType.DECIMAL4);
+      } else if (decimal.getPrecision() <= 18) {
+        return Optional.of(PhysicalType.DECIMAL8);
+      } else {
+        return Optional.of(PhysicalType.DECIMAL16);
+      }
+    }
+
+    @Override
+    public Optional<PhysicalType> visit(DateLogicalTypeAnnotation ignored) {
+      return Optional.of(PhysicalType.DATE);
+    }
+
+    @Override
+    public Optional<PhysicalType> visit(TimeLogicalTypeAnnotation ignored) {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<PhysicalType> visit(TimestampLogicalTypeAnnotation timestamps) {
+      switch (timestamps.getUnit()) {
+        case MICROS:
+          if (timestamps.isAdjustedToUTC()) {
+            return Optional.of(PhysicalType.TIMESTAMPTZ);
+          } else {
+            return Optional.of(PhysicalType.TIMESTAMPNTZ);
+          }
+        case NANOS:
+        default:
+          return Optional.empty();
+      }
+    }
+
+    @Override
+    public Optional<PhysicalType> visit(IntLogicalTypeAnnotation ints) {
+      if (!ints.isSigned()) {
+        return Optional.empty();
+      }
+
+      switch (ints.getBitWidth()) {
+        case 8:
+          return Optional.of(PhysicalType.INT8);
+        case 16:
+          return Optional.of(PhysicalType.INT16);
+        case 32:
+          return Optional.of(PhysicalType.INT32);
+        case 64:
+          return Optional.of(PhysicalType.INT64);
+        default:
+          return Optional.empty();
+      }
+    }
+
+    @Override
+    public Optional<PhysicalType> visit(UUIDLogicalTypeAnnotation uuidLogicalType) {
+      return Optional.empty();
+    }
+  }
+
+  static class VariantMetrics {
+    private final long valueCount;
+    private final long nullCount;
+    private final VariantValue lowerBound;
+    private final VariantValue upperBound;
+    private final Deque<String> fieldNames = Lists.newLinkedList();
+    private String lazyFieldName = null;
+
+    public VariantMetrics(long valueCount, long nullCount) {
+      this.valueCount = valueCount;
+      this.nullCount = nullCount;
+      this.lowerBound = null;
+      this.upperBound = null;
+    }
+
+    public VariantMetrics(
+        long valueCount, long nullCount, VariantValue lowerBound, VariantValue upperBound) {
+      this.valueCount = valueCount;
+      this.nullCount = nullCount;
+      this.lowerBound = truncateLowerBound(lowerBound);
+      this.upperBound = truncateUpperBound(upperBound);
+    }
+
+    VariantMetrics prependFieldName(String name) {
+      this.lazyFieldName = null;
+      fieldNames.addFirst(name);
+      return this;
+    }
+
+    public String fieldName() {
+      if (null == lazyFieldName) {
+        this.lazyFieldName = String.join(".", fieldNames);
+      }
+
+      return lazyFieldName;
+    }
+
+    public long valueCount() {
+      return valueCount;
+    }
+
+    public long nullCount() {
+      return nullCount;
+    }
+
+    public VariantValue lowerBound() {
+      return lowerBound;
+    }
+
+    public VariantValue upperBound() {
+      return upperBound;
+    }
+
+    private static VariantValue truncateLowerBound(VariantValue value) {
+      switch (value.type()) {
+        case STRING:
+          return Variants.of(
+              PhysicalType.STRING,
+              UnicodeUtil.truncateStringMin((String) value.asPrimitive().get(), 16));
+        case BINARY:
+          return Variants.of(
+              PhysicalType.BINARY,
+              BinaryUtil.truncateBinaryMin((ByteBuffer) value.asPrimitive().get(), 16));
+        default:
+          return value;
+      }
+    }
+
+    private static VariantValue truncateUpperBound(VariantValue value) {
+      switch (value.type()) {
+        case STRING:
+          String truncatedString =
+              UnicodeUtil.truncateStringMax((String) value.asPrimitive().get(), 16);
+          return truncatedString != null ? Variants.of(PhysicalType.STRING, truncatedString) : null;
+        case BINARY:
+          ByteBuffer truncatedBuffer =
+              BinaryUtil.truncateBinaryMin((ByteBuffer) value.asPrimitive().get(), 16);
+          return truncatedBuffer != null ? Variants.of(PhysicalType.BINARY, truncatedBuffer) : null;
+        default:
+          return value;
+      }
+    }
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -46,6 +46,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
 
   private static final Metrics EMPTY_METRICS = new Metrics(0L, null, null, null, null);
 
+  private final Schema schema;
   private final long targetRowGroupSize;
   private final Map<String, String> metadata;
   private final ParquetProperties props;
@@ -84,6 +85,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
       MetricsConfig metricsConfig,
       ParquetFileWriter.Mode writeMode,
       FileEncryptionProperties encryptionProperties) {
+    this.schema = schema;
     this.targetRowGroupSize = rowGroupSize;
     this.props = properties;
     this.metadata = ImmutableMap.copyOf(metadata);
@@ -142,7 +144,8 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
   public Metrics metrics() {
     Preconditions.checkState(closed, "Cannot return metrics for unclosed writer");
     if (writer != null) {
-      return ParquetUtil.footerMetrics(writer.getFooter(), model.metrics(), metricsConfig);
+      return ParquetMetrics.metrics(
+          schema, parquetSchema, metricsConfig, writer.getFooter(), model.metrics());
     }
     return EMPTY_METRICS;
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -154,7 +154,7 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
   }
 
   @Override
-  public Type variant(org.apache.iceberg.types.Types.VariantType expected, Type variant) {
+  public Type variant(org.apache.iceberg.types.Types.VariantType expected, GroupType variantGroup, Type variant) {
     return variant;
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -154,7 +154,8 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
   }
 
   @Override
-  public Type variant(org.apache.iceberg.types.Types.VariantType expected, GroupType variantGroup, Type variant) {
+  public Type variant(
+      org.apache.iceberg.types.Types.VariantType expected, GroupType variantGroup, Type variant) {
     return variant;
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
@@ -211,13 +211,13 @@ public class TypeWithSchemaVisitor<T> {
   }
 
   private static <T> T visitVariant(
-      Types.VariantType variant, GroupType group, TypeWithSchemaVisitor<T> visitor) {
+      Types.VariantType variant, GroupType variantGroup, TypeWithSchemaVisitor<T> visitor) {
     ParquetVariantVisitor<T> variantVisitor = visitor.variantVisitor();
     if (variantVisitor != null) {
-      T variantResult = ParquetVariantVisitor.visit(group, variantVisitor);
-      return visitor.variant(variant, variantResult);
+      T variantResult = ParquetVariantVisitor.visit(variantGroup, variantVisitor);
+      return visitor.variant(variant, variantGroup, variantResult);
     } else {
-      return visitor.variant(variant, null);
+      return visitor.variant(variant, variantGroup, null);
     }
   }
 
@@ -237,7 +237,7 @@ public class TypeWithSchemaVisitor<T> {
     return null;
   }
 
-  public T variant(Types.VariantType iVariant, T result) {
+  public T variant(Types.VariantType iVariant, GroupType variant, T result) {
     throw new UnsupportedOperationException("Not implemented for variant");
   }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
@@ -1,0 +1,503 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.InternalWriter;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.BinaryUtil;
+import org.apache.iceberg.util.UnicodeUtil;
+import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.ShreddedObject;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantObject;
+import org.apache.iceberg.variants.VariantPrimitive;
+import org.apache.iceberg.variants.VariantTestUtil;
+import org.apache.iceberg.variants.VariantValue;
+import org.apache.iceberg.variants.Variants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+
+public class TestVariantMetrics {
+  private static final VariantMetadata METADATA =
+      VariantMetadata.from(VariantTestUtil.createMetadata(Set.of("a", "b", "c", "d", "e"), true));
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.optional(2, "var", Types.VariantType.get()));
+
+  private static final VariantMetadata EMPTY = Variants.emptyMetadata();
+
+  private static final String ROOT_FIELD = "";
+
+  private static final VariantValue[] PRIMITIVES =
+      new VariantValue[] {
+        Variants.of(true),
+        Variants.of(false),
+        Variants.of((byte) 34),
+        Variants.of((byte) -34),
+        Variants.of((short) 1234),
+        Variants.of((short) -1234),
+        Variants.of(12345),
+        Variants.of(-12345),
+        Variants.of(9876543210L),
+        Variants.of(-9876543210L),
+        Variants.of(10.11F),
+        Variants.of(-10.11F),
+        Variants.of(14.3D),
+        Variants.of(-14.3D),
+        Variants.ofIsoDate("2024-11-07"),
+        Variants.ofIsoDate("1957-11-07"),
+        Variants.ofIsoTimestamptz("2024-11-07T12:33:54.123456+00:00"),
+        Variants.ofIsoTimestamptz("1957-11-07T12:33:54.123456+00:00"),
+        Variants.ofIsoTimestampntz("2024-11-07T12:33:54.123456"),
+        Variants.ofIsoTimestampntz("1957-11-07T12:33:54.123456"),
+        Variants.of(new BigDecimal("123456.789")), // decimal4
+        Variants.of(new BigDecimal("-123456.789")), // decimal4
+        Variants.of(new BigDecimal("123456789.987654321")), // decimal8
+        Variants.of(new BigDecimal("-123456789.987654321")), // decimal8
+        Variants.of(new BigDecimal("9876543210.123456789")), // decimal16
+        Variants.of(new BigDecimal("-9876543210.123456789")), // decimal16
+        Variants.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),
+        Variants.of("iceberg"),
+      };
+
+  @ParameterizedTest
+  @FieldSource("PRIMITIVES")
+  public void testShreddedPrimitiveTypes(VariantValue value) throws IOException {
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(value),
+            Variant.of(EMPTY, value),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null);
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 3L, 2, 3L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds().size()).isEqualTo(2);
+    assertThat(metrics.lowerBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(0L);
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(
+            bytes -> {
+              VariantObject bounds = Variant.from(bytes).value().asObject();
+              return bounds.get(ROOT_FIELD);
+            })
+        .isEqualTo(value);
+
+    assertThat(metrics.upperBounds().size()).isEqualTo(2);
+    assertThat(metrics.upperBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(2L);
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(
+            bytes -> {
+              VariantObject bounds = Variant.from(bytes).value().asObject();
+              return bounds.get(ROOT_FIELD);
+            })
+        .isEqualTo(value);
+  }
+
+  @ParameterizedTest
+  @FieldSource("PRIMITIVES")
+  public void testShreddedPrimitiveRange(VariantValue value) throws IOException {
+    VariantValue largerValue = increment(value);
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(value),
+            Variant.of(EMPTY, largerValue),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null,
+            Variant.of(EMPTY, value));
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 4L, 2, 4L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds().size()).isEqualTo(2);
+    assertThat(metrics.lowerBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(0L);
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(
+            bytes -> {
+              VariantObject bounds = Variant.from(bytes).value().asObject();
+              return bounds.get(ROOT_FIELD);
+            })
+        .isEqualTo(value);
+
+    assertThat(metrics.upperBounds().size()).isEqualTo(2);
+    assertThat(metrics.upperBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(3L);
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(
+            bytes -> {
+              VariantObject bounds = Variant.from(bytes).value().asObject();
+              return bounds.get(ROOT_FIELD);
+            })
+        .isEqualTo(largerValue);
+  }
+
+  @ParameterizedTest
+  @FieldSource("PRIMITIVES")
+  public void testShreddedPrimitiveTypeMismatch(VariantValue value) throws IOException {
+    // a value of another type will cause lower/upper bounds to be omitted
+    VariantValue otherValue =
+        value.type() == PhysicalType.STRING ? Variants.of(34) : Variants.of("iceberg");
+
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(value),
+            Variant.of(EMPTY, value),
+            Variant.of(EMPTY, otherValue));
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 2L, 2, 2L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 0L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
+    assertThat(metrics.upperBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+  }
+
+  @Test
+  public void testVariantFloatNaN() throws IOException {
+    // NaN values are not counted because there is no ID for FieldMetrics
+    VariantValue floatValue = Variants.of(1.0F);
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(floatValue),
+            Variant.of(EMPTY, floatValue),
+            Variant.of(EMPTY, Variants.of(Float.NaN)));
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 2L, 2, 2L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 0L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
+    assertThat(metrics.upperBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+  }
+
+  @Test
+  public void testVariantDoubleNaN() throws IOException {
+    // NaN values are not counted because there is no ID for FieldMetrics
+    VariantValue doubleValue = Variants.of(1.0D);
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(doubleValue),
+            Variant.of(EMPTY, doubleValue),
+            Variant.of(EMPTY, Variants.of(Double.NaN)));
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 2L, 2, 2L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 0L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
+    assertThat(metrics.upperBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+  }
+
+  @Test
+  public void testAllNull() throws IOException {
+    ShreddedObject object = Variants.object(METADATA);
+    object.put("a", Variants.ofIsoDate("2025-03-17"));
+    object.put("b", Variants.of(34));
+    object.put("c", Variants.of("iceberg"));
+    Metrics metrics =
+        writeParquet((id, name) -> ParquetVariantUtil.toParquetSchema(object), null, null);
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 2L, 2, 2L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 2L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
+    assertThat(metrics.upperBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+  }
+
+  @Test
+  public void testUnshredded() throws IOException {
+    ShreddedObject object = Variants.object(METADATA);
+    object.put("a", Variants.ofIsoDate("2025-03-17"));
+    object.put("b", Variants.of(34));
+    object.put("c", Variants.of("iceberg"));
+    Metrics metrics = writeParquet((id, name) -> null, Variant.of(METADATA, object), null);
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 2L, 2, 2L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
+    assertThat(metrics.upperBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+  }
+
+  @Test
+  public void testShreddedObject() throws IOException {
+    VariantValue date = Variants.ofIsoDate("2025-03-17");
+    VariantValue num = Variants.of(34);
+    VariantValue str = Variants.of("iceberg");
+    VariantValue dec = Variants.of(new BigDecimal("123456.789"));
+
+    ShreddedObject inner = Variants.object(METADATA);
+    inner.put("e", dec);
+    ShreddedObject object = Variants.object(METADATA);
+    object.put("a", date);
+    object.put("b", num);
+    object.put("c", str);
+    object.put("d", inner);
+
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(object),
+            Variant.of(EMPTY, num),
+            Variant.of(EMPTY, Variants.object(EMPTY)),
+            Variant.of(METADATA, object),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null);
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 5L, 2, 5L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    VariantMetadata boundMetadata = Variants.metadata("a", "b", "c", "d.e");
+    ShreddedObject expectedBounds = Variants.object(boundMetadata);
+    expectedBounds.put("a", date);
+    expectedBounds.put("b", num);
+    expectedBounds.put("c", str);
+    expectedBounds.put("d.e", dec);
+
+    assertThat(metrics.lowerBounds().size()).isEqualTo(2);
+    assertThat(metrics.lowerBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(0L);
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(bytes -> Variant.from(bytes).value())
+        .isEqualTo(expectedBounds);
+
+    assertThat(metrics.upperBounds().size()).isEqualTo(2);
+    assertThat(metrics.upperBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(4L);
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(bytes -> Variant.from(bytes).value())
+        .isEqualTo(expectedBounds);
+  }
+
+  @Test
+  public void testPartiallyShreddedObject() throws IOException {
+    VariantValue date = Variants.ofIsoDate("2025-03-17");
+    VariantValue num = Variants.of(34);
+    VariantValue str = Variants.of("iceberg");
+    VariantValue dec = Variants.of(new BigDecimal("123456.789"));
+
+    ShreddedObject inner = Variants.object(METADATA);
+    inner.put("e", dec);
+    ShreddedObject object = Variants.object(METADATA);
+    object.put("a", date);
+    object.put("b", num);
+    object.put("c", str);
+    object.put("d", inner);
+
+    // used to produce the shredding schema
+    ShreddedObject example = Variants.object(METADATA);
+    example.put("a", date);
+    example.put("b", num);
+
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(example),
+            Variant.of(EMPTY, num),
+            Variant.of(EMPTY, Variants.object(EMPTY)),
+            Variant.of(METADATA, object),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null);
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 5L, 2, 5L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    // only a and b were shredded so the other fields are not present
+    VariantMetadata boundMetadata = Variants.metadata("a", "b");
+    ShreddedObject expectedBounds = Variants.object(boundMetadata);
+    expectedBounds.put("a", date);
+    expectedBounds.put("b", num);
+
+    assertThat(metrics.lowerBounds().size()).isEqualTo(2);
+    assertThat(metrics.lowerBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(0L);
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(bytes -> Variant.from(bytes).value())
+        .isEqualTo(expectedBounds);
+
+    assertThat(metrics.upperBounds().size()).isEqualTo(2);
+    assertThat(metrics.upperBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(4L);
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(bytes -> Variant.from(bytes).value())
+        .isEqualTo(expectedBounds);
+  }
+
+  @Test
+  public void testShreddedObjectFieldTypeMismatch() throws IOException {
+    VariantValue date = Variants.ofIsoDate("2025-03-17");
+    VariantValue num = Variants.of(34);
+    VariantValue str = Variants.of("iceberg");
+    VariantValue dec = Variants.of(new BigDecimal("123456.789"));
+
+    ShreddedObject inner = Variants.object(METADATA);
+    inner.put("e", dec);
+    ShreddedObject object = Variants.object(METADATA);
+    object.put("a", date);
+    object.put("b", num);
+    object.put("c", str);
+    object.put("d", inner);
+
+    ShreddedObject mismatched = Variants.object(METADATA);
+    mismatched.put("a", Variants.ofNull()); // does not affect metrics
+    mismatched.put("b", Variants.of((byte) -1)); // int and byte mismatch
+    mismatched.put("c", num); // string and int mismatch
+    // d is missing and does not affect metrics
+
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(object),
+            Variant.of(EMPTY, num),
+            Variant.of(EMPTY, mismatched),
+            Variant.of(EMPTY, Variants.object(EMPTY)),
+            Variant.of(METADATA, object),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null);
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 6L, 2, 6L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    // only a and b were shredded so the other fields are not present
+    VariantMetadata boundMetadata = Variants.metadata("a", "d.e");
+    ShreddedObject expectedBounds = Variants.object(boundMetadata);
+    expectedBounds.put("a", date);
+    expectedBounds.put("d.e", dec);
+
+    assertThat(metrics.lowerBounds().size()).isEqualTo(2);
+    assertThat(metrics.lowerBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(0L);
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(bytes -> Variant.from(bytes).value())
+        .isEqualTo(expectedBounds);
+
+    assertThat(metrics.upperBounds().size()).isEqualTo(2);
+    assertThat(metrics.upperBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(5L);
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(bytes -> Variant.from(bytes).value())
+        .isEqualTo(expectedBounds);
+  }
+
+  private Metrics writeParquet(VariantShreddingFunction shredding, Variant... variants)
+      throws IOException {
+    OutputFile out = new InMemoryOutputFile();
+    GenericRecord record = GenericRecord.create(SCHEMA);
+
+    FileAppender<Record> writer =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc(shredding)
+            .createWriterFunc(fileSchema -> InternalWriter.create(SCHEMA.asStruct(), fileSchema))
+            .build();
+
+    try (writer) {
+      for (int id = 0; id < variants.length; id += 1) {
+        record.setField("id", (long) id);
+        record.setField("var", variants[id]);
+        writer.add(record);
+      }
+    }
+
+    return writer.metrics();
+  }
+
+  private static VariantValue increment(VariantValue value) {
+    VariantPrimitive<?> primitive = value.asPrimitive();
+    switch (value.type()) {
+      case BOOLEAN_TRUE:
+      case BOOLEAN_FALSE:
+        return Variants.of(true);
+      case INT8:
+        return Variants.of(value.type(), (byte) ((Byte) primitive.get() + 1));
+      case INT16:
+        return Variants.of(value.type(), (short) ((Short) primitive.get() + 1));
+      case INT32:
+      case DATE:
+        return Variants.of(value.type(), (Integer) primitive.get() + 1);
+      case INT64:
+      case TIMESTAMPTZ:
+      case TIMESTAMPNTZ:
+        return Variants.of(value.type(), (Long) primitive.get() + 1L);
+      case FLOAT:
+        return Variants.of(value.type(), (Float) primitive.get() + 1.0F);
+      case DOUBLE:
+        return Variants.of(value.type(), (Double) primitive.get() + 1.0D);
+      case DECIMAL4:
+      case DECIMAL8:
+      case DECIMAL16:
+        return Variants.of(value.type(), ((BigDecimal) primitive.get()).add(BigDecimal.ONE));
+      case BINARY:
+        return Variants.of(
+            value.type(), BinaryUtil.truncateBinaryMax((ByteBuffer) primitive.get(), 2));
+      case STRING:
+        return Variants.of(
+            value.type(), UnicodeUtil.truncateStringMax((String) primitive.get(), 5));
+    }
+
+    throw new UnsupportedOperationException("Cannot increment value: " + value);
+  }
+}

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
@@ -153,8 +153,7 @@ public class TestVariantWriters {
             .collect(Collectors.toList());
 
     List<Record> actual =
-        writeAndRead(
-            (id, name) -> ParquetVariantUtil.toParquetSchema(variant.value()), expected);
+        writeAndRead((id, name) -> ParquetVariantUtil.toParquetSchema(variant.value()), expected);
 
     assertThat(actual.size()).isEqualTo(expected.size());
 


### PR DESCRIPTION
This implements metrics for Variant types stored in Parquet files, using new visitors to produce the metrics.

This also refactors the existing metrics code to use a visitor. If I remember correctly, the metrics code predates the Parquet visitor. I think the visitor version is cleaner.