### PR TITLE
Migrate Spark 3.4 TestBase related tests in spark and actions

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
@@ -46,10 +46,9 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TestSpark3Util extends SparkTestBase {
+public class TestSpark3Util extends TestBase {
   @Test
   public void testDescribeSortOrder() {
     Schema schema =
@@ -57,46 +56,44 @@ public class TestSpark3Util extends SparkTestBase {
             required(1, "data", Types.StringType.get()),
             required(2, "time", Types.TimestampType.withoutZone()));
 
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "data DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("Identity", schema, 1)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "bucket(1, data) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("bucket[1]", schema, 1)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "truncate(data, 3) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("truncate[3]", schema, 1)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "years(time) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("year", schema, 2)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "months(time) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("month", schema, 2)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "days(time) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("day", schema, 2)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "hours(time) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("hour", schema, 2)));
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "unknown(data) DESC NULLS FIRST",
-        Spark3Util.describe(buildSortOrder("unknown", schema, 1)));
+    assertThat(Spark3Util.describe(buildSortOrder("Identity", schema, 1)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("data DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("bucket[1]", schema, 1)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("bucket(1, data) DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("truncate[3]", schema, 1)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("truncate(data, 3) DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("year", schema, 2)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("years(time) DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("month", schema, 2)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("months(time) DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("day", schema, 2)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("days(time) DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("hour", schema, 2)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("hours(time) DESC NULLS FIRST");
+
+    assertThat(Spark3Util.describe(buildSortOrder("unknown", schema, 1)))
+        .as("Sort order isn't correct.")
+        .isEqualTo("unknown(data) DESC NULLS FIRST");
 
     // multiple sort orders
     SortOrder multiOrder =
         SortOrder.builderFor(schema).asc("time", NULLS_FIRST).asc("data", NULLS_LAST).build();
-    Assert.assertEquals(
-        "Sort order isn't correct.",
-        "time ASC NULLS FIRST, data ASC NULLS LAST",
-        Spark3Util.describe(multiOrder));
+    assertThat(Spark3Util.describe(multiOrder))
+        .as("Sort order isn't correct.")
+        .isEqualTo("time ASC NULLS FIRST, data ASC NULLS LAST");
   }
 
   @Test
@@ -110,10 +107,10 @@ public class TestSpark3Util extends SparkTestBase {
                 Types.MapType.ofOptional(4, 5, Types.StringType.get(), Types.LongType.get())),
             required(6, "time", Types.TimestampType.withoutZone()));
 
-    Assert.assertEquals(
-        "Schema description isn't correct.",
-        "struct<data: list<string> not null,pairs: map<string, bigint>,time: timestamp not null>",
-        Spark3Util.describe(schema));
+    assertThat(Spark3Util.describe(schema))
+        .as("Schema description isn't correct.")
+        .isEqualTo(
+            "struct<data: list<string> not null,pairs: map<string, bigint>,time: timestamp not null>");
   }
 
   @Test
@@ -126,7 +123,7 @@ public class TestSpark3Util extends SparkTestBase {
     sql("CREATE TABLE %s (c1 bigint, c2 string, c3 string) USING iceberg", tableFullName);
 
     Table table = Spark3Util.loadIcebergTable(spark, tableFullName);
-    Assert.assertTrue(table.name().equals(tableFullName));
+    assertThat(table.name()).isEqualTo(tableFullName);
   }
 
   @Test
@@ -134,8 +131,9 @@ public class TestSpark3Util extends SparkTestBase {
     spark.conf().set("spark.sql.catalog.test_cat", SparkCatalog.class.getName());
     spark.conf().set("spark.sql.catalog.test_cat.type", "hive");
     Catalog catalog = Spark3Util.loadIcebergCatalog(spark, "test_cat");
-    Assert.assertTrue(
-        "Should retrieve underlying catalog class", catalog instanceof CachingCatalog);
+    assertThat(catalog)
+        .as("Should retrieve underlying catalog class")
+        .isInstanceOf(CachingCatalog.class);
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
@@ -19,18 +19,19 @@
 package org.apache.iceberg.spark;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class TestSparkSessionCatalog extends SparkTestBase {
+public class TestSparkSessionCatalog extends TestBase {
   private final String envHmsUriKey = "spark.hadoop." + METASTOREURIS.varname;
   private final String catalogHmsUriKey = "spark.sql.catalog.spark_catalog.uri";
   private final String hmsUri = hiveConf.get(METASTOREURIS.varname);
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpCatalog() {
     spark
         .conf()
@@ -38,7 +39,7 @@ public class TestSparkSessionCatalog extends SparkTestBase {
     spark.conf().set("spark.sql.catalog.spark_catalog.type", "hive");
   }
 
-  @Before
+  @BeforeEach
   public void setupHmsUri() {
     spark.sessionState().catalogManager().reset();
     spark.conf().set(envHmsUriKey, hmsUri);
@@ -48,52 +49,35 @@ public class TestSparkSessionCatalog extends SparkTestBase {
   @Test
   public void testValidateHmsUri() {
     // HMS uris match
-    Assert.assertTrue(
-        spark
-            .sessionState()
-            .catalogManager()
-            .v2SessionCatalog()
-            .defaultNamespace()[0]
-            .equals("default"));
+    assertThat(spark.sessionState().catalogManager().v2SessionCatalog().defaultNamespace())
+        .containsExactly("default");
 
     // HMS uris doesn't match
     spark.sessionState().catalogManager().reset();
     String catalogHmsUri = "RandomString";
     spark.conf().set(envHmsUriKey, hmsUri);
     spark.conf().set(catalogHmsUriKey, catalogHmsUri);
-    IllegalArgumentException exception =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> spark.sessionState().catalogManager().v2SessionCatalog());
-    String errorMessage =
-        String.format(
-            "Inconsistent Hive metastore URIs: %s (Spark session) != %s (spark_catalog)",
-            hmsUri, catalogHmsUri);
-    Assert.assertEquals(errorMessage, exception.getMessage());
+
+    assertThatThrownBy(() -> spark.sessionState().catalogManager().v2SessionCatalog())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            String.format(
+                "Inconsistent Hive metastore URIs: %s (Spark session) != %s (spark_catalog)",
+                hmsUri, catalogHmsUri));
 
     // no env HMS uri, only catalog HMS uri
     spark.sessionState().catalogManager().reset();
     spark.conf().set(catalogHmsUriKey, hmsUri);
     spark.conf().unset(envHmsUriKey);
-    Assert.assertTrue(
-        spark
-            .sessionState()
-            .catalogManager()
-            .v2SessionCatalog()
-            .defaultNamespace()[0]
-            .equals("default"));
+    assertThat(spark.sessionState().catalogManager().v2SessionCatalog().defaultNamespace())
+        .containsExactly("default");
 
     // no catalog HMS uri, only env HMS uri
     spark.sessionState().catalogManager().reset();
     spark.conf().set(envHmsUriKey, hmsUri);
     spark.conf().unset(catalogHmsUriKey);
-    Assert.assertTrue(
-        spark
-            .sessionState()
-            .catalogManager()
-            .v2SessionCatalog()
-            .defaultNamespace()[0]
-            .equals("default"));
+    assertThat(spark.sessionState().catalogManager().v2SessionCatalog().defaultNamespace())
+        .containsExactly("default");
   }
 
   @Test
@@ -102,11 +86,15 @@ public class TestSparkSessionCatalog extends SparkTestBase {
 
     // load permanent UDF in Hive via FunctionCatalog
     spark.sql(String.format("CREATE FUNCTION perm_upper AS '%s'", functionClass));
-    Assert.assertEquals("Load permanent UDF in Hive", "XYZ", scalarSql("SELECT perm_upper('xyz')"));
+    assertThat(scalarSql("SELECT perm_upper('xyz')"))
+        .as("Load permanent UDF in Hive")
+        .isEqualTo("XYZ");
 
     // load temporary UDF in Hive via FunctionCatalog
     spark.sql(String.format("CREATE TEMPORARY FUNCTION temp_upper AS '%s'", functionClass));
-    Assert.assertEquals("Load temporary UDF in Hive", "XYZ", scalarSql("SELECT temp_upper('xyz')"));
+    assertThat(scalarSql("SELECT temp_upper('xyz')"))
+        .as("Load temporary UDF in Hive")
+        .isEqualTo("XYZ");
 
     // TODO: fix loading Iceberg built-in functions in SessionCatalog
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -19,9 +19,13 @@
 package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -33,6 +37,9 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -45,19 +52,16 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TestDeleteReachableFilesAction extends SparkTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestDeleteReachableFilesAction extends TestBase {
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
       new Schema(
@@ -113,15 +117,25 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
           .withRecordCount(1)
           .build();
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private File tableDir;
+  @Parameter private int formatVersion;
+
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(2, 3);
+  }
 
   private Table table;
 
-  @Before
+  @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.newFolder();
     String tableLocation = tableDir.toURI().toString();
-    this.table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
+    this.table =
+        TABLES.create(
+            SCHEMA,
+            SPEC,
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
     spark.conf().set("spark.sql.shuffle.partitions", SHUFFLE_PARTITIONS);
   }
 
@@ -133,33 +147,32 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
       long expectedManifestListsDeleted,
       long expectedOtherFilesDeleted,
       DeleteReachableFiles.Result results) {
-    Assert.assertEquals(
-        "Incorrect number of manifest files deleted",
-        expectedManifestsDeleted,
-        results.deletedManifestsCount());
-    Assert.assertEquals(
-        "Incorrect number of datafiles deleted",
-        expectedDatafiles,
-        results.deletedDataFilesCount());
-    Assert.assertEquals(
-        "Incorrect number of position delete files deleted",
-        expectedPosDeleteFiles,
-        results.deletedPositionDeleteFilesCount());
-    Assert.assertEquals(
-        "Incorrect number of equality delete files deleted",
-        expectedEqDeleteFiles,
-        results.deletedEqualityDeleteFilesCount());
-    Assert.assertEquals(
-        "Incorrect number of manifest lists deleted",
-        expectedManifestListsDeleted,
-        results.deletedManifestListsCount());
-    Assert.assertEquals(
-        "Incorrect number of other lists deleted",
-        expectedOtherFilesDeleted,
-        results.deletedOtherFilesCount());
+    assertThat(results.deletedManifestsCount())
+        .as("Incorrect number of manifest files deleted")
+        .isEqualTo(expectedManifestsDeleted);
+
+    assertThat(results.deletedDataFilesCount())
+        .as("Incorrect number of datafiles deleted")
+        .isEqualTo(expectedDatafiles);
+
+    assertThat(results.deletedPositionDeleteFilesCount())
+        .as("Incorrect number of position delete files deleted")
+        .isEqualTo(expectedPosDeleteFiles);
+
+    assertThat(results.deletedEqualityDeleteFilesCount())
+        .as("Incorrect number of equality delete files deleted")
+        .isEqualTo(expectedEqDeleteFiles);
+
+    assertThat(results.deletedManifestListsCount())
+        .as("Incorrect number of manifest lists deleted")
+        .isEqualTo(expectedManifestListsDeleted);
+
+    assertThat(results.deletedOtherFilesCount())
+        .as("Incorrect number of other lists deleted")
+        .isEqualTo(expectedOtherFilesDeleted);
   }
 
-  @Test
+  @TestTemplate
   public void dataFilesCleanupWithParallelTasks() {
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -196,19 +209,20 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
 
     // Verifies that the delete methods ran in the threads created by the provided ExecutorService
     // ThreadFactory
-    Assert.assertEquals(
-        deleteThreads,
-        Sets.newHashSet("remove-files-0", "remove-files-1", "remove-files-2", "remove-files-3"));
+    assertThat(deleteThreads)
+        .containsExactlyInAnyOrder(
+            "remove-files-0", "remove-files-1", "remove-files-2", "remove-files-3");
 
     Lists.newArrayList(FILE_A, FILE_B, FILE_C, FILE_D)
         .forEach(
             file ->
-                Assert.assertTrue(
-                    "FILE_A should be deleted", deletedFiles.contains(FILE_A.location())));
+                assertThat(deletedFiles)
+                    .as("FILE_A should be deleted")
+                    .contains(FILE_A.location()));
     checkRemoveFilesResults(4L, 0, 0, 6L, 4L, 6, result);
   }
 
-  @Test
+  @TestTemplate
   public void testWithExpiringDanglingStageCommit() {
     table.location();
     // `A` commit
@@ -226,7 +240,7 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     checkRemoveFilesResults(3L, 0, 0, 3L, 3L, 5, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveFileActionOnEmptyTable() {
     DeleteReachableFiles.Result result =
         sparkActions().deleteReachableFiles(metadataLocation(table)).io(table.io()).execute();
@@ -234,7 +248,7 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     checkRemoveFilesResults(0, 0, 0, 0, 0, 2, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveFilesActionWithReducedVersionsTable() {
     table.updateProperties().set(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "2").commit();
     table.newAppend().appendFile(FILE_A).commit();
@@ -254,7 +268,7 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     checkRemoveFilesResults(4, 0, 0, 5, 5, 8, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveFilesAction() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -265,8 +279,9 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     checkRemoveFilesResults(2, 0, 0, 2, 2, 4, baseRemoveFilesSparkAction.execute());
   }
 
-  @Test
+  @TestTemplate
   public void testPositionDeleteFiles() {
+    assumeThat(formatVersion).as("DV is not supported in Spark 3.4").isEqualTo(2);
     table.newAppend().appendFile(FILE_A).commit();
 
     table.newAppend().appendFile(FILE_B).commit();
@@ -278,7 +293,7 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     checkRemoveFilesResults(2, 1, 0, 3, 3, 5, baseRemoveFilesSparkAction.execute());
   }
 
-  @Test
+  @TestTemplate
   public void testEqualityDeleteFiles() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -291,7 +306,7 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     checkRemoveFilesResults(2, 0, 1, 3, 3, 5, baseRemoveFilesSparkAction.execute());
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveFilesActionWithDefaultIO() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -304,7 +319,7 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     checkRemoveFilesResults(2, 0, 0, 2, 2, 4, baseRemoveFilesSparkAction.execute());
   }
 
-  @Test
+  @TestTemplate
   public void testUseLocalIterator() {
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -329,14 +344,13 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
 
           checkRemoveFilesResults(3L, 0, 0, 4L, 3L, 5, results);
 
-          Assert.assertEquals(
-              "Expected total jobs to be equal to total number of shuffle partitions",
-              totalJobsRun,
-              SHUFFLE_PARTITIONS);
+          assertThat(totalJobsRun)
+              .as("Expected total jobs to be equal to total number of shuffle partitions")
+              .isEqualTo(SHUFFLE_PARTITIONS);
         });
   }
 
-  @Test
+  @TestTemplate
   public void testIgnoreMetadataFilesNotFound() {
     table.updateProperties().set(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "1").commit();
 
@@ -345,11 +359,10 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         sparkActions().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
-    Assert.assertTrue(
-        "Should remove v1 file",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("v1.metadata.json")));
+    assertThat(result.orphanFileLocations()).as("Should delete 1 file").hasSize(1);
+    assertThat(StreamSupport.stream(result.orphanFileLocations().spliterator(), false))
+        .as("Should remove v1 file")
+        .anyMatch(file -> file.contains("v1.metadata.json"));
 
     DeleteReachableFiles baseRemoveFilesSparkAction =
         sparkActions().deleteReachableFiles(metadataLocation(table)).io(table.io());
@@ -358,7 +371,7 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     checkRemoveFilesResults(1, 0, 0, 1, 1, 4, res);
   }
 
-  @Test
+  @TestTemplate
   public void testEmptyIOThrowsException() {
     DeleteReachableFiles baseRemoveFilesSparkAction =
         sparkActions().deleteReachableFiles(metadataLocation(table)).io(null);
@@ -368,7 +381,7 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
         .hasMessage("File IO cannot be null");
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveFilesActionWhenGarbageCollectionDisabled() {
     table.updateProperties().set(TableProperties.GC_ENABLED, "false").commit();
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -19,10 +19,14 @@
 package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,6 +40,9 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReachableFileUtil;
 import org.apache.iceberg.Schema;
@@ -51,19 +58,19 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TestExpireSnapshotsAction extends SparkTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestExpireSnapshotsAction extends TestBase {
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
       new Schema(
@@ -119,17 +126,27 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
           .withRecordCount(1)
           .build();
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
+  @Parameter private int formatVersion;
 
-  private File tableDir;
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(2, 3);
+  }
+
+  @TempDir private File tableDir;
   private String tableLocation;
   private Table table;
 
-  @Before
+  @BeforeEach
   public void setupTableLocation() throws Exception {
-    this.tableDir = temp.newFolder();
     this.tableLocation = tableDir.toURI().toString();
-    this.table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
+    this.table =
+        TABLES.create(
+            SCHEMA,
+            SPEC,
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
     spark.conf().set("spark.sql.shuffle.partitions", SHUFFLE_PARTITIONS);
   }
 
@@ -153,29 +170,28 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
       long expectedManifestListsDeleted,
       ExpireSnapshots.Result results) {
 
-    Assert.assertEquals(
-        "Incorrect number of manifest files deleted",
-        expectedManifestsDeleted,
-        results.deletedManifestsCount());
-    Assert.assertEquals(
-        "Incorrect number of datafiles deleted",
-        expectedDatafiles,
-        results.deletedDataFilesCount());
-    Assert.assertEquals(
-        "Incorrect number of pos deletefiles deleted",
-        expectedPosDeleteFiles,
-        results.deletedPositionDeleteFilesCount());
-    Assert.assertEquals(
-        "Incorrect number of eq deletefiles deleted",
-        expectedEqDeleteFiles,
-        results.deletedEqualityDeleteFilesCount());
-    Assert.assertEquals(
-        "Incorrect number of manifest lists deleted",
-        expectedManifestListsDeleted,
-        results.deletedManifestListsCount());
+    assertThat(results.deletedManifestsCount())
+        .as("Incorrect number of manifest files deleted")
+        .isEqualTo(expectedManifestsDeleted);
+
+    assertThat(results.deletedDataFilesCount())
+        .as("Incorrect number of datafiles deleted")
+        .isEqualTo(expectedDatafiles);
+
+    assertThat(results.deletedPositionDeleteFilesCount())
+        .as("Incorrect number of pos deletefiles deleted")
+        .isEqualTo(expectedPosDeleteFiles);
+
+    assertThat(results.deletedEqualityDeleteFilesCount())
+        .as("Incorrect number of eq deletefiles deleted")
+        .isEqualTo(expectedEqDeleteFiles);
+
+    assertThat(results.deletedManifestListsCount())
+        .as("Incorrect number of manifest lists deleted")
+        .isEqualTo(expectedManifestListsDeleted);
   }
 
-  @Test
+  @TestTemplate
   public void testFilesCleaned() throws Exception {
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -188,13 +204,12 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     ExpireSnapshots.Result results =
         SparkActions.get().expireSnapshots(table).expireOlderThan(end).execute();
 
-    Assert.assertEquals(
-        "Table does not have 1 snapshot after expiration", 1, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Table does not have 1 snapshot after expiration").hasSize(1);
 
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, results);
   }
 
-  @Test
+  @TestTemplate
   public void dataFilesCleanupWithParallelTasks() throws IOException {
 
     table.newFastAppend().appendFile(FILE_A).commit();
@@ -234,18 +249,17 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     // Verifies that the delete methods ran in the threads created by the provided ExecutorService
     // ThreadFactory
-    Assert.assertEquals(
-        deleteThreads,
-        Sets.newHashSet(
-            "remove-snapshot-0", "remove-snapshot-1", "remove-snapshot-2", "remove-snapshot-3"));
+    assertThat(deleteThreads)
+        .containsExactlyInAnyOrder(
+            "remove-snapshot-0", "remove-snapshot-1", "remove-snapshot-2", "remove-snapshot-3");
 
-    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.location()));
-    Assert.assertTrue("FILE_B should be deleted", deletedFiles.contains(FILE_B.location()));
+    assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.location());
+    assertThat(deletedFiles).as("FILE_B should be deleted").contains(FILE_B.location());
 
     checkExpirationResults(2L, 0L, 0L, 3L, 3L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testNoFilesDeletedWhenNoSnapshotsExpired() throws Exception {
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -253,7 +267,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 0L, results);
   }
 
-  @Test
+  @TestTemplate
   public void testCleanupRepeatedOverwrites() throws Exception {
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -269,7 +283,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     checkExpirationResults(1L, 0L, 0L, 39L, 20L, results);
   }
 
-  @Test
+  @TestTemplate
   public void testRetainLastWithExpireOlderThan() {
     table
         .newAppend()
@@ -296,13 +310,11 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     // Retain last 2 snapshots
     SparkActions.get().expireSnapshots(table).expireOlderThan(t3).retainLast(2).execute();
 
-    Assert.assertEquals(
-        "Should have two snapshots.", 2, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertEquals(
-        "First snapshot should not present.", null, table.snapshot(firstSnapshotId));
+    assertThat(table.snapshots()).as("Should have two snapshots.").hasSize(2);
+    assertThat(table.snapshot(firstSnapshotId)).as("First snapshot should not present.").isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testExpireTwoSnapshotsById() throws Exception {
     table
         .newAppend()
@@ -330,17 +342,14 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .expireSnapshotId(secondSnapshotID)
             .execute();
 
-    Assert.assertEquals(
-        "Should have one snapshots.", 1, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertEquals(
-        "First snapshot should not present.", null, table.snapshot(firstSnapshotId));
-    Assert.assertEquals(
-        "Second snapshot should not be present.", null, table.snapshot(secondSnapshotID));
+    assertThat(table.snapshots()).as("Should have one snapshot.").hasSize(1);
+    assertThat(table.snapshot(firstSnapshotId)).as("First snapshot should not present.").isNull();
+    assertThat(table.snapshot(secondSnapshotID)).as("Second snapshot should not present.").isNull();
 
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRetainLastWithExpireById() {
     table
         .newAppend()
@@ -366,14 +375,12 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .retainLast(3)
             .execute();
 
-    Assert.assertEquals(
-        "Should have two snapshots.", 2, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertEquals(
-        "First snapshot should not present.", null, table.snapshot(firstSnapshotId));
+    assertThat(table.snapshots()).as("Should have 2 snapshots.").hasSize(2);
+    assertThat(table.snapshot(firstSnapshotId)).as("First snapshot should not present.").isNull();
     checkExpirationResults(0L, 0L, 0L, 0L, 1L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRetainLastWithTooFewSnapshots() {
     table
         .newAppend()
@@ -393,16 +400,14 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     ExpireSnapshots.Result result =
         SparkActions.get().expireSnapshots(table).expireOlderThan(t2).retainLast(3).execute();
 
-    Assert.assertEquals(
-        "Should have two snapshots", 2, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertEquals(
-        "First snapshot should still present",
-        firstSnapshotId,
-        table.snapshot(firstSnapshotId).snapshotId());
+    assertThat(table.snapshots()).as("Should have two snapshots.").hasSize(2);
+    assertThat(table.snapshot(firstSnapshotId))
+        .as("First snapshot should still be present.")
+        .isNotNull();
     checkExpirationResults(0L, 0L, 0L, 0L, 0L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRetainLastKeepsExpiringSnapshot() {
     table
         .newAppend()
@@ -434,14 +439,14 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .retainLast(2)
             .execute();
 
-    Assert.assertEquals(
-        "Should have three snapshots.", 3, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertNotNull(
-        "Second snapshot should present.", table.snapshot(secondSnapshot.snapshotId()));
+    assertThat(table.snapshots()).as("Should have three snapshots.").hasSize(3);
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("First snapshot should be present.")
+        .isNotNull();
     checkExpirationResults(0L, 0L, 0L, 0L, 1L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireSnapshotsWithDisabledGarbageCollection() {
     table.updateProperties().set(TableProperties.GC_ENABLED, "false").commit();
 
@@ -453,7 +458,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             "Cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)");
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThanMultipleCalls() {
     table
         .newAppend()
@@ -482,14 +487,14 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .expireOlderThan(thirdSnapshot.timestampMillis())
             .execute();
 
-    Assert.assertEquals(
-        "Should have one snapshots.", 1, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertNull(
-        "Second snapshot should not present.", table.snapshot(secondSnapshot.snapshotId()));
+    assertThat(table.snapshots()).as("Should have one snapshot.").hasSize(1);
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("Second snapshot should not present.")
+        .isNull();
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRetainLastMultipleCalls() {
     table
         .newAppend()
@@ -519,21 +524,21 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .retainLast(1)
             .execute();
 
-    Assert.assertEquals(
-        "Should have one snapshots.", 1, Lists.newArrayList(table.snapshots()).size());
-    Assert.assertNull(
-        "Second snapshot should not present.", table.snapshot(secondSnapshot.snapshotId()));
+    assertThat(table.snapshots()).as("Should have one snapshot.").hasSize(1);
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("Second snapshot should not present.")
+        .isNull();
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testRetainZeroSnapshots() {
     assertThatThrownBy(() -> SparkActions.get().expireSnapshots(table).retainLast(0).execute())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Number of snapshots to retain must be at least 1, cannot be: 0");
   }
 
-  @Test
+  @TestTemplate
   public void testScanExpiredManifestInValidSnapshotAppend() {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -552,11 +557,11 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.location()));
+    assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.location());
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, result);
   }
 
-  @Test
+  @TestTemplate
   public void testScanExpiredManifestInValidSnapshotFastAppend() {
     table
         .updateProperties()
@@ -581,7 +586,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.location()));
+    assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.location());
     checkExpirationResults(1L, 0L, 0L, 1L, 2L, result);
   }
 
@@ -589,7 +594,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
    * Test on table below, and expiring the staged commit `B` using `expireOlderThan` API. Table: A -
    * C ` B (staged)
    */
-  @Test
+  @TestTemplate
   public void testWithExpiringDanglingStageCommit() {
     // `A` commit
     table.newAppend().appendFile(FILE_A).commit();
@@ -638,8 +643,9 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
                 expectedDeletes.add(file.path());
               }
             });
-    Assert.assertSame(
-        "Files deleted count should be expected", expectedDeletes.size(), deletedFiles.size());
+    assertThat(expectedDeletes)
+        .as("Files deleted count should be expected")
+        .hasSameSizeAs(deletedFiles);
     // Take the diff
     expectedDeletes.removeAll(deletedFiles);
     Assert.assertTrue("Exactly same files should be deleted", expectedDeletes.isEmpty());
@@ -649,7 +655,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
    * Expire cherry-pick the commit as shown below, when `B` is in table's current state Table: A - B
    * - C <--current snapshot `- D (source=B)
    */
-  @Test
+  @TestTemplate
   public void testWithCherryPickTableSnapshot() {
     // `A` commit
     table.newAppend().appendFile(FILE_A).commit();
@@ -704,7 +710,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
    * Test on table below, and expiring `B` which is not in current table state. 1) Expire `B` 2) All
    * commit Table: A - C - D (B) ` B (staged)
    */
-  @Test
+  @TestTemplate
   public void testWithExpiringStagedThenCherrypick() {
     // `A` commit
     table.newAppend().appendFile(FILE_A).commit();
@@ -768,7 +774,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, secondResult);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThan() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -791,37 +797,34 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertEquals(
-        "Expire should not change current snapshot",
-        snapshotId,
-        table.currentSnapshot().snapshotId());
-    Assert.assertNull(
-        "Expire should remove the oldest snapshot", table.snapshot(firstSnapshot.snapshotId()));
-    Assert.assertEquals(
-        "Should remove only the expired manifest list location",
-        Sets.newHashSet(firstSnapshot.manifestListLocation()),
-        deletedFiles);
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Expire should not change current snapshot.")
+        .isEqualTo(snapshotId);
+    assertThat(table.snapshot(firstSnapshot.snapshotId()))
+        .as("Expire should remove the oldest snapshot.")
+        .isNull();
+    assertThat(deletedFiles)
+        .as("Should remove only the expired manifest list location.")
+        .containsExactly(firstSnapshot.manifestListLocation());
 
     checkExpirationResults(0, 0, 0, 0, 1, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThanWithDelete() {
     table.newAppend().appendFile(FILE_A).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
-    Assert.assertEquals(
-        "Should create one manifest", 1, firstSnapshot.allManifests(table.io()).size());
+    assertThat(firstSnapshot.allManifests(table.io())).as("Should create one manifest").hasSize(1);
 
     rightAfterSnapshot();
 
     table.newDelete().deleteFile(FILE_A).commit();
 
     Snapshot secondSnapshot = table.currentSnapshot();
-    Assert.assertEquals(
-        "Should create replace manifest with a rewritten manifest",
-        1,
-        secondSnapshot.allManifests(table.io()).size());
+    assertThat(secondSnapshot.allManifests(table.io()))
+        .as("Should create replace manifest with a rewritten manifest")
+        .hasSize(1);
 
     table.newAppend().appendFile(FILE_B).commit();
 
@@ -840,19 +843,18 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertEquals(
-        "Expire should not change current snapshot",
-        snapshotId,
-        table.currentSnapshot().snapshotId());
-    Assert.assertNull(
-        "Expire should remove the oldest snapshot", table.snapshot(firstSnapshot.snapshotId()));
-    Assert.assertNull(
-        "Expire should remove the second oldest snapshot",
-        table.snapshot(secondSnapshot.snapshotId()));
-
-    Assert.assertEquals(
-        "Should remove expired manifest lists and deleted data file",
-        Sets.newHashSet(
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Expire should not change current snapshot.")
+        .isEqualTo(snapshotId);
+    assertThat(table.snapshot(firstSnapshot.snapshotId()))
+        .as("Expire should remove the oldest snapshot.")
+        .isNull();
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("Expire should remove the second oldest snapshot.")
+        .isNull();
+    assertThat(deletedFiles)
+        .as("Should remove expired manifest lists and deleted data file.")
+        .containsExactlyInAnyOrder(
             firstSnapshot.manifestListLocation(), // snapshot expired
             firstSnapshot
                 .allManifests(table.io())
@@ -863,13 +865,12 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
                 .allManifests(table.io())
                 .get(0)
                 .path(), // manifest contained only deletes, was dropped
-            FILE_A.location()), // deleted
-        deletedFiles);
+            FILE_A.location());
 
     checkExpirationResults(1, 0, 0, 2, 2, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThanWithDeleteInMergedManifests() {
     // merge every commit
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "0").commit();
@@ -877,8 +878,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
-    Assert.assertEquals(
-        "Should create one manifest", 1, firstSnapshot.allManifests(table.io()).size());
+    assertThat(firstSnapshot.allManifests(table.io())).as("Should create one manifest").hasSize(1);
 
     rightAfterSnapshot();
 
@@ -888,10 +888,9 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
         .commit();
 
     Snapshot secondSnapshot = table.currentSnapshot();
-    Assert.assertEquals(
-        "Should replace manifest with a rewritten manifest",
-        1,
-        secondSnapshot.allManifests(table.io()).size());
+    assertThat(secondSnapshot.allManifests(table.io()))
+        .as("Should replace manifest with a rewritten manifest")
+        .hasSize(1);
 
     table
         .newFastAppend() // do not merge to keep the last snapshot's manifest valid
@@ -913,32 +912,30 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertEquals(
-        "Expire should not change current snapshot",
-        snapshotId,
-        table.currentSnapshot().snapshotId());
-    Assert.assertNull(
-        "Expire should remove the oldest snapshot", table.snapshot(firstSnapshot.snapshotId()));
-    Assert.assertNull(
-        "Expire should remove the second oldest snapshot",
-        table.snapshot(secondSnapshot.snapshotId()));
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Expire should not change current snapshot.")
+        .isEqualTo(snapshotId);
+    assertThat(table.snapshot(firstSnapshot.snapshotId()))
+        .as("Expire should remove the oldest snapshot.")
+        .isNull();
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("Expire should remove the second oldest snapshot.")
+        .isNull();
 
-    Assert.assertEquals(
-        "Should remove expired manifest lists and deleted data file",
-        Sets.newHashSet(
+    assertThat(deletedFiles)
+        .as("Should remove expired manifest lists and deleted data file.")
+        .containsExactlyInAnyOrder(
             firstSnapshot.manifestListLocation(), // snapshot expired
             firstSnapshot
                 .allManifests(table.io())
                 .get(0)
                 .path(), // manifest was rewritten for delete
             secondSnapshot.manifestListLocation(), // snapshot expired
-            FILE_A.location()), // deleted
-        deletedFiles);
-
+            FILE_A.location());
     checkExpirationResults(1, 0, 0, 1, 2, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThanWithRollback() {
     // merge every commit
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "0").commit();
@@ -946,8 +943,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
-    Assert.assertEquals(
-        "Should create one manifest", 1, firstSnapshot.allManifests(table.io()).size());
+    assertThat(firstSnapshot.allManifests(table.io())).as("Should create one manifest").hasSize(1);
 
     rightAfterSnapshot();
 
@@ -957,8 +953,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     Set<ManifestFile> secondSnapshotManifests =
         Sets.newHashSet(secondSnapshot.allManifests(table.io()));
     secondSnapshotManifests.removeAll(firstSnapshot.allManifests(table.io()));
-    Assert.assertEquals(
-        "Should add one new manifest for append", 1, secondSnapshotManifests.size());
+    assertThat(secondSnapshotManifests).as("Should add one new manifest for append").hasSize(1);
 
     table.manageSnapshots().rollbackTo(firstSnapshot.snapshotId()).commit();
 
@@ -975,34 +970,32 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertEquals(
-        "Expire should not change current snapshot",
-        snapshotId,
-        table.currentSnapshot().snapshotId());
-    Assert.assertNotNull(
-        "Expire should keep the oldest snapshot, current",
-        table.snapshot(firstSnapshot.snapshotId()));
-    Assert.assertNull(
-        "Expire should remove the orphaned snapshot", table.snapshot(secondSnapshot.snapshotId()));
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Expire should not change current snapshot.")
+        .isEqualTo(snapshotId);
 
-    Assert.assertEquals(
-        "Should remove expired manifest lists and reverted appended data file",
-        Sets.newHashSet(
+    assertThat(table.snapshot(firstSnapshot.snapshotId()))
+        .as("Expire should keep the oldest snapshot, current.")
+        .isNotNull();
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("Expire should remove the orphaned snapshot.")
+        .isNull();
+
+    assertThat(deletedFiles)
+        .as("Should remove expired manifest lists and reverted appended data file")
+        .containsExactlyInAnyOrder(
             secondSnapshot.manifestListLocation(), // snapshot expired
-            Iterables.getOnlyElement(secondSnapshotManifests)
-                .path()), // manifest is no longer referenced
-        deletedFiles);
+            Iterables.getOnlyElement(secondSnapshotManifests).path());
 
     checkExpirationResults(0, 0, 0, 1, 1, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThanWithRollbackAndMergedManifests() {
     table.newAppend().appendFile(FILE_A).commit();
 
     Snapshot firstSnapshot = table.currentSnapshot();
-    Assert.assertEquals(
-        "Should create one manifest", 1, firstSnapshot.allManifests(table.io()).size());
+    assertThat(firstSnapshot.allManifests(table.io())).as("Should create one manifest").hasSize(1);
 
     rightAfterSnapshot();
 
@@ -1012,8 +1005,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     Set<ManifestFile> secondSnapshotManifests =
         Sets.newHashSet(secondSnapshot.allManifests(table.io()));
     secondSnapshotManifests.removeAll(firstSnapshot.allManifests(table.io()));
-    Assert.assertEquals(
-        "Should add one new manifest for append", 1, secondSnapshotManifests.size());
+    assertThat(secondSnapshotManifests).as("Should add one new manifest for append").hasSize(1);
 
     table.manageSnapshots().rollbackTo(firstSnapshot.snapshotId()).commit();
 
@@ -1030,35 +1022,32 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .deleteWith(deletedFiles::add)
             .execute();
 
-    Assert.assertEquals(
-        "Expire should not change current snapshot",
-        snapshotId,
-        table.currentSnapshot().snapshotId());
-    Assert.assertNotNull(
-        "Expire should keep the oldest snapshot, current",
-        table.snapshot(firstSnapshot.snapshotId()));
-    Assert.assertNull(
-        "Expire should remove the orphaned snapshot", table.snapshot(secondSnapshot.snapshotId()));
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Expire should not change current snapshot.")
+        .isEqualTo(snapshotId);
 
-    Assert.assertEquals(
-        "Should remove expired manifest lists and reverted appended data file",
-        Sets.newHashSet(
+    assertThat(table.snapshot(firstSnapshot.snapshotId()))
+        .as("Expire should keep the oldest snapshot, current.")
+        .isNotNull();
+    assertThat(table.snapshot(secondSnapshot.snapshotId()))
+        .as("Expire should remove the orphaned snapshot.")
+        .isNull();
+
+    assertThat(deletedFiles)
+        .as("Should remove expired manifest lists and reverted appended data file")
+        .containsExactlyInAnyOrder(
             secondSnapshot.manifestListLocation(), // snapshot expired
             Iterables.getOnlyElement(secondSnapshotManifests)
                 .path(), // manifest is no longer referenced
-            FILE_B.location()), // added, but rolled back
-        deletedFiles);
+            FILE_B.location());
 
     checkExpirationResults(1, 0, 0, 1, 1, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOlderThanWithDeleteFile() {
-    table
-        .updateProperties()
-        .set(TableProperties.FORMAT_VERSION, "2")
-        .set(TableProperties.MANIFEST_MERGE_ENABLED, "false")
-        .commit();
+    assumeThat(formatVersion).as("DV is not supported in Spark 3.4").isEqualTo(2);
+    table.updateProperties().set(TableProperties.MANIFEST_MERGE_ENABLED, "false").commit();
 
     // Add Data File
     table.newAppend().appendFile(FILE_A).commit();
@@ -1111,15 +1100,14 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .map(CharSequence::toString)
             .collect(Collectors.toSet()));
 
-    Assert.assertEquals(
-        "Should remove expired manifest lists and deleted data file",
-        expectedDeletes,
-        deletedFiles);
+    assertThat(deletedFiles)
+        .as("Should remove expired manifest lists and deleted data file")
+        .isEqualTo(expectedDeletes);
 
     checkExpirationResults(1, 1, 1, 6, 4, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireOnEmptyTable() {
     Set<String> deletedFiles = Sets.newHashSet();
 
@@ -1134,7 +1122,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     checkExpirationResults(0, 0, 0, 0, 0, result);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireAction() {
     table.newAppend().appendFile(FILE_A).commit();
 
@@ -1159,28 +1147,30 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     List<FileInfo> pending = pendingDeletes.collectAsList();
 
-    Assert.assertEquals(
-        "Should not change current snapshot", snapshotId, table.currentSnapshot().snapshotId());
-    Assert.assertNull(
-        "Should remove the oldest snapshot", table.snapshot(firstSnapshot.snapshotId()));
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Should not change current snapshot.")
+        .isEqualTo(snapshotId);
 
-    Assert.assertEquals("Pending deletes should contain one row", 1, pending.size());
-    Assert.assertEquals(
-        "Pending delete should be the expired manifest list location",
-        firstSnapshot.manifestListLocation(),
-        pending.get(0).getPath());
-    Assert.assertEquals(
-        "Pending delete should be a manifest list", "Manifest List", pending.get(0).getType());
+    assertThat(table.snapshot(firstSnapshot.snapshotId()))
+        .as("Should remove the oldest snapshot")
+        .isNull();
 
-    Assert.assertEquals("Should not delete any files", 0, deletedFiles.size());
+    assertThat(pending.get(0).getPath())
+        .as("Pending delete should be the expired manifest list location")
+        .isEqualTo(firstSnapshot.manifestListLocation());
 
-    Assert.assertEquals(
-        "Multiple calls to expire should return the same count of deleted files",
-        pendingDeletes.count(),
-        action.expireFiles().count());
+    assertThat(pending.get(0).getType())
+        .as("Pending delete should be a manifest list")
+        .isEqualTo("Manifest List");
+
+    assertThat(deletedFiles).as("Should not delete any files").isEmpty();
+
+    assertThat(action.expireFiles().count())
+        .as("Multiple calls to expire should return the same count of deleted files")
+        .isEqualTo(pendingDeletes.count());
   }
 
-  @Test
+  @TestTemplate
   public void testUseLocalIterator() {
     table.newFastAppend().appendFile(FILE_A).commit();
 
@@ -1207,14 +1197,14 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
           checkExpirationResults(1L, 0L, 0L, 1L, 2L, results);
 
-          Assert.assertEquals(
-              "Expected total number of jobs with stream-results should match the expected number",
-              4L,
-              jobsRunDuringStreamResults);
+          assertThat(jobsRunDuringStreamResults)
+              .as(
+                  "Expected total number of jobs with stream-results should match the expected number")
+              .isEqualTo(4L);
         });
   }
 
-  @Test
+  @TestTemplate
   public void testExpireAfterExecute() {
     table
         .newAppend()
@@ -1243,18 +1233,18 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     checkExpirationResults(0L, 0L, 0L, 0L, 1L, result);
 
     List<FileInfo> typedExpiredFiles = action.expireFiles().collectAsList();
-    Assert.assertEquals("Expired results must match", 1, typedExpiredFiles.size());
+    assertThat(typedExpiredFiles).as("Expired results must match").hasSize(1);
 
     List<FileInfo> untypedExpiredFiles = action.expireFiles().collectAsList();
-    Assert.assertEquals("Expired results must match", 1, untypedExpiredFiles.size());
+    assertThat(untypedExpiredFiles).as("Expired results must match").hasSize(1);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireFileDeletionMostExpired() {
     textExpireAllCheckFilesDeleted(5, 2);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireFileDeletionMostRetained() {
     textExpireAllCheckFilesDeleted(2, 5);
   }
@@ -1311,11 +1301,12 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
         .deleteWith(deletedFiles::add)
         .execute();
 
-    Assert.assertEquals(
-        "All reachable files before expiration should be deleted", expectedDeletes, deletedFiles);
+    assertThat(deletedFiles)
+        .as("All reachable files before expiration should be deleted")
+        .isEqualTo(expectedDeletes);
   }
 
-  @Test
+  @TestTemplate
   public void testExpireSomeCheckFilesDeleted() {
 
     table.newAppend().appendFile(FILE_A).commit();
@@ -1343,9 +1334,8 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     // C, D should be retained (live)
     // B should be retained (previous snapshot points to it)
     // A should be deleted
-    Assert.assertTrue(deletedFiles.contains(FILE_A.location()));
-    Assert.assertFalse(deletedFiles.contains(FILE_B.location()));
-    Assert.assertFalse(deletedFiles.contains(FILE_C.location()));
-    Assert.assertFalse(deletedFiles.contains(FILE_D.location()));
+    assertThat(deletedFiles)
+        .contains(FILE_A.location())
+        .doesNotContain(FILE_B.location(), FILE_C.location(), FILE_D.location());
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -31,6 +32,9 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -39,17 +43,18 @@ import org.apache.iceberg.actions.RemoveDanglingDeleteFiles;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Encoders;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import scala.Tuple2;
 
-public class TestRemoveDanglingDeleteAction extends SparkTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRemoveDanglingDeleteAction extends TestBase {
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
       new Schema(
@@ -197,18 +202,24 @@ public class TestRemoveDanglingDeleteAction extends SparkTestBase {
           .withFileSizeInBytes(10)
           .withRecordCount(1)
           .build();
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  @TempDir private File tableDir;
+  @Parameter private int formatVersion;
+
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(2, 3);
+  }
 
   private String tableLocation = null;
   private Table table;
 
-  @Before
+  @BeforeEach
   public void before() throws Exception {
-    File tableDir = temp.newFolder();
     this.tableLocation = tableDir.toURI().toString();
   }
 
-  @After
+  @AfterEach
   public void after() {
     TABLES.dropTable(tableLocation);
   }
@@ -228,7 +239,7 @@ public class TestRemoveDanglingDeleteAction extends SparkTestBase {
             tableLocation);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedDeletesWithLesserSeqNo() {
     setupPartitionedTable();
     // Add Data Files
@@ -322,7 +333,7 @@ public class TestRemoveDanglingDeleteAction extends SparkTestBase {
     assertThat(actualAfter).isEqualTo(expectedAfter);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedDeletesWithEqSeqNo() {
     setupPartitionedTable();
     // Add Data Files
@@ -410,7 +421,7 @@ public class TestRemoveDanglingDeleteAction extends SparkTestBase {
     assertThat(actualAfter).isEqualTo(expectedAfter);
   }
 
-  @Test
+  @TestTemplate
   public void testUnpartitionedTable() {
     setupUnpartitionedTable();
     table

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkFileRewriter.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkFileRewriter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.actions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
@@ -33,17 +34,15 @@ import org.apache.iceberg.actions.SizeBasedFileRewriter;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StringType;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-public class TestSparkFileRewriter extends SparkTestBase {
+public class TestSparkFileRewriter extends TestBase {
 
   private static final TableIdentifier TABLE_IDENT = TableIdentifier.of("default", "tbl");
   private static final Schema SCHEMA =
@@ -54,7 +53,7 @@ public class TestSparkFileRewriter extends SparkTestBase {
       PartitionSpec.builderFor(SCHEMA).identity("dep").build();
   private static final SortOrder SORT_ORDER = SortOrder.builderFor(SCHEMA).asc("id").build();
 
-  @After
+  @AfterEach
   public void removeTable() {
     catalog.dropTable(TABLE_IDENT);
   }
@@ -111,9 +110,9 @@ public class TestSparkFileRewriter extends SparkTestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assert.assertEquals("Must have 1 group", 1, Iterables.size(groups));
+    assertThat(groups).as("Must have 1 group").hasSize(1);
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
-    Assert.assertEquals("Must rewrite 2 files", 2, group.size());
+    assertThat(group).as("Must rewrite 2 files").hasSize(2);
   }
 
   private void checkDataFilesDeleteThreshold(SizeBasedDataRewriter rewriter) {
@@ -130,9 +129,9 @@ public class TestSparkFileRewriter extends SparkTestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assert.assertEquals("Must have 1 group", 1, Iterables.size(groups));
+    assertThat(groups).as("Must have 1 group").hasSize(1);
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
-    Assert.assertEquals("Must rewrite 1 file", 1, group.size());
+    assertThat(group).as("Must rewrite 1 file").hasSize(1);
   }
 
   private void checkDataFileGroupWithEnoughFiles(SizeBasedDataRewriter rewriter) {
@@ -153,9 +152,9 @@ public class TestSparkFileRewriter extends SparkTestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assert.assertEquals("Must have 1 group", 1, Iterables.size(groups));
+    assertThat(groups).as("Must have 1 group").hasSize(1);
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
-    Assert.assertEquals("Must rewrite 4 files", 4, group.size());
+    assertThat(group).as("Must rewrite 4 files").hasSize(4);
   }
 
   private void checkDataFileGroupWithEnoughData(SizeBasedDataRewriter rewriter) {
@@ -173,9 +172,9 @@ public class TestSparkFileRewriter extends SparkTestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assert.assertEquals("Must have 1 group", 1, Iterables.size(groups));
+    assertThat(groups).as("Must have 1 group").hasSize(1);
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
-    Assert.assertEquals("Must rewrite 3 files", 3, group.size());
+    assertThat(group).as("Must rewrite 3 files").hasSize(3);
   }
 
   private void checkDataFileGroupWithTooMuchData(SizeBasedDataRewriter rewriter) {
@@ -191,9 +190,9 @@ public class TestSparkFileRewriter extends SparkTestBase {
     rewriter.init(options);
 
     Iterable<List<FileScanTask>> groups = rewriter.planFileGroups(tasks);
-    Assert.assertEquals("Must have 1 group", 1, Iterables.size(groups));
+    assertThat(groups).as("Must have 1 group").hasSize(1);
     List<FileScanTask> group = Iterables.getOnlyElement(groups);
-    Assert.assertEquals("Must rewrite big file", 1, group.size());
+    assertThat(group).as("Must rewrite big file").hasSize(1);
   }
 
   @Test
@@ -237,9 +236,9 @@ public class TestSparkFileRewriter extends SparkTestBase {
     Table table = catalog.createTable(TABLE_IDENT, SCHEMA);
     SparkBinPackDataRewriter rewriter = new SparkBinPackDataRewriter(spark, table);
 
-    Assert.assertEquals(
-        "Rewriter must report all supported options",
-        ImmutableSet.of(
+    assertThat(rewriter.validOptions())
+        .as("Rewriter must report all supported options")
+        .containsExactlyInAnyOrder(
             SparkBinPackDataRewriter.TARGET_FILE_SIZE_BYTES,
             SparkBinPackDataRewriter.MIN_FILE_SIZE_BYTES,
             SparkBinPackDataRewriter.MAX_FILE_SIZE_BYTES,
@@ -247,8 +246,7 @@ public class TestSparkFileRewriter extends SparkTestBase {
             SparkBinPackDataRewriter.REWRITE_ALL,
             SparkBinPackDataRewriter.MAX_FILE_GROUP_SIZE_BYTES,
             SparkBinPackDataRewriter.DELETE_FILE_THRESHOLD,
-            SparkBinPackDataRewriter.DELETE_RATIO_THRESHOLD),
-        rewriter.validOptions());
+            SparkBinPackDataRewriter.DELETE_RATIO_THRESHOLD);
   }
 
   @Test
@@ -256,9 +254,9 @@ public class TestSparkFileRewriter extends SparkTestBase {
     Table table = catalog.createTable(TABLE_IDENT, SCHEMA);
     SparkSortDataRewriter rewriter = new SparkSortDataRewriter(spark, table, SORT_ORDER);
 
-    Assert.assertEquals(
-        "Rewriter must report all supported options",
-        ImmutableSet.of(
+    assertThat(rewriter.validOptions())
+        .as("Rewriter must report all supported options")
+        .containsExactlyInAnyOrder(
             SparkSortDataRewriter.SHUFFLE_PARTITIONS_PER_FILE,
             SparkSortDataRewriter.TARGET_FILE_SIZE_BYTES,
             SparkSortDataRewriter.MIN_FILE_SIZE_BYTES,
@@ -268,8 +266,7 @@ public class TestSparkFileRewriter extends SparkTestBase {
             SparkSortDataRewriter.MAX_FILE_GROUP_SIZE_BYTES,
             SparkSortDataRewriter.DELETE_FILE_THRESHOLD,
             SparkSortDataRewriter.DELETE_RATIO_THRESHOLD,
-            SparkSortDataRewriter.COMPRESSION_FACTOR),
-        rewriter.validOptions());
+            SparkSortDataRewriter.COMPRESSION_FACTOR);
   }
 
   @Test
@@ -278,9 +275,9 @@ public class TestSparkFileRewriter extends SparkTestBase {
     ImmutableList<String> zOrderCols = ImmutableList.of("id");
     SparkZOrderDataRewriter rewriter = new SparkZOrderDataRewriter(spark, table, zOrderCols);
 
-    Assert.assertEquals(
-        "Rewriter must report all supported options",
-        ImmutableSet.of(
+    assertThat(rewriter.validOptions())
+        .as("Rewriter must report all supported options")
+        .containsExactlyInAnyOrder(
             SparkZOrderDataRewriter.SHUFFLE_PARTITIONS_PER_FILE,
             SparkZOrderDataRewriter.TARGET_FILE_SIZE_BYTES,
             SparkZOrderDataRewriter.MIN_FILE_SIZE_BYTES,
@@ -292,8 +289,7 @@ public class TestSparkFileRewriter extends SparkTestBase {
             SparkZOrderDataRewriter.DELETE_RATIO_THRESHOLD,
             SparkZOrderDataRewriter.COMPRESSION_FACTOR,
             SparkZOrderDataRewriter.MAX_OUTPUT_SIZE,
-            SparkZOrderDataRewriter.VAR_LENGTH_CONTRIBUTION),
-        rewriter.validOptions());
+            SparkZOrderDataRewriter.VAR_LENGTH_CONTRIBUTION);
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
@@ -49,8 +49,8 @@ public class TestSparkSessionCatalog extends TestBase {
   @Test
   public void testValidateHmsUri() {
     // HMS uris match
-    assertThat(spark.sessionState().catalogManager().v2SessionCatalog().defaultNamespace()[0])
-        .isEqualTo("default");
+    assertThat(spark.sessionState().catalogManager().v2SessionCatalog().defaultNamespace())
+        .containsExactly("default");
 
     // HMS uris doesn't match
     spark.sessionState().catalogManager().reset();
@@ -69,15 +69,15 @@ public class TestSparkSessionCatalog extends TestBase {
     spark.sessionState().catalogManager().reset();
     spark.conf().set(catalogHmsUriKey, hmsUri);
     spark.conf().unset(envHmsUriKey);
-    assertThat(spark.sessionState().catalogManager().v2SessionCatalog().defaultNamespace()[0])
-        .isEqualTo("default");
+    assertThat(spark.sessionState().catalogManager().v2SessionCatalog().defaultNamespace())
+        .containsExactly("default");
 
     // no catalog HMS uri, only env HMS uri
     spark.sessionState().catalogManager().reset();
     spark.conf().set(envHmsUriKey, hmsUri);
     spark.conf().unset(catalogHmsUriKey);
-    assertThat(spark.sessionState().catalogManager().v2SessionCatalog().defaultNamespace()[0])
-        .isEqualTo("default");
+    assertThat(spark.sessionState().catalogManager().v2SessionCatalog().defaultNamespace())
+        .containsExactly("default");
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -53,7 +53,6 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.BeforeEach;
@@ -211,9 +210,8 @@ public class TestDeleteReachableFilesAction extends TestBase {
     // Verifies that the delete methods ran in the threads created by the provided ExecutorService
     // ThreadFactory
     assertThat(deleteThreads)
-        .isEqualTo(
-            Sets.newHashSet(
-                "remove-files-0", "remove-files-1", "remove-files-2", "remove-files-3"));
+        .containsExactlyInAnyOrder(
+            "remove-files-0", "remove-files-1", "remove-files-2", "remove-files-3");
 
     Lists.newArrayList(FILE_A, FILE_B, FILE_C, FILE_D)
         .forEach(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -254,12 +254,8 @@ public class TestExpireSnapshotsAction extends TestBase {
     // Verifies that the delete methods ran in the threads created by the provided ExecutorService
     // ThreadFactory
     assertThat(deleteThreads)
-        .isEqualTo(
-            Sets.newHashSet(
-                "remove-snapshot-0",
-                "remove-snapshot-1",
-                "remove-snapshot-2",
-                "remove-snapshot-3"));
+        .containsExactlyInAnyOrder(
+            "remove-snapshot-0", "remove-snapshot-1", "remove-snapshot-2", "remove-snapshot-3");
 
     assertThat(deletedFiles).as("FILE_A should be deleted").contains(FILE_A.location());
     assertThat(deletedFiles).as("FILE_B should be deleted").contains(FILE_B.location());
@@ -813,7 +809,7 @@ public class TestExpireSnapshotsAction extends TestBase {
         .isNull();
     assertThat(deletedFiles)
         .as("Should remove only the expired manifest list location.")
-        .isEqualTo(Sets.newHashSet(firstSnapshot.manifestListLocation()));
+        .containsExactly(firstSnapshot.manifestListLocation());
 
     checkExpirationResults(0, 0, 0, 0, 1, result);
   }
@@ -862,20 +858,18 @@ public class TestExpireSnapshotsAction extends TestBase {
         .isNull();
     assertThat(deletedFiles)
         .as("Should remove expired manifest lists and deleted data file.")
-        .isEqualTo(
-            Sets.newHashSet(
-                firstSnapshot.manifestListLocation(), // snapshot expired
-                firstSnapshot
-                    .allManifests(table.io())
-                    .get(0)
-                    .path(), // manifest was rewritten for delete
-                secondSnapshot.manifestListLocation(), // snapshot expired
-                secondSnapshot
-                    .allManifests(table.io())
-                    .get(0)
-                    .path(), // manifest contained only deletes, was dropped
-                FILE_A.location()) // deleted
-            );
+        .containsExactlyInAnyOrder(
+            firstSnapshot.manifestListLocation(), // snapshot expired
+            firstSnapshot
+                .allManifests(table.io())
+                .get(0)
+                .path(), // manifest was rewritten for delete
+            secondSnapshot.manifestListLocation(), // snapshot expired
+            secondSnapshot
+                .allManifests(table.io())
+                .get(0)
+                .path(), // manifest contained only deletes, was dropped
+            FILE_A.location());
 
     checkExpirationResults(1, 0, 0, 2, 2, result);
   }
@@ -933,16 +927,14 @@ public class TestExpireSnapshotsAction extends TestBase {
 
     assertThat(deletedFiles)
         .as("Should remove expired manifest lists and deleted data file.")
-        .isEqualTo(
-            Sets.newHashSet(
-                firstSnapshot.manifestListLocation(), // snapshot expired
-                firstSnapshot
-                    .allManifests(table.io())
-                    .get(0)
-                    .path(), // manifest was rewritten for delete
-                secondSnapshot.manifestListLocation(), // snapshot expired
-                FILE_A.location()) // deleted
-            );
+        .containsExactlyInAnyOrder(
+            firstSnapshot.manifestListLocation(), // snapshot expired
+            firstSnapshot
+                .allManifests(table.io())
+                .get(0)
+                .path(), // manifest was rewritten for delete
+            secondSnapshot.manifestListLocation(), // snapshot expired
+            FILE_A.location());
     checkExpirationResults(1, 0, 0, 1, 2, result);
   }
 
@@ -994,12 +986,9 @@ public class TestExpireSnapshotsAction extends TestBase {
 
     assertThat(deletedFiles)
         .as("Should remove expired manifest lists and reverted appended data file")
-        .isEqualTo(
-            Sets.newHashSet(
-                secondSnapshot.manifestListLocation(), // snapshot expired
-                Iterables.getOnlyElement(secondSnapshotManifests)
-                    .path()) // manifest is no longer referenced
-            );
+        .containsExactlyInAnyOrder(
+            secondSnapshot.manifestListLocation(), // snapshot expired
+            Iterables.getOnlyElement(secondSnapshotManifests).path());
 
     checkExpirationResults(0, 0, 0, 1, 1, result);
   }
@@ -1048,13 +1037,11 @@ public class TestExpireSnapshotsAction extends TestBase {
 
     assertThat(deletedFiles)
         .as("Should remove expired manifest lists and reverted appended data file")
-        .isEqualTo(
-            Sets.newHashSet(
-                secondSnapshot.manifestListLocation(), // snapshot expired
-                Iterables.getOnlyElement(secondSnapshotManifests)
-                    .path(), // manifest is no longer referenced
-                FILE_B.location()) // added, but rolled back
-            );
+        .containsExactlyInAnyOrder(
+            secondSnapshot.manifestListLocation(), // snapshot expired
+            Iterables.getOnlyElement(secondSnapshotManifests)
+                .path(), // manifest is no longer referenced
+            FILE_B.location());
 
     checkExpirationResults(1, 0, 0, 1, 1, result);
   }
@@ -1180,7 +1167,7 @@ public class TestExpireSnapshotsAction extends TestBase {
         .as("Pending delete should be a manifest list")
         .isEqualTo("Manifest List");
 
-    assertThat(deletedFiles).as("Should not delete any files").hasSize(0);
+    assertThat(deletedFiles).as("Should not delete any files").isEmpty();
 
     assertThat(action.expireFiles().count())
         .as("Multiple calls to expire should return the same count of deleted files")
@@ -1351,9 +1338,8 @@ public class TestExpireSnapshotsAction extends TestBase {
     // C, D should be retained (live)
     // B should be retained (previous snapshot points to it)
     // A should be deleted
-    assertThat(deletedFiles).contains(FILE_A.location());
-    assertThat(deletedFiles).doesNotContain(FILE_B.location());
-    assertThat(deletedFiles).doesNotContain(FILE_C.location());
-    assertThat(deletedFiles).doesNotContain(FILE_D.location());
+    assertThat(deletedFiles)
+        .contains(FILE_A.location())
+        .doesNotContain(FILE_B.location(), FILE_C.location(), FILE_D.location());
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkFileRewriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkFileRewriter.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.actions.SizeBasedFileRewriter;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.types.Types.IntegerType;
@@ -261,16 +260,15 @@ public class TestSparkFileRewriter extends TestBase {
 
     assertThat(rewriter.validOptions())
         .as("Rewriter must report all supported options")
-        .isEqualTo(
-            ImmutableSet.of(
-                SparkBinPackDataRewriter.TARGET_FILE_SIZE_BYTES,
-                SparkBinPackDataRewriter.MIN_FILE_SIZE_BYTES,
-                SparkBinPackDataRewriter.MAX_FILE_SIZE_BYTES,
-                SparkBinPackDataRewriter.MIN_INPUT_FILES,
-                SparkBinPackDataRewriter.REWRITE_ALL,
-                SparkBinPackDataRewriter.MAX_FILE_GROUP_SIZE_BYTES,
-                SparkBinPackDataRewriter.DELETE_FILE_THRESHOLD,
-                SparkBinPackDataRewriter.DELETE_RATIO_THRESHOLD));
+        .containsExactlyInAnyOrder(
+            SparkBinPackDataRewriter.TARGET_FILE_SIZE_BYTES,
+            SparkBinPackDataRewriter.MIN_FILE_SIZE_BYTES,
+            SparkBinPackDataRewriter.MAX_FILE_SIZE_BYTES,
+            SparkBinPackDataRewriter.MIN_INPUT_FILES,
+            SparkBinPackDataRewriter.REWRITE_ALL,
+            SparkBinPackDataRewriter.MAX_FILE_GROUP_SIZE_BYTES,
+            SparkBinPackDataRewriter.DELETE_FILE_THRESHOLD,
+            SparkBinPackDataRewriter.DELETE_RATIO_THRESHOLD);
   }
 
   @Test
@@ -280,18 +278,17 @@ public class TestSparkFileRewriter extends TestBase {
 
     assertThat(rewriter.validOptions())
         .as("Rewriter must report all supported options")
-        .isEqualTo(
-            ImmutableSet.of(
-                SparkSortDataRewriter.SHUFFLE_PARTITIONS_PER_FILE,
-                SparkSortDataRewriter.TARGET_FILE_SIZE_BYTES,
-                SparkSortDataRewriter.MIN_FILE_SIZE_BYTES,
-                SparkSortDataRewriter.MAX_FILE_SIZE_BYTES,
-                SparkSortDataRewriter.MIN_INPUT_FILES,
-                SparkSortDataRewriter.REWRITE_ALL,
-                SparkSortDataRewriter.MAX_FILE_GROUP_SIZE_BYTES,
-                SparkSortDataRewriter.DELETE_FILE_THRESHOLD,
-                SparkSortDataRewriter.DELETE_RATIO_THRESHOLD,
-                SparkSortDataRewriter.COMPRESSION_FACTOR));
+        .containsExactlyInAnyOrder(
+            SparkSortDataRewriter.SHUFFLE_PARTITIONS_PER_FILE,
+            SparkSortDataRewriter.TARGET_FILE_SIZE_BYTES,
+            SparkSortDataRewriter.MIN_FILE_SIZE_BYTES,
+            SparkSortDataRewriter.MAX_FILE_SIZE_BYTES,
+            SparkSortDataRewriter.MIN_INPUT_FILES,
+            SparkSortDataRewriter.REWRITE_ALL,
+            SparkSortDataRewriter.MAX_FILE_GROUP_SIZE_BYTES,
+            SparkSortDataRewriter.DELETE_FILE_THRESHOLD,
+            SparkSortDataRewriter.DELETE_RATIO_THRESHOLD,
+            SparkSortDataRewriter.COMPRESSION_FACTOR);
   }
 
   @Test
@@ -302,20 +299,19 @@ public class TestSparkFileRewriter extends TestBase {
 
     assertThat(rewriter.validOptions())
         .as("Rewriter must report all supported options")
-        .isEqualTo(
-            ImmutableSet.of(
-                SparkZOrderDataRewriter.SHUFFLE_PARTITIONS_PER_FILE,
-                SparkZOrderDataRewriter.TARGET_FILE_SIZE_BYTES,
-                SparkZOrderDataRewriter.MIN_FILE_SIZE_BYTES,
-                SparkZOrderDataRewriter.MAX_FILE_SIZE_BYTES,
-                SparkZOrderDataRewriter.MIN_INPUT_FILES,
-                SparkZOrderDataRewriter.REWRITE_ALL,
-                SparkZOrderDataRewriter.MAX_FILE_GROUP_SIZE_BYTES,
-                SparkZOrderDataRewriter.DELETE_FILE_THRESHOLD,
-                SparkZOrderDataRewriter.DELETE_RATIO_THRESHOLD,
-                SparkZOrderDataRewriter.COMPRESSION_FACTOR,
-                SparkZOrderDataRewriter.MAX_OUTPUT_SIZE,
-                SparkZOrderDataRewriter.VAR_LENGTH_CONTRIBUTION));
+        .containsExactlyInAnyOrder(
+            SparkZOrderDataRewriter.SHUFFLE_PARTITIONS_PER_FILE,
+            SparkZOrderDataRewriter.TARGET_FILE_SIZE_BYTES,
+            SparkZOrderDataRewriter.MIN_FILE_SIZE_BYTES,
+            SparkZOrderDataRewriter.MAX_FILE_SIZE_BYTES,
+            SparkZOrderDataRewriter.MIN_INPUT_FILES,
+            SparkZOrderDataRewriter.REWRITE_ALL,
+            SparkZOrderDataRewriter.MAX_FILE_GROUP_SIZE_BYTES,
+            SparkZOrderDataRewriter.DELETE_FILE_THRESHOLD,
+            SparkZOrderDataRewriter.DELETE_RATIO_THRESHOLD,
+            SparkZOrderDataRewriter.COMPRESSION_FACTOR,
+            SparkZOrderDataRewriter.MAX_OUTPUT_SIZE,
+            SparkZOrderDataRewriter.VAR_LENGTH_CONTRIBUTION);
   }
 
   @Test


### PR DESCRIPTION
*Migrate Spark 3.4 tests based on JUnit 4 to Junit5 with AssertJ style. This is related to https://github.com/apache/iceberg/issues/7160*

This PR migrates `SparkTestBase` related tests in Spark 3.4 into JUnit 5 with AssertJ. The following classes are included in this PR:

* In `spark` package:
  * `TestSparkSessionCatalog` 
  * `TestSpark3Util`
* In `spark.actions` package:
  *  `TestDeleteReachableFilesAction`
  * `TestExpireSnapshotsAction`
  * `TestRemoveDanglingDeleteAction`
  * `TestRewriteTablePathsAction` 
  * `TestSparkFileRewriter`  
