### PR TITLE
Core: Fix default and initial value handling on table creation

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/AssignFreshIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/AssignFreshIds.java
@@ -88,16 +88,7 @@ class AssignFreshIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
     for (int i = 0; i < length; i += 1) {
       Types.NestedField field = fields.get(i);
       Type type = types.next();
-      newFields.add(
-          Types.NestedField.builder()
-              .isOptional(field.isOptional())
-              .withId(newIds.get(i))
-              .withName(field.name())
-              .ofType(type)
-              .withDoc(field.doc())
-              .withInitialDefault(field.initialDefaultLiteral())
-              .withWriteDefault(field.writeDefaultLiteral())
-              .build());
+      newFields.add(Types.NestedField.from(field).withId(newIds.get(i)).ofType(type).build());
     }
 
     return Types.StructType.of(newFields);

--- a/api/src/main/java/org/apache/iceberg/types/AssignFreshIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/AssignFreshIds.java
@@ -88,11 +88,16 @@ class AssignFreshIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
     for (int i = 0; i < length; i += 1) {
       Types.NestedField field = fields.get(i);
       Type type = types.next();
-      if (field.isOptional()) {
-        newFields.add(Types.NestedField.optional(newIds.get(i), field.name(), type, field.doc()));
-      } else {
-        newFields.add(Types.NestedField.required(newIds.get(i), field.name(), type, field.doc()));
-      }
+      newFields.add(
+          Types.NestedField.builder()
+              .isOptional(field.isOptional())
+              .withId(newIds.get(i))
+              .withName(field.name())
+              .ofType(type)
+              .withDoc(field.doc())
+              .withInitialDefault(field.initialDefaultLiteral())
+              .withWriteDefault(field.writeDefaultLiteral())
+              .build());
     }
 
     return Types.StructType.of(newFields);

--- a/api/src/main/java/org/apache/iceberg/types/AssignIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/AssignIds.java
@@ -56,11 +56,7 @@ class AssignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
     for (int i = 0; i < length; i += 1) {
       Types.NestedField field = fields.get(i);
       Type type = types.next();
-      if (field.isOptional()) {
-        newFields.add(Types.NestedField.optional(newIds.get(i), field.name(), type, field.doc()));
-      } else {
-        newFields.add(Types.NestedField.required(newIds.get(i), field.name(), type, field.doc()));
-      }
+      newFields.add(Types.NestedField.from(field).withId(newIds.get(i)).ofType(type).build());
     }
 
     return Types.StructType.of(newFields);

--- a/api/src/main/java/org/apache/iceberg/types/ReassignDoc.java
+++ b/api/src/main/java/org/apache/iceberg/types/ReassignDoc.java
@@ -50,13 +50,8 @@ class ReassignDoc extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
       Preconditions.checkNotNull(docField, "Field " + fieldId + " not found in source schema");
 
-      if (field.isRequired()) {
-        newFields.add(
-            Types.NestedField.required(fieldId, field.name(), types.get(i), docField.doc()));
-      } else {
-        newFields.add(
-            Types.NestedField.optional(fieldId, field.name(), types.get(i), docField.doc()));
-      }
+      newFields.add(
+          Types.NestedField.from(field).ofType(types.get(i)).withDoc(docField.doc()).build());
     }
 
     return Types.StructType.of(newFields);

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -653,6 +653,108 @@ public class TestTypeUtil {
     assertThat(actualSchema.asStruct()).isEqualTo(expectedSchema.asStruct());
   }
 
+  @Test
+  public void testAssignIds() {
+    Schema schema =
+        new Schema(
+            Lists.newArrayList(
+                required(0, "a", Types.IntegerType.get()),
+                Types.NestedField.required("c")
+                    .withId(1)
+                    .ofType(Types.IntegerType.get())
+                    .withInitialDefault(Literal.of(23))
+                    .withWriteDefault(Literal.of(34))
+                    .build(),
+                required(2, "B", Types.IntegerType.get())));
+
+    Type actualSchema = TypeUtil.assignIds(schema.asStruct(), oldId -> oldId + 10);
+    Schema expectedSchema =
+        new Schema(
+            Lists.newArrayList(
+                required(10, "a", Types.IntegerType.get()),
+                Types.NestedField.required("c")
+                    .withId(11)
+                    .ofType(Types.IntegerType.get())
+                    .withInitialDefault(Literal.of(23))
+                    .withWriteDefault(Literal.of(34))
+                    .build(),
+                required(12, "B", Types.IntegerType.get())));
+
+    assertThat(actualSchema).isEqualTo(expectedSchema.asStruct());
+  }
+
+  @Test
+  public void testAssignFreshIds() {
+    Schema schema =
+        new Schema(
+            Lists.newArrayList(
+                required(0, "a", Types.IntegerType.get()),
+                Types.NestedField.required("c")
+                    .withId(1)
+                    .ofType(Types.IntegerType.get())
+                    .withInitialDefault(Literal.of(23))
+                    .withWriteDefault(Literal.of(34))
+                    .build(),
+                required(2, "B", Types.IntegerType.get())));
+
+    Schema actualSchema = TypeUtil.assignFreshIds(schema, new AtomicInteger(10)::incrementAndGet);
+    Schema expectedSchema =
+        new Schema(
+            Lists.newArrayList(
+                required(11, "a", Types.IntegerType.get()),
+                Types.NestedField.required("c")
+                    .withId(12)
+                    .ofType(Types.IntegerType.get())
+                    .withInitialDefault(Literal.of(23))
+                    .withWriteDefault(Literal.of(34))
+                    .build(),
+                required(13, "B", Types.IntegerType.get())));
+
+    assertThat(actualSchema.asStruct()).isEqualTo(expectedSchema.asStruct());
+  }
+
+  @Test
+  public void testReassignDoc() {
+    Schema schema =
+        new Schema(
+            Lists.newArrayList(
+                required(0, "a", Types.IntegerType.get()),
+                Types.NestedField.required("c")
+                    .withId(1)
+                    .ofType(Types.IntegerType.get())
+                    .withInitialDefault(Literal.of(23))
+                    .withWriteDefault(Literal.of(34))
+                    .build(),
+                required(2, "B", Types.IntegerType.get())));
+
+    Schema docSchema =
+        new Schema(
+            Lists.newArrayList(
+                required(0, "a", Types.IntegerType.get(), "a_doc"),
+                Types.NestedField.required("c")
+                    .withId(1)
+                    .ofType(Types.IntegerType.get())
+                    .withDoc("c_doc")
+                    .build(),
+                required(2, "B", Types.IntegerType.get(), "b_doc")));
+
+    Schema actualSchema = TypeUtil.reassignDoc(schema, docSchema);
+    Schema expectedSchema =
+        new Schema(
+            Lists.newArrayList(
+                required(0, "a", Types.IntegerType.get(), "a_doc"),
+                Types.NestedField.required("c")
+                    .withId(1)
+                    .ofType(Types.IntegerType.get())
+                    .withInitialDefault(Literal.of(23))
+                    .withWriteDefault(Literal.of(34))
+                    .withDoc("c_doc")
+                    .build(),
+                required(2, "B", Types.IntegerType.get(), "b_doc")));
+
+    assertThat(actualSchema.asStruct()).isEqualTo(expectedSchema.asStruct());
+  }
+
   private static Stream<Arguments> testTypes() {
     return Stream.of(
         Arguments.of(Types.UnknownType.get()),

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -686,7 +686,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
-  public void testCreateTableWithDefaultValue() {
+  public void testCreateTableWithDefaultColumnValue() {
     C catalog = catalog();
 
     TableIdentifier ident = TableIdentifier.of("ns", "table");

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -62,6 +62,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.metrics.CommitReport;
 import org.apache.iceberg.metrics.MetricsReport;
@@ -682,6 +683,38 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .containsEntry("prop1", "val1");
 
     assertThat(catalog.dropTable(ident)).as("Should successfully drop table").isTrue();
+  }
+
+  @Test
+  public void testCreateTableWithDefaultValue() {
+    C catalog = catalog();
+
+    TableIdentifier ident = TableIdentifier.of("ns", "table");
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(ident.namespace());
+    }
+
+    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
+
+    Schema schemaWithDefault =
+        new Schema(
+            List.of(
+                Types.NestedField.required("colWithDefault")
+                    .withId(1)
+                    .ofType(Types.IntegerType.get())
+                    .withWriteDefault(Literal.of(10))
+                    .withInitialDefault(Literal.of(12))
+                    .build()));
+
+    catalog
+        .buildTable(ident, schemaWithDefault)
+        .withLocation("file:/tmp/ns/table")
+        .withProperty(TableProperties.FORMAT_VERSION, "3")
+        .create();
+    assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
+    assertThat(schemaWithDefault.asStruct())
+        .isEqualTo(catalog.loadTable(ident).schema().asStruct());
   }
 
   @Test


### PR DESCRIPTION
Fix for #12495

During table creation the schema is updated and new fieldIds are assigned based on the original schema. The new field data is copied from the original one, but the default and the initial values were not copied. 