### PR TITLE
Core: JDBCCatalog's dropView() should purge metadata files if GC is enabled

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
@@ -273,7 +274,7 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
     if (purge) {
       try {
         lastMetadata = ops.current();
-      } catch (NoSuchTableException e) {
+      } catch (NotFoundException e) {
         LOG.warn(
             "Failed to load table metadata for table: {}, continuing drop without purge",
             identifier,
@@ -616,7 +617,7 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
     ViewMetadata lastViewMetadata = null;
     try {
       lastViewMetadata = ops.current();
-    } catch (NoSuchViewException e) {
+    } catch (NotFoundException e) {
       LOG.warn("Failed to load view metadata for view: {}", identifier, e);
     }
 

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -52,7 +52,6 @@ import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
-import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -274,7 +274,7 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
     if (purge) {
       try {
         lastMetadata = ops.current();
-      } catch (NotFoundException e) {
+      } catch (NoSuchTableException e) {
         LOG.warn(
             "Failed to load table metadata for table: {}, continuing drop without purge",
             identifier,
@@ -617,7 +617,7 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
     ViewMetadata lastViewMetadata = null;
     try {
       lastViewMetadata = ops.current();
-    } catch (NotFoundException e) {
+    } catch (NoSuchViewException e) {
       LOG.warn("Failed to load view metadata for view: {}", identifier, e);
     }
 

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcViewCatalog.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 
 import java.io.File;
-import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.UUID;

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcViewCatalog.java
@@ -22,12 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 
+import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Catalog;
@@ -157,15 +157,12 @@ public class TestJdbcViewCatalog extends ViewCatalogTests<JdbcCatalog> {
                 .create();
 
     assertThat(catalog.viewExists(identifier)).isTrue();
-    Path viewLocation = new Path(view.location());
-    String currentMetadataLocation = view.operations().current().metadataFileLocation();
+    String metadataFileLocation = view.operations().current().metadataFileLocation();
+    assertThat(metadataFileLocation).isNotNull();
+    File currentMetadataLocation = new File(metadataFileLocation);
 
     catalog.dropView(identifier);
-    assertThat(
-            viewLocation
-                .getFileSystem(new Configuration())
-                .exists(new Path(currentMetadataLocation)))
-        .isTrue();
+    assertThat(currentMetadataLocation.exists()).isTrue();
     assertThat(catalog.viewExists(identifier)).isFalse();
   }
 
@@ -183,15 +180,12 @@ public class TestJdbcViewCatalog extends ViewCatalogTests<JdbcCatalog> {
                 .create();
 
     assertThat(catalog.viewExists(identifier)).isTrue();
-    Path viewLocation = new Path(view.location());
-    String currentMetadataLocation = view.operations().current().metadataFileLocation();
+    String metadataFileLocation = view.operations().current().metadataFileLocation();
+    assertThat(metadataFileLocation).isNotNull();
+    File currentMetadataLocation = new File(metadataFileLocation);
 
     catalog.dropView(identifier);
-    assertThat(
-            viewLocation
-                .getFileSystem(new Configuration())
-                .exists(new Path(currentMetadataLocation)))
-        .isFalse();
+    assertThat(currentMetadataLocation.exists()).isFalse();
     assertThat(catalog.viewExists(identifier)).isFalse();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcViewCatalog.java
@@ -18,14 +18,18 @@
  */
 package org.apache.iceberg.jdbc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -137,5 +141,57 @@ public class TestJdbcViewCatalog extends ViewCatalogTests<JdbcCatalog> {
           .isInstanceOf(AlreadyExistsException.class)
           .hasMessageStartingWith("View already exists: " + identifier);
     }
+  }
+
+  @Test
+  public void dropViewShouldNotDropMetadataFileIfGcNotEnabled() throws IOException {
+    TableIdentifier identifier = TableIdentifier.of("namespace1", "view");
+    BaseView view =
+        (BaseView)
+            catalog
+                .buildView(identifier)
+                .withQuery("spark", "select * from tbl")
+                .withSchema(SCHEMA)
+                .withDefaultNamespace(Namespace.of("namespace1"))
+                .withProperty(TableProperties.GC_ENABLED, "false")
+                .create();
+
+    assertThat(catalog.viewExists(identifier)).isTrue();
+    Path viewLocation = new Path(view.location());
+    String currentMetadataLocation = view.operations().current().metadataFileLocation();
+
+    catalog.dropView(identifier);
+    assertThat(
+            viewLocation
+                .getFileSystem(new Configuration())
+                .exists(new Path(currentMetadataLocation)))
+        .isTrue();
+    assertThat(catalog.viewExists(identifier)).isFalse();
+  }
+
+  @Test
+  public void dropViewShouldDropMetadataFileIfGcEnabled() throws IOException {
+    TableIdentifier identifier = TableIdentifier.of("namespace1", "view");
+    BaseView view =
+        (BaseView)
+            catalog
+                .buildView(identifier)
+                .withQuery("spark", "select * from tbl")
+                .withSchema(SCHEMA)
+                .withDefaultNamespace(Namespace.of("namespace1"))
+                .withProperty(TableProperties.GC_ENABLED, "true")
+                .create();
+
+    assertThat(catalog.viewExists(identifier)).isTrue();
+    Path viewLocation = new Path(view.location());
+    String currentMetadataLocation = view.operations().current().metadataFileLocation();
+
+    catalog.dropView(identifier);
+    assertThat(
+            viewLocation
+                .getFileSystem(new Configuration())
+                .exists(new Path(currentMetadataLocation)))
+        .isFalse();
+    assertThat(catalog.viewExists(identifier)).isFalse();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcViewCatalog.java
@@ -144,7 +144,7 @@ public class TestJdbcViewCatalog extends ViewCatalogTests<JdbcCatalog> {
   }
 
   @Test
-  public void dropViewShouldNotDropMetadataFileIfGcNotEnabled() throws IOException {
+  public void dropViewShouldNotDropMetadataFileIfGcNotEnabled() {
     TableIdentifier identifier = TableIdentifier.of("namespace1", "view");
     BaseView view =
         (BaseView)
@@ -162,12 +162,12 @@ public class TestJdbcViewCatalog extends ViewCatalogTests<JdbcCatalog> {
     File currentMetadataLocation = new File(metadataFileLocation);
 
     catalog.dropView(identifier);
-    assertThat(currentMetadataLocation.exists()).isTrue();
+    assertThat(currentMetadataLocation).exists();
     assertThat(catalog.viewExists(identifier)).isFalse();
   }
 
   @Test
-  public void dropViewShouldDropMetadataFileIfGcEnabled() throws IOException {
+  public void dropViewShouldDropMetadataFileIfGcEnabled() {
     TableIdentifier identifier = TableIdentifier.of("namespace1", "view");
     BaseView view =
         (BaseView)
@@ -185,7 +185,7 @@ public class TestJdbcViewCatalog extends ViewCatalogTests<JdbcCatalog> {
     File currentMetadataLocation = new File(metadataFileLocation);
 
     catalog.dropView(identifier);
-    assertThat(currentMetadataLocation.exists()).isFalse();
+    assertThat(currentMetadataLocation).doesNotExist();
     assertThat(catalog.viewExists(identifier)).isFalse();
   }
 }


### PR DESCRIPTION
 - `HiveCatalog` implemented `dropView` in https://github.com/apache/iceberg/pull/9852 and the view metadata will be purged from storage if `TableProperties.GC_ENABLED` is `true`(default)
 - I think `JdbcCatalog` should also purge view metadata in the same way.
 - Tests are borrowed from https://github.com/apache/iceberg/pull/9852/files