### PR TITLE
Flink: backport for fix read config of connector.iceberg.max-allowed-planning-failures to 1.18 and 1.19

### DIFF
--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
@@ -557,7 +557,7 @@ public class ScanContext implements Serializable {
           .planParallelism(flinkReadConf.workerPoolSize())
           .includeColumnStats(flinkReadConf.includeColumnStats())
           .maxPlanningSnapshotCount(flinkReadConf.maxPlanningSnapshotCount())
-          .maxAllowedPlanningFailures(maxAllowedPlanningFailures)
+          .maxAllowedPlanningFailures(flinkReadConf.maxAllowedPlanningFailures())
           .watermarkColumn(flinkReadConf.watermarkColumn())
           .watermarkColumnTimeUnit(flinkReadConf.watermarkColumnTimeUnit());
     }

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
@@ -557,7 +557,7 @@ public class ScanContext implements Serializable {
           .planParallelism(flinkReadConf.workerPoolSize())
           .includeColumnStats(flinkReadConf.includeColumnStats())
           .maxPlanningSnapshotCount(flinkReadConf.maxPlanningSnapshotCount())
-          .maxAllowedPlanningFailures(maxAllowedPlanningFailures)
+          .maxAllowedPlanningFailures(flinkReadConf.maxAllowedPlanningFailures())
           .watermarkColumn(flinkReadConf.watermarkColumn())
           .watermarkColumnTimeUnit(flinkReadConf.watermarkColumnTimeUnit());
     }


### PR DESCRIPTION
backport #12585 to the 1.19, and 1.18 branches