### PR TITLE
Core: Fix locationProvider implementation for SerializableTable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -86,7 +86,7 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
     this.sortOrderAsJson = SortOrderParser.toJson(table.sortOrder());
     this.io = fileIO(table);
     this.encryption = table.encryption();
-    this.locationProviderTry = TryUtil.run(() -> table.locationProvider());
+    this.locationProviderTry = TryUtil.run(table::locationProvider);
     this.refs = SerializableMap.copyOf(table.refs());
     this.uuid = table.uuid();
     this.formatVersion = formatVersion(table);

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -42,10 +42,10 @@ import org.apache.iceberg.util.TryUtil;
  * table metadata, it directly persists the current schema, spec, sort order, table properties to
  * avoid reading the metadata file from other nodes for frequently needed metadata.
  *
- * <p>The implementation assumes the passed instances of {@link FileIO}, {@link EncryptionManager}
- * are serializable. If you are serializing the table using a custom serialization framework like
- * Kryo, those instances of {@link FileIO}, {@link EncryptionManager} must be supported by that
- * particular serialization framework.
+ * <p>The implementation assumes the passed instances of {@link FileIO}, {@link EncryptionManager},
+ * {@link LocationProvider} are serializable. If you are serializing the table using a custom
+ * serialization framework like Kryo, those instances of {@link FileIO}, {@link EncryptionManager},
+ * {@link LocationProvider} must be supported by that particular serialization framework.
  *
  * <p><em>Note:</em> loading the complete metadata from a large number of nodes can overwhelm the
  * storage.

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -268,7 +268,7 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
   @Override
   public LocationProvider locationProvider() {
     try {
-      return locationProviderTry.get();
+      return this.locationProviderTry.get();
     } catch (Exception e) {
       if (e instanceof RuntimeException) {
         throw (RuntimeException) e;

--- a/core/src/main/java/org/apache/iceberg/util/TryUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TryUtil.java
@@ -21,9 +21,7 @@ package org.apache.iceberg.util;
 import java.io.Serializable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-/**
- * Utility for executing code that may throw exceptions and deferring exception handling.
- */
+/** Utility for executing code that may throw exceptions and deferring exception handling. */
 public class TryUtil {
   private TryUtil() {}
 
@@ -38,8 +36,8 @@ public class TryUtil {
   }
 
   /**
-   * Executes the given operation and returns a Try object containing either the result
-   * or the exception.
+   * Executes the given operation and returns a Try object containing either the result or the
+   * exception.
    *
    * @param operation the operation to execute
    * @param <T> the type of the result
@@ -69,37 +67,30 @@ public class TryUtil {
       this.exception = exception;
     }
 
-    /**
-     * Creates a successful Try with the given value.
-     */
+    /** Creates a successful Try with the given value. */
     public static <T> Try<T> success(T value) {
       return new Try<>(value, null);
     }
 
-    /**
-     * Creates a failed Try with the given exception.
-     */
+    /** Creates a failed Try with the given exception. */
     public static <T> Try<T> failure(Exception exception) {
       Preconditions.checkNotNull(exception, "Exception cannot be null");
       return new Try<>(null, exception);
     }
 
-    /**
-     * Checks if the operation was successful.
-     */
+    /** Checks if the operation was successful. */
     public boolean isSuccess() {
       return exception == null;
     }
 
-    /**
-     * Checks if the operation failed.
-     */
+    /** Checks if the operation failed. */
     public boolean isFailure() {
       return exception != null;
     }
 
     /**
-     * Gets the value if the operation was successful, or throws the original exception if it failed.
+     * Gets the value if the operation was successful, or throws the original exception if it
+     * failed.
      *
      * @return the result value
      * @throws Exception the original exception if the operation failed
@@ -112,7 +103,8 @@ public class TryUtil {
     }
 
     /**
-     * Gets the value if the operation was successful, or returns the provided default value if it failed.
+     * Gets the value if the operation was successful, or returns the provided default value if it
+     * failed.
      */
     public T orElse(T defaultValue) {
       return isSuccess() ? value : defaultValue;

--- a/core/src/main/java/org/apache/iceberg/util/TryUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TryUtil.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.io.Serializable;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Utility for executing code that may throw exceptions and deferring exception handling.
+ */
+public class TryUtil {
+  private TryUtil() {}
+
+  /**
+   * Functional interface for operations that may throw exceptions.
+   *
+   * @param <T> return type of the operation
+   */
+  @FunctionalInterface
+  public interface ThrowingSupplier<T> {
+    T get() throws Exception;
+  }
+
+  /**
+   * Executes the given operation and returns a Try object containing either the result
+   * or the exception.
+   *
+   * @param operation the operation to execute
+   * @param <T> the type of the result
+   * @return a Try object containing either the result or the exception
+   */
+  public static <T> Try<T> run(ThrowingSupplier<T> operation) {
+    try {
+      return Try.success(operation.get());
+    } catch (Exception e) {
+      return Try.failure(e);
+    }
+  }
+
+  /**
+   * Container for the result of an operation that might throw an exception.
+   *
+   * @param <T> the type of the result
+   */
+  public static class Try<T> implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final T value;
+    private final Exception exception;
+
+    private Try(T value, Exception exception) {
+      this.value = value;
+      this.exception = exception;
+    }
+
+    /**
+     * Creates a successful Try with the given value.
+     */
+    public static <T> Try<T> success(T value) {
+      return new Try<>(value, null);
+    }
+
+    /**
+     * Creates a failed Try with the given exception.
+     */
+    public static <T> Try<T> failure(Exception exception) {
+      Preconditions.checkNotNull(exception, "Exception cannot be null");
+      return new Try<>(null, exception);
+    }
+
+    /**
+     * Checks if the operation was successful.
+     */
+    public boolean isSuccess() {
+      return exception == null;
+    }
+
+    /**
+     * Checks if the operation failed.
+     */
+    public boolean isFailure() {
+      return exception != null;
+    }
+
+    /**
+     * Gets the value if the operation was successful, or throws the original exception if it failed.
+     *
+     * @return the result value
+     * @throws Exception the original exception if the operation failed
+     */
+    public T get() throws Exception {
+      if (exception != null) {
+        throw exception;
+      }
+      return value;
+    }
+
+    /**
+     * Gets the value if the operation was successful, or returns the provided default value if it failed.
+     */
+    public T orElse(T defaultValue) {
+      return isSuccess() ? value : defaultValue;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/util/TestTryUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTryUtil.java
@@ -18,13 +18,12 @@
  */
 package org.apache.iceberg.util;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
 
 public class TestTryUtil {
 
@@ -41,9 +40,11 @@ public class TestTryUtil {
   @Test
   public void testFailedOperation() {
     Exception testException = new IllegalArgumentException("test exception");
-    TryUtil.Try<String> result = TryUtil.run(() -> {
-      throw testException;
-    });
+    TryUtil.Try<String> result =
+        TryUtil.run(
+            () -> {
+              throw testException;
+            });
 
     Assertions.assertThat(result.isSuccess()).isFalse();
     Assertions.assertThat(result.isFailure()).isTrue();
@@ -53,19 +54,22 @@ public class TestTryUtil {
   @Test
   public void testGetWithFailure() {
     Exception testException = new IllegalArgumentException("test exception");
-    TryUtil.Try<String> result = TryUtil.run(() -> {
-      throw testException;
-    });
+    TryUtil.Try<String> result =
+        TryUtil.run(
+            () -> {
+              throw testException;
+            });
 
-    Assertions.assertThatThrownBy(result::get)
-        .isSameAs(testException);
+    Assertions.assertThatThrownBy(result::get).isSameAs(testException);
   }
 
   @Test
   public void testCheckedException() {
-    TryUtil.Try<String> result = TryUtil.run(() -> {
-      throw new Exception("checked exception");
-    });
+    TryUtil.Try<String> result =
+        TryUtil.run(
+            () -> {
+              throw new Exception("checked exception");
+            });
 
     Assertions.assertThat(result.isFailure()).isTrue();
     Assertions.assertThatThrownBy(result::get)
@@ -76,13 +80,14 @@ public class TestTryUtil {
   @Test
   public void testRuntimeException() {
     RuntimeException runtimeException = new RuntimeException("runtime exception");
-    TryUtil.Try<String> result = TryUtil.run(() -> {
-      throw runtimeException;
-    });
+    TryUtil.Try<String> result =
+        TryUtil.run(
+            () -> {
+              throw runtimeException;
+            });
 
     Assertions.assertThat(result.isFailure()).isTrue();
-    Assertions.assertThatThrownBy(result::get)
-        .isSameAs(runtimeException);
+    Assertions.assertThatThrownBy(result::get).isSameAs(runtimeException);
   }
 
   @Test
@@ -96,9 +101,11 @@ public class TestTryUtil {
 
   @Test
   public void testOrElseWithDefaultValue() {
-    TryUtil.Try<String> result = TryUtil.run(() -> {
-      throw new RuntimeException("test exception");
-    });
+    TryUtil.Try<String> result =
+        TryUtil.run(
+            () -> {
+              throw new RuntimeException("test exception");
+            });
 
     Assertions.assertThat(result.orElse("default value")).isEqualTo("default value");
   }
@@ -126,7 +133,11 @@ public class TestTryUtil {
   @Test
   public void testSerializationWithException() throws Exception {
     Exception original_exception = new IllegalArgumentException("test exception");
-    TryUtil.Try<String> original = TryUtil.run(() -> { throw original_exception; });
+    TryUtil.Try<String> original =
+        TryUtil.run(
+            () -> {
+              throw original_exception;
+            });
     // Serialize to byte array
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     ObjectOutputStream out = new ObjectOutputStream(bytes);

--- a/core/src/test/java/org/apache/iceberg/util/TestTryUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTryUtil.java
@@ -18,11 +18,13 @@
  */
 package org.apache.iceberg.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class TestTryUtil {
@@ -31,10 +33,10 @@ public class TestTryUtil {
   public void testSuccessfulOperation() throws Exception {
     TryUtil.Try<String> result = TryUtil.run(() -> "success");
 
-    Assertions.assertThat(result.isSuccess()).isTrue();
-    Assertions.assertThat(result.isFailure()).isFalse();
-    Assertions.assertThat(result.get()).isEqualTo("success");
-    Assertions.assertThat(result.orElse("default")).isEqualTo("success");
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.isFailure()).isFalse();
+    assertThat(result.get()).isEqualTo("success");
+    assertThat(result.orElse("default")).isEqualTo("success");
   }
 
   @Test
@@ -46,9 +48,9 @@ public class TestTryUtil {
               throw testException;
             });
 
-    Assertions.assertThat(result.isSuccess()).isFalse();
-    Assertions.assertThat(result.isFailure()).isTrue();
-    Assertions.assertThat(result.orElse("default")).isEqualTo("default");
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.isFailure()).isTrue();
+    assertThat(result.orElse("default")).isEqualTo("default");
   }
 
   @Test
@@ -60,7 +62,7 @@ public class TestTryUtil {
               throw testException;
             });
 
-    Assertions.assertThatThrownBy(result::get).isSameAs(testException);
+    assertThatThrownBy(result::get).isSameAs(testException);
   }
 
   @Test
@@ -71,8 +73,8 @@ public class TestTryUtil {
               throw new Exception("checked exception");
             });
 
-    Assertions.assertThat(result.isFailure()).isTrue();
-    Assertions.assertThatThrownBy(result::get)
+    assertThat(result.isFailure()).isTrue();
+    assertThatThrownBy(result::get)
         .isInstanceOf(Exception.class)
         .hasMessage("checked exception");
   }
@@ -86,17 +88,17 @@ public class TestTryUtil {
               throw runtimeException;
             });
 
-    Assertions.assertThat(result.isFailure()).isTrue();
-    Assertions.assertThatThrownBy(result::get).isSameAs(runtimeException);
+    assertThat(result.isFailure()).isTrue();
+    assertThatThrownBy(result::get).isSameAs(runtimeException);
   }
 
   @Test
   public void testNullValue() throws Exception {
     TryUtil.Try<String> result = TryUtil.run(() -> null);
 
-    Assertions.assertThat(result.isSuccess()).isTrue();
-    Assertions.assertThat(result.get()).isNull();
-    Assertions.assertThat(result.orElse("default")).isNull();
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.get()).isNull();
+    assertThat(result.orElse("default")).isNull();
   }
 
   @Test
@@ -107,7 +109,7 @@ public class TestTryUtil {
               throw new RuntimeException("test exception");
             });
 
-    Assertions.assertThat(result.orElse("default value")).isEqualTo("default value");
+    assertThat(result.orElse("default value")).isEqualTo("default value");
   }
 
   @Test
@@ -126,17 +128,17 @@ public class TestTryUtil {
     in.close();
 
     // Verify state is preserved
-    Assertions.assertThat(deserialized.isSuccess()).isTrue();
-    Assertions.assertThat(deserialized.get()).isEqualTo("serialized value");
+    assertThat(deserialized.isSuccess()).isTrue();
+    assertThat(deserialized.get()).isEqualTo("serialized value");
   }
 
   @Test
   public void testSerializationWithException() throws Exception {
-    Exception original_exception = new IllegalArgumentException("test exception");
+    Exception originalException = new IllegalArgumentException("test exception");
     TryUtil.Try<String> original =
         TryUtil.run(
             () -> {
-              throw original_exception;
+              throw originalException;
             });
     // Serialize to byte array
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
@@ -150,8 +152,8 @@ public class TestTryUtil {
     in.close();
 
     // Verify state is preserved
-    Assertions.assertThat(deserialized.isFailure()).isTrue();
-    Assertions.assertThatThrownBy(deserialized::get)
+    assertThat(deserialized.isFailure()).isTrue();
+    assertThatThrownBy(deserialized::get)
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("test exception");
   }

--- a/core/src/test/java/org/apache/iceberg/util/TestTryUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTryUtil.java
@@ -74,9 +74,7 @@ public class TestTryUtil {
             });
 
     assertThat(result.isFailure()).isTrue();
-    assertThatThrownBy(result::get)
-        .isInstanceOf(Exception.class)
-        .hasMessage("checked exception");
+    assertThatThrownBy(result::get).isInstanceOf(Exception.class).hasMessage("checked exception");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/util/TestTryUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTryUtil.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public class TestTryUtil {
+
+  @Test
+  public void testSuccessfulOperation() throws Exception {
+    TryUtil.Try<String> result = TryUtil.run(() -> "success");
+
+    Assertions.assertThat(result.isSuccess()).isTrue();
+    Assertions.assertThat(result.isFailure()).isFalse();
+    Assertions.assertThat(result.get()).isEqualTo("success");
+    Assertions.assertThat(result.orElse("default")).isEqualTo("success");
+  }
+
+  @Test
+  public void testFailedOperation() {
+    Exception testException = new IllegalArgumentException("test exception");
+    TryUtil.Try<String> result = TryUtil.run(() -> {
+      throw testException;
+    });
+
+    Assertions.assertThat(result.isSuccess()).isFalse();
+    Assertions.assertThat(result.isFailure()).isTrue();
+    Assertions.assertThat(result.orElse("default")).isEqualTo("default");
+  }
+
+  @Test
+  public void testGetWithFailure() {
+    Exception testException = new IllegalArgumentException("test exception");
+    TryUtil.Try<String> result = TryUtil.run(() -> {
+      throw testException;
+    });
+
+    Assertions.assertThatThrownBy(result::get)
+        .isSameAs(testException);
+  }
+
+  @Test
+  public void testCheckedException() {
+    TryUtil.Try<String> result = TryUtil.run(() -> {
+      throw new Exception("checked exception");
+    });
+
+    Assertions.assertThat(result.isFailure()).isTrue();
+    Assertions.assertThatThrownBy(result::get)
+        .isInstanceOf(Exception.class)
+        .hasMessage("checked exception");
+  }
+
+  @Test
+  public void testRuntimeException() {
+    RuntimeException runtimeException = new RuntimeException("runtime exception");
+    TryUtil.Try<String> result = TryUtil.run(() -> {
+      throw runtimeException;
+    });
+
+    Assertions.assertThat(result.isFailure()).isTrue();
+    Assertions.assertThatThrownBy(result::get)
+        .isSameAs(runtimeException);
+  }
+
+  @Test
+  public void testNullValue() throws Exception {
+    TryUtil.Try<String> result = TryUtil.run(() -> null);
+
+    Assertions.assertThat(result.isSuccess()).isTrue();
+    Assertions.assertThat(result.get()).isNull();
+    Assertions.assertThat(result.orElse("default")).isNull();
+  }
+
+  @Test
+  public void testOrElseWithDefaultValue() {
+    TryUtil.Try<String> result = TryUtil.run(() -> {
+      throw new RuntimeException("test exception");
+    });
+
+    Assertions.assertThat(result.orElse("default value")).isEqualTo("default value");
+  }
+
+  @Test
+  public void testSerialization() throws Exception {
+    TryUtil.Try<String> original = TryUtil.run(() -> "serialized value");
+
+    // Serialize to byte array
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream out = new ObjectOutputStream(bytes);
+    out.writeObject(original);
+    out.close();
+
+    // Deserialize from byte array
+    ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    TryUtil.Try<String> deserialized = (TryUtil.Try<String>) in.readObject();
+    in.close();
+
+    // Verify state is preserved
+    Assertions.assertThat(deserialized.isSuccess()).isTrue();
+    Assertions.assertThat(deserialized.get()).isEqualTo("serialized value");
+  }
+
+  @Test
+  public void testSerializationWithException() throws Exception {
+    Exception original_exception = new IllegalArgumentException("test exception");
+    TryUtil.Try<String> original = TryUtil.run(() -> { throw original_exception; });
+    // Serialize to byte array
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream out = new ObjectOutputStream(bytes);
+    out.writeObject(original);
+    out.close();
+
+    // Deserialize from byte array
+    ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    TryUtil.Try<String> deserialized = (TryUtil.Try<String>) in.readObject();
+    in.close();
+
+    // Verify state is preserved
+    Assertions.assertThat(deserialized.isFailure()).isTrue();
+    Assertions.assertThatThrownBy(deserialized::get)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("test exception");
+  }
+}


### PR DESCRIPTION
Closes #11527 in a way that does not break fixes provided by changes needed to fix #9029.

It eagerly calculates the location provider field, but wraps that into a newly implemented wrapper `TryUtil.Try` that only throws an error if code really needs to use that location provider. In case table needs to be read only by other processes the error is not thrown, even if there is an error with getting the location provider object. 