### PR TITLE
Core: Simplify AuthManager API

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/VendedCredentialsProvider.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/VendedCredentialsProvider.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.auth.AuthManager;
 import org.apache.iceberg.rest.auth.AuthManagers;
+import org.apache.iceberg.rest.auth.AuthScopes;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
@@ -88,9 +89,11 @@ public class VendedCredentialsProvider implements AwsCredentialsProvider, SdkAut
     if (null == client) {
       synchronized (this) {
         if (null == client) {
-          authManager = AuthManagers.loadAuthManager("s3-credentials-refresh", properties);
           HTTPClient httpClient = HTTPClient.builder(properties).uri(catalogEndpoint).build();
-          authSession = authManager.catalogSession(httpClient, properties);
+          authManager =
+              AuthManagers.loadAuthManager("s3-credentials-refresh", properties)
+                  .withClient(httpClient);
+          authSession = authManager.authSession(AuthScopes.Standalone.of(properties));
           client = httpClient.withAuthSession(authSession);
         }
       }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.ResourcePaths;
 import org.apache.iceberg.rest.auth.AuthManager;
 import org.apache.iceberg.rest.auth.AuthManagers;
+import org.apache.iceberg.rest.auth.AuthScopes;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
 import org.apache.iceberg.rest.auth.OAuth2Util;
@@ -156,7 +157,8 @@ public abstract class S3V4RestSignerClient
     if (null == authSession) {
       synchronized (S3V4RestSignerClient.class) {
         if (null == authSession) {
-          authManager = AuthManagers.loadAuthManager("s3-signer", properties());
+          authManager =
+              AuthManagers.loadAuthManager("s3-signer", properties()).withClient(httpClient());
           ImmutableMap.Builder<String, String> properties =
               ImmutableMap.<String, String>builder()
                   .putAll(properties())
@@ -173,7 +175,8 @@ public abstract class S3V4RestSignerClient
             properties.put(OAuth2Properties.CREDENTIAL, credential());
           }
 
-          authSession = authManager.tableSession(httpClient(), properties.buildKeepingLast());
+          authSession =
+              authManager.authSession(AuthScopes.Standalone.of(properties.buildKeepingLast()));
         }
       }
     }

--- a/aws/src/test/java/org/apache/iceberg/aws/TestRESTSigV4Signer.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestRESTSigV4Signer.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.auth.AuthManager;
 import org.apache.iceberg.rest.auth.AuthManagers;
 import org.apache.iceberg.rest.auth.AuthProperties;
+import org.apache.iceberg.rest.auth.AuthScopes;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.responses.ConfigResponse;
@@ -78,8 +79,8 @@ public class TestRESTSigV4Signer {
             .build()
             .withAuthSession(AuthSession.EMPTY);
 
-    authManager = AuthManagers.loadAuthManager("test", properties);
-    AuthSession authSession = authManager.catalogSession(httpClient, properties);
+    authManager = AuthManagers.loadAuthManager("test", properties).withClient(httpClient);
+    AuthSession authSession = authManager.authSession(AuthScopes.Standalone.of(properties));
 
     client = httpClient.withAuthSession(authSession);
   }

--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthScope.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthScope.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.auth;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * A scope for authentication. A scope is a set of properties that define how an {@link AuthSession}
+ * should be created, what credentials should be used, and how the session should be cached.
+ */
+public interface AuthScope {
+
+  /** Properties that define the scope. */
+  Map<String, String> properties();
+
+  /**
+   * The parent {@link AuthSession} for this scope, if any. Parent sessions are generally used to
+   * provide default values for properties when the current scope has no value defined for them.
+   */
+  @Nullable
+  AuthSession parent();
+
+  /**
+   * Whether the {@link AuthSession} created for this scope should be cached.
+   *
+   * <p>If this method returns true, the {@link AuthManager} is responsible for the session's
+   * lifecycle and should close the session when it is no longer needed. If this method returns
+   * false, the session should be closed by the caller when it is no longer needed.
+   */
+  boolean cacheable();
+
+  /** Returns a new scope identical to this one, but with the given parent session. */
+  AuthScope withParent(AuthSession parent);
+}

