### PR TITLE
Spec: Add details on GZIP compressed metadata files

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -1477,7 +1477,6 @@ Table metadata is serialized as a JSON object according to the following table. 
 
 A metadata JSON file may be compressed with [GZIP](https://datatracker.ietf.org/doc/html/rfc1952).
 
-
 |Metadata field|JSON representation|Example|
 |--- |--- |--- |
 |**`format-version`**|`JSON int`|`1`|

--- a/format/spec.md
+++ b/format/spec.md
@@ -1473,7 +1473,7 @@ The following table describes the possible values for the some of the field with
 
 ### Table Metadata and Snapshots
 
-Table metadata is serialized as a JSON object according to the following table. Snapshots are not serialized separately. Instead, they are stored in the table metadata JSON. 
+Table metadata is serialized as a JSON object according to the following table. Snapshots are not serialized separately. Instead, they are stored in the table metadata JSON.
 
 A metadata JSON file may be compressed with [GZIP](https://datatracker.ietf.org/doc/html/rfc1952).
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -1475,7 +1475,7 @@ The following table describes the possible values for the some of the field with
 
 Table metadata is serialized as a JSON object according to the following table. Snapshots are not serialized separately. Instead, they are stored in the table metadata JSON. 
 
-A metadata JSON file name must end in `.metadata.json`. A metadata JSON file may be compressed with [GZIP](https://datatracker.ietf.org/doc/html/rfc1952). A GZIP compressed file name must end with `.gz.metadata.json`.
+A metadata JSON file may be compressed with [GZIP](https://datatracker.ietf.org/doc/html/rfc1952).
 
 
 |Metadata field|JSON representation|Example|
@@ -1764,9 +1764,9 @@ The reference Java implementation uses a type 4 uuid and XORs the 4 most signifi
 
 Java writes `-1` for "no current snapshot" with V1 and V2 tables and considers this equivalent to omitted or `null`. This has never been formalized in the spec, but for compatibility, other implementations can accept `-1` as `null`. Java will no longer write `-1` and will use `null` for "no current snapshot" for all tables with a version greater than or equal to V3.
 
-### Legacy naming for GZIP compressed Metadata JSON files
+### Naming for GZIP compressed Metadata JSON files
 
-Some implementations have written GZIP compressed metadata JSON files with the suffix `metadata.json.gz`. The reference Java implementation will interpret files with this naming convention as GZIP files for backwards compatibility.
+Some implementations require that GZIP compressed files have the suffix `.gz.metadata.json` to be read correctly. The Java reference implementation can additionally read GZIP compressed files with the suffix `metadata.json.gz`.  
 
 ## Appendix G: Geospatial Notes
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -1475,7 +1475,7 @@ The following table describes the possible values for the some of the field with
 
 Table metadata is serialized as a JSON object according to the following table. Snapshots are not serialized separately. Instead, they are stored in the table metadata JSON. 
 
-A metadata JSON file must end in `.metadata.json`. A metadata JSON file may be compressed with [GZIP](https://datatracker.ietf.org/doc/html/rfc1952). A GZIP compressed file must end with `gz.metadata.json`.
+A metadata JSON file must end in `.metadata.json`. A metadata JSON file may be compressed with [GZIP](https://datatracker.ietf.org/doc/html/rfc1952). A GZIP compressed file must end with `.gz.metadata.json`.
 
 
 |Metadata field|JSON representation|Example|

--- a/format/spec.md
+++ b/format/spec.md
@@ -1475,7 +1475,7 @@ The following table describes the possible values for the some of the field with
 
 Table metadata is serialized as a JSON object according to the following table. Snapshots are not serialized separately. Instead, they are stored in the table metadata JSON. 
 
-A metadata JSON file must end in `.metadata.json`. A metadata JSON file may be compressed with [GZIP](https://datatracker.ietf.org/doc/html/rfc1952). A GZIP compressed file must end with `.gz.metadata.json`.
+A metadata JSON file name must end in `.metadata.json`. A metadata JSON file may be compressed with [GZIP](https://datatracker.ietf.org/doc/html/rfc1952). A GZIP compressed file name must end with `.gz.metadata.json`.
 
 
 |Metadata field|JSON representation|Example|

--- a/format/spec.md
+++ b/format/spec.md
@@ -1766,7 +1766,7 @@ Java writes `-1` for "no current snapshot" with V1 and V2 tables and considers t
 
 ### Legacy naming for GZIP compressed Metadata JSON files
 
-Some implementations have written GZIP compressed metadata JSON files with the suffix `metadata.json.gz`. The reference Java implementation will interpret files with this naming convention as GZIP files.
+Some implementations have written GZIP compressed metadata JSON files with the suffix `metadata.json.gz`. The reference Java implementation will interpret files with this naming convention as GZIP files for backwards compatibility.
 
 ## Appendix G: Geospatial Notes
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -1473,7 +1473,10 @@ The following table describes the possible values for the some of the field with
 
 ### Table Metadata and Snapshots
 
-Table metadata is serialized as a JSON object according to the following table. Snapshots are not serialized separately. Instead, they are stored in the table metadata JSON.
+Table metadata is serialized as a JSON object according to the following table. Snapshots are not serialized separately. Instead, they are stored in the table metadata JSON. 
+
+A metadata JSON file must end in `.metadata.json`. A metadata JSON file may be compressed with [GZIP](https://datatracker.ietf.org/doc/html/rfc1952). A GZIP compressed file must end with `gz.metadata.json`.
+
 
 |Metadata field|JSON representation|Example|
 |--- |--- |--- |
@@ -1760,6 +1763,10 @@ Writers should produce positive values for snapshot ids in a manner that minimiz
 The reference Java implementation uses a type 4 uuid and XORs the 4 most significant bytes with the 4 least significant bytes then ANDs with the maximum long value to arrive at a pseudo-random snapshot id with a low probability of collision.
 
 Java writes `-1` for "no current snapshot" with V1 and V2 tables and considers this equivalent to omitted or `null`. This has never been formalized in the spec, but for compatibility, other implementations can accept `-1` as `null`. Java will no longer write `-1` and will use `null` for "no current snapshot" for all tables with a version greater than or equal to V3.
+
+### Legacy naming for GZIP compressed Metadata JSON files
+
+Some implementations have written GZIP compressed metadata JSON files with the suffix `metadata.json.gz`. The reference Java implementation will interpret files with this naming convention as GZIP files.
 
 ## Appendix G: Geospatial Notes
 


### PR DESCRIPTION
This is a PR documenting current behavior and is not intended to introduce functionality but rather document functionality that has already been implemented for quite some time and has not made it into the specification.

There are two aspects:
1.  File name conventions for GZIP files.  Both python and Java reference implementation have expectations for how these files are named and will not work without this naming convention.  Additionally the naming convention is required for filesystem commits but this is on the path to deprecation.
2. Document the simple fact that GZIP compression is supported for metadata.

The logic documented is reverse engineered from [TableMetadataParser.Codec](http://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/TableMetadataParser.java#L68).  Which is a little bit odd, since in theory it allows for file names like `v0gz.metadata.json.foo` to correctly return as GZIP.

I assume the file name needs to end in `.metadata.json` based on [FileFormat.fromFileName](http://github.com/apache/iceberg/blob/e47e99a0dd3a500134633df640522c8c8fb56a2b/api/src/main/java/org/apache/iceberg/FileFormat.java#L60) which I assume would end up crashing if a null value was returned and from the specification mandating these file names for commits (even though this isn't strictly necessary for catalog based commits).