### PR TITLE
Core, Parquet, ORC: Fix missing data when writing unknown

### DIFF
--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/ArrowReaderTest.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/ArrowReaderTest.java
@@ -874,7 +874,7 @@ public class ArrowReaderTest {
     FileAppender<GenericRecord> appender =
         Parquet.write(Files.localOutput(parquetFile))
             .schema(table.schema())
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .build();
     try {
       appender.addAll(records);

--- a/core/src/test/java/org/apache/iceberg/data/DataTest.java
+++ b/core/src/test/java/org/apache/iceberg/data/DataTest.java
@@ -152,7 +152,7 @@ public abstract class DataTest {
         new Schema(
             required(1, "id", LongType.get()),
             optional(2, "test_type", type),
-            optional(3, "trailing_data", Types.StringType.get())));
+            required(3, "trailing_data", Types.StringType.get())));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/data/DataTest.java
+++ b/core/src/test/java/org/apache/iceberg/data/DataTest.java
@@ -148,7 +148,11 @@ public abstract class DataTest {
         .as("variant is not yet implemented")
         .isTrue();
 
-    writeAndValidate(new Schema(required(1, "id", LongType.get()), optional(2, "test_type", type)));
+    writeAndValidate(
+        new Schema(
+            required(1, "id", LongType.get()),
+            optional(2, "test_type", type),
+            optional(3, "trailing_data", Types.StringType.get())));
   }
 
   @Test

--- a/data/src/jmh/java/org/apache/iceberg/GenericParquetReaderBenchmark.java
+++ b/data/src/jmh/java/org/apache/iceberg/GenericParquetReaderBenchmark.java
@@ -40,7 +40,7 @@ public class GenericParquetReaderBenchmark extends ReaderBenchmark {
   protected FileAppender<Record> writer(File file, Schema schema) throws IOException {
     return Parquet.write(Files.localOutput(file))
         .schema(schema)
-        .createWriterFunc(GenericParquetWriter::buildWriter)
+        .createWriterFunc(GenericParquetWriter::create)
         .build();
   }
 }

--- a/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
@@ -145,7 +145,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
         case PARQUET:
           return Parquet.write(encryptedOutputFile)
               .schema(schema)
-              .createWriterFunc(GenericParquetWriter::buildWriter)
+              .createWriterFunc(GenericParquetWriter::create)
               .setAll(config)
               .metricsConfig(metricsConfig)
               .overwrite()
@@ -222,7 +222,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
 
         case PARQUET:
           return Parquet.writeDeletes(file)
-              .createWriterFunc(GenericParquetWriter::buildWriter)
+              .createWriterFunc(GenericParquetWriter::create)
               .withPartition(partition)
               .overwrite()
               .setAll(config)
@@ -276,7 +276,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
 
         case PARQUET:
           return Parquet.writeDeletes(file)
-              .createWriterFunc(GenericParquetWriter::buildWriter)
+              .createWriterFunc(GenericParquetWriter::create)
               .withPartition(partition)
               .overwrite()
               .setAll(config)

