### PR TITLE
AWS: Update the aws-bundle with latest dependencies

### DIFF
--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -522,12 +522,6 @@ Project URL: https://github.com/aws/aws-s3-accessgrants-plugin-java-v2
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk.crt  Name: aws-crt  Version: 0.29.10
-Project URL: https://github.com/awslabs/aws-crt-java
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
 Group: software.amazon.s3.analyticsaccelerator  Name: analyticsaccelerator-s3  Version: 1.0.0
 Project URL: https://github.com/awslabs/analytics-accelerator-s3
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0

--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -514,3 +514,20 @@ License: The Apache Software License, Version 2.0 - http://www.apache.org/licens
 Group: software.amazon.eventstream  Name: eventstream  Version: 1.0.1
 Project URL: https://github.com/awslabs/aws-eventstream-java
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.s3.accessgrants  Name: aws-s3-accessgrants-java-plugin  Version: 2.3.0
+Project URL: https://github.com/aws/aws-s3-accessgrants-plugin-java-v2
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+Group: software.amazon.awssdk.crt  Name: aws-crt  Version: 0.29.10
+Project URL: https://github.com/awslabs/aws-crt-java
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+Group: software.amazon.s3.analyticsaccelerator  Name: analyticsaccelerator-s3  Version: 1.0.0
+Project URL: https://github.com/awslabs/analytics-accelerator-s3
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0

--- a/aws-bundle/NOTICE
+++ b/aws-bundle/NOTICE
@@ -45,7 +45,6 @@ NOTICE for Group: software.amazon.awssdk  Name: sso  Version: 2.29.52
 NOTICE for Group: software.amazon.awssdk  Name: sts  Version: 2.29.52
 NOTICE for Group: software.amazon.awssdk  Name: utils  Version: 2.29.52
 NOTICE for Group: software.amazon.s3.accessgrants  Name: aws-s3-accessgrants-java-plugin  Version: 2.3.0
-NOTICE for Group: software.amazon.awssdk.crt  Name: aws-crt  Version: 0.29.10
 NOTICE for Group: software.amazon.s3.analyticsaccelerator  Name: analyticsaccelerator-s3  Version: 1.0.0
 
 AWS SDK for Java 2.0

--- a/aws-bundle/NOTICE
+++ b/aws-bundle/NOTICE
@@ -44,6 +44,9 @@ NOTICE for Group: software.amazon.awssdk  Name: sdk-core  Version: 2.29.52
 NOTICE for Group: software.amazon.awssdk  Name: sso  Version: 2.29.52
 NOTICE for Group: software.amazon.awssdk  Name: sts  Version: 2.29.52
 NOTICE for Group: software.amazon.awssdk  Name: utils  Version: 2.29.52
