### PR TITLE
REST: HTTPRequest.baseUri() should be nullable

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPRequest.java
@@ -111,7 +111,7 @@ class TestHTTPRequest {
             () ->
                 ImmutableHTTPRequest.builder()
                     .method(HTTPRequest.HTTPMethod.GET)
-                    .path("v1/namespaces") // wrong leading slash
+                    .path("v1/namespaces")
                     .build())
         .isInstanceOf(RESTException.class)
         .hasMessage("Received a request with a relative path and no base URI: v1/namespaces");

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPRequest.java
@@ -78,14 +78,12 @@ class TestHTTPRequest {
             URI.create("https://authserver.com/token")),
         Arguments.of(
             ImmutableHTTPRequest.builder()
-                .baseUri(URI.create("http://localhost:8080/foo"))
                 .method(HTTPRequest.HTTPMethod.GET)
                 .path("http://authserver.com/token") // absolute path HTTP
                 .build(),
             URI.create("http://authserver.com/token")),
         Arguments.of(
             ImmutableHTTPRequest.builder()
-                .baseUri(URI.create("http://localhost:8080/foo"))
                 .method(HTTPRequest.HTTPMethod.GET)
                 // absolute path with trailing slash: should be preserved
                 .path("http://authserver.com/token/")
@@ -105,6 +103,18 @@ class TestHTTPRequest {
         .isInstanceOf(RESTException.class)
         .hasMessage(
             "Received a malformed path for a REST request: /v1/namespaces. Paths should not start with /");
+  }
+
+  @Test
+  public void relativePathWithoutBaseUri() {
+    assertThatThrownBy(
+            () ->
+                ImmutableHTTPRequest.builder()
+                    .method(HTTPRequest.HTTPMethod.GET)
+                    .path("v1/namespaces") // wrong leading slash
+                    .build())
+        .isInstanceOf(RESTException.class)
+        .hasMessage("Received a request with a relative path and no base URI: v1/namespaces");
   }
 
   @Test


### PR DESCRIPTION
Before the introduction of `HTTPRequest`, it was technically possible, although unlikely, to create an `HTTPClient` without base URI. In such cases, all requests must have an absolute path.

This is currently not possible anymore, because `HTTPRequest.baseUri()` cannot be null.

This PR fixes this small behavioral regression by allowing `HTTPRequest.baseUri()` to return null, when the request path is absolute.