### PR TITLE
AWS: Update S3 async client configurations and docs for analytics-accelerator-s3

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -58,9 +58,18 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   @Override
   public S3AsyncClient s3Async() {
     if (s3FileIOProperties.isS3CRTEnabled()) {
-      return S3AsyncClient.crtBuilder().applyMutation(this::applyAssumeRoleConfigurations).build();
+      return S3AsyncClient.crtBuilder()
+          .applyMutation(this::applyAssumeRoleConfigurations)
+          .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+          .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+          .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
+          .build();
     }
-    return S3AsyncClient.builder().applyMutation(this::applyAssumeRoleConfigurations).build();
+    return S3AsyncClient.builder()
+        .applyMutation(this::applyAssumeRoleConfigurations)
+        .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+        .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+        .build();
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -62,6 +62,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
           .applyMutation(this::applyAssumeRoleConfigurations)
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
           .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+          .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
           .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
           .build();
     }
@@ -69,6 +70,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
         .applyMutation(this::applyAssumeRoleConfigurations)
         .applyMutation(awsClientProperties::applyClientRegionConfiguration)
         .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+        .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .build();
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -125,12 +125,14 @@ public class AwsClientFactories {
         return S3AsyncClient.crtBuilder()
             .applyMutation(awsClientProperties::applyClientRegionConfiguration)
             .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+            .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
             .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
             .build();
       }
       return S3AsyncClient.builder()
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
           .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+          .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
           .build();
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -122,9 +122,16 @@ public class AwsClientFactories {
     @Override
     public S3AsyncClient s3Async() {
       if (s3FileIOProperties.isS3CRTEnabled()) {
-        return S3AsyncClient.crtBuilder().build();
+        return S3AsyncClient.crtBuilder()
+            .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+            .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+            .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
+            .build();
       }
-      return S3AsyncClient.builder().build();
+      return S3AsyncClient.builder()
+          .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+          .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+          .build();
     }
 
     @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
 
 public class AwsClientProperties implements Serializable {
   /**
@@ -136,6 +137,21 @@ public class AwsClientProperties implements Serializable {
   }
 
   /**
+   * Configure a CRT client region.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3AsyncClient.crtBuilder().applyMutation(awsClientProperties::applyClientRegionConfiguration)
+   * </pre>
+   */
+  public <T extends S3CrtAsyncClientBuilder> void applyClientRegionConfiguration(T builder) {
+    if (clientRegion != null) {
+      builder.region(Region.of(clientRegion));
+    }
+  }
+
+  /**
    * Configure the credential provider for AWS clients.
    *
    * <p>Sample usage:
@@ -145,6 +161,21 @@ public class AwsClientProperties implements Serializable {
    * </pre>
    */
   public <T extends AwsClientBuilder> void applyClientCredentialConfigurations(T builder) {
+    if (!Strings.isNullOrEmpty(this.clientCredentialsProvider)) {
+      builder.credentialsProvider(credentialsProvider(this.clientCredentialsProvider));
+    }
+  }
+
+  /**
+   * Configure the credential provider for CRT clients.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3AsyncClient.crtBuilder().applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+   * </pre>
+   */
+  public <T extends S3CrtAsyncClientBuilder> void applyClientCredentialConfigurations(T builder) {
     if (!Strings.isNullOrEmpty(this.clientCredentialsProvider)) {
       builder.credentialsProvider(credentialsProvider(this.clientCredentialsProvider));
     }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -137,7 +137,7 @@ public class AwsClientProperties implements Serializable {
   }
 
   /**
-   * Configure a CRT client region.
+   * Configure an S3 CRT client region.
    *
    * <p>Sample usage:
    *
@@ -167,7 +167,7 @@ public class AwsClientProperties implements Serializable {
   }
 
   /**
-   * Configure the credential provider for CRT clients.
+   * Configure the credential provider for S3 CRT clients.
    *
    * <p>Sample usage:
    *

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -66,12 +66,14 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
       return S3AsyncClient.crtBuilder()
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
           .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+          .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
           .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
           .build();
     }
     return S3AsyncClient.builder()
         .applyMutation(awsClientProperties::applyClientRegionConfiguration)
         .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+        .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .build();
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -63,8 +63,15 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
   @Override
   public S3AsyncClient s3Async() {
     if (s3FileIOProperties.isS3CRTEnabled()) {
-      return S3AsyncClient.crtBuilder().build();
+      return S3AsyncClient.crtBuilder()
+          .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+          .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+          .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
+          .build();
     }
-    return S3AsyncClient.builder().build();
+    return S3AsyncClient.builder()
+        .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+        .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
+        .build();
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -100,7 +100,7 @@ public class S3FileIOProperties implements Serializable {
 
   public static final boolean S3_CRT_ENABLED_DEFAULT = true;
 
-  /** This property is used to specify the max concurrency for CRT Async clients. */
+  /** This property is used to specify the max concurrency for S3 CRT clients. */
   public static final String S3_CRT_MAX_CONCURRENCY = "s3.crt.max-concurrency";
 
   /**
@@ -1042,7 +1042,7 @@ public class S3FileIOProperties implements Serializable {
   }
 
   /**
-   * Override the endpoint for an S3 CRT async client
+   * Override the endpoint for an S3 CRT client
    *
    * <p>Sample usage:
    *

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -48,6 +48,7 @@ import software.amazon.awssdk.core.retry.conditions.OrRetryCondition;
 import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.core.retry.conditions.RetryOnExceptionsCondition;
 import software.amazon.awssdk.core.retry.conditions.TokenBucketRetryCondition;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
@@ -1020,6 +1021,36 @@ public class S3FileIOProperties implements Serializable {
    * </pre>
    */
   public <T extends S3ClientBuilder> void applyEndpointConfigurations(T builder) {
+    if (endpoint != null) {
+      builder.endpointOverride(URI.create(endpoint));
+    }
+  }
+
+  /**
+   * Override the endpoint for an S3 async client
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3AsyncClient.builder().applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+   * </pre>
+   */
+  public <T extends S3AsyncClientBuilder> void applyEndpointConfigurations(T builder) {
+    if (endpoint != null) {
+      builder.endpointOverride(URI.create(endpoint));
+    }
+  }
+
+  /**
+   * Override the endpoint for an S3 CRT async client
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3AsyncClient.crtBuilder().applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+   * </pre>
+   */
+  public <T extends S3CrtAsyncClientBuilder> void applyEndpointConfigurations(T builder) {
     if (endpoint != null) {
       builder.endpointOverride(URI.create(endpoint));
     }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -50,6 +50,7 @@ import software.amazon.awssdk.core.retry.conditions.RetryOnExceptionsCondition;
 import software.amazon.awssdk.core.retry.conditions.TokenBucketRetryCondition;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Tag;
 
@@ -97,6 +98,17 @@ public class S3FileIOProperties implements Serializable {
   public static final String S3_CRT_ENABLED = "s3.crt.enabled";
 
   public static final boolean S3_CRT_ENABLED_DEFAULT = true;
+
+  /** This property is used to specify the max concurrency for CRT Async clients. */
+  public static final String S3_CRT_MAX_CONCURRENCY = "s3.crt.max-concurrency";
+
+  /**
+   * To fully benefit from the analytics-accelerator-s3 library where this S3 CRT client is used, it
+   * is recommended to initialize with higher concurrency.
+   *
+   * <p>For more details, see: https://github.com/awslabs/analytics-accelerator-s3
+   */
+  public static final int S3_CRT_MAX_CONCURRENCY_DEFAULT = 500;
 
   /**
    * The fallback-to-iam property allows users to customize whether or not they would like their
@@ -513,6 +525,7 @@ public class S3FileIOProperties implements Serializable {
   private final boolean isS3AnalyticsAcceleratorEnabled;
   private final Map<String, String> s3AnalyticsacceleratorProperties;
   private final boolean isS3CRTEnabled;
+  private final int s3CrtMaxConcurrency;
   private String writeStorageClass;
   private int s3RetryNumRetries;
   private long s3RetryMinWaitMs;
@@ -560,6 +573,7 @@ public class S3FileIOProperties implements Serializable {
     this.isS3AnalyticsAcceleratorEnabled = S3_ANALYTICS_ACCELERATOR_ENABLED_DEFAULT;
     this.s3AnalyticsacceleratorProperties = Maps.newHashMap();
     this.isS3CRTEnabled = S3_CRT_ENABLED_DEFAULT;
+    this.s3CrtMaxConcurrency = S3_CRT_MAX_CONCURRENCY_DEFAULT;
     this.allProperties = Maps.newHashMap();
 
     ValidationException.check(
@@ -679,6 +693,9 @@ public class S3FileIOProperties implements Serializable {
         PropertyUtil.propertiesWithPrefix(properties, S3_ANALYTICS_ACCELERATOR_PROPERTIES_PREFIX);
     this.isS3CRTEnabled =
         PropertyUtil.propertyAsBoolean(properties, S3_CRT_ENABLED, S3_CRT_ENABLED_DEFAULT);
+    this.s3CrtMaxConcurrency =
+        PropertyUtil.propertyAsInt(
+            properties, S3_CRT_MAX_CONCURRENCY, S3_CRT_MAX_CONCURRENCY_DEFAULT);
 
     ValidationException.check(
         keyIdAccessKeyBothConfigured(),
@@ -803,6 +820,10 @@ public class S3FileIOProperties implements Serializable {
 
   public boolean isS3CRTEnabled() {
     return isS3CRTEnabled;
+  }
+
+  public int s3CrtMaxConcurrency() {
+    return s3CrtMaxConcurrency;
   }
 
   public String endpoint() {
@@ -1096,6 +1117,10 @@ public class S3FileIOProperties implements Serializable {
         configBuilder
             .putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_PREFIX, S3_FILE_IO_USER_AGENT)
             .build());
+  }
+
+  public S3CrtAsyncClientBuilder applyS3CrtConfigurations(S3CrtAsyncClientBuilder builder) {
+    return builder.maxConcurrency(s3CrtMaxConcurrency());
   }
 
   /**

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -37,9 +37,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Tag;
 
@@ -51,6 +53,7 @@ public class TestS3FileIOProperties {
   private static final String S3_DELETE_TAG_KEY = "my_key";
   private static final String S3_DELETE_TAG_VALUE = "my_value";
 
+  @SuppressWarnings("MethodLength")
   @Test
   public void testS3FileIOPropertiesDefaultValues() {
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties();
@@ -122,8 +125,18 @@ public class TestS3FileIOProperties {
         .isEqualTo(s3FileIOProperties.isDeleteEnabled());
 
     assertThat(Collections.emptyMap()).isEqualTo(s3FileIOProperties.bucketToAccessPointMapping());
+
+    assertThat(S3FileIOProperties.S3_CRT_MAX_CONCURRENCY_DEFAULT)
+        .isEqualTo(s3FileIOProperties.s3CrtMaxConcurrency());
+
+    assertThat(S3FileIOProperties.S3_CRT_ENABLED_DEFAULT)
+        .isEqualTo(s3FileIOProperties.isS3CRTEnabled());
+
+    assertThat(S3FileIOProperties.S3_ANALYTICS_ACCELERATOR_ENABLED_DEFAULT)
+        .isEqualTo(s3FileIOProperties.isS3AnalyticsAcceleratorEnabled());
   }
 
+  @SuppressWarnings("MethodLength")
   @Test
   public void testS3FileIOProperties() {
     Map<String, String> map = getTestProperties();
@@ -265,6 +278,20 @@ public class TestS3FileIOProperties {
             String.valueOf(s3FileIOProperties.isRemoteSigningEnabled()));
 
     assertThat(map).containsEntry(S3FileIOProperties.WRITE_STORAGE_CLASS, "INTELLIGENT_TIERING");
+
+    assertThat(map)
+        .containsEntry(
+            S3FileIOProperties.S3_CRT_MAX_CONCURRENCY,
+            String.valueOf(s3FileIOProperties.s3CrtMaxConcurrency()));
+
+    assertThat(map)
+        .containsEntry(
+            S3FileIOProperties.S3_CRT_ENABLED, String.valueOf(s3FileIOProperties.isS3CRTEnabled()));
+
+    assertThat(map)
+        .containsEntry(
+            S3FileIOProperties.S3_ANALYTICS_ACCELERATOR_ENABLED,
+            String.valueOf(s3FileIOProperties.isS3AnalyticsAcceleratorEnabled()));
   }
 
   @Test
@@ -412,6 +439,9 @@ public class TestS3FileIOProperties {
     map.put(S3FileIOProperties.PRELOAD_CLIENT_ENABLED, "true");
     map.put(S3FileIOProperties.REMOTE_SIGNING_ENABLED, "true");
     map.put(S3FileIOProperties.WRITE_STORAGE_CLASS, "INTELLIGENT_TIERING");
+    map.put(S3FileIOProperties.S3_CRT_MAX_CONCURRENCY, "200");
+    map.put(S3FileIOProperties.S3_CRT_ENABLED, "false");
+    map.put(S3FileIOProperties.S3_ANALYTICS_ACCELERATOR_ENABLED, "true");
     return map;
   }
 
@@ -489,9 +519,17 @@ public class TestS3FileIOProperties {
     properties.put(S3FileIOProperties.ENDPOINT, "endpoint");
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
     S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
+    S3AsyncClientBuilder mockS3AsyncClientBuilder = Mockito.mock(S3AsyncClientBuilder.class);
+    S3CrtAsyncClientBuilder mockS3CrtAsyncClientBuilder =
+        Mockito.mock(S3CrtAsyncClientBuilder.class);
 
     s3FileIOProperties.applyEndpointConfigurations(mockS3ClientBuilder);
+    s3FileIOProperties.applyEndpointConfigurations(mockS3AsyncClientBuilder);
+    s3FileIOProperties.applyEndpointConfigurations(mockS3CrtAsyncClientBuilder);
+
     Mockito.verify(mockS3ClientBuilder).endpointOverride(Mockito.any(URI.class));
+    Mockito.verify(mockS3AsyncClientBuilder).endpointOverride(Mockito.any(URI.class));
+    Mockito.verify(mockS3CrtAsyncClientBuilder).endpointOverride(Mockito.any(URI.class));
   }
 
   @Test
@@ -503,6 +541,17 @@ public class TestS3FileIOProperties {
 
     Mockito.verify(mockS3ClientBuilder)
         .overrideConfiguration(Mockito.any(ClientOverrideConfiguration.class));
+  }
+
+  @Test
+  public void testApplyS3CrtConfigurations() {
+    Map<String, String> properties = Maps.newHashMap();
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+    S3CrtAsyncClientBuilder mockS3CrtAsyncClientBuilder =
+        Mockito.mock(S3CrtAsyncClientBuilder.class);
+    s3FileIOProperties.applyS3CrtConfigurations(mockS3CrtAsyncClientBuilder);
+
+    Mockito.verify(mockS3CrtAsyncClientBuilder).maxConcurrency(Mockito.any(Integer.class));
   }
 
   @Test

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -580,7 +580,7 @@ spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCata
     --conf spark.sql.catalog.my_catalog.s3.analytics-accelerator.enabled=true
 ```
 
-Our library can work with either the [S3 CRT client](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html) or the [S3AsyncClient](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3AsyncClient.html). We recommend that you use the S3 CRT client due to its enhanced connection pool management and [higher throughput on downloads](https://aws.amazon.com/blogs/developer/introducing-crt-based-s3-client-and-the-s3-transfer-manager-in-the-aws-sdk-for-java-2-x/).
+The Analytics Accelerator Library can work with either the [S3 CRT client](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html) or the [S3AsyncClient](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3AsyncClient.html). The library recommends that you use the S3 CRT client due to its enhanced connection pool management and [higher throughput on downloads](https://aws.amazon.com/blogs/developer/introducing-crt-based-s3-client-and-the-s3-transfer-manager-in-the-aws-sdk-for-java-2-x/).
 
 ##### Client Configuration
 

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -582,16 +582,16 @@ spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCata
 
 The Analytics Accelerator Library can work with either the [S3 CRT client](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html) or the [S3AsyncClient](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3AsyncClient.html). The library recommends that you use the S3 CRT client due to its enhanced connection pool management and [higher throughput on downloads](https://aws.amazon.com/blogs/developer/introducing-crt-based-s3-client-and-the-s3-transfer-manager-in-the-aws-sdk-for-java-2-x/).
 
-##### Client Configuration
+#### Client Configuration
 
 | Property               | Default | Description                                                  |
 |------------------------|---------|--------------------------------------------------------------|
 | s3.crt.enabled         | `true`  | Controls if the S3 Async clients should be created using CRT |
-| s3.crt.max-concurrency | `500`   | Max concurrency for S3 CRT Async clients                     |
+| s3.crt.max-concurrency | `500`   | Max concurrency for S3 CRT clients                           |
 
 Additional library specific configurations are organized into the following sections:
 
-##### Logical IO Configuration
+#### Logical IO Configuration
 
 | Property                                                               | Default               | Description                                                                |
 |------------------------------------------------------------------------|-----------------------|----------------------------------------------------------------------------|
@@ -609,7 +609,7 @@ Additional library specific configurations are organized into the following sect
 | s3.analytics-accelerator.logicalio.parquet.format.selector.regex       | `^.*.(parquet\|par)$` | Regex pattern to identify parquet files                                    |
 | s3.analytics-accelerator.logicalio.prefetching.mode                    | `ROW_GROUP`           | Prefetching mode (valid values: `OFF`, `ALL`, `ROW_GROUP`, `COLUMN_BOUND`) |
 
-##### Physical IO Configuration
+#### Physical IO Configuration
 
 | Property                                                     | Default | Description                                 |
 |--------------------------------------------------------------|---------|---------------------------------------------|
@@ -621,7 +621,7 @@ Additional library specific configurations are organized into the following sect
 | s3.analytics-accelerator.physicalio.sequentialprefetch.base  | `2.0`   | Base factor for sequential prefetch sizing  |
 | s3.analytics-accelerator.physicalio.sequentialprefetch.speed | `1.0`   | Speed factor for sequential prefetch growth |
 
-##### Telemetry Configuration
+#### Telemetry Configuration
 
 | Property                                                               | Default                             | Description                                                              |
 |------------------------------------------------------------------------|-------------------------------------|--------------------------------------------------------------------------|
@@ -634,7 +634,7 @@ Additional library specific configurations are organized into the following sect
 | s3.analytics-accelerator.telemetry.logging.name                        | `com.amazon.connector.s3.telemetry` | Logger name for telemetry                                                |
 | s3.analytics-accelerator.telemetry.format                              | `default`                           | Telemetry output format (valid values: `json`, `default`)                |
 
-##### Object Client Configuration
+#### Object Client Configuration
 
 | Property                                 | Default | Description                                                    |
 |------------------------------------------|---------|----------------------------------------------------------------|

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -565,6 +565,81 @@ spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCata
 
 For more details on using S3 Acceleration, please refer to [Configuring fast, secure file transfers using Amazon S3 Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html).
 
+### S3 Analytics Accelerator
+
+The [Analytics Accelerator Library for Amazon S3](https://github.com/awslabs/analytics-accelerator-s3) helps you accelerate access to Amazon S3 data from your applications. This open-source solution reduces processing times and compute costs for your data analytics workloads.
+
+In order to enable S3 Analytics Accelerator Library to work in Iceberg, you can set the `s3.analytics-accelerator.enabled` catalog property to `true`. By default, this property is set to `false`.
+
+For example, to use S3 Analytics Accelerator with Spark, you can start the Spark SQL shell with:
+```
+spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
+    --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket2/my/key/prefix \
+    --conf spark.sql.catalog.my_catalog.type=glue \
+    --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+    --conf spark.sql.catalog.my_catalog.s3.analytics-accelerator.enabled=true
+```
+
+Our library can work with either the [S3 CRT client](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html) or the [S3AsyncClient](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3AsyncClient.html). We recommend that you use the S3 CRT client due to its enhanced connection pool management and [higher throughput on downloads](https://aws.amazon.com/blogs/developer/introducing-crt-based-s3-client-and-the-s3-transfer-manager-in-the-aws-sdk-for-java-2-x/).
+
+##### Client Configuration
+
+| Property               | Default | Description                                                  |
+|------------------------|---------|--------------------------------------------------------------|
+| s3.crt.enabled         | `true`  | Controls if the S3 Async clients should be created using CRT |
+| s3.crt.max-concurrency | `500`   | Max concurrency for S3 CRT Async clients                     |
+
+Additional library specific configurations are organized into the following sections:
+
+##### Logical IO Configuration
+
+| Property                                                               | Default               | Description                                                                |
+|------------------------------------------------------------------------|-----------------------|----------------------------------------------------------------------------|
+| s3.analytics-accelerator.logicalio.prefetch.footer.enabled             | `true`                | Controls whether footer prefetching is enabled                             |
+| s3.analytics-accelerator.logicalio.prefetch.page.index.enabled         | `true`                | Controls whether page index prefetching is enabled                         |
+| s3.analytics-accelerator.logicalio.prefetch.file.metadata.size         | `32KB`                | Size of metadata to prefetch for regular files                             |
+| s3.analytics-accelerator.logicalio.prefetch.large.file.metadata.size   | `1MB`                 | Size of metadata to prefetch for large files                               |
+| s3.analytics-accelerator.logicalio.prefetch.file.page.index.size       | `1MB`                 | Size of page index to prefetch for regular files                           |
+| s3.analytics-accelerator.logicalio.prefetch.large.file.page.index.size | `8MB`                 | Size of page index to prefetch for large files                             |
+| s3.analytics-accelerator.logicalio.large.file.size                     | `1GB`                 | Threshold to consider a file as large                                      |
+| s3.analytics-accelerator.logicalio.small.objects.prefetching.enabled   | `true`                | Controls prefetching for small objects                                     |
+| s3.analytics-accelerator.logicalio.small.object.size.threshold         | `3MB`                 | Size threshold for small object prefetching                                |
+| s3.analytics-accelerator.logicalio.parquet.metadata.store.size         | `45`                  | Size of the parquet metadata store                                         |
+| s3.analytics-accelerator.logicalio.max.column.access.store.size        | `15`                  | Maximum size of column access store                                        |
+| s3.analytics-accelerator.logicalio.parquet.format.selector.regex       | `^.*.(parquet\|par)$` | Regex pattern to identify parquet files                                    |
+| s3.analytics-accelerator.logicalio.prefetching.mode                    | `ROW_GROUP`           | Prefetching mode (valid values: `OFF`, `ALL`, `ROW_GROUP`, `COLUMN_BOUND`) |
+
+##### Physical IO Configuration
+
+| Property                                                     | Default | Description                                 |
+|--------------------------------------------------------------|---------|---------------------------------------------|
+| s3.analytics-accelerator.physicalio.metadatastore.capacity   | `50`    | Capacity of the metadata store              |
+| s3.analytics-accelerator.physicalio.blocksizebytes           | `8MB`   | Size of blocks for data transfer            |
+| s3.analytics-accelerator.physicalio.readaheadbytes           | `64KB`  | Number of bytes to read ahead               |
+| s3.analytics-accelerator.physicalio.maxrangesizebytes        | `8MB`   | Maximum size of range requests              |
+| s3.analytics-accelerator.physicalio.partsizebytes            | `8MB`   | Size of individual parts for transfer       |
+| s3.analytics-accelerator.physicalio.sequentialprefetch.base  | `2.0`   | Base factor for sequential prefetch sizing  |
+| s3.analytics-accelerator.physicalio.sequentialprefetch.speed | `1.0`   | Speed factor for sequential prefetch growth |
+
+##### Telemetry Configuration
+
+| Property                                                               | Default                             | Description                                                              |
+|------------------------------------------------------------------------|-------------------------------------|--------------------------------------------------------------------------|
+| s3.analytics-accelerator.telemetry.level                               | `STANDARD`                          | Telemetry detail level (valid values: `CRITICAL`, `STANDARD`, `VERBOSE`) |
+| s3.analytics-accelerator.telemetry.std.out.enabled                     | `false`                             | Enable stdout telemetry output                                           |
+| s3.analytics-accelerator.telemetry.logging.enabled                     | `true`                              | Enable logging telemetry output                                          |
+| s3.analytics-accelerator.telemetry.aggregations.enabled                | `false`                             | Enable telemetry aggregations                                            |
+| s3.analytics-accelerator.telemetry.aggregations.flush.interval.seconds | `-1`                                | Interval to flush aggregated telemetry                                   |
+| s3.analytics-accelerator.telemetry.logging.level                       | `INFO`                              | Log level for telemetry                                                  |
+| s3.analytics-accelerator.telemetry.logging.name                        | `com.amazon.connector.s3.telemetry` | Logger name for telemetry                                                |
+| s3.analytics-accelerator.telemetry.format                              | `default`                           | Telemetry output format (valid values: `json`, `default`)                |
+
+##### Object Client Configuration
+
+| Property                                 | Default | Description                                                    |
+|------------------------------------------|---------|----------------------------------------------------------------|
+| s3.analytics-accelerator.useragentprefix | `null`  | Custom prefix to add to the `User-Agent` string in S3 requests |
+
 ### S3 Dual-stack
 
 [S3 Dual-stack](https://docs.aws.amazon.com/AmazonS3/latest/userguide/dual-stack-endpoints.html) allows a client to access an S3 bucket through a dual-stack endpoint. 


### PR DESCRIPTION
This is a followup PR for #12299 to:
- Configure `max-concurrency` for CRT based async clients.
- Extend client region and credentials configuration mutations for async clients.
- Add docs for the `analytics-accelerator-s3` integration.