+NOTICE for Group: software.amazon.s3.accessgrants  Name: aws-s3-accessgrants-java-plugin  Version: 2.3.0
+NOTICE for Group: software.amazon.awssdk.crt  Name: aws-crt  Version: 0.29.10
+NOTICE for Group: software.amazon.s3.analyticsaccelerator  Name: analyticsaccelerator-s3  Version: 1.0.0
 
 AWS SDK for Java 2.0
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -25,8 +25,11 @@ project(":iceberg-aws-bundle") {
 
   dependencies {
     implementation platform(libs.awssdk.bom)
+    implementation libs.awssdk.s3accessgrants
+    implementation libs.awssdk.crt
     implementation "software.amazon.awssdk:apache-client"
     implementation "software.amazon.awssdk:auth"
+    implementation "software.amazon.awssdk:crt-core"
     implementation "software.amazon.awssdk:http-auth-aws-crt"
     implementation "software.amazon.awssdk:iam"
     implementation "software.amazon.awssdk:sso"
@@ -36,6 +39,8 @@ project(":iceberg-aws-bundle") {
     implementation "software.amazon.awssdk:sts"
     implementation "software.amazon.awssdk:dynamodb"
     implementation "software.amazon.awssdk:lakeformation"
+
+    implementation libs.analyticsaccelerator.s3
   }
 
   shadowJar {

--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -26,7 +26,6 @@ project(":iceberg-aws-bundle") {
   dependencies {
     implementation platform(libs.awssdk.bom)
     implementation libs.awssdk.s3accessgrants
-    implementation libs.awssdk.crt
     implementation "software.amazon.awssdk:apache-client"
     implementation "software.amazon.awssdk:auth"
     implementation "software.amazon.awssdk:crt-core"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ awaitility = "4.3.0"
 awssdk-bom = "2.29.52"
 azuresdk-bom = "1.2.31"
 awssdk-s3accessgrants = "2.3.0"
+awssdk-crt = "0.29.10"
 bson-ver = "4.11.5"
 caffeine = "2.9.3"
 calcite = "1.39.0"
@@ -97,6 +98,7 @@ arrow-vector = { module = "org.apache.arrow:arrow-vector", version.ref = "arrow"
 avro-avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 awssdk-bom = { module = "software.amazon.awssdk:bom", version.ref = "awssdk-bom" }
 awssdk-s3accessgrants = { module = "software.amazon.s3.accessgrants:aws-s3-accessgrants-java-plugin", version.ref = "awssdk-s3accessgrants" }
+awssdk-crt = { module = "software.amazon.awssdk.crt:aws-crt", version.ref = "awssdk-crt" }
 azuresdk-bom = { module = "com.azure:azure-sdk-bom", version.ref = "azuresdk-bom" }
 bson = { module = "org.mongodb:bson", version.ref = "bson-ver"}
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,6 @@ awaitility = "4.3.0"
 awssdk-bom = "2.29.52"
 azuresdk-bom = "1.2.31"
 awssdk-s3accessgrants = "2.3.0"
-awssdk-crt = "0.29.10"
 bson-ver = "4.11.5"
 caffeine = "2.9.3"
 calcite = "1.39.0"
@@ -98,7 +97,6 @@ arrow-vector = { module = "org.apache.arrow:arrow-vector", version.ref = "arrow"
 avro-avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 awssdk-bom = { module = "software.amazon.awssdk:bom", version.ref = "awssdk-bom" }
 awssdk-s3accessgrants = { module = "software.amazon.s3.accessgrants:aws-s3-accessgrants-java-plugin", version.ref = "awssdk-s3accessgrants" }
-awssdk-crt = { module = "software.amazon.awssdk.crt:aws-crt", version.ref = "awssdk-crt" }
 azuresdk-bom = { module = "com.azure:azure-sdk-bom", version.ref = "azuresdk-bom" }
 bson = { module = "org.mongodb:bson", version.ref = "bson-ver"}
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }

--- a/kafka-connect/kafka-connect-runtime/hive/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/hive/LICENSE
@@ -1940,3 +1940,9 @@ Project URL (from POM): https://github.com/mongodb/mongo-java-driver
 License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
+
+Group: software.amazon.s3.analyticsaccelerator  Name: analyticsaccelerator-s3  Version: 1.0.0
+Project URL: https://github.com/awslabs/analytics-accelerator-s3
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------

--- a/kafka-connect/kafka-connect-runtime/hive/NOTICE
+++ b/kafka-connect/kafka-connect-runtime/hive/NOTICE
@@ -232,6 +232,7 @@ Group: software.amazon.awssdk  Name: sdk-core  Version: 2.29.52
 Group: software.amazon.awssdk  Name: sso  Version: 2.29.52
 Group: software.amazon.awssdk  Name: sts  Version: 2.29.52
 Group: software.amazon.awssdk  Name: utils  Version: 2.29.52
+Group: software.amazon.s3.analyticsaccelerator  Name: analyticsaccelerator-s3  Version: 1.0.0
 
 Notice: 
 | AWS SDK for Java 2.0

--- a/kafka-connect/kafka-connect-runtime/main/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/main/LICENSE
@@ -1454,3 +1454,9 @@ Project URL (from POM): https://github.com/mongodb/mongo-java-driver
 License (from POM): The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
+
+Group: software.amazon.s3.analyticsaccelerator  Name: analyticsaccelerator-s3  Version: 1.0.0
+Project URL: https://github.com/awslabs/analytics-accelerator-s3
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------

--- a/kafka-connect/kafka-connect-runtime/main/NOTICE
+++ b/kafka-connect/kafka-connect-runtime/main/NOTICE
@@ -163,6 +163,7 @@ Group: software.amazon.awssdk  Name: sdk-core  Version: 2.29.52
 Group: software.amazon.awssdk  Name: sso  Version: 2.29.52
 Group: software.amazon.awssdk  Name: sts  Version: 2.29.52
 Group: software.amazon.awssdk  Name: utils  Version: 2.29.52
+Group: software.amazon.s3.analyticsaccelerator  Name: analyticsaccelerator-s3  Version: 1.0.0
 
 Notice: 
 | AWS SDK for Java 2.0


### PR DESCRIPTION
This PR adds the dependencies from #12299 to `aws-bundle`. It also adds some missing `aws` dependencies and updates the corresponding `LICENSE`  and `NOTICE` files.