--- a/data/src/main/java/org/apache/iceberg/data/GenericFileWriterFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericFileWriterFactory.java
@@ -80,17 +80,17 @@ class GenericFileWriterFactory extends BaseFileWriterFactory<Record> {
 
   @Override
   protected void configureDataWrite(Parquet.DataWriteBuilder builder) {
-    builder.createWriterFunc(GenericParquetWriter::buildWriter);
+    builder.createWriterFunc(GenericParquetWriter::create);
   }
 
   @Override
   protected void configureEqualityDelete(Parquet.DeleteWriteBuilder builder) {
-    builder.createWriterFunc(GenericParquetWriter::buildWriter);
+    builder.createWriterFunc(GenericParquetWriter::create);
   }
 
   @Override
   protected void configurePositionDelete(Parquet.DeleteWriteBuilder builder) {
-    builder.createWriterFunc(GenericParquetWriter::buildWriter);
+    builder.createWriterFunc(GenericParquetWriter::create);
   }
 
   @Override

--- a/data/src/main/java/org/apache/iceberg/data/PartitionStatsHandler.java
+++ b/data/src/main/java/org/apache/iceberg/data/PartitionStatsHandler.java
@@ -206,7 +206,7 @@ public class PartitionStatsHandler {
       case PARQUET:
         return Parquet.writeData(outputFile)
             .schema(dataSchema)
-            .createWriterFunc(InternalWriter::create)
+            .createWriterFunc(InternalWriter::createWriter)
             .withSpec(PartitionSpec.unpartitioned())
             .build();
       case AVRO:

--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilterTypes.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilterTypes.java
@@ -210,7 +210,7 @@ public class TestMetricsRowGroupFilterTypes {
     try (FileAppender<Record> appender =
         Parquet.write(outFile)
             .schema(FILE_SCHEMA)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .build()) {
       appender.addAll(records);
     }

--- a/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
@@ -86,7 +86,7 @@ public class TestGenericData extends DataTest {
     try (FileAppender<Record> appender =
         Parquet.write(Files.localOutput(testFile))
             .schema(writeSchema)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .build()) {
       appender.addAll(expected);
     }

--- a/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericReadProjection.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericReadProjection.java
@@ -40,7 +40,7 @@ public class TestGenericReadProjection extends TestReadProjection {
     try (FileAppender<Record> appender =
         Parquet.write(Files.localOutput(file))
             .schema(writeSchema)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .build()) {
       appender.add(record);
     }

--- a/data/src/test/java/org/apache/iceberg/parquet/TestParquetMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/parquet/TestParquetMetrics.java
@@ -80,7 +80,7 @@ public class TestParquetMetrics extends TestMetrics {
         Parquet.write(file)
             .schema(schema)
             .setAll(properties)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .metricsConfig(metricsConfig)
             .build();
     try (FileAppender<Record> appender = writer) {

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java
@@ -222,7 +222,7 @@ public class TestFlinkParquetReader extends DataTest {
     try (FileAppender<Record> writer =
         Parquet.write(Files.localOutput(testFile))
             .schema(writeSchema)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .build()) {
       writer.addAll(iterable);
     }

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
@@ -591,7 +591,8 @@ public class FlinkParquetWriters {
   private static class RowDataWriter extends ParquetValueWriters.StructWriter<RowData> {
     private final RowData.FieldGetter[] fieldGetter;
 
-    RowDataWriter(int[] fieldIndexes, List<ParquetValueWriter<?>> writers, List<LogicalType> types) {
+    RowDataWriter(
+        int[] fieldIndexes, List<ParquetValueWriter<?>> writers, List<LogicalType> types) {
       super(writers);
       fieldGetter = new RowData.FieldGetter[types.size()];
       for (int i = 0; i < types.size(); i += 1) {

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.RowType.RowField;
@@ -87,16 +88,22 @@ public class FlinkParquetWriters {
     @Override
     public ParquetValueWriter<?> struct(
         RowType sStruct, GroupType struct, List<ParquetValueWriter<?>> fieldWriters) {
-      List<Type> fields = struct.getFields();
       List<RowField> flinkFields = sStruct.getFields();
       List<ParquetValueWriter<?>> writers = Lists.newArrayListWithExpectedSize(fieldWriters.size());
       List<LogicalType> flinkTypes = Lists.newArrayList();
-      for (int i = 0; i < fields.size(); i += 1) {
-        writers.add(newOption(struct.getType(i), fieldWriters.get(i)));
-        flinkTypes.add(flinkFields.get(i).getType());
+      int[] fieldIndexes = new int[fieldWriters.size()];
+      int fieldIndex = 0;
+      for (int i = 0; i < flinkFields.size(); i += 1) {
+        LogicalType flinkType = flinkFields.get(i).getType();
+        if (!flinkType.is(LogicalTypeRoot.NULL)) {
+          writers.add(newOption(struct.getType(fieldIndex), fieldWriters.get(fieldIndex)));
+          flinkTypes.add(flinkType);
+          fieldIndexes[fieldIndex] = i;
+          fieldIndex += 1;
+        }
       }
 
-      return new RowDataWriter(writers, flinkTypes);
+      return new RowDataWriter(fieldIndexes, writers, flinkTypes);
     }
 
     @Override
@@ -584,11 +591,11 @@ public class FlinkParquetWriters {
   private static class RowDataWriter extends ParquetValueWriters.StructWriter<RowData> {
     private final RowData.FieldGetter[] fieldGetter;
 
-    RowDataWriter(List<ParquetValueWriter<?>> writers, List<LogicalType> types) {
+    RowDataWriter(int[] fieldIndexes, List<ParquetValueWriter<?>> writers, List<LogicalType> types) {
       super(writers);
       fieldGetter = new RowData.FieldGetter[types.size()];
       for (int i = 0; i < types.size(); i += 1) {
-        fieldGetter[i] = FlinkRowData.createFieldGetter(types.get(i), i);
+        fieldGetter[i] = FlinkRowData.createFieldGetter(types.get(i), fieldIndexes[i]);
       }
     }
 

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java
@@ -222,7 +222,7 @@ public class TestFlinkParquetReader extends DataTest {
     try (FileAppender<Record> writer =
         Parquet.write(Files.localOutput(testFile))
             .schema(writeSchema)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .build()) {
       writer.addAll(iterable);
     }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java
@@ -222,7 +222,7 @@ public class TestFlinkParquetReader extends DataTest {
     try (FileAppender<Record> writer =
         Parquet.write(Files.localOutput(testFile))
             .schema(writeSchema)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .build()) {
       writer.addAll(iterable);
     }

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriter.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriter.java
@@ -60,7 +60,7 @@ public class GenericOrcWriter implements OrcRowWriter<Record> {
         TypeDescription record,
         List<String> names,
         List<OrcValueWriter<?>> fields) {
-      return new RecordWriter(fields);
+      return new RecordWriter(iStruct, fields);
     }
 
     @Override
@@ -156,8 +156,8 @@ public class GenericOrcWriter implements OrcRowWriter<Record> {
 
   private static class RecordWriter extends GenericOrcWriters.StructWriter<Record> {
 
-    RecordWriter(List<OrcValueWriter<?>> writers) {
-      super(writers);
+    RecordWriter(Types.StructType struct, List<OrcValueWriter<?>> writers) {
+      super(struct, writers);
     }
 
     @Override

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
@@ -670,11 +670,11 @@ public class GenericOrcWriters {
 
     // value writer index to record field index
     int[] indexes = new int[numWriters];
-    int i = 0;
+    int writerIndex = 0;
     for (int pos = 0; pos < recordFields.size(); pos += 1) {
       if (recordFields.get(pos).type().typeId() != Type.TypeID.UNKNOWN) {
-        indexes[i] = pos;
-        i += 1;
+        indexes[writerIndex] = pos;
+        writerIndex += 1;
       }
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/InternalParquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/InternalParquet.java
@@ -33,7 +33,7 @@ public class InternalParquet {
   }
 
   private static Parquet.WriteBuilder writeInternal(OutputFile outputFile) {
-    return Parquet.write(outputFile).createWriterFunc(InternalWriter::create);
+    return Parquet.write(outputFile).createWriterFunc(InternalWriter::createWriter);
   }
 
   private static Parquet.ReadBuilder readInternal(InputFile inputFile) {

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
@@ -49,7 +49,7 @@ abstract class BaseParquetWriter<T> {
   }
 
   protected abstract ParquetValueWriters.StructWriter<T> createStructWriter(
-      List<ParquetValueWriter<?>> writers);
+      Types.StructType struct, List<ParquetValueWriter<?>> writers);
 
   protected abstract ParquetValueWriter<?> fixedWriter(ColumnDescriptor desc);
 
@@ -85,7 +85,7 @@ abstract class BaseParquetWriter<T> {
         writers.add(ParquetValueWriters.option(fieldType, fieldD, fieldWriters.get(i)));
       }
 
-      return createStructWriter(writers);
+      return createStructWriter(iceberg, writers);
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
@@ -45,6 +45,8 @@ public class GenericParquetWriter extends BaseParquetWriter<Record> {
   private GenericParquetWriter() {}
 
   /**
+   * Build a writer for a Parquet schema.
+   *
    * @deprecated will be removed in 1.10.0; use {@link #create(Schema, MessageType)} instead.
    */
   @Deprecated
@@ -57,9 +59,12 @@ public class GenericParquetWriter extends BaseParquetWriter<Record> {
   }
 
   /**
+   * Create a struct writer from a list of writers.
+   *
    * @deprecated will be removed in 1.10.0; use {@link #createWriter(Types.StructType, MessageType)}
    *     instead.
    */
+  @Deprecated
   protected StructWriter<Record> createStructWriter(List<ParquetValueWriter<?>> writers) {
     return ParquetValueWriters.recordWriter(null, writers);
   }

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
@@ -44,6 +44,10 @@ public class GenericParquetWriter extends BaseParquetWriter<Record> {
 
   private GenericParquetWriter() {}
 
+  /**
+   * @deprecated will be removed in 1.10.0; use {@link #create(Schema, MessageType)} instead.
+   */
+  @Deprecated
   public static ParquetValueWriter<Record> buildWriter(MessageType type) {
     return INSTANCE.createWriter(type);
   }
@@ -52,13 +56,10 @@ public class GenericParquetWriter extends BaseParquetWriter<Record> {
     return INSTANCE.createWriter(schema.asStruct(), type);
   }
 
-  public static ParquetValueWriter<Record> create(Types.StructType struct, MessageType type) {
-    return INSTANCE.createWriter(struct, type);
-  }
-
   @Override
-  protected StructWriter<Record> createStructWriter(List<ParquetValueWriter<?>> writers) {
-    return ParquetValueWriters.recordWriter(writers);
+  protected StructWriter<Record> createStructWriter(
+      Types.StructType struct, List<ParquetValueWriter<?>> writers) {
+    return ParquetValueWriters.recordWriter(struct, writers);
   }
 
   @Override

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
@@ -56,6 +56,14 @@ public class GenericParquetWriter extends BaseParquetWriter<Record> {
     return INSTANCE.createWriter(schema.asStruct(), type);
   }
 
+  /**
+   * @deprecated will be removed in 1.10.0; use {@link #createWriter(Types.StructType, MessageType)}
+   *     instead.
+   */
+  protected StructWriter<Record> createStructWriter(List<ParquetValueWriter<?>> writers) {
+    return ParquetValueWriters.recordWriter(null, writers);
+  }
+
   @Override
   protected StructWriter<Record> createStructWriter(
       Types.StructType struct, List<ParquetValueWriter<?>> writers) {

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalWriter.java
@@ -59,6 +59,14 @@ public class InternalWriter<T extends StructLike> extends BaseParquetWriter<T> {
     return (ParquetValueWriter<T>) INSTANCE.createWriter(struct, type);
   }
 
+  /**
+   * @deprecated will be removed in 1.10.0; use {@link #createWriter(Types.StructType, MessageType)}
+   *     instead.
+   */
+  protected StructWriter<T> createStructWriter(List<ParquetValueWriter<?>> writers) {
+    return ParquetValueWriters.recordWriter(null, writers);
+  }
+
   @Override
   protected StructWriter<T> createStructWriter(
       Types.StructType struct, List<ParquetValueWriter<?>> writers) {

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalWriter.java
@@ -40,11 +40,15 @@ public class InternalWriter<T extends StructLike> extends BaseParquetWriter<T> {
 
   private InternalWriter() {}
 
+  /**
+   * @deprecated will be removed in 1.10.0; use {@link #createWriter(Schema, MessageType)} instead.
+   */
+  @Deprecated
   public static <T extends StructLike> ParquetValueWriter<T> create(MessageType type) {
     return create((Types.StructType) null, type);
   }
 
-  public static <T extends StructLike> ParquetValueWriter<T> create(
+  public static <T extends StructLike> ParquetValueWriter<T> createWriter(
       Schema schema, MessageType type) {
     return create(schema.asStruct(), type);
   }
@@ -56,8 +60,9 @@ public class InternalWriter<T extends StructLike> extends BaseParquetWriter<T> {
   }
 
   @Override
-  protected StructWriter<T> createStructWriter(List<ParquetValueWriter<?>> writers) {
-    return ParquetValueWriters.recordWriter(writers);
+  protected StructWriter<T> createStructWriter(
+      Types.StructType struct, List<ParquetValueWriter<?>> writers) {
+    return ParquetValueWriters.recordWriter(struct, writers);
   }
 
   @Override

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalWriter.java
@@ -41,6 +41,8 @@ public class InternalWriter<T extends StructLike> extends BaseParquetWriter<T> {
   private InternalWriter() {}
 
   /**
+   * Build a writer for a Parquet schema.
+   *
    * @deprecated will be removed in 1.10.0; use {@link #createWriter(Schema, MessageType)} instead.
    */
   @Deprecated
@@ -60,9 +62,12 @@ public class InternalWriter<T extends StructLike> extends BaseParquetWriter<T> {
   }
 
   /**
+   * Create a struct writer from a list of writers.
+   *
    * @deprecated will be removed in 1.10.0; use {@link #createWriter(Types.StructType, MessageType)}
    *     instead.
    */
+  @Deprecated
   protected StructWriter<T> createStructWriter(List<ParquetValueWriter<?>> writers) {
     return ParquetValueWriters.recordWriter(null, writers);
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
@@ -714,11 +714,11 @@ public class ParquetValueWriters {
 
     // value writer index to record field index
     int[] indexes = new int[numWriters];
-    int i = 0;
+    int writerIndex = 0;
     for (int pos = 0; pos < recordFields.size(); pos += 1) {
       if (recordFields.get(pos).type().typeId() != org.apache.iceberg.types.Type.TypeID.UNKNOWN) {
-        indexes[i] = pos;
-        i += 1;
+        indexes[writerIndex] = pos;
+        writerIndex += 1;
       }
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
@@ -133,6 +133,18 @@ public class ParquetValueWriters {
     return new MapWriter<>(dl, rl, keyWriter, valueWriter);
   }
 
+  /**
+   * Create a struct writer that produces a StructLike record.
+   *
+   * @deprecated will be removed in 1.10.0; use {@link #recordWriter(Types.StructType, List)}
+   *     instead.
+   */
+  @Deprecated
+  public static <T extends StructLike> StructWriter<T> recordWriter(
+      List<ParquetValueWriter<?>> writers) {
+    return recordWriter(null, writers);
+  }
+
   public static <T extends StructLike> StructWriter<T> recordWriter(
       Types.StructType struct, List<ParquetValueWriter<?>> writers) {
     return new RecordWriter<>(struct, writers);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
@@ -633,12 +633,16 @@ public class ParquetValueWriters {
     private final List<TripleWriter<?>> children;
 
     protected StructWriter(List<ParquetValueWriter<?>> writers) {
-      this(null, writers);
+      this((Types.StructType) null, writers);
+    }
+
+    protected StructWriter(Types.StructType struct, List<ParquetValueWriter<?>> writers) {
+      this(writerToFieldIndex(struct, writers.size()), writers);
     }
 
     @SuppressWarnings("unchecked")
-    protected StructWriter(Types.StructType struct, List<ParquetValueWriter<?>> writers) {
-      this.fieldIndexes = writerToFieldIndex(struct, writers.size());
+    protected StructWriter(int[] fieldIndexes, List<ParquetValueWriter<?>> writers) {
+      this.fieldIndexes = fieldIndexes;
       this.writers =
           (ParquetValueWriter<Object>[])
               Array.newInstance(ParquetValueWriter.class, writers.size());

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestInternalParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestInternalParquet.java
@@ -80,7 +80,7 @@ public class TestInternalParquet extends DataTest {
     try (DataWriter<StructLike> dataWriter =
         Parquet.writeData(outputFile)
             .schema(writeSchema)
-            .createWriterFunc(fileSchema -> InternalWriter.create(writeSchema, fileSchema))
+            .createWriterFunc(InternalWriter::createWriter)
             .overwrite()
             .withSpec(PartitionSpec.unpartitioned())
             .build()) {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
@@ -85,7 +85,7 @@ public class TestParquetDataWriter {
     DataWriter<Record> dataWriter =
         Parquet.writeData(file)
             .schema(SCHEMA)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .overwrite()
             .withSpec(PartitionSpec.unpartitioned())
             .withSortOrder(sortOrder)
@@ -144,7 +144,7 @@ public class TestParquetDataWriter {
         Parquet.writeData(file)
             .metricsConfig(MetricsConfig.forTable(testTable))
             .schema(SCHEMA)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .overwrite()
             .withSpec(PartitionSpec.unpartitioned())
             .build();
@@ -217,7 +217,7 @@ public class TestParquetDataWriter {
         Parquet.writeData(file)
             .metricsConfig(MetricsConfig.forTable(testTable))
             .schema(SCHEMA)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .overwrite()
             .withSpec(PartitionSpec.unpartitioned())
             .build();

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDeleteWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDeleteWriters.java
@@ -77,7 +77,7 @@ public class TestParquetDeleteWriters {
     OutputFile out = Files.localOutput(temp);
     EqualityDeleteWriter<Record> deleteWriter =
         Parquet.writeDeletes(out)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .overwrite()
             .rowSchema(SCHEMA)
             .withSpec(PartitionSpec.unpartitioned())
@@ -127,7 +127,7 @@ public class TestParquetDeleteWriters {
     OutputFile out = Files.localOutput(temp);
     PositionDeleteWriter<Record> deleteWriter =
         Parquet.writeDeletes(out)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .overwrite()
             .rowSchema(SCHEMA)
             .withSpec(PartitionSpec.unpartitioned())
@@ -183,7 +183,7 @@ public class TestParquetDeleteWriters {
     OutputFile out = Files.localOutput(temp);
     PositionDeleteWriter<Void> deleteWriter =
         Parquet.writeDeletes(out)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .overwrite()
             .withSpec(PartitionSpec.unpartitioned())
             .transformPaths(

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -402,7 +402,7 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
       DataWriter<GenericRecord> dataWriter =
           Parquet.writeData(file)
               .forTable(table)
-              .createWriterFunc(GenericParquetWriter::buildWriter)
+              .createWriterFunc(GenericParquetWriter::create)
               .overwrite()
               .build();
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -658,7 +658,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             .buildPositionWriter();
       case PARQUET:
         return Parquet.writeDeletes(outputFile)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .withPartition(partition)
             .rowSchema(rowSchema)
             .withSpec(spec)

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -398,7 +398,7 @@ public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase
       DataWriter<GenericRecord> dataWriter =
           Parquet.writeData(file)
               .forTable(table)
-              .createWriterFunc(GenericParquetWriter::buildWriter)
+              .createWriterFunc(GenericParquetWriter::create)
               .overwrite()
               .build();
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -691,7 +691,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             .buildPositionWriter();
       case PARQUET:
         return Parquet.writeDeletes(outputFile)
-            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .createWriterFunc(GenericParquetWriter::create)
             .withPartition(partition)
             .rowSchema(rowSchema)
             .withSpec(spec)


### PR DESCRIPTION
This fixes ORC and Parquet writers with unknown columns.

Previously, writers assumed that the Iceberg schema of the incoming data and the outgoing Parquet schema matched. However, unknown is not represented in file schemas, which led to an index mismatch. The value for an unknown column was being used by index and passed to the next writer. In some cases, this is not caught because the data is valid when the fields did not align (for example if there is only one more field and it is optional).

The fix is to pass the Iceberg schema into the write builder and account for columns that are present in data records but are not passed to a writer.

This updates all paths that called Parquet's `GenericParquetWriter` or `InternalWriter` to pass the data schema. This was not necessary in ORC because the write builder already passes the data schema.

Avro does not need to be fixed because unknown is converted to a NULL schema and a null writer is used.