### PR TITLE
Parquet, Core: Enable passing Variant tests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroEncoderUtil.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroEncoderUtil.java
@@ -40,6 +40,11 @@ public class TestAvroEncoderUtil extends DataTest {
   }
 
   @Override
+  protected boolean supportsVariant() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(org.apache.iceberg.Schema schema) throws IOException {
     List<GenericData.Record> expected = RandomAvroData.generate(schema, 100, 1990L);
     Map<Type, Schema> typeToSchema = AvroSchemaUtil.convertTypes(schema.asStruct(), "test");

--- a/data/src/test/java/org/apache/iceberg/data/parquet/TestParquetEncryptionWithWriteSupport.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/TestParquetEncryptionWithWriteSupport.java
@@ -57,6 +57,21 @@ public class TestParquetEncryptionWithWriteSupport extends DataTest {
   private static final ByteBuffer AAD_PREFIX = ByteBuffer.allocate(16);
 
   @Override
+  protected boolean supportsUnknown() {
+    return true;
+  }
+
+  @Override
+  protected boolean supportsTimestampNanos() {
+    return true;
+  }
+
+  @Override
+  protected boolean supportsVariant() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expected = RandomGenericData.generate(schema, 100, 0L);
     writeAndValidate(schema, expected);
@@ -77,7 +92,7 @@ public class TestParquetEncryptionWithWriteSupport extends DataTest {
             .schema(schema)
             .withFileEncryptionKey(FILE_DEK)
             .withAADPrefix(AAD_PREFIX)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(fileSchema -> GenericParquetWriter.create(schema, fileSchema))
             .build()) {
       appender.addAll(expected);
     }

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
@@ -26,11 +26,13 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.parquet.ParquetValueWriter;
 import org.apache.iceberg.parquet.ParquetValueWriters;
 import org.apache.iceberg.parquet.ParquetValueWriters.StructWriter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
@@ -44,6 +46,14 @@ public class GenericParquetWriter extends BaseParquetWriter<Record> {
 
   public static ParquetValueWriter<Record> buildWriter(MessageType type) {
     return INSTANCE.createWriter(type);
+  }
+
+  public static ParquetValueWriter<Record> create(Schema schema, MessageType type) {
+    return INSTANCE.createWriter(schema.asStruct(), type);
+  }
+
+  public static ParquetValueWriter<Record> create(Types.StructType struct, MessageType type) {
+    return INSTANCE.createWriter(struct, type);
   }
 
   @Override

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalWriter.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.data.parquet;
 
 import java.util.List;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.parquet.ParquetValueWriter;
 import org.apache.iceberg.parquet.ParquetValueWriters;
@@ -40,7 +41,12 @@ public class InternalWriter<T extends StructLike> extends BaseParquetWriter<T> {
   private InternalWriter() {}
 
   public static <T extends StructLike> ParquetValueWriter<T> create(MessageType type) {
-    return create(null, type);
+    return create((Types.StructType) null, type);
+  }
+
+  public static <T extends StructLike> ParquetValueWriter<T> create(
+      Schema schema, MessageType type) {
+    return create(schema.asStruct(), type);
   }
 
   @SuppressWarnings("unchecked")

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestInternalParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestInternalParquet.java
@@ -52,6 +52,11 @@ public class TestInternalParquet extends DataTest {
   }
 
   @Override
+  protected boolean supportsVariant() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expected = RandomInternalData.generate(schema, 100, 1376L);
     writeAndValidate(schema, expected);
@@ -75,7 +80,7 @@ public class TestInternalParquet extends DataTest {
     try (DataWriter<StructLike> dataWriter =
         Parquet.writeData(outputFile)
             .schema(writeSchema)
-            .createWriterFunc(InternalWriter::create)
+            .createWriterFunc(fileSchema -> InternalWriter.create(writeSchema, fileSchema))
             .overwrite()
             .withSpec(PartitionSpec.unpartitioned())
             .build()) {


### PR DESCRIPTION
This enables `supportsVariant()` in `DataTest` suites where the support exists and works.