--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthScopes.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthScopes.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.auth;
+
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.RESTUtil;
+import org.immutables.value.Value;
+
+/** Well-known scopes for authentication. */
+@Value.Enclosing
+public interface AuthScopes {
+
+  /**
+   * A scope that represents the initial authentication request from the catalog to the config
+   * endpoint. This is a short-lived scope that has no parent and is never cached.
+   */
+  @Value.Immutable
+  abstract class Initial implements AuthScope {
+
+    @Override
+    public abstract Map<String, String> properties();
+
+    @Override
+    public final AuthSession parent() {
+      return null;
+    }
+
+    @Override
+    public final boolean cacheable() {
+      return false;
+    }
+
+    @Override
+    public final Initial withParent(AuthSession parent) {
+      return this;
+    }
+
+    public static Initial of(Map<String, String> properties) {
+      return ImmutableAuthScopes.Initial.builder().properties(properties).build();
+    }
+  }
+
+  /**
+   * A scope that represents the catalog. The catalog scope is long-lived, has no parent and is
+   * never cached.
+   */
+  @Value.Immutable
+  abstract class Catalog implements AuthScope {
+
+    @Override
+    public abstract Map<String, String> properties();
+
+    @Override
+    public final AuthSession parent() {
+      return null;
+    }
+
+    @Override
+    public final boolean cacheable() {
+      return false;
+    }
+
+    @Override
+    public final Catalog withParent(AuthSession parent) {
+      return this;
+    }
+
+    public static Catalog of(Map<String, String> properties) {
+      return ImmutableAuthScopes.Catalog.builder().properties(properties).build();
+    }
+  }
+
+  /**
+   * A scope that represents a {@link SessionCatalog.SessionContext}. It is always cached. Its
+   * mandatory parent is expected to be in {@link Catalog} scope.
+   */
+  @Value.Immutable
+  abstract class Contextual implements AuthScope {
+
+    public abstract SessionCatalog.SessionContext context();
+
+    @Value.Lazy
+    @Override
+    public Map<String, String> properties() {
+      Map<String, String> properties =
+          context().properties() == null ? Map.of() : context().properties();
+      Map<String, String> credentials =
+          context().credentials() == null ? Map.of() : context().credentials();
+      return RESTUtil.merge(properties, credentials);
+    }
+
+    @Override
+    @Nonnull
+    public abstract AuthSession parent();
+
+    @Override
+    public final boolean cacheable() {
+      return true;
+    }
+
+    public static Contextual of(SessionCatalog.SessionContext context, AuthSession parent) {
+      return ImmutableAuthScopes.Contextual.builder().context(context).parent(parent).build();
+    }
+  }
+
+  /**
+   * A scope that represents a table or view. It is always cached. Its mandatory parent is expected
+   * to be in {@link Contextual} scope.
+   */
+  @Value.Immutable
+  abstract class Table implements AuthScope {
+
+    public abstract TableIdentifier identifier();
+
+    @Override
+    public abstract Map<String, String> properties();
+
+    @Override
+    @Nonnull
+    public abstract AuthSession parent();
+
+    @Override
+    public final boolean cacheable() {
+      return true;
+    }
+
+    public static Table of(
+        TableIdentifier identifier, Map<String, String> properties, AuthSession parent) {
+      return ImmutableAuthScopes.Table.builder()
+          .identifier(identifier)
+          .properties(properties)
+          .parent(parent)
+          .build();
+    }
+  }
+
+  /**
+   * A general-purpose scope. Such scopes are used in components like request signers or credential
+   * refreshers. Standalone scopes by default are not cached, and have no parent.
+   */
+  @Value.Immutable
+  abstract class Standalone implements AuthScope {
+
+    @Override
+    public abstract Map<String, String> properties();
+
+    @Value.Default
+    @Override
+    public boolean cacheable() {
+      return false;
+    }
+
+    public static Standalone of(Map<String, String> properties) {
+      return ImmutableAuthScopes.Standalone.builder().properties(properties).build();
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/auth/BasicAuthManager.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/BasicAuthManager.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.rest.auth;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.rest.HTTPHeaders;
-import org.apache.iceberg.rest.RESTClient;
 
 /** An auth manager that adds static BASIC authentication data to outgoing HTTP requests. */
 public final class BasicAuthManager implements AuthManager {
@@ -31,7 +30,8 @@ public final class BasicAuthManager implements AuthManager {
   }
 
   @Override
-  public AuthSession catalogSession(RESTClient sharedClient, Map<String, String> properties) {
+  public AuthSession authSession(AuthScope scope) {
+    Map<String, String> properties = scope.properties();
     Preconditions.checkArgument(
         properties.containsKey(AuthProperties.BASIC_USERNAME),
         "Invalid username: missing required property %s",

--- a/core/src/main/java/org/apache/iceberg/rest/auth/NoopAuthManager.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/NoopAuthManager.java
@@ -18,9 +18,6 @@
  */
 package org.apache.iceberg.rest.auth;
 
-import java.util.Map;
-import org.apache.iceberg.rest.RESTClient;
-
 /** An auth manager that does not add any authentication data to outgoing HTTP requests. */
 public class NoopAuthManager implements AuthManager {
 
@@ -29,7 +26,7 @@ public class NoopAuthManager implements AuthManager {
   }
 
   @Override
-  public AuthSession catalogSession(RESTClient sharedClient, Map<String, String> properties) {
+  public AuthSession authSession(AuthScope scope) {
     return AuthSession.EMPTY;
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestBasicAuthManager.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestBasicAuthManager.java
@@ -30,7 +30,7 @@ class TestBasicAuthManager {
   @Test
   void missingUsername() {
     try (AuthManager authManager = new BasicAuthManager("test")) {
-      assertThatThrownBy(() -> authManager.catalogSession(null, Map.of()))
+      assertThatThrownBy(() -> authManager.authSession(AuthScopes.Standalone.of(Map.of())))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessage(
               "Invalid username: missing required property %s", AuthProperties.BASIC_USERNAME);
@@ -41,7 +41,7 @@ class TestBasicAuthManager {
   void missingPassword() {
     try (AuthManager authManager = new BasicAuthManager("test")) {
       Map<String, String> properties = Map.of(AuthProperties.BASIC_USERNAME, "alice");
-      assertThatThrownBy(() -> authManager.catalogSession(null, properties))
+      assertThatThrownBy(() -> authManager.authSession(AuthScopes.Standalone.of(properties)))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessage(
               "Invalid password: missing required property %s", AuthProperties.BASIC_PASSWORD);
@@ -53,7 +53,7 @@ class TestBasicAuthManager {
     Map<String, String> properties =
         Map.of(AuthProperties.BASIC_USERNAME, "alice", AuthProperties.BASIC_PASSWORD, "secret");
     try (AuthManager authManager = new BasicAuthManager("test");
-        AuthSession session = authManager.catalogSession(null, properties)) {
+        AuthSession session = authManager.authSession(AuthScopes.Standalone.of(properties))) {
       assertThat(session)
           .isEqualTo(
               DefaultAuthSession.of(HTTPHeaders.of(OAuth2Util.basicAuthHeaders("alice:secret"))));

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/OAuth2RefreshCredentialsHandler.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/OAuth2RefreshCredentialsHandler.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.auth.AuthManager;
 import org.apache.iceberg.rest.auth.AuthManagers;
+import org.apache.iceberg.rest.auth.AuthScopes;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
@@ -107,9 +108,11 @@ public class OAuth2RefreshCredentialsHandler
     if (null == client) {
       synchronized (this) {
         if (null == client) {
-          authManager = AuthManagers.loadAuthManager("gcs-credentials-refresh", properties);
           HTTPClient httpClient = HTTPClient.builder(properties).uri(catalogEndpoint).build();
-          authSession = authManager.catalogSession(httpClient, properties);
+          authManager =
+              AuthManagers.loadAuthManager("gcs-credentials-refresh", properties)
+                  .withClient(httpClient);
+          authSession = authManager.authSession(AuthScopes.Standalone.of(properties));
           client = httpClient.withAuthSession(authSession);
         }
       }


### PR DESCRIPTION
The current `AuthManager` interface exposes various methods for creating sessions: `initSession()`, `catalogSession()`, `contextualSession()`, `tableSession()`, etc.

Naming its methods after the intended usage of the returned session was, in hindsight, a questionable design choice: in some cases, the right method to call may not be so obvious, and if more session "flavors" are need in the future, more methods would need to be added to the interface.

This PR aims at fixing this by unifying all previous methods under one single method. The increased flexibility of the new method is due to its argument of type `AuthScope`, which can be freely implemented according to the caller's needs.