### PR TITLE
WIP: add view support for Glue Catalog

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogView.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogView.java
@@ -1,0 +1,842 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.glue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.iceberg.BaseMetastoreTableOperations;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.aws.AwsClientFactories;
+import org.apache.iceberg.aws.AwsClientFactory;
+import org.apache.iceberg.aws.AwsIntegTestUtil;
+import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.view.BaseView;
+import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
+import org.apache.iceberg.view.ImmutableViewVersion;
+import org.apache.iceberg.view.SQLViewRepresentation;
+import org.apache.iceberg.view.View;
+import org.apache.iceberg.view.ViewCatalogTests;
+import org.apache.iceberg.view.ViewHistoryEntry;
+import org.apache.iceberg.view.ViewMetadata;
+import org.apache.iceberg.view.ViewUtil;
+import org.assertj.core.api.Assumptions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.CreateTableRequest;
+import software.amazon.awssdk.services.glue.model.DeleteTableRequest;
+import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTableResponse;
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TableInput;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public class TestGlueCatalogView extends ViewCatalogTests<GlueCatalog> {
+
+  protected static final String TEST_BUCKET_NAME = AwsIntegTestUtil.testBucketName();
+  protected static final String CATALOG_NAME = "glue";
+  protected static final String TEST_PATH_PREFIX = getRandomName();
+  protected static final List<String> NAMESPACES = Lists.newArrayList();
+
+  protected static final AwsClientFactory CLIENT_FACTORY = AwsClientFactories.defaultFactory();
+  protected static final GlueClient GLUE = CLIENT_FACTORY.glue();
+  protected static final S3Client S3 = CLIENT_FACTORY.s3();
+
+  protected static GlueCatalog glueCatalog;
+  protected static final String TEST_BUCKET_PATH =
+      "s3://" + TEST_BUCKET_NAME + "/" + TEST_PATH_PREFIX;
+
+  @BeforeAll
+  public static void beforeClass() {
+    glueCatalog = new GlueCatalog();
+    AwsProperties awsProperties = new AwsProperties();
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties();
+    s3FileIOProperties.setDeleteBatchSize(10);
+    glueCatalog.initialize(
+        CATALOG_NAME,
+        TEST_BUCKET_PATH,
+        awsProperties,
+        s3FileIOProperties,
+        GLUE,
+        null,
+        ImmutableMap.of());
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    AwsProperties properties = new AwsProperties();
+    properties.setGlueCatalogSkipNameValidation(true);
+    glueCatalog = new GlueCatalog();
+    glueCatalog.initialize(
+        CATALOG_NAME,
+        TEST_BUCKET_PATH,
+        properties,
+        new org.apache.iceberg.aws.s3.S3FileIOProperties(),
+        GLUE,
+        null,
+        ImmutableMap.of());
+
+    try {
+      Namespace ns = Namespace.of("ns");
+      if (!glueCatalog.namespaceExists(ns)) {
+        glueCatalog.createNamespace(ns);
+        NAMESPACES.add("ns");
+      }
+
+      Namespace ns1 = Namespace.of("ns1");
+      if (!glueCatalog.namespaceExists(ns1)) {
+        glueCatalog.createNamespace(ns1);
+        NAMESPACES.add("ns1");
+      }
+
+      Namespace ns2 = Namespace.of("ns2");
+      if (!glueCatalog.namespaceExists(ns2)) {
+        glueCatalog.createNamespace(ns2);
+        NAMESPACES.add("ns2");
+      }
+    } catch (Exception e) {
+      // Failure to create namespace will be caught by test assertions
+    }
+    cleanupTestData();
+  }
+
+  /** Cleans up tables and views before test execution. */
+  private void cleanupTestData() {
+    // First, delete the tables directly through Glue
+    try {
+      deleteTableIgnoringNotFound("view");
+      deleteTableIgnoringNotFound("renamedView");
+    } catch (Exception e) {
+      System.out.println("Clean up Error: " + e.getMessage());
+    }
+
+    // Then, clean up views through the catalog
+    try {
+      // Clean up any other views in the namespace
+      try {
+        Namespace ns = Namespace.of("ns");
+        if (catalog().namespaceExists(ns)) {
+          for (TableIdentifier view : catalog().listViews(ns)) {
+            catalog().dropView(view);
+          }
+
+          for (TableIdentifier table : catalog().listTables(ns)) {
+            catalog().dropTable(table);
+          }
+        }
+      } catch (Exception e) {
+        // Namespace doesn't exist or unable to list views - no impact on tests
+      }
+
+      try {
+        Namespace ns = Namespace.of("ns1");
+        if (catalog().namespaceExists(ns)) {
+          for (TableIdentifier view : catalog().listViews(ns)) {
+            catalog().dropView(view);
+          }
+
+          for (TableIdentifier table : catalog().listTables(ns)) {
+            catalog().dropTable(table);
+          }
+        }
+      } catch (Exception e) {
+        // Namespace doesn't exist or unable to list views - no impact on tests
+      }
+
+      try {
+        Namespace ns = Namespace.of("ns2");
+        if (catalog().namespaceExists(ns)) {
+          for (TableIdentifier view : catalog().listViews(ns)) {
+            catalog().dropView(view);
+          }
+
+          for (TableIdentifier table : catalog().listTables(ns)) {
+            catalog().dropTable(table);
+          }
+        }
+      } catch (Exception e) {
+        // Namespace doesn't exist or unable to list views - no impact on tests
+      }
+    } catch (Exception e) {
+      System.out.println("Warning: Failed to cleanup views: " + e.getMessage());
+    }
+  }
+
+  private void deleteTableIgnoringNotFound(String tableName) {
+    try {
+      GLUE.deleteTable(
+          DeleteTableRequest.builder()
+              .catalogId(awsProperties().glueCatalogId())
+              .databaseName("ns")
+              .name(tableName)
+              .build());
+    } catch (EntityNotFoundException e) {
+      // Entity doesn't exist - this is one of the expected states
+    }
+  }
+
+  @AfterAll
+  public static void afterClass() {
+    AwsIntegTestUtil.cleanGlueCatalog(GLUE, NAMESPACES);
+    AwsIntegTestUtil.cleanS3GeneralPurposeBucket(S3, TEST_BUCKET_NAME, TEST_PATH_PREFIX);
+  }
+
+  @Override
+  protected GlueCatalog catalog() {
+    return glueCatalog;
+  }
+
+  @Override
+  protected Catalog tableCatalog() {
+    return glueCatalog;
+  }
+
+  protected static String getRandomName() {
+    return UUID.randomUUID().toString().replace("-", "");
+  }
+
+  protected String createNamespace() {
+    String namespace = getRandomName();
+    NAMESPACES.add(namespace);
+    glueCatalog.createNamespace(Namespace.of(namespace));
+    return namespace;
+  }
+
+  protected AwsProperties awsProperties() {
+    return new AwsProperties();
+  }
+
+  @Override
+  @Test
+  public void completeCreateView() {
+    TableIdentifier identifier = TableIdentifier.of("ns", "view");
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(identifier.namespace());
+    }
+
+    assertThat(catalog().viewExists(identifier)).as("View should not exist").isFalse();
+
+    String location = String.format("s3://%s/%s/ns/view", TEST_BUCKET_NAME, TEST_PATH_PREFIX);
+
+    View view =
+        catalog()
+            .buildView(identifier)
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(identifier.namespace())
+            .withDefaultCatalog(catalog().name())
+            .withQuery("spark", "select * from ns.tbl")
+            .withQuery("trino", "select * from ns.tbl using X")
+            .withProperty("prop1", "val1")
+            .withProperty("prop2", "val2")
+            .withLocation(location)
+            .create();
+
+    assertThat(view).isNotNull();
+    assertThat(catalog().viewExists(identifier)).as("View should exist").isTrue();
+    assertThat(((BaseView) view).operations().current().metadataFileLocation()).isNotNull();
+
+    if (!overridesRequestedLocation()) {
+      assertThat(view.location()).isEqualTo(location);
+    } else {
+      assertThat(view.location()).isNotNull();
+    }
+
+    // validate view settings
+    assertThat(view.uuid())
+        .isEqualTo(UUID.fromString(((BaseView) view).operations().current().uuid()));
+    assertThat(view.name()).isEqualTo(ViewUtil.fullViewName(catalog().name(), identifier));
+    assertThat(view.properties()).containsEntry("prop1", "val1").containsEntry("prop2", "val2");
+    assertThat(view.history())
+        .hasSize(1)
+        .first()
+        .extracting(ViewHistoryEntry::versionId)
+        .isEqualTo(1);
+    assertThat(view.currentVersion().operation()).isEqualTo("create");
+    assertThat(view.schema().schemaId()).isEqualTo(0);
+    assertThat(view.schema().asStruct()).isEqualTo(SCHEMA.asStruct());
+    assertThat(view.schemas()).hasSize(1).containsKey(0);
+    assertThat(view.versions()).hasSize(1).containsExactly(view.currentVersion());
+
+    assertThat(view.currentVersion())
+        .isEqualTo(
+            ImmutableViewVersion.builder()
+                .timestampMillis(view.currentVersion().timestampMillis())
+                .versionId(1)
+                .schemaId(0)
+                .summary(view.currentVersion().summary())
+                .defaultNamespace(identifier.namespace())
+                .defaultCatalog(catalog().name())
+                .addRepresentations(
+                    ImmutableSQLViewRepresentation.builder()
+                        .sql("select * from ns.tbl")
+                        .dialect("spark")
+                        .build())
+                .addRepresentations(
+                    ImmutableSQLViewRepresentation.builder()
+                        .sql("select * from ns.tbl using X")
+                        .dialect("trino")
+                        .build())
+                .build());
+
+    assertThat(catalog().dropView(identifier)).isTrue();
+    assertThat(catalog().viewExists(identifier)).as("View should not exist").isFalse();
+  }
+
+  @Override
+  @Test
+  public void createAndReplaceViewWithLocation() {
+    TableIdentifier identifier = TableIdentifier.of("ns", "view");
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(identifier.namespace());
+    }
+
+    assertThat(catalog().viewExists(identifier)).as("View should not exist").isFalse();
+
+    String location = String.format("s3://%s/%s/ns/view", TEST_BUCKET_NAME, TEST_PATH_PREFIX);
+    View view =
+        catalog()
+            .buildView(identifier)
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(identifier.namespace())
+            .withQuery("trino", "select * from ns.tbl")
+            .withLocation(location)
+            .create();
+
+    assertThat(catalog().viewExists(identifier)).as("View should exist").isTrue();
+
+    if (!overridesRequestedLocation()) {
+      assertThat(view.location()).isEqualTo(location);
+    } else {
+      assertThat(view.location()).isNotNull();
+    }
+
+    String updatedLocation =
+        String.format("s3://%s/%s/updated/ns/view", TEST_BUCKET_NAME, TEST_PATH_PREFIX);
+    view =
+        catalog()
+            .buildView(identifier)
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(identifier.namespace())
+            .withQuery("trino", "select * from ns.tbl")
+            .withLocation(updatedLocation)
+            .replace();
+
+    if (!overridesRequestedLocation()) {
+      assertThat(view.location()).isEqualTo(updatedLocation);
+    } else {
+      assertThat(view.location()).isNotNull();
+    }
+
+    assertThat(catalog().dropView(identifier)).isTrue();
+    assertThat(catalog().viewExists(identifier)).as("View should not exist").isFalse();
+  }
+
+  @Override
+  @Test
+  public void renameViewTargetAlreadyExistsAsView() {
+    TableIdentifier viewOne = TableIdentifier.of("ns", "viewOne");
+    TableIdentifier viewTwo = TableIdentifier.of("ns", "viewTwo");
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(viewOne.namespace());
+    }
+
+    for (TableIdentifier identifier : ImmutableList.of(viewOne, viewTwo)) {
+      assertThat(catalog().viewExists(identifier)).as("View should not exist").isFalse();
+
+      catalog()
+          .buildView(identifier)
+          .withSchema(SCHEMA)
+          .withDefaultNamespace(viewOne.namespace())
+          .withQuery("spark", "select * from ns.tbl")
+          .create();
+
+      assertThat(catalog().viewExists(identifier)).as("View should exist").isTrue();
+    }
+
+    assertThatThrownBy(() -> catalog().renameView(viewOne, viewTwo))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("Cannot rename ns.viewOne to ns.viewTwo. Glue Table already exists");
+  }
+
+  @Override
+  @Test
+  public void renameViewTargetAlreadyExistsAsTable() {
+    Assumptions.assumeThat(tableCatalog())
+        .as("Only valid for catalogs that support tables")
+        .isNotNull();
+
+    TableIdentifier viewIdentifier = TableIdentifier.of("ns", "view");
+    TableIdentifier tableIdentifier = TableIdentifier.of("ns", "table");
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(tableIdentifier.namespace());
+    }
+
+    assertThat(tableCatalog().tableExists(tableIdentifier)).as("Table should not exist").isFalse();
+
+    tableCatalog().buildTable(tableIdentifier, SCHEMA).create();
+
+    assertThat(tableCatalog().tableExists(tableIdentifier)).as("Table should exist").isTrue();
+
+    assertThat(catalog().viewExists(viewIdentifier)).as("View should not exist").isFalse();
+
+    catalog()
+        .buildView(viewIdentifier)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(viewIdentifier.namespace())
+        .withQuery("spark", "select * from ns.tbl")
+        .create();
+
+    assertThat(catalog().viewExists(viewIdentifier)).as("View should exist").isTrue();
+
+    assertThatThrownBy(() -> catalog().renameView(viewIdentifier, tableIdentifier))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("Cannot rename ns.view to ns.table. Glue Table already exists");
+  }
+
+  @Override
+  @Test
+  public void updateViewLocation() {
+    TableIdentifier identifier = TableIdentifier.of("ns", "view");
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(identifier.namespace());
+    }
+
+    assertThat(catalog().viewExists(identifier)).as("View should not exist").isFalse();
+
+    String location = String.format("s3://%s/%s/ns/view", TEST_BUCKET_NAME, TEST_PATH_PREFIX);
+    View view =
+        catalog()
+            .buildView(identifier)
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(identifier.namespace())
+            .withQuery("trino", "select * from ns.tbl")
+            .withLocation(location)
+            .create();
+
+    assertThat(catalog().viewExists(identifier)).as("View should exist").isTrue();
+    if (!overridesRequestedLocation()) {
+      assertThat(view.location()).isEqualTo(location);
+    } else {
+      assertThat(view.location()).isNotNull();
+    }
+
+    String updatedLocation =
+        String.format("s3://%s/%s/updated/ns/view", TEST_BUCKET_NAME, TEST_PATH_PREFIX);
+    view.updateLocation().setLocation(updatedLocation).commit();
+
+    View updatedView = catalog().loadView(identifier);
+
+    if (!overridesRequestedLocation()) {
+      assertThat(updatedView.location()).isEqualTo(updatedLocation);
+    } else {
+      assertThat(view.location()).isNotNull();
+    }
+
+    // history and view versions should stay the same after updating view properties
+    assertThat(updatedView.history()).hasSize(1).isEqualTo(view.history());
+    assertThat(updatedView.versions()).hasSize(1).containsExactly(view.currentVersion());
+
+    assertThat(catalog().dropView(identifier)).isTrue();
+    assertThat(catalog().viewExists(identifier)).as("View should not exist").isFalse();
+  }
+
+  @Override
+  @Test
+  public void renameViewUsingDifferentNamespace() {
+    TableIdentifier from = TableIdentifier.of("ns", "view");
+    TableIdentifier to = TableIdentifier.of("ns1", "renamedView");
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(from.namespace());
+      catalog().createNamespace(to.namespace());
+    }
+
+    assertThat(catalog().viewExists(from)).as("View should not exist").isFalse();
+
+    View view =
+        catalog()
+            .buildView(from)
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(from.namespace())
+            .withQuery("spark", "select * from ns.tbl")
+            .create();
+
+    assertThat(catalog().viewExists(from)).as("View should exist").isTrue();
+
+    ViewMetadata original = ((BaseView) view).operations().current();
+
+    catalog().renameView(from, to);
+
+    assertThat(catalog().viewExists(from)).as("View should not exist with old name").isFalse();
+    assertThat(catalog().viewExists(to)).as("View should exist with new name").isTrue();
+
+    // ensure view metadata didn't change after renaming
+    View renamed = catalog().loadView(to);
+    assertThat(((BaseView) renamed).operations().current())
+        .usingRecursiveComparison()
+        .ignoringFieldsOfTypes(Schema.class)
+        .isEqualTo(original);
+
+    assertThat(catalog().dropView(from)).isFalse();
+    assertThat(catalog().dropView(to)).isTrue();
+    assertThat(catalog().viewExists(to)).as("View should not exist").isFalse();
+  }
+
+  @Test
+  public void testGlueTableTypeIsVirtualView() {
+    String namespace = createNamespace();
+    TableIdentifier identifier = TableIdentifier.of(namespace, "test_view");
+
+    View view =
+        catalog()
+            .buildView(identifier)
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(identifier.namespace())
+            .withQuery("spark", "select * from test.table")
+            .create();
+
+    // Verify the Glue table has correct table type
+    GetTableResponse response =
+        GLUE.getTable(
+            GetTableRequest.builder()
+                .catalogId(awsProperties().glueCatalogId())
+                .databaseName(namespace)
+                .name(identifier.name())
+                .build());
+
+    Table glueTable = response.table();
+
+    assertThat(glueTable.tableType()).isEqualTo("VIRTUAL_VIEW");
+    assertThat(glueTable.parameters())
+        .containsEntry(BaseMetastoreTableOperations.TABLE_TYPE_PROP, "iceberg-view");
+
+    // Test SQL text is saved correctly
+    SQLViewRepresentation sql = view.sqlFor("spark");
+    assertThat(sql.sql()).isEqualTo("select * from test.table");
+    assertThat(glueTable.viewOriginalText()).isEqualTo("select * from test.table");
+    assertThat(glueTable.viewExpandedText()).isEqualTo("select * from test.table");
+  }
+
+  @Test
+  public void testListViewsFiltersNonIcebergViews() {
+    String namespace = createNamespace();
+    String icebergViewName = "iceberg_view";
+    String regularViewName = "regular_view";
+
+    // Create a regular Glue view (non-Iceberg)
+    Map<String, String> regularProperties = Maps.newHashMap();
+    TableInput regularViewInput =
+        TableInput.builder()
+            .name(regularViewName)
+            .tableType("VIRTUAL_VIEW")
+            .parameters(regularProperties)
+            .viewOriginalText("SELECT * FROM some_table")
+            .build();
+
+    GLUE.createTable(
+        CreateTableRequest.builder()
+            .catalogId(awsProperties().glueCatalogId())
+            .databaseName(namespace)
+            .tableInput(regularViewInput)
+            .build());
+
+    // Create an Iceberg view
+    TableIdentifier icebergViewId = TableIdentifier.of(namespace, icebergViewName);
+    catalog()
+        .buildView(icebergViewId)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(icebergViewId.namespace())
+        .withQuery("spark", "select * from test.table")
+        .create();
+
+    // listViews should only return the Iceberg view
+    assertThat(catalog().listViews(Namespace.of(namespace)))
+        .hasSize(1)
+        .extracting(TableIdentifier::name)
+        .containsExactly(icebergViewName);
+  }
+
+  @Test
+  public void testDropViewVerifiesIcebergView() {
+    String namespace = createNamespace();
+    String regularViewName = "regular_view";
+
+    // Create a regular Glue view (non-Iceberg)
+    Map<String, String> regularProperties = Maps.newHashMap();
+    TableInput regularViewInput =
+        TableInput.builder()
+            .name(regularViewName)
+            .tableType("VIRTUAL_VIEW")
+            .parameters(regularProperties)
+            .viewOriginalText("SELECT * FROM some_table")
+            .build();
+
+    GLUE.createTable(
+        CreateTableRequest.builder()
+            .catalogId(awsProperties().glueCatalogId())
+            .databaseName(namespace)
+            .tableInput(regularViewInput)
+            .build());
+
+    TableIdentifier regularViewId = TableIdentifier.of(namespace, regularViewName);
+
+    // Dropping a non-Iceberg view should return false
+    assertThat(catalog().dropView(regularViewId)).isFalse();
+
+    // Regular view should still exist in Glue
+    GetTableResponse response =
+        GLUE.getTable(
+            GetTableRequest.builder()
+                .catalogId(awsProperties().glueCatalogId())
+                .databaseName(namespace)
+                .name(regularViewName)
+                .build());
+
+    assertThat(response.table()).isNotNull();
+  }
+
+  @Test
+  public void testRenameViewCheckTargetExists() {
+    String namespace = createNamespace();
+    String sourceViewName = "source_view";
+    String targetViewName = "target_view";
+
+    // Create source (Iceberg) view
+    TableIdentifier sourceViewId = TableIdentifier.of(namespace, sourceViewName);
+    catalog()
+        .buildView(sourceViewId)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(sourceViewId.namespace())
+        .withQuery("spark", "select * from test.table")
+        .create();
+
+    // Create target (non-Iceberg) view
+    Map<String, String> targetProperties = Maps.newHashMap();
+    TableInput targetViewInput =
+        TableInput.builder()
+            .name(targetViewName)
+            .tableType("VIRTUAL_VIEW")
+            .parameters(targetProperties)
+            .viewOriginalText("SELECT * FROM some_table")
+            .build();
+
+    GLUE.createTable(
+        CreateTableRequest.builder()
+            .catalogId(awsProperties().glueCatalogId())
+            .databaseName(namespace)
+            .tableInput(targetViewInput)
+            .build());
+
+    TableIdentifier targetViewId = TableIdentifier.of(namespace, targetViewName);
+
+    // Should throw AlreadyExistsException since target already exists
+    assertThatThrownBy(() -> catalog().renameView(sourceViewId, targetViewId))
+        .isInstanceOf(AlreadyExistsException.class);
+  }
+
+  @Test
+  public void testIcebergTableAndViewCannotHaveSameName() {
+    String namespace = createNamespace();
+    String name = "same_name";
+
+    // Create a regular Iceberg table
+    TableIdentifier tableId = TableIdentifier.of(namespace, name);
+    tableCatalog().buildTable(tableId, SCHEMA).create();
+
+    // Try to create a view with the same name
+    assertThatThrownBy(
+            () ->
+                catalog()
+                    .buildView(tableId)
+                    .withSchema(SCHEMA)
+                    .withDefaultNamespace(tableId.namespace())
+                    .withQuery("spark", "select * from test.table")
+                    .create())
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("Table with same name already exists");
+
+    // Cleanup
+    tableCatalog().dropTable(tableId);
+  }
+
+  @Test
+  public void testTableCannotShareNameWithView() {
+    String namespace = createNamespace();
+    String name = "view_name";
+
+    // Create a view
+    TableIdentifier viewId = TableIdentifier.of(namespace, name);
+    catalog()
+        .buildView(viewId)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(viewId.namespace())
+        .withQuery("spark", "select * from test.table")
+        .create();
+
+    // Try to create a table with the same name
+    assertThatThrownBy(() -> tableCatalog().buildTable(viewId, SCHEMA).create())
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("View with same name already exists");
+  }
+
+  @Test
+  public void testDropViewCleansGlueMetadata() {
+    String namespace = createNamespace();
+    String viewName = "drop_view_test";
+
+    TableIdentifier viewId = TableIdentifier.of(namespace, viewName);
+    catalog()
+        .buildView(viewId)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(viewId.namespace())
+        .withQuery("spark", "select * from test.table")
+        .create();
+
+    // Verify the view exists
+    assertThat(catalog().viewExists(viewId)).isTrue();
+
+    // Drop the view
+    assertThat(catalog().dropView(viewId)).isTrue();
+
+    // Verify the view no longer exists in Glue Catalog
+    assertThatThrownBy(
+            () ->
+                GLUE.getTable(
+                    GetTableRequest.builder()
+                        .catalogId(awsProperties().glueCatalogId())
+                        .databaseName(namespace)
+                        .name(viewName)
+                        .build()))
+        .isInstanceOf(EntityNotFoundException.class);
+  }
+
+  @Test
+  public void testDropNamespaceWithViews() {
+    String namespace = createNamespace();
+    String viewName = "view_for_drop_namespace";
+
+    TableIdentifier viewId = TableIdentifier.of(namespace, viewName);
+    catalog()
+        .buildView(viewId)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(viewId.namespace())
+        .withQuery("spark", "select * from test.table")
+        .create();
+
+    // Verify the view exists
+    assertThat(catalog().viewExists(viewId)).isTrue();
+
+    // Try to drop the namespace, should fail since it contains views
+    assertThatThrownBy(() -> catalog().dropNamespace(Namespace.of(namespace)))
+        .hasMessageContaining("Cannot drop namespace " + namespace + " because it still contains");
+
+    // Drop the view first
+    assertThat(catalog().dropView(viewId)).isTrue();
+
+    // Now we should be able to drop the namespace
+    assertThat(catalog().dropNamespace(Namespace.of(namespace))).isTrue();
+  }
+
+  @Test
+  public void testMultiDialectViews() {
+    String namespace = createNamespace();
+    String viewName = "multi_dialect_view";
+
+    TableIdentifier viewId = TableIdentifier.of(namespace, viewName);
+    View view =
+        catalog()
+            .buildView(viewId)
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(viewId.namespace())
+            .withQuery("spark", "select * from test.table")
+            .withQuery("trino", "SELECT * FROM test.table")
+            .create();
+
+    // Check that we can retrieve both dialects
+    assertThat(view.sqlFor("spark").sql()).isEqualTo("select * from test.table");
+    assertThat(view.sqlFor("trino").sql()).isEqualTo("SELECT * FROM test.table");
+
+    // Check that we save the first dialect to Glue view text
+    GetTableResponse response =
+        GLUE.getTable(
+            GetTableRequest.builder()
+                .catalogId(awsProperties().glueCatalogId())
+                .databaseName(namespace)
+                .name(viewName)
+                .build());
+
+    String viewText = response.table().viewOriginalText();
+
+    // Since order is not guaranteed in maps, we check for either dialect
+    assertThat(viewText)
+        .satisfiesAnyOf(
+            text -> assertThat(text).isEqualTo("select * from test.table"),
+            text -> assertThat(text).isEqualTo("SELECT * FROM test.table"));
+  }
+
+  @Test
+  public void testViewMetadataLocationFormat() {
+    String namespace = createNamespace();
+    String viewName = "view_metadata_test";
+
+    TableIdentifier viewId = TableIdentifier.of(namespace, viewName);
+    catalog()
+        .buildView(viewId)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(viewId.namespace())
+        .withQuery("spark", "select * from test.table")
+        .create();
+
+    // Check Glue parameters contain metadata location
+    GetTableResponse response =
+        GLUE.getTable(
+            GetTableRequest.builder()
+                .catalogId(awsProperties().glueCatalogId())
+                .databaseName(namespace)
+                .name(viewName)
+                .build());
+
+    String metadataLocation =
+        response.table().parameters().get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
+    assertThat(metadataLocation).isNotNull();
+    assertThat(metadataLocation).contains("metadata/");
+    assertThat(metadataLocation).endsWith(".metadata.json");
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
@@ -44,6 +43,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.Configurable;
@@ -58,6 +58,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.util.LockManagers;
 import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.view.BaseMetastoreViewCatalog;
+import org.apache.iceberg.view.ViewBuilder;
+import org.apache.iceberg.view.ViewOperations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.glue.GlueClient;
@@ -80,7 +83,7 @@ import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.glue.model.TableInput;
 import software.amazon.awssdk.services.glue.model.UpdateDatabaseRequest;
 
-public class GlueCatalog extends BaseMetastoreCatalog
+public class GlueCatalog extends BaseMetastoreViewCatalog
     implements SupportsNamespaces, Configurable<Configuration> {
 
   private static final Logger LOG = LoggerFactory.getLogger(GlueCatalog.class);
@@ -95,6 +98,8 @@ public class GlueCatalog extends BaseMetastoreCatalog
   private CloseableGroup closeableGroup;
   private Map<String, String> catalogProperties;
   private FileIOTracker fileIOTracker;
+  static final String ICEBERG_VIEW_TYPE_VALUE = "iceberg-view";
+  static final String GLUE_VIRTUAL_VIEW_TYPE = "VIRTUAL_VIEW";
 
   // Attempt to set versionId if available on the path
   private static final DynMethods.UnboundMethod SET_VERSION_ID =
@@ -416,14 +421,17 @@ public class GlueCatalog extends BaseMetastoreCatalog
             .parameters(fromTable.parameters())
             .storageDescriptor(fromTable.storageDescriptor());
 
-    glue.createTable(
-        CreateTableRequest.builder()
-            .catalogId(awsProperties.glueCatalogId())
-            .databaseName(toTableDbName)
-            .tableInput(tableInputBuilder.name(toTableName).build())
-            .build());
-    LOG.info("created rename destination table {}", to);
-
+    try {
+      glue.createTable(
+          CreateTableRequest.builder()
+              .catalogId(awsProperties.glueCatalogId())
+              .databaseName(toTableDbName)
+              .tableInput(tableInputBuilder.name(toTableName).build())
+              .build());
+      LOG.info("created rename destination table {}", to);
+    } catch (software.amazon.awssdk.services.glue.model.AlreadyExistsException e) {
+      throw new AlreadyExistsException(e, "Cannot rename %s to %s. View already exists", from, to);
+    }
     try {
       dropTable(from, false);
     } catch (Exception e) {
@@ -459,6 +467,269 @@ public class GlueCatalog extends BaseMetastoreCatalog
     } catch (software.amazon.awssdk.services.glue.model.AlreadyExistsException e) {
       throw new AlreadyExistsException(
           "Cannot create namespace %s because it already exists in Glue", namespace);
+    }
+  }
+
+  @Override
+  protected ViewOperations newViewOps(TableIdentifier viewIdentifier) {
+    Map<String, String> effectiveProperties =
+        catalogProperties == null ? ImmutableMap.of() : ImmutableMap.copyOf(catalogProperties);
+
+    return new GlueViewOperations(
+        glue,
+        lockManager,
+        catalogName,
+        awsProperties,
+        effectiveProperties,
+        hadoopConf,
+        viewIdentifier);
+  }
+
+  private boolean isGlueIcebergView(Table table) {
+    return table != null
+        && "VIRTUAL_VIEW".equalsIgnoreCase(table.tableType())
+        && table.parameters() != null
+        && ICEBERG_VIEW_TYPE_VALUE.equalsIgnoreCase(
+            table.parameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP));
+  }
+
+  @Override
+  public boolean dropView(TableIdentifier identifier) {
+    String dbName =
+        IcebergToGlueConverter.getDatabaseName(
+            identifier, awsProperties.glueCatalogSkipNameValidation());
+    String tblName =
+        IcebergToGlueConverter.getTableName(
+            identifier, awsProperties.glueCatalogSkipNameValidation());
+
+    try {
+      GetTableResponse response =
+          glue.getTable(
+              GetTableRequest.builder()
+                  .catalogId(awsProperties.glueCatalogId())
+                  .databaseName(dbName)
+                  .name(tblName)
+                  .build());
+      Table glueTable = response.table();
+
+      if (!isGlueIcebergView(glueTable)) {
+        LOG.warn("dropView({}) called but Glue table is not an iceberg-view", identifier);
+        return false;
+      }
+
+      glue.deleteTable(
+          DeleteTableRequest.builder()
+              .catalogId(awsProperties.glueCatalogId())
+              .databaseName(dbName)
+              .name(tblName)
+              .build());
+      LOG.info("Successfully dropped view {} from Glue", identifier);
+
+      return true;
+
+    } catch (EntityNotFoundException e) {
+      LOG.warn("Cannot dropView({}), table not found in Glue", identifier, e);
+      return false;
+    } catch (RuntimeException e) {
+      LOG.error("Failed to drop view {} due to unexpected exception", identifier, e);
+      throw e;
+    }
+  }
+
+  @Override
+  public List<TableIdentifier> listViews(Namespace namespace) {
+    String dbName =
+        IcebergToGlueConverter.toDatabaseName(
+            namespace, awsProperties.glueCatalogSkipNameValidation());
+
+    List<TableIdentifier> results = Lists.newArrayList();
+    String nextToken = null;
+
+    try {
+      do {
+        GetTablesResponse response =
+            glue.getTables(
+                GetTablesRequest.builder()
+                    .catalogId(awsProperties.glueCatalogId())
+                    .databaseName(dbName)
+                    .nextToken(nextToken)
+                    .build());
+        nextToken = response.nextToken();
+
+        if (response.hasTableList()) {
+          for (Table t : response.tableList()) {
+            if (isGlueIcebergView(t)) {
+              TableIdentifier tid = GlueToIcebergConverter.toTableId(t);
+              results.add(tid);
+            }
+          }
+        }
+      } while (nextToken != null);
+
+      LOG.debug("listViews({}) -> {}", namespace, results);
+      return results;
+
+    } catch (EntityNotFoundException e) {
+      throw new NoSuchNamespaceException("Glue database not found or not accessible: %s", e);
+    } catch (RuntimeException e) {
+      LOG.error("Failed to list all views under {}", namespace, e);
+      throw e;
+    }
+  }
+
+  @Override
+  public void renameView(TableIdentifier from, TableIdentifier to) {
+    if (!namespaceExists(to.namespace())) {
+      throw new NoSuchNamespaceException(
+          "Cannot rename %s to %s because Namespace does not exist: %s", from, to, to.namespace());
+    }
+
+    Table fromView;
+    String fromTableDbName =
+        IcebergToGlueConverter.getDatabaseName(from, awsProperties.glueCatalogSkipNameValidation());
+    String fromTableName =
+        IcebergToGlueConverter.getTableName(from, awsProperties.glueCatalogSkipNameValidation());
+
+    String toTableDbName =
+        IcebergToGlueConverter.getDatabaseName(to, awsProperties.glueCatalogSkipNameValidation());
+    String toTableName =
+        IcebergToGlueConverter.getTableName(to, awsProperties.glueCatalogSkipNameValidation());
+
+    try {
+      GetTableResponse response =
+          glue.getTable(
+              GetTableRequest.builder()
+                  .catalogId(awsProperties.glueCatalogId())
+                  .databaseName(fromTableDbName)
+                  .name(fromTableName)
+                  .build());
+      fromView = response.table();
+
+      if (fromView.parameters() == null
+          || !ICEBERG_VIEW_TYPE_VALUE.equalsIgnoreCase(
+              fromView.parameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP))) {
+        throw new NoSuchTableException(
+            "Cannot rename %s because it is not an iceberg view in Glue (table_type != iceberg-view)",
+            from);
+      }
+    } catch (EntityNotFoundException e) {
+      throw new NoSuchViewException(
+          e, "Cannot rename %s because the View does not exist in Glue", from);
+    }
+
+    TableInput.Builder tableInputBuilder =
+        TableInput.builder()
+            .owner(fromView.owner())
+            .tableType("VIRTUAL_VIEW")
+            .parameters(fromView.parameters())
+            .storageDescriptor(fromView.storageDescriptor())
+            .viewOriginalText(fromView.viewOriginalText())
+            .viewExpandedText(fromView.viewExpandedText());
+
+    try {
+      glue.createTable(
+          CreateTableRequest.builder()
+              .catalogId(awsProperties.glueCatalogId())
+              .databaseName(toTableDbName)
+              .tableInput(tableInputBuilder.name(toTableName).build())
+              .build());
+      LOG.info("Created rename destination Glue view {}", to);
+    } catch (software.amazon.awssdk.services.glue.model.AlreadyExistsException e) {
+
+      throw new AlreadyExistsException(
+          "Cannot rename %s.%s to %s.%s. Glue Table already exists",
+          fromTableDbName, fromTableName, toTableDbName, toTableName);
+    }
+
+    try {
+      dropView(from);
+    } catch (Exception e) {
+      LOG.error("Failed to drop old view {} after renaming to {}, rolling back...", from, to, e);
+      glue.deleteTable(
+          DeleteTableRequest.builder()
+              .catalogId(awsProperties.glueCatalogId())
+              .databaseName(toTableDbName)
+              .name(toTableName)
+              .build());
+      throw e;
+    }
+    LOG.info("Successfully renamed Glue view from {} to {}", from, to);
+  }
+
+  @Override
+  public boolean tableExists(TableIdentifier identifier) {
+    String dbName =
+        IcebergToGlueConverter.getDatabaseName(
+            identifier, awsProperties.glueCatalogSkipNameValidation());
+    String tblName =
+        IcebergToGlueConverter.getTableName(
+            identifier, awsProperties.glueCatalogSkipNameValidation());
+
+    try {
+      GetTableResponse response =
+          glue.getTable(
+              GetTableRequest.builder()
+                  .catalogId(awsProperties.glueCatalogId())
+                  .databaseName(dbName)
+                  .name(tblName)
+                  .build());
+      Table glueTable = response.table();
+
+      return glueTable != null
+          && glueTable.parameters() != null
+          && BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.equalsIgnoreCase(
+              glueTable.parameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP));
+    } catch (EntityNotFoundException e) {
+      return false;
+    } catch (RuntimeException re) {
+      LOG.error("Failed to check tableExists for {}", identifier, re);
+      throw re;
+    }
+  }
+
+  @Override
+  public boolean viewExists(TableIdentifier identifier) {
+    String dbName =
+        IcebergToGlueConverter.getDatabaseName(
+            identifier, awsProperties.glueCatalogSkipNameValidation());
+    String tblName =
+        IcebergToGlueConverter.getTableName(
+            identifier, awsProperties.glueCatalogSkipNameValidation());
+
+    try {
+      GetTableResponse response =
+          glue.getTable(
+              GetTableRequest.builder()
+                  .catalogId(awsProperties.glueCatalogId())
+                  .databaseName(dbName)
+                  .name(tblName)
+                  .build());
+      Table glueTable = response.table();
+
+      return glueTable != null
+          && GLUE_VIRTUAL_VIEW_TYPE.equalsIgnoreCase(glueTable.tableType())
+          && glueTable.parameters() != null
+          && ICEBERG_VIEW_TYPE_VALUE.equalsIgnoreCase(
+              glueTable.parameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP));
+
+    } catch (EntityNotFoundException e) {
+      return false;
+    } catch (RuntimeException re) {
+      LOG.error("Failed to check viewExists for {}", identifier, re);
+      throw re;
+    }
+  }
+
+  @Override
+  public ViewBuilder buildView(TableIdentifier identifier) {
+    return new GlueCatalogViewBuilder(identifier);
+  }
+
+  private class GlueCatalogViewBuilder extends BaseMetastoreViewCatalog.BaseViewBuilder {
+    public GlueCatalogViewBuilder(TableIdentifier identifier) {
+      super(identifier);
+      withProperties(
+          PropertyUtil.propertiesWithPrefix(GlueCatalog.this.properties(), "table-default."));
     }
   }
 
