### PR TITLE
Core: fix "Unclosed S3FileIO" warning in JdbcCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -151,6 +151,7 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(metricsReporter());
     closeableGroup.addCloseable(connections);
+    closeableGroup.addCloseable(io);
     closeableGroup.setSuppressCloseFailure(true);
   }
 


### PR DESCRIPTION
See https://github.com/apache/iceberg/issues/12539

I am adding the `io` to the `closeableGroup` with this PR. Any FileIO that is opened should ideally be closed and not left to linger for the garbage collector to pick up.

The `io` variable is passed to `JdbcViewOperations` and `JdbcTableOperations` outside this class, but those already get the `connections` variable passed in as well that gets closed. This makes me not super worried about a usages outside this class (this might be worth revisting?).