### PR TITLE
AWS: Don't fetch credential from endpoint if properties contain a valid credential

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/VendedCredentialsProvider.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/VendedCredentialsProvider.java
@@ -22,8 +22,10 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.rest.ErrorHandlers;
 import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.HTTPHeaders;
@@ -52,7 +54,7 @@ public class VendedCredentialsProvider implements AwsCredentialsProvider, SdkAut
     Preconditions.checkArgument(null != properties.get(URI), "Invalid URI: null");
     this.properties = properties;
     this.credentialCache =
-        CachedSupplier.builder(this::refreshCredential)
+        CachedSupplier.builder(() -> credentialFromProperties().orElseGet(this::refreshCredential))
             .cachedValueName(VendedCredentialsProvider.class.getName())
             .build();
   }
@@ -99,6 +101,39 @@ public class VendedCredentialsProvider implements AwsCredentialsProvider, SdkAut
             LoadCredentialsResponse.class,
             Map.of(),
             ErrorHandlers.defaultErrorHandler());
+  }
+
+  private Optional<RefreshResult<AwsCredentials>> credentialFromProperties() {
+    String accessKeyId = properties.get(S3FileIOProperties.ACCESS_KEY_ID);
+    String secretAccessKey = properties.get(S3FileIOProperties.SECRET_ACCESS_KEY);
+    String sessionToken = properties.get(S3FileIOProperties.SESSION_TOKEN);
+    String tokenExpiresAtMillis = properties.get(S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS);
+    if (Strings.isNullOrEmpty(accessKeyId)
+        || Strings.isNullOrEmpty(secretAccessKey)
+        || Strings.isNullOrEmpty(sessionToken)
+        || Strings.isNullOrEmpty(tokenExpiresAtMillis)) {
+      return Optional.empty();
+    }
+
+    Instant expiresAt = Instant.ofEpochMilli(Long.parseLong(tokenExpiresAtMillis));
+    Instant prefetchAt = expiresAt.minus(5, ChronoUnit.MINUTES);
+
+    if (Instant.now().isAfter(prefetchAt)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        RefreshResult.builder(
+                (AwsCredentials)
+                    AwsSessionCredentials.builder()
+                        .accessKeyId(accessKeyId)
+                        .secretAccessKey(secretAccessKey)
+                        .sessionToken(sessionToken)
+                        .expirationTime(expiresAt)
+                        .build())
+            .staleTime(expiresAt)
+            .prefetchTime(prefetchAt)
+            .build());
   }
 
   private RefreshResult<AwsCredentials> refreshCredential() {


### PR DESCRIPTION
When the `VendedCredentialProvider` is created, the `properties` typically already contain a valid credential from the first time a table is loaded. This PR uses the credential from the properties and otherwise falls back to loading a valid credential from the refresh endpoint in case the credential in `properties` is incomplete or expired.