### PR TITLE
Generic Serializer and DeSerializer for control topic consumers and producers

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -100,7 +100,6 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public static final int SCHEMA_UPDATE_RETRIES = 2; // 3 total attempts
   public static final int CREATE_TABLE_RETRIES = 2; // 3 total attempts
-  public static final String KAFKA_SERDE_PROP_PREFIX = "serde.";
 
   @VisibleForTesting static final String COMMA_NO_PARENS_REGEX = ",(?![^()]*+\\))";
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -100,6 +100,7 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public static final int SCHEMA_UPDATE_RETRIES = 2; // 3 total attempts
   public static final int CREATE_TABLE_RETRIES = 2; // 3 total attempts
+  public static final String KAFKA_SERDE_PROP_PREFIX = "iceberg.kafka.serde.";
 
   @VisibleForTesting static final String COMMA_NO_PARENS_REGEX = ",(?![^()]*+\\))";
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -100,7 +100,7 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public static final int SCHEMA_UPDATE_RETRIES = 2; // 3 total attempts
   public static final int CREATE_TABLE_RETRIES = 2; // 3 total attempts
-  public static final String KAFKA_SERDE_PROP_PREFIX = "iceberg.kafka.serde.";
+  public static final String KAFKA_SERDE_PROP_PREFIX = "serde.";
 
   @VisibleForTesting static final String COMMA_NO_PARENS_REGEX = ",(?![^()]*+\\))";
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/KafkaClientFactory.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/KafkaClientFactory.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg.connect.channel;
 
-import static org.apache.iceberg.connect.IcebergSinkConfig.KAFKA_SERDE_PROP_PREFIX;
-
 import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
@@ -41,6 +39,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 class KafkaClientFactory {
   private final Map<String, String> kafkaProps;
   private final Map<String, Object> kafkaSerdeProps = Maps.newHashMap();
+  public static final String KAFKA_SERDE_PROP_PREFIX = "serde.";
 
   KafkaClientFactory(Map<String, String> kafkaProps) {
     this.kafkaProps = kafkaProps;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/KafkaClientFactory.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/KafkaClientFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.connect.channel;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -30,26 +31,65 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
+import static org.apache.iceberg.connect.IcebergSinkConfig.KAFKA_SERDE_PROP_PREFIX;
+
 class KafkaClientFactory {
   private final Map<String, String> kafkaProps;
+  private final Map<String, Object> kafkaSerdeProps = Maps.newHashMap();
 
   KafkaClientFactory(Map<String, String> kafkaProps) {
     this.kafkaProps = kafkaProps;
+    Iterator<Map.Entry<String, String>> iterator = kafkaProps.entrySet().iterator();
+    while (iterator.hasNext()) {
+      Map.Entry<String, String> entry = iterator.next();
+      if (entry.getKey().startsWith(KAFKA_SERDE_PROP_PREFIX)) {
+        kafkaSerdeProps.put(entry.getKey().substring(KAFKA_SERDE_PROP_PREFIX.length()), entry.getValue());
+        iterator.remove(); // Safe removal while iterating
+      }
+    }
   }
 
+  @SuppressWarnings("unchecked")
   Producer<String, byte[]> createProducer(String transactionalId) {
     Map<String, Object> producerProps = Maps.newHashMap(kafkaProps);
     producerProps.putIfAbsent(ProducerConfig.CLIENT_ID_CONFIG, UUID.randomUUID().toString());
     producerProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
-    KafkaProducer<String, byte[]> result =
-        new KafkaProducer<>(producerProps, new StringSerializer(), new ByteArraySerializer());
-    result.initTransactions();
-    return result;
+
+    try {
+      // Resolve key and value serializer classes safely
+      Object keySerializerProp = kafkaSerdeProps.getOrDefault(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+      Object valueSerializerProp = kafkaSerdeProps.getOrDefault(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+
+      // Convert String to Class if necessary
+      Class<? extends Serializer<String>> keySerializerClass = (keySerializerProp instanceof String)
+              ? (Class<? extends Serializer<String>>) Class.forName((String) keySerializerProp)
+              : (Class<? extends Serializer<String>>) keySerializerProp;
+
+      Class<? extends Serializer<byte[]>> valueSerializerClass = (valueSerializerProp instanceof String)
+              ? (Class<? extends Serializer<byte[]>>) Class.forName((String) valueSerializerProp)
+              : (Class<? extends Serializer<byte[]>>) valueSerializerProp;
+
+      Serializer<String> keySerializer = keySerializerClass.getDeclaredConstructor().newInstance();
+      keySerializer.configure(kafkaSerdeProps, true);
+      Serializer<byte[]> valueSerializer = valueSerializerClass.getDeclaredConstructor().newInstance();
+      valueSerializer.configure(kafkaSerdeProps, false);
+      KafkaProducer<String, byte[]> result =
+              new KafkaProducer<>(producerProps, keySerializer, valueSerializer);
+      result.initTransactions();
+      return result;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to instantiate control topic producer", e);
+    }
   }
 
+
+
+  @SuppressWarnings("unchecked")
   Consumer<String, byte[]> createConsumer(String consumerGroupId) {
     Map<String, Object> consumerProps = Maps.newHashMap(kafkaProps);
     consumerProps.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
@@ -57,9 +97,35 @@ class KafkaClientFactory {
     consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
     consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
     consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroupId);
-    return new KafkaConsumer<>(
-        consumerProps, new StringDeserializer(), new ByteArrayDeserializer());
+
+    try {
+      // Resolve key and value deserializer classes safely
+      Object keyDeserializerProp = kafkaSerdeProps.getOrDefault(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+      Object valueDeserializerProp = kafkaSerdeProps.getOrDefault(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+
+      // Convert String to Class if necessary
+      Class<? extends Deserializer<String>> keyDeserializerClass = (keyDeserializerProp instanceof String)
+              ? (Class<? extends Deserializer<String>>) Class.forName((String) keyDeserializerProp)
+              : (Class<? extends Deserializer<String>>) keyDeserializerProp;
+
+      Class<? extends Deserializer<byte[]>> valueDeserializerClass = (valueDeserializerProp instanceof String)
+              ? (Class<? extends Deserializer<byte[]>>) Class.forName((String) valueDeserializerProp)
+              : (Class<? extends Deserializer<byte[]>>) valueDeserializerProp;
+
+      // Instantiate deserializers
+      Deserializer<String> keyDeserializer = keyDeserializerClass.getDeclaredConstructor().newInstance();
+      keyDeserializer.configure(kafkaSerdeProps, true);
+      Deserializer<byte[]> valueDeserializer = valueDeserializerClass.getDeclaredConstructor().newInstance();
+      valueDeserializer.configure(kafkaSerdeProps, false);
+
+      return new KafkaConsumer<>(
+              consumerProps, keyDeserializer, valueDeserializer);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to instantiate control topic consumer", e);
+    }
   }
+
+
 
   Admin createAdmin() {
     Map<String, Object> adminProps = Maps.newHashMap(kafkaProps);


### PR DESCRIPTION
**Issue**

- Currently the consumers and producers responsible for consuming and producing from control topic is hardcoded to have **StringSerializer** and **StringDeSerializer** for **Key** and **ByteArraySerializer** and **ByteArrayDeserializer** for **value**. This is although not an issue as the producers and consumers are of <String, byte[]> but limits users in certain ways like the following:
         - If the size of control message is large kafka throws LargeMessageException and the only way for users is to keep on increasing the topic size at the broker levels.
         - If user wants a level of encryption and decryption for the control topic data for privacy issues then there is no way we can achieve that.

**Solution**

- This PR proposes to take the **Serializer** and **Deserializer** from config and it will allow only those ** Serializer** and ** Deserializer** which extends from **Serializer<byte[]>** and **Deserializer<byte[]>**, this way still not breaking the contact the producers and consumers have.

**Motivation**

- This change is motivated from the large message issue we faced as we operate at a very large scale and when ever we do bootstrapping with large commit-intervals, we face large message exception and for that we have our own **Serializer** and **Deserializer** which handles that very efficiently which we also will be pushing to OSS for wider audience. 