@@ -552,9 +823,13 @@ public class GlueCatalog extends BaseMetastoreCatalog
       if (isGlueIcebergTable(table)) {
         throw new NamespaceNotEmptyException(
             "Cannot drop namespace %s because it still contains Iceberg tables", namespace);
+      } else if (isGlueIcebergView(table)) {
+        throw new NamespaceNotEmptyException(
+            "Cannot drop namespace %s because it still contains Iceberg views", namespace);
       } else {
         throw new NamespaceNotEmptyException(
-            "Cannot drop namespace %s because it still contains non-Iceberg tables", namespace);
+            "Cannot drop namespace %s because it still contains non-Iceberg tables or views",
+            namespace);
       }
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.aws.glue;
 
+import static org.apache.iceberg.aws.glue.GlueCatalog.ICEBERG_VIEW_TYPE_VALUE;
+
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -127,6 +129,12 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
     String metadataLocation = null;
     Table table = getGlueTable();
     if (table != null) {
+      if (GlueCatalog.GLUE_VIRTUAL_VIEW_TYPE.equalsIgnoreCase(table.tableType())
+          && ICEBERG_VIEW_TYPE_VALUE.equalsIgnoreCase(table.parameters().get(TABLE_TYPE_PROP))) {
+        disableRefresh();
+        throw new AlreadyExistsException(
+            "View with same name already exists: %s.%s", databaseName, tableName);
+      }
       checkIfTableIsIceberg(table, tableName());
       metadataLocation = table.parameters().get(METADATA_LOCATION_PROP);
     } else {
@@ -155,11 +163,16 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
       newMetadataLocation = writeNewMetadataIfRequired(newTable, metadata);
       lock(newMetadataLocation);
       Table glueTable = getGlueTable();
+      if (glueTable != null
+          && GlueCatalog.GLUE_VIRTUAL_VIEW_TYPE.equalsIgnoreCase(glueTable.tableType())) {
+        throw new AlreadyExistsException(
+            "View with same name already exists: %s.%s", databaseName, tableName);
+      }
       checkMetadataLocation(glueTable, base);
       Map<String, String> properties = prepareProperties(glueTable, newMetadataLocation);
       persistGlueTable(glueTable, properties, metadata, retryDetector);
       commitStatus = CommitStatus.SUCCESS;
-    } catch (CommitFailedException e) {
+    } catch (CommitFailedException | AlreadyExistsException e) {
       throw e;
     } catch (RuntimeException persistFailure) {
       boolean isAwsServiceException = persistFailure instanceof AwsServiceException;

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueViewOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueViewOperations.java
@@ -1,0 +1,514 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.glue;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.iceberg.BaseMetastoreTableOperations;
+import org.apache.iceberg.LockManager;
+import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.aws.util.RetryDetector;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.view.BaseViewOperations;
+import org.apache.iceberg.view.SQLViewRepresentation;
+import org.apache.iceberg.view.ViewMetadata;
+import org.apache.iceberg.view.ViewRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.AccessDeniedException;
+import software.amazon.awssdk.services.glue.model.ConcurrentModificationException;
+import software.amazon.awssdk.services.glue.model.CreateTableRequest;
+import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTableResponse;
+import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TableInput;
+import software.amazon.awssdk.services.glue.model.UpdateTableRequest;
+
+/** Implementation of ViewOperations for AWS Glue Data Catalog. */
+public class GlueViewOperations extends BaseViewOperations implements AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(GlueViewOperations.class);
+
+  private final GlueClient glue;
+  private final LockManager lockManager;
+  private final AwsProperties awsProperties;
+  private final String databaseName;
+  private final String viewName;
+  private final String fullViewName;
+  private final String commitLockEntityId;
+  private final FileIO fileIO;
+
+  /**
+   * Creates a new GlueViewOperations instance.
+   *
+   * @param glue Glue client
+   * @param lockManager Lock manager
+   * @param catalogName Catalog name
+   * @param awsProperties AWS properties
+   * @param catalogProperties Catalog properties
+   * @param hadoopConf Hadoop configuration
+   * @param viewIdentifier View identifier
+   */
+  GlueViewOperations(
+      GlueClient glue,
+      LockManager lockManager,
+      String catalogName,
+      AwsProperties awsProperties,
+      Map<String, String> catalogProperties,
+      Object hadoopConf,
+      TableIdentifier viewIdentifier) {
+    this.glue = glue;
+    this.lockManager = lockManager;
+    this.awsProperties = awsProperties;
+    this.databaseName =
+        IcebergToGlueConverter.getDatabaseName(
+            viewIdentifier, awsProperties.glueCatalogSkipNameValidation());
+    this.viewName =
+        IcebergToGlueConverter.getTableName(
+            viewIdentifier, awsProperties.glueCatalogSkipNameValidation());
+    this.fullViewName = String.format("%s.%s.%s", catalogName, databaseName, viewName);
+    this.commitLockEntityId = String.format("%s.%s", databaseName, viewName);
+    this.fileIO = GlueTableOperations.initializeFileIO(catalogProperties, hadoopConf);
+  }
+
+  @Override
+  public void close() {
+    if (fileIO != null) {
+      try {
+        fileIO.close();
+      } catch (Exception e) {
+        LOG.error("Failed to close FileIO: {}", e.getMessage(), e);
+      }
+    }
+  }
+
+  @Override
+  protected void doRefresh() {
+    String metadataLocation = null;
+    Table table = getGlueTable();
+
+    if (table != null) {
+      String table_type = table.parameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP);
+
+      if (table_type == null) {
+        throw new NoSuchViewException("Iceberg View does not exist: %s.%s", databaseName, viewName);
+      }
+
+      if (table_type.equalsIgnoreCase(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE)) {
+        throw new AlreadyExistsException(
+            "Table with same name already exists: %s.%s", databaseName, viewName);
+      }
+
+      if (table_type.equalsIgnoreCase(GlueCatalog.ICEBERG_VIEW_TYPE_VALUE)) {
+        metadataLocation = table.parameters().get("metadata_location");
+      } else {
+        return;
+      }
+    } else {
+      if (currentMetadataLocation() != null) {
+        throw new NoSuchViewException("View does not exist: %s", databaseName + "." + viewName);
+      } else {
+        this.disableRefresh();
+        return;
+      }
+    }
+    refreshFromMetadataLocation(metadataLocation);
+  }
+
+  @Override
+  protected void doCommit(ViewMetadata base, ViewMetadata metadata) {
+    String newMetadataLocation = writeNewMetadataIfRequired(metadata);
+    CommitStatus commitStatus = CommitStatus.FAILURE;
+    RetryDetector retryDetector = new RetryDetector();
+
+    try {
+      if (lockManager != null) {
+        // Acquire a lock if needed
+        if (!lockManager.acquire(commitLockEntityId, newMetadataLocation)) {
+          throw new IllegalStateException(
+              String.format("Cannot acquire lock for commit: %s", commitLockEntityId));
+        }
+      }
+
+      Table glueTable = getGlueTable();
+
+      if (glueTable != null) {
+        String tableType = glueTable.parameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP);
+        String glueTableType = glueTable.tableType();
+
+        if (!"VIRTUAL_VIEW".equalsIgnoreCase(glueTableType)) {
+          if (BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.equalsIgnoreCase(tableType)) {
+            throw new AlreadyExistsException(
+                "Table with same name already exists: %s.%s", databaseName, viewName);
+          } else {
+            throw new ValidationException(
+                "Cannot create view %s.%s, a non-Iceberg table with the same name exists",
+                databaseName, viewName);
+          }
+        } else if (!"iceberg-view".equalsIgnoreCase(tableType) && base == null) {
+          throw new ValidationException(
+              "Cannot create view %s.%s, a non-Iceberg view with the same name exists",
+              databaseName, viewName);
+        }
+      }
+
+      // For replace operations, we skip the metadata location check
+      // base = null for create, non-null for replace
+      boolean isReplace = base != null;
+      if (!isReplace) {
+        // Only check metadata location if this is not a replace operation
+        if (!checkMetadataLocation(glueTable, base)) {
+          throw new CommitFailedException(
+              "Cannot commit %s because base metadata location '%s' is not same as the current Glue location '%s'",
+              fullViewName,
+              null,
+              glueTable != null
+                  ? glueTable.parameters().get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP)
+                  : null);
+        }
+      }
+
+      // Prepare properties for the update
+      Map<String, String> parameters = prepareParameters(glueTable, metadata, newMetadataLocation);
+
+      // Persist the changes to Glue
+      if (glueTable != null) {
+        LOG.debug("Committing existing Glue view: {}", fullViewName);
+        updateGlueView(metadata, parameters, retryDetector);
+      } else {
+        LOG.debug("Committing new Glue view: {}", fullViewName);
+        createGlueView(metadata, parameters, retryDetector);
+      }
+
+      commitStatus = CommitStatus.SUCCESS;
+
+    } catch (CommitFailedException e) {
+      throw e;
+    } catch (RuntimeException persistFailure) {
+      LOG.error("Error during commit for view {}", fullViewName, persistFailure);
+
+      boolean isAwsServiceException = persistFailure instanceof AwsServiceException;
+
+      // If this is an AWS service exception, and we didn't retry, or it's some other exception,
+      // let's check if the commit actually succeeded
+      if (!isAwsServiceException || retryDetector.retried()) {
+        LOG.warn(
+            "Received unexpected failure when committing to {}, validating if commit ended up succeeding.",
+            fullViewName,
+            persistFailure);
+        commitStatus = checkCommitStatus(newMetadataLocation);
+      }
+
+      if (commitStatus != CommitStatus.SUCCESS && isAwsServiceException) {
+        handleAwsExceptions((AwsServiceException) persistFailure);
+      }
+
+      switch (commitStatus) {
+        case SUCCESS:
+          break;
+        case FAILURE:
+          throw new CommitFailedException(
+              persistFailure, "Cannot commit %s due to unexpected exception", fullViewName);
+        case UNKNOWN:
+          throw new CommitStateUnknownException(persistFailure);
+      }
+
+    } finally {
+      try {
+        if (commitStatus == CommitStatus.FAILURE && newMetadataLocation != null) {
+          // Clean up the uncommitted metadata file
+          io().deleteFile(newMetadataLocation);
+        }
+      } catch (RuntimeException e) {
+        LOG.error("Failed to clean up metadata location: {}", newMetadataLocation, e);
+      } finally {
+        if (lockManager != null) {
+          lockManager.release(commitLockEntityId, newMetadataLocation);
+        }
+      }
+    }
+  }
+
+  /**
+   * Get the Glue table for this view.
+   *
+   * @return The Glue table or null if it doesn't exist
+   */
+  private Table getGlueTable() {
+    try {
+      GetTableResponse response =
+          glue.getTable(
+              GetTableRequest.builder()
+                  .catalogId(awsProperties.glueCatalogId())
+                  .databaseName(databaseName)
+                  .name(viewName)
+                  .build());
+      return response.table();
+    } catch (EntityNotFoundException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Check if the base metadata location matches the current metadata location.
+   *
+   * @param glueTable The Glue table
+   * @param base The base view metadata
+   * @return True if the metadata locations match or if both are null
+   */
+  private boolean checkMetadataLocation(Table glueTable, ViewMetadata base) {
+    String glueMetadataLocation =
+        glueTable != null
+            ? glueTable.parameters().get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP)
+            : null;
+    String baseMetadataLocation = base != null ? base.metadataFileLocation() : null;
+    return Objects.equals(baseMetadataLocation, glueMetadataLocation);
+  }
+
+  /**
+   * Prepare parameters for a Glue table update or creation.
+   *
+   * @param glueTable The existing Glue table or null if creating a new one
+   * @param metadata The view metadata
+   * @param newMetadataLocation The new metadata location
+   * @return The parameters map for the Glue table
+   */
+  private Map<String, String> prepareParameters(
+      Table glueTable, ViewMetadata metadata, String newMetadataLocation) {
+    Map<String, String> parameters;
+
+    if (glueTable != null && glueTable.parameters() != null) {
+      parameters = Maps.newHashMap(glueTable.parameters());
+    } else {
+      parameters = Maps.newHashMap();
+    }
+
+    // Add standard Iceberg parameters
+    parameters.put(BaseMetastoreTableOperations.TABLE_TYPE_PROP, "iceberg-view");
+    parameters.put(BaseMetastoreTableOperations.METADATA_LOCATION_PROP, newMetadataLocation);
+
+    if (currentMetadataLocation() != null && !currentMetadataLocation().isEmpty()) {
+      parameters.put(
+          BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation());
+    }
+
+    // Add view properties
+    parameters.putAll(metadata.properties());
+
+    // Remove any obsolete properties
+    if (glueTable != null && glueTable.parameters() != null) {
+      Set<String> obsoleteProps = Sets.newHashSet();
+      glueTable
+          .parameters()
+          .forEach(
+              (key, value) -> {
+                if (!key.equals(BaseMetastoreTableOperations.TABLE_TYPE_PROP)
+                    && !key.equals(BaseMetastoreTableOperations.METADATA_LOCATION_PROP)
+                    && !key.equals(BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP)
+                    && !metadata.properties().containsKey(key)) {
+                  obsoleteProps.add(key);
+                }
+              });
+      obsoleteProps.forEach(parameters::remove);
+    }
+
+    return parameters;
+  }
+
+  /**
+   * Create a new Glue view.
+   *
+   * @param metadata The view metadata
+   * @param parameters The parameters for the Glue table
+   * @param retryDetector The retry detector
+   */
+  private void createGlueView(
+      ViewMetadata metadata, Map<String, String> parameters, RetryDetector retryDetector) {
+    String sqlText = extractSqlText(metadata);
+
+    // Create a new Glue table
+    glue.createTable(
+        CreateTableRequest.builder()
+            .overrideConfiguration(c -> c.addMetricPublisher(retryDetector))
+            .catalogId(awsProperties.glueCatalogId())
+            .databaseName(databaseName)
+            .tableInput(
+                TableInput.builder()
+                    .name(viewName)
+                    .tableType(GlueCatalog.GLUE_VIRTUAL_VIEW_TYPE)
+                    .parameters(parameters)
+                    .storageDescriptor(
+                        StorageDescriptor.builder().location(metadata.location()).build())
+                    .viewOriginalText(sqlText)
+                    .viewExpandedText(sqlText)
+                    .build())
+            .build());
+  }
+
+  /**
+   * Update an existing Glue view.
+   *
+   * @param metadata The view metadata
+   * @param parameters The parameters for the Glue table
+   * @param retryDetector The retry detector
+   */
+  private void updateGlueView(
+      ViewMetadata metadata, Map<String, String> parameters, RetryDetector retryDetector) {
+    String sqlText = extractSqlText(metadata);
+
+    StorageDescriptor storageDescriptor =
+        StorageDescriptor.builder()
+            .location(metadata.location())
+            .build();
+
+    // Update the existing Glue table
+    UpdateTableRequest.Builder updateTableRequest =
+        UpdateTableRequest.builder()
+            .overrideConfiguration(c -> c.addMetricPublisher(retryDetector))
+            .catalogId(awsProperties.glueCatalogId())
+            .databaseName(databaseName)
+            .skipArchive(awsProperties.glueCatalogSkipArchive())
+            .tableInput(
+                TableInput.builder()
+                    .name(viewName)
+                    .tableType(GlueCatalog.GLUE_VIRTUAL_VIEW_TYPE)
+                    .parameters(parameters)
+                    .storageDescriptor(storageDescriptor)
+                    .viewOriginalText(sqlText)
+                    .viewExpandedText(sqlText)
+                    .build());
+
+    glue.updateTable(updateTableRequest.build());
+  }
+
+  /**
+   * Extract SQL text from view metadata.
+   *
+   * @param metadata The view metadata
+   * @return The SQL text for the view
+   */
+  private String extractSqlText(ViewMetadata metadata) {
+    SQLViewRepresentation closest = null;
+
+    // Try to find a representation for the view
+    if (metadata.currentVersion() != null && metadata.currentVersion().representations() != null) {
+      for (ViewRepresentation representation : metadata.currentVersion().representations()) {
+        if (representation instanceof SQLViewRepresentation) {
+          SQLViewRepresentation sqlViewRepresentation = (SQLViewRepresentation) representation;
+
+          // Prefer a Hive SQL representation if available
+          if (sqlViewRepresentation.dialect().equalsIgnoreCase("hive")) {
+            return sqlViewRepresentation.sql();
+          } else if (closest == null) {
+            closest = sqlViewRepresentation;
+          }
+        }
+      }
+    }
+
+    return closest != null ? closest.sql() : "";
+  }
+
+  /**
+   * Check the status of a commit.
+   *
+   * @param newMetadataLocation The new metadata location
+   * @return The commit status
+   */
+  private CommitStatus checkCommitStatus(String newMetadataLocation) {
+    try {
+      Table table = getGlueTable();
+
+      if (table == null) {
+        return CommitStatus.FAILURE;
+      }
+
+      String metadataLocation =
+          table.parameters().get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
+
+      if (metadataLocation != null && metadataLocation.equals(newMetadataLocation)) {
+        return CommitStatus.SUCCESS;
+      } else {
+        return CommitStatus.FAILURE;
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to check commit status for {}", fullViewName, e);
+      return CommitStatus.UNKNOWN;
+    }
+  }
+
+  /**
+   * Handle AWS exceptions.
+   *
+   * @param awsException The AWS exception
+   * @throws CommitFailedException if the exception indicates a commit failure
+   * @throws AlreadyExistsException if the view already exists
+   * @throws ValidationException if there is a validation error
+   */
+  private void handleAwsExceptions(AwsServiceException awsException) {
+    if (awsException instanceof ConcurrentModificationException) {
+      throw new CommitFailedException(
+          awsException, "Cannot commit %s because Glue detected concurrent update", fullViewName);
+    } else if (awsException
+        instanceof software.amazon.awssdk.services.glue.model.AlreadyExistsException) {
+      throw new AlreadyExistsException(
+          awsException, "Cannot commit %s because its Glue table already exists", fullViewName);
+    } else if (awsException instanceof EntityNotFoundException) {
+      throw new NoSuchViewException(
+          awsException,
+          "Cannot commit %s because Glue cannot find the requested entity",
+          fullViewName);
+    } else if (awsException instanceof AccessDeniedException) {
+      throw new ValidationException(
+          awsException, "Cannot commit %s because of insufficient permissions", fullViewName);
+    } else if (awsException
+        instanceof software.amazon.awssdk.services.glue.model.ValidationException) {
+      throw new ValidationException(
+          awsException, "Cannot commit %s because of Glue validation error", fullViewName);
+    } else {
+      // For 5xx errors, we'll let the caller retry
+      int statusCode = awsException.statusCode();
+      if (statusCode < 500 || statusCode >= 600) {
+        throw awsException;
+      }
+    }
+  }
+
+  @Override
+  protected String viewName() {
+    return fullViewName;
+  }
+
+  @Override
+  protected FileIO io() {
+    return fileIO;
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -569,7 +569,8 @@ public class TestGlueCatalog {
 
     assertThatThrownBy(() -> glueCatalog.dropNamespace(Namespace.of("db1")))
         .isInstanceOf(NamespaceNotEmptyException.class)
-        .hasMessage("Cannot drop namespace db1 because it still contains non-Iceberg tables");
+        .hasMessage(
+            "Cannot drop namespace db1 because it still contains non-Iceberg tables or views");
   }
 
   @Test
@@ -678,5 +679,141 @@ public class TestGlueCatalog {
             S3FileIOProperties.WRITE_TAGS_PREFIX.concat(
                 S3FileIOProperties.S3_TAG_ICEBERG_NAMESPACE),
             "db");
+  }
+
+  @Test
+  public void testDropView() {
+    TableIdentifier viewIdent = TableIdentifier.of("db", "drop_view");
+    Table glueView =
+        Table.builder()
+            .databaseName("db")
+            .name("drop_view")
+            .tableType("VIRTUAL_VIEW")
+            .parameters(
+                ImmutableMap.of(
+                    "table_type", "iceberg-view", "metadata_location", "s3://xx/metadata.json"))
+            .build();
+
+    Mockito.doReturn(GetTableResponse.builder().table(glueView).build())
+        .when(glue)
+        .getTable(Mockito.any(GetTableRequest.class));
+    Mockito.doReturn(DeleteTableResponse.builder().build())
+        .when(glue)
+        .deleteTable(Mockito.any(DeleteTableRequest.class));
+
+    boolean dropped = glueCatalog.dropView(viewIdent);
+    assertThat(dropped).isTrue();
+
+    Mockito.verify(glue, Mockito.times(1))
+        .deleteTable(
+            Mockito.argThat(
+                (DeleteTableRequest r) ->
+                    r.databaseName().equals("db") && r.name().equals("drop_view")));
+  }
+
+  @Test
+  public void testDropViewNotFound() {
+    TableIdentifier viewIdent = TableIdentifier.of("db", "no_view");
+    Mockito.doThrow(EntityNotFoundException.builder().build())
+        .when(glue)
+        .getTable(Mockito.any(GetTableRequest.class));
+
+    boolean result = glueCatalog.dropView(viewIdent);
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void testDropViewButItsNotView() {
+    TableIdentifier viewIdent = TableIdentifier.of("db", "not_view");
+    Table glueTable =
+        Table.builder()
+            .databaseName("db")
+            .name("not_view")
+            .tableType("EXTERNAL_TABLE")
+            .parameters(ImmutableMap.of("table_type", "iceberg-table")) // not "iceberg-view"
+            .build();
+
+    Mockito.doReturn(GetTableResponse.builder().table(glueTable).build())
+        .when(glue)
+        .getTable(Mockito.any(GetTableRequest.class));
+
+    boolean dropped = glueCatalog.dropView(viewIdent);
+    assertThat(dropped).isFalse();
+  }
+
+  @Test
+  public void testListViews() {
+    Mockito.doReturn(
+            GetTablesResponse.builder()
+                .tableList(
+                    Table.builder()
+                        .databaseName("db")
+                        .name("my_view")
+                        .tableType("VIRTUAL_VIEW")
+                        .parameters(
+                            ImmutableMap.of(
+                                "table_type",
+                                "iceberg-view",
+                                "metadata_location",
+                                "s3://v1/metadata.json"))
+                        .build(),
+                    Table.builder()
+                        .databaseName("db")
+                        .name("my_table")
+                        .tableType("EXTERNAL_TABLE")
+                        .parameters(ImmutableMap.of("table_type", "iceberg-table"))
+                        .build())
+                .build())
+        .when(glue)
+        .getTables(Mockito.any(GetTablesRequest.class));
+
+    List<TableIdentifier> views = glueCatalog.listViews(Namespace.of("db"));
+    assertThat(views).hasSize(1);
+    assertThat(views.get(0)).isEqualTo(TableIdentifier.of("db", "my_view"));
+  }
+
+  @Test
+  public void testRenameView() {
+    TableIdentifier from = TableIdentifier.of("db", "old_view");
+    TableIdentifier to = TableIdentifier.of("db", "new_view");
+
+    Mockito.doReturn(
+            GetDatabaseResponse.builder().database(Database.builder().name("db").build()).build())
+        .when(glue)
+        .getDatabase(Mockito.any(GetDatabaseRequest.class));
+
+    Table existingView =
+        Table.builder()
+            .databaseName("db")
+            .name("old_view")
+            .tableType("VIRTUAL_VIEW")
+            .parameters(ImmutableMap.of("table_type", "iceberg-view"))
+            .build();
+    Mockito.doReturn(GetTableResponse.builder().table(existingView).build())
+        .when(glue)
+        .getTable(Mockito.<GetTableRequest>argThat(r -> "old_view".equals(r.name())));
+
+    Mockito.doThrow(EntityNotFoundException.builder().build())
+        .when(glue)
+        .getTable(Mockito.<GetTableRequest>argThat(r -> "new_view".equals(r.name())));
+
+    Mockito.doReturn(CreateTableResponse.builder().build())
+        .when(glue)
+        .createTable(Mockito.any(CreateTableRequest.class));
+    Mockito.doReturn(DeleteTableResponse.builder().build())
+        .when(glue)
+        .deleteTable(Mockito.any(DeleteTableRequest.class));
+
+    glueCatalog.renameView(from, to);
+
+    Mockito.verify(glue, Mockito.times(1))
+        .createTable(
+            Mockito.argThat(
+                (CreateTableRequest r) ->
+                    r.tableInput().name().equals("new_view")
+                        && "VIRTUAL_VIEW".equals(r.tableInput().tableType())
+                        && "iceberg-view".equals(r.tableInput().parameters().get("table_type"))));
+    Mockito.verify(glue, Mockito.times(1))
+        .deleteTable(Mockito.argThat((DeleteTableRequest r) -> r.name().equals("old_view")));
   }
 }


### PR DESCRIPTION
Adds support for creating and managing Iceberg views in the AWS Glue Catalog implementation. Although AWS Glue recently introduced a REST Catalog endpoint, it currently does not support creating Iceberg views:

```
java.lang.UnsupportedOperationException: Server does not support endpoint: POST /v1/{prefix}/namespaces/{namespace}/views
```

Even after the REST endpoint adds view support, many users still rely on the older Glue Catalog implementation, which view functionality is currently not supported. Then, this feature addition will enable users to create and manage Iceberg views through Glue Catalog as Iceberg Catalog.

Fixes https://github.com/apache/iceberg/issues/12488