### PR TITLE
Spark: prefix SparkTable with 'iceberg' to clearly identify Iceberg table

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -394,7 +394,7 @@ public class SparkTable
 
   @Override
   public String toString() {
-    return icebergTable.toString();
+    return "Iceberg[" + icebergTable.toString() + "]";
   }
 
   @Override

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -394,7 +394,7 @@ public class SparkTable
 
   @Override
   public String toString() {
-    return "Iceberg[" + icebergTable.toString() + "]";
+    return "iceberg[" + icebergTable.toString() + "]";
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -394,7 +394,7 @@ public class SparkTable
 
   @Override
   public String toString() {
-    return icebergTable.toString();
+    return "Iceberg[" + icebergTable.toString() + "]";
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -394,7 +394,7 @@ public class SparkTable
 
   @Override
   public String toString() {
-    return "Iceberg[" + icebergTable.toString() + "]";
+    return "iceberg[" + icebergTable.toString() + "]";
   }
 
   @Override


### PR DESCRIPTION
This PR prefixes SparkTable with `iceberg` to clearly identify Iceberg tables and enable metadata collectors (e.g., DataHub) to correctly extract information from Spark's `ProgressReporter`.