### PR TITLE
Spark 3.4: Backport Spark actions changes in Spark rewrite_table_path procedure (#12006 #12172 #11929 #12282 #12569)

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -239,7 +239,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   private String jobDesc() {
-    if (startVersionName != null) {
+    if (startVersionName == null) {
       return String.format(
           "Replacing path prefixes '%s' with '%s' in the metadata files of table %s,"
               + "up to version '%s'.",

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.RewriteTablePathUtil.RewriteResult;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
@@ -272,8 +273,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
         ((HasTableOperations) newStaticTable(endVersionName, table.io())).operations().current();
 
     Preconditions.checkArgument(
-        endMetadata.statisticsFiles() == null || endMetadata.statisticsFiles().isEmpty(),
-        "Statistic files are not supported yet.");
+        endMetadata.partitionStatisticsFiles() == null
+            || endMetadata.partitionStatisticsFiles().isEmpty(),
+        "Partition statistics files are not supported yet.");
 
     // rebuild version files
     RewriteResult<Snapshot> rewriteVersionResult = rewriteVersionFiles(endMetadata);
@@ -341,7 +343,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   private RewriteResult<Snapshot> rewriteVersionFiles(TableMetadata endMetadata) {
     RewriteResult<Snapshot> result = new RewriteResult<>();
     result.toRewrite().addAll(endMetadata.snapshots());
-    result.copyPlan().add(rewriteVersionFile(endMetadata, endVersionName));
+    result.copyPlan().addAll(rewriteVersionFile(endMetadata, endVersionName));
 
     List<MetadataLogEntry> versions = endMetadata.previousFiles();
     for (int i = versions.size() - 1; i >= 0; i--) {
@@ -357,19 +359,50 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
           new StaticTableOperations(versionFilePath, table.io()).current();
 
       result.toRewrite().addAll(tableMetadata.snapshots());
-      result.copyPlan().add(rewriteVersionFile(tableMetadata, versionFilePath));
+      result.copyPlan().addAll(rewriteVersionFile(tableMetadata, versionFilePath));
     }
 
     return result;
   }
 
-  private Pair<String, String> rewriteVersionFile(TableMetadata metadata, String versionFilePath) {
+  private Set<Pair<String, String>> rewriteVersionFile(
+      TableMetadata metadata, String versionFilePath) {
+    Set<Pair<String, String>> result = Sets.newHashSet();
     String stagingPath = RewriteTablePathUtil.stagingPath(versionFilePath, stagingDir);
     TableMetadata newTableMetadata =
         RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix);
     TableMetadataParser.overwrite(newTableMetadata, table.io().newOutputFile(stagingPath));
-    return Pair.of(
-        stagingPath, RewriteTablePathUtil.newPath(versionFilePath, sourcePrefix, targetPrefix));
+    result.add(
+        Pair.of(
+            stagingPath,
+            RewriteTablePathUtil.newPath(versionFilePath, sourcePrefix, targetPrefix)));
+
+    // include statistics files in copy plan
+    result.addAll(
+        statsFileCopyPlan(metadata.statisticsFiles(), newTableMetadata.statisticsFiles()));
+    return result;
+  }
+
+  private Set<Pair<String, String>> statsFileCopyPlan(
+      List<StatisticsFile> beforeStats, List<StatisticsFile> afterStats) {
+    Set<Pair<String, String>> result = Sets.newHashSet();
+    if (beforeStats.isEmpty()) {
+      return result;
+    }
+
+    Preconditions.checkArgument(
+        beforeStats.size() == afterStats.size(),
+        "Before and after path rewrite, statistic files count should be same");
+    for (int i = 0; i < beforeStats.size(); i++) {
+      StatisticsFile before = beforeStats.get(i);
+      StatisticsFile after = afterStats.get(i);
+      Preconditions.checkArgument(
+          before.fileSizeInBytes() == after.fileSizeInBytes(),
+          "Before and after path rewrite, statistic file size should be same");
+      result.add(
+          Pair.of(RewriteTablePathUtil.stagingPath(before.path(), stagingDir), after.path()));
+    }
+    return result;
   }
 
   /**

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -246,6 +246,52 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @Test
+  public void testIncrementalRewrite() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable =
+        TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), location);
+    List<ThreeColumnRecord> recordsA =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> dfA = spark.createDataFrame(recordsA, ThreeColumnRecord.class).coalesce(1);
+
+    // Write first increment to source table
+    dfA.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(location);
+    assertThat(spark.read().format("iceberg").load(location).count()).isEqualTo(1);
+
+    // Replicate first increment to target table
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .execute();
+    copyTableFiles(result);
+    assertThat(spark.read().format("iceberg").load(targetTableLocation()).count()).isEqualTo(1);
+
+    // Write second increment to source table
+    List<ThreeColumnRecord> recordsB =
+        Lists.newArrayList(new ThreeColumnRecord(2, "BBBBBBBBB", "BBB"));
+    Dataset<Row> dfB = spark.createDataFrame(recordsB, ThreeColumnRecord.class).coalesce(1);
+    dfB.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(location);
+    assertThat(spark.read().format("iceberg").load(location).count()).isEqualTo(2);
+
+    // Replicate second increment to target table
+    sourceTable.refresh();
+    Table targetTable = TABLES.load(targetTableLocation());
+    String targetTableMetadata = currentMetadata(targetTable).metadataFileLocation();
+    String startVersion = fileName(targetTableMetadata);
+    RewriteTablePath.Result incrementalRewriteResult =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .startVersion(startVersion)
+            .execute();
+    copyTableFiles(incrementalRewriteResult);
+    List<Object[]> actual = rowsSorted(targetTableLocation(), "c1");
+    List<Object[]> expected = rowsSorted(location, "c1");
+    assertEquals("Rows should match after copy", expected, actual);
+  }
+
+  @Test
   public void testTableWith3Snapshots(@TempDir Path location1, @TempDir Path location2)
       throws Exception {
     String location = newTableLocation();
@@ -1141,6 +1187,10 @@ public class TestRewriteTablePathsAction extends TestBase {
 
   private List<Object[]> rows(String location) {
     return rowsToJava(spark.read().format("iceberg").load(location).collectAsList());
+  }
+
+  private List<Object[]> rowsSorted(String location, String sortCol) {
+    return rowsToJava(spark.read().format("iceberg").load(location).sort(sortCol).collectAsList());
   }
 
   private PositionDelete<GenericRecord> positionDelete(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -37,8 +37,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.GenericStatisticsFile;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ImmutableGenericPartitionStatisticsFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
@@ -59,7 +59,6 @@ import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -868,24 +867,27 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @Test
-  public void testStatisticFile() throws IOException {
+  public void testPartitionStatisticFile() throws IOException {
     String sourceTableLocation = newTableLocation();
     Map<String, String> properties = Maps.newHashMap();
     properties.put("format-version", "2");
-    String tableName = "v2tblwithstats";
+    String tableName = "v2tblwithPartStats";
     Table sourceTable =
         createMetastoreTable(sourceTableLocation, properties, "default", tableName, 0);
 
     TableMetadata metadata = currentMetadata(sourceTable);
-    TableMetadata withStatistics =
+    TableMetadata withPartStatistics =
         TableMetadata.buildFrom(metadata)
-            .setStatistics(
-                new GenericStatisticsFile(
-                    43, "/some/path/to/stats/file", 128, 27, ImmutableList.of()))
+            .setPartitionStatistics(
+                ImmutableGenericPartitionStatisticsFile.builder()
+                    .snapshotId(11L)
+                    .path("/some/partition/stats/file.parquet")
+                    .fileSizeInBytes(42L)
+                    .build())
             .build();
 
     OutputFile file = sourceTable.io().newOutputFile(metadata.metadataFileLocation());
-    TableMetadataParser.overwrite(withStatistics, file);
+    TableMetadataParser.overwrite(withPartStatistics, file);
 
     assertThatThrownBy(
             () ->
@@ -894,7 +896,36 @@ public class TestRewriteTablePathsAction extends TestBase {
                     .rewriteLocationPrefix(sourceTableLocation, targetTableLocation())
                     .execute())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Statistic files are not supported yet");
+        .hasMessageContaining("Partition statistics files are not supported yet");
+  }
+
+  @Test
+  public void testTableWithManyStatisticFiles() throws IOException {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("format-version", "2");
+    String tableName = "v2tblwithmanystats";
+    Table sourceTable =
+        createMetastoreTable(sourceTableLocation, properties, "default", tableName, 0);
+
+    int iterations = 10;
+    for (int i = 0; i < iterations; i++) {
+      sql("insert into hive.default.%s values (%s, 'AAAAAAAAAA', 'AAAA')", tableName, i);
+      sourceTable.refresh();
+      actions().computeTableStats(sourceTable).execute();
+    }
+
+    sourceTable.refresh();
+    assertThat(sourceTable.statisticsFiles().size()).isEqualTo(iterations);
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, targetTableLocation())
+            .execute();
+
+    checkFileNum(
+        iterations * 2 + 1, iterations, iterations, iterations, iterations * 6 + 1, result);
   }
 
   @Test
@@ -1062,6 +1093,16 @@ public class TestRewriteTablePathsAction extends TestBase {
       int manifestFileCount,
       int totalCount,
       RewriteTablePath.Result result) {
+    checkFileNum(versionFileCount, manifestListCount, manifestFileCount, 0, totalCount, result);
+  }
+
+  protected void checkFileNum(
+      int versionFileCount,
+      int manifestListCount,
+      int manifestFileCount,
+      int statisticsFileCount,
+      int totalCount,
+      RewriteTablePath.Result result) {
     List<String> filesToMove =
         spark
             .read()
@@ -1082,6 +1123,9 @@ public class TestRewriteTablePathsAction extends TestBase {
     assertThat(filesToMove.stream().filter(isManifest).count())
         .as("Wrong rebuilt Manifest file file count")
         .isEqualTo(manifestFileCount);
+    assertThat(filesToMove.stream().filter(f -> f.endsWith(".stats")).count())
+        .withFailMessage("Wrong rebuilt Statistic file count")
+        .isEqualTo(statisticsFileCount);
     assertThat(filesToMove.size()).as("Wrong total file count").isEqualTo(totalCount);
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -40,6 +41,7 @@ import org.apache.iceberg.GenericStatisticsFile;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StaticTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
@@ -47,6 +49,7 @@ import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.ExpireSnapshots;
 import org.apache.iceberg.actions.RewriteTablePath;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.FileHelpers;
@@ -57,6 +60,7 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkCatalog;
@@ -64,6 +68,7 @@ import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.SparkEnv;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Dataset;
@@ -112,7 +117,7 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @AfterEach
-  public void cleanupTableSetup() throws Exception {
+  public void cleanupTableSetup() {
     dropNameSpaces();
   }
 
@@ -126,6 +131,11 @@ public class TestRewriteTablePathsAction extends TestBase {
 
   protected Table createTableWithSnapshots(
       String location, int snapshotNumber, Map<String, String> properties) {
+    return createTableWithSnapshots(location, snapshotNumber, properties, "append");
+  }
+
+  private Table createTableWithSnapshots(
+      String location, int snapshotNumber, Map<String, String> properties, String mode) {
     Table newTable = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, location);
 
     List<ThreeColumnRecord> records =
@@ -134,7 +144,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
 
     for (int i = 0; i < snapshotNumber; i++) {
-      df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(location);
+      df.select("c1", "c2", "c3").write().format("iceberg").mode(mode).save(location);
     }
 
     return newTable;
@@ -478,10 +488,13 @@ public class TestRewriteTablePathsAction extends TestBase {
     Table sourceTable = createTableWithSnapshots(location, 2);
     // expire the first snapshot
     Table staticTable = newStaticTable(location + "metadata/v2.metadata.json", table.io());
-    actions()
-        .expireSnapshots(sourceTable)
-        .expireSnapshotId(staticTable.currentSnapshot().snapshotId())
-        .execute();
+    int expiredManifestListCount = 1;
+    ExpireSnapshots.Result expireResult =
+        actions()
+            .expireSnapshots(sourceTable)
+            .expireSnapshotId(staticTable.currentSnapshot().snapshotId())
+            .execute();
+    assertThat(expireResult.deletedManifestListsCount()).isEqualTo(expiredManifestListCount);
 
     // create 100 more snapshots
     List<ThreeColumnRecord> records =
@@ -492,9 +505,12 @@ public class TestRewriteTablePathsAction extends TestBase {
     }
     sourceTable.refresh();
 
+    // each iteration generate 1 version file, 1 manifest list, 1 manifest and 1 data file
+    int totalIteration = 102;
     // v1/v2/v3.metadata.json has been deleted in v104.metadata.json, and there is no way to find
     // the first snapshot
     // from the version file history
+    int missingVersionFile = 1;
     RewriteTablePath.Result result =
         actions()
             .rewriteTablePath(sourceTable)
@@ -502,7 +518,12 @@ public class TestRewriteTablePathsAction extends TestBase {
             .rewriteLocationPrefix(location, targetTableLocation())
             .execute();
 
-    checkFileNum(101, 101, 101, 406, result);
+    checkFileNum(
+        totalIteration - missingVersionFile,
+        totalIteration - expiredManifestListCount,
+        totalIteration,
+        totalIteration * 4 - missingVersionFile - expiredManifestListCount,
+        result);
   }
 
   @Test
@@ -534,13 +555,76 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @Test
+  public void testRewritePathWithNonLiveEntry() throws Exception {
+    String location = newTableLocation();
+    // first overwrite generate 1 manifest and 1 data file
+    // each subsequent overwrite on unpartitioned table generate 2 manifests and 1 data file
+    Table tableWith3Snaps = createTableWithSnapshots(location, 3, Maps.newHashMap(), "overwrite");
+
+    Snapshot oldest = SnapshotUtil.oldestAncestor(tableWith3Snaps);
+    String oldestDataFilePath =
+        Iterables.getOnlyElement(
+                tableWith3Snaps.snapshot(oldest.snapshotId()).addedDataFiles(tableWith3Snaps.io()))
+            .location();
+    String deletedDataFilePathInTargetLocation =
+        String.format("%sdata/%s", targetTableLocation(), fileName(oldestDataFilePath));
+
+    // expire the oldest snapshot and remove oldest DataFile
+    ExpireSnapshots.Result expireResult =
+        actions().expireSnapshots(tableWith3Snaps).expireSnapshotId(oldest.snapshotId()).execute();
+    assertThat(expireResult)
+        .as("Should deleted 1 data files in root snapshot")
+        .extracting(
+            ExpireSnapshots.Result::deletedManifestListsCount,
+            ExpireSnapshots.Result::deletedManifestsCount,
+            ExpireSnapshots.Result::deletedDataFilesCount)
+        .contains(1L, 1L, 1L);
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(tableWith3Snaps)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(tableWith3Snaps.location(), targetTableLocation())
+            .execute();
+
+    // 5 version files include 1 table creation 3 overwrite and 1 snapshot expiration
+    // 3 overwrites generate 3 manifest list and 5 manifests with 3 data files
+    // snapshot expiration removed 1 of each
+    checkFileNum(5, 2, 4, 13, result);
+
+    // copy the metadata files and data files
+    copyTableFiles(result);
+
+    // expect deleted data file is excluded from rewrite and copy
+    List<String> copiedDataFiles =
+        spark
+            .read()
+            .format("iceberg")
+            .load(targetTableLocation() + "#all_files")
+            .select("file_path")
+            .as(Encoders.STRING())
+            .collectAsList();
+    assertThat(copiedDataFiles).hasSize(2).doesNotContain(deletedDataFilePathInTargetLocation);
+
+    // expect manifest entries still contain deleted entry
+    List<String> copiedEntries =
+        spark
+            .read()
+            .format("iceberg")
+            .load(targetTableLocation() + "#all_entries")
+            .filter("status == 2")
+            .select("data_file.file_path")
+            .as(Encoders.STRING())
+            .collectAsList();
+    assertThat(copiedEntries).contains(deletedDataFilePathInTargetLocation);
+  }
+
+  @Test
   public void testStartSnapshotWithoutValidSnapshot() throws Exception {
     // expire one snapshot
     actions().expireSnapshots(table).expireSnapshotId(table.currentSnapshot().parentId()).execute();
 
-    assertThat(((List) table.snapshots()).size())
-        .withFailMessage("1 out 2 snapshot has been removed")
-        .isEqualTo(1);
+    assertThat(table.snapshots()).hasSize(1);
 
     RewriteTablePath.Result result =
         actions()
@@ -573,7 +657,7 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @Test
-  public void testMoveVersionWithInvalidSnapshots() throws Exception {
+  public void testMoveVersionWithInvalidSnapshots() {
     // expire one snapshot
     actions().expireSnapshots(table).expireSnapshotId(table.currentSnapshot().parentId()).execute();
 
@@ -939,16 +1023,20 @@ public class TestRewriteTablePathsAction extends TestBase {
             .load(result.fileListLocation())
             .as(Encoders.STRING())
             .collectAsList();
-    assertThat(filesToMove.stream().filter(f -> f.endsWith(".metadata.json")).count())
-        .withFailMessage("Wrong rebuilt version file count")
+    Predicate<String> isManifest = f -> f.endsWith("-m0.avro") || f.endsWith("-m1.avro");
+    Predicate<String> isManifestList = f -> f.contains("snap-") && f.endsWith(".avro");
+    Predicate<String> isMetadataJSON = f -> f.endsWith(".metadata.json");
+
+    assertThat(filesToMove.stream().filter(isMetadataJSON).count())
+        .as("Wrong rebuilt version file count")
         .isEqualTo(versionFileCount);
-    assertThat(filesToMove.stream().filter(f -> f.contains("snap-")).count())
-        .withFailMessage("Wrong rebuilt Manifest list file count")
+    assertThat(filesToMove.stream().filter(isManifestList).count())
+        .as("Wrong rebuilt Manifest list file count")
         .isEqualTo(manifestListCount);
-    assertThat(filesToMove.stream().filter(f -> f.endsWith("-m0.avro")).count())
-        .withFailMessage("Wrong rebuilt Manifest file file count")
+    assertThat(filesToMove.stream().filter(isManifest).count())
+        .as("Wrong rebuilt Manifest file file count")
         .isEqualTo(manifestFileCount);
-    assertThat(filesToMove.size()).withFailMessage("Wrong total file count").isEqualTo(totalCount);
+    assertThat(filesToMove.size()).as("Wrong total file count").isEqualTo(totalCount);
   }
 
   protected String newTableLocation() throws IOException {


### PR DESCRIPTION
backport #12006 #12172 #11929 #12282 #12569