### PR TITLE
Core: Use `buildKeepingLast` for table properties in REST table builder

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -922,7 +922,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       AuthSession session = tableSession(response.config(), session(context));
       TableMetadata base = response.tableMetadata();
 
-      Map<String, String> tableProperties = propertiesBuilder.build();
+      Map<String, String> tableProperties = propertiesBuilder.buildKeepingLast();
       TableMetadata replacement =
           base.buildReplacement(
               schema,
@@ -984,7 +984,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     }
 
     private LoadTableResponse stageCreate() {
-      Map<String, String> tableProperties = propertiesBuilder.build();
+      Map<String, String> tableProperties = propertiesBuilder.buildKeepingLast();
 
       CreateTableRequest request =
           CreateTableRequest.builder()

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -659,7 +659,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
-  public void testDefaultTableProperties() {
+  public void testDefaultTablePropertiesCreate() {
     C catalog = catalog();
 
     TableIdentifier ident = TableIdentifier.of("ns", "table");
@@ -685,7 +685,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
-  public void testDefaultTablePropertiesTransaction() {
+  public void testDefaultTablePropertiesCreateTransaction() {
     C catalog = catalog();
 
     TableIdentifier ident = TableIdentifier.of("ns", "table");
@@ -697,17 +697,18 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
 
     catalog()
-            .buildTable(ident, SCHEMA)
-            .withProperty("default-key2", "catalog-overridden-key2")
-            .withProperty("prop1", "val1")
-            .createTransaction().commitTransaction();
+        .buildTable(ident, SCHEMA)
+        .withProperty("default-key2", "catalog-overridden-key2")
+        .withProperty("prop1", "val1")
+        .createTransaction()
+        .commitTransaction();
 
     Table table = catalog.loadTable(ident);
 
     assertThat(table.properties())
-            .containsEntry("default-key1", "catalog-default-key1")
-            .containsEntry("default-key2", "catalog-overridden-key2")
-            .containsEntry("prop1", "val1");
+        .containsEntry("default-key1", "catalog-default-key1")
+        .containsEntry("default-key2", "catalog-overridden-key2")
+        .containsEntry("prop1", "val1");
 
     assertThat(catalog.dropTable(ident)).as("Should successfully drop table").isTrue();
   }

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -685,6 +685,34 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
+  public void testDefaultTablePropertiesTransaction() {
+    C catalog = catalog();
+
+    TableIdentifier ident = TableIdentifier.of("ns", "table");
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(ident.namespace());
+    }
+
+    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
+
+    catalog()
+            .buildTable(ident, SCHEMA)
+            .withProperty("default-key2", "catalog-overridden-key2")
+            .withProperty("prop1", "val1")
+            .createTransaction().commitTransaction();
+
+    Table table = catalog.loadTable(ident);
+
+    assertThat(table.properties())
+            .containsEntry("default-key1", "catalog-default-key1")
+            .containsEntry("default-key2", "catalog-overridden-key2")
+            .containsEntry("prop1", "val1");
+
+    assertThat(catalog.dropTable(ident)).as("Should successfully drop table").isTrue();
+  }
+
+  @Test
   public void testLoadTable() {
     C catalog = catalog();
 


### PR DESCRIPTION
Closes https://github.com/apache/iceberg/issues/12525.