### PR TITLE
ORC: Implement initial default values for readers

### DIFF
--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReader.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReader.java
@@ -70,7 +70,7 @@ public class FlinkOrcReader implements OrcRowReader<RowData> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return FlinkOrcReaders.struct(fields, iStruct, idToConstant);
+      return FlinkOrcReaders.struct(fields, record, iStruct, idToConstant);
     }
 
     @Override

--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReaders.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReaders.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
@@ -91,8 +92,11 @@ class FlinkOrcReaders {
   }
 
   public static OrcValueReader<RowData> struct(
-      List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-    return new StructReader(readers, struct, idToConstant);
+      List<OrcValueReader<?>> readers,
+      TypeDescription record,
+      Types.StructType struct,
+      Map<Integer, ?> idToConstant) {
+    return new StructReader(readers, record, struct, idToConstant);
   }
 
   private static class StringReader implements OrcValueReader<StringData> {
@@ -265,8 +269,11 @@ class FlinkOrcReaders {
     private final int numFields;
 
     StructReader(
-        List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-      super(readers, struct, idToConstant);
+        List<OrcValueReader<?>> readers,
+        TypeDescription record,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant) {
+      super(readers, record, struct, idToConstant, RowDataUtil::convertConstant);
       this.numFields = struct.fields().size();
     }
 

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReader.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReader.java
@@ -70,7 +70,7 @@ public class FlinkOrcReader implements OrcRowReader<RowData> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return FlinkOrcReaders.struct(fields, iStruct, idToConstant);
+      return FlinkOrcReaders.struct(fields, record, iStruct, idToConstant);
     }
 
     @Override

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReaders.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReaders.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
@@ -91,8 +92,11 @@ class FlinkOrcReaders {
   }
 
   public static OrcValueReader<RowData> struct(
-      List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-    return new StructReader(readers, struct, idToConstant);
+      List<OrcValueReader<?>> readers,
+      TypeDescription record,
+      Types.StructType struct,
+      Map<Integer, ?> idToConstant) {
+    return new StructReader(readers, record, struct, idToConstant);
   }
 
   private static class StringReader implements OrcValueReader<StringData> {
@@ -265,8 +269,11 @@ class FlinkOrcReaders {
     private final int numFields;
 
     StructReader(
-        List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-      super(readers, struct, idToConstant);
+        List<OrcValueReader<?>> readers,
+        TypeDescription record,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant) {
+      super(readers, record, struct, idToConstant, RowDataUtil::convertConstant);
       this.numFields = struct.fields().size();
     }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReader.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReader.java
@@ -70,7 +70,7 @@ public class FlinkOrcReader implements OrcRowReader<RowData> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return FlinkOrcReaders.struct(fields, iStruct, idToConstant);
+      return FlinkOrcReaders.struct(fields, record, iStruct, idToConstant);
     }
 
     @Override

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReaders.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReaders.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
@@ -91,8 +92,11 @@ class FlinkOrcReaders {
   }
 
   public static OrcValueReader<RowData> struct(
-      List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-    return new StructReader(readers, struct, idToConstant);
+      List<OrcValueReader<?>> readers,
+      TypeDescription record,
+      Types.StructType struct,
+      Map<Integer, ?> idToConstant) {
+    return new StructReader(readers, record, struct, idToConstant);
   }
 
   private static class StringReader implements OrcValueReader<StringData> {
@@ -265,8 +269,11 @@ class FlinkOrcReaders {
     private final int numFields;
 
     StructReader(
-        List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-      super(readers, struct, idToConstant);
+        List<OrcValueReader<?>> readers,
+        TypeDescription record,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant) {
+      super(readers, record, struct, idToConstant, RowDataUtil::convertConstant);
       this.numFields = struct.fields().size();
     }
 

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
@@ -76,7 +76,7 @@ public class GenericOrcReader implements OrcRowReader<Record> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return GenericOrcReaders.struct(fields, expected, idToConstant);
+      return GenericOrcReaders.struct(fields, record, expected, idToConstant);
     }
 
     @Override

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -67,6 +67,7 @@ public final class ORCSchemaUtil {
 
   static final String ICEBERG_ID_ATTRIBUTE = "iceberg.id";
   static final String ICEBERG_REQUIRED_ATTRIBUTE = "iceberg.required";
+  static final String ICEBERG_ORIGINAL_MISSING = "iceberg.original-missing";
 
   /**
    * The name of the ORC {@link TypeDescription} attribute indicating the Iceberg type corresponding
@@ -383,19 +384,15 @@ public final class ORCSchemaUtil {
           if (isRequired) {
             Preconditions.checkArgument(
                 field.initialDefault() != null,
-                "Missing required field: %s (%s)",
-                root.findColumnName(fieldId),
-                type);
+                "Missing required field: %s",
+                root.findColumnName(fieldId));
           }
 
-          if (field.initialDefault() != null) {
-            throw new UnsupportedOperationException(
-                String.format(
-                    "ORC cannot read default value for field %s (%s): %s",
-                    root.findColumnName(fieldId), type, field.initialDefault()));
-          }
-
+          // Create the type for the missing attribute
           orcType = convert(fieldId, type, false);
+          if (orcType != null) {
+            orcType.setAttribute(ICEBERG_ORIGINAL_MISSING, "true");
+          }
         }
     }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -77,7 +77,7 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return SparkOrcValueReaders.struct(fields, expected, idToConstant);
+      return SparkOrcValueReaders.struct(fields, record, expected, idToConstant);
     }
 
     @Override

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -26,8 +26,10 @@ import org.apache.iceberg.orc.OrcValueReader;
 import org.apache.iceberg.orc.OrcValueReaders;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
@@ -70,8 +72,11 @@ public class SparkOrcValueReaders {
   }
 
   static OrcValueReader<?> struct(
-      List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-    return new StructReader(readers, struct, idToConstant);
+      List<OrcValueReader<?>> readers,
+      TypeDescription record,
+      Types.StructType struct,
+      Map<Integer, ?> idToConstant) {
+    return new StructReader(readers, record, struct, idToConstant);
   }
 
   static OrcValueReader<?> array(OrcValueReader<?> elementReader) {
@@ -143,8 +148,11 @@ public class SparkOrcValueReaders {
     private final int numFields;
 
     protected StructReader(
-        List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-      super(readers, struct, idToConstant);
+        List<OrcValueReader<?>> readers,
+        TypeDescription record,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant) {
+      super(readers, record, struct, idToConstant, SparkUtil::internalToSpark);
       this.numFields = struct.fields().size();
     }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -77,7 +77,7 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return SparkOrcValueReaders.struct(fields, expected, idToConstant);
+      return SparkOrcValueReaders.struct(fields, record, expected, idToConstant);
     }
 
     @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -26,8 +26,10 @@ import org.apache.iceberg.orc.OrcValueReader;
 import org.apache.iceberg.orc.OrcValueReaders;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
@@ -70,8 +72,11 @@ public class SparkOrcValueReaders {
   }
 
   static OrcValueReader<?> struct(
-      List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-    return new StructReader(readers, struct, idToConstant);
+      List<OrcValueReader<?>> readers,
+      TypeDescription record,
+      Types.StructType struct,
+      Map<Integer, ?> idToConstant) {
+    return new StructReader(readers, record, struct, idToConstant);
   }
 
   static OrcValueReader<?> array(OrcValueReader<?> elementReader) {
@@ -143,8 +148,11 @@ public class SparkOrcValueReaders {
     private final int numFields;
 
     protected StructReader(
-        List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-      super(readers, struct, idToConstant);
+        List<OrcValueReader<?>> readers,
+        TypeDescription record,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant) {
+      super(readers, record, struct, idToConstant, SparkUtil::internalToSpark);
       this.numFields = struct.fields().size();
     }
 


### PR DESCRIPTION
A possible implementation for the ORC initial default values.
2 main changes:
- The Iceberg type (`TypeDescription  record`) is pushed down to the GenericOrcReaders.StructReader
- The ORC type stores an attribute (`.getAttributeValue(ORCSchemaUtil.ICEBERG_ORIGINAL_MISSING)`) to filter out the columns which are needed, but not present in the ORC file

Based on this 2 information the reader could decide on when to use the initial default values.