### PR TITLE
Revert "OpenAPI: Handle NamespaceNotEmptyException when dropping a namespace"

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -410,17 +410,7 @@ paths:
         204:
           description: Success, no content
         400:
-          description:
-            A bad request error or a NamespaceNotEmptyException in case the namespace is not empty
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/BadRequestErrorResponse'
-              examples:
-                NamespaceNotEmptyExample:
-                  $ref: '#/components/examples/NamespaceNotEmptyError'
-                BadRequestExample:
-                  $ref: '#/components/examples/BadRequestError'
+          $ref: '#/components/responses/BadRequestErrorResponse'
         401:
           $ref: '#/components/responses/UnauthorizedResponse'
         403:
@@ -4706,16 +4696,6 @@ components:
   #######################################
   examples:
 
-    BadRequestError:
-      summary: The request is malformed
-      value: {
-        "error": {
-          "message": "Malformed request",
-          "type": "BadRequestException",
-          "code": 400
-        }
-      }
-
     ListTablesEmptyExample:
       summary: An empty list for a namespace with no tables
       value: {
@@ -4763,16 +4743,6 @@ components:
             "code": 409
           }
         }
-
-    NamespaceNotEmptyError:
-      summary: The requested namespace is not empty
-      value: {
-        "error": {
-          "message": "The given namespace is not empty",
-          "type": "NamespaceNotEmptyException",
-          "code": 400
-        }
-      }
 
     NoSuchPlanIdError:
       summary: The plan id does not exist


### PR DESCRIPTION
This reverts commit fe258463f5aba15d45bbe1e401d50279aef05fc5.

I actually wanted to propose a change through GH directly but accidentally hit "merge" instead of opening a new PR, since this is a Spec change that should go through a VOTE