### PR TITLE
Make reporter() method public so that it can be accessed by Trino for BaseTable creation

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -54,7 +54,7 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
     this.reporter = reporter;
   }
 
-  MetricsReporter reporter() {
+  public MetricsReporter reporter() {
     return reporter;
   }
 


### PR DESCRIPTION
This PR implements:
* https://github.com/apache/iceberg/issues/12513

To unblock the next step of fixing:
* https://github.com/trinodb/trino/issues/25303