### PR TITLE
Spark: Call configureTable in ScanTestBase to ensure proper table configuration

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
@@ -96,6 +96,7 @@ public abstract class ScanTestBase extends AvroDataTest {
     Table table =
         tables.create(
             writeSchema, PartitionSpec.unpartitioned(), tableProperties, location.toString());
+    configureTable(table);
 
     // Important: use the table's schema for the rest of the test
     // When tables are created, the column ids are reassigned.


### PR DESCRIPTION
Seems like `configureTable` is not currently in use. This PR explicitly calls `configureTable` to configure the table.