### PR TITLE
AWS: fix incorrect parent session when calling delegate auth manager

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthManager.java
@@ -60,7 +60,8 @@ public class RESTSigV4AuthManager implements AuthManager {
   }
 
   @Override
-  public AuthSession contextualSession(SessionCatalog.SessionContext context, AuthSession parent) {
+  public RESTSigV4AuthSession contextualSession(
+      SessionCatalog.SessionContext context, AuthSession parent) {
     AwsProperties contextProperties =
         new AwsProperties(RESTUtil.merge(catalogProperties, context.properties()));
     RESTSigV4AuthSession sigV4Parent = (RESTSigV4AuthSession) parent;
@@ -69,7 +70,7 @@ public class RESTSigV4AuthManager implements AuthManager {
   }
 
   @Override
-  public AuthSession tableSession(
+  public RESTSigV4AuthSession tableSession(
       TableIdentifier table, Map<String, String> properties, AuthSession parent) {
     AwsProperties tableProperties =
         new AwsProperties(RESTUtil.merge(catalogProperties, properties));

--- a/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthManager.java
@@ -63,7 +63,8 @@ public class RESTSigV4AuthManager implements AuthManager {
   @Override
   public RESTSigV4AuthSession contextualSession(
       SessionCatalog.SessionContext context, AuthSession parent) {
-    Preconditions.checkState(parent instanceof RESTSigV4AuthSession, "parent session is not SigV4");
+    Preconditions.checkState(
+        parent instanceof RESTSigV4AuthSession, "Parent session is not SigV4: %s", parent);
     AwsProperties contextProperties =
         new AwsProperties(
             RESTUtil.merge(
@@ -80,7 +81,8 @@ public class RESTSigV4AuthManager implements AuthManager {
   @Override
   public RESTSigV4AuthSession tableSession(
       TableIdentifier table, Map<String, String> properties, AuthSession parent) {
-    Preconditions.checkState(parent instanceof RESTSigV4AuthSession, "parent session is not SigV4");
+    Preconditions.checkState(
+        parent instanceof RESTSigV4AuthSession, "Parent session is not SigV4: %s", parent);
     AwsProperties tableProperties =
         new AwsProperties(RESTUtil.merge(catalogProperties, properties));
     RESTSigV4AuthSession sigV4Parent = (RESTSigV4AuthSession) parent;

--- a/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthManager.java
@@ -63,6 +63,7 @@ public class RESTSigV4AuthManager implements AuthManager {
   @Override
   public RESTSigV4AuthSession contextualSession(
       SessionCatalog.SessionContext context, AuthSession parent) {
+    Preconditions.checkState(parent instanceof RESTSigV4AuthSession, "parent session is not SigV4");
     AwsProperties contextProperties =
         new AwsProperties(
             RESTUtil.merge(
@@ -79,6 +80,7 @@ public class RESTSigV4AuthManager implements AuthManager {
   @Override
   public RESTSigV4AuthSession tableSession(
       TableIdentifier table, Map<String, String> properties, AuthSession parent) {
+    Preconditions.checkState(parent instanceof RESTSigV4AuthSession, "parent session is not SigV4");
     AwsProperties tableProperties =
         new AwsProperties(RESTUtil.merge(catalogProperties, properties));
     RESTSigV4AuthSession sigV4Parent = (RESTSigV4AuthSession) parent;

--- a/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthManager.java
@@ -64,8 +64,9 @@ public class RESTSigV4AuthManager implements AuthManager {
   public AuthSession contextualSession(SessionCatalog.SessionContext context, AuthSession parent) {
     AwsProperties contextProperties =
         new AwsProperties(RESTUtil.merge(catalogProperties, context.properties()));
+    RESTSigV4AuthSession sigV4Parent = (RESTSigV4AuthSession) parent;
     return new RESTSigV4AuthSession(
-        signer, delegate.contextualSession(context, parent), contextProperties);
+        signer, delegate.contextualSession(context, sigV4Parent.delegate()), contextProperties);
   }
 
   @Override
@@ -73,8 +74,9 @@ public class RESTSigV4AuthManager implements AuthManager {
       TableIdentifier table, Map<String, String> properties, AuthSession parent) {
     AwsProperties tableProperties =
         new AwsProperties(RESTUtil.merge(catalogProperties, properties));
+    RESTSigV4AuthSession sigV4Parent = (RESTSigV4AuthSession) parent;
     return new RESTSigV4AuthSession(
-        signer, delegate.tableSession(table, properties, parent), tableProperties);
+        signer, delegate.tableSession(table, properties, sigV4Parent.delegate()), tableProperties);
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthManager.java
@@ -33,7 +33,6 @@ import software.amazon.awssdk.auth.signer.Aws4Signer;
  *
  * <p>It takes a delegate AuthManager to handle double authentication cases, e.g. on top of OAuth2.
  */
-@SuppressWarnings("unused") // loaded by reflection
 public class RESTSigV4AuthManager implements AuthManager {
 
   private final Aws4Signer signer = Aws4Signer.create();
@@ -41,7 +40,7 @@ public class RESTSigV4AuthManager implements AuthManager {
 
   private Map<String, String> catalogProperties = Map.of();
 
-  public RESTSigV4AuthManager(String name, AuthManager delegate) {
+  public RESTSigV4AuthManager(String ignored, AuthManager delegate) {
     this.delegate = Preconditions.checkNotNull(delegate, "Invalid delegate: null");
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthManager.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.aws;
 
 import java.util.Map;
+import java.util.Optional;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -63,7 +64,13 @@ public class RESTSigV4AuthManager implements AuthManager {
   public RESTSigV4AuthSession contextualSession(
       SessionCatalog.SessionContext context, AuthSession parent) {
     AwsProperties contextProperties =
-        new AwsProperties(RESTUtil.merge(catalogProperties, context.properties()));
+        new AwsProperties(
+            RESTUtil.merge(
+                catalogProperties,
+                // Use both context properties and credentials to create the AwsProperties instance
+                RESTUtil.merge(
+                    Optional.ofNullable(context.properties()).orElseGet(Map::of),
+                    Optional.ofNullable(context.credentials()).orElseGet(Map::of))));
     RESTSigV4AuthSession sigV4Parent = (RESTSigV4AuthSession) parent;
     return new RESTSigV4AuthSession(
         signer, delegate.contextualSession(context, sigV4Parent.delegate()), contextProperties);

--- a/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthSession.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthSession.java
@@ -73,6 +73,10 @@ public class RESTSigV4AuthSession implements AuthSession {
     this.credentialsProvider = awsProperties.restCredentialsProvider();
   }
 
+  public AuthSession delegate() {
+    return delegate;
+  }
+
   @Override
   public HTTPRequest authenticate(HTTPRequest request) {
     return sign(delegate.authenticate(request));


### PR DESCRIPTION
Also fixes a potential issue with context credentials, and improves unit tests.