### PR TITLE
Flink: fix read config of connector.iceberg.max-allowed-planning-failures

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
@@ -557,7 +557,7 @@ public class ScanContext implements Serializable {
           .planParallelism(flinkReadConf.workerPoolSize())
           .includeColumnStats(flinkReadConf.includeColumnStats())
           .maxPlanningSnapshotCount(flinkReadConf.maxPlanningSnapshotCount())
-          .maxAllowedPlanningFailures(maxAllowedPlanningFailures)
+          .maxAllowedPlanningFailures(flinkReadConf.maxAllowedPlanningFailures())
           .watermarkColumn(flinkReadConf.watermarkColumn())
           .watermarkColumnTimeUnit(flinkReadConf.watermarkColumnTimeUnit());
     }


### PR DESCRIPTION
In the current code, the assignment of connector.iceberg.max-allowed-planning-failures uses FlinkReadOptions.MAX_ALLOWED_PLANNING_FAILURES_OPTION.defaultValue() instead of retrieving it from flinkReadConf. 

As a result, this configuration always remains at its default value of 3 and cannot be modified. 

This PR primarily aims to resolve this issue by ensuring that the configuration can be correctly assigned from the Flink config.