### PR TITLE
[Do not merge] Failing RCK test for `createTransaction` default table properties

### DIFF
--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -685,6 +685,34 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
+  public void testDefaultTablePropertiesTransaction() {
+    C catalog = catalog();
+
+    TableIdentifier ident = TableIdentifier.of("ns", "table");
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(ident.namespace());
+    }
+
+    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
+
+    catalog()
+            .buildTable(ident, SCHEMA)
+            .withProperty("default-key2", "catalog-overridden-key2")
+            .withProperty("prop1", "val1")
+            .createTransaction().commitTransaction();
+
+    Table table = catalog.loadTable(ident);
+
+    assertThat(table.properties())
+            .containsEntry("default-key1", "catalog-default-key1")
+            .containsEntry("default-key2", "catalog-overridden-key2")
+            .containsEntry("prop1", "val1");
+
+    assertThat(catalog.dropTable(ident)).as("Should successfully drop table").isTrue();
+  }
+
+  @Test
   public void testLoadTable() {
     C catalog = catalog();
 


### PR DESCRIPTION
Test fails with

```
Multiple entries with same key: default-key2=catalog-overridden-key2 and default-key2=catalog-default-key2
java.lang.IllegalArgumentException: Multiple entries with same key: default-key2=catalog-overridden-key2 and default-key2=catalog-default-key2
```