### PR TITLE
Build: Enforce error message check on Exception assertions

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -93,6 +93,18 @@
         <property name="message" value="assertThatThrownBy() should be statically imported from org.assertj.core.api.Assertions"/>
     </module>
     <module name="RegexpMultiline">
+        <property name="id" value="AssertThatThrownByWithMessageCheck"/>
+        <property name="matchAcrossLines" value="true"/>
+        <property name="format" value="assertThatThrownBy\((?:(?!\.hasMessage\w*\().)*?isInstanceOf\((?:(?!\.hasMessage\w*\().)*?;"/>
+        <property name="message" value="assertThatThrownBy must include a message check like .hasMessageContaining(...)"/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="id" value="AssertThatExceptionOfTypeWithMessageCheck"/>
+        <property name="matchAcrossLines" value="true"/>
+        <property name="format" value="assertThatExceptionOfType\((?:(?!\.withMessage\w*\().)*?isThrownBy\((?:(?!\.withMessage\w*\().)*?;"/>
+        <property name="message" value="assertThatExceptionOfType must include a message check like .withMessageContaining(...)"/>
+    </module>
+    <module name="RegexpMultiline">
         <property name="format" value="^\s*import\s+\Qorg.assertj.core.api.Assertions;\E" />
         <property name="message" value="org.assertj.core.api.Assertions should only be used with static imports" />
     </module>

--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -94,12 +94,14 @@
     </module>
     <module name="RegexpMultiline">
         <property name="id" value="AssertThatThrownByWithMessageCheck"/>
+        <property name="fileExtensions" value="java"/>
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="assertThatThrownBy\((?:(?!\.hasMessage\w*\().)*?isInstanceOf\((?:(?!\.hasMessage\w*\().)*?;"/>
         <property name="message" value="assertThatThrownBy must include a message check like .hasMessageContaining(...)"/>
     </module>
     <module name="RegexpMultiline">
         <property name="id" value="AssertThatExceptionOfTypeWithMessageCheck"/>
+        <property name="fileExtensions" value="java"/>
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="assertThatExceptionOfType\((?:(?!\.withMessage\w*\().)*?isThrownBy\((?:(?!\.withMessage\w*\().)*?;"/>
         <property name="message" value="assertThatExceptionOfType must include a message check like .withMessageContaining(...)"/>

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1172,6 +1172,11 @@ acceptedBreaks:
         \ java.util.function.Consumer<T>)"
       justification: "Removing deprecated code"
   "1.8.0":
+    org.apache.iceberg:iceberg-api:
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.Metrics"
+      new: "class org.apache.iceberg.Metrics"
+      justification: "Java serialization across versions is not guaranteed"
     org.apache.iceberg:iceberg-core:
     - code: "java.method.removed"
       old: "method java.lang.String[] org.apache.iceberg.hadoop.Util::blockLocations(org.apache.iceberg.CombinedScanTask,\

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/TestLocalAliyunOSS.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/TestLocalAliyunOSS.java
@@ -52,6 +52,7 @@ public class TestLocalAliyunOSS {
   private final String bucketName = OSS_TEST_EXTENSION.testBucketName();
   private final Random random = new Random(1);
 
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   private static void assertThrows(Runnable runnable, String expectedErrorCode) {
     assertThatThrownBy(runnable::run)
         .isInstanceOf(OSSException.class)

--- a/api/src/main/java/org/apache/iceberg/Metrics.java
+++ b/api/src/main/java/org/apache/iceberg/Metrics.java
@@ -40,6 +40,10 @@ public class Metrics implements Serializable {
 
   public Metrics() {}
 
+  public Metrics(long rowCount) {
+    this.rowCount = rowCount;
+  }
+
   public Metrics(
       Long rowCount,
       Map<Integer, Long> columnSizes,

--- a/api/src/main/java/org/apache/iceberg/util/BinaryUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BinaryUtil.java
@@ -77,13 +77,29 @@ public class BinaryUtil {
   }
 
   /**
+   * Returns a byte buffer whose length is lesser than or equal to truncateLength and is lower than
+   * the given input
+   */
+  public static ByteBuffer truncateBinaryMin(ByteBuffer input, int length) {
+    return truncateBinary(input, length);
+  }
+
+  /**
    * Returns a byte buffer whose length is lesser than or equal to truncateLength and is greater
    * than the given input
    */
   public static Literal<ByteBuffer> truncateBinaryMax(Literal<ByteBuffer> input, int length) {
-    ByteBuffer inputBuffer = input.value();
+    ByteBuffer truncated = truncateBinaryMax(input.value(), length);
+    return truncated != null ? Literal.of(truncated) : null;
+  }
+
+  /**
+   * Returns a byte buffer whose length is lesser than or equal to truncateLength and is greater
+   * than the given input
+   */
+  public static ByteBuffer truncateBinaryMax(ByteBuffer inputBuffer, int length) {
     if (length >= inputBuffer.remaining()) {
-      return input;
+      return inputBuffer;
     }
 
     // Truncate the input to the specified truncate length.
@@ -99,7 +115,7 @@ public class BinaryUtil {
         // Return a byte buffer whose position is zero and limit is i + 1
         truncatedInput.position(0);
         truncatedInput.limit(i + 1);
-        return Literal.of(truncatedInput);
+        return truncatedInput;
       }
     }
     return null; // Cannot find a valid upper bound

--- a/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
@@ -65,17 +65,38 @@ public class UnicodeUtil {
   }
 
   /**
+   * Returns a valid String that is lower than the given input such that the number of unicode
+   * characters in the truncated String is lesser than or equal to length
+   */
+  public static String truncateStringMin(String input, int length) {
+    return truncateString(input, length).toString();
+  }
+
+  /**
    * Returns a valid unicode charsequence that is greater than the given input such that the number
    * of unicode characters in the truncated charSequence is lesser than or equal to length
    */
   public static Literal<CharSequence> truncateStringMax(Literal<CharSequence> input, int length) {
-    CharSequence inputCharSeq = input.value();
+    CharSequence truncated = internalTruncateMax(input.value(), length);
+    return truncated != null ? Literal.of(truncated) : null;
+  }
+
+  /**
+   * Returns a valid String that is greater than the given input such that the number of unicode
+   * characters in the truncated String is lesser than or equal to length
+   */
+  public static String truncateStringMax(String input, int length) {
+    CharSequence truncated = internalTruncateMax(input, length);
+    return truncated != null ? truncated.toString() : null;
+  }
+
+  private static CharSequence internalTruncateMax(CharSequence inputCharSeq, int length) {
     // Truncate the input to the specified truncate length.
     StringBuilder truncatedStringBuilder = new StringBuilder(truncateString(inputCharSeq, length));
 
     // No need to increment if the input length is under the truncate length
     if (inputCharSeq.length() == truncatedStringBuilder.length()) {
-      return input;
+      return inputCharSeq;
     }
 
     // Try incrementing the code points from the end
@@ -88,7 +109,7 @@ public class UnicodeUtil {
         truncatedStringBuilder.setLength(offsetByCodePoint);
         // Append next code point to the truncated substring
         truncatedStringBuilder.appendCodePoint(nextCodePoint);
-        return Literal.of(truncatedStringBuilder.toString());
+        return truncatedStringBuilder.toString();
       }
     }
     return null; // Cannot find a valid upper bound

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedObject.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedObject.java
@@ -224,6 +224,16 @@ class SerializedObject implements VariantObject, SerializedValue {
   }
 
   @Override
+  public int hashCode() {
+    return VariantObject.hash(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return VariantObject.equals(this, obj);
+  }
+
+  @Override
   public String toString() {
     return VariantObject.asString(this);
   }

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedPrimitive.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedPrimitive.java
@@ -129,6 +129,16 @@ class SerializedPrimitive implements VariantPrimitive<Object>, SerializedValue {
   }
 
   @Override
+  public int hashCode() {
+    return VariantPrimitive.hash(this);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return VariantPrimitive.equals(this, other);
+  }
+
+  @Override
   public String toString() {
     return VariantPrimitive.asString(this);
   }

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedShortString.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedShortString.java
@@ -68,6 +68,16 @@ class SerializedShortString implements VariantPrimitive<String>, SerializedValue
   }
 
   @Override
+  public int hashCode() {
+    return VariantPrimitive.hash(this);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return VariantPrimitive.equals(this, other);
+  }
+
+  @Override
   public String toString() {
     return VariantPrimitive.asString(this);
   }

--- a/api/src/main/java/org/apache/iceberg/variants/VariantObject.java
+++ b/api/src/main/java/org/apache/iceberg/variants/VariantObject.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.variants;
 
+import java.util.Objects;
+
 /** An variant object value. */
 public interface VariantObject extends VariantValue {
   /** Returns the {@link VariantValue} for the field named {@code name} in this object. */
@@ -56,5 +58,38 @@ public interface VariantObject extends VariantValue {
     builder.append("})");
 
     return builder.toString();
+  }
+
+  static int hash(VariantObject self) {
+    int hash = 17;
+    for (String field : self.fieldNames()) {
+      hash = 59 * hash + field.hashCode();
+      hash = 59 * hash + self.get(field).hashCode();
+    }
+
+    return hash;
+  }
+
+  static boolean equals(VariantObject self, Object obj) {
+    if (self == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof VariantObject)) {
+      return false;
+    }
+
+    VariantObject other = (VariantObject) obj;
+    if (self.numFields() != other.numFields()) {
+      return false;
+    }
+
+    for (String field : self.fieldNames()) {
+      if (!Objects.equals(self.get(field), other.get(field))) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/api/src/main/java/org/apache/iceberg/variants/VariantPrimitive.java
+++ b/api/src/main/java/org/apache/iceberg/variants/VariantPrimitive.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.variants;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.DateTimeUtil;
@@ -49,5 +50,22 @@ public interface VariantPrimitive<T> extends VariantValue {
 
   static String asString(VariantPrimitive<?> primitive) {
     return "Variant(type=" + primitive.type() + ", value=" + primitive.valueAsString() + ")";
+  }
+
+  static int hash(VariantPrimitive<?> self) {
+    return Objects.hash(self.type(), self.get());
+  }
+
+  static boolean equals(VariantPrimitive<?> self, Object obj) {
+    if (self == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof VariantPrimitive)) {
+      return false;
+    }
+
+    VariantPrimitive<?> other = (VariantPrimitive<?>) obj;
+    return Objects.equals(self.type(), other.type()) && Objects.equals(self.get(), other.get());
   }
 }

--- a/api/src/main/java/org/apache/iceberg/variants/VariantUtil.java
+++ b/api/src/main/java/org/apache/iceberg/variants/VariantUtil.java
@@ -164,6 +164,10 @@ class VariantUtil {
     }
   }
 
+  static byte metadataHeader(boolean isSorted, int offsetSize) {
+    return (byte) (((offsetSize - 1) << 6) | (isSorted ? 0b10000 : 0) | 0b0001);
+  }
+
   static byte primitiveHeader(int primitiveType) {
     return (byte) (primitiveType << Primitives.PRIMITIVE_TYPE_SHIFT);
   }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
@@ -381,7 +381,8 @@ public class TestExpressionBinding {
   @FieldSource("UNSUPPORTED_PATHS")
   public void testExtractBindingWithInvalidPath(String path) {
     assertThatThrownBy(() -> Binder.bind(STRUCT, lessThan(extract("var", path, "long"), 100)))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageMatching("(Unsupported|Invalid) path.*");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/expressions/TestPathParsing.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestPathParsing.java
@@ -66,6 +66,8 @@ public class TestPathParsing {
   @ParameterizedTest
   @FieldSource("INVALID_PATHS")
   public void testExtractBindingWithInvalidPath(String path) {
-    assertThatThrownBy(() -> PathUtil.parse(path)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> PathUtil.parse(path))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageMatching("(Unsupported|Invalid) path.*");
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestTimestampLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestTimestampLiteralConversions.java
@@ -165,12 +165,14 @@ public class TestTimestampLiteralConversions {
 
     assertThatThrownBy(() -> isoTimestampNanosWithZoneOffset.to(Types.TimestampType.withoutZone()))
         .as("Should not convert timestamp with offset to a timestamp without zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThatThrownBy(
             () -> isoTimestampNanosWithZoneOffset.to(Types.TimestampNanoType.withoutZone()))
         .as("Should not convert timestamp with offset to a timestamp without zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThat(isoTimestampNanosWithZoneOffset.to(Types.TimestampType.withZone()).value())
         .isEqualTo(1510842668000000L);
@@ -186,12 +188,14 @@ public class TestTimestampLiteralConversions {
 
     assertThatThrownBy(() -> isoTimestampMicrosWithZoneOffset.to(Types.TimestampType.withoutZone()))
         .as("Should not convert timestamp with offset to a timestamp without zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThatThrownBy(
             () -> isoTimestampMicrosWithZoneOffset.to(Types.TimestampNanoType.withoutZone()))
         .as("Should not convert timestamp with offset to a timestamp without zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThat(isoTimestampMicrosWithZoneOffset.to(Types.TimestampType.withZone()).value())
         .isEqualTo(1510842668000001L);
@@ -207,12 +211,14 @@ public class TestTimestampLiteralConversions {
 
     assertThatThrownBy(() -> isoTimestampNanosWithoutZoneOffset.to(Types.TimestampType.withZone()))
         .as("Should not convert timestamp without offset to a timestamp with zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThatThrownBy(
             () -> isoTimestampNanosWithoutZoneOffset.to(Types.TimestampNanoType.withZone()))
         .as("Should not convert timestamp without offset to a timestamp with zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThat(isoTimestampNanosWithoutZoneOffset.to(Types.TimestampType.withoutZone()).value())
         .isEqualTo(1510842668000000L);
@@ -228,12 +234,14 @@ public class TestTimestampLiteralConversions {
 
     assertThatThrownBy(() -> isoTimestampMicrosWithoutZoneOffset.to(Types.TimestampType.withZone()))
         .as("Should not convert timestamp without offset to a timestamp with zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThatThrownBy(
             () -> isoTimestampMicrosWithoutZoneOffset.to(Types.TimestampNanoType.withZone()))
         .as("Should not convert timestamp without offset to a timestamp with zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThat(isoTimestampMicrosWithoutZoneOffset.to(Types.TimestampType.withoutZone()).value())
         .isEqualTo(1510842668000001L);

--- a/api/src/test/java/org/apache/iceberg/io/TestCloseableGroup.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestCloseableGroup.java
@@ -92,7 +92,9 @@ public class TestCloseableGroup {
     closeableGroup.addCloseable(closeable2);
     closeableGroup.addCloseable(closeable3);
 
-    assertThatThrownBy(closeableGroup::close).isEqualTo(ioException);
+    assertThatThrownBy(closeableGroup::close)
+        .hasMessage(ioException.getMessage())
+        .isEqualTo(ioException);
     Mockito.verify(closeable1).close();
     Mockito.verify(closeable2).close();
     Mockito.verifyNoInteractions(closeable3);
@@ -112,7 +114,9 @@ public class TestCloseableGroup {
     closeableGroup.addCloseable(closeable2);
     closeableGroup.addCloseable(closeable3);
 
-    assertThatThrownBy(closeableGroup::close).isEqualTo(ioException);
+    assertThatThrownBy(closeableGroup::close)
+        .hasMessage(ioException.getMessage())
+        .isEqualTo(ioException);
     Mockito.verify(closeable1).close();
     Mockito.verify(closeable2).close();
     Mockito.verifyNoInteractions(closeable3);
@@ -129,6 +133,7 @@ public class TestCloseableGroup {
 
     assertThatThrownBy(closeableGroup::close)
         .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining(generalException.getMessage())
         .hasRootCause(generalException);
   }
 

--- a/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
@@ -92,7 +92,9 @@ public class TestCloseableIterable {
     CloseableIterable<Integer> concat5 =
         CloseableIterable.concat(Lists.newArrayList(empty, empty, empty));
 
-    assertThatThrownBy(() -> Iterables.getLast(concat5)).isInstanceOf(NoSuchElementException.class);
+    assertThatThrownBy(() -> Iterables.getLast(concat5))
+        .isInstanceOf(NoSuchElementException.class)
+        .hasMessage(null);
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
@@ -52,6 +52,7 @@ public class TestExceptionUtil {
                     },
                     CustomCheckedException.class))
         .isInstanceOf(CustomCheckedException.class)
+        .hasMessage(exc.getMessage())
         .isEqualTo(exc)
         .extracting(e -> Arrays.asList(e.getSuppressed()))
         .asInstanceOf(InstanceOfAssertFactories.LIST)
@@ -81,6 +82,7 @@ public class TestExceptionUtil {
                     CustomCheckedException.class,
                     IOException.class))
         .isInstanceOf(CustomCheckedException.class)
+        .hasMessage(exc.getMessage())
         .isEqualTo(exc)
         .extracting(e -> Arrays.asList(e.getSuppressed()))
         .asInstanceOf(InstanceOfAssertFactories.LIST)
@@ -111,6 +113,7 @@ public class TestExceptionUtil {
                     IOException.class,
                     ClassNotFoundException.class))
         .isInstanceOf(CustomCheckedException.class)
+        .hasMessage(exc.getMessage())
         .isEqualTo(exc)
         .extracting(e -> Arrays.asList(e.getSuppressed()))
         .asInstanceOf(InstanceOfAssertFactories.LIST)
@@ -136,6 +139,7 @@ public class TestExceptionUtil {
                       throw suppressedTwo;
                     }))
         .isInstanceOf(RuntimeException.class)
+        .hasMessage(exc.getMessage())
         .isEqualTo(exc)
         .extracting(e -> Arrays.asList(e.getSuppressed()))
         .asInstanceOf(InstanceOfAssertFactories.LIST)

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedMetadata.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedMetadata.java
@@ -39,7 +39,9 @@ public class TestSerializedMetadata {
 
     assertThat(metadata.isSorted()).isFalse();
     assertThat(metadata.dictionarySize()).isEqualTo(0);
-    assertThatThrownBy(() -> metadata.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> metadata.get(0))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test
@@ -109,7 +111,9 @@ public class TestSerializedMetadata {
     assertThat(metadata.get(2)).isEqualTo("c");
     assertThat(metadata.get(3)).isEqualTo("d");
     assertThat(metadata.get(4)).isEqualTo("e");
-    assertThatThrownBy(() -> metadata.get(5)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> metadata.get(5))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test
@@ -125,7 +129,9 @@ public class TestSerializedMetadata {
     assertThat(metadata.get(2)).isEqualTo("xyz");
     assertThat(metadata.get(3)).isEqualTo("d");
     assertThat(metadata.get(4)).isEqualTo("e");
-    assertThatThrownBy(() -> metadata.get(5)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> metadata.get(5))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test
@@ -142,7 +148,9 @@ public class TestSerializedMetadata {
     assertThat(metadata.get(2)).isEqualTo("xyz");
     assertThat(metadata.get(3)).isEqualTo("d");
     assertThat(metadata.get(4)).isEqualTo("e");
-    assertThatThrownBy(() -> metadata.get(5)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> metadata.get(5))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test
@@ -229,7 +237,8 @@ public class TestSerializedMetadata {
   @Test
   public void testMissingLength() {
     assertThatThrownBy(() -> SerializedMetadata.from(new byte[] {0x01}))
-        .isInstanceOf(IndexOutOfBoundsException.class);
+        .isInstanceOf(IndexOutOfBoundsException.class)
+        .hasMessage(null);
   }
 
   @Test
@@ -237,6 +246,7 @@ public class TestSerializedMetadata {
     // missing the 4th length byte
     assertThatThrownBy(
             () -> SerializedMetadata.from(new byte[] {(byte) 0b11010001, 0x00, 0x00, 0x00}))
-        .isInstanceOf(IndexOutOfBoundsException.class);
+        .isInstanceOf(IndexOutOfBoundsException.class)
+        .hasMessage(null);
   }
 }

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedMetadata.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedMetadata.java
@@ -235,18 +235,20 @@ public class TestSerializedMetadata {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testMissingLength() {
+    // no check on the underlying error msg as it might be missing based on the JDK version
     assertThatThrownBy(() -> SerializedMetadata.from(new byte[] {0x01}))
-        .isInstanceOf(IndexOutOfBoundsException.class)
-        .hasMessage(null);
+        .isInstanceOf(IndexOutOfBoundsException.class);
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testLengthTooShort() {
     // missing the 4th length byte
+    // no check on the underlying error msg as it might be missing based on the JDK version
     assertThatThrownBy(
             () -> SerializedMetadata.from(new byte[] {(byte) 0b11010001, 0x00, 0x00, 0x00}))
-        .isInstanceOf(IndexOutOfBoundsException.class)
-        .hasMessage(null);
+        .isInstanceOf(IndexOutOfBoundsException.class);
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
@@ -136,7 +136,7 @@ public class TestAssumeRoleAwsClientFactory {
                 glueCatalog.createNamespace(
                     Namespace.of("denied_" + UUID.randomUUID().toString().replace("-", ""))))
         .isInstanceOf(AccessDeniedException.class)
-        .hasMessageContaining("Access denied");
+        .hasMessageContaining("not authorized to perform: glue:CreateDatabase");
 
     Namespace namespace = Namespace.of("allowed_" + UUID.randomUUID().toString().replace("-", ""));
     try {
@@ -181,7 +181,7 @@ public class TestAssumeRoleAwsClientFactory {
                     .newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/denied/file")
                     .exists())
         .isInstanceOf(S3Exception.class)
-        .hasMessageContaining("s3 exception")
+        .hasMessageContaining("Forbidden")
         .asInstanceOf(InstanceOfAssertFactories.type(S3Exception.class))
         .extracting(SdkServiceException::statusCode)
         .isEqualTo(403);

--- a/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
@@ -135,7 +135,8 @@ public class TestAssumeRoleAwsClientFactory {
             () ->
                 glueCatalog.createNamespace(
                     Namespace.of("denied_" + UUID.randomUUID().toString().replace("-", ""))))
-        .isInstanceOf(AccessDeniedException.class);
+        .isInstanceOf(AccessDeniedException.class)
+        .hasMessageContaining("Access denied");
 
     Namespace namespace = Namespace.of("allowed_" + UUID.randomUUID().toString().replace("-", ""));
     try {
@@ -180,6 +181,7 @@ public class TestAssumeRoleAwsClientFactory {
                     .newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/denied/file")
                     .exists())
         .isInstanceOf(S3Exception.class)
+        .hasMessageContaining("s3 exception")
         .asInstanceOf(InstanceOfAssertFactories.type(S3Exception.class))
         .extracting(SdkServiceException::statusCode)
         .isEqualTo(403);

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -713,7 +713,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
     Table table = glueCatalog.loadTable(identifier);
     String metadataLocation = ((BaseTable) table).operations().current().metadataFileLocation();
     assertThatThrownBy(() -> glueCatalog.registerTable(identifier, metadataLocation))
-        .isInstanceOf(AlreadyExistsException.class);
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("Already exists");
     assertThat(glueCatalog.dropTable(identifier, true)).isTrue();
     assertThat(glueCatalog.dropNamespace(Namespace.of(namespace))).isTrue();
   }

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -714,7 +714,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
     String metadataLocation = ((BaseTable) table).operations().current().metadataFileLocation();
     assertThatThrownBy(() -> glueCatalog.registerTable(identifier, metadataLocation))
         .isInstanceOf(AlreadyExistsException.class)
-        .hasMessageContaining("Already exists");
+        .hasMessageContaining("Table already exists");
     assertThat(glueCatalog.dropTable(identifier, true)).isTrue();
     assertThat(glueCatalog.dropNamespace(Namespace.of(namespace))).isTrue();
   }

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
@@ -152,7 +152,7 @@ public class TestLakeFormationAwsClientFactory {
     try {
       assertThatThrownBy(() -> glueCatalog.createNamespace(deniedNamespace))
           .isInstanceOf(AccessDeniedException.class)
-          .hasMessageContaining("Access denied");
+          .hasMessageContaining("not authorized to perform: glue:CreateDatabase");
     } catch (AssertionError e) {
       glueCatalog.dropNamespace(deniedNamespace);
       throw e;

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
@@ -151,7 +151,8 @@ public class TestLakeFormationAwsClientFactory {
         Namespace.of("denied_" + UUID.randomUUID().toString().replace("-", ""));
     try {
       assertThatThrownBy(() -> glueCatalog.createNamespace(deniedNamespace))
-          .isInstanceOf(AccessDeniedException.class);
+          .isInstanceOf(AccessDeniedException.class)
+          .hasMessageContaining("Access denied");
     } catch (AssertionError e) {
       glueCatalog.dropNamespace(deniedNamespace);
       throw e;

--- a/core/src/main/java/org/apache/iceberg/FieldMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/FieldMetrics.java
@@ -27,6 +27,18 @@ public class FieldMetrics<T> {
   private final T lowerBound;
   private final T upperBound;
 
+  public FieldMetrics(int id, long valueCount, long nullValueCount) {
+    this(id, valueCount, nullValueCount, -1L, null, null);
+  }
+
+  public FieldMetrics(int id, long valueCount, long nullValueCount, T lowerBound, T upperBound) {
+    this(id, valueCount, nullValueCount, -1L, lowerBound, upperBound);
+  }
+
+  public FieldMetrics(int id, long valueCount, long nullValueCount, long nanValueCount) {
+    this(id, valueCount, nullValueCount, nanValueCount, null, null);
+  }
+
   public FieldMetrics(
       int id,
       long valueCount,

--- a/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
@@ -22,8 +22,10 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
@@ -31,6 +33,14 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("checkstyle:VisibilityModifier")
 abstract class FileCleanupStrategy {
+  private final Consumer<String> defaultDeleteFunc =
+      new Consumer<>() {
+        @Override
+        public void accept(String file) {
+          fileIO.deleteFile(file);
+        }
+      };
+
   private static final Logger LOG = LoggerFactory.getLogger(FileCleanupStrategy.class);
 
   protected final FileIO fileIO;
@@ -74,14 +84,32 @@ abstract class FileCleanupStrategy {
   }
 
   protected void deleteFiles(Set<String> pathsToDelete, String fileType) {
-    Tasks.foreach(pathsToDelete)
-        .executeWith(deleteExecutorService)
-        .retry(3)
-        .stopRetryOn(NotFoundException.class)
-        .suppressFailureWhenFinished()
-        .onFailure(
-            (file, thrown) -> LOG.warn("Delete failed for {} file: {}", fileType, file, thrown))
-        .run(deleteFunc::accept);
+    if (deleteFunc == null && fileIO instanceof SupportsBulkOperations) {
+      try {
+        ((SupportsBulkOperations) fileIO).deleteFiles(pathsToDelete);
+      } catch (BulkDeletionFailureException e) {
+        LOG.warn(
+            "Bulk deletion failed for {} of {} {} file(s)",
+            e.numberFailedObjects(),
+            pathsToDelete.size(),
+            fileType,
+            e);
+      } catch (RuntimeException e) {
+        LOG.warn("Bulk deletion failed", e);
+      }
+    } else {
+      Consumer<String> deleteFuncToUse = deleteFunc == null ? defaultDeleteFunc : deleteFunc;
+
+      Tasks.foreach(pathsToDelete)
+          .executeWith(deleteExecutorService)
+          .retry(3)
+          .stopRetryOn(NotFoundException.class)
+          .stopOnFailure()
+          .suppressFailureWhenFinished()
+          .onFailure(
+              (file, thrown) -> LOG.warn("Delete failed for {} file: {}", fileType, file, thrown))
+          .run(deleteFuncToUse::accept);
+    }
   }
 
   protected boolean hasAnyStatisticsFiles(TableMetadata tableMetadata) {

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -65,14 +65,6 @@ class RemoveSnapshots implements ExpireSnapshots {
   private static final ExecutorService DEFAULT_DELETE_EXECUTOR_SERVICE =
       MoreExecutors.newDirectExecutorService();
 
-  private final Consumer<String> defaultDelete =
-      new Consumer<String>() {
-        @Override
-        public void accept(String file) {
-          ops.io().deleteFile(file);
-        }
-      };
-
   private final TableOperations ops;
   private final Set<Long> idsToRemove = Sets.newHashSet();
   private final long now;
@@ -81,7 +73,7 @@ class RemoveSnapshots implements ExpireSnapshots {
   private TableMetadata base;
   private long defaultExpireOlderThan;
   private int defaultMinNumSnapshots;
-  private Consumer<String> deleteFunc = defaultDelete;
+  private Consumer<String> deleteFunc = null;
   private ExecutorService deleteExecutorService = DEFAULT_DELETE_EXECUTOR_SERVICE;
   private ExecutorService planExecutorService = ThreadPools.getWorkerPool();
   private Boolean incrementalCleanup;

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -626,7 +626,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
       client
           .withAuthSession(contextualSession)
-          .delete(paths.namespace(ns), null, Map.of(), ErrorHandlers.namespaceErrorHandler());
+          .delete(paths.namespace(ns), null, Map.of(), ErrorHandlers.dropNamespaceErrorHandler());
       return true;
     } catch (NoSuchNamespaceException e) {
       return false;

--- a/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
@@ -210,6 +210,16 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
   }
 
   @Override
+  public int hashCode() {
+    return VariantPrimitive.hash(this);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return VariantPrimitive.equals(this, other);
+  }
+
+  @Override
   public String toString() {
     return VariantPrimitive.asString(this);
   }

--- a/core/src/main/java/org/apache/iceberg/variants/Variants.java
+++ b/core/src/main/java/org/apache/iceberg/variants/Variants.java
@@ -20,6 +20,10 @@ package org.apache.iceberg.variants;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
 import org.apache.iceberg.util.DateTimeUtil;
 
 public class Variants {
@@ -31,6 +35,63 @@ public class Variants {
 
   public static VariantMetadata metadata(ByteBuffer metadata) {
     return SerializedMetadata.from(metadata);
+  }
+
+  public static VariantMetadata metadata(String... fieldNames) {
+    return metadata(Arrays.asList(fieldNames));
+  }
+
+  public static VariantMetadata metadata(Collection<String> fieldNames) {
+    if (fieldNames.isEmpty()) {
+      return emptyMetadata();
+    }
+
+    int numElements = fieldNames.size();
+    ByteBuffer[] nameBuffers = new ByteBuffer[numElements];
+    boolean sorted = true;
+    String last = null;
+    int pos = 0;
+    int dataSize = 0;
+    for (String name : fieldNames) {
+      nameBuffers[pos] = ByteBuffer.wrap(name.getBytes(StandardCharsets.UTF_8));
+      dataSize += nameBuffers[pos].remaining();
+      if (last != null && last.compareTo(name) >= 0) {
+        sorted = false;
+      }
+
+      last = name;
+      pos += 1;
+    }
+
+    int offsetSize = VariantUtil.sizeOf(dataSize);
+    int offsetListOffset = 1 /* header size */ + offsetSize /* dictionary size */;
+    int dataOffset = offsetListOffset + ((1 + numElements) * offsetSize);
+    int totalSize = dataOffset + dataSize;
+
+    byte header = VariantUtil.metadataHeader(sorted, offsetSize);
+    ByteBuffer buffer = ByteBuffer.allocate(totalSize).order(ByteOrder.LITTLE_ENDIAN);
+
+    buffer.put(0, header);
+    VariantUtil.writeLittleEndianUnsigned(buffer, numElements, 1, offsetSize);
+
+    // write offsets and strings
+    int nextOffset = 0;
+    int index = 0;
+    for (ByteBuffer nameBuffer : nameBuffers) {
+      // write the offset and the string
+      VariantUtil.writeLittleEndianUnsigned(
+          buffer, nextOffset, offsetListOffset + (index * offsetSize), offsetSize);
+      int nameSize = VariantUtil.writeBufferAbsolute(buffer, dataOffset + nextOffset, nameBuffer);
+      // update the offset and index
+      nextOffset += nameSize;
+      index += 1;
+    }
+
+    // write the final size of the data section
+    VariantUtil.writeLittleEndianUnsigned(
+        buffer, nextOffset, offsetListOffset + (index * offsetSize), offsetSize);
+
+    return SerializedMetadata.from(buffer);
   }
 
   public static VariantValue value(VariantMetadata metadata, ByteBuffer value) {
@@ -53,6 +114,10 @@ public class Variants {
     }
 
     throw new UnsupportedOperationException("Metadata is required for object: " + object);
+  }
+
+  public static boolean isNull(ByteBuffer valueBuffer) {
+    return VariantUtil.readByte(valueBuffer, 0) == 0;
   }
 
   public static <T> VariantPrimitive<T> of(PhysicalType type, T value) {

--- a/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
@@ -591,7 +591,9 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(group.filter(5)).isEqualTo(new DeleteFile[] {});
 
     // it should not be possible to add more elements upon indexing
-    assertThatThrownBy(() -> group.add(file1)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> group.add(file1))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Can't add files upon indexing");
   }
 
   @TestTemplate
@@ -625,7 +627,9 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(group.filter(4, FILE_A)).isEqualTo(new DeleteFile[] {});
 
     // it should not be possible to add more elements upon indexing
-    assertThatThrownBy(() -> group.add(SPEC, file1)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> group.add(SPEC, file1))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Can't add files upon indexing");
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestClientPoolImpl.java
+++ b/core/src/test/java/org/apache/iceberg/TestClientPoolImpl.java
@@ -52,7 +52,8 @@ public class TestClientPoolImpl {
         new MockClientPoolImpl(2, RetryableException.class, true, maxRetries)) {
       assertThatThrownBy(
               () -> mockClientPool.run(client -> client.succeedAfter(succeedAfterAttempts)))
-          .isInstanceOf(RetryableException.class);
+          .isInstanceOf(RetryableException.class)
+          .hasMessage(null);
       assertThat(mockClientPool.reconnectionAttempts()).isEqualTo(maxRetries);
     }
   }
@@ -62,7 +63,8 @@ public class TestClientPoolImpl {
     try (MockClientPoolImpl mockClientPool =
         new MockClientPoolImpl(2, RetryableException.class, true, 3)) {
       assertThatThrownBy(() -> mockClientPool.run(MockClient::failWithNonRetryable, true))
-          .isInstanceOf(NonRetryableException.class);
+          .isInstanceOf(NonRetryableException.class)
+          .hasMessage(null);
       assertThat(mockClientPool.reconnectionAttempts()).isEqualTo(0);
     }
   }
@@ -72,7 +74,8 @@ public class TestClientPoolImpl {
     try (MockClientPoolImpl mockClientPool =
         new MockClientPoolImpl(2, RetryableException.class, false, 3)) {
       assertThatThrownBy(() -> mockClientPool.run(client -> client.succeedAfter(3)))
-          .isInstanceOf(RetryableException.class);
+          .isInstanceOf(RetryableException.class)
+          .hasMessage(null);
       assertThat(mockClientPool.reconnectionAttempts()).isEqualTo(0);
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
@@ -273,10 +273,10 @@ public class TestManifestReaderStats extends TestBase {
         .isEqualTo(FILE_PATH); // always select file path in all test cases
   }
 
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   private void assertNullRecordCount(DataFile dataFile) {
     // record count is a primitive type, accessing null record count will throw NPE
-    assertThatThrownBy(dataFile::recordCount)
-        .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("\"this.recordCount\" is null");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(dataFile::recordCount).isInstanceOf(NullPointerException.class);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
@@ -221,32 +221,38 @@ public class TestManifestReaderStats extends TestBase {
 
     if (dataFile.valueCounts() != null) {
       assertThatThrownBy(() -> dataFile.valueCounts().clear(), "Should not be modifiable")
-          .isInstanceOf(UnsupportedOperationException.class);
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(null);
     }
 
     if (dataFile.nullValueCounts() != null) {
       assertThatThrownBy(() -> dataFile.nullValueCounts().clear(), "Should not be modifiable")
-          .isInstanceOf(UnsupportedOperationException.class);
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(null);
     }
 
     if (dataFile.nanValueCounts() != null) {
       assertThatThrownBy(() -> dataFile.nanValueCounts().clear(), "Should not be modifiable")
-          .isInstanceOf(UnsupportedOperationException.class);
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(null);
     }
 
     if (dataFile.upperBounds() != null) {
       assertThatThrownBy(() -> dataFile.upperBounds().clear(), "Should not be modifiable")
-          .isInstanceOf(UnsupportedOperationException.class);
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(null);
     }
 
     if (dataFile.lowerBounds() != null) {
       assertThatThrownBy(() -> dataFile.lowerBounds().clear(), "Should not be modifiable")
-          .isInstanceOf(UnsupportedOperationException.class);
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(null);
     }
 
     if (dataFile.columnSizes() != null) {
       assertThatThrownBy(() -> dataFile.columnSizes().clear(), "Should not be modifiable")
-          .isInstanceOf(UnsupportedOperationException.class);
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(null);
     }
 
     assertThat(dataFile.location())
@@ -269,6 +275,8 @@ public class TestManifestReaderStats extends TestBase {
 
   private void assertNullRecordCount(DataFile dataFile) {
     // record count is a primitive type, accessing null record count will throw NPE
-    assertThatThrownBy(dataFile::recordCount).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(dataFile::recordCount)
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("\"this.recordCount\" is null");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -355,17 +355,10 @@ public abstract class TestMetrics {
 
     Metrics metrics = getMetrics(schema, record);
     assertThat(metrics.recordCount()).isEqualTo(1L);
-    if (fileFormat() != FileFormat.ORC) {
-      assertCounts(1, 1L, 0L, metrics);
-      assertCounts(2, 1L, 0L, metrics);
-      assertCounts(4, 3L, 0L, metrics);
-      assertCounts(6, 1L, 0L, metrics);
-    } else {
-      assertCounts(1, null, null, metrics);
-      assertCounts(2, null, null, metrics);
-      assertCounts(4, null, null, metrics);
-      assertCounts(6, null, null, metrics);
-    }
+    assertCounts(1, null, null, metrics);
+    assertCounts(2, null, null, metrics);
+    assertCounts(4, null, null, metrics);
+    assertCounts(6, null, null, metrics);
     assertBounds(1, IntegerType.get(), null, null, metrics);
     assertBounds(2, StringType.get(), null, null, metrics);
     assertBounds(4, IntegerType.get(), null, null, metrics);

--- a/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
@@ -133,6 +133,7 @@ public abstract class TestReadProjection {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testEmptyProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -147,9 +148,8 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("out of bounds");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
@@ -147,7 +147,9 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> projected.get(0))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -381,7 +381,8 @@ public class TestHadoopCommits extends HadoopTableTestBase {
     // inject the mockFS into the TableOperations
     doReturn(mockFs).when(spyOps).getFileSystem(any(), any());
     assertThatThrownBy(() -> spyOps.commit(tops.current(), meta1))
-        .isInstanceOf(CommitFailedException.class);
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("Cannot commit changes based on stale table metadata");
 
     // Verifies that there is no temporary metadata.json files left on rename failures.
     Set<String> actual =

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
@@ -57,14 +57,16 @@ public class TestInMemoryFileIO {
   public void testNewInputFileNotFound() {
     InMemoryFileIO fileIO = new InMemoryFileIO();
     assertThatExceptionOfType(NotFoundException.class)
-        .isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file"));
+        .isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file"))
+        .withMessageContaining("No in-memory file found");
   }
 
   @Test
   public void testDeleteFileNotFound() {
     InMemoryFileIO fileIO = new InMemoryFileIO();
     assertThatExceptionOfType(NotFoundException.class)
-        .isThrownBy(() -> fileIO.deleteFile("s3://nonexistent/file"));
+        .isThrownBy(() -> fileIO.deleteFile("s3://nonexistent/file"))
+        .withMessageContaining("No in-memory file found");
   }
 
   @Test
@@ -73,7 +75,8 @@ public class TestInMemoryFileIO {
     InMemoryFileIO fileIO = new InMemoryFileIO();
     fileIO.addFile(location, "hello world".getBytes());
     assertThatExceptionOfType(AlreadyExistsException.class)
-        .isThrownBy(() -> fileIO.newOutputFile(location).create());
+        .isThrownBy(() -> fileIO.newOutputFile(location).create())
+        .withMessage("Already exists");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -84,7 +84,7 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
       ImmutableMap.<Class<? extends Exception>, Integer>builder()
           .put(IllegalArgumentException.class, 400)
           .put(ValidationException.class, 400)
-          .put(NamespaceNotEmptyException.class, 400) // TODO: should this be more specific?
+          .put(NamespaceNotEmptyException.class, 409)
           .put(NotAuthorizedException.class, 401)
           .put(ForbiddenException.class, 403)
           .put(NoSuchNamespaceException.class, 404)

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -2273,7 +2273,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         .when(adapter)
         .execute(reqMatcher(HTTPMethod.POST), any(), any(), any());
     assertThatThrownBy(() -> catalog.loadTable(TABLE).newFastAppend().appendFile(file).commit())
-        .isInstanceOf(NotAuthorizedException.class);
+        .isInstanceOf(NotAuthorizedException.class)
+        .hasMessage("not authorized");
 
     // Extract the UpdateTableRequest to determine the path of the manifest list that should be
     // cleaned up
@@ -2288,7 +2289,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                   (MetadataUpdate.AddSnapshot) body.updates().get(0);
               assertThatThrownBy(
                       () -> table.io().newInputFile(addSnapshot.snapshot().manifestListLocation()))
-                  .isInstanceOf(NotFoundException.class);
+                  .isInstanceOf(NotFoundException.class)
+                  .hasMessageContaining("No in-memory file found");
             });
   }
 
@@ -2308,7 +2310,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         .when(adapter)
         .execute(reqMatcher(HTTPMethod.POST), any(), any(), any());
     assertThatThrownBy(() -> catalog.loadTable(TABLE).newFastAppend().appendFile(FILE_A).commit())
-        .isInstanceOf(ServiceFailureException.class);
+        .isInstanceOf(ServiceFailureException.class)
+        .hasMessage("some service failure");
 
     // Extract the UpdateTableRequest to determine the path of the manifest list that should still
     // exist even though the commit failed
@@ -2344,7 +2347,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Transaction createTableTransaction = catalog.newCreateTableTransaction(newTable, SCHEMA);
     createTableTransaction.newAppend().appendFile(FILE_A).commit();
     assertThatThrownBy(createTableTransaction::commitTransaction)
-        .isInstanceOf(NotAuthorizedException.class);
+        .isInstanceOf(NotAuthorizedException.class)
+        .hasMessage("not authorized");
 
     assertThat(allRequests(adapter))
         .anySatisfy(
@@ -2367,7 +2371,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                               .loadTable(TABLE)
                               .io()
                               .newInputFile(addSnapshot.snapshot().manifestListLocation()))
-                  .isInstanceOf(NotFoundException.class);
+                  .isInstanceOf(NotFoundException.class)
+                  .hasMessageContaining("No in-memory file found");
             });
   }
 
@@ -2389,7 +2394,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Transaction createTableTransaction = catalog.newCreateTableTransaction(newTable, SCHEMA);
     createTableTransaction.newAppend().appendFile(FILE_A).commit();
     assertThatThrownBy(createTableTransaction::commitTransaction)
-        .isInstanceOf(ServiceFailureException.class);
+        .isInstanceOf(ServiceFailureException.class)
+        .hasMessage("some service failure");
 
     assertThat(allRequests(adapter))
         .anySatisfy(
@@ -2429,7 +2435,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Transaction replaceTableTransaction = catalog.newReplaceTableTransaction(TABLE, SCHEMA, false);
     replaceTableTransaction.newAppend().appendFile(FILE_A).commit();
     assertThatThrownBy(replaceTableTransaction::commitTransaction)
-        .isInstanceOf(NotAuthorizedException.class);
+        .isInstanceOf(NotAuthorizedException.class)
+        .hasMessage("not authorized");
 
     assertThat(allRequests(adapter))
         .anySatisfy(
@@ -2449,7 +2456,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
               String manifestListLocation = addSnapshot.snapshot().manifestListLocation();
               assertThatThrownBy(
                       () -> catalog.loadTable(TABLE).io().newInputFile(manifestListLocation))
-                  .isInstanceOf(NotFoundException.class);
+                  .isInstanceOf(NotFoundException.class)
+                  .hasMessageContaining("No in-memory file found");
             });
   }
 
@@ -2470,7 +2478,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Transaction replaceTableTransaction = catalog.newReplaceTableTransaction(TABLE, SCHEMA, false);
     replaceTableTransaction.newAppend().appendFile(FILE_A).commit();
     assertThatThrownBy(replaceTableTransaction::commitTransaction)
-        .isInstanceOf(ServiceFailureException.class);
+        .isInstanceOf(ServiceFailureException.class)
+        .hasMessage("some service failure");
 
     assertThat(allRequests(adapter))
         .anySatisfy(

--- a/core/src/test/java/org/apache/iceberg/util/TestPartitionMap.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestPartitionMap.java
@@ -233,9 +233,15 @@ public class TestPartitionMap {
   @Test
   public void testNullKey() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
-    assertThatThrownBy(() -> map.put(null, "value")).isInstanceOf(NullPointerException.class);
-    assertThatThrownBy(() -> map.get(null)).isInstanceOf(NullPointerException.class);
-    assertThatThrownBy(() -> map.remove(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> map.put(null, "value"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("\"key\" is null");
+    assertThatThrownBy(() -> map.get(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("does not support null keys");
+    assertThatThrownBy(() -> map.remove(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("does not support null keys");
   }
 
   @Test
@@ -253,15 +259,20 @@ public class TestPartitionMap {
     map.put(BY_DATA_SPEC.specId(), Row.of("bbb"), "v2");
 
     assertThatThrownBy(() -> map.keySet().add(Pair.of(1, null)))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
     assertThatThrownBy(() -> map.values().add("other"))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
     assertThatThrownBy(() -> map.entrySet().add(null))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
     assertThatThrownBy(() -> map.entrySet().iterator().next().setValue("other"))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot set value");
     assertThatThrownBy(() -> map.entrySet().iterator().remove())
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
   }
 
   @Test

--- a/data/src/test/java/org/apache/iceberg/TestMergingMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/TestMergingMetrics.java
@@ -25,14 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
@@ -91,8 +87,7 @@ public abstract class TestMergingMetrics<T> {
               optional(27, "timestamp", Types.TimestampType.withZone())));
 
   private static final Map<Types.NestedField, Integer> FIELDS_WITH_NAN_COUNT_TO_ID =
-      ImmutableMap.of(
-          FLOAT_FIELD, 3, DOUBLE_FIELD, 4, FLOAT_LIST, 10, MAP_FIELD_1, 18, MAP_FIELD_2, 22);
+      ImmutableMap.of(FLOAT_FIELD, 3, DOUBLE_FIELD, 4);
 
   // create a schema with all supported fields
   protected static final Schema SCHEMA =
@@ -142,23 +137,15 @@ public abstract class TestMergingMetrics<T> {
     Map<Integer, ByteBuffer> upperBounds = metrics.upperBounds();
     Map<Integer, ByteBuffer> lowerBounds = metrics.lowerBounds();
 
+    assertThat(nanValueCount.size()).isEqualTo(2);
     assertNaNCountMatch(1L, nanValueCount, FLOAT_FIELD);
     assertNaNCountMatch(1L, nanValueCount, DOUBLE_FIELD);
-    assertNaNCountMatch(2L, nanValueCount, FLOAT_LIST);
-    assertNaNCountMatch(1L, nanValueCount, MAP_FIELD_1);
-    assertNaNCountMatch(3L, nanValueCount, MAP_FIELD_2);
 
-    assertBoundValueMatch(null, upperBounds, FLOAT_FIELD);
-    assertBoundValueMatch(null, upperBounds, DOUBLE_FIELD);
-    assertBoundValueMatch(3.3F, upperBounds, FLOAT_LIST);
-    assertBoundValueMatch(0F, upperBounds, MAP_FIELD_1);
-    assertBoundValueMatch(2D, upperBounds, MAP_FIELD_2);
+    assertThat(upperBounds.size()).isEqualTo(1);
+    assertBoundValueMatch(3, upperBounds, ID_FIELD);
 
-    assertBoundValueMatch(null, lowerBounds, FLOAT_FIELD);
-    assertBoundValueMatch(null, lowerBounds, DOUBLE_FIELD);
-    assertBoundValueMatch(-25.1F, lowerBounds, FLOAT_LIST);
-    assertBoundValueMatch(0F, lowerBounds, MAP_FIELD_1);
-    assertBoundValueMatch(0D, lowerBounds, MAP_FIELD_2);
+    assertThat(lowerBounds.size()).isEqualTo(1);
+    assertBoundValueMatch(3, lowerBounds, ID_FIELD);
   }
 
   @TestTemplate
@@ -196,19 +183,13 @@ public abstract class TestMergingMetrics<T> {
       Long expected, Map<Integer, Long> nanValueCount, Types.NestedField field) {
     assertThat(nanValueCount)
         .as(String.format("NaN count for field %s does not match expected", field.name()))
-        .containsEntry(FIELDS_WITH_NAN_COUNT_TO_ID.get(field), expected);
+        .containsEntry(field.fieldId(), expected);
   }
 
   private void assertBoundValueMatch(
       Number expected, Map<Integer, ByteBuffer> boundMap, Types.NestedField field) {
-    if (field.type().isNestedType() && fileFormat == FileFormat.ORC) {
-      // we don't update floating column bounds values within ORC nested columns
-      return;
-    }
-
-    int actualFieldId = FIELDS_WITH_NAN_COUNT_TO_ID.get(field);
-    ByteBuffer byteBuffer = boundMap.get(actualFieldId);
-    Type type = SCHEMA.findType(actualFieldId);
+    ByteBuffer byteBuffer = boundMap.get(field.fieldId());
+    Type type = SCHEMA.findType(field.fieldId());
     assertThat(byteBuffer == null ? null : Conversions.<T>fromByteBuffer(type, byteBuffer))
         .as(String.format("Bound value for field %s must match", field.name()))
         .isEqualTo(expected);
@@ -236,47 +217,7 @@ public abstract class TestMergingMetrics<T> {
           expectedNaNCount,
           DOUBLE_FIELD,
           (Double) record.getField(DOUBLE_FIELD.name()));
-
-      List<Float> floatList = (List<Float>) record.getField(FLOAT_LIST.name());
-      if (floatList != null) {
-        updateExpectedValueFromRecords(
-            upperBounds, lowerBounds, expectedNaNCount, FLOAT_LIST, floatList);
-      }
-
-      Map<Float, ?> map1 = (Map<Float, ?>) record.getField(MAP_FIELD_1.name());
-      if (map1 != null) {
-        updateExpectedValueFromRecords(
-            upperBounds, lowerBounds, expectedNaNCount, MAP_FIELD_1, map1.keySet());
-      }
-
-      Map<?, Double> map2 = (Map<?, Double>) record.getField(MAP_FIELD_2.name());
-      if (map2 != null) {
-        updateExpectedValueFromRecords(
-            upperBounds, lowerBounds, expectedNaNCount, MAP_FIELD_2, map2.values());
-      }
     }
-  }
-
-  private <T1 extends Number> void updateExpectedValueFromRecords(
-      Map<Types.NestedField, AtomicReference<Number>> upperBounds,
-      Map<Types.NestedField, AtomicReference<Number>> lowerBounds,
-      Map<Types.NestedField, AtomicLong> expectedNaNCount,
-      Types.NestedField key,
-      Collection<T1> vals) {
-    List<Number> nonNullNumbers =
-        vals.stream().filter(v -> !NaNUtil.isNaN(v)).collect(Collectors.toList());
-    Optional<Number> maxOptional =
-        nonNullNumbers.stream()
-            .filter(Objects::nonNull)
-            .reduce((v1, v2) -> getMinOrMax(v1, v2, true));
-    Optional<Number> minOptional =
-        nonNullNumbers.stream()
-            .filter(Objects::nonNull)
-            .reduce((v1, v2) -> getMinOrMax(v1, v2, false));
-
-    expectedNaNCount.get(key).addAndGet(vals.size() - nonNullNumbers.size());
-    maxOptional.ifPresent(max -> updateBound(key, max, upperBounds, true));
-    minOptional.ifPresent(min -> updateBound(key, min, lowerBounds, false));
   }
 
   private void updateExpectedValuePerRecord(

--- a/data/src/test/java/org/apache/iceberg/data/TestReadProjection.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestReadProjection.java
@@ -195,7 +195,9 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> projected.get(0))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test

--- a/data/src/test/java/org/apache/iceberg/data/TestReadProjection.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestReadProjection.java
@@ -181,6 +181,7 @@ public abstract class TestReadProjection {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testEmptyProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -195,9 +196,8 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("out of bounds");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @Test

--- a/data/src/test/java/org/apache/iceberg/io/TestGenericSortedPosDeleteWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestGenericSortedPosDeleteWriter.java
@@ -168,6 +168,7 @@ public class TestGenericSortedPosDeleteWriter extends TestBase {
   }
 
   @TestTemplate
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testSortedPosDeleteWithSchemaAndNullRow() throws IOException {
     List<Record> rowSet =
         Lists.newArrayList(createRow(0, "aaa"), createRow(1, "bbb"), createRow(2, "ccc"));

--- a/dell/src/test/java/org/apache/iceberg/dell/mock/ecs/TestExceptionCode.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/mock/ecs/TestExceptionCode.java
@@ -68,6 +68,7 @@ public class TestExceptionCode {
         });
   }
 
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void assertS3Exception(String message, int httpCode, String errorCode, Runnable task) {
     assertThatThrownBy(task::run)
         .isInstanceOf(S3Exception.class)

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -427,6 +427,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // validation.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (dt INTEGER)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot change column type: dt: string -> int");
   }
@@ -557,6 +558,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // because Iceberg's SchemaUpdate does not allow incompatible changes.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (PRIMARY KEY (col1) NOT ENFORCED)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot add field col1 as an identifier field: not a required field");
 
@@ -564,12 +566,14 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // because Iceberg's SchemaUpdate does not allow incompatible changes.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (PRIMARY KEY (id, col1) NOT ENFORCED)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot add field col1 as an identifier field: not a required field");
 
     // Dropping constraints is not supported yet
     assertThatThrownBy(() -> sql("ALTER TABLE tl DROP PRIMARY KEY"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(UnsupportedOperationException.class)
         .hasRootCauseMessage("Unsupported table change: DropConstraint.");
   }

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -434,7 +434,8 @@ public class TestRewriteDataFilesAction extends CatalogTestBase {
                     .useStartingSequenceNumber(false)
                     .execute(),
             "Rewrite using new sequence number should fail")
-        .isInstanceOf(ValidationException.class);
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot commit, found new delete for replaced data file");
 
     // Rewrite using the starting sequence number should succeed
     RewriteDataFilesActionResult result =

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -427,6 +427,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // validation.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (dt INTEGER)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot change column type: dt: string -> int");
   }
@@ -557,6 +558,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // because Iceberg's SchemaUpdate does not allow incompatible changes.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (PRIMARY KEY (col1) NOT ENFORCED)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot add field col1 as an identifier field: not a required field");
 
@@ -564,12 +566,14 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // because Iceberg's SchemaUpdate does not allow incompatible changes.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (PRIMARY KEY (id, col1) NOT ENFORCED)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot add field col1 as an identifier field: not a required field");
 
     // Dropping constraints is not supported yet
     assertThatThrownBy(() -> sql("ALTER TABLE tl DROP PRIMARY KEY"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(UnsupportedOperationException.class)
         .hasRootCauseMessage("Unsupported table change: DropConstraint.");
   }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -434,7 +434,8 @@ public class TestRewriteDataFilesAction extends CatalogTestBase {
                     .useStartingSequenceNumber(false)
                     .execute(),
             "Rewrite using new sequence number should fail")
-        .isInstanceOf(ValidationException.class);
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot commit, found new delete for replaced data file");
 
     // Rewrite using the starting sequence number should succeed
     RewriteDataFilesActionResult result =

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -461,6 +461,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // validation.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (dt INTEGER)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot change column type: dt: string -> int");
   }
@@ -591,6 +592,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // because Iceberg's SchemaUpdate does not allow incompatible changes.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (PRIMARY KEY (col1) NOT ENFORCED)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot add field col1 as an identifier field: not a required field");
 
@@ -598,12 +600,14 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // because Iceberg's SchemaUpdate does not allow incompatible changes.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (PRIMARY KEY (id, col1) NOT ENFORCED)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot add field col1 as an identifier field: not a required field");
 
     // Dropping constraints is not supported yet
     assertThatThrownBy(() -> sql("ALTER TABLE tl DROP PRIMARY KEY"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(UnsupportedOperationException.class)
         .hasRootCauseMessage("Unsupported table change: DropConstraint.");
   }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -441,7 +441,8 @@ public class TestRewriteDataFilesAction extends CatalogTestBase {
                     .useStartingSequenceNumber(false)
                     .execute(),
             "Rewrite using new sequence number should fail")
-        .isInstanceOf(ValidationException.class);
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot commit, found new delete for replaced data file");
 
     // Rewrite using the starting sequence number should succeed
     RewriteDataFilesActionResult result =

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSInputStreamTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSInputStreamTest.java
@@ -166,7 +166,9 @@ public class GCSInputStreamTest {
     SeekableInputStream closed =
         new GCSInputStream(storage, blobId, null, gcpProperties, MetricsContext.nullMetrics());
     closed.close();
-    assertThatThrownBy(() -> closed.seek(0)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> closed.seek(0))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("already closed");
   }
 
   @Test

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -442,7 +442,8 @@ public class TestHiveCommits extends HiveTableBaseTest {
     }
 
     assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
-        .isInstanceOf(OutOfMemoryError.class);
+        .isInstanceOf(OutOfMemoryError.class)
+        .hasMessage(null);
 
     ops.refresh();
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
@@ -479,7 +479,8 @@ public class TestHiveViewCommits {
     }
 
     assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
-        .isInstanceOf(OutOfMemoryError.class);
+        .isInstanceOf(OutOfMemoryError.class)
+        .hasMessage(null);
 
     ops.refresh();
 

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/JsonToMapTransformTest.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/JsonToMapTransformTest.java
@@ -84,7 +84,9 @@ public class JsonToMapTransformTest extends FileLoads {
               offset,
               timestamp,
               TimestampType.CREATE_TIME);
-      assertThatThrownBy(() -> smt.apply(record)).isInstanceOf(JsonToMapException.class);
+      assertThatThrownBy(() -> smt.apply(record))
+          .isInstanceOf(JsonToMapException.class)
+          .hasMessageContaining("not valid json");
     }
   }
 
@@ -103,7 +105,9 @@ public class JsonToMapTransformTest extends FileLoads {
               offset,
               timestamp,
               TimestampType.CREATE_TIME);
-      assertThatThrownBy(() -> smt.apply(record)).isInstanceOf(JsonToMapException.class);
+      assertThatThrownBy(() -> smt.apply(record))
+          .isInstanceOf(JsonToMapException.class)
+          .hasMessageContaining("not valid json");
     }
   }
 

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/JsonToMapUtilsTest.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/JsonToMapUtilsTest.java
@@ -124,7 +124,8 @@ class JsonToMapUtilsTest extends FileLoads {
   public void primitiveBasedOnSchemaThrows() {
     assertThatThrownBy(
             () -> JsonToMapUtils.extractValue(objNode.get("string"), Schema.Type.STRUCT, ""))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Unexpected type STRUCT for field");
   }
 
   @Test
@@ -327,9 +328,17 @@ class JsonToMapUtilsTest extends FileLoads {
     assertThat(result.get("empty_string")).isEqualTo("");
 
     // assert empty fields don't show up on the struct
-    assertThatThrownBy(() -> result.get("null")).isInstanceOf(RuntimeException.class);
-    assertThatThrownBy(() -> result.get("empty_obj")).isInstanceOf(RuntimeException.class);
-    assertThatThrownBy(() -> result.get("empty_arr")).isInstanceOf(RuntimeException.class);
-    assertThatThrownBy(() -> result.get("empty_arr_arr")).isInstanceOf(RuntimeException.class);
+    assertThatThrownBy(() -> result.get("null"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a valid field name");
+    assertThatThrownBy(() -> result.get("empty_obj"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a valid field name");
+    assertThatThrownBy(() -> result.get("empty_arr"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a valid field name");
+    assertThatThrownBy(() -> result.get("empty_arr_arr"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a valid field name");
   }
 }

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/JsonToMapUtilsTest.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/JsonToMapUtilsTest.java
@@ -125,7 +125,7 @@ class JsonToMapUtilsTest extends FileLoads {
     assertThatThrownBy(
             () -> JsonToMapUtils.extractValue(objNode.get("string"), Schema.Type.STRUCT, ""))
         .isInstanceOf(RuntimeException.class)
-        .hasMessage("Unexpected type STRUCT for field");
+        .hasMessageContaining("Unexpected type STRUCT for field");
   }
 
   @Test

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/KafkaMetadataTransformTest.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/KafkaMetadataTransformTest.java
@@ -83,8 +83,12 @@ public class KafkaMetadataTransformTest {
             TimestampType.CREATE_TIME);
     try (KafkaMetadataTransform smt = new KafkaMetadataTransform()) {
       smt.configure(ImmutableMap.of());
-      assertThatThrownBy(() -> smt.apply(recordNotMap)).isInstanceOf(RuntimeException.class);
-      assertThatThrownBy(() -> smt.apply(recordNotStruct)).isInstanceOf(RuntimeException.class);
+      assertThatThrownBy(() -> smt.apply(recordNotMap))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Only Map objects supported in absence of schema");
+      assertThatThrownBy(() -> smt.apply(recordNotStruct))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Only Struct objects supported");
     }
   }
 
@@ -186,7 +190,8 @@ public class KafkaMetadataTransformTest {
               () -> {
                 smt.configure(ImmutableMap.of("external_field", "external,*,,,value"));
               })
-          .isInstanceOf(RuntimeException.class);
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Could not parse external,*,,,value");
     }
   }
 

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/MongoDebeziumTransformTest.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/MongoDebeziumTransformTest.java
@@ -563,6 +563,8 @@ public class MongoDebeziumTransformTest {
             TimestampType.CREATE_TIME);
 
     MongoDebeziumTransform smt = getTransformer("array");
-    assertThatThrownBy(() -> smt.apply(record)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> smt.apply(record))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("malformed record topic");
   }
 }

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/debezium/connector/mongodb/transforms/MongoArrayConverterTest.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/debezium/connector/mongodb/transforms/MongoArrayConverterTest.java
@@ -113,7 +113,8 @@ public class MongoArrayConverterTest {
                 converter.addFieldSchema(entry, builder);
               }
             })
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a homogenous array");
   }
 
   @Test
@@ -127,7 +128,8 @@ public class MongoArrayConverterTest {
                 converter.addFieldSchema(entry, builder);
               }
             })
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not the same type for all documents in the array");
   }
 
   @Test

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -494,7 +494,8 @@ public class TestNessieTable extends BaseTestIceberg {
             () ->
                 catalog.registerTable(
                     TABLE_IDENTIFIER, "file:" + metadataVersionFiles.get(0) + "invalidName"))
-        .isInstanceOf(NotFoundException.class);
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Failed to open input stream for file");
     // Case 5: null identifier
     assertThatThrownBy(
             () ->

--- a/orc/src/test/java/org/apache/iceberg/orc/TestORCFileIOProxies.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestORCFileIOProxies.java
@@ -45,7 +45,8 @@ public class TestORCFileIOProxies {
 
     // Cannot use the filesystem for any other operation
     assertThatThrownBy(() -> ifs.getFileStatus(new Path(localFile.location())))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
 
     // Cannot use the filesystem for any other path
     assertThatThrownBy(() -> ifs.open(new Path("/tmp/dummy")))
@@ -67,7 +68,8 @@ public class TestORCFileIOProxies {
     }
     // No other operation is supported
     assertThatThrownBy(() -> ofs.open(new Path(outputFile.location())))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
     // No other path is supported
     assertThatThrownBy(() -> ofs.create(new Path("/tmp/dummy")))
         .isInstanceOf(IllegalArgumentException.class)

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -390,7 +390,8 @@ abstract class BaseParquetReaders<T> {
     }
 
     @Override
-    public ParquetValueReader<?> variant(Types.VariantType iVariant, ParquetValueReader<?> reader) {
+    public ParquetValueReader<?> variant(
+        Types.VariantType iVariant, GroupType variant, ParquetValueReader<?> reader) {
       return reader;
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
@@ -162,7 +162,8 @@ abstract class BaseParquetWriter<T> {
     }
 
     @Override
-    public ParquetValueWriter<?> variant(Types.VariantType iVariant, ParquetValueWriter<?> result) {
+    public ParquetValueWriter<?> variant(
+        Types.VariantType iVariant, GroupType variant, ParquetValueWriter<?> result) {
       return result;
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
@@ -1,0 +1,639 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import java.nio.ByteBuffer;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.iceberg.FieldMetrics;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.MetricsModes;
+import org.apache.iceberg.MetricsUtil;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Multimap;
+import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.BinaryUtil;
+import org.apache.iceberg.util.NaNUtil;
+import org.apache.iceberg.util.UnicodeUtil;
+import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.ShreddedObject;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantValue;
+import org.apache.iceberg.variants.Variants;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+class ParquetMetrics {
+  private ParquetMetrics() {}
+
+  static Metrics metrics(
+      Schema schema,
+      MessageType type,
+      MetricsConfig metricsConfig,
+      ParquetMetadata metadata,
+      Stream<FieldMetrics<?>> fields) {
+    long rowCount = 0L;
+    Map<Integer, Long> columnSizes = Maps.newHashMap();
+    Multimap<ColumnPath, ColumnChunkMetaData> columns =
+        Multimaps.newMultimap(Maps.newHashMap(), Lists::newArrayList);
+    for (BlockMetaData block : metadata.getBlocks()) {
+      rowCount += block.getRowCount();
+      for (ColumnChunkMetaData column : block.getColumns()) {
+        columns.put(column.getPath(), column);
+
+        Type.ID id =
+            type.getColumnDescription(column.getPath().toArray()).getPrimitiveType().getId();
+        if (null == id) {
+          continue;
+        }
+
+        int fieldId = id.intValue();
+        MetricsModes.MetricsMode mode = MetricsUtil.metricsMode(schema, metricsConfig, fieldId);
+        if (mode != MetricsModes.None.get()) {
+          columnSizes.put(fieldId, columnSizes.getOrDefault(fieldId, 0L) + column.getTotalSize());
+        }
+      }
+    }
+
+    Map<Integer, FieldMetrics<?>> metricsById =
+        fields.collect(Collectors.toMap(FieldMetrics::id, Function.identity()));
+
+    Iterable<FieldMetrics<ByteBuffer>> results =
+        TypeWithSchemaVisitor.visit(
+            schema.asStruct(),
+            type,
+            new MetricsVisitor(schema, metricsConfig, metricsById, columns));
+
+    Map<Integer, Long> valueCounts = Maps.newHashMap();
+    Map<Integer, Long> nullValueCounts = Maps.newHashMap();
+    Map<Integer, Long> nanValueCounts = Maps.newHashMap();
+    Map<Integer, ByteBuffer> lowerBounds = Maps.newHashMap();
+    Map<Integer, ByteBuffer> upperBounds = Maps.newHashMap();
+
+    for (FieldMetrics<ByteBuffer> metrics : results) {
+      int id = metrics.id();
+      if (metrics.valueCount() >= 0) {
+        valueCounts.put(id, metrics.valueCount());
+      }
+
+      if (metrics.nullValueCount() >= 0) {
+        nullValueCounts.put(id, metrics.nullValueCount());
+      }
+
+      if (metrics.nanValueCount() >= 0) {
+        nanValueCounts.put(id, metrics.nanValueCount());
+      }
+
+      if (metrics.lowerBound() != null) {
+        lowerBounds.put(id, metrics.lowerBound());
+      }
+
+      if (metrics.upperBound() != null) {
+        upperBounds.put(id, metrics.upperBound());
+      }
+    }
+
+    return new Metrics(
+        rowCount,
+        columnSizes,
+        valueCounts,
+        nullValueCounts,
+        nanValueCounts,
+        lowerBounds,
+        upperBounds);
+  }
+
+  private static class MetricsVisitor
+      extends TypeWithSchemaVisitor<Iterable<FieldMetrics<ByteBuffer>>> {
+    private final Schema schema;
+    private final MetricsConfig metricsConfig;
+    private final Map<Integer, FieldMetrics<?>> metricsById;
+    private final Multimap<ColumnPath, ColumnChunkMetaData> columns;
+
+    private MetricsVisitor(
+        Schema schema,
+        MetricsConfig metricsConfig,
+        Map<Integer, FieldMetrics<?>> metricsById,
+        Multimap<ColumnPath, ColumnChunkMetaData> columns) {
+      this.schema = schema;
+      this.metricsConfig = metricsConfig;
+      this.metricsById = metricsById;
+      this.columns = columns;
+    }
+
+    @Override
+    public Iterable<FieldMetrics<ByteBuffer>> message(
+        Types.StructType iStruct,
+        MessageType message,
+        List<Iterable<FieldMetrics<ByteBuffer>>> fieldResults) {
+      return Iterables.concat(fieldResults);
+    }
+
+    @Override
+    public Iterable<FieldMetrics<ByteBuffer>> struct(
+        Types.StructType iStruct,
+        GroupType struct,
+        List<Iterable<FieldMetrics<ByteBuffer>>> fieldResults) {
+      return Iterables.concat(fieldResults);
+    }
+
+    @Override
+    public Iterable<FieldMetrics<ByteBuffer>> list(
+        Types.ListType iList, GroupType array, Iterable<FieldMetrics<ByteBuffer>> elementResults) {
+      // remove lower and upper bounds for repeated fields
+      return ImmutableList.of();
+    }
+
+    @Override
+    public Iterable<FieldMetrics<ByteBuffer>> map(
+        Types.MapType iMap,
+        GroupType map,
+        Iterable<FieldMetrics<ByteBuffer>> keyResults,
+        Iterable<FieldMetrics<ByteBuffer>> valueResults) {
+      // repeated fields are not currently supported
+      return ImmutableList.of();
+    }
+
+    @Override
+    public Iterable<FieldMetrics<ByteBuffer>> primitive(
+        org.apache.iceberg.types.Type.PrimitiveType iPrimitive, PrimitiveType primitive) {
+      Type.ID id = primitive.getId();
+      if (null == id) {
+        return ImmutableList.of();
+      }
+      int fieldId = id.intValue();
+
+      MetricsModes.MetricsMode mode = MetricsUtil.metricsMode(schema, metricsConfig, fieldId);
+      if (mode == MetricsModes.None.get()) {
+        return ImmutableList.of();
+      }
+
+      int length = truncateLength(mode);
+
+      FieldMetrics<ByteBuffer> metrics = metricsFromFieldMetrics(fieldId, iPrimitive, length);
+      if (metrics != null) {
+        return ImmutableList.of(metrics);
+      }
+
+      metrics = metricsFromFooter(fieldId, iPrimitive, primitive, length);
+      if (metrics != null) {
+        return ImmutableList.of(metrics);
+      }
+
+      return ImmutableList.of();
+    }
+
+    private FieldMetrics<ByteBuffer> metricsFromFieldMetrics(
+        int fieldId, org.apache.iceberg.types.Type.PrimitiveType icebergType, int truncateLength) {
+      FieldMetrics<?> fieldMetrics = metricsById.get(fieldId);
+      if (null == fieldMetrics) {
+        return null;
+      } else if (truncateLength <= 0) {
+        return new FieldMetrics<>(
+            fieldMetrics.id(),
+            fieldMetrics.valueCount(),
+            fieldMetrics.nullValueCount(),
+            fieldMetrics.nanValueCount());
+      } else {
+        Object lowerBound =
+            truncateLowerBound(icebergType, fieldMetrics.lowerBound(), truncateLength);
+        Object upperBound =
+            truncateUpperBound(icebergType, fieldMetrics.upperBound(), truncateLength);
+        ByteBuffer lower = Conversions.toByteBuffer(icebergType, lowerBound);
+        ByteBuffer upper = Conversions.toByteBuffer(icebergType, upperBound);
+        return new FieldMetrics<>(
+            fieldMetrics.id(),
+            fieldMetrics.valueCount(),
+            fieldMetrics.nullValueCount(),
+            fieldMetrics.nanValueCount(),
+            lower,
+            upper);
+      }
+    }
+
+    private FieldMetrics<ByteBuffer> metricsFromFooter(
+        int fieldId,
+        org.apache.iceberg.types.Type.PrimitiveType icebergType,
+        PrimitiveType primitive,
+        int truncateLength) {
+      if (primitive.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
+        return null;
+      } else if (truncateLength <= 0) {
+        return counts(fieldId);
+      } else {
+        return bounds(fieldId, icebergType, primitive, truncateLength);
+      }
+    }
+
+    private FieldMetrics<ByteBuffer> counts(int fieldId) {
+      ColumnPath path = ColumnPath.get(currentPath());
+      long valueCount = 0;
+      long nullCount = 0;
+
+      for (ColumnChunkMetaData column : columns.get(path)) {
+        Statistics<?> stats = column.getStatistics();
+        if (stats == null || stats.isEmpty()) {
+          return null;
+        }
+
+        nullCount += stats.getNumNulls();
+        valueCount += column.getValueCount();
+      }
+
+      return new FieldMetrics<>(fieldId, valueCount, nullCount);
+    }
+
+    private <T> FieldMetrics<ByteBuffer> bounds(
+        int fieldId,
+        org.apache.iceberg.types.Type.PrimitiveType icebergType,
+        PrimitiveType primitive,
+        int truncateLength) {
+      if (icebergType == null) {
+        return null;
+      }
+
+      ColumnPath path = ColumnPath.get(currentPath());
+      Comparator<T> comparator = Comparators.forType(icebergType);
+      long valueCount = 0;
+      long nullCount = 0;
+      T lowerBound = null;
+      T upperBound = null;
+
+      for (ColumnChunkMetaData column : columns.get(path)) {
+        Statistics<?> stats = column.getStatistics();
+        if (stats == null || stats.isEmpty()) {
+          return null;
+        }
+
+        nullCount += stats.getNumNulls();
+        valueCount += column.getValueCount();
+
+        if (stats.hasNonNullValue()) {
+          T chunkMin =
+              ParquetConversions.convertValue(icebergType, primitive, stats.genericGetMin());
+          if (lowerBound == null || comparator.compare(chunkMin, lowerBound) < 0) {
+            lowerBound = chunkMin;
+          }
+
+          T chunkMax =
+              ParquetConversions.convertValue(icebergType, primitive, stats.genericGetMax());
+          if (upperBound == null || comparator.compare(chunkMax, upperBound) > 0) {
+            upperBound = chunkMax;
+          }
+        }
+      }
+
+      if (NaNUtil.isNaN(lowerBound) || NaNUtil.isNaN(upperBound)) {
+        return new FieldMetrics<>(fieldId, valueCount, nullCount);
+      }
+
+      lowerBound = truncateLowerBound(icebergType, lowerBound, truncateLength);
+      upperBound = truncateUpperBound(icebergType, upperBound, truncateLength);
+
+      ByteBuffer lower = Conversions.toByteBuffer(icebergType, lowerBound);
+      ByteBuffer upper = Conversions.toByteBuffer(icebergType, upperBound);
+
+      return new FieldMetrics<>(fieldId, valueCount, nullCount, lower, upper);
+    }
+
+    @Override
+    @SuppressWarnings("CyclomaticComplexity")
+    public Iterable<FieldMetrics<ByteBuffer>> variant(
+        Types.VariantType iVariant, GroupType variant, Iterable<FieldMetrics<ByteBuffer>> ignored) {
+      Type.ID id = variant.getId();
+      if (null == id) {
+        return ImmutableList.of();
+      }
+      int fieldId = id.intValue();
+
+      MetricsModes.MetricsMode mode = MetricsUtil.metricsMode(schema, metricsConfig, fieldId);
+      if (mode == MetricsModes.None.get()) {
+        return ImmutableList.of();
+      }
+
+      List<ParquetVariantUtil.VariantMetrics> results =
+          Lists.newArrayList(
+              ParquetVariantVisitor.visit(variant, new MetricsVariantVisitor(currentPath())));
+
+      if (results.isEmpty()) {
+        return ImmutableList.of();
+      }
+
+      ParquetVariantUtil.VariantMetrics metadataCounts = results.get(0);
+      if (mode == MetricsModes.Counts.get() || results.size() == 1) {
+        return ImmutableList.of(
+            new FieldMetrics<>(fieldId, metadataCounts.valueCount(), metadataCounts.nullCount()));
+      }
+
+      Set<String> fieldNames = Sets.newTreeSet();
+      for (ParquetVariantUtil.VariantMetrics result : results.subList(1, results.size())) {
+        if (result.lowerBound() != null || result.upperBound() != null) {
+          fieldNames.add(result.fieldName());
+        }
+      }
+
+      if (fieldNames.isEmpty()) {
+        return ImmutableList.of(
+            new FieldMetrics<>(fieldId, metadataCounts.valueCount(), metadataCounts.nullCount()));
+      }
+
+      VariantMetadata metadata = Variants.metadata(fieldNames);
+      ShreddedObject lowerBounds = Variants.object(metadata);
+      ShreddedObject upperBounds = Variants.object(metadata);
+      for (ParquetVariantUtil.VariantMetrics result : results.subList(1, results.size())) {
+        String fieldName = result.fieldName();
+        if (result.lowerBound() != null) {
+          lowerBounds.put(fieldName, result.lowerBound());
+        }
+
+        if (result.upperBound() != null) {
+          upperBounds.put(fieldName, result.upperBound());
+        }
+      }
+
+      return ImmutableList.of(
+          new FieldMetrics<>(
+              fieldId,
+              metadataCounts.valueCount(),
+              metadataCounts.nullCount(),
+              ParquetVariantUtil.toByteBuffer(metadata, lowerBounds),
+              ParquetVariantUtil.toByteBuffer(metadata, upperBounds)));
+    }
+
+    private class MetricsVariantVisitor
+        extends ParquetVariantVisitor<Iterable<ParquetVariantUtil.VariantMetrics>> {
+      private final Deque<String> fieldNames = Lists.newLinkedList();
+      private final String[] basePath;
+
+      private MetricsVariantVisitor(String[] basePath) {
+        this.basePath = basePath;
+      }
+
+      @Override
+      public void beforeField(Type type) {
+        fieldNames.addLast(type.getName());
+      }
+
+      @Override
+      public void afterField(Type type) {
+        fieldNames.removeLast();
+      }
+
+      private Stream<String> currentPath() {
+        return Streams.concat(Stream.of(basePath), fieldNames.stream());
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> variant(
+          GroupType variant,
+          Iterable<ParquetVariantUtil.VariantMetrics> metadataResults,
+          Iterable<ParquetVariantUtil.VariantMetrics> valueResults) {
+        return Iterables.concat(metadataResults, valueResults);
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> object(
+          GroupType object,
+          Iterable<ParquetVariantUtil.VariantMetrics> valueResult,
+          List<Iterable<ParquetVariantUtil.VariantMetrics>> fieldResults) {
+        // shredded fields are not allowed in the variant-encoded value so the stats are trusted
+        // even if value result has non-null values
+        GroupType shreddedFields = object.getType(TYPED_VALUE).asGroupType();
+        List<Iterable<ParquetVariantUtil.VariantMetrics>> results = Lists.newArrayList();
+
+        // for each field, prepend the field name
+        for (int i = 0; i < fieldResults.size(); i += 1) {
+          String name = shreddedFields.getFieldName(i);
+          results.add(
+              Iterables.transform(fieldResults.get(i), result -> result.prependFieldName(name)));
+        }
+
+        // return metrics for all sub-fields
+        return Iterables.concat(results);
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> array(
+          GroupType array,
+          Iterable<ParquetVariantUtil.VariantMetrics> valueResult,
+          Iterable<ParquetVariantUtil.VariantMetrics> elementResult) {
+        return ImmutableList.of();
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> value(
+          GroupType value,
+          Iterable<ParquetVariantUtil.VariantMetrics> valueResult,
+          Iterable<ParquetVariantUtil.VariantMetrics> typedResult) {
+        if (null == valueResult) {
+          // a value field was not present so the typed metrics can be used
+          return typedResult;
+        }
+
+        ParquetVariantUtil.VariantMetrics valueMetrics = Iterables.getOnlyElement(valueResult);
+        if (typedResult != null && valueMetrics.valueCount() == valueMetrics.nullCount()) {
+          // all the variant-encoded values are null, so the typed stats can be used
+          return typedResult;
+        } else {
+          // any non-null encoded variant invalidates the typed lower and upper bounds
+          return ImmutableList.of();
+        }
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> metadata(PrimitiveType metadata) {
+        ParquetVariantUtil.VariantMetrics counts = counts();
+        if (counts != null) {
+          return ImmutableList.of(counts);
+        } else {
+          return ImmutableList.of();
+        }
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> serialized(PrimitiveType value) {
+        ParquetVariantUtil.VariantMetrics counts = counts();
+        if (counts != null) {
+          return ImmutableList.of(counts);
+        } else {
+          return ImmutableList.of();
+        }
+      }
+
+      @Override
+      public Iterable<ParquetVariantUtil.VariantMetrics> primitive(PrimitiveType primitive) {
+        ParquetVariantUtil.VariantMetrics result = metrics(primitive);
+        if (result != null) {
+          return ImmutableList.of(result);
+        } else {
+          return ImmutableList.of();
+        }
+      }
+
+      private ParquetVariantUtil.VariantMetrics counts() {
+        ColumnPath path = ColumnPath.get(currentPath().toArray(String[]::new));
+        long valueCount = 0;
+        long nullCount = 0;
+
+        for (ColumnChunkMetaData column : columns.get(path)) {
+          Statistics<?> stats = column.getStatistics();
+          if (stats == null || stats.isEmpty()) {
+            // the null count is unknown
+            return null;
+          }
+
+          boolean hasOnlyNullVariants;
+          if (stats.hasNonNullValue()) {
+            hasOnlyNullVariants =
+                Variants.isNull(ByteBuffer.wrap(stats.getMinBytes()))
+                    && Variants.isNull(ByteBuffer.wrap(stats.getMaxBytes()));
+          } else {
+            // use the null count because the min/max were not defined
+            hasOnlyNullVariants = false;
+          }
+
+          valueCount += column.getValueCount();
+          nullCount += hasOnlyNullVariants ? column.getValueCount() : stats.getNumNulls();
+        }
+
+        return new ParquetVariantUtil.VariantMetrics(valueCount, nullCount);
+      }
+
+      @SuppressWarnings("CyclomaticComplexity")
+      private <T> ParquetVariantUtil.VariantMetrics metrics(PrimitiveType primitive) {
+        PhysicalType variantType = ParquetVariantUtil.convert(primitive);
+        if (null == variantType) {
+          // the type could not be converted and is either invalid or unsupported
+          return null;
+        }
+
+        ColumnPath path = ColumnPath.get(currentPath().toArray(String[]::new));
+        Comparator<T> comparator = ParquetVariantUtil.comparator(variantType);
+        int scale = ParquetVariantUtil.scale(primitive);
+        long valueCount = 0;
+        long nullCount = 0;
+        T lowerBound = null;
+        T upperBound = null;
+
+        for (ColumnChunkMetaData column : columns.get(path)) {
+          Statistics<?> stats = column.getStatistics();
+          if (stats == null || stats.isEmpty()) {
+            return null;
+          }
+
+          nullCount += stats.getNumNulls();
+          valueCount += column.getValueCount();
+
+          if (stats.hasNonNullValue()) {
+            T chunkMin = ParquetVariantUtil.convertValue(variantType, scale, stats.genericGetMin());
+            if (lowerBound == null || comparator.compare(chunkMin, lowerBound) < 0) {
+              lowerBound = chunkMin;
+            }
+
+            T chunkMax = ParquetVariantUtil.convertValue(variantType, scale, stats.genericGetMax());
+            if (upperBound == null || comparator.compare(chunkMax, upperBound) > 0) {
+              upperBound = chunkMax;
+            }
+          }
+        }
+
+        if (NaNUtil.isNaN(lowerBound) || NaNUtil.isNaN(upperBound)) {
+          return null;
+        }
+
+        if (lowerBound != null && upperBound != null) {
+          VariantValue lower = Variants.of(variantType, lowerBound);
+          VariantValue upper = Variants.of(variantType, upperBound);
+          return new ParquetVariantUtil.VariantMetrics(valueCount, nullCount, lower, upper);
+        } else {
+          return new ParquetVariantUtil.VariantMetrics(valueCount, nullCount);
+        }
+      }
+    }
+  }
+
+  private static int truncateLength(MetricsModes.MetricsMode mode) {
+    if (mode == MetricsModes.None.get()) {
+      return 0;
+    } else if (mode == MetricsModes.Counts.get()) {
+      return 0;
+    } else if (mode instanceof MetricsModes.Truncate) {
+      return ((MetricsModes.Truncate) mode).length();
+    } else {
+      return Integer.MAX_VALUE;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T truncateLowerBound(
+      org.apache.iceberg.types.Type.PrimitiveType type, T value, int length) {
+    if (null == value) {
+      return null;
+    }
+
+    switch (type.typeId()) {
+      case STRING:
+        return (T) UnicodeUtil.truncateStringMin((String) value, length);
+      case BINARY:
+        return (T) BinaryUtil.truncateBinaryMin((ByteBuffer) value, length);
+      default:
+        return value;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T truncateUpperBound(
+      org.apache.iceberg.types.Type.PrimitiveType type, T value, int length) {
+    if (null == value) {
+      return null;
+    }
+
+    switch (type.typeId()) {
+      case STRING:
+        return (T) UnicodeUtil.truncateStringMax((String) value, length);
+      case BINARY:
+        return (T) BinaryUtil.truncateBinaryMax((ByteBuffer) value, length);
+      default:
+        return value;
+    }
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -21,45 +21,29 @@ package org.apache.iceberg.parquet;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.FieldMetrics;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
-import org.apache.iceberg.MetricsModes;
-import org.apache.iceberg.MetricsModes.MetricsMode;
-import org.apache.iceberg.MetricsUtil;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.RuntimeIOException;
-import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.types.Conversions;
-import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.BinaryUtil;
-import org.apache.iceberg.util.UnicodeUtil;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.EncodingStats;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReader;
-import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
-import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.MessageType;
@@ -89,125 +73,16 @@ public class ParquetUtil {
     return footerMetrics(metadata, fieldMetrics, metricsConfig, null);
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public static Metrics footerMetrics(
       ParquetMetadata metadata,
       Stream<FieldMetrics<?>> fieldMetrics,
       MetricsConfig metricsConfig,
       NameMapping nameMapping) {
     Preconditions.checkNotNull(fieldMetrics, "fieldMetrics should not be null");
-
-    long rowCount = 0;
-    Map<Integer, Long> columnSizes = Maps.newHashMap();
-    Map<Integer, Long> valueCounts = Maps.newHashMap();
-    Map<Integer, Long> nullValueCounts = Maps.newHashMap();
-    Map<Integer, Literal<?>> lowerBounds = Maps.newHashMap();
-    Map<Integer, Literal<?>> upperBounds = Maps.newHashMap();
-    Set<Integer> missingStats = Sets.newHashSet();
-
-    // ignore metrics for fields we failed to determine reliable IDs
+    MessageType messageType = metadata.getFileMetaData().getSchema();
     MessageType parquetTypeWithIds = getParquetTypeWithIds(metadata, nameMapping);
     Schema fileSchema = ParquetSchemaUtil.convertAndPrune(parquetTypeWithIds);
-
-    Map<Integer, FieldMetrics<?>> fieldMetricsMap =
-        fieldMetrics.collect(Collectors.toMap(FieldMetrics::id, Function.identity()));
-
-    List<BlockMetaData> blocks = metadata.getBlocks();
-    for (BlockMetaData block : blocks) {
-      rowCount += block.getRowCount();
-      for (ColumnChunkMetaData column : block.getColumns()) {
-
-        Integer fieldId = fileSchema.aliasToId(column.getPath().toDotString());
-        if (fieldId == null) {
-          // fileSchema may contain a subset of columns present in the file
-          // as we prune columns we could not assign ids
-          continue;
-        }
-
-        MetricsMode metricsMode = MetricsUtil.metricsMode(fileSchema, metricsConfig, fieldId);
-        if (metricsMode == MetricsModes.None.get()) {
-          continue;
-        }
-
-        increment(columnSizes, fieldId, column.getTotalSize());
-        increment(valueCounts, fieldId, column.getValueCount());
-
-        Statistics stats = column.getStatistics();
-        if (stats != null && !stats.isEmpty()) {
-          increment(nullValueCounts, fieldId, stats.getNumNulls());
-
-          // when there are metrics gathered by Iceberg for a column, we should use those instead
-          // of the ones from Parquet
-          if (metricsMode != MetricsModes.Counts.get() && !fieldMetricsMap.containsKey(fieldId)) {
-            Types.NestedField field = fileSchema.findField(fieldId);
-            if (field != null && stats.hasNonNullValue() && shouldStoreBounds(column, fileSchema)) {
-              Literal<?> min =
-                  ParquetConversions.fromParquetPrimitive(
-                      field.type(), column.getPrimitiveType(), stats.genericGetMin());
-              updateMin(lowerBounds, fieldId, field.type(), min, metricsMode);
-              Literal<?> max =
-                  ParquetConversions.fromParquetPrimitive(
-                      field.type(), column.getPrimitiveType(), stats.genericGetMax());
-              updateMax(upperBounds, fieldId, field.type(), max, metricsMode);
-            }
-          }
-        } else {
-          missingStats.add(fieldId);
-        }
-      }
-    }
-
-    // discard accumulated values if any stats were missing
-    for (Integer fieldId : missingStats) {
-      nullValueCounts.remove(fieldId);
-      lowerBounds.remove(fieldId);
-      upperBounds.remove(fieldId);
-    }
-
-    updateFromFieldMetrics(fieldMetricsMap, metricsConfig, fileSchema, lowerBounds, upperBounds);
-
-    return new Metrics(
-        rowCount,
-        columnSizes,
-        valueCounts,
-        nullValueCounts,
-        MetricsUtil.createNanValueCounts(
-            fieldMetricsMap.values().stream(), metricsConfig, fileSchema),
-        toBufferMap(fileSchema, lowerBounds),
-        toBufferMap(fileSchema, upperBounds));
-  }
-
-  private static void updateFromFieldMetrics(
-      Map<Integer, FieldMetrics<?>> idToFieldMetricsMap,
-      MetricsConfig metricsConfig,
-      Schema schema,
-      Map<Integer, Literal<?>> lowerBounds,
-      Map<Integer, Literal<?>> upperBounds) {
-    idToFieldMetricsMap
-        .entrySet()
-        .forEach(
-            entry -> {
-              int fieldId = entry.getKey();
-              FieldMetrics<?> metrics = entry.getValue();
-              MetricsMode metricsMode = MetricsUtil.metricsMode(schema, metricsConfig, fieldId);
-
-              // only check for MetricsModes.None, since we don't truncate float/double values.
-              if (metricsMode != MetricsModes.None.get()) {
-                if (!metrics.hasBounds()) {
-                  lowerBounds.remove(fieldId);
-                  upperBounds.remove(fieldId);
-                } else if (metrics.upperBound() instanceof Float) {
-                  lowerBounds.put(fieldId, Literal.of((Float) metrics.lowerBound()));
-                  upperBounds.put(fieldId, Literal.of((Float) metrics.upperBound()));
-                } else if (metrics.upperBound() instanceof Double) {
-                  lowerBounds.put(fieldId, Literal.of((Double) metrics.lowerBound()));
-                  upperBounds.put(fieldId, Literal.of((Double) metrics.upperBound()));
-                } else {
-                  throw new UnsupportedOperationException(
-                      "Expected only float or double column metrics");
-                }
-              }
-            });
+    return ParquetMetrics.metrics(fileSchema, messageType, metricsConfig, metadata, fieldMetrics);
   }
 
   private static MessageType getParquetTypeWithIds(
@@ -236,116 +111,6 @@ public class ParquetUtil {
     }
     Collections.sort(splitOffsets);
     return splitOffsets;
-  }
-
-  // we allow struct nesting, but not maps or arrays
-  private static boolean shouldStoreBounds(ColumnChunkMetaData column, Schema schema) {
-    if (column.getPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
-      // stats for INT96 are not reliable
-      return false;
-    }
-
-    ColumnPath columnPath = column.getPath();
-    Iterator<String> pathIterator = columnPath.iterator();
-    Type currentType = schema.asStruct();
-
-    while (pathIterator.hasNext()) {
-      if (currentType == null || !currentType.isStructType()) {
-        return false;
-      }
-      String fieldName = pathIterator.next();
-      currentType = currentType.asStructType().fieldType(fieldName);
-    }
-
-    return currentType != null && currentType.isPrimitiveType();
-  }
-
-  private static void increment(Map<Integer, Long> columns, int fieldId, long amount) {
-    if (columns != null) {
-      if (columns.containsKey(fieldId)) {
-        columns.put(fieldId, columns.get(fieldId) + amount);
-      } else {
-        columns.put(fieldId, amount);
-      }
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T> void updateMin(
-      Map<Integer, Literal<?>> lowerBounds,
-      int id,
-      Type type,
-      Literal<T> min,
-      MetricsMode metricsMode) {
-    Literal<T> currentMin = (Literal<T>) lowerBounds.get(id);
-    if (currentMin == null || min.comparator().compare(min.value(), currentMin.value()) < 0) {
-      if (metricsMode == MetricsModes.Full.get()) {
-        lowerBounds.put(id, min);
-      } else {
-        MetricsModes.Truncate truncateMode = (MetricsModes.Truncate) metricsMode;
-        int truncateLength = truncateMode.length();
-        switch (type.typeId()) {
-          case STRING:
-            lowerBounds.put(
-                id, UnicodeUtil.truncateStringMin((Literal<CharSequence>) min, truncateLength));
-            break;
-          case FIXED:
-          case BINARY:
-            lowerBounds.put(
-                id, BinaryUtil.truncateBinaryMin((Literal<ByteBuffer>) min, truncateLength));
-            break;
-          default:
-            lowerBounds.put(id, min);
-        }
-      }
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T> void updateMax(
-      Map<Integer, Literal<?>> upperBounds,
-      int id,
-      Type type,
-      Literal<T> max,
-      MetricsMode metricsMode) {
-    Literal<T> currentMax = (Literal<T>) upperBounds.get(id);
-    if (currentMax == null || max.comparator().compare(max.value(), currentMax.value()) > 0) {
-      if (metricsMode == MetricsModes.Full.get()) {
-        upperBounds.put(id, max);
-      } else {
-        MetricsModes.Truncate truncateMode = (MetricsModes.Truncate) metricsMode;
-        int truncateLength = truncateMode.length();
-        switch (type.typeId()) {
-          case STRING:
-            Literal<CharSequence> truncatedMaxString =
-                UnicodeUtil.truncateStringMax((Literal<CharSequence>) max, truncateLength);
-            if (truncatedMaxString != null) {
-              upperBounds.put(id, truncatedMaxString);
-            }
-            break;
-          case FIXED:
-          case BINARY:
-            Literal<ByteBuffer> truncatedMaxBinary =
-                BinaryUtil.truncateBinaryMax((Literal<ByteBuffer>) max, truncateLength);
-            if (truncatedMaxBinary != null) {
-              upperBounds.put(id, truncatedMaxBinary);
-            }
-            break;
-          default:
-            upperBounds.put(id, max);
-        }
-      }
-    }
-  }
-
-  private static Map<Integer, ByteBuffer> toBufferMap(Schema schema, Map<Integer, Literal<?>> map) {
-    Map<Integer, ByteBuffer> bufferMap = Maps.newHashMap();
-    for (Map.Entry<Integer, Literal<?>> entry : map.entrySet()) {
-      bufferMap.put(
-          entry.getKey(),
-          Conversions.toByteBuffer(schema.findType(entry.getKey()), entry.getValue().value()));
-    }
-    return bufferMap;
   }
 
   @SuppressWarnings("deprecation")

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
@@ -1,0 +1,476 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.util.BinaryUtil;
+import org.apache.iceberg.util.UnicodeUtil;
+import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.VariantArray;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantObject;
+import org.apache.iceberg.variants.VariantPrimitive;
+import org.apache.iceberg.variants.VariantValue;
+import org.apache.iceberg.variants.VariantVisitor;
+import org.apache.iceberg.variants.Variants;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.IntLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.LogicalTypeAnnotationVisitor;
+import org.apache.parquet.schema.LogicalTypeAnnotation.StringLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
+
+class ParquetVariantUtil {
+  private ParquetVariantUtil() {}
+
+  /**
+   * Convert a Parquet {@link PrimitiveType} to the equivalent Variant {@link PhysicalType}.
+   *
+   * @param primitive a Parquet {@link PrimitiveType}
+   * @return a Variant {@link PhysicalType}
+   * @throws UnsupportedOperationException if the Parquet type is not equivalent to a variant type
+   */
+  static PhysicalType convert(PrimitiveType primitive) {
+    LogicalTypeAnnotation annotation = primitive.getLogicalTypeAnnotation();
+    if (annotation != null) {
+      return annotation.accept(PhysicalTypeConverter.INSTANCE).orElse(null);
+    }
+
+    switch (primitive.getPrimitiveTypeName()) {
+      case BOOLEAN:
+        return PhysicalType.BOOLEAN_TRUE;
+      case INT32:
+        return PhysicalType.INT32;
+      case INT64:
+        return PhysicalType.INT64;
+      case FLOAT:
+        return PhysicalType.FLOAT;
+      case DOUBLE:
+        return PhysicalType.DOUBLE;
+      case BINARY:
+        return PhysicalType.BINARY;
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Serialize Variant metadata and value in a single concatenated buffer.
+   *
+   * @param metadata a {VariantMetadata}
+   * @param value a {VariantValue}
+   * @return a buffer containing the metadata and value serialized and concatenated
+   */
+  static ByteBuffer toByteBuffer(VariantMetadata metadata, VariantValue value) {
+    ByteBuffer buffer =
+        ByteBuffer.allocate(metadata.sizeInBytes() + value.sizeInBytes())
+            .order(ByteOrder.LITTLE_ENDIAN);
+    metadata.writeTo(buffer, 0);
+    value.writeTo(buffer, metadata.sizeInBytes());
+    return buffer;
+  }
+
+  /**
+   * Converts a Parquet primitive value to a Variant in-memory value for the given {@link
+   * PhysicalType type}.
+   *
+   * @param primitive a primitive variant {@link PhysicalType}
+   * @param scale decimal scale used when the value is a decimal
+   * @param value a value from Parquet value to convert
+   * @param <T> Java type used for values of the given Variant physical type
+   * @return the primitive value
+   */
+  @SuppressWarnings("unchecked")
+  static <T> T convertValue(PhysicalType primitive, int scale, Object value) {
+    switch (primitive) {
+      case BOOLEAN_FALSE:
+      case BOOLEAN_TRUE:
+      case INT32:
+      case INT64:
+      case DATE:
+      case TIMESTAMPTZ:
+      case TIMESTAMPNTZ:
+      case FLOAT:
+      case DOUBLE:
+        return (T) value;
+      case INT8:
+        return (T) (Byte) ((Number) value).byteValue();
+      case INT16:
+        return (T) (Short) ((Number) value).shortValue();
+      case DECIMAL4:
+      case DECIMAL8:
+        return (T) BigDecimal.valueOf(((Number) value).longValue(), scale);
+      case DECIMAL16:
+        return (T) new BigDecimal(new BigInteger(((Binary) value).getBytes()), scale);
+      case BINARY:
+        return (T) ((Binary) value).toByteBuffer();
+      case STRING:
+        return (T) ((Binary) value).toStringUsingUTF8();
+      default:
+        throw new IllegalStateException("Invalid bound type: " + primitive);
+    }
+  }
+
+  /**
+   * Returns a comparator for values of the given primitive {@link PhysicalType type}.
+   *
+   * @param primitive a primitive variant {@link PhysicalType}
+   * @param <T> Java type used for values of the given Variant physical type
+   * @return a comparator for in-memory values of the given type
+   */
+  @SuppressWarnings("unchecked")
+  static <T> Comparator<T> comparator(PhysicalType primitive) {
+    if (primitive == PhysicalType.BINARY) {
+      return (Comparator<T>) Comparators.unsignedBytes();
+    } else {
+      return (Comparator<T>) Comparator.naturalOrder();
+    }
+  }
+
+  /**
+   * Returns a decimal scale if the primitive is a decimal, or 0 otherwise.
+   *
+   * @param primitive a primitive type
+   * @return decimal scale if the primitive is a decimal, 0 otherwise
+   */
+  static int scale(PrimitiveType primitive) {
+    LogicalTypeAnnotation annotation = primitive.getLogicalTypeAnnotation();
+    if (annotation instanceof DecimalLogicalTypeAnnotation) {
+      return ((DecimalLogicalTypeAnnotation) annotation).getScale();
+    }
+
+    return 0;
+  }
+
+  /**
+   * Creates a Parquet schema to fully shred the {@link VariantValue}.
+   *
+   * @param value a variant value
+   * @return a Parquet schema that can fully shred the value
+   */
+  static Type toParquetSchema(VariantValue value) {
+    return VariantVisitor.visit(value, new ParquetSchemaProducer());
+  }
+
+  private static class PhysicalTypeConverter implements LogicalTypeAnnotationVisitor<PhysicalType> {
+    private static final PhysicalTypeConverter INSTANCE = new PhysicalTypeConverter();
+
+    @Override
+    public Optional<PhysicalType> visit(StringLogicalTypeAnnotation ignored) {
+      return Optional.of(PhysicalType.STRING);
+    }
+
+    @Override
+    public Optional<PhysicalType> visit(DecimalLogicalTypeAnnotation decimal) {
+      if (decimal.getPrecision() <= 9) {
+        return Optional.of(PhysicalType.DECIMAL4);
+      } else if (decimal.getPrecision() <= 18) {
+        return Optional.of(PhysicalType.DECIMAL8);
+      } else {
+        return Optional.of(PhysicalType.DECIMAL16);
+      }
+    }
+
+    @Override
+    public Optional<PhysicalType> visit(DateLogicalTypeAnnotation ignored) {
+      return Optional.of(PhysicalType.DATE);
+    }
+
+    @Override
+    public Optional<PhysicalType> visit(TimeLogicalTypeAnnotation ignored) {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<PhysicalType> visit(TimestampLogicalTypeAnnotation timestamps) {
+      switch (timestamps.getUnit()) {
+        case MICROS:
+          if (timestamps.isAdjustedToUTC()) {
+            return Optional.of(PhysicalType.TIMESTAMPTZ);
+          } else {
+            return Optional.of(PhysicalType.TIMESTAMPNTZ);
+          }
+        case NANOS:
+        default:
+          return Optional.empty();
+      }
+    }
+
+    @Override
+    public Optional<PhysicalType> visit(IntLogicalTypeAnnotation ints) {
+      if (!ints.isSigned()) {
+        return Optional.empty();
+      }
+
+      switch (ints.getBitWidth()) {
+        case 8:
+          return Optional.of(PhysicalType.INT8);
+        case 16:
+          return Optional.of(PhysicalType.INT16);
+        case 32:
+          return Optional.of(PhysicalType.INT32);
+        case 64:
+          return Optional.of(PhysicalType.INT64);
+        default:
+          return Optional.empty();
+      }
+    }
+
+    @Override
+    public Optional<PhysicalType> visit(UUIDLogicalTypeAnnotation uuidLogicalType) {
+      return Optional.empty();
+    }
+  }
+
+  static class VariantMetrics {
+    private final long valueCount;
+    private final long nullCount;
+    private final VariantValue lowerBound;
+    private final VariantValue upperBound;
+    private final Deque<String> fieldNames = Lists.newLinkedList();
+    private String lazyFieldName = null;
+
+    VariantMetrics(long valueCount, long nullCount) {
+      this.valueCount = valueCount;
+      this.nullCount = nullCount;
+      this.lowerBound = null;
+      this.upperBound = null;
+    }
+
+    VariantMetrics(
+        long valueCount, long nullCount, VariantValue lowerBound, VariantValue upperBound) {
+      this.valueCount = valueCount;
+      this.nullCount = nullCount;
+      this.lowerBound = truncateLowerBound(lowerBound);
+      this.upperBound = truncateUpperBound(upperBound);
+    }
+
+    VariantMetrics prependFieldName(String name) {
+      this.lazyFieldName = null;
+      fieldNames.addFirst(name);
+      return this;
+    }
+
+    public String fieldName() {
+      if (null == lazyFieldName) {
+        this.lazyFieldName = String.join(".", fieldNames);
+      }
+
+      return lazyFieldName;
+    }
+
+    public long valueCount() {
+      return valueCount;
+    }
+
+    public long nullCount() {
+      return nullCount;
+    }
+
+    public VariantValue lowerBound() {
+      return lowerBound;
+    }
+
+    public VariantValue upperBound() {
+      return upperBound;
+    }
+
+    private static VariantValue truncateLowerBound(VariantValue value) {
+      switch (value.type()) {
+        case STRING:
+          return Variants.of(
+              PhysicalType.STRING,
+              UnicodeUtil.truncateStringMin((String) value.asPrimitive().get(), 16));
+        case BINARY:
+          return Variants.of(
+              PhysicalType.BINARY,
+              BinaryUtil.truncateBinaryMin((ByteBuffer) value.asPrimitive().get(), 16));
+        default:
+          return value;
+      }
+    }
+
+    private static VariantValue truncateUpperBound(VariantValue value) {
+      switch (value.type()) {
+        case STRING:
+          String truncatedString =
+              UnicodeUtil.truncateStringMax((String) value.asPrimitive().get(), 16);
+          return truncatedString != null ? Variants.of(PhysicalType.STRING, truncatedString) : null;
+        case BINARY:
+          ByteBuffer truncatedBuffer =
+              BinaryUtil.truncateBinaryMin((ByteBuffer) value.asPrimitive().get(), 16);
+          return truncatedBuffer != null ? Variants.of(PhysicalType.BINARY, truncatedBuffer) : null;
+        default:
+          return value;
+      }
+    }
+  }
+
+  private static class ParquetSchemaProducer extends VariantVisitor<Type> {
+    @Override
+    public Type object(VariantObject object, List<String> names, List<Type> typedValues) {
+      if (object.numFields() < 1) {
+        // Parquet cannot write  typed_value group with no fields
+        return null;
+      }
+
+      List<GroupType> fields = Lists.newArrayList();
+      int index = 0;
+      for (String name : names) {
+        Type typedValue = typedValues.get(index);
+        fields.add(field(name, typedValue));
+        index += 1;
+      }
+
+      return objectFields(fields);
+    }
+
+    @Override
+    public Type array(VariantArray array, List<Type> elementResults) {
+      return null;
+    }
+
+    @Override
+    public Type primitive(VariantPrimitive<?> primitive) {
+      switch (primitive.type()) {
+        case NULL:
+          return null;
+        case BOOLEAN_TRUE:
+        case BOOLEAN_FALSE:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.BOOLEAN);
+        case INT8:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT32, LogicalTypeAnnotation.intType(8));
+        case INT16:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT32, LogicalTypeAnnotation.intType(16));
+        case INT32:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.INT32);
+        case INT64:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.INT64);
+        case FLOAT:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.FLOAT);
+        case DOUBLE:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.DOUBLE);
+        case DECIMAL4:
+          BigDecimal decimal4 = (BigDecimal) primitive.get();
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT32,
+              LogicalTypeAnnotation.decimalType(decimal4.scale(), 9));
+        case DECIMAL8:
+          BigDecimal decimal8 = (BigDecimal) primitive.get();
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT64,
+              LogicalTypeAnnotation.decimalType(decimal8.scale(), 18));
+        case DECIMAL16:
+          BigDecimal decimal16 = (BigDecimal) primitive.get();
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.BINARY,
+              LogicalTypeAnnotation.decimalType(decimal16.scale(), 38));
+        case DATE:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT32, LogicalTypeAnnotation.dateType());
+        case TIMESTAMPTZ:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT64,
+              LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS));
+        case TIMESTAMPNTZ:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.INT64,
+              LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.MICROS));
+        case BINARY:
+          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.BINARY);
+        case STRING:
+          return shreddedPrimitive(
+              PrimitiveType.PrimitiveTypeName.BINARY, LogicalTypeAnnotation.stringType());
+      }
+
+      throw new UnsupportedOperationException("Unsupported shredding type: " + primitive.type());
+    }
+
+    private static GroupType objectFields(List<GroupType> fields) {
+      Types.GroupBuilder<GroupType> builder = Types.buildGroup(Type.Repetition.OPTIONAL);
+      for (GroupType field : fields) {
+        checkField(field);
+        builder.addField(field);
+      }
+
+      return builder.named("typed_value");
+    }
+
+    private static void checkField(GroupType fieldType) {
+      Preconditions.checkArgument(
+          fieldType.isRepetition(Type.Repetition.REQUIRED),
+          "Invalid field type repetition: %s should be REQUIRED",
+          fieldType.getRepetition());
+    }
+
+    private static GroupType field(String name, Type shreddedType) {
+      Types.GroupBuilder<GroupType> builder =
+          Types.buildGroup(Type.Repetition.REQUIRED)
+              .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+              .named("value");
+
+      if (shreddedType != null) {
+        checkShreddedType(shreddedType);
+        builder.addField(shreddedType);
+      }
+
+      return builder.named(name);
+    }
+
+    private static void checkShreddedType(Type shreddedType) {
+      Preconditions.checkArgument(
+          shreddedType.getName().equals("typed_value"),
+          "Invalid shredded type name: %s should be typed_value",
+          shreddedType.getName());
+      Preconditions.checkArgument(
+          shreddedType.isRepetition(Type.Repetition.OPTIONAL),
+          "Invalid shredded type repetition: %s should be OPTIONAL",
+          shreddedType.getRepetition());
+    }
+
+    private static Type shreddedPrimitive(PrimitiveType.PrimitiveTypeName primitive) {
+      return Types.optional(primitive).named("typed_value");
+    }
+
+    private static Type shreddedPrimitive(
+        PrimitiveType.PrimitiveTypeName primitive, LogicalTypeAnnotation annotation) {
+      return Types.optional(primitive).as(annotation).named("typed_value");
+    }
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -46,6 +46,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
 
   private static final Metrics EMPTY_METRICS = new Metrics(0L, null, null, null, null);
 
+  private final Schema schema;
   private final long targetRowGroupSize;
   private final Map<String, String> metadata;
   private final ParquetProperties props;
@@ -84,6 +85,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
       MetricsConfig metricsConfig,
       ParquetFileWriter.Mode writeMode,
       FileEncryptionProperties encryptionProperties) {
+    this.schema = schema;
     this.targetRowGroupSize = rowGroupSize;
     this.props = properties;
     this.metadata = ImmutableMap.copyOf(metadata);
@@ -142,7 +144,8 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
   public Metrics metrics() {
     Preconditions.checkState(closed, "Cannot return metrics for unclosed writer");
     if (writer != null) {
-      return ParquetUtil.footerMetrics(writer.getFooter(), model.metrics(), metricsConfig);
+      return ParquetMetrics.metrics(
+          schema, parquetSchema, metricsConfig, writer.getFooter(), model.metrics());
     }
     return EMPTY_METRICS;
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -154,7 +154,8 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
   }
 
   @Override
-  public Type variant(org.apache.iceberg.types.Types.VariantType expected, Type variant) {
+  public Type variant(
+      org.apache.iceberg.types.Types.VariantType expected, GroupType variantGroup, Type variant) {
     return variant;
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
@@ -211,13 +211,13 @@ public class TypeWithSchemaVisitor<T> {
   }
 
   private static <T> T visitVariant(
-      Types.VariantType variant, GroupType group, TypeWithSchemaVisitor<T> visitor) {
+      Types.VariantType variant, GroupType variantGroup, TypeWithSchemaVisitor<T> visitor) {
     ParquetVariantVisitor<T> variantVisitor = visitor.variantVisitor();
     if (variantVisitor != null) {
-      T variantResult = ParquetVariantVisitor.visit(group, variantVisitor);
-      return visitor.variant(variant, variantResult);
+      T variantResult = ParquetVariantVisitor.visit(variantGroup, variantVisitor);
+      return visitor.variant(variant, variantGroup, variantResult);
     } else {
-      return visitor.variant(variant, null);
+      return visitor.variant(variant, variantGroup, null);
     }
   }
 
@@ -237,7 +237,7 @@ public class TypeWithSchemaVisitor<T> {
     return null;
   }
 
-  public T variant(Types.VariantType iVariant, T result) {
+  public T variant(Types.VariantType iVariant, GroupType variant, T result) {
     throw new UnsupportedOperationException("Not implemented for variant");
   }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
@@ -1,0 +1,503 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.InternalWriter;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.BinaryUtil;
+import org.apache.iceberg.util.UnicodeUtil;
+import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.ShreddedObject;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantObject;
+import org.apache.iceberg.variants.VariantPrimitive;
+import org.apache.iceberg.variants.VariantTestUtil;
+import org.apache.iceberg.variants.VariantValue;
+import org.apache.iceberg.variants.Variants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+
+public class TestVariantMetrics {
+  private static final VariantMetadata METADATA =
+      VariantMetadata.from(VariantTestUtil.createMetadata(Set.of("a", "b", "c", "d", "e"), true));
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.optional(2, "var", Types.VariantType.get()));
+
+  private static final VariantMetadata EMPTY = Variants.emptyMetadata();
+
+  private static final String ROOT_FIELD = "";
+
+  private static final VariantValue[] PRIMITIVES =
+      new VariantValue[] {
+        Variants.of(true),
+        Variants.of(false),
+        Variants.of((byte) 34),
+        Variants.of((byte) -34),
+        Variants.of((short) 1234),
+        Variants.of((short) -1234),
+        Variants.of(12345),
+        Variants.of(-12345),
+        Variants.of(9876543210L),
+        Variants.of(-9876543210L),
+        Variants.of(10.11F),
+        Variants.of(-10.11F),
+        Variants.of(14.3D),
+        Variants.of(-14.3D),
+        Variants.ofIsoDate("2024-11-07"),
+        Variants.ofIsoDate("1957-11-07"),
+        Variants.ofIsoTimestamptz("2024-11-07T12:33:54.123456+00:00"),
+        Variants.ofIsoTimestamptz("1957-11-07T12:33:54.123456+00:00"),
+        Variants.ofIsoTimestampntz("2024-11-07T12:33:54.123456"),
+        Variants.ofIsoTimestampntz("1957-11-07T12:33:54.123456"),
+        Variants.of(new BigDecimal("123456.789")), // decimal4
+        Variants.of(new BigDecimal("-123456.789")), // decimal4
+        Variants.of(new BigDecimal("123456789.987654321")), // decimal8
+        Variants.of(new BigDecimal("-123456789.987654321")), // decimal8
+        Variants.of(new BigDecimal("9876543210.123456789")), // decimal16
+        Variants.of(new BigDecimal("-9876543210.123456789")), // decimal16
+        Variants.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),
+        Variants.of("iceberg"),
+      };
+
+  @ParameterizedTest
+  @FieldSource("PRIMITIVES")
+  public void testShreddedPrimitiveTypes(VariantValue value) throws IOException {
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(value),
+            Variant.of(EMPTY, value),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null);
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 3L, 2, 3L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds().size()).isEqualTo(2);
+    assertThat(metrics.lowerBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(0L);
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(
+            bytes -> {
+              VariantObject bounds = Variant.from(bytes).value().asObject();
+              return bounds.get(ROOT_FIELD);
+            })
+        .isEqualTo(value);
+
+    assertThat(metrics.upperBounds().size()).isEqualTo(2);
+    assertThat(metrics.upperBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(2L);
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(
+            bytes -> {
+              VariantObject bounds = Variant.from(bytes).value().asObject();
+              return bounds.get(ROOT_FIELD);
+            })
+        .isEqualTo(value);
+  }
+
+  @ParameterizedTest
+  @FieldSource("PRIMITIVES")
+  public void testShreddedPrimitiveRange(VariantValue value) throws IOException {
+    VariantValue largerValue = increment(value);
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(value),
+            Variant.of(EMPTY, largerValue),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null,
+            Variant.of(EMPTY, value));
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 4L, 2, 4L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds().size()).isEqualTo(2);
+    assertThat(metrics.lowerBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(0L);
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(
+            bytes -> {
+              VariantObject bounds = Variant.from(bytes).value().asObject();
+              return bounds.get(ROOT_FIELD);
+            })
+        .isEqualTo(value);
+
+    assertThat(metrics.upperBounds().size()).isEqualTo(2);
+    assertThat(metrics.upperBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(3L);
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(
+            bytes -> {
+              VariantObject bounds = Variant.from(bytes).value().asObject();
+              return bounds.get(ROOT_FIELD);
+            })
+        .isEqualTo(largerValue);
+  }
+
+  @ParameterizedTest
+  @FieldSource("PRIMITIVES")
+  public void testShreddedPrimitiveTypeMismatch(VariantValue value) throws IOException {
+    // a value of another type will cause lower/upper bounds to be omitted
+    VariantValue otherValue =
+        value.type() == PhysicalType.STRING ? Variants.of(34) : Variants.of("iceberg");
+
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(value),
+            Variant.of(EMPTY, value),
+            Variant.of(EMPTY, otherValue));
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 2L, 2, 2L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 0L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
+    assertThat(metrics.upperBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+  }
+
+  @Test
+  public void testVariantFloatNaN() throws IOException {
+    // NaN values are not counted because there is no ID for FieldMetrics
+    VariantValue floatValue = Variants.of(1.0F);
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(floatValue),
+            Variant.of(EMPTY, floatValue),
+            Variant.of(EMPTY, Variants.of(Float.NaN)));
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 2L, 2, 2L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 0L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
+    assertThat(metrics.upperBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+  }
+
+  @Test
+  public void testVariantDoubleNaN() throws IOException {
+    // NaN values are not counted because there is no ID for FieldMetrics
+    VariantValue doubleValue = Variants.of(1.0D);
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(doubleValue),
+            Variant.of(EMPTY, doubleValue),
+            Variant.of(EMPTY, Variants.of(Double.NaN)));
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 2L, 2, 2L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 0L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
+    assertThat(metrics.upperBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+  }
+
+  @Test
+  public void testAllNull() throws IOException {
+    ShreddedObject object = Variants.object(METADATA);
+    object.put("a", Variants.ofIsoDate("2025-03-17"));
+    object.put("b", Variants.of(34));
+    object.put("c", Variants.of("iceberg"));
+    Metrics metrics =
+        writeParquet((id, name) -> ParquetVariantUtil.toParquetSchema(object), null, null);
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 2L, 2, 2L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 2L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
+    assertThat(metrics.upperBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+  }
+
+  @Test
+  public void testUnshredded() throws IOException {
+    ShreddedObject object = Variants.object(METADATA);
+    object.put("a", Variants.ofIsoDate("2025-03-17"));
+    object.put("b", Variants.of(34));
+    object.put("c", Variants.of("iceberg"));
+    Metrics metrics = writeParquet((id, name) -> null, Variant.of(METADATA, object), null);
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 2L, 2, 2L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    assertThat(metrics.lowerBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
+    assertThat(metrics.upperBounds())
+        .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+  }
+
+  @Test
+  public void testShreddedObject() throws IOException {
+    VariantValue date = Variants.ofIsoDate("2025-03-17");
+    VariantValue num = Variants.of(34);
+    VariantValue str = Variants.of("iceberg");
+    VariantValue dec = Variants.of(new BigDecimal("123456.789"));
+
+    ShreddedObject inner = Variants.object(METADATA);
+    inner.put("e", dec);
+    ShreddedObject object = Variants.object(METADATA);
+    object.put("a", date);
+    object.put("b", num);
+    object.put("c", str);
+    object.put("d", inner);
+
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(object),
+            Variant.of(EMPTY, num),
+            Variant.of(EMPTY, Variants.object(EMPTY)),
+            Variant.of(METADATA, object),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null);
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 5L, 2, 5L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    VariantMetadata boundMetadata = Variants.metadata("a", "b", "c", "d.e");
+    ShreddedObject expectedBounds = Variants.object(boundMetadata);
+    expectedBounds.put("a", date);
+    expectedBounds.put("b", num);
+    expectedBounds.put("c", str);
+    expectedBounds.put("d.e", dec);
+
+    assertThat(metrics.lowerBounds().size()).isEqualTo(2);
+    assertThat(metrics.lowerBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(0L);
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(bytes -> Variant.from(bytes).value())
+        .isEqualTo(expectedBounds);
+
+    assertThat(metrics.upperBounds().size()).isEqualTo(2);
+    assertThat(metrics.upperBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(4L);
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(bytes -> Variant.from(bytes).value())
+        .isEqualTo(expectedBounds);
+  }
+
+  @Test
+  public void testPartiallyShreddedObject() throws IOException {
+    VariantValue date = Variants.ofIsoDate("2025-03-17");
+    VariantValue num = Variants.of(34);
+    VariantValue str = Variants.of("iceberg");
+    VariantValue dec = Variants.of(new BigDecimal("123456.789"));
+
+    ShreddedObject inner = Variants.object(METADATA);
+    inner.put("e", dec);
+    ShreddedObject object = Variants.object(METADATA);
+    object.put("a", date);
+    object.put("b", num);
+    object.put("c", str);
+    object.put("d", inner);
+
+    // used to produce the shredding schema
+    ShreddedObject example = Variants.object(METADATA);
+    example.put("a", date);
+    example.put("b", num);
+
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(example),
+            Variant.of(EMPTY, num),
+            Variant.of(EMPTY, Variants.object(EMPTY)),
+            Variant.of(METADATA, object),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null);
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 5L, 2, 5L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    // only a and b were shredded so the other fields are not present
+    VariantMetadata boundMetadata = Variants.metadata("a", "b");
+    ShreddedObject expectedBounds = Variants.object(boundMetadata);
+    expectedBounds.put("a", date);
+    expectedBounds.put("b", num);
+
+    assertThat(metrics.lowerBounds().size()).isEqualTo(2);
+    assertThat(metrics.lowerBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(0L);
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(bytes -> Variant.from(bytes).value())
+        .isEqualTo(expectedBounds);
+
+    assertThat(metrics.upperBounds().size()).isEqualTo(2);
+    assertThat(metrics.upperBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(4L);
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(bytes -> Variant.from(bytes).value())
+        .isEqualTo(expectedBounds);
+  }
+
+  @Test
+  public void testShreddedObjectFieldTypeMismatch() throws IOException {
+    VariantValue date = Variants.ofIsoDate("2025-03-17");
+    VariantValue num = Variants.of(34);
+    VariantValue str = Variants.of("iceberg");
+    VariantValue dec = Variants.of(new BigDecimal("123456.789"));
+
+    ShreddedObject inner = Variants.object(METADATA);
+    inner.put("e", dec);
+    ShreddedObject object = Variants.object(METADATA);
+    object.put("a", date);
+    object.put("b", num);
+    object.put("c", str);
+    object.put("d", inner);
+
+    ShreddedObject mismatched = Variants.object(METADATA);
+    mismatched.put("a", Variants.ofNull()); // does not affect metrics
+    mismatched.put("b", Variants.of((byte) -1)); // int and byte mismatch
+    mismatched.put("c", num); // string and int mismatch
+    // d is missing and does not affect metrics
+
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(object),
+            Variant.of(EMPTY, num),
+            Variant.of(EMPTY, mismatched),
+            Variant.of(EMPTY, Variants.object(EMPTY)),
+            Variant.of(METADATA, object),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null);
+
+    assertThat(metrics.valueCounts()).isEqualTo(Map.of(1, 6L, 2, 6L));
+    assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
+    assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
+
+    // only a and b were shredded so the other fields are not present
+    VariantMetadata boundMetadata = Variants.metadata("a", "d.e");
+    ShreddedObject expectedBounds = Variants.object(boundMetadata);
+    expectedBounds.put("a", date);
+    expectedBounds.put("d.e", dec);
+
+    assertThat(metrics.lowerBounds().size()).isEqualTo(2);
+    assertThat(metrics.lowerBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(0L);
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(bytes -> Variant.from(bytes).value())
+        .isEqualTo(expectedBounds);
+
+    assertThat(metrics.upperBounds().size()).isEqualTo(2);
+    assertThat(metrics.upperBounds().get(1))
+        .extracting(bytes -> Conversions.fromByteBuffer(Types.LongType.get(), bytes))
+        .isEqualTo(5L);
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(bytes -> Variant.from(bytes).value())
+        .isEqualTo(expectedBounds);
+  }
+
+  private Metrics writeParquet(VariantShreddingFunction shredding, Variant... variants)
+      throws IOException {
+    OutputFile out = new InMemoryOutputFile();
+    GenericRecord record = GenericRecord.create(SCHEMA);
+
+    FileAppender<Record> writer =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc(shredding)
+            .createWriterFunc(fileSchema -> InternalWriter.create(SCHEMA.asStruct(), fileSchema))
+            .build();
+
+    try (writer) {
+      for (int id = 0; id < variants.length; id += 1) {
+        record.setField("id", (long) id);
+        record.setField("var", variants[id]);
+        writer.add(record);
+      }
+    }
+
+    return writer.metrics();
+  }
+
+  private static VariantValue increment(VariantValue value) {
+    VariantPrimitive<?> primitive = value.asPrimitive();
+    switch (value.type()) {
+      case BOOLEAN_TRUE:
+      case BOOLEAN_FALSE:
+        return Variants.of(true);
+      case INT8:
+        return Variants.of(value.type(), (byte) ((Byte) primitive.get() + 1));
+      case INT16:
+        return Variants.of(value.type(), (short) ((Short) primitive.get() + 1));
+      case INT32:
+      case DATE:
+        return Variants.of(value.type(), (Integer) primitive.get() + 1);
+      case INT64:
+      case TIMESTAMPTZ:
+      case TIMESTAMPNTZ:
+        return Variants.of(value.type(), (Long) primitive.get() + 1L);
+      case FLOAT:
+        return Variants.of(value.type(), (Float) primitive.get() + 1.0F);
+      case DOUBLE:
+        return Variants.of(value.type(), (Double) primitive.get() + 1.0D);
+      case DECIMAL4:
+      case DECIMAL8:
+      case DECIMAL16:
+        return Variants.of(value.type(), ((BigDecimal) primitive.get()).add(BigDecimal.ONE));
+      case BINARY:
+        return Variants.of(
+            value.type(), BinaryUtil.truncateBinaryMax((ByteBuffer) primitive.get(), 2));
+      case STRING:
+        return Variants.of(
+            value.type(), UnicodeUtil.truncateStringMax((String) primitive.get(), 5));
+    }
+
+    throw new UnsupportedOperationException("Cannot increment value: " + value);
+  }
+}

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
@@ -36,26 +36,16 @@ import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.variants.Variant;
-import org.apache.iceberg.variants.VariantArray;
 import org.apache.iceberg.variants.VariantMetadata;
 import org.apache.iceberg.variants.VariantObject;
-import org.apache.iceberg.variants.VariantPrimitive;
 import org.apache.iceberg.variants.VariantTestUtil;
-import org.apache.iceberg.variants.VariantValue;
-import org.apache.iceberg.variants.VariantVisitor;
 import org.apache.iceberg.variants.Variants;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.LogicalTypeAnnotation;
-import org.apache.parquet.schema.PrimitiveType;
-import org.apache.parquet.schema.Type;
-import org.apache.parquet.schema.Types.GroupBuilder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 
@@ -148,7 +138,8 @@ public class TestVariantWriters {
   public void testShreddedValues(Variant variant) throws IOException {
     Record record = RECORD.copy("id", 1, "var", variant);
 
-    Record actual = writeAndRead((id, name) -> toParquetSchema(variant.value()), record);
+    Record actual =
+        writeAndRead((id, name) -> ParquetVariantUtil.toParquetSchema(variant.value()), record);
 
     InternalTestHelpers.assertEquals(SCHEMA.asStruct(), record, actual);
   }
@@ -161,7 +152,8 @@ public class TestVariantWriters {
             .mapToObj(i -> RECORD.copy("id", i, "var", VARIANTS[i]))
             .collect(Collectors.toList());
 
-    List<Record> actual = writeAndRead((id, name) -> toParquetSchema(variant.value()), expected);
+    List<Record> actual =
+        writeAndRead((id, name) -> ParquetVariantUtil.toParquetSchema(variant.value()), expected);
 
     assertThat(actual.size()).isEqualTo(expected.size());
 
@@ -196,147 +188,6 @@ public class TestVariantWriters {
             .createReaderFunc(fileSchema -> InternalReader.create(SCHEMA, fileSchema))
             .build()) {
       return Lists.newArrayList(reader);
-    }
-  }
-
-  private Type toParquetSchema(VariantValue value) {
-    return VariantVisitor.visit(value, new ParquetSchemaProducer());
-  }
-
-  private static class ParquetSchemaProducer extends VariantVisitor<Type> {
-    @Override
-    public Type object(VariantObject object, List<String> names, List<Type> typedValues) {
-      if (object.numFields() < 1) {
-        // Parquet cannot write  typed_value group with no fields
-        return null;
-      }
-
-      List<GroupType> fields = Lists.newArrayList();
-      int index = 0;
-      for (String name : names) {
-        Type typedValue = typedValues.get(index);
-        fields.add(field(name, typedValue));
-        index += 1;
-      }
-
-      return objectFields(fields);
-    }
-
-    @Override
-    public Type array(VariantArray array, List<Type> elementResults) {
-      throw null;
-    }
-
-    @Override
-    public Type primitive(VariantPrimitive<?> primitive) {
-      switch (primitive.type()) {
-        case NULL:
-          return null;
-        case BOOLEAN_TRUE:
-        case BOOLEAN_FALSE:
-          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.BOOLEAN);
-        case INT8:
-          return shreddedPrimitive(
-              PrimitiveType.PrimitiveTypeName.INT32, LogicalTypeAnnotation.intType(8));
-        case INT16:
-          return shreddedPrimitive(
-              PrimitiveType.PrimitiveTypeName.INT32, LogicalTypeAnnotation.intType(16));
-        case INT32:
-          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.INT32);
-        case INT64:
-          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.INT64);
-        case FLOAT:
-          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.FLOAT);
-        case DOUBLE:
-          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.DOUBLE);
-        case DECIMAL4:
-          BigDecimal decimal4 = (BigDecimal) primitive.get();
-          return shreddedPrimitive(
-              PrimitiveType.PrimitiveTypeName.INT32,
-              LogicalTypeAnnotation.decimalType(decimal4.scale(), 9));
-        case DECIMAL8:
-          BigDecimal decimal8 = (BigDecimal) primitive.get();
-          return shreddedPrimitive(
-              PrimitiveType.PrimitiveTypeName.INT64,
-              LogicalTypeAnnotation.decimalType(decimal8.scale(), 18));
-        case DECIMAL16:
-          BigDecimal decimal16 = (BigDecimal) primitive.get();
-          return shreddedPrimitive(
-              PrimitiveType.PrimitiveTypeName.BINARY,
-              LogicalTypeAnnotation.decimalType(decimal16.scale(), 38));
-        case DATE:
-          return shreddedPrimitive(
-              PrimitiveType.PrimitiveTypeName.INT32, LogicalTypeAnnotation.dateType());
-        case TIMESTAMPTZ:
-          return shreddedPrimitive(
-              PrimitiveType.PrimitiveTypeName.INT64,
-              LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS));
-        case TIMESTAMPNTZ:
-          return shreddedPrimitive(
-              PrimitiveType.PrimitiveTypeName.INT64,
-              LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.MICROS));
-        case BINARY:
-          return shreddedPrimitive(PrimitiveType.PrimitiveTypeName.BINARY);
-        case STRING:
-          return shreddedPrimitive(
-              PrimitiveType.PrimitiveTypeName.BINARY, LogicalTypeAnnotation.stringType());
-      }
-
-      throw new UnsupportedOperationException("Unsupported shredding type: " + primitive.type());
-    }
-
-    private static GroupType objectFields(List<GroupType> fields) {
-      GroupBuilder<GroupType> builder =
-          org.apache.parquet.schema.Types.buildGroup(Type.Repetition.OPTIONAL);
-      for (GroupType field : fields) {
-        checkField(field);
-        builder.addField(field);
-      }
-
-      return builder.named("typed_value");
-    }
-
-    private static void checkField(GroupType fieldType) {
-      Preconditions.checkArgument(
-          fieldType.isRepetition(Type.Repetition.REQUIRED),
-          "Invalid field type repetition: %s should be REQUIRED",
-          fieldType.getRepetition());
-    }
-
-    private static GroupType field(String name, Type shreddedType) {
-      GroupBuilder<GroupType> builder =
-          org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
-              .optional(PrimitiveType.PrimitiveTypeName.BINARY)
-              .named("value");
-
-      if (shreddedType != null) {
-        checkShreddedType(shreddedType);
-        builder.addField(shreddedType);
-      }
-
-      return builder.named(name);
-    }
-
-    private static void checkShreddedType(Type shreddedType) {
-      Preconditions.checkArgument(
-          shreddedType.getName().equals("typed_value"),
-          "Invalid shredded type name: %s should be typed_value",
-          shreddedType.getName());
-      Preconditions.checkArgument(
-          shreddedType.isRepetition(Type.Repetition.OPTIONAL),
-          "Invalid shredded type repetition: %s should be OPTIONAL",
-          shreddedType.getRepetition());
-    }
-
-    private static Type shreddedPrimitive(PrimitiveType.PrimitiveTypeName primitive) {
-      return org.apache.parquet.schema.Types.optional(primitive).named("typed_value");
-    }
-
-    private static Type shreddedPrimitive(
-        PrimitiveType.PrimitiveTypeName primitive, LogicalTypeAnnotation annotation) {
-      return org.apache.parquet.schema.Types.optional(primitive)
-          .as(annotation)
-          .named("typed_value");
     }
   }
 }

--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -192,6 +192,10 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
     antlr libs.antlr.antlr4
   }
 
+  test {
+    useJUnitPlatform()
+  }
+
   generateGrammarSource {
     maxHeapSize = "64m"
     arguments += ['-visitor', '-package', 'org.apache.spark.sql.catalyst.parser.extensions']

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.hive.HiveCatalog;
+import org.apache.iceberg.hive.TestHiveMetastore;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.CatalogTestBase;
+import org.apache.iceberg.spark.TestBase;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.internal.SQLConf;
+import org.junit.jupiter.api.BeforeAll;
+
+public abstract class ExtensionsTestBase extends CatalogTestBase {
+
+  private static final Random RANDOM = ThreadLocalRandom.current();
+
+  @BeforeAll
+  public static void startMetastoreAndSpark() {
+    TestBase.metastore = new TestHiveMetastore();
+    metastore.start();
+    TestBase.hiveConf = metastore.hiveConf();
+
+    TestBase.spark.close();
+
+    TestBase.spark =
+        SparkSession.builder()
+            .master("local[2]")
+            .config("spark.testing", "true")
+            .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+            .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
+            .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+            .config("spark.sql.shuffle.partitions", "4")
+            .config("spark.sql.hive.metastorePartitionPruningFallbackOnException", "true")
+            .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
+            .config(
+                SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), String.valueOf(RANDOM.nextBoolean()))
+            .enableHiveSupport()
+            .getOrCreate();
+
+    TestBase.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+
+    TestBase.catalog =
+        (HiveCatalog)
+            CatalogUtil.loadCatalog(
+                HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
+  }
+}

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -76,6 +76,7 @@ public class TestCallStatementParser {
   @Test
   public void testDelegateUnsupportedProcedure() {
     assertThatThrownBy(() -> parser.parsePlan("CALL cat.d.t()"))
+        .hasMessageContaining("Syntax error")
         .isInstanceOf(ParseException.class)
         .satisfies(
             exception -> {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
@@ -177,6 +177,7 @@ public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.cherrypick_snapshot('n', 't', 1L)", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -177,6 +177,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.expire_snapshots('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
@@ -178,6 +178,7 @@ public class TestFastForwardBranchProcedure extends SparkExtensionsTestBase {
             () ->
                 sql("CALL %s.custom.fast_forward('test_table', 'main', 'newBranch')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadUpdate.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadUpdate.java
@@ -39,7 +39,6 @@ import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.junit.Test;
-import org.junit.jupiter.api.TestTemplate;
 
 public class TestMergeOnReadUpdate extends TestUpdate {
 
@@ -160,7 +159,7 @@ public class TestMergeOnReadUpdate extends TestUpdate {
         sql("SELECT * FROM %s ORDER BY dep ASC, id ASC", selectTarget()));
   }
 
-  @TestTemplate
+  @Test
   public void testUpdateWithDVAndHistoricalPositionDeletes() {
     assumeThat(formatVersion).isEqualTo(2);
     createTableWithDeleteGranularity(

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -18,19 +18,29 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE;
+import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE_REST;
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.commons.collections.ListUtils;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
@@ -39,8 +49,11 @@ import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.spark.source.SimpleRecord;
@@ -51,27 +64,74 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.types.StructType;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestMetadataTables extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestMetadataTables extends ExtensionsTestBase {
+  @Parameter(index = 3)
+  private int formatVersion;
 
-  public TestMetadataTables(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, formatVersion = {3}")
+  protected static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        SparkCatalogConfig.HIVE.properties(),
+        2
+      },
+      {
+        SparkCatalogConfig.HADOOP.catalogName(),
+        SparkCatalogConfig.HADOOP.implementation(),
+        SparkCatalogConfig.HADOOP.properties(),
+        2
+      },
+      {
+        SparkCatalogConfig.SPARK.catalogName(),
+        SparkCatalogConfig.SPARK.implementation(),
+        SparkCatalogConfig.SPARK.properties(),
+        2
+      },
+      {
+        SparkCatalogConfig.SPARK.catalogName(),
+        SparkCatalogConfig.SPARK.implementation(),
+        SparkCatalogConfig.SPARK.properties(),
+        3
+      },
+      {
+        SparkCatalogConfig.REST.catalogName(),
+        SparkCatalogConfig.REST.implementation(),
+        ImmutableMap.builder()
+            .putAll(SparkCatalogConfig.REST.properties())
+            .put(CatalogProperties.URI, restCatalog.properties().get(CatalogProperties.URI))
+            .build(),
+        2
+      },
+      {
+        SparkCatalogConfig.REST.catalogName(),
+        SparkCatalogConfig.REST.implementation(),
+        ImmutableMap.builder()
+            .putAll(SparkCatalogConfig.REST.properties())
+            .put(CatalogProperties.URI, restCatalog.properties().get(CatalogProperties.URI))
+            .build(),
+        3
+      }
+    };
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testUnpartitionedTable() throws Exception {
     sql(
         "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES"
-            + "('format-version'='2', 'write.delete.mode'='merge-on-read')",
-        tableName);
+            + "('format-version'='%s', 'write.delete.mode'='merge-on-read')",
+        tableName, formatVersion);
 
     List<SimpleRecord> records =
         Lists.newArrayList(
@@ -90,8 +150,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
     List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
     List<ManifestFile> expectedDeleteManifests = TestHelpers.deleteManifests(table);
-    Assert.assertEquals("Should have 1 data manifest", 1, expectedDataManifests.size());
-    Assert.assertEquals("Should have 1 delete manifest", 1, expectedDeleteManifests.size());
+    assertThat(expectedDataManifests).as("Should have 1 data manifest").hasSize(1);
+    assertThat(expectedDeleteManifests).as("Should have 1 delete manifest").hasSize(1);
 
     Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
     Schema filesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".files").schema();
@@ -99,13 +159,12 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     // check delete files table
     Dataset<Row> actualDeleteFilesDs = spark.sql("SELECT * FROM " + tableName + ".delete_files");
     List<Row> actualDeleteFiles = TestHelpers.selectNonDerived(actualDeleteFilesDs).collectAsList();
-    Assert.assertEquals(
-        "Metadata table should return one delete file", 1, actualDeleteFiles.size());
+    assertThat(actualDeleteFiles).as("Metadata table should return one delete file").hasSize(1);
 
     List<Record> expectedDeleteFiles =
         expectedEntries(
             table, FileContent.POSITION_DELETES, entriesTableSchema, expectedDeleteManifests, null);
-    Assert.assertEquals("Should be one delete file manifest entry", 1, expectedDeleteFiles.size());
+    assertThat(expectedDeleteFiles).as("Should be one delete file manifest entry").hasSize(1);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDeleteFilesDs),
         expectedDeleteFiles.get(0),
@@ -114,11 +173,11 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     // check data files table
     Dataset<Row> actualDataFilesDs = spark.sql("SELECT * FROM " + tableName + ".data_files");
     List<Row> actualDataFiles = TestHelpers.selectNonDerived(actualDataFilesDs).collectAsList();
-    Assert.assertEquals("Metadata table should return one data file", 1, actualDataFiles.size());
+    assertThat(actualDataFiles).as("Metadata table should return one data file").hasSize(1);
 
     List<Record> expectedDataFiles =
         expectedEntries(table, FileContent.DATA, entriesTableSchema, expectedDataManifests, null);
-    Assert.assertEquals("Should be one data file manifest entry", 1, expectedDataFiles.size());
+    assertThat(expectedDataFiles).as("Should be one data file manifest entry").hasSize(1);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDataFilesDs),
         expectedDataFiles.get(0),
@@ -129,27 +188,87 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
         spark.sql("SELECT * FROM " + tableName + ".files ORDER BY content");
     List<Row> actualFiles = TestHelpers.selectNonDerived(actualFilesDs).collectAsList();
 
-    Assert.assertEquals("Metadata table should return two files", 2, actualFiles.size());
+    assertThat(actualFiles).as("Metadata table should return two files").hasSize(2);
 
     List<Record> expectedFiles =
         Stream.concat(expectedDataFiles.stream(), expectedDeleteFiles.stream())
             .collect(Collectors.toList());
-    Assert.assertEquals("Should have two files manifest entries", 2, expectedFiles.size());
+    assertThat(expectedFiles).as("Should have two files manifest entries").hasSize(2);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(0), actualFiles.get(0));
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(1), actualFiles.get(1));
   }
 
-  @Test
+  @TestTemplate
+  public void testPositionDeletesTable() throws Exception {
+    sql(
+        "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES"
+            + "('format-version'='%s', 'write.delete.mode'='merge-on-read')",
+        tableName, formatVersion);
+
+    List<SimpleRecord> records =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"),
+            new SimpleRecord(2, "b"),
+            new SimpleRecord(3, "c"),
+            new SimpleRecord(4, "d"));
+    spark
+        .createDataset(records, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(tableName)
+        .append();
+
+    sql("DELETE FROM %s WHERE id=1 OR id=3", tableName);
+
+    // check delete files table
+    assertThat(sql("SELECT * FROM %s.delete_files", tableName)).hasSize(1);
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    DataFile dataFile = Iterables.getOnlyElement(TestHelpers.dataFiles(table));
+    DeleteFile deleteFile = Iterables.getOnlyElement(TestHelpers.deleteFiles(table));
+
+    List<Object[]> expectedRows;
+    if (formatVersion >= 3) {
+      expectedRows =
+          ImmutableList.of(
+              row(
+                  dataFile.location(),
+                  0L,
+                  null,
+                  dataFile.specId(),
+                  deleteFile.location(),
+                  deleteFile.contentOffset(),
+                  deleteFile.contentSizeInBytes()),
+              row(
+                  dataFile.location(),
+                  2L,
+                  null,
+                  dataFile.specId(),
+                  deleteFile.location(),
+                  deleteFile.contentOffset(),
+                  deleteFile.contentSizeInBytes()));
+    } else {
+      expectedRows =
+          ImmutableList.of(
+              row(dataFile.location(), 0L, null, dataFile.specId(), deleteFile.location()),
+              row(dataFile.location(), 2L, null, dataFile.specId(), deleteFile.location()));
+    }
+
+    // check position_deletes table
+    assertThat(sql("SELECT * FROM %s.position_deletes", tableName))
+        .hasSize(2)
+        .containsExactlyElementsOf(expectedRows);
+  }
+
+  @TestTemplate
   public void testPartitionedTable() throws Exception {
     sql(
         "CREATE TABLE %s (id bigint, data string) "
             + "USING iceberg "
             + "PARTITIONED BY (data) "
             + "TBLPROPERTIES"
-            + "('format-version'='2', 'write.delete.mode'='merge-on-read')",
-        tableName);
+            + "('format-version'='%s', 'write.delete.mode'='merge-on-read')",
+        tableName, formatVersion);
 
     List<SimpleRecord> recordsA =
         Lists.newArrayList(new SimpleRecord(1, "a"), new SimpleRecord(2, "a"));
@@ -175,8 +294,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
     List<ManifestFile> expectedDeleteManifests = TestHelpers.deleteManifests(table);
-    Assert.assertEquals("Should have 2 data manifests", 2, expectedDataManifests.size());
-    Assert.assertEquals("Should have 2 delete manifests", 2, expectedDeleteManifests.size());
+    assertThat(expectedDataManifests).as("Should have 2 data manifest").hasSize(2);
+    assertThat(expectedDeleteManifests).as("Should have 2 delete manifest").hasSize(2);
 
     Schema filesTableSchema =
         Spark3Util.loadIcebergTable(spark, tableName + ".delete_files").schema();
@@ -185,15 +304,13 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Record> expectedDeleteFiles =
         expectedEntries(
             table, FileContent.POSITION_DELETES, entriesTableSchema, expectedDeleteManifests, "a");
-    Assert.assertEquals(
-        "Should have one delete file manifest entry", 1, expectedDeleteFiles.size());
+    assertThat(expectedDeleteFiles).as("Should have one delete file manifest entry").hasSize(1);
 
     Dataset<Row> actualDeleteFilesDs =
         spark.sql("SELECT * FROM " + tableName + ".delete_files " + "WHERE partition.data='a'");
     List<Row> actualDeleteFiles = actualDeleteFilesDs.collectAsList();
 
-    Assert.assertEquals(
-        "Metadata table should return one delete file", 1, actualDeleteFiles.size());
+    assertThat(actualDeleteFiles).as("Metadata table should return one delete file").hasSize(1);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDeleteFilesDs),
         expectedDeleteFiles.get(0),
@@ -202,13 +319,13 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     // Check data files table
     List<Record> expectedDataFiles =
         expectedEntries(table, FileContent.DATA, entriesTableSchema, expectedDataManifests, "a");
-    Assert.assertEquals("Should have one data file manifest entry", 1, expectedDataFiles.size());
+    assertThat(expectedDataFiles).as("Should have one data file manifest entry").hasSize(1);
 
     Dataset<Row> actualDataFilesDs =
         spark.sql("SELECT * FROM " + tableName + ".data_files " + "WHERE partition.data='a'");
 
     List<Row> actualDataFiles = TestHelpers.selectNonDerived(actualDataFilesDs).collectAsList();
-    Assert.assertEquals("Metadata table should return one data file", 1, actualDataFiles.size());
+    assertThat(actualDataFiles).as("Metadata table should return one data file").hasSize(1);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDataFilesDs),
         expectedDataFiles.get(0),
@@ -216,37 +333,34 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     List<Row> actualPartitionsWithProjection =
         spark.sql("SELECT file_count FROM " + tableName + ".partitions ").collectAsList();
-    Assert.assertEquals(
-        "Metadata table should return two partitions record",
-        2,
-        actualPartitionsWithProjection.size());
-    for (int i = 0; i < 2; ++i) {
-      Assert.assertEquals(1, actualPartitionsWithProjection.get(i).get(0));
-    }
+    assertThat(actualPartitionsWithProjection)
+        .as("Metadata table should return two partitions record")
+        .hasSize(2)
+        .containsExactly(RowFactory.create(1), RowFactory.create(1));
 
     // Check files table
     List<Record> expectedFiles =
         Stream.concat(expectedDataFiles.stream(), expectedDeleteFiles.stream())
             .collect(Collectors.toList());
-    Assert.assertEquals("Should have two file manifest entries", 2, expectedFiles.size());
+    assertThat(expectedFiles).as("Should have two file manifest entries").hasSize(2);
 
     Dataset<Row> actualFilesDs =
         spark.sql(
             "SELECT * FROM " + tableName + ".files " + "WHERE partition.data='a' ORDER BY content");
     List<Row> actualFiles = TestHelpers.selectNonDerived(actualFilesDs).collectAsList();
-    Assert.assertEquals("Metadata table should return two files", 2, actualFiles.size());
+    assertThat(actualFiles).as("Metadata table should return two files").hasSize(2);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(0), actualFiles.get(0));
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(1), actualFiles.get(1));
   }
 
-  @Test
+  @TestTemplate
   public void testAllFilesUnpartitioned() throws Exception {
     sql(
         "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES"
-            + "('format-version'='2', 'write.delete.mode'='merge-on-read')",
-        tableName);
+            + "('format-version'='%s', 'write.delete.mode'='merge-on-read')",
+        tableName, formatVersion);
 
     List<SimpleRecord> records =
         Lists.newArrayList(
@@ -265,13 +379,13 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
     List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
-    Assert.assertEquals("Should have 1 data manifest", 1, expectedDataManifests.size());
+    assertThat(expectedDataManifests).as("Should have 1 data manifest").hasSize(1);
     List<ManifestFile> expectedDeleteManifests = TestHelpers.deleteManifests(table);
-    Assert.assertEquals("Should have 1 delete manifest", 1, expectedDeleteManifests.size());
+    assertThat(expectedDeleteManifests).as("Should have 1 delete manifest").hasSize(1);
 
     // Clear table to test whether 'all_files' can read past files
     List<Object[]> results = sql("DELETE FROM %s", tableName);
-    Assert.assertEquals("Table should be cleared", 0, results.size());
+    assertThat(results).as("Table should be cleared").isEmpty();
 
     Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
     Schema filesTableSchema =
@@ -283,8 +397,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     List<Record> expectedDataFiles =
         expectedEntries(table, FileContent.DATA, entriesTableSchema, expectedDataManifests, null);
-    Assert.assertEquals("Should be one data file manifest entry", 1, expectedDataFiles.size());
-    Assert.assertEquals("Metadata table should return one data file", 1, actualDataFiles.size());
+    assertThat(expectedDataFiles).as("Should be one data file manifest entry").hasSize(1);
+    assertThat(actualDataFiles).as("Metadata table should return one data file").hasSize(1);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDataFilesDs),
         expectedDataFiles.get(0),
@@ -297,9 +411,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Record> expectedDeleteFiles =
         expectedEntries(
             table, FileContent.POSITION_DELETES, entriesTableSchema, expectedDeleteManifests, null);
-    Assert.assertEquals("Should be one delete file manifest entry", 1, expectedDeleteFiles.size());
-    Assert.assertEquals(
-        "Metadata table should return one delete file", 1, actualDeleteFiles.size());
+    assertThat(expectedDeleteFiles).as("Should be one delete file manifest entry").hasSize(1);
+    assertThat(actualDeleteFiles).as("Metadata table should return one delete file").hasSize(1);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDeleteFilesDs),
         expectedDeleteFiles.get(0),
@@ -311,12 +424,12 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Row> actualFiles = actualFilesDs.collectAsList();
     List<Record> expectedFiles = ListUtils.union(expectedDataFiles, expectedDeleteFiles);
     expectedFiles.sort(Comparator.comparing(r -> ((Integer) r.get("content"))));
-    Assert.assertEquals("Metadata table should return two files", 2, actualFiles.size());
+    assertThat(actualFiles).as("Metadata table should return two files").hasSize(2);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles, actualFiles);
   }
 
-  @Test
+  @TestTemplate
   public void testAllFilesPartitioned() throws Exception {
     // Create table and insert data
     sql(
@@ -324,8 +437,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
             + "USING iceberg "
             + "PARTITIONED BY (data) "
             + "TBLPROPERTIES"
-            + "('format-version'='2', 'write.delete.mode'='merge-on-read')",
-        tableName);
+            + "('format-version'='%s', 'write.delete.mode'='merge-on-read')",
+        tableName, formatVersion);
 
     List<SimpleRecord> recordsA =
         Lists.newArrayList(new SimpleRecord(1, "a"), new SimpleRecord(2, "a"));
@@ -348,13 +461,13 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
     List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
-    Assert.assertEquals("Should have 2 data manifests", 2, expectedDataManifests.size());
+    assertThat(expectedDataManifests).as("Should have 2 data manifests").hasSize(2);
     List<ManifestFile> expectedDeleteManifests = TestHelpers.deleteManifests(table);
-    Assert.assertEquals("Should have 1 delete manifest", 1, expectedDeleteManifests.size());
+    assertThat(expectedDeleteManifests).as("Should have 1 delete manifest").hasSize(1);
 
     // Clear table to test whether 'all_files' can read past files
     List<Object[]> results = sql("DELETE FROM %s", tableName);
-    Assert.assertEquals("Table should be cleared", 0, results.size());
+    assertThat(results).as("Table should be cleared").isEmpty();
 
     Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
     Schema filesTableSchema =
@@ -366,8 +479,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Row> actualDataFiles = TestHelpers.selectNonDerived(actualDataFilesDs).collectAsList();
     List<Record> expectedDataFiles =
         expectedEntries(table, FileContent.DATA, entriesTableSchema, expectedDataManifests, "a");
-    Assert.assertEquals("Should be one data file manifest entry", 1, expectedDataFiles.size());
-    Assert.assertEquals("Metadata table should return one data file", 1, actualDataFiles.size());
+    assertThat(expectedDataFiles).as("Should be one data file manifest entry").hasSize(1);
+    assertThat(actualDataFiles).as("Metadata table should return one data file").hasSize(1);
     TestHelpers.assertEqualsSafe(
         SparkSchemaUtil.convert(TestHelpers.selectNonDerived(actualDataFilesDs).schema())
             .asStruct(),
@@ -382,8 +495,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Record> expectedDeleteFiles =
         expectedEntries(
             table, FileContent.POSITION_DELETES, entriesTableSchema, expectedDeleteManifests, "a");
-    Assert.assertEquals("Should be one data file manifest entry", 1, expectedDeleteFiles.size());
-    Assert.assertEquals("Metadata table should return one data file", 1, actualDeleteFiles.size());
+    assertThat(expectedDeleteFiles).as("Should be one data file manifest entry").hasSize(1);
+    assertThat(actualDeleteFiles).as("Metadata table should return one data file").hasSize(1);
 
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDeleteFilesDs),
@@ -401,12 +514,12 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     List<Record> expectedFiles = ListUtils.union(expectedDataFiles, expectedDeleteFiles);
     expectedFiles.sort(Comparator.comparing(r -> ((Integer) r.get("content"))));
-    Assert.assertEquals("Metadata table should return two files", 2, actualFiles.size());
+    assertThat(actualFiles).as("Metadata table should return two files").hasSize(2);
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualDataFilesDs), expectedFiles, actualFiles);
   }
 
-  @Test
+  @TestTemplate
   public void testMetadataLogEntries() throws Exception {
     // Create table and insert data
     sql(
@@ -414,8 +527,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
             + "USING iceberg "
             + "PARTITIONED BY (data) "
             + "TBLPROPERTIES "
-            + "('format-version'='2')",
-        tableName);
+            + "('format-version'='%s')",
+        tableName, formatVersion);
 
     List<SimpleRecord> recordsA =
         Lists.newArrayList(new SimpleRecord(1, "a"), new SimpleRecord(2, "a"));
@@ -463,8 +576,9 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
         sql(
             "SELECT * FROM %s.metadata_log_entries WHERE latest_snapshot_id = %s",
             tableName, currentSnapshotId);
-    Assert.assertEquals(
-        "metadataLogEntries table should return 1 row", 1, metadataLogWithFilters.size());
+    assertThat(metadataLogWithFilters)
+        .as("metadataLogEntries table should return 1 row")
+        .hasSize(1);
     assertEquals(
         "Result should match the latest snapshot entry",
         ImmutableList.of(
@@ -485,15 +599,16 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     metadataFiles.add(tableMetadata.metadataFileLocation());
     List<Object[]> metadataLogWithProjection =
         sql("SELECT file FROM %s.metadata_log_entries", tableName);
-    Assert.assertEquals(
-        "metadataLogEntries table should return 3 rows", 3, metadataLogWithProjection.size());
+    assertThat(metadataLogWithProjection)
+        .as("metadataLogEntries table should return 3 rows")
+        .hasSize(3);
     assertEquals(
         "metadataLog entry should be of same file",
         metadataFiles.stream().map(this::row).collect(Collectors.toList()),
         metadataLogWithProjection);
   }
 
-  @Test
+  @TestTemplate
   public void testFilesTableTimeTravelWithSchemaEvolution() throws Exception {
     // Create table and insert data
     sql(
@@ -501,8 +616,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
             + "USING iceberg "
             + "PARTITIONED BY (data) "
             + "TBLPROPERTIES"
-            + "('format-version'='2', 'write.delete.mode'='merge-on-read')",
-        tableName);
+            + "('format-version'='%s', 'write.delete.mode'='merge-on-read')",
+        tableName, formatVersion);
 
     List<SimpleRecord> recordsA =
         Lists.newArrayList(new SimpleRecord(1, "a"), new SimpleRecord(2, "a"));
@@ -527,9 +642,7 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
                 optional(3, "category", Types.StringType.get())));
 
     spark.createDataFrame(newRecords, newSparkSchema).coalesce(1).writeTo(tableName).append();
-
     table.refresh();
-
     Long currentSnapshotId = table.currentSnapshot().snapshotId();
 
     Dataset<Row> actualFilesDs =
@@ -545,7 +658,7 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Record> expectedFiles =
         expectedEntries(table, FileContent.DATA, entriesTableSchema, expectedDataManifests, null);
 
-    Assert.assertEquals("actualFiles size should be 2", 2, actualFiles.size());
+    assertThat(actualFiles).as("actualFiles size should be 2").hasSize(2);
 
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(0), actualFiles.get(0));
@@ -553,13 +666,12 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(1), actualFiles.get(1));
 
-    Assert.assertEquals(
-        "expectedFiles and actualFiles size should be the same",
-        actualFiles.size(),
-        expectedFiles.size());
+    assertThat(actualFiles)
+        .as("expectedFiles and actualFiles size should be the same")
+        .hasSameSizeAs(expectedFiles);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotReferencesMetatable() throws Exception {
     // Create table and insert data
     sql(
@@ -567,8 +679,8 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
             + "USING iceberg "
             + "PARTITIONED BY (data) "
             + "TBLPROPERTIES"
-            + "('format-version'='2', 'write.delete.mode'='merge-on-read')",
-        tableName);
+            + "('format-version'='%s', 'write.delete.mode'='merge-on-read')",
+        tableName, formatVersion);
 
     List<SimpleRecord> recordsA =
         Lists.newArrayList(new SimpleRecord(1, "a"), new SimpleRecord(2, "a"));
@@ -605,43 +717,64 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
         .commit();
     // Check refs table
     List<Row> references = spark.sql("SELECT * FROM " + tableName + ".refs").collectAsList();
-    Assert.assertEquals("Refs table should return 3 rows", 3, references.size());
+    assertThat(references).as("Refs table should return 3 rows").hasSize(3);
     List<Row> branches =
         spark.sql("SELECT * FROM " + tableName + ".refs WHERE type='BRANCH'").collectAsList();
-    Assert.assertEquals("Refs table should return 2 branches", 2, branches.size());
+    assertThat(branches).as("Refs table should return 2 branches").hasSize(2);
     List<Row> tags =
         spark.sql("SELECT * FROM " + tableName + ".refs WHERE type='TAG'").collectAsList();
-    Assert.assertEquals("Refs table should return 1 tag", 1, tags.size());
+    assertThat(tags).as("Refs table should return 1 tag").hasSize(1);
 
     // Check branch entries in refs table
     List<Row> mainBranch =
         spark
             .sql("SELECT * FROM " + tableName + ".refs WHERE name = 'main' AND type='BRANCH'")
             .collectAsList();
-    Assert.assertEquals("main", mainBranch.get(0).getAs("name"));
-    Assert.assertEquals("BRANCH", mainBranch.get(0).getAs("type"));
-    Assert.assertEquals(currentSnapshotId, mainBranch.get(0).getAs("snapshot_id"));
+    assertThat(mainBranch)
+        .hasSize(1)
+        .containsExactly(RowFactory.create("main", "BRANCH", currentSnapshotId, null, null, null));
+    assertThat(mainBranch.get(0).schema().fieldNames())
+        .containsExactly(
+            "name",
+            "type",
+            "snapshot_id",
+            "max_reference_age_in_ms",
+            "min_snapshots_to_keep",
+            "max_snapshot_age_in_ms");
 
     List<Row> testBranch =
         spark
             .sql("SELECT * FROM " + tableName + ".refs WHERE name = 'testBranch' AND type='BRANCH'")
             .collectAsList();
-    Assert.assertEquals("testBranch", testBranch.get(0).getAs("name"));
-    Assert.assertEquals("BRANCH", testBranch.get(0).getAs("type"));
-    Assert.assertEquals(currentSnapshotId, testBranch.get(0).getAs("snapshot_id"));
-    Assert.assertEquals(Long.valueOf(10), testBranch.get(0).getAs("max_reference_age_in_ms"));
-    Assert.assertEquals(Integer.valueOf(20), testBranch.get(0).getAs("min_snapshots_to_keep"));
-    Assert.assertEquals(Long.valueOf(30), testBranch.get(0).getAs("max_snapshot_age_in_ms"));
+    assertThat(testBranch)
+        .hasSize(1)
+        .containsExactly(
+            RowFactory.create("testBranch", "BRANCH", currentSnapshotId, 10L, 20L, 30L));
+    assertThat(testBranch.get(0).schema().fieldNames())
+        .containsExactly(
+            "name",
+            "type",
+            "snapshot_id",
+            "max_reference_age_in_ms",
+            "min_snapshots_to_keep",
+            "max_snapshot_age_in_ms");
 
     // Check tag entries in refs table
     List<Row> testTag =
         spark
             .sql("SELECT * FROM " + tableName + ".refs WHERE name = 'testTag' AND type='TAG'")
             .collectAsList();
-    Assert.assertEquals("testTag", testTag.get(0).getAs("name"));
-    Assert.assertEquals("TAG", testTag.get(0).getAs("type"));
-    Assert.assertEquals(currentSnapshotId, testTag.get(0).getAs("snapshot_id"));
-    Assert.assertEquals(Long.valueOf(50), testTag.get(0).getAs("max_reference_age_in_ms"));
+    assertThat(testTag)
+        .hasSize(1)
+        .containsExactly(RowFactory.create("testTag", "TAG", currentSnapshotId, 50L, null, null));
+    assertThat(testTag.get(0).schema().fieldNames())
+        .containsExactly(
+            "name",
+            "type",
+            "snapshot_id",
+            "max_reference_age_in_ms",
+            "min_snapshots_to_keep",
+            "max_snapshot_age_in_ms");
 
     // Check projection in refs table
     List<Row> testTagProjection =
@@ -651,12 +784,12 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
                     + tableName
                     + ".refs where type='TAG'")
             .collectAsList();
-    Assert.assertEquals("testTag", testTagProjection.get(0).getAs("name"));
-    Assert.assertEquals("TAG", testTagProjection.get(0).getAs("type"));
-    Assert.assertEquals(currentSnapshotId, testTagProjection.get(0).getAs("snapshot_id"));
-    Assert.assertEquals(
-        Long.valueOf(50), testTagProjection.get(0).getAs("max_reference_age_in_ms"));
-    Assert.assertNull(testTagProjection.get(0).getAs("min_snapshots_to_keep"));
+    assertThat(testTagProjection)
+        .hasSize(1)
+        .containsExactly(RowFactory.create("testTag", "TAG", currentSnapshotId, 50L, null));
+    assertThat(testTagProjection.get(0).schema().fieldNames())
+        .containsExactly(
+            "name", "type", "snapshot_id", "max_reference_age_in_ms", "min_snapshots_to_keep");
 
     List<Row> mainBranchProjection =
         spark
@@ -665,21 +798,23 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
                     + tableName
                     + ".refs WHERE name = 'main' AND type = 'BRANCH'")
             .collectAsList();
-    Assert.assertEquals("main", mainBranchProjection.get(0).getAs("name"));
-    Assert.assertEquals("BRANCH", mainBranchProjection.get(0).getAs("type"));
+    assertThat(mainBranchProjection)
+        .hasSize(1)
+        .containsExactly(RowFactory.create("main", "BRANCH"));
+    assertThat(mainBranchProjection.get(0).schema().fieldNames()).containsExactly("name", "type");
 
     List<Row> testBranchProjection =
         spark
             .sql(
-                "SELECT type, name, max_reference_age_in_ms, snapshot_id FROM "
+                "SELECT name, type, snapshot_id, max_reference_age_in_ms FROM "
                     + tableName
                     + ".refs WHERE name = 'testBranch' AND type = 'BRANCH'")
             .collectAsList();
-    Assert.assertEquals("testBranch", testBranchProjection.get(0).getAs("name"));
-    Assert.assertEquals("BRANCH", testBranchProjection.get(0).getAs("type"));
-    Assert.assertEquals(currentSnapshotId, testBranchProjection.get(0).getAs("snapshot_id"));
-    Assert.assertEquals(
-        Long.valueOf(10), testBranchProjection.get(0).getAs("max_reference_age_in_ms"));
+    assertThat(testBranchProjection)
+        .hasSize(1)
+        .containsExactly(RowFactory.create("testBranch", "BRANCH", currentSnapshotId, 10L));
+    assertThat(testBranchProjection.get(0).schema().fieldNames())
+        .containsExactly("name", "type", "snapshot_id", "max_reference_age_in_ms");
   }
 
   /**
@@ -722,5 +857,120 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     }
     Record partition = (Record) file.get(4);
     return partValue.equals(partition.get(0).toString());
+  }
+
+  @TestTemplate
+  public void metadataLogEntriesAfterReplacingTable() throws Exception {
+    assumeThat(catalogConfig.get(ICEBERG_CATALOG_TYPE))
+        .as(
+            "need to fix https://github.com/apache/iceberg/issues/11109 before enabling this for the REST catalog")
+        .isNotEqualTo(ICEBERG_CATALOG_TYPE_REST);
+
+    sql(
+        "CREATE TABLE %s (id bigint, data string) "
+            + "USING iceberg "
+            + "PARTITIONED BY (data) "
+            + "TBLPROPERTIES "
+            + "('format-version'='%s')",
+        tableName, formatVersion);
+
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
+    assertThat(tableMetadata.snapshots()).isEmpty();
+    assertThat(tableMetadata.snapshotLog()).isEmpty();
+    assertThat(tableMetadata.currentSnapshot()).isNull();
+
+    Object[] firstEntry =
+        row(
+            DateTimeUtils.toJavaTimestamp(tableMetadata.lastUpdatedMillis() * 1000),
+            tableMetadata.metadataFileLocation(),
+            null,
+            null,
+            null);
+
+    assertThat(sql("SELECT * FROM %s.metadata_log_entries", tableName)).containsExactly(firstEntry);
+
+    sql("INSERT INTO %s (id, data) VALUES (1, 'a')", tableName);
+
+    tableMetadata = ((HasTableOperations) table).operations().refresh();
+    assertThat(tableMetadata.snapshots()).hasSize(1);
+    assertThat(tableMetadata.snapshotLog()).hasSize(1);
+    Snapshot currentSnapshot = tableMetadata.currentSnapshot();
+
+    Object[] secondEntry =
+        row(
+            DateTimeUtils.toJavaTimestamp(tableMetadata.lastUpdatedMillis() * 1000),
+            tableMetadata.metadataFileLocation(),
+            currentSnapshot.snapshotId(),
+            currentSnapshot.schemaId(),
+            currentSnapshot.sequenceNumber());
+
+    assertThat(sql("SELECT * FROM %s.metadata_log_entries", tableName))
+        .containsExactly(firstEntry, secondEntry);
+
+    sql("INSERT INTO %s (id, data) VALUES (1, 'a')", tableName);
+
+    tableMetadata = ((HasTableOperations) table).operations().refresh();
+    assertThat(tableMetadata.snapshots()).hasSize(2);
+    assertThat(tableMetadata.snapshotLog()).hasSize(2);
+    currentSnapshot = tableMetadata.currentSnapshot();
+
+    Object[] thirdEntry =
+        row(
+            DateTimeUtils.toJavaTimestamp(tableMetadata.lastUpdatedMillis() * 1000),
+            tableMetadata.metadataFileLocation(),
+            currentSnapshot.snapshotId(),
+            currentSnapshot.schemaId(),
+            currentSnapshot.sequenceNumber());
+
+    assertThat(sql("SELECT * FROM %s.metadata_log_entries", tableName))
+        .containsExactly(firstEntry, secondEntry, thirdEntry);
+
+    sql(
+        "CREATE OR REPLACE TABLE %s (id bigint, data string) "
+            + "USING iceberg "
+            + "PARTITIONED BY (data) "
+            + "TBLPROPERTIES "
+            + "('format-version'='%s')",
+        tableName, formatVersion);
+
+    tableMetadata = ((HasTableOperations) table).operations().refresh();
+    assertThat(tableMetadata.snapshots()).hasSize(2);
+    assertThat(tableMetadata.snapshotLog()).hasSize(2);
+
+    // currentSnapshot is null but the metadata_log_entries will refer to the last snapshot from the
+    // snapshotLog
+    assertThat(tableMetadata.currentSnapshot()).isNull();
+    HistoryEntry historyEntry = tableMetadata.snapshotLog().get(1);
+    Snapshot lastSnapshot = tableMetadata.snapshot(historyEntry.snapshotId());
+
+    Object[] fourthEntry =
+        row(
+            DateTimeUtils.toJavaTimestamp(tableMetadata.lastUpdatedMillis() * 1000),
+            tableMetadata.metadataFileLocation(),
+            lastSnapshot.snapshotId(),
+            lastSnapshot.schemaId(),
+            lastSnapshot.sequenceNumber());
+
+    assertThat(sql("SELECT * FROM %s.metadata_log_entries", tableName))
+        .containsExactly(firstEntry, secondEntry, thirdEntry, fourthEntry);
+
+    sql("INSERT INTO %s (id, data) VALUES (1, 'a')", tableName);
+
+    tableMetadata = ((HasTableOperations) table).operations().refresh();
+    assertThat(tableMetadata.snapshots()).hasSize(3);
+    assertThat(tableMetadata.snapshotLog()).hasSize(3);
+    currentSnapshot = tableMetadata.currentSnapshot();
+
+    Object[] fifthEntry =
+        row(
+            DateTimeUtils.toJavaTimestamp(tableMetadata.lastUpdatedMillis() * 1000),
+            tableMetadata.metadataFileLocation(),
+            currentSnapshot.snapshotId(),
+            currentSnapshot.schemaId(),
+            currentSnapshot.sequenceNumber());
+
+    assertThat(sql("SELECT * FROM %s.metadata_log_entries", tableName))
+        .containsExactly(firstEntry, secondEntry, thirdEntry, fourthEntry, fifthEntry);
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestPublishChangesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestPublishChangesProcedure.java
@@ -175,6 +175,7 @@ public class TestPublishChangesProcedure extends SparkExtensionsTestBase {
     assertThatThrownBy(
             () -> sql("CALL %s.custom.publish_changes('n', 't', 'not_valid')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -264,6 +264,7 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.remove_orphan_files('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -720,6 +720,7 @@ public class TestRewriteDataFilesProcedure extends SparkExtensionsTestBase {
         .hasMessage("Named and positional arguments cannot be mixed");
 
     assertThatThrownBy(() -> sql("CALL %s.custom.rewrite_data_files('n', 't')", catalogName))
+        .hasMessageContaining("Syntax error")
         .isInstanceOf(ParseException.class)
         .satisfies(
             exception -> {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -283,6 +283,7 @@ public class TestRewriteManifestsProcedure extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.rewrite_manifests('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
@@ -260,6 +260,7 @@ public class TestRollbackToSnapshotProcedure extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.rollback_to_snapshot('n', 't', 1L)", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
@@ -303,6 +303,7 @@ public class TestRollbackToTimestampProcedure extends SparkExtensionsTestBase {
     assertThatThrownBy(
             () -> sql("CALL %s.custom.rollback_to_timestamp('n', 't', %s)", catalogName, timestamp))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
@@ -208,6 +208,7 @@ public class TestSetCurrentSnapshotProcedure extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.set_current_snapshot('n', 't', 1L)", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -54,6 +54,9 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
   private final int sortOrderIdPosition;
   private final int fileSpecIdPosition;
   private final int equalityIdsPosition;
+  private final int referencedDataFilePosition;
+  private final int contentOffsetPosition;
+  private final int contentSizePosition;
   private final Type lowerBoundsType;
   private final Type upperBoundsType;
   private final Type keyMetadataType;
@@ -103,6 +106,9 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     this.sortOrderIdPosition = positions.get(DataFile.SORT_ORDER_ID.name());
     this.fileSpecIdPosition = positions.get(DataFile.SPEC_ID.name());
     this.equalityIdsPosition = positions.get(DataFile.EQUALITY_IDS.name());
+    this.referencedDataFilePosition = positions.get(DataFile.REFERENCED_DATA_FILE.name());
+    this.contentOffsetPosition = positions.get(DataFile.CONTENT_OFFSET.name());
+    this.contentSizePosition = positions.get(DataFile.CONTENT_SIZE.name());
   }
 
   public F wrap(Row row) {
@@ -229,6 +235,27 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
   @Override
   public List<Integer> equalityFieldIds() {
     return wrapped.isNullAt(equalityIdsPosition) ? null : wrapped.getList(equalityIdsPosition);
+  }
+
+  public String referencedDataFile() {
+    if (wrapped.isNullAt(referencedDataFilePosition)) {
+      return null;
+    }
+    return wrapped.getString(referencedDataFilePosition);
+  }
+
+  public Long contentOffset() {
+    if (wrapped.isNullAt(contentOffsetPosition)) {
+      return null;
+    }
+    return wrapped.getLong(contentOffsetPosition);
+  }
+
+  public Long contentSizeInBytes() {
+    if (wrapped.isNullAt(contentSizePosition)) {
+      return null;
+    }
+    return wrapped.getLong(contentSizePosition);
   }
 
   private int fieldPosition(String name, StructType sparkType) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.PositionDeletesTable.PositionDeletesBatchScan;
 import org.apache.iceberg.RewriteJobOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.actions.ImmutableRewritePositionDeleteFiles;
 import org.apache.iceberg.actions.RewritePositionDeleteFiles;
 import org.apache.iceberg.actions.RewritePositionDeletesCommitManager;
@@ -403,6 +404,9 @@ public class RewritePositionDeleteFilesSparkAction
         PARTIAL_PROGRESS_MAX_COMMITS,
         maxCommits,
         PARTIAL_PROGRESS_ENABLED);
+
+    Preconditions.checkArgument(
+        TableUtil.formatVersion(table) <= 2, "Cannot rewrite position deletes for V3 table");
   }
 
   private String jobDesc(RewritePositionDeletesGroup group, RewriteExecutionContext ctx) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
@@ -31,10 +31,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.PositionDeletesScanTask;
+import org.apache.iceberg.PositionDeletesTable;
 import org.apache.iceberg.PositionDeletesTable.PositionDeletesBatchScan;
 import org.apache.iceberg.RewriteJobOrder;
 import org.apache.iceberg.StructLike;
@@ -50,6 +52,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -123,6 +126,11 @@ public class RewritePositionDeleteFilesSparkAction
 
     validateAndInitOptions();
 
+    if (TableUtil.formatVersion(table) >= 3 && !requiresRewriteToDVs()) {
+      LOG.info("v2 deletes in {} have already been rewritten to v3 DVs", table.name());
+      return EMPTY_RESULT;
+    }
+
     StructLikeMap<List<List<PositionDeletesScanTask>>> fileGroupsByPartition = planFileGroups();
     RewriteExecutionContext ctx = new RewriteExecutionContext(fileGroupsByPartition);
 
@@ -137,6 +145,29 @@ public class RewritePositionDeleteFilesSparkAction
       return doExecuteWithPartialProgress(ctx, groupStream, commitManager());
     } else {
       return doExecute(ctx, groupStream, commitManager());
+    }
+  }
+
+  private boolean requiresRewriteToDVs() {
+    PositionDeletesBatchScan scan =
+        (PositionDeletesBatchScan)
+            MetadataTableUtils.createMetadataTableInstance(
+                    table, MetadataTableType.POSITION_DELETES)
+                .newBatchScan();
+    try (CloseableIterator<PositionDeletesScanTask> it =
+        CloseableIterable.filter(
+                CloseableIterable.transform(
+                    scan.baseTableFilter(filter)
+                        .caseSensitive(caseSensitive)
+                        .select(PositionDeletesTable.DELETE_FILE_PATH)
+                        .ignoreResiduals()
+                        .planFiles(),
+                    task -> (PositionDeletesScanTask) task),
+                t -> t.file().format() != FileFormat.PUFFIN)
+            .iterator()) {
+      return it.hasNext();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
   }
 
@@ -161,7 +192,6 @@ public class RewritePositionDeleteFilesSparkAction
 
   private CloseableIterable<PositionDeletesScanTask> planFiles(Table deletesTable) {
     PositionDeletesBatchScan scan = (PositionDeletesBatchScan) deletesTable.newBatchScan();
-
     return CloseableIterable.transform(
         scan.baseTableFilter(filter).caseSensitive(caseSensitive).ignoreResiduals().planFiles(),
         task -> (PositionDeletesScanTask) task);
@@ -404,9 +434,6 @@ public class RewritePositionDeleteFilesSparkAction
         PARTIAL_PROGRESS_MAX_COMMITS,
         maxCommits,
         PARTIAL_PROGRESS_ENABLED);
-
-    Preconditions.checkArgument(
-        TableUtil.formatVersion(table) <= 2, "Cannot rewrite position deletes for V3 table");
   }
 
   private String jobDesc(RewritePositionDeletesGroup group, RewriteExecutionContext ctx) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/DVIterator.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/DVIterator.java
@@ -84,6 +84,9 @@ class DVIterator implements CloseableIterator<InternalRow> {
           rowValues.add(deleteFile.contentOffset());
         } else if (fieldId == MetadataColumns.CONTENT_SIZE_IN_BYTES_COLUMN_ID) {
           rowValues.add(ScanTaskUtil.contentSizeInBytes(deleteFile));
+        } else if (fieldId == MetadataColumns.DELETE_FILE_ROW_FIELD_ID) {
+          // DVs don't track the row that was deleted
+          rowValues.add(null);
         }
       }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/DVIterator.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/DVIterator.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.BaseDeleteLoader;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.unsafe.types.UTF8String;
+
+class DVIterator implements CloseableIterator<InternalRow> {
+  private final DeleteFile deleteFile;
+  private final Schema projection;
+  private final Map<Integer, ?> idToConstant;
+  private final Iterator<Long> positions;
+  private Integer deletedPositionIndex;
+  private GenericInternalRow row;
+
+  DVIterator(
+      InputFile inputFile, DeleteFile deleteFile, Schema projection, Map<Integer, ?> idToConstant) {
+    this.deleteFile = deleteFile;
+    this.projection = projection;
+    this.idToConstant = idToConstant;
+    List<Long> pos = Lists.newArrayList();
+    new BaseDeleteLoader(ignored -> inputFile)
+        .loadPositionDeletes(ImmutableList.of(deleteFile), deleteFile.referencedDataFile())
+        .forEach(pos::add);
+    this.positions = pos.iterator();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return positions.hasNext();
+  }
+
+  @Override
+  public InternalRow next() {
+    long position = positions.next();
+
+    if (null == row) {
+      List<Object> rowValues = Lists.newArrayList();
+      for (Types.NestedField column : projection.columns()) {
+        int fieldId = column.fieldId();
+        if (fieldId == MetadataColumns.DELETE_FILE_PATH.fieldId()) {
+          rowValues.add(UTF8String.fromString(deleteFile.referencedDataFile()));
+        } else if (fieldId == MetadataColumns.DELETE_FILE_POS.fieldId()) {
+          rowValues.add(position);
+          // remember the index where the deleted position needs to be set
+          deletedPositionIndex = rowValues.size() - 1;
+        } else if (fieldId == MetadataColumns.PARTITION_COLUMN_ID) {
+          rowValues.add(idToConstant.get(MetadataColumns.PARTITION_COLUMN_ID));
+        } else if (fieldId == MetadataColumns.SPEC_ID_COLUMN_ID) {
+          rowValues.add(idToConstant.get(MetadataColumns.SPEC_ID_COLUMN_ID));
+        } else if (fieldId == MetadataColumns.FILE_PATH_COLUMN_ID) {
+          rowValues.add(idToConstant.get(MetadataColumns.FILE_PATH_COLUMN_ID));
+        }
+      }
+
+      this.row = new GenericInternalRow(rowValues.toArray());
+    } else if (null != deletedPositionIndex) {
+      // only update the deleted position if necessary, everything else stays the same
+      row.update(deletedPositionIndex, position);
+    }
+
+    return row;
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException("Remove is not supported");
+  }
+
+  @Override
+  public void close() {}
+}

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/DVIterator.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/DVIterator.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ScanTaskUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -79,6 +80,10 @@ class DVIterator implements CloseableIterator<InternalRow> {
           rowValues.add(idToConstant.get(MetadataColumns.SPEC_ID_COLUMN_ID));
         } else if (fieldId == MetadataColumns.FILE_PATH_COLUMN_ID) {
           rowValues.add(idToConstant.get(MetadataColumns.FILE_PATH_COLUMN_ID));
+        } else if (fieldId == MetadataColumns.CONTENT_OFFSET_COLUMN_ID) {
+          rowValues.add(deleteFile.contentOffset());
+        } else if (fieldId == MetadataColumns.CONTENT_SIZE_IN_BYTES_COLUMN_ID) {
+          rowValues.add(ScanTaskUtil.contentSizeInBytes(deleteFile));
         }
       }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
@@ -73,6 +73,7 @@ class PositionDeletesRowReader extends BaseRowReader<PositionDeletesScanTask>
     return Stream.of(task.file());
   }
 
+  @SuppressWarnings("resource") // handled by BaseReader
   @Override
   protected CloseableIterator<InternalRow> open(PositionDeletesScanTask task) {
     String filePath = task.file().location();

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.primitives.Ints;
+import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -89,6 +90,10 @@ class PositionDeletesRowReader extends BaseRowReader<PositionDeletesScanTask>
     Expression residualWithoutConstants =
         ExpressionUtil.extractByIdInclusive(
             task.residual(), expectedSchema(), caseSensitive(), Ints.toArray(nonConstantFieldIds));
+
+    if (ContentFileUtil.isDV(task.file())) {
+      return new DVIterator(inputFile, task.file(), expectedSchema(), idToConstant);
+    }
 
     return newIterable(
             inputFile,

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -52,12 +52,12 @@ import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.io.PartitioningWriter;
 import org.apache.iceberg.io.RollingDataWriter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.SparkWriteRequirements;
+import org.apache.iceberg.util.DataFileSet;
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskContext$;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -480,7 +480,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     @Override
     public void commit(WriterCommitMessage[] messages) {
       FileRewriteCoordinator coordinator = FileRewriteCoordinator.get();
-      coordinator.stageRewrite(table, fileSetID, ImmutableSet.copyOf(files(messages)));
+      coordinator.stageRewrite(table, fileSetID, DataFileSet.of(files(messages)));
     }
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/CatalogTestBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/CatalogTestBase.java
@@ -29,7 +29,7 @@ public abstract class CatalogTestBase extends TestBaseWithCatalog {
 
   // these parameters are broken out to avoid changes that need to modify lots of test suites
   @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
-  public static Object[][] parameters() {
+  protected static Object[][] parameters() {
     return new Object[][] {
       {
         SparkCatalogConfig.HIVE.catalogName(),

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.actions;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,12 +33,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -45,6 +46,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.GenericBlobMetadata;
 import org.apache.iceberg.GenericStatisticsFile;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
@@ -64,12 +68,10 @@ import org.apache.iceberg.puffin.Puffin;
 import org.apache.iceberg.puffin.PuffinWriter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.SparkSQLProperties;
-import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.spark.actions.DeleteOrphanFilesSparkAction.StringToFileURI;
 import org.apache.iceberg.spark.source.FilePathLastModifiedRecord;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
@@ -80,13 +82,13 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public abstract class TestRemoveOrphanFilesAction extends TestBase {
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   protected static final Schema SCHEMA =
@@ -97,17 +99,23 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
   protected static final PartitionSpec SPEC =
       PartitionSpec.builderFor(SCHEMA).truncate("c2", 2).identity("c3").build();
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
-  private File tableDir = null;
+  @TempDir private File tableDir = null;
   protected String tableLocation = null;
+  protected Map<String, String> properties;
+  @Parameter private int formatVersion;
 
-  @Before
-  public void setupTableLocation() throws Exception {
-    this.tableDir = temp.newFolder();
-    this.tableLocation = tableDir.toURI().toString();
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(2, 3);
   }
 
-  @Test
+  @BeforeEach
+  public void setupTableLocation() throws Exception {
+    this.tableLocation = tableDir.toURI().toString();
+    properties = ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+  }
+
+  @TestTemplate
   public void testDryRun() throws IOException, InterruptedException {
     Table table =
         TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), tableLocation);
@@ -129,7 +137,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .select("file_path")
             .as(Encoders.STRING())
             .collectAsList();
-    Assert.assertEquals("Should be 2 valid files", 2, validFiles.size());
+    assertThat(validFiles).as("Should be 2 valid files").hasSize(2);
 
     df.write().mode("append").parquet(tableLocation + "/data");
 
@@ -140,11 +148,11 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .filter(FileStatus::isFile)
             .map(file -> file.getPath().toString())
             .collect(Collectors.toList());
-    Assert.assertEquals("Should be 3 files", 3, allFiles.size());
+    assertThat(allFiles).as("Should be 3 valid files").hasSize(3);
 
     List<String> invalidFiles = Lists.newArrayList(allFiles);
     invalidFiles.removeAll(validFiles);
-    Assert.assertEquals("Should be 1 invalid file", 1, invalidFiles.size());
+    assertThat(invalidFiles).as("Should be 1 invalid file").hasSize(1);
 
     waitUntilAfter(System.currentTimeMillis());
 
@@ -152,9 +160,9 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     DeleteOrphanFiles.Result result1 =
         actions.deleteOrphanFiles(table).deleteWith(s -> {}).execute();
-    Assert.assertTrue(
-        "Default olderThan interval should be safe",
-        Iterables.isEmpty(result1.orphanFileLocations()));
+    assertThat(result1.orphanFileLocations())
+        .as("Default olderThan interval should be safe")
+        .isEmpty();
 
     DeleteOrphanFiles.Result result2 =
         actions
@@ -162,14 +170,21 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .olderThan(System.currentTimeMillis())
             .deleteWith(s -> {})
             .execute();
-    Assert.assertEquals("Action should find 1 file", invalidFiles, result2.orphanFileLocations());
-    Assert.assertTrue("Invalid file should be present", fs.exists(new Path(invalidFiles.get(0))));
+    assertThat(result2.orphanFileLocations())
+        .as("Action should find 1 file")
+        .isEqualTo(invalidFiles);
+    assertThat(fs.exists(new Path(invalidFiles.get(0))))
+        .as("Invalid file should be present")
+        .isTrue();
 
     DeleteOrphanFiles.Result result3 =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
-    Assert.assertEquals("Action should delete 1 file", invalidFiles, result3.orphanFileLocations());
-    Assert.assertFalse(
-        "Invalid file should not be present", fs.exists(new Path(invalidFiles.get(0))));
+    assertThat(result3.orphanFileLocations())
+        .as("Action should delete 1 file")
+        .isEqualTo(invalidFiles);
+    assertThat(fs.exists(new Path(invalidFiles.get(0))))
+        .as("Invalid file should not be present")
+        .isFalse();
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records);
@@ -178,10 +193,10 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
         resultDF.as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testAllValidFilesAreKept() throws IOException, InterruptedException {
     Table table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
 
@@ -205,13 +220,13 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     List<Snapshot> snapshots = Lists.newArrayList(table.snapshots());
 
     List<String> snapshotFiles1 = snapshotFiles(snapshots.get(0).snapshotId());
-    Assert.assertEquals(1, snapshotFiles1.size());
+    assertThat(snapshotFiles1).hasSize(1);
 
     List<String> snapshotFiles2 = snapshotFiles(snapshots.get(1).snapshotId());
-    Assert.assertEquals(1, snapshotFiles2.size());
+    assertThat(snapshotFiles2).hasSize(1);
 
     List<String> snapshotFiles3 = snapshotFiles(snapshots.get(2).snapshotId());
-    Assert.assertEquals(2, snapshotFiles3.size());
+    assertThat(snapshotFiles3).hasSize(2);
 
     df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data");
     df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA");
@@ -225,25 +240,25 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 4 files", 4, Iterables.size(result.orphanFileLocations()));
+    assertThat(result.orphanFileLocations()).as("Should delete 4 files").hasSize(4);
 
     Path dataPath = new Path(tableLocation + "/data");
     FileSystem fs = dataPath.getFileSystem(spark.sessionState().newHadoopConf());
 
     for (String fileLocation : snapshotFiles1) {
-      Assert.assertTrue("All snapshot files must remain", fs.exists(new Path(fileLocation)));
+      assertThat(fs.exists(new Path(fileLocation))).as("All snapshot files must remain").isTrue();
     }
 
     for (String fileLocation : snapshotFiles2) {
-      Assert.assertTrue("All snapshot files must remain", fs.exists(new Path(fileLocation)));
+      assertThat(fs.exists(new Path(fileLocation))).as("All snapshot files must remain").isTrue();
     }
 
     for (String fileLocation : snapshotFiles3) {
-      Assert.assertTrue("All snapshot files must remain", fs.exists(new Path(fileLocation)));
+      assertThat(fs.exists(new Path(fileLocation))).as("All snapshot files must remain").isTrue();
     }
   }
 
-  @Test
+  @TestTemplate
   public void orphanedFileRemovedWithParallelTasks() throws InterruptedException, IOException {
     Table table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
 
@@ -299,16 +314,15 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     // Verifies that the delete methods ran in the threads created by the provided ExecutorService
     // ThreadFactory
-    Assert.assertEquals(
-        deleteThreads,
-        Sets.newHashSet(
-            "remove-orphan-0", "remove-orphan-1", "remove-orphan-2", "remove-orphan-3"));
-
-    Assert.assertEquals("Should delete 4 files", 4, deletedFiles.size());
+    assertThat(deleteThreads)
+        .containsExactlyInAnyOrder(
+            "remove-orphan-0", "remove-orphan-1", "remove-orphan-2", "remove-orphan-3");
+    assertThat(deletedFiles).hasSize(4);
   }
 
-  @Test
+  @TestTemplate
   public void testWapFilesAreKept() throws InterruptedException {
+    assumeThat(formatVersion).as("currently fails with DVs").isEqualTo(2);
     Map<String, String> props = Maps.newHashMap();
     props.put(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED, "true");
     Table table = TABLES.create(SCHEMA, SPEC, props, tableLocation);
@@ -328,7 +342,9 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
         resultDF.as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
-    Assert.assertEquals("Should not return data from the staged snapshot", records, actualRecords);
+    assertThat(actualRecords)
+        .as("Should not return data from the staged snapshot")
+        .isEqualTo(records);
 
     waitUntilAfter(System.currentTimeMillis());
 
@@ -337,11 +353,10 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertTrue(
-        "Should not delete any files", Iterables.isEmpty(result.orphanFileLocations()));
+    assertThat(result.orphanFileLocations()).as("Should not delete any files").isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void testMetadataFolderIsIntact() throws InterruptedException {
     // write data directly to the table location
     Map<String, String> props = Maps.newHashMap();
@@ -363,15 +378,15 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
+    assertThat(result.orphanFileLocations()).as("Should delete 1 file").hasSize(1);
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
         resultDF.as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
-    Assert.assertEquals("Rows must match", records, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(records);
   }
 
-  @Test
+  @TestTemplate
   public void testOlderThanTimestamp() throws InterruptedException {
     Table table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
 
@@ -397,11 +412,10 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(timestamp).execute();
 
-    Assert.assertEquals(
-        "Should delete only 2 files", 2, Iterables.size(result.orphanFileLocations()));
+    assertThat(result.orphanFileLocations()).as("Should delete only 2 files").hasSize(2);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveUnreachableMetadataVersionFiles() throws InterruptedException {
     Map<String, String> props = Maps.newHashMap();
     props.put(TableProperties.WRITE_DATA_LOCATION, tableLocation);
@@ -423,11 +437,8 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
-    Assert.assertTrue(
-        "Should remove v1 file",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("v1.metadata.json")));
+    assertThat(result.orphanFileLocations())
+        .containsExactly(tableLocation + "metadata/v1.metadata.json");
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records);
@@ -436,10 +447,10 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
         resultDF.as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testManyTopLevelPartitions() throws InterruptedException {
     Table table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
 
@@ -459,14 +470,13 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertTrue(
-        "Should not delete any files", Iterables.isEmpty(result.orphanFileLocations()));
+    assertThat(result.orphanFileLocations()).as("Should not delete any files").isEmpty();
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
-    Assert.assertEquals("Rows count must match", records.size(), resultDF.count());
+    assertThat(resultDF.count()).as("Rows count must match").isEqualTo(records.size());
   }
 
-  @Test
+  @TestTemplate
   public void testManyLeafPartitions() throws InterruptedException {
     Table table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
 
@@ -486,14 +496,13 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertTrue(
-        "Should not delete any files", Iterables.isEmpty(result.orphanFileLocations()));
+    assertThat(result.orphanFileLocations()).as("Should not delete any files").isEmpty();
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
-    Assert.assertEquals("Row count must match", records.size(), resultDF.count());
+    assertThat(resultDF.count()).as("Row count must match").isEqualTo(records.size());
   }
 
-  @Test
+  @TestTemplate
   public void testHiddenPartitionPaths() throws InterruptedException {
     Schema schema =
         new Schema(
@@ -523,10 +532,10 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 2 files", 2, Iterables.size(result.orphanFileLocations()));
+    assertThat(result.orphanFileLocations()).as("Should delete 2 files").hasSize(2);
   }
 
-  @Test
+  @TestTemplate
   public void testHiddenPartitionPathsWithPartitionEvolution() throws InterruptedException {
     Schema schema =
         new Schema(
@@ -559,10 +568,10 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 2 files", 2, Iterables.size(result.orphanFileLocations()));
+    assertThat(result.orphanFileLocations()).as("Should delete 2 files").hasSize(2);
   }
 
-  @Test
+  @TestTemplate
   public void testHiddenPathsStartingWithPartitionNamesAreIgnored()
       throws InterruptedException, IOException {
     Schema schema =
@@ -595,8 +604,8 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 0 files", 0, Iterables.size(result.orphanFileLocations()));
-    Assert.assertTrue(fs.exists(pathToFileInHiddenFolder));
+    assertThat(result.orphanFileLocations()).as("Should delete 0 files").isEmpty();
+    assertThat(fs.exists(pathToFileInHiddenFolder)).isTrue();
   }
 
   private List<String> snapshotFiles(long snapshotId) {
@@ -610,7 +619,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         .collectAsList();
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveOrphanFilesWithRelativeFilePath() throws IOException, InterruptedException {
     Table table =
         TABLES.create(
@@ -635,7 +644,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .select("file_path")
             .as(Encoders.STRING())
             .collectAsList();
-    Assert.assertEquals("Should be 1 valid files", 1, validFiles.size());
+    assertThat(validFiles).as("Should be 1 valid file").hasSize(1);
     String validFile = validFiles.get(0);
 
     df.write().mode("append").parquet(tableLocation + "/data");
@@ -647,11 +656,11 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .filter(FileStatus::isFile)
             .map(file -> file.getPath().toString())
             .collect(Collectors.toList());
-    Assert.assertEquals("Should be 2 files", 2, allFiles.size());
+    assertThat(allFiles).as("Should be 2 files").hasSize(2);
 
     List<String> invalidFiles = Lists.newArrayList(allFiles);
     invalidFiles.removeIf(file -> file.contains(validFile));
-    Assert.assertEquals("Should be 1 invalid file", 1, invalidFiles.size());
+    assertThat(invalidFiles).as("Should be 1 invalid file").hasSize(1);
 
     waitUntilAfter(System.currentTimeMillis());
 
@@ -662,11 +671,15 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .olderThan(System.currentTimeMillis())
             .deleteWith(s -> {})
             .execute();
-    Assert.assertEquals("Action should find 1 file", invalidFiles, result.orphanFileLocations());
-    Assert.assertTrue("Invalid file should be present", fs.exists(new Path(invalidFiles.get(0))));
+    assertThat(result.orphanFileLocations())
+        .as("Action should find 1 file")
+        .isEqualTo(invalidFiles);
+    assertThat(fs.exists(new Path(invalidFiles.get(0))))
+        .as("Invalid file should be present")
+        .isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveOrphanFilesWithHadoopCatalog() throws InterruptedException {
     HadoopCatalog catalog = new HadoopCatalog(new Configuration(), tableLocation);
     String namespaceName = "testDb";
@@ -693,24 +706,18 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         SparkActions.get().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals(
-        "Should delete only 1 files", 1, Iterables.size(result.orphanFileLocations()));
+    assertThat(result.orphanFileLocations()).as("Should delete only 1 file").hasSize(1);
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(table.location());
     List<ThreeColumnRecord> actualRecords =
         resultDF.as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
-    Assert.assertEquals("Rows must match", records, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(records);
   }
 
-  @Test
+  @TestTemplate
   public void testHiveCatalogTable() throws IOException {
-    Table table =
-        catalog.createTable(
-            TableIdentifier.of("default", "hivetestorphan"),
-            SCHEMA,
-            SPEC,
-            tableLocation,
-            Maps.newHashMap());
+    TableIdentifier identifier = TableIdentifier.of("default", randomName("hivetestorphan"));
+    Table table = catalog.createTable(identifier, SCHEMA, SPEC, tableLocation, properties);
 
     List<ThreeColumnRecord> records =
         Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
@@ -721,7 +728,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         .write()
         .format("iceberg")
         .mode("append")
-        .save("default.hivetestorphan");
+        .save(identifier.toString());
 
     String location = table.location().replaceFirst("file:", "");
     new File(location + "/data/trashfile").createNewFile();
@@ -731,13 +738,12 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .deleteOrphanFiles(table)
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    Assert.assertTrue(
-        "trash file should be removed",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+    assertThat(result.orphanFileLocations())
+        .as("trash file should be removed")
+        .contains("file:" + location + "/data/trashfile");
   }
 
-  @Test
+  @TestTemplate
   public void testGarbageCollectionDisabled() {
     Table table =
         TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), tableLocation);
@@ -757,7 +763,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             "Cannot delete orphan files: GC is disabled (deleting files may corrupt other tables)");
   }
 
-  @Test
+  @TestTemplate
   public void testCompareToFileList() throws IOException, InterruptedException {
     Table table =
         TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), tableLocation);
@@ -782,7 +788,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
                         file.getPath().toString(), new Timestamp(file.getModificationTime())))
             .collect(Collectors.toList());
 
-    Assert.assertEquals("Should be 2 valid files", 2, validFiles.size());
+    assertThat(validFiles).as("Should be 2 valid files").hasSize(2);
 
     df.write().mode("append").parquet(tableLocation + "/data");
 
@@ -795,7 +801,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
                         file.getPath().toString(), new Timestamp(file.getModificationTime())))
             .collect(Collectors.toList());
 
-    Assert.assertEquals("Should be 3 files", 3, allFiles.size());
+    assertThat(allFiles).as("Should be 3 files").hasSize(3);
 
     List<FilePathLastModifiedRecord> invalidFiles = Lists.newArrayList(allFiles);
     invalidFiles.removeAll(validFiles);
@@ -803,7 +809,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         invalidFiles.stream()
             .map(FilePathLastModifiedRecord::getFilePath)
             .collect(Collectors.toList());
-    Assert.assertEquals("Should be 1 invalid file", 1, invalidFiles.size());
+    assertThat(invalidFiles).as("Should be 1 invalid file").hasSize(1);
 
     // sleep for 1 second to ensure files will be old enough
     waitUntilAfter(System.currentTimeMillis());
@@ -822,9 +828,9 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .compareToFileList(compareToFileList)
             .deleteWith(s -> {})
             .execute();
-    Assert.assertTrue(
-        "Default olderThan interval should be safe",
-        Iterables.isEmpty(result1.orphanFileLocations()));
+    assertThat(result1.orphanFileLocations())
+        .as("Default olderThan interval should be safe")
+        .isEmpty();
 
     DeleteOrphanFiles.Result result2 =
         actions
@@ -833,10 +839,12 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .olderThan(System.currentTimeMillis())
             .deleteWith(s -> {})
             .execute();
-    Assert.assertEquals(
-        "Action should find 1 file", invalidFilePaths, result2.orphanFileLocations());
-    Assert.assertTrue(
-        "Invalid file should be present", fs.exists(new Path(invalidFilePaths.get(0))));
+    assertThat(result2.orphanFileLocations())
+        .as("Action should find 1 file")
+        .isEqualTo(invalidFilePaths);
+    assertThat(fs.exists(new Path(invalidFilePaths.get(0))))
+        .as("Invalid file should be present")
+        .isTrue();
 
     DeleteOrphanFiles.Result result3 =
         actions
@@ -844,10 +852,12 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .compareToFileList(compareToFileList)
             .olderThan(System.currentTimeMillis())
             .execute();
-    Assert.assertEquals(
-        "Action should delete 1 file", invalidFilePaths, result3.orphanFileLocations());
-    Assert.assertFalse(
-        "Invalid file should not be present", fs.exists(new Path(invalidFilePaths.get(0))));
+    assertThat(result3.orphanFileLocations())
+        .as("Action should delete 1 file")
+        .isEqualTo(invalidFilePaths);
+    assertThat(fs.exists(new Path(invalidFilePaths.get(0))))
+        .as("Invalid file should not be present")
+        .isFalse();
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records);
@@ -856,7 +866,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
         resultDF.as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
 
     List<FilePathLastModifiedRecord> outsideLocationMockFiles =
         Lists.newArrayList(new FilePathLastModifiedRecord("/tmp/mock1", new Timestamp(0L)));
@@ -873,8 +883,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .compareToFileList(compareToFileListWithOutsideLocation)
             .deleteWith(s -> {})
             .execute();
-    Assert.assertEquals(
-        "Action should find nothing", Lists.newArrayList(), result4.orphanFileLocations());
+    assertThat(result4.orphanFileLocations()).as("Action should find nothing").isEmpty();
   }
 
   protected long waitUntilAfter(long timestampMillis) {
@@ -885,7 +894,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     return current;
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveOrphanFilesWithStatisticFiles() throws Exception {
     Table table =
         TABLES.create(
@@ -954,35 +963,32 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
     Iterable<String> orphanFileLocations = result.orphanFileLocations();
-    assertThat(orphanFileLocations).as("Should be orphan files").hasSize(1);
-    assertThat(Iterables.getOnlyElement(orphanFileLocations))
-        .as("Deleted file")
-        .isEqualTo(statsLocation.toURI().toString());
-    assertThat(statsLocation.exists()).as("stats file should be deleted").isFalse();
+    assertThat(orphanFileLocations).hasSize(1).containsExactly(statsLocation.toURI().toString());
+    assertThat(statsLocation).as("stats file should be deleted").doesNotExist();
   }
 
-  @Test
+  @TestTemplate
   public void testPathsWithExtraSlashes() {
     List<String> validFiles = Lists.newArrayList("file:///dir1/dir2/file1");
     List<String> actualFiles = Lists.newArrayList("file:///dir1/////dir2///file1");
     executeTest(validFiles, actualFiles, Lists.newArrayList());
   }
 
-  @Test
+  @TestTemplate
   public void testPathsWithValidFileHavingNoAuthority() {
     List<String> validFiles = Lists.newArrayList("hdfs:///dir1/dir2/file1");
     List<String> actualFiles = Lists.newArrayList("hdfs://servicename/dir1/dir2/file1");
     executeTest(validFiles, actualFiles, Lists.newArrayList());
   }
 
-  @Test
+  @TestTemplate
   public void testPathsWithActualFileHavingNoAuthority() {
     List<String> validFiles = Lists.newArrayList("hdfs://servicename/dir1/dir2/file1");
     List<String> actualFiles = Lists.newArrayList("hdfs:///dir1/dir2/file1");
     executeTest(validFiles, actualFiles, Lists.newArrayList());
   }
 
-  @Test
+  @TestTemplate
   public void testPathsWithEqualSchemes() {
     List<String> validFiles = Lists.newArrayList("scheme1://bucket1/dir1/dir2/file1");
     List<String> actualFiles = Lists.newArrayList("scheme2://bucket1/dir1/dir2/file1");
@@ -1011,7 +1017,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         DeleteOrphanFiles.PrefixMismatchMode.ERROR);
   }
 
-  @Test
+  @TestTemplate
   public void testPathsWithEqualAuthorities() {
     List<String> validFiles = Lists.newArrayList("hdfs://servicename1/dir1/dir2/file1");
     List<String> actualFiles = Lists.newArrayList("hdfs://servicename2/dir1/dir2/file1");
@@ -1040,7 +1046,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         DeleteOrphanFiles.PrefixMismatchMode.ERROR);
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveOrphanFileActionWithDeleteMode() {
     List<String> validFiles = Lists.newArrayList("hdfs://servicename1/dir1/dir2/file1");
     List<String> actualFiles = Lists.newArrayList("hdfs://servicename2/dir1/dir2/file1");
@@ -1052,6 +1058,10 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         ImmutableMap.of(),
         ImmutableMap.of(),
         DeleteOrphanFiles.PrefixMismatchMode.DELETE);
+  }
+
+  protected String randomName(String prefix) {
+    return prefix + UUID.randomUUID().toString().replace("-", "");
   }
 
   private void executeTest(
@@ -1081,6 +1091,6 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     List<String> orphanFiles =
         DeleteOrphanFilesSparkAction.findOrphanFiles(
             spark, toFileUri.apply(actualFileDS), toFileUri.apply(validFileDS), mode);
-    Assert.assertEquals(expectedOrphanFiles, orphanFiles);
+    assertThat(orphanFiles).isEqualTo(expectedOrphanFiles);
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
@@ -18,23 +18,21 @@
  */
 package org.apache.iceberg.spark.actions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
-import java.util.Map;
-import java.util.stream.StreamSupport;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.expressions.Transform;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
 
 public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
-  @Test
+  @TestTemplate
   public void testSparkCatalogTable() throws Exception {
     spark.conf().set("spark.sql.catalog.mycat", "org.apache.iceberg.spark.SparkCatalog");
     spark.conf().set("spark.sql.catalog.mycat.type", "hadoop");
@@ -42,29 +40,28 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     SparkCatalog cat = (SparkCatalog) spark.sessionState().catalogManager().catalog("mycat");
 
     String[] database = {"default"};
-    Identifier id = Identifier.of(database, "table");
-    Map<String, String> options = Maps.newHashMap();
+    Identifier id = Identifier.of(database, randomName("table"));
     Transform[] transforms = {};
-    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, options);
+    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, properties);
     SparkTable table = (SparkTable) cat.loadTable(id);
 
-    spark.sql("INSERT INTO mycat.default.table VALUES (1,1,1)");
+    sql("INSERT INTO mycat.default.%s VALUES (1,1,1)", id.name());
 
     String location = table.table().location().replaceFirst("file:", "");
-    new File(location + "/data/trashfile").createNewFile();
+    String trashFile = randomName("/data/trashfile");
+    new File(location + trashFile).createNewFile();
 
     DeleteOrphanFiles.Result results =
         SparkActions.get()
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    Assert.assertTrue(
-        "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+    assertThat(results.orphanFileLocations())
+        .as("trash file should be removed")
+        .contains("file:" + location + trashFile);
   }
 
-  @Test
+  @TestTemplate
   public void testSparkCatalogNamedHadoopTable() throws Exception {
     spark.conf().set("spark.sql.catalog.hadoop", "org.apache.iceberg.spark.SparkCatalog");
     spark.conf().set("spark.sql.catalog.hadoop.type", "hadoop");
@@ -72,29 +69,28 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     SparkCatalog cat = (SparkCatalog) spark.sessionState().catalogManager().catalog("hadoop");
 
     String[] database = {"default"};
-    Identifier id = Identifier.of(database, "table");
-    Map<String, String> options = Maps.newHashMap();
+    Identifier id = Identifier.of(database, randomName("table"));
     Transform[] transforms = {};
-    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, options);
+    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, properties);
     SparkTable table = (SparkTable) cat.loadTable(id);
 
-    spark.sql("INSERT INTO hadoop.default.table VALUES (1,1,1)");
+    sql("INSERT INTO hadoop.default.%s VALUES (1,1,1)", id.name());
 
     String location = table.table().location().replaceFirst("file:", "");
-    new File(location + "/data/trashfile").createNewFile();
+    String trashFile = randomName("/data/trashfile");
+    new File(location + trashFile).createNewFile();
 
     DeleteOrphanFiles.Result results =
         SparkActions.get()
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    Assert.assertTrue(
-        "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+    assertThat(results.orphanFileLocations())
+        .as("trash file should be removed")
+        .contains("file:" + location + trashFile);
   }
 
-  @Test
+  @TestTemplate
   public void testSparkCatalogNamedHiveTable() throws Exception {
     spark.conf().set("spark.sql.catalog.hive", "org.apache.iceberg.spark.SparkCatalog");
     spark.conf().set("spark.sql.catalog.hive.type", "hadoop");
@@ -102,29 +98,28 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     SparkCatalog cat = (SparkCatalog) spark.sessionState().catalogManager().catalog("hive");
 
     String[] database = {"default"};
-    Identifier id = Identifier.of(database, "table");
-    Map<String, String> options = Maps.newHashMap();
+    Identifier id = Identifier.of(database, randomName("table"));
     Transform[] transforms = {};
-    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, options);
+    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, properties);
     SparkTable table = (SparkTable) cat.loadTable(id);
 
-    spark.sql("INSERT INTO hive.default.table VALUES (1,1,1)");
+    sql("INSERT INTO hive.default.%s VALUES (1,1,1)", id.name());
 
     String location = table.table().location().replaceFirst("file:", "");
-    new File(location + "/data/trashfile").createNewFile();
+    String trashFile = randomName("/data/trashfile");
+    new File(location + trashFile).createNewFile();
 
     DeleteOrphanFiles.Result results =
         SparkActions.get()
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    Assert.assertTrue(
-        "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+    assertThat(results.orphanFileLocations())
+        .as("trash file should be removed")
+        .contains("file:" + location + trashFile);
   }
 
-  @Test
+  @TestTemplate
   public void testSparkSessionCatalogHadoopTable() throws Exception {
     spark
         .conf()
@@ -135,29 +130,28 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
         (SparkSessionCatalog) spark.sessionState().catalogManager().v2SessionCatalog();
 
     String[] database = {"default"};
-    Identifier id = Identifier.of(database, "table");
-    Map<String, String> options = Maps.newHashMap();
+    Identifier id = Identifier.of(database, randomName("table"));
     Transform[] transforms = {};
-    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, options);
+    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, properties);
     SparkTable table = (SparkTable) cat.loadTable(id);
 
-    spark.sql("INSERT INTO default.table VALUES (1,1,1)");
+    sql("INSERT INTO default.%s VALUES (1,1,1)", id.name());
 
     String location = table.table().location().replaceFirst("file:", "");
-    new File(location + "/data/trashfile").createNewFile();
+    String trashFile = randomName("/data/trashfile");
+    new File(location + trashFile).createNewFile();
 
     DeleteOrphanFiles.Result results =
         SparkActions.get()
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    Assert.assertTrue(
-        "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+    assertThat(results.orphanFileLocations())
+        .as("trash file should be removed")
+        .contains("file:" + location + trashFile);
   }
 
-  @Test
+  @TestTemplate
   public void testSparkSessionCatalogHiveTable() throws Exception {
     spark
         .conf()
@@ -168,30 +162,29 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
 
     String[] database = {"default"};
     Identifier id = Identifier.of(database, "sessioncattest");
-    Map<String, String> options = Maps.newHashMap();
     Transform[] transforms = {};
     cat.dropTable(id);
-    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, options);
+    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, properties);
     SparkTable table = (SparkTable) cat.loadTable(id);
 
-    spark.sql("INSERT INTO default.sessioncattest VALUES (1,1,1)");
+    sql("INSERT INTO default.sessioncattest VALUES (1,1,1)");
 
     String location = table.table().location().replaceFirst("file:", "");
-    new File(location + "/data/trashfile").createNewFile();
+    String trashFile = randomName("/data/trashfile");
+    new File(location + trashFile).createNewFile();
 
     DeleteOrphanFiles.Result results =
         SparkActions.get()
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    Assert.assertTrue(
-        "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+    assertThat(results.orphanFileLocations())
+        .as("trash file should be removed")
+        .contains("file:" + location + trashFile);
   }
 
-  @After
-  public void resetSparkSessionCatalog() throws Exception {
+  @AfterEach
+  public void resetSparkSessionCatalog() {
     spark.conf().unset("spark.sql.catalog.spark_catalog");
     spark.conf().unset("spark.sql.catalog.spark_catalog.type");
     spark.conf().unset("spark.sql.catalog.spark_catalog.warehouse");

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -1156,7 +1156,7 @@ public class TestRewriteManifestsAction extends TestBase {
       Table table, StructLike partition, List<Pair<CharSequence, Long>> deletes)
       throws IOException {
     OutputFile outputFile = Files.localOutput(File.createTempFile("junit", null, temp.toFile()));
-    return FileHelpers.writeDeleteFile(table, outputFile, partition, deletes);
+    return FileHelpers.writeDeleteFile(table, outputFile, partition, deletes, formatVersion);
   }
 
   private DeleteFile writeEqDeletes(Table table, String key, Object... values) throws IOException {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -37,11 +37,14 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
@@ -64,6 +67,7 @@ import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -95,7 +99,9 @@ public class TestRewriteManifestsAction extends TestBase {
           optional(2, "c2", Types.StringType.get()),
           optional(3, "c3", Types.StringType.get()));
 
-  @Parameters(name = "snapshotIdInheritanceEnabled = {0}, useCaching = {1}, formatVersion = {2}")
+  @Parameters(
+      name =
+          "snapshotIdInheritanceEnabled = {0}, useCaching = {1}, shouldStageManifests = {2}, formatVersion = {3}")
   public static Object[] parameters() {
     return new Object[][] {
       new Object[] {"true", "true", false, 1},
@@ -126,6 +132,65 @@ public class TestRewriteManifestsAction extends TestBase {
   @BeforeEach
   public void setupTableLocation() throws Exception {
     this.tableLocation = tableDir.toURI().toString();
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsPreservesOptionalFields() throws IOException {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    DataFile dataFile1 = newDataFile(table, "c1=0");
+    DataFile dataFile2 = newDataFile(table, "c1=0");
+    DataFile dataFile3 = newDataFile(table, "c1=0");
+    table
+        .newFastAppend()
+        .appendFile(dataFile1)
+        .appendFile(dataFile2)
+        .appendFile(dataFile3)
+        .commit();
+
+    DeleteFile deleteFile1 = newDeletes(table, dataFile1);
+    assertDeletes(dataFile1, deleteFile1);
+    table.newRowDelta().addDeletes(deleteFile1).commit();
+
+    DeleteFile deleteFile2 = newDeletes(table, dataFile2);
+    assertDeletes(dataFile2, deleteFile2);
+    table.newRowDelta().addDeletes(deleteFile2).commit();
+
+    DeleteFile deleteFile3 = newDeletes(table, dataFile3);
+    assertDeletes(dataFile3, deleteFile3);
+    table.newRowDelta().addDeletes(deleteFile3).commit();
+
+    SparkActions actions = SparkActions.get();
+
+    actions
+        .rewriteManifests(table)
+        .rewriteIf(manifest -> true)
+        .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    table.refresh();
+
+    try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+      for (FileScanTask fileTask : tasks) {
+        DataFile dataFile = fileTask.file();
+        DeleteFile deleteFile = Iterables.getOnlyElement(fileTask.deletes());
+        if (dataFile.location().equals(dataFile1.location())) {
+          assertThat(deleteFile.referencedDataFile()).isEqualTo(deleteFile1.referencedDataFile());
+          assertEqual(deleteFile, deleteFile1);
+        } else if (dataFile.location().equals(dataFile2.location())) {
+          assertThat(deleteFile.referencedDataFile()).isEqualTo(deleteFile2.referencedDataFile());
+          assertEqual(deleteFile, deleteFile2);
+        } else {
+          assertThat(deleteFile.referencedDataFile()).isEqualTo(deleteFile3.referencedDataFile());
+          assertEqual(deleteFile, deleteFile3);
+        }
+      }
+    }
   }
 
   @TestTemplate
@@ -892,6 +957,62 @@ public class TestRewriteManifestsAction extends TestBase {
     assertThat(deleteManifests).hasSizeGreaterThanOrEqualTo(2);
   }
 
+  @TestTemplate
+  public void testRewriteManifestsAfterUpgradeToV3() throws IOException {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
+    Map<String, String> options = ImmutableMap.of(TableProperties.FORMAT_VERSION, "2");
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    DataFile dataFile1 = newDataFile(table, "c1=1");
+    DeleteFile deleteFile1 = newDeletes(table, dataFile1);
+    table.newRowDelta().addRows(dataFile1).addDeletes(deleteFile1).commit();
+
+    DataFile dataFile2 = newDataFile(table, "c1=1");
+    DeleteFile deleteFile2 = newDeletes(table, dataFile2);
+    table.newRowDelta().addRows(dataFile2).addDeletes(deleteFile2).commit();
+
+    // upgrade the table to enable DVs
+    table.updateProperties().set(TableProperties.FORMAT_VERSION, "3").commit();
+
+    DataFile dataFile3 = newDataFile(table, "c1=1");
+    DeleteFile dv3 = newDV(table, dataFile3);
+    table.newRowDelta().addRows(dataFile3).addDeletes(dv3).commit();
+
+    SparkActions actions = SparkActions.get();
+
+    RewriteManifests.Result result =
+        actions
+            .rewriteManifests(table)
+            .rewriteIf(manifest -> true)
+            .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+            .execute();
+
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 6 manifests").hasSize(6);
+    assertThat(result.addedManifests()).as("Action should add 2 manifests").hasSize(2);
+    assertManifestsLocation(result.addedManifests());
+
+    table.refresh();
+
+    try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+      for (FileScanTask fileTask : tasks) {
+        DataFile dataFile = fileTask.file();
+        DeleteFile deleteFile = Iterables.getOnlyElement(fileTask.deletes());
+        if (dataFile.location().equals(dataFile1.location())) {
+          assertThat(deleteFile.referencedDataFile()).isEqualTo(deleteFile1.referencedDataFile());
+          assertEqual(deleteFile, deleteFile1);
+        } else if (dataFile.location().equals(dataFile2.location())) {
+          assertThat(deleteFile.referencedDataFile()).isEqualTo(deleteFile2.referencedDataFile());
+          assertEqual(deleteFile, deleteFile2);
+        } else {
+          assertThat(deleteFile.referencedDataFile()).isEqualTo(dv3.referencedDataFile());
+          assertEqual(deleteFile, dv3);
+        }
+      }
+    }
+  }
+
   private List<ThreeColumnRecord> actualRecords() {
     return spark
         .read()
@@ -975,14 +1096,36 @@ public class TestRewriteManifestsAction extends TestBase {
         .withRecordCount(1);
   }
 
+  private DeleteFile newDeletes(Table table, DataFile dataFile) {
+    return formatVersion >= 3 ? newDV(table, dataFile) : newDeleteFileWithRef(table, dataFile);
+  }
+
+  private DeleteFile newDeleteFileWithRef(Table table, DataFile dataFile) {
+    return FileGenerationUtil.generatePositionDeleteFileWithRef(table, dataFile);
+  }
+
+  private DeleteFile newDV(Table table, DataFile dataFile) {
+    return FileGenerationUtil.generateDV(table, dataFile);
+  }
+
   private DeleteFile newDeleteFile(Table table, String partitionPath) {
-    return FileMetadata.deleteFileBuilder(table.spec())
-        .ofPositionDeletes()
-        .withPath("/path/to/pos-deletes-" + UUID.randomUUID() + ".parquet")
-        .withFileSizeInBytes(5)
-        .withPartitionPath(partitionPath)
-        .withRecordCount(1)
-        .build();
+    return formatVersion >= 3
+        ? FileMetadata.deleteFileBuilder(table.spec())
+            .ofPositionDeletes()
+            .withPath("/path/to/pos-deletes-" + UUID.randomUUID() + ".puffin")
+            .withFileSizeInBytes(5)
+            .withPartitionPath(partitionPath)
+            .withRecordCount(1)
+            .withContentOffset(ThreadLocalRandom.current().nextInt())
+            .withContentSizeInBytes(ThreadLocalRandom.current().nextInt())
+            .build()
+        : FileMetadata.deleteFileBuilder(table.spec())
+            .ofPositionDeletes()
+            .withPath("/path/to/pos-deletes-" + UUID.randomUUID() + ".parquet")
+            .withFileSizeInBytes(5)
+            .withPartitionPath(partitionPath)
+            .withRecordCount(1)
+            .build();
   }
 
   private List<Pair<CharSequence, Long>> generatePosDeletes(String predicate) {
@@ -1032,5 +1175,27 @@ public class TestRewriteManifestsAction extends TestBase {
 
     OutputFile outputFile = Files.localOutput(File.createTempFile("junit", null, temp.toFile()));
     return FileHelpers.writeDeleteFile(table, outputFile, partition, deletes, deleteSchema);
+  }
+
+  private void assertDeletes(DataFile dataFile, DeleteFile deleteFile) {
+    assertThat(deleteFile.referencedDataFile()).isEqualTo(dataFile.location());
+    if (formatVersion >= 3) {
+      assertThat(deleteFile.contentOffset()).isNotNull();
+      assertThat(deleteFile.contentSizeInBytes()).isNotNull();
+    } else {
+      assertThat(deleteFile.contentOffset()).isNull();
+      assertThat(deleteFile.contentSizeInBytes()).isNull();
+    }
+  }
+
+  private void assertEqual(DeleteFile deleteFile1, DeleteFile deleteFile2) {
+    assertThat(deleteFile1.location()).isEqualTo(deleteFile2.location());
+    assertThat(deleteFile1.content()).isEqualTo(deleteFile2.content());
+    assertThat(deleteFile1.specId()).isEqualTo(deleteFile2.specId());
+    assertThat(deleteFile1.partition()).isEqualTo(deleteFile2.partition());
+    assertThat(deleteFile1.format()).isEqualTo(deleteFile2.format());
+    assertThat(deleteFile1.referencedDataFile()).isEqualTo(deleteFile2.referencedDataFile());
+    assertThat(deleteFile1.contentOffset()).isEqualTo(deleteFile2.contentOffset());
+    assertThat(deleteFile1.contentSizeInBytes()).isEqualTo(deleteFile2.contentSizeInBytes());
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -46,6 +47,9 @@ import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.Schema;
@@ -66,8 +70,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkTableUtil;
-import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.SparkWriteOptions;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
@@ -76,17 +80,13 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.TableIdentifier;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(Parameterized.class)
-public class TestRewriteManifestsAction extends SparkTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRewriteManifestsAction extends TestBase {
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
@@ -98,36 +98,37 @@ public class TestRewriteManifestsAction extends SparkTestBase {
   @Parameters(name = "snapshotIdInheritanceEnabled = {0}, useCaching = {1}, formatVersion = {2}")
   public static Object[] parameters() {
     return new Object[][] {
-      new Object[] {"true", "true", 1},
-      new Object[] {"false", "true", 1},
-      new Object[] {"true", "false", 2},
-      new Object[] {"false", "false", 2}
+      new Object[] {"true", "true", false, 1},
+      new Object[] {"false", "true", true, 1},
+      new Object[] {"true", "false", false, 2},
+      new Object[] {"false", "false", false, 2},
+      new Object[] {"true", "false", false, 3},
+      new Object[] {"false", "false", false, 3}
     };
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @Parameter private String snapshotIdInheritanceEnabled;
 
-  private final String snapshotIdInheritanceEnabled;
-  private final String useCaching;
-  private final int formatVersion;
-  private final boolean shouldStageManifests;
+  @Parameter(index = 1)
+  private String useCaching;
+
+  @Parameter(index = 2)
+  private boolean shouldStageManifests;
+
+  @Parameter(index = 3)
+  private int formatVersion;
+
   private String tableLocation = null;
 
-  public TestRewriteManifestsAction(
-      String snapshotIdInheritanceEnabled, String useCaching, int formatVersion) {
-    this.snapshotIdInheritanceEnabled = snapshotIdInheritanceEnabled;
-    this.useCaching = useCaching;
-    this.formatVersion = formatVersion;
-    this.shouldStageManifests = formatVersion == 1 && snapshotIdInheritanceEnabled.equals("false");
-  }
+  @TempDir private Path temp;
+  @TempDir private File tableDir;
 
-  @Before
+  @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.newFolder();
     this.tableLocation = tableDir.toURI().toString();
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteManifestsEmptyTable() throws IOException {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
@@ -135,7 +136,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
 
-    Assert.assertNull("Table must be empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
 
     SparkActions actions = SparkActions.get();
 
@@ -143,13 +144,13 @@ public class TestRewriteManifestsAction extends SparkTestBase {
         .rewriteManifests(table)
         .rewriteIf(manifest -> true)
         .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
-        .stagingLocation(temp.newFolder().toString())
+        .stagingLocation(java.nio.file.Files.createTempDirectory(temp, "junit").toString())
         .execute();
 
-    Assert.assertNull("Table must stay empty", table.currentSnapshot());
+    assertThat(table.currentSnapshot()).as("Table must stay empty").isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteSmallManifestsNonPartitionedTable() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
@@ -171,7 +172,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     table.refresh();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 2 manifests before rewrite", 2, manifests.size());
+    assertThat(manifests).as("Should have 2 manifests before rewrite").hasSize(2);
 
     SparkActions actions = SparkActions.get();
 
@@ -182,20 +183,18 @@ public class TestRewriteManifestsAction extends SparkTestBase {
             .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
             .execute();
 
-    Assert.assertEquals(
-        "Action should rewrite 2 manifests", 2, Iterables.size(result.rewrittenManifests()));
-    Assert.assertEquals(
-        "Action should add 1 manifests", 1, Iterables.size(result.addedManifests()));
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifests").hasSize(2);
+    assertThat(result.addedManifests()).as("Action should add 1 manifests").hasSize(1);
     assertManifestsLocation(result.addedManifests());
 
     table.refresh();
 
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 1 manifests after rewrite", 1, newManifests.size());
+    assertThat(newManifests).as("Should have 1 manifests after rewrite").hasSize(1);
 
-    Assert.assertEquals(4, (long) newManifests.get(0).existingFilesCount());
-    Assert.assertFalse(newManifests.get(0).hasAddedFiles());
-    Assert.assertFalse(newManifests.get(0).hasDeletedFiles());
+    assertThat(newManifests.get(0).existingFilesCount()).isEqualTo(4);
+    assertThat(newManifests.get(0).hasAddedFiles()).isFalse();
+    assertThat(newManifests.get(0).hasDeletedFiles()).isFalse();
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records1);
@@ -205,10 +204,10 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     List<ThreeColumnRecord> actualRecords =
         resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
 
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteManifestsWithCommitStateUnknownException() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
@@ -230,7 +229,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     table.refresh();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 2 manifests before rewrite", 2, manifests.size());
+    assertThat(manifests).as("Should have 2 manifests before rewrite").hasSize(2);
 
     SparkActions actions = SparkActions.get();
 
@@ -258,11 +257,11 @@ public class TestRewriteManifestsAction extends SparkTestBase {
 
     // table should reflect the changes, since the commit was successful
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 1 manifests after rewrite", 1, newManifests.size());
+    assertThat(newManifests).as("Should have 1 manifests after rewrite").hasSize(1);
 
-    Assert.assertEquals(4, (long) newManifests.get(0).existingFilesCount());
-    Assert.assertFalse(newManifests.get(0).hasAddedFiles());
-    Assert.assertFalse(newManifests.get(0).hasDeletedFiles());
+    assertThat(newManifests.get(0).existingFilesCount()).isEqualTo(4);
+    assertThat(newManifests.get(0).hasAddedFiles()).isFalse();
+    assertThat(newManifests.get(0).hasDeletedFiles()).isFalse();
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records1);
@@ -272,10 +271,10 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     List<ThreeColumnRecord> actualRecords =
         resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
 
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteSmallManifestsPartitionedTable() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
     Map<String, String> options = Maps.newHashMap();
@@ -309,7 +308,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     table.refresh();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 4 manifests before rewrite", 4, manifests.size());
+    assertThat(manifests).as("Should have 4 manifests before rewrite").hasSize(4);
 
     SparkActions actions = SparkActions.get();
 
@@ -329,24 +328,22 @@ public class TestRewriteManifestsAction extends SparkTestBase {
             .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
             .execute();
 
-    Assert.assertEquals(
-        "Action should rewrite 4 manifests", 4, Iterables.size(result.rewrittenManifests()));
-    Assert.assertEquals(
-        "Action should add 2 manifests", 2, Iterables.size(result.addedManifests()));
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 4 manifests").hasSize(4);
+    assertThat(result.addedManifests()).as("Action should add 2 manifests").hasSize(2);
     assertManifestsLocation(result.addedManifests());
 
     table.refresh();
 
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 2 manifests after rewrite", 2, newManifests.size());
+    assertThat(newManifests).as("Should have 2 manifests after rewrite").hasSize(2);
 
-    Assert.assertEquals(4, (long) newManifests.get(0).existingFilesCount());
-    Assert.assertFalse(newManifests.get(0).hasAddedFiles());
-    Assert.assertFalse(newManifests.get(0).hasDeletedFiles());
+    assertThat(newManifests.get(0).existingFilesCount()).isEqualTo(4);
+    assertThat(newManifests.get(0).hasAddedFiles()).isFalse();
+    assertThat(newManifests.get(0).hasDeletedFiles()).isFalse();
 
-    Assert.assertEquals(4, (long) newManifests.get(1).existingFilesCount());
-    Assert.assertFalse(newManifests.get(1).hasAddedFiles());
-    Assert.assertFalse(newManifests.get(1).hasDeletedFiles());
+    assertThat(newManifests.get(1).existingFilesCount()).isEqualTo(4);
+    assertThat(newManifests.get(1).hasAddedFiles()).isFalse();
+    assertThat(newManifests.get(1).hasDeletedFiles()).isFalse();
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records1);
@@ -358,10 +355,10 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     List<ThreeColumnRecord> actualRecords =
         resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
 
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteImportedManifests() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c3").build();
     Map<String, String> options = Maps.newHashMap();
@@ -372,7 +369,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     List<ThreeColumnRecord> records =
         Lists.newArrayList(
             new ThreeColumnRecord(1, null, "AAAA"), new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB"));
-    File parquetTableDir = temp.newFolder("parquet_table");
+    File parquetTableDir = temp.resolve("parquet_table").toFile();
     String parquetTableLocation = parquetTableDir.toURI().toString();
 
     try {
@@ -386,7 +383,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
           .partitionBy("c3")
           .saveAsTable("parquet_table");
 
-      File stagingDir = temp.newFolder("staging-dir");
+      File stagingDir = temp.resolve("staging-dir").toFile();
       SparkTableUtil.importSparkTable(
           spark, new TableIdentifier("parquet_table"), table, stagingDir.toString());
 
@@ -398,7 +395,8 @@ public class TestRewriteManifestsAction extends SparkTestBase {
 
       SparkActions actions = SparkActions.get();
 
-      String rewriteStagingLocation = temp.newFolder().toString();
+      String rewriteStagingLocation =
+          java.nio.file.Files.createTempDirectory(temp, "junit").toString();
 
       RewriteManifests.Result result =
           actions
@@ -408,12 +406,10 @@ public class TestRewriteManifestsAction extends SparkTestBase {
               .stagingLocation(rewriteStagingLocation)
               .execute();
 
-      Assert.assertEquals(
-          "Action should rewrite all manifests",
-          snapshot.allManifests(table.io()),
-          result.rewrittenManifests());
-      Assert.assertEquals(
-          "Action should add 1 manifest", 1, Iterables.size(result.addedManifests()));
+      assertThat(result.rewrittenManifests())
+          .as("Action should rewrite all manifests")
+          .isEqualTo(snapshot.allManifests(table.io()));
+      assertThat(result.addedManifests()).as("Action should add 1 manifest").hasSize(1);
       assertManifestsLocation(result.addedManifests(), rewriteStagingLocation);
 
     } finally {
@@ -421,7 +417,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteLargeManifestsPartitionedTable() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c3").build();
     Map<String, String> options = Maps.newHashMap();
@@ -437,7 +433,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     table.newFastAppend().appendManifest(appendManifest).commit();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 1 manifests before rewrite", 1, manifests.size());
+    assertThat(manifests).as("Should have 1 manifests before rewrite").hasSize(1);
 
     // set the target manifest size to a small value to force splitting records into multiple files
     table
@@ -449,7 +445,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
 
     SparkActions actions = SparkActions.get();
 
-    String stagingLocation = temp.newFolder().toString();
+    String stagingLocation = java.nio.file.Files.createTempDirectory(temp, "junit").toString();
 
     RewriteManifests.Result result =
         actions
@@ -469,7 +465,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     assertThat(newManifests).hasSizeGreaterThanOrEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteManifestsWithPredicate() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
     Map<String, String> options = Maps.newHashMap();
@@ -493,11 +489,11 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     table.refresh();
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 3 manifests before rewrite", 3, manifests.size());
+    assertThat(manifests).as("Should have 3 manifests before rewrite").hasSize(3);
 
     SparkActions actions = SparkActions.get();
 
-    String stagingLocation = temp.newFolder().toString();
+    String stagingLocation = java.nio.file.Files.createTempDirectory(temp, "junit").toString();
 
     // rewrite only the first manifest
     RewriteManifests.Result result =
@@ -511,22 +507,22 @@ public class TestRewriteManifestsAction extends SparkTestBase {
             .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
             .execute();
 
-    Assert.assertEquals(
-        "Action should rewrite 2 manifest", 2, Iterables.size(result.rewrittenManifests()));
-    Assert.assertEquals(
-        "Action should add 1 manifests", 1, Iterables.size(result.addedManifests()));
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifest").hasSize(2);
+    assertThat(result.addedManifests()).as("Action should add 1 manifests").hasSize(1);
     assertManifestsLocation(result.addedManifests(), stagingLocation);
 
     table.refresh();
 
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 2 manifests after rewrite", 2, newManifests.size());
-
-    Assert.assertFalse("First manifest must be rewritten", newManifests.contains(manifests.get(0)));
-    Assert.assertFalse(
-        "Second manifest must be rewritten", newManifests.contains(manifests.get(1)));
-    Assert.assertTrue(
-        "Third manifest must not be rewritten", newManifests.contains(manifests.get(2)));
+    assertThat(newManifests)
+        .as("Should have 2 manifests after rewrite")
+        .hasSize(2)
+        .as("First manifest must be rewritten")
+        .doesNotContain(manifests.get(0))
+        .as("Second manifest must be rewritten")
+        .doesNotContain(manifests.get(1))
+        .as("Third manifest must not be rewritten")
+        .contains(manifests.get(2));
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.add(records1.get(0));
@@ -539,10 +535,10 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     List<ThreeColumnRecord> actualRecords =
         resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
 
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteSmallManifestsNonPartitionedV2Table() {
     assumeThat(formatVersion).isGreaterThan(1);
 
@@ -567,7 +563,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     DataFile file2 = Iterables.getOnlyElement(snapshot2.addedDataFiles(table.io()));
 
     List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 2 manifests before rewrite", 2, manifests.size());
+    assertThat(manifests).as("Should have 2 manifests before rewrite").hasSize(2);
 
     SparkActions actions = SparkActions.get();
     RewriteManifests.Result result =
@@ -575,21 +571,19 @@ public class TestRewriteManifestsAction extends SparkTestBase {
             .rewriteManifests(table)
             .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
             .execute();
-    Assert.assertEquals(
-        "Action should rewrite 2 manifests", 2, Iterables.size(result.rewrittenManifests()));
-    Assert.assertEquals(
-        "Action should add 1 manifests", 1, Iterables.size(result.addedManifests()));
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifests").hasSize(2);
+    assertThat(result.addedManifests()).as("Action should add 1 manifests").hasSize(1);
     assertManifestsLocation(result.addedManifests());
 
     table.refresh();
 
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-    Assert.assertEquals("Should have 1 manifests after rewrite", 1, newManifests.size());
+    assertThat(newManifests).as("Should have 1 manifests after rewrite").hasSize(1);
 
     ManifestFile newManifest = Iterables.getOnlyElement(newManifests);
-    Assert.assertEquals(2, (long) newManifest.existingFilesCount());
-    Assert.assertFalse(newManifest.hasAddedFiles());
-    Assert.assertFalse(newManifest.hasDeletedFiles());
+    assertThat(newManifest.existingFilesCount()).isEqualTo(2);
+    assertThat(newManifest.hasAddedFiles()).isFalse();
+    assertThat(newManifest.hasDeletedFiles()).isFalse();
 
     validateDataManifest(
         table,
@@ -607,10 +601,10 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     List<ThreeColumnRecord> actualRecords =
         resultDF.sort("c1", "c2").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
 
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteLargeManifestsEvolvedUnpartitionedV1Table() throws IOException {
     assumeThat(formatVersion).isEqualTo(1);
 
@@ -659,9 +653,9 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     assertThat(manifests).hasSizeGreaterThanOrEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteSmallDeleteManifestsNonPartitionedTable() throws IOException {
-    assumeThat(formatVersion).isGreaterThan(1);
+    assumeThat(formatVersion).isEqualTo(2);
 
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
@@ -732,9 +726,9 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     assertThat(actualRecords()).isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteSmallDeleteManifestsPartitionedTable() throws IOException {
-    assumeThat(formatVersion).isGreaterThan(1);
+    assumeThat(formatVersion).isEqualTo(2);
 
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c3").build();
     Map<String, String> options = Maps.newHashMap();
@@ -835,9 +829,9 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     assertThat(actualRecords()).isEqualTo(expectedRecords);
   }
 
-  @Test
+  @TestTemplate
   public void testRewriteLargeDeleteManifestsPartitionedTable() throws IOException {
-    assumeThat(formatVersion).isGreaterThan(1);
+    assumeThat(formatVersion).isEqualTo(2);
 
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c3").build();
     Map<String, String> options = Maps.newHashMap();
@@ -874,7 +868,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
 
     SparkActions actions = SparkActions.get();
 
-    String stagingLocation = temp.newFolder().toString();
+    String stagingLocation = java.nio.file.Files.createTempDirectory(temp, "junit").toString();
 
     RewriteManifests.Result result =
         actions
@@ -948,8 +942,8 @@ public class TestRewriteManifestsAction extends SparkTestBase {
   }
 
   private ManifestFile writeManifest(Table table, List<DataFile> files) throws IOException {
-    File manifestFile = temp.newFile("generated-manifest.avro");
-    Assert.assertTrue(manifestFile.delete());
+    File manifestFile = File.createTempFile("generated-manifest", ".avro", temp.toFile());
+    assertThat(manifestFile.delete()).isTrue();
     OutputFile outputFile = table.io().newOutputFile(manifestFile.getCanonicalPath());
 
     ManifestWriter<DataFile> writer =
@@ -1018,7 +1012,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
   private Pair<DeleteFile, CharSequenceSet> writePosDeletes(
       Table table, StructLike partition, List<Pair<CharSequence, Long>> deletes)
       throws IOException {
-    OutputFile outputFile = Files.localOutput(temp.newFile());
+    OutputFile outputFile = Files.localOutput(File.createTempFile("junit", null, temp.toFile()));
     return FileHelpers.writeDeleteFile(table, outputFile, partition, deletes);
   }
 
@@ -1036,7 +1030,7 @@ public class TestRewriteManifestsAction extends SparkTestBase {
       deletes.add(delete.copy(key, value));
     }
 
-    OutputFile outputFile = Files.localOutput(temp.newFile());
+    OutputFile outputFile = Files.localOutput(File.createTempFile("junit", null, temp.toFile()));
     return FileHelpers.writeDeleteFile(table, outputFile, partition, deletes, deleteSchema);
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.functions.expr;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -378,7 +379,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
 
     List<Object[]> actualRecords = records(table);
     List<Object[]> actualDeletes = deleteRecords(table);
-    assertEquals("Rows must match", expectedRecords, actualRecords);
+    assertEquals("Rows", expectedRecords, actualRecords);
     assertThat(actualDeletes).as("New position deletes").isEmpty();
   }
 
@@ -450,7 +451,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     table.refresh();
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
-    assertThat(expectedRecords).hasSize(12000);
+    assertThat(expectedRecords).hasSize(12000); // 16000 data - 4000 delete rows
     assertThat(expectedDeletes).hasSize(4000);
 
     SparkActions.get(spark)
@@ -695,19 +696,47 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testRewritePositionDeletesForV3TableFails() {
-    Table table =
-        validationCatalog.createTable(
-            TableIdentifier.of("default", TABLE_NAME),
-            SCHEMA,
-            PartitionSpec.unpartitioned(),
-            tableProperties(3));
+  public void testRewriteV2PositionDeletesToV3DVs() throws IOException {
+    Table table = createTableUnpartitioned(2, SCALE);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
+    assertThat(dataFiles).hasSize(2);
+    assertThat(deleteFiles(table)).hasSize(2).allMatch(file -> file.format() == FileFormat.PARQUET);
 
-    writeRecords(table, 2, SCALE);
+    List<Object[]> expectedRecords = records(table);
+    List<Object[]> expectedDeletes = deleteRecords(table);
+    assertThat(expectedRecords).hasSize(2000);
+    assertThat(expectedDeletes).hasSize(2000);
+    assertThat(dvRecords(table)).isEmpty();
 
-    assertThatThrownBy(() -> SparkActions.get(spark).rewritePositionDeletes(table).execute())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot rewrite position deletes for V3 table");
+    // upgrade the table to V3
+    table.updateProperties().set(TableProperties.FORMAT_VERSION, "3").commit();
+
+    // v2 position deletes should now be rewritten to DVs
+    Result result =
+        SparkActions.get(spark)
+            .rewritePositionDeletes(table)
+            .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
+            .execute();
+    assertThat(result.rewrittenDeleteFilesCount()).isEqualTo(2);
+    assertThat(result.addedDeleteFilesCount()).isEqualTo(2);
+    assertThat(deleteFiles(table)).hasSize(2).allMatch(file -> file.format() == FileFormat.PUFFIN);
+    assertThat(dvRecords(table)).hasSize(2);
+
+    // rewriting DVs via rewritePositionDeletes shouldn't be possible anymore
+    assertThat(SparkActions.get(spark).rewritePositionDeletes(table).execute().rewriteResults())
+        .isEmpty();
+  }
+
+  private List<Row> dvRecords(Table table) {
+    return spark
+        .read()
+        .format("iceberg")
+        .load(name(table) + ".position_deletes")
+        .select("file_path", "delete_file_path")
+        .where(col("delete_file_path").endsWith(".puffin"))
+        .distinct()
+        .collectAsList();
   }
 
   private Table createTablePartitioned(int partitions, int files, int numRecords) {
@@ -743,7 +772,9 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
         TableProperties.FORMAT_VERSION,
         String.valueOf(formatVersion),
         TableProperties.DEFAULT_FILE_FORMAT,
-        format.toString());
+        format.toString(),
+        TableProperties.DELETE_GRANULARITY,
+        DeleteGranularity.PARTITION.toString());
   }
 
   private void writeRecords(Table table, int files, int numRecords) {
@@ -764,6 +795,7 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     assertThat(partitionTypeSize)
         .as("This method currently supports only two columns as partition columns")
         .isLessThanOrEqualTo(2);
+
     BiFunction<Integer, List<Integer>, ThreeColumnRecord> recordFunction =
         (i, partValues) -> {
           switch (partitionTypeSize) {
@@ -877,8 +909,8 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
               "Number of delete files per partition should be "
                   + "evenly divisible by requested deletes per data file times number of data files in this partition")
           .isZero();
-      int deleteFileSize = deletesForPartition / deleteFilesPerPartition;
 
+      int deleteFileSize = deletesForPartition / deleteFilesPerPartition;
       int counter = 0;
       List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
       for (DataFile partitionFile : partitionFiles) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -55,8 +55,10 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.actions.RewritePositionDeleteFiles.FileGroupRewriteResult;
 import org.apache.iceberg.actions.RewritePositionDeleteFiles.Result;
+import org.apache.iceberg.actions.SizeBasedDataRewriter;
 import org.apache.iceberg.actions.SizeBasedFileRewriter;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.FileHelpers;
@@ -381,6 +383,95 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     List<Object[]> actualDeletes = deleteRecords(table);
     assertEquals("Rows", expectedRecords, actualRecords);
     assertThat(actualDeletes).as("New position deletes").isEmpty();
+  }
+
+  @TestTemplate
+  public void testRemoveDanglingDVsAfterCompaction() {
+    sql(
+        "create table %s (s string, id string) PARTITIONED BY (bucket(8, id)) "
+            + "tblproperties ('format-version'='3',"
+            + "'write.update.mode'='merge-on-read',"
+            + "'write.delete.mode'='merge-on-read',"
+            + "'write.merge.mode'='merge-on-read')",
+        tableName);
+    sql("insert into %s select * from (values ('foo', '1'), ('bar', '1')) order by 1", tableName);
+    sql("insert into %s select * from (values ('foo', '1'), ('bat', '1')) order by 1", tableName);
+    sql("insert into %s select * from (values ('bar', '1'), ('bat', '1')) order by 1", tableName);
+
+    List<Object[]> objects = sql("select * from %s.files", tableName);
+    assertThat(objects).hasSize(3);
+
+    sql("delete from %s where s = 'foo'", tableName);
+    assertThat(sql("select * from %s.files", tableName)).hasSize(5);
+
+    sql("delete from %s where s = 'bar'", tableName);
+    assertThat(sql("select * from %s.files", tableName)).hasSize(6);
+
+    assertThat(sql("select * from %s.data_files", tableName)).hasSize(3);
+    assertThat(sql("select * from %s.delete_files", tableName)).hasSize(3);
+
+    Set<DeleteFile> deleteFilesBefore =
+        TestHelpers.deleteFiles(validationCatalog.loadTable(tableIdent));
+    assertThat(deleteFilesBefore).hasSize(3);
+
+    RewriteDataFiles.Result result =
+        SparkActions.get(spark)
+            .rewriteDataFiles(validationCatalog.loadTable(tableIdent))
+            .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
+            .option(RewriteDataFiles.REMOVE_DANGLING_DELETES, "true")
+            .execute();
+
+    Set<DeleteFile> deleteFilesAfter =
+        TestHelpers.deleteFiles(validationCatalog.loadTable(tableIdent));
+    assertThat(deleteFilesAfter).isEmpty();
+    assertThat(result.addedDataFilesCount()).isEqualTo(1);
+    assertThat(result.rewrittenDataFilesCount()).isEqualTo(3);
+    assertThat(sql("select * from %s.delete_files", tableName)).hasSameSizeAs(deleteFilesAfter);
+    assertThat(result.removedDeleteFilesCount()).isEqualTo(deleteFilesBefore.size());
+  }
+
+  @TestTemplate
+  public void testValidDVsAreNotRemovedDuringDanglingDeletesRemoval() {
+    sql(
+        "create table %s (s string, id string) PARTITIONED BY (bucket(8, id)) "
+            + "tblproperties ('format-version'='3',"
+            + "'write.update.mode'='merge-on-read',"
+            + "'write.delete.mode'='merge-on-read',"
+            + "'write.merge.mode'='merge-on-read')",
+        tableName);
+    sql("insert into %s select * from (values ('foo', '1'), ('bar', '1')) order by 1", tableName);
+    sql("insert into %s select * from (values ('foo', '1'), ('bat', '1')) order by 1", tableName);
+    sql("insert into %s select * from (values ('bar', '1'), ('bat', '1')) order by 1", tableName);
+
+    List<Object[]> objects = sql("select * from %s.files", tableName);
+    assertThat(objects).hasSize(3);
+
+    sql("delete from %s where s = 'foo'", tableName);
+    assertThat(sql("select * from %s.files", tableName)).hasSize(5);
+
+    assertThat(sql("select * from %s.data_files", tableName)).hasSize(3);
+    assertThat(sql("select * from %s.delete_files", tableName)).hasSize(2);
+
+    Set<DeleteFile> deleteFilesBefore =
+        TestHelpers.deleteFiles(validationCatalog.loadTable(tableIdent));
+    assertThat(deleteFilesBefore).hasSize(2);
+
+    // data files are not compacted and removing dangling deletes should not remove valid DVs
+    RewriteDataFiles.Result result =
+        SparkActions.get(spark)
+            .rewriteDataFiles(validationCatalog.loadTable(tableIdent))
+            .option(RewriteDataFiles.REMOVE_DANGLING_DELETES, "true")
+            .option(SizeBasedFileRewriter.MIN_FILE_SIZE_BYTES, "0")
+            .option(SizeBasedDataRewriter.DELETE_RATIO_THRESHOLD, "1.0")
+            .execute();
+
+    Set<DeleteFile> deleteFilesAfter =
+        TestHelpers.deleteFiles(validationCatalog.loadTable(tableIdent));
+    assertThat(deleteFilesAfter).isEqualTo(deleteFilesBefore);
+    assertThat(result.addedDataFilesCount()).isEqualTo(0);
+    assertThat(result.rewrittenDataFilesCount()).isEqualTo(0);
+    assertThat(sql("select * from %s.delete_files", tableName)).hasSameSizeAs(deleteFilesAfter);
+    assertThat(result.removedDeleteFilesCount()).isEqualTo(0);
   }
 
   @TestTemplate

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -56,7 +56,6 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Type;
@@ -852,7 +851,7 @@ public class TestHelpers {
   }
 
   public static Set<DeleteFile> deleteFiles(Table table) {
-    Set<DeleteFile> deleteFiles = Sets.newHashSet();
+    DeleteFileSet deleteFiles = DeleteFileSet.create();
 
     for (FileScanTask task : table.newScan().planFiles()) {
       deleteFiles.addAll(task.deletes());

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesReader.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesReader.java
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.iceberg.BaseScanTaskGroup;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PositionDeletesScanTask;
+import org.apache.iceberg.PositionDeletesTable;
+import org.apache.iceberg.ScanTask;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.TestBase;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.CharSequenceSet;
+import org.apache.iceberg.util.Pair;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestPositionDeletesReader extends TestBase {
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "id", Types.IntegerType.get()), optional(2, "data", Types.StringType.get()));
+  private static final PartitionSpec SPEC =
+      PartitionSpec.builderFor(SCHEMA).bucket("data", 16).build();
+
+  private Table table;
+  private DataFile dataFile1;
+  private DataFile dataFile2;
+
+  @TempDir private Path temp;
+
+  @Parameter(index = 0)
+  private int formatVersion;
+
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return ImmutableList.of(2, 3);
+  }
+
+  @BeforeEach
+  public void before() throws IOException {
+    table =
+        catalog.createTable(
+            TableIdentifier.of("default", "test"),
+            SCHEMA,
+            SPEC,
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)));
+
+    GenericRecord record = GenericRecord.create(table.schema());
+    List<Record> records1 = Lists.newArrayList();
+    records1.add(record.copy("id", 29, "data", "a"));
+    records1.add(record.copy("id", 43, "data", "b"));
+    records1.add(record.copy("id", 61, "data", "c"));
+    records1.add(record.copy("id", 89, "data", "d"));
+
+    List<Record> records2 = Lists.newArrayList();
+    records2.add(record.copy("id", 100, "data", "e"));
+    records2.add(record.copy("id", 121, "data", "f"));
+    records2.add(record.copy("id", 122, "data", "g"));
+
+    dataFile1 = writeDataFile(records1);
+    dataFile2 = writeDataFile(records2);
+    table.newAppend().appendFile(dataFile1).appendFile(dataFile2).commit();
+  }
+
+  @AfterEach
+  public void after() {
+    catalog.dropTable(TableIdentifier.of("default", "test"));
+  }
+
+  @TestTemplate
+  public void readPositionDeletesTableWithNoDeleteFiles() {
+    Table positionDeletesTable =
+        catalog.loadTable(TableIdentifier.of("default", "test", "position_deletes"));
+
+    assertThat(positionDeletesTable.newBatchScan().planFiles()).isEmpty();
+  }
+
+  @TestTemplate
+  public void readPositionDeletesTableWithMultipleDeleteFiles() throws IOException {
+    Pair<DeleteFile, CharSequenceSet> posDeletes1 =
+        FileHelpers.writeDeleteFile(
+            table,
+            Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
+            TestHelpers.Row.of(0),
+            Lists.newArrayList(
+                Pair.of(dataFile1.location(), 0L), Pair.of(dataFile1.location(), 1L)),
+            formatVersion);
+
+    Pair<DeleteFile, CharSequenceSet> posDeletes2 =
+        FileHelpers.writeDeleteFile(
+            table,
+            Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
+            TestHelpers.Row.of(0),
+            Lists.newArrayList(
+                Pair.of(dataFile2.location(), 2L), Pair.of(dataFile2.location(), 3L)),
+            formatVersion);
+
+    DeleteFile deleteFile1 = posDeletes1.first();
+    DeleteFile deleteFile2 = posDeletes2.first();
+    table
+        .newRowDelta()
+        .addDeletes(deleteFile1)
+        .addDeletes(deleteFile2)
+        .validateDataFilesExist(posDeletes1.second())
+        .validateDataFilesExist(posDeletes2.second())
+        .commit();
+
+    Table positionDeletesTable =
+        catalog.loadTable(TableIdentifier.of("default", "test", "position_deletes"));
+
+    Schema projectedSchema =
+        positionDeletesTable
+            .schema()
+            .select(
+                MetadataColumns.DELETE_FILE_PATH.name(),
+                MetadataColumns.DELETE_FILE_POS.name(),
+                PositionDeletesTable.DELETE_FILE_PATH);
+
+    List<ScanTask> scanTasks =
+        Lists.newArrayList(
+            positionDeletesTable.newBatchScan().project(projectedSchema).planFiles());
+    assertThat(scanTasks).hasSize(2);
+
+    assertThat(scanTasks.get(0)).isInstanceOf(PositionDeletesScanTask.class);
+    PositionDeletesScanTask scanTask1 = (PositionDeletesScanTask) scanTasks.get(0);
+
+    try (PositionDeletesRowReader reader =
+        new PositionDeletesRowReader(
+            table,
+            new BaseScanTaskGroup<>(null, ImmutableList.of(scanTask1)),
+            positionDeletesTable.schema(),
+            projectedSchema,
+            false)) {
+      List<InternalRow> actualRows = Lists.newArrayList();
+      while (reader.next()) {
+        actualRows.add(reader.get().copy());
+      }
+
+      String dataFileLocation =
+          formatVersion >= 3 ? deleteFile1.referencedDataFile() : dataFile1.location();
+      Object[] first = {
+        UTF8String.fromString(dataFileLocation), 0L, UTF8String.fromString(deleteFile1.location())
+      };
+      Object[] second = {
+        UTF8String.fromString(dataFileLocation), 1L, UTF8String.fromString(deleteFile1.location())
+      };
+      assertThat(internalRowsToJava(actualRows, projectedSchema))
+          .hasSize(2)
+          .containsExactly(first, second);
+    }
+
+    assertThat(scanTasks.get(1)).isInstanceOf(PositionDeletesScanTask.class);
+    PositionDeletesScanTask scanTask2 = (PositionDeletesScanTask) scanTasks.get(1);
+    try (PositionDeletesRowReader reader =
+        new PositionDeletesRowReader(
+            table,
+            new BaseScanTaskGroup<>(null, ImmutableList.of(scanTask2)),
+            positionDeletesTable.schema(),
+            projectedSchema,
+            false)) {
+      List<InternalRow> actualRows = Lists.newArrayList();
+      while (reader.next()) {
+        actualRows.add(reader.get().copy());
+      }
+
+      String dataFileLocation =
+          formatVersion >= 3 ? deleteFile2.referencedDataFile() : dataFile2.location();
+      Object[] first = {
+        UTF8String.fromString(dataFileLocation), 2L, UTF8String.fromString(deleteFile2.location())
+      };
+      Object[] second = {
+        UTF8String.fromString(dataFileLocation), 3L, UTF8String.fromString(deleteFile2.location())
+      };
+      assertThat(internalRowsToJava(actualRows, projectedSchema))
+          .hasSize(2)
+          .containsExactly(first, second);
+    }
+  }
+
+  @TestTemplate
+  public void readPositionDeletesTableWithDifferentColumnOrdering() throws IOException {
+    Pair<DeleteFile, CharSequenceSet> posDeletes1 =
+        FileHelpers.writeDeleteFile(
+            table,
+            Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
+            TestHelpers.Row.of(0),
+            Lists.newArrayList(
+                Pair.of(dataFile1.location(), 0L), Pair.of(dataFile1.location(), 1L)),
+            formatVersion);
+
+    DeleteFile deleteFile1 = posDeletes1.first();
+    table
+        .newRowDelta()
+        .addDeletes(deleteFile1)
+        .validateDataFilesExist(posDeletes1.second())
+        .commit();
+
+    Table positionDeletesTable =
+        catalog.loadTable(TableIdentifier.of("default", "test", "position_deletes"));
+
+    // select a few fields in backwards order
+    Schema projectedSchema =
+        new Schema(MetadataColumns.DELETE_FILE_POS, MetadataColumns.DELETE_FILE_PATH);
+
+    List<ScanTask> scanTasks =
+        Lists.newArrayList(
+            positionDeletesTable.newBatchScan().project(projectedSchema).planFiles());
+    assertThat(scanTasks).hasSize(1);
+
+    assertThat(scanTasks.get(0)).isInstanceOf(PositionDeletesScanTask.class);
+    PositionDeletesScanTask scanTask1 = (PositionDeletesScanTask) scanTasks.get(0);
+
+    try (PositionDeletesRowReader reader =
+        new PositionDeletesRowReader(
+            table,
+            new BaseScanTaskGroup<>(null, ImmutableList.of(scanTask1)),
+            positionDeletesTable.schema(),
+            projectedSchema,
+            false)) {
+      List<InternalRow> actualRows = Lists.newArrayList();
+      while (reader.next()) {
+        actualRows.add(reader.get().copy());
+      }
+
+      assertThat(internalRowsToJava(actualRows, projectedSchema))
+          .hasSize(2)
+          .containsExactly(
+              new Object[] {0L, UTF8String.fromString(dataFile1.location())},
+              new Object[] {1L, UTF8String.fromString(dataFile1.location())});
+    }
+  }
+
+  private DataFile writeDataFile(List<Record> records) throws IOException {
+    return FileHelpers.writeDataFile(
+        table,
+        Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
+        TestHelpers.Row.of(0),
+        records);
+  }
+
+  private List<Object[]> internalRowsToJava(List<InternalRow> rows, Schema projection) {
+    return rows.stream().map(row -> toJava(row, projection)).collect(Collectors.toList());
+  }
+
+  private Object[] toJava(InternalRow row, Schema projection) {
+    Object[] values = new Object[row.numFields()];
+    for (int i = 0; i < projection.columns().size(); i++) {
+      values[i] = row.get(i, SparkSchemaUtil.convert(projection.columns().get(i).type()));
+    }
+    return values;
+  }
+}

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesReader.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesReader.java
@@ -157,13 +157,17 @@ public class TestPositionDeletesReader extends TestBase {
     Table positionDeletesTable =
         catalog.loadTable(TableIdentifier.of("default", "test", "position_deletes"));
 
-    Schema projectedSchema =
-        positionDeletesTable
-            .schema()
-            .select(
-                MetadataColumns.DELETE_FILE_PATH.name(),
-                MetadataColumns.DELETE_FILE_POS.name(),
-                PositionDeletesTable.DELETE_FILE_PATH);
+    List<String> columns =
+        Lists.newArrayList(
+            MetadataColumns.DELETE_FILE_PATH.name(),
+            MetadataColumns.DELETE_FILE_POS.name(),
+            PositionDeletesTable.DELETE_FILE_PATH);
+    if (formatVersion >= 3) {
+      columns.add(PositionDeletesTable.CONTENT_OFFSET);
+      columns.add(PositionDeletesTable.CONTENT_SIZE_IN_BYTES);
+    }
+
+    Schema projectedSchema = positionDeletesTable.schema().select(columns);
 
     List<ScanTask> scanTasks =
         Lists.newArrayList(
@@ -187,15 +191,27 @@ public class TestPositionDeletesReader extends TestBase {
 
       String dataFileLocation =
           formatVersion >= 3 ? deleteFile1.referencedDataFile() : dataFile1.location();
-      Object[] first = {
-        UTF8String.fromString(dataFileLocation), 0L, UTF8String.fromString(deleteFile1.location())
-      };
-      Object[] second = {
-        UTF8String.fromString(dataFileLocation), 1L, UTF8String.fromString(deleteFile1.location())
-      };
+      List<Object> first =
+          Lists.newArrayList(
+              UTF8String.fromString(dataFileLocation),
+              0L,
+              UTF8String.fromString(deleteFile1.location()));
+      List<Object> second =
+          Lists.newArrayList(
+              UTF8String.fromString(dataFileLocation),
+              1L,
+              UTF8String.fromString(deleteFile1.location()));
+
+      if (formatVersion >= 3) {
+        first.add(deleteFile1.contentOffset());
+        first.add(deleteFile1.contentSizeInBytes());
+        second.add(deleteFile1.contentOffset());
+        second.add(deleteFile1.contentSizeInBytes());
+      }
+
       assertThat(internalRowsToJava(actualRows, projectedSchema))
           .hasSize(2)
-          .containsExactly(first, second);
+          .containsExactly(first.toArray(), second.toArray());
     }
 
     assertThat(scanTasks.get(1)).isInstanceOf(PositionDeletesScanTask.class);
@@ -214,15 +230,27 @@ public class TestPositionDeletesReader extends TestBase {
 
       String dataFileLocation =
           formatVersion >= 3 ? deleteFile2.referencedDataFile() : dataFile2.location();
-      Object[] first = {
-        UTF8String.fromString(dataFileLocation), 2L, UTF8String.fromString(deleteFile2.location())
-      };
-      Object[] second = {
-        UTF8String.fromString(dataFileLocation), 3L, UTF8String.fromString(deleteFile2.location())
-      };
+      List<Object> first =
+          Lists.newArrayList(
+              UTF8String.fromString(dataFileLocation),
+              2L,
+              UTF8String.fromString(deleteFile2.location()));
+      List<Object> second =
+          Lists.newArrayList(
+              UTF8String.fromString(dataFileLocation),
+              3L,
+              UTF8String.fromString(deleteFile2.location()));
+
+      if (formatVersion >= 3) {
+        first.add(deleteFile2.contentOffset());
+        first.add(deleteFile2.contentSizeInBytes());
+        second.add(deleteFile2.contentOffset());
+        second.add(deleteFile2.contentSizeInBytes());
+      }
+
       assertThat(internalRowsToJava(actualRows, projectedSchema))
           .hasSize(2)
-          .containsExactly(first, second);
+          .containsExactly(first.toArray(), second.toArray());
     }
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesTable.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesTable.java
@@ -18,6 +18,11 @@
  */
 package org.apache.iceberg.spark.source;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.io.File;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
@@ -34,6 +39,9 @@ import org.apache.iceberg.Files;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Partitioning;
@@ -55,34 +63,31 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.PositionDeletesRewriteCoordinator;
 import org.apache.iceberg.spark.ScanTaskSetManager;
 import org.apache.iceberg.spark.SparkCatalogConfig;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkStructLike;
 import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
+import org.apache.iceberg.util.DeleteFileSet;
 import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.ScanTaskUtil;
 import org.apache.iceberg.util.StructLikeSet;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.functions;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestPositionDeletesTable extends SparkCatalogTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestPositionDeletesTable extends CatalogTestBase {
 
   public static final Schema SCHEMA =
       new Schema(
@@ -95,44 +100,56 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
           "cache-enabled", "false");
   private static final List<String> NON_PATH_COLS =
       ImmutableList.of("file_path", "pos", "row", "partition", "spec_id");
+  private static final List<String> NON_PATH_V3_COLS =
+      ImmutableList.<String>builder()
+          .addAll(NON_PATH_COLS)
+          .add("content_offset")
+          .add("content_size_in_bytes")
+          .build();
 
-  private final FileFormat format;
+  @Parameter(index = 3)
+  private FileFormat format;
 
-  @Parameterized.Parameters(
+  @Parameter(index = 4)
+  private int formatVersion;
+
+  @Parameters(
       name =
-          "formatVersion = {0}, catalogName = {1}, implementation = {2}, config = {3}, fileFormat = {4}")
+          "catalogName = {1}, implementation = {2}, config = {3}, fileFormat = {4}, formatVersion = {5}")
   public static Object[][] parameters() {
     return new Object[][] {
       {
         SparkCatalogConfig.HIVE.catalogName(),
         SparkCatalogConfig.HIVE.implementation(),
         CATALOG_PROPS,
-        FileFormat.PARQUET
+        FileFormat.PARQUET,
+        2
       },
       {
         SparkCatalogConfig.HIVE.catalogName(),
         SparkCatalogConfig.HIVE.implementation(),
         CATALOG_PROPS,
-        FileFormat.AVRO
+        FileFormat.AVRO,
+        2
       },
       {
         SparkCatalogConfig.HIVE.catalogName(),
         SparkCatalogConfig.HIVE.implementation(),
         CATALOG_PROPS,
-        FileFormat.ORC
+        FileFormat.ORC,
+        2
+      },
+      {
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        CATALOG_PROPS,
+        FileFormat.PARQUET,
+        3
       },
     };
   }
 
-  public TestPositionDeletesTable(
-      String catalogName, String implementation, Map<String, String> config, FileFormat format) {
-    super(catalogName, implementation, config);
-    this.format = format;
-  }
-
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
-
-  @Test
+  @TestTemplate
   public void testNullRows() throws IOException {
     String tableName = "null_rows";
     Table tab = createTable(tableName, SCHEMA, PartitionSpec.unpartitioned());
@@ -145,7 +162,11 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     deletes.add(Pair.of(dFile.location(), 1L));
     Pair<DeleteFile, CharSequenceSet> posDeletes =
         FileHelpers.writeDeleteFile(
-            tab, Files.localOutput(temp.newFile()), TestHelpers.Row.of(0), deletes);
+            tab,
+            Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
+            TestHelpers.Row.of(0),
+            deletes,
+            formatVersion);
     tab.newRowDelta().addDeletes(posDeletes.first()).commit();
 
     StructLikeSet actual = actual(tableName, tab);
@@ -153,14 +174,15 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     List<PositionDelete<?>> expectedDeletes =
         Lists.newArrayList(
             positionDelete(dFile.location(), 0L), positionDelete(dFile.location(), 1L));
-    StructLikeSet expected = expected(tab, expectedDeletes, null, posDeletes.first().location());
+    StructLikeSet expected = expected(tab, expectedDeletes, null, posDeletes.first());
 
-    Assert.assertEquals("Position Delete table should contain expected rows", expected, actual);
+    assertThat(actual).as("Position Delete table should contain expected rows").isEqualTo(expected);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedTable() throws IOException {
+    assumeThat(formatVersion).as("DVs don't have row info in PositionDeletesTable").isEqualTo(2);
     // Create table with two partitions
     String tableName = "partitioned_table";
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
@@ -181,15 +203,15 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     StructLikeSet actual = actual(tableName, tab, "row.data='b'");
     GenericRecord partitionB = GenericRecord.create(tab.spec().partitionType());
     partitionB.setField("data", "b");
-    StructLikeSet expected =
-        expected(tab, deletesB.first(), partitionB, deletesB.second().location());
+    StructLikeSet expected = expected(tab, deletesB.first(), partitionB, deletesB.second());
 
-    Assert.assertEquals("Position Delete table should contain expected rows", expected, actual);
+    assertThat(actual).as("Position Delete table should contain expected rows").isEqualTo(expected);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testSelect() throws IOException {
+    assumeThat(formatVersion).as("DVs don't have row info in PositionDeletesTable").isEqualTo(2);
     // Create table with two partitions
     String tableName = "select";
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
@@ -245,11 +267,81 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
         };
     actual.sort(comp);
     expected.sort(comp);
-    assertEquals("Position Delete table should contain expected rows", expected, actual);
+    assertThat(actual)
+        .as("Position Delete table should contain expected rows")
+        .usingRecursiveComparison()
+        .isEqualTo(expected);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
+  public void testSelectWithDVs() throws IOException {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+    String tableName = "select_with_dvs";
+    Table tab = createTable(tableName, SCHEMA, PartitionSpec.unpartitioned());
+
+    DataFile dataFileA = dataFile(tab);
+    DataFile dataFileB = dataFile(tab);
+
+    tab.newAppend().appendFile(dataFileA).appendFile(dataFileB).commit();
+
+    Pair<List<PositionDelete<?>>, DeleteFile> deletesA = deleteFile(tab, dataFileA);
+    Pair<List<PositionDelete<?>>, DeleteFile> deletesB = deleteFile(tab, dataFileB);
+
+    tab.newRowDelta().addDeletes(deletesA.second()).addDeletes(deletesB.second()).commit();
+
+    // Select certain columns
+    Dataset<Row> df =
+        spark
+            .read()
+            .format("iceberg")
+            .load("default." + tableName + ".position_deletes")
+            .select(
+                "pos", "file_path", "delete_file_path", "content_offset", "content_size_in_bytes");
+    List<Object[]> actual = rowsToJava(df.collectAsList());
+
+    // Select cols from expected delete values
+    List<Object[]> expected = Lists.newArrayList();
+    BiFunction<PositionDelete<?>, DeleteFile, Object[]> toRow =
+        (delete, file) ->
+            row(
+                delete.get(1, Long.class),
+                file.referencedDataFile(),
+                file.location(),
+                file.contentOffset(),
+                ScanTaskUtil.contentSizeInBytes(file));
+
+    expected.addAll(
+        deletesA.first().stream()
+            .map(d -> toRow.apply(d, deletesA.second()))
+            .collect(Collectors.toList()));
+    expected.addAll(
+        deletesB.first().stream()
+            .map(d -> toRow.apply(d, deletesB.second()))
+            .collect(Collectors.toList()));
+
+    // Sort by pos and file_path
+    Comparator<Object[]> comp =
+        (o1, o2) -> {
+          int result = Long.compare((long) o1[0], (long) o2[0]);
+          if (result != 0) {
+            return result;
+          } else {
+            return ((String) o1[1]).compareTo((String) o2[1]);
+          }
+        };
+
+    actual.sort(comp);
+    expected.sort(comp);
+
+    assertThat(actual)
+        .as("Position Delete table should contain expected rows")
+        .usingRecursiveComparison()
+        .isEqualTo(expected);
+    dropTable(tableName);
+  }
+
+  @TestTemplate
   public void testSplitTasks() throws IOException {
     String tableName = "big_table";
     Table tab = createTable(tableName, SCHEMA, PartitionSpec.unpartitioned());
@@ -264,7 +356,7 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     DataFile dFile =
         FileHelpers.writeDataFile(
             tab,
-            Files.localOutput(temp.newFile()),
+            Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
             org.apache.iceberg.TestHelpers.Row.of(),
             dataRecords);
     tab.newAppend().appendFile(dFile).commit();
@@ -275,31 +367,34 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     }
     DeleteFile posDeletes =
         FileHelpers.writePosDeleteFile(
-            tab, Files.localOutput(temp.newFile()), TestHelpers.Row.of(0), deletes);
+            tab,
+            Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
+            TestHelpers.Row.of(0),
+            deletes,
+            formatVersion);
     tab.newRowDelta().addDeletes(posDeletes).commit();
 
     Table deleteTable =
         MetadataTableUtils.createMetadataTableInstance(tab, MetadataTableType.POSITION_DELETES);
 
     if (format.equals(FileFormat.AVRO)) {
-      Assert.assertTrue(
-          "Position delete scan should produce more than one split",
-          Iterables.size(deleteTable.newBatchScan().planTasks()) > 1);
+      assertThat(deleteTable.newBatchScan().planTasks())
+          .as("Position delete scan should produce more than one split")
+          .hasSizeGreaterThan(1);
     } else {
-      Assert.assertEquals(
-          "Position delete scan should produce one split",
-          1,
-          Iterables.size(deleteTable.newBatchScan().planTasks()));
+      assertThat(deleteTable.newBatchScan().planTasks())
+          .as("Position delete scan should produce one split")
+          .hasSize(1);
     }
 
     StructLikeSet actual = actual(tableName, tab);
-    StructLikeSet expected = expected(tab, deletes, null, posDeletes.location());
+    StructLikeSet expected = expected(tab, deletes, null, posDeletes);
 
-    Assert.assertEquals("Position Delete table should contain expected rows", expected, actual);
+    assertThat(actual).as("Position Delete table should contain expected rows").isEqualTo(expected);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionFilter() throws IOException {
     // Create table with two partitions
     String tableName = "partition_filter";
@@ -322,26 +417,28 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     GenericRecord partitionRecordTemplate = GenericRecord.create(tab.spec().partitionType());
     Record partitionA = partitionRecordTemplate.copy("data", "a");
     Record partitionB = partitionRecordTemplate.copy("data", "b");
-    StructLikeSet expectedA =
-        expected(tab, deletesA.first(), partitionA, deletesA.second().location());
-    StructLikeSet expectedB =
-        expected(tab, deletesB.first(), partitionB, deletesB.second().location());
+    StructLikeSet expectedA = expected(tab, deletesA.first(), partitionA, deletesA.second());
+    StructLikeSet expectedB = expected(tab, deletesB.first(), partitionB, deletesB.second());
     StructLikeSet allExpected = StructLikeSet.create(deletesTab.schema().asStruct());
     allExpected.addAll(expectedA);
     allExpected.addAll(expectedB);
 
     // Select deletes from all partitions
     StructLikeSet actual = actual(tableName, tab);
-    Assert.assertEquals("Position Delete table should contain expected rows", allExpected, actual);
+    assertThat(actual)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(allExpected);
 
     // Select deletes from one partition
     StructLikeSet actual2 = actual(tableName, tab, "partition.data = 'a' AND pos >= 0");
 
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedA, actual2);
+    assertThat(actual2)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedA);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionTransformFilter() throws IOException {
     // Create table with two partitions
     String tableName = "partition_filter";
@@ -365,26 +462,28 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     GenericRecord partitionRecordTemplate = GenericRecord.create(tab.spec().partitionType());
     Record partitionA = partitionRecordTemplate.copy("data_trunc", "a");
     Record partitionB = partitionRecordTemplate.copy("data_trunc", "b");
-    StructLikeSet expectedA =
-        expected(tab, deletesA.first(), partitionA, deletesA.second().location());
-    StructLikeSet expectedB =
-        expected(tab, deletesB.first(), partitionB, deletesB.second().location());
+    StructLikeSet expectedA = expected(tab, deletesA.first(), partitionA, deletesA.second());
+    StructLikeSet expectedB = expected(tab, deletesB.first(), partitionB, deletesB.second());
     StructLikeSet allExpected = StructLikeSet.create(deletesTable.schema().asStruct());
     allExpected.addAll(expectedA);
     allExpected.addAll(expectedB);
 
     // Select deletes from all partitions
     StructLikeSet actual = actual(tableName, tab);
-    Assert.assertEquals("Position Delete table should contain expected rows", allExpected, actual);
+    assertThat(actual)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(allExpected);
 
     // Select deletes from one partition
     StructLikeSet actual2 = actual(tableName, tab, "partition.data_trunc = 'a' AND pos >= 0");
 
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedA, actual2);
+    assertThat(actual2)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedA);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionEvolutionReplace() throws Exception {
     // Create table with spec (data)
     String tableName = "partition_evolution";
@@ -416,26 +515,25 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     GenericRecord partitionRecordTemplate = GenericRecord.create(Partitioning.partitionType(tab));
     Record partitionA = partitionRecordTemplate.copy("data", "a");
     StructLikeSet expectedA =
-        expected(tab, deletesA.first(), partitionA, dataSpec, deletesA.second().location());
+        expected(tab, deletesA.first(), partitionA, dataSpec, deletesA.second());
     StructLikeSet actualA = actual(tableName, tab, "partition.data = 'a' AND pos >= 0");
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedA, actualA);
+    assertThat(actualA)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedA);
 
     // Query partition of new spec
     Record partition10 = partitionRecordTemplate.copy("id", 10);
     StructLikeSet expected10 =
-        expected(
-            tab,
-            deletes10.first(),
-            partition10,
-            tab.spec().specId(),
-            deletes10.second().location());
+        expected(tab, deletes10.first(), partition10, tab.spec().specId(), deletes10.second());
     StructLikeSet actual10 = actual(tableName, tab, "partition.id = 10 AND pos >= 0");
 
-    Assert.assertEquals("Position Delete table should contain expected rows", expected10, actual10);
+    assertThat(actual10)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expected10);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionEvolutionAdd() throws Exception {
     // Create unpartitioned table
     String tableName = "partition_evolution_add";
@@ -466,9 +564,11 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     GenericRecord partitionRecordTemplate = GenericRecord.create(Partitioning.partitionType(tab));
     Record partitionA = partitionRecordTemplate.copy("data", "a");
     StructLikeSet expectedA =
-        expected(tab, deletesA.first(), partitionA, specId1, deletesA.second().location());
+        expected(tab, deletesA.first(), partitionA, specId1, deletesA.second());
     StructLikeSet actualA = actual(tableName, tab, "partition.data = 'a' AND pos >= 0");
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedA, actualA);
+    assertThat(actualA)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedA);
 
     // Select deletes from 'unpartitioned' data
     Record unpartitionedRecord = partitionRecordTemplate.copy("data", null);
@@ -478,18 +578,17 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
             deletesUnpartitioned.first(),
             unpartitionedRecord,
             specId0,
-            deletesUnpartitioned.second().location());
+            deletesUnpartitioned.second());
     StructLikeSet actualUnpartitioned =
         actual(tableName, tab, "partition.data IS NULL and pos >= 0");
 
-    Assert.assertEquals(
-        "Position Delete table should contain expected rows",
-        expectedUnpartitioned,
-        actualUnpartitioned);
+    assertThat(actualUnpartitioned)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedUnpartitioned);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionEvolutionRemove() throws Exception {
     // Create table with spec (data)
     String tableName = "partition_evolution_remove";
@@ -521,9 +620,11 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     GenericRecord partitionRecordTemplate = GenericRecord.create(Partitioning.partitionType(tab));
     Record partitionA = partitionRecordTemplate.copy("data", "a");
     StructLikeSet expectedA =
-        expected(tab, deletesA.first(), partitionA, specId0, deletesA.second().location());
+        expected(tab, deletesA.first(), partitionA, specId0, deletesA.second());
     StructLikeSet actualA = actual(tableName, tab, "partition.data = 'a' AND pos >= 0");
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedA, actualA);
+    assertThat(actualA)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedA);
 
     // Select deletes from 'unpartitioned' spec
     Record unpartitionedRecord = partitionRecordTemplate.copy("data", null);
@@ -533,18 +634,17 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
             deletesUnpartitioned.first(),
             unpartitionedRecord,
             specId1,
-            deletesUnpartitioned.second().location());
+            deletesUnpartitioned.second());
     StructLikeSet actualUnpartitioned =
         actual(tableName, tab, "partition.data IS NULL and pos >= 0");
 
-    Assert.assertEquals(
-        "Position Delete table should contain expected rows",
-        expectedUnpartitioned,
-        actualUnpartitioned);
+    assertThat(actualUnpartitioned)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedUnpartitioned);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testSpecIdFilter() throws Exception {
     // Create table with spec (data)
     String tableName = "spec_id_filter";
@@ -578,28 +678,26 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
             deletesUnpartitioned.first(),
             partitionRecordTemplate,
             unpartitionedSpec,
-            deletesUnpartitioned.second().location());
+            deletesUnpartitioned.second());
     StructLikeSet actualUnpartitioned =
         actual(tableName, tab, String.format("spec_id = %d", unpartitionedSpec));
-    Assert.assertEquals(
-        "Position Delete table should contain expected rows",
-        expectedUnpartitioned,
-        actualUnpartitioned);
+    assertThat(actualUnpartitioned)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedUnpartitioned);
 
     // Select deletes from 'data' partition spec
     StructLike partitionA = partitionRecordTemplate.copy("data", "a");
     StructLike partitionB = partitionRecordTemplate.copy("data", "b");
     StructLikeSet expected =
-        expected(tab, deletesA.first(), partitionA, dataSpec, deletesA.second().location());
-    expected.addAll(
-        expected(tab, deletesB.first(), partitionB, dataSpec, deletesB.second().location()));
+        expected(tab, deletesA.first(), partitionA, dataSpec, deletesA.second());
+    expected.addAll(expected(tab, deletesB.first(), partitionB, dataSpec, deletesB.second()));
 
     StructLikeSet actual = actual(tableName, tab, String.format("spec_id = %d", dataSpec));
-    Assert.assertEquals("Position Delete table should contain expected rows", expected, actual);
+    assertThat(actual).as("Position Delete table should contain expected rows").isEqualTo(expected);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testSchemaEvolutionAdd() throws Exception {
     // Create table with original schema
     String tableName = "schema_evolution_add";
@@ -645,22 +743,24 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
           padded.set(3, null);
           d.set(2, padded);
         });
-    StructLikeSet expectedA =
-        expected(tab, expectedDeletesA, partitionA, deletesA.second().location());
+    StructLikeSet expectedA = expected(tab, expectedDeletesA, partitionA, deletesA.second());
     StructLikeSet actualA = actual(tableName, tab, "partition.data = 'a' AND pos >= 0");
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedA, actualA);
+    assertThat(actualA)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedA);
 
     // Select deletes from new schema
     Record partitionC = partitionRecordTemplate.copy("data", "c");
-    StructLikeSet expectedC =
-        expected(tab, deletesC.first(), partitionC, deletesC.second().location());
+    StructLikeSet expectedC = expected(tab, deletesC.first(), partitionC, deletesC.second());
     StructLikeSet actualC = actual(tableName, tab, "partition.data = 'c' and pos >= 0");
 
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedC, actualC);
+    assertThat(actualC)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedC);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testSchemaEvolutionRemove() throws Exception {
     // Create table with original schema
     String tableName = "schema_evolution_remove";
@@ -707,22 +807,24 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
           padded.set(1, nested.get(1));
           d.set(2, padded);
         });
-    StructLikeSet expectedA =
-        expected(tab, expectedDeletesA, partitionA, deletesA.second().location());
+    StructLikeSet expectedA = expected(tab, expectedDeletesA, partitionA, deletesA.second());
     StructLikeSet actualA = actual(tableName, tab, "partition.data = 'a' AND pos >= 0");
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedA, actualA);
+    assertThat(actualA)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedA);
 
     // Select deletes from new schema
     Record partitionC = partitionRecordTemplate.copy("data", "c");
-    StructLikeSet expectedC =
-        expected(tab, deletesC.first(), partitionC, deletesC.second().location());
+    StructLikeSet expectedC = expected(tab, deletesC.first(), partitionC, deletesC.second());
     StructLikeSet actualC = actual(tableName, tab, "partition.data = 'c' and pos >= 0");
 
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedC, actualC);
+    assertThat(actualC)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedC);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testWrite() throws IOException, NoSuchTableException {
     String tableName = "test_write";
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
@@ -754,7 +856,7 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
                 .option(SparkReadOptions.FILE_OPEN_COST, Integer.MAX_VALUE)
                 .load(posDeletesTableName);
 
-        Assert.assertEquals(1, scanDF.javaRDD().getNumPartitions());
+        assertThat(scanDF.javaRDD().getNumPartitions()).isEqualTo(1);
         scanDF
             .writeTo(posDeletesTableName)
             .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, fileSetID)
@@ -768,8 +870,8 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     GenericRecord partitionRecordTemplate = GenericRecord.create(tab.spec().partitionType());
     Record partitionA = partitionRecordTemplate.copy("data", "a");
     Record partitionB = partitionRecordTemplate.copy("data", "b");
-    StructLikeSet expectedA = expected(tab, deletesA.first(), partitionA, null);
-    StructLikeSet expectedB = expected(tab, deletesB.first(), partitionB, null);
+    StructLikeSet expectedA = expected(tab, deletesA.first(), partitionA, deletesA.second(), false);
+    StructLikeSet expectedB = expected(tab, deletesB.first(), partitionB, deletesB.second(), false);
     StructLikeSet allExpected =
         StructLikeSet.create(
             TypeUtil.selectNot(
@@ -779,12 +881,15 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     allExpected.addAll(expectedB);
 
     // Compare values without 'delete_file_path' as these have been rewritten
-    StructLikeSet actual = actual(tableName, tab, null, NON_PATH_COLS);
-    Assert.assertEquals("Position Delete table should contain expected rows", allExpected, actual);
+    StructLikeSet actual =
+        actual(tableName, tab, null, formatVersion >= 3 ? NON_PATH_V3_COLS : NON_PATH_COLS);
+    assertThat(actual)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(allExpected);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testWriteUnpartitionedNullRows() throws Exception {
     String tableName = "write_null_rows";
     Table tab = createTable(tableName, SCHEMA, PartitionSpec.unpartitioned());
@@ -797,7 +902,11 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     deletes.add(Pair.of(dFile.location(), 1L));
     Pair<DeleteFile, CharSequenceSet> posDeletes =
         FileHelpers.writeDeleteFile(
-            tab, Files.localOutput(temp.newFile()), TestHelpers.Row.of(0), deletes);
+            tab,
+            Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
+            TestHelpers.Row.of(0),
+            deletes,
+            formatVersion);
     tab.newRowDelta().addDeletes(posDeletes.first()).commit();
 
     Table posDeletesTable =
@@ -814,7 +923,7 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
               .option(SparkReadOptions.SCAN_TASK_SET_ID, fileSetID)
               .option(SparkReadOptions.FILE_OPEN_COST, Integer.MAX_VALUE)
               .load(posDeletesTableName);
-      Assert.assertEquals(1, scanDF.javaRDD().getNumPartitions());
+      assertThat(scanDF.javaRDD().getNumPartitions()).isEqualTo(1);
       scanDF
           .writeTo(posDeletesTableName)
           .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, fileSetID)
@@ -823,20 +932,29 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
       commit(tab, posDeletesTable, fileSetID, 1);
     }
 
+    List<String> columns = ImmutableList.of("file_path", "pos", "row", "spec_id");
+    if (formatVersion >= 3) {
+      columns =
+          ImmutableList.<String>builder()
+              .addAll(columns)
+              .add("content_offset")
+              .add("content_size_in_bytes")
+              .build();
+    }
+
     // Compare values without 'delete_file_path' as these have been rewritten
-    StructLikeSet actual =
-        actual(tableName, tab, null, ImmutableList.of("file_path", "pos", "row", "spec_id"));
+    StructLikeSet actual = actual(tableName, tab, null, columns);
 
     List<PositionDelete<?>> expectedDeletes =
         Lists.newArrayList(
             positionDelete(dFile.location(), 0L), positionDelete(dFile.location(), 1L));
-    StructLikeSet expected = expected(tab, expectedDeletes, null, null);
+    StructLikeSet expected = expected(tab, expectedDeletes, null, posDeletes.first(), false);
 
-    Assert.assertEquals("Position Delete table should contain expected rows", expected, actual);
+    assertThat(actual).as("Position Delete table should contain expected rows").isEqualTo(expected);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testWriteMixedRows() throws Exception {
     String tableName = "write_mixed_rows";
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
@@ -852,7 +970,11 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     deletes.add(Pair.of(dataFileA.location(), 1L));
     Pair<DeleteFile, CharSequenceSet> deletesWithoutRow =
         FileHelpers.writeDeleteFile(
-            tab, Files.localOutput(temp.newFile()), TestHelpers.Row.of("a"), deletes);
+            tab,
+            Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
+            TestHelpers.Row.of("a"),
+            deletes,
+            formatVersion);
 
     Pair<List<PositionDelete<?>>, DeleteFile> deletesWithRow = deleteFile(tab, dataFileB, "b");
 
@@ -876,7 +998,7 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
                 .format("iceberg")
                 .option(SparkReadOptions.SCAN_TASK_SET_ID, fileSetID)
                 .load(posDeletesTableName);
-        Assert.assertEquals(1, scanDF.javaRDD().getNumPartitions());
+        assertThat(scanDF.javaRDD().getNumPartitions()).isEqualTo(1);
         scanDF
             .writeTo(posDeletesTableName)
             .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, fileSetID)
@@ -888,11 +1010,7 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
 
     // Compare values without 'delete_file_path' as these have been rewritten
     StructLikeSet actual =
-        actual(
-            tableName,
-            tab,
-            null,
-            ImmutableList.of("file_path", "pos", "row", "partition", "spec_id"));
+        actual(tableName, tab, null, formatVersion >= 3 ? NON_PATH_V3_COLS : NON_PATH_COLS);
 
     // Prepare expected values
     GenericRecord partitionRecordTemplate = GenericRecord.create(tab.spec().partitionType());
@@ -909,14 +1027,18 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
             Lists.newArrayList(
                 positionDelete(dataFileA.location(), 0L), positionDelete(dataFileA.location(), 1L)),
             partitionA,
-            null));
-    allExpected.addAll(expected(tab, deletesWithRow.first(), partitionB, null));
+            deletesWithoutRow.first(),
+            false));
+    allExpected.addAll(
+        expected(tab, deletesWithRow.first(), partitionB, deletesWithRow.second(), false));
 
-    Assert.assertEquals("Position Delete table should contain expected rows", allExpected, actual);
+    assertThat(actual)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(allExpected);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testWritePartitionEvolutionAdd() throws Exception {
     // Create unpartitioned table
     String tableName = "write_partition_evolution_add";
@@ -960,7 +1082,7 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
               .option(SparkReadOptions.SCAN_TASK_SET_ID, fileSetID)
               .option(SparkReadOptions.FILE_OPEN_COST, Integer.MAX_VALUE)
               .load(posDeletesTableName);
-      Assert.assertEquals(1, scanDF.javaRDD().getNumPartitions());
+      assertThat(scanDF.javaRDD().getNumPartitions()).isEqualTo(1);
       scanDF
           .writeTo(posDeletesTableName)
           .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, fileSetID)
@@ -974,13 +1096,22 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     GenericRecord partitionRecordTemplate = GenericRecord.create(Partitioning.partitionType(tab));
     Record unpartitionedRecord = partitionRecordTemplate.copy("data", null);
     StructLikeSet expectedUnpartitioned =
-        expected(tab, deletesUnpartitioned.first(), unpartitionedRecord, specId0, null);
+        expected(
+            tab,
+            deletesUnpartitioned.first(),
+            unpartitionedRecord,
+            specId0,
+            deletesUnpartitioned.second(),
+            false);
     StructLikeSet actualUnpartitioned =
-        actual(tableName, tab, "partition.data IS NULL", NON_PATH_COLS);
-    Assert.assertEquals(
-        "Position Delete table should contain expected rows",
-        expectedUnpartitioned,
-        actualUnpartitioned);
+        actual(
+            tableName,
+            tab,
+            "partition.data IS NULL",
+            formatVersion >= 3 ? NON_PATH_V3_COLS : NON_PATH_COLS);
+    assertThat(actualUnpartitioned)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedUnpartitioned);
 
     // Read/write back new partition spec (data)
     for (String partValue : ImmutableList.of("a", "b")) {
@@ -995,7 +1126,7 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
                 .option(SparkReadOptions.SCAN_TASK_SET_ID, fileSetID)
                 .option(SparkReadOptions.FILE_OPEN_COST, Integer.MAX_VALUE)
                 .load(posDeletesTableName);
-        Assert.assertEquals(1, scanDF.javaRDD().getNumPartitions());
+        assertThat(scanDF.javaRDD().getNumPartitions()).isEqualTo(1);
         scanDF
             .writeTo(posDeletesTableName)
             .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, fileSetID)
@@ -1014,17 +1145,23 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
             TypeUtil.selectNot(
                     posDeletesTable.schema(), ImmutableSet.of(MetadataColumns.FILE_PATH_COLUMN_ID))
                 .asStruct());
-    expectedAll.addAll(expected(tab, deletesA.first(), partitionA, specId1, null));
-    expectedAll.addAll(expected(tab, deletesB.first(), partitionB, specId1, null));
+    expectedAll.addAll(
+        expected(tab, deletesA.first(), partitionA, specId1, deletesA.second(), false));
+    expectedAll.addAll(
+        expected(tab, deletesB.first(), partitionB, specId1, deletesB.second(), false));
     StructLikeSet actualAll =
-        actual(tableName, tab, "partition.data = 'a' OR partition.data = 'b'", NON_PATH_COLS);
-    Assert.assertEquals(
-        "Position Delete table should contain expected rows", expectedAll, actualAll);
-
+        actual(
+            tableName,
+            tab,
+            "partition.data = 'a' OR partition.data = 'b'",
+            formatVersion >= 3 ? NON_PATH_V3_COLS : NON_PATH_COLS);
+    assertThat(actualAll)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedAll);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testWritePartitionEvolutionDisallowed() throws Exception {
     // Create unpartitioned table
     String tableName = "write_partition_evolution_write";
@@ -1053,24 +1190,31 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
               .option(SparkReadOptions.SCAN_TASK_SET_ID, fileSetID)
               .option(SparkReadOptions.FILE_OPEN_COST, Integer.MAX_VALUE)
               .load(posDeletesTableName);
-      Assert.assertEquals(1, scanDF.javaRDD().getNumPartitions());
+      assertThat(scanDF.javaRDD().getNumPartitions()).isEqualTo(1);
 
       // Add partition field to render the original un-partitioned dataset un-commitable
       tab.updateSpec().addField("data").commit();
     }
 
-    Assert.assertThrows(
-        AnalysisException.class,
-        () ->
-            scanDF
-                .writeTo(posDeletesTableName)
-                .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, fileSetID)
-                .append());
+    assertThatThrownBy(
+            () ->
+                scanDF
+                    .writeTo(posDeletesTableName)
+                    .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, fileSetID)
+                    .append())
+        .isInstanceOf(AnalysisException.class)
+        .hasMessage(
+            "[INCOMPATIBLE_DATA_FOR_TABLE.CANNOT_FIND_DATA] Cannot write incompatible data for the table `"
+                + catalogName
+                + "`.`default`.`"
+                + tableName
+                + "`.`position_deletes`"
+                + ": Cannot find data for the output column `partition`.");
 
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testWriteSchemaEvolutionAdd() throws Exception {
     // Create table with original schema
     String tableName = "write_schema_evolution_add";
@@ -1118,7 +1262,7 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
               .option(SparkReadOptions.FILE_OPEN_COST, Integer.MAX_VALUE)
               .load(posDeletesTableName);
 
-      Assert.assertEquals(1, scanDF.javaRDD().getNumPartitions());
+      assertThat(scanDF.javaRDD().getNumPartitions()).isEqualTo(1);
       scanDF
           .writeTo(posDeletesTableName)
           .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, fileSetID)
@@ -1142,9 +1286,16 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
           padded.set(3, null);
           d.set(2, padded);
         });
-    StructLikeSet expectedA = expected(tab, expectedDeletesA, partitionA, null);
-    StructLikeSet actualA = actual(tableName, tab, "partition.data = 'a'", NON_PATH_COLS);
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedA, actualA);
+    StructLikeSet expectedA = expected(tab, expectedDeletesA, partitionA, deletesA.second(), false);
+    StructLikeSet actualA =
+        actual(
+            tableName,
+            tab,
+            "partition.data = 'a'",
+            formatVersion >= 3 ? NON_PATH_V3_COLS : NON_PATH_COLS);
+    assertThat(actualA)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedA);
 
     // rewrite files of new schema
     try (CloseableIterable<ScanTask> tasks = tasks(posDeletesTable, "data", "c")) {
@@ -1159,7 +1310,7 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
               .option(SparkReadOptions.FILE_OPEN_COST, Integer.MAX_VALUE)
               .load(posDeletesTableName);
 
-      Assert.assertEquals(1, scanDF.javaRDD().getNumPartitions());
+      assertThat(scanDF.javaRDD().getNumPartitions()).isEqualTo(1);
       scanDF
           .writeTo(posDeletesTableName)
           .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, fileSetID)
@@ -1170,14 +1321,21 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
 
     // Select deletes from new schema
     Record partitionC = partitionRecordTemplate.copy("data", "c");
-    StructLikeSet expectedC = expected(tab, deletesC.first(), partitionC, null);
-    StructLikeSet actualC = actual(tableName, tab, "partition.data = 'c'", NON_PATH_COLS);
+    StructLikeSet expectedC = expected(tab, deletesC.first(), partitionC, deletesC.second(), false);
+    StructLikeSet actualC =
+        actual(
+            tableName,
+            tab,
+            "partition.data = 'c'",
+            formatVersion >= 3 ? NON_PATH_V3_COLS : NON_PATH_COLS);
 
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedC, actualC);
+    assertThat(actualC)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedC);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testWriteSchemaEvolutionRemove() throws Exception {
     // Create table with original schema
     String tableName = "write_schema_evolution_remove";
@@ -1228,7 +1386,7 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
                 .option(SparkReadOptions.SCAN_TASK_SET_ID, fileSetID)
                 .option(SparkReadOptions.FILE_OPEN_COST, Integer.MAX_VALUE)
                 .load(posDeletesTableName);
-        Assert.assertEquals(1, scanDF.javaRDD().getNumPartitions());
+        assertThat(scanDF.javaRDD().getNumPartitions()).isEqualTo(1);
         scanDF
             .writeTo(posDeletesTableName)
             .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, fileSetID)
@@ -1251,20 +1409,34 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
           padded.set(1, nested.get(1));
           d.set(2, padded);
         });
-    StructLikeSet expectedA = expected(tab, expectedDeletesA, partitionA, null);
-    StructLikeSet actualA = actual(tableName, tab, "partition.data = 'a'", NON_PATH_COLS);
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedA, actualA);
+    StructLikeSet expectedA = expected(tab, expectedDeletesA, partitionA, deletesA.second(), false);
+    StructLikeSet actualA =
+        actual(
+            tableName,
+            tab,
+            "partition.data = 'a'",
+            formatVersion >= 3 ? NON_PATH_V3_COLS : NON_PATH_COLS);
+    assertThat(actualA)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedA);
 
     // Select deletes from new schema
     Record partitionC = partitionRecordTemplate.copy("data", "c");
-    StructLikeSet expectedC = expected(tab, deletesC.first(), partitionC, null);
-    StructLikeSet actualC = actual(tableName, tab, "partition.data = 'c'", NON_PATH_COLS);
+    StructLikeSet expectedC = expected(tab, deletesC.first(), partitionC, deletesC.second(), false);
+    StructLikeSet actualC =
+        actual(
+            tableName,
+            tab,
+            "partition.data = 'c'",
+            formatVersion >= 3 ? NON_PATH_V3_COLS : NON_PATH_COLS);
 
-    Assert.assertEquals("Position Delete table should contain expected rows", expectedC, actualC);
+    assertThat(actualC)
+        .as("Position Delete table should contain expected rows")
+        .isEqualTo(expectedC);
     dropTable(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testNormalWritesNotAllowed() throws IOException {
     String tableName = "test_normal_write_not_allowed";
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
@@ -1280,10 +1452,9 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
 
     Dataset<Row> scanDF = spark.read().format("iceberg").load(posDeletesTableName);
 
-    Assert.assertThrows(
-        "position_deletes table can only be written by RewriteDeleteFiles",
-        IllegalArgumentException.class,
-        () -> scanDF.writeTo(posDeletesTableName).append());
+    assertThatThrownBy(() -> scanDF.writeTo(posDeletesTableName).append())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Can only write to " + posDeletesTableName + " via actions");
 
     dropTable(tableName);
   }
@@ -1318,6 +1489,7 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
                   .filter(f -> cols.contains(f.name()))
                   .collect(Collectors.toList()));
     }
+
     Types.StructType finalProjection = projection;
     StructLikeSet set = StructLikeSet.create(projection);
     df.collectAsList()
@@ -1334,7 +1506,7 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     Map<String, String> properties =
         ImmutableMap.of(
             TableProperties.FORMAT_VERSION,
-            "2",
+            String.valueOf(formatVersion),
             TableProperties.DEFAULT_FILE_FORMAT,
             format.toString());
     return validationCatalog.createTable(
@@ -1367,13 +1539,23 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
       List<PositionDelete<?>> deletes,
       StructLike partitionStruct,
       int specId,
-      String deleteFilePath) {
+      DeleteFile deleteFile) {
+    return expected(testTable, deletes, partitionStruct, specId, deleteFile, true);
+  }
+
+  private StructLikeSet expected(
+      Table testTable,
+      List<PositionDelete<?>> deletes,
+      StructLike partitionStruct,
+      int specId,
+      DeleteFile deleteFile,
+      boolean includeDeleteFilePath) {
     Table deletesTable =
         MetadataTableUtils.createMetadataTableInstance(
             testTable, MetadataTableType.POSITION_DELETES);
     Types.StructType posDeleteSchema = deletesTable.schema().asStruct();
     // Do not compare file paths
-    if (deleteFilePath == null) {
+    if (!includeDeleteFilePath) {
       posDeleteSchema =
           TypeUtil.selectNot(
                   deletesTable.schema(), ImmutableSet.of(MetadataColumns.FILE_PATH_COLUMN_ID))
@@ -1387,13 +1569,18 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
               GenericRecord record = GenericRecord.create(finalSchema);
               record.setField("file_path", p.path());
               record.setField("pos", p.pos());
-              record.setField("row", p.row());
+              record.setField("row", formatVersion >= 3 ? null : p.row());
               if (partitionStruct != null) {
                 record.setField("partition", partitionStruct);
               }
               record.setField("spec_id", specId);
-              if (deleteFilePath != null) {
-                record.setField("delete_file_path", deleteFilePath);
+              if (includeDeleteFilePath) {
+                record.setField("delete_file_path", deleteFile.location());
+              }
+              if (formatVersion >= 3) {
+                record.setField("content_offset", deleteFile.contentOffset());
+                record.setField(
+                    "content_size_in_bytes", ScanTaskUtil.contentSizeInBytes(deleteFile));
               }
               return record;
             })
@@ -1405,8 +1592,23 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
       Table testTable,
       List<PositionDelete<?>> deletes,
       StructLike partitionStruct,
-      String deleteFilePath) {
-    return expected(testTable, deletes, partitionStruct, testTable.spec().specId(), deleteFilePath);
+      DeleteFile deleteFile) {
+    return expected(testTable, deletes, partitionStruct, testTable.spec().specId(), deleteFile);
+  }
+
+  private StructLikeSet expected(
+      Table testTable,
+      List<PositionDelete<?>> deletes,
+      StructLike partitionStruct,
+      DeleteFile deleteFile,
+      boolean includeDeleteFilePath) {
+    return expected(
+        testTable,
+        deletes,
+        partitionStruct,
+        testTable.spec().specId(),
+        deleteFile,
+        includeDeleteFilePath);
   }
 
   private DataFile dataFile(Table tab, Object... partValues) throws IOException {
@@ -1459,7 +1661,10 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
 
     TestHelpers.Row partitionInfo = TestHelpers.Row.of(partFieldValues);
     return FileHelpers.writeDataFile(
-        tab, Files.localOutput(temp.newFile()), partitionInfo, records);
+        tab,
+        Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
+        partitionInfo,
+        records);
   }
 
   private Pair<List<PositionDelete<?>>, DeleteFile> deleteFile(
@@ -1507,7 +1712,11 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
 
     DeleteFile deleteFile =
         FileHelpers.writePosDeleteFile(
-            tab, Files.localOutput(temp.newFile()), partitionInfo, deletes);
+            tab,
+            Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
+            partitionInfo,
+            deletes,
+            formatVersion);
     return Pair.of(deletes, deleteFile);
   }
 
@@ -1527,18 +1736,20 @@ public class TestPositionDeletesTable extends SparkCatalogTestBase {
     Set<DeleteFile> rewrittenFiles =
         ScanTaskSetManager.get().fetchTasks(posDeletesTable, fileSetID).stream()
             .map(t -> ((PositionDeletesScanTask) t).file())
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(DeleteFileSet::create));
     Set<DeleteFile> addedFiles = rewriteCoordinator.fetchNewFiles(posDeletesTable, fileSetID);
 
     // Assert new files and old files are equal in number but different in paths
-    Assert.assertEquals(expectedSourceFiles, rewrittenFiles.size());
-    Assert.assertEquals(expectedTargetFiles, addedFiles.size());
+    assertThat(rewrittenFiles).hasSize(expectedSourceFiles);
+    assertThat(addedFiles).hasSize(expectedTargetFiles);
 
     List<String> sortedAddedFiles =
         addedFiles.stream().map(ContentFile::location).sorted().collect(Collectors.toList());
     List<String> sortedRewrittenFiles =
         rewrittenFiles.stream().map(ContentFile::location).sorted().collect(Collectors.toList());
-    Assert.assertNotEquals("Lists should not be the same", sortedAddedFiles, sortedRewrittenFiles);
+    assertThat(sortedRewrittenFiles)
+        .as("Lists should not be the same")
+        .isNotEqualTo(sortedAddedFiles);
 
     baseTab
         .newRewrite()

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesTable.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesTable.java
@@ -1203,13 +1203,10 @@ public class TestPositionDeletesTable extends CatalogTestBase {
                     .option(SparkWriteOptions.REWRITTEN_FILE_SCAN_TASK_SET_ID, fileSetID)
                     .append())
         .isInstanceOf(AnalysisException.class)
-        .hasMessage(
-            "[INCOMPATIBLE_DATA_FOR_TABLE.CANNOT_FIND_DATA] Cannot write incompatible data for the table `"
-                + catalogName
-                + "`.`default`.`"
-                + tableName
-                + "`.`position_deletes`"
-                + ": Cannot find data for the output column `partition`.");
+        .hasMessageContaining(
+            "Cannot write incompatible data to table '%s.default.%s.position_deletes'",
+            catalogName, tableName)
+        .hasMessageContaining("Cannot find data for output column 'partition'.");
 
     dropTable(tableName);
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -141,7 +141,9 @@ public abstract class TestReadProjection {
 
     Assert.assertNotNull("Should read a non-null record", projected);
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> projected.get(0))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -127,6 +127,7 @@ public abstract class TestReadProjection {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testEmptyProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -141,9 +142,8 @@ public abstract class TestReadProjection {
 
     Assert.assertNotNull("Should read a non-null record", projected);
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("out of bounds");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @Test

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -72,6 +72,7 @@ public class TestCallStatementParser {
   public void testDelegateUnsupportedProcedure() {
     assertThatThrownBy(() -> parser.parsePlan("CALL cat.d.t()"))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
@@ -171,6 +171,7 @@ public class TestCherrypickSnapshotProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.cherrypick_snapshot('n', 't', 1L)", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -170,6 +170,7 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.expire_snapshots('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
@@ -172,6 +172,7 @@ public class TestFastForwardBranchProcedure extends ExtensionsTestBase {
             () ->
                 sql("CALL %s.custom.fast_forward('test_table', 'main', 'newBranch')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestPublishChangesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestPublishChangesProcedure.java
@@ -169,6 +169,7 @@ public class TestPublishChangesProcedure extends ExtensionsTestBase {
     assertThatThrownBy(
             () -> sql("CALL %s.custom.publish_changes('n', 't', 'not_valid')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -252,6 +252,7 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.remove_orphan_files('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -721,6 +721,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.rewrite_data_files('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -294,6 +294,7 @@ public class TestRewriteManifestsProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.rewrite_manifests('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
@@ -256,6 +256,7 @@ public class TestRollbackToSnapshotProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.rollback_to_snapshot('n', 't', 1L)", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
@@ -297,6 +297,7 @@ public class TestRollbackToTimestampProcedure extends ExtensionsTestBase {
     assertThatThrownBy(
             () -> sql("CALL %s.custom.rollback_to_timestamp('n', 't', %s)", catalogName, timestamp))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
@@ -205,6 +205,7 @@ public class TestSetCurrentSnapshotProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.set_current_snapshot('n', 't', 1L)", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
@@ -57,9 +57,9 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    assertThat(StreamSupport.stream(results.orphanFileLocations().spliterator(), false))
+    assertThat(results.orphanFileLocations())
         .as("trash file should be removed")
-        .anyMatch(file -> file.contains("file:" + location + trashFile));
+        .contains("file:" + location + trashFile);
   }
 
   @TestTemplate
@@ -86,9 +86,9 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    assertThat(StreamSupport.stream(results.orphanFileLocations().spliterator(), false))
+    assertThat(results.orphanFileLocations())
         .as("trash file should be removed")
-        .anyMatch(file -> file.contains("file:" + location + trashFile));
+        .contains("file:" + location + trashFile);
   }
 
   @TestTemplate
@@ -148,9 +148,9 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    assertThat(StreamSupport.stream(results.orphanFileLocations().spliterator(), false))
+    assertThat(results.orphanFileLocations())
         .as("trash file should be removed")
-        .anyMatch(file -> file.contains("file:" + location + trashFile));
+        .contains("file:" + location + trashFile);
   }
 
   @TestTemplate
@@ -169,7 +169,7 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, properties);
     SparkTable table = (SparkTable) cat.loadTable(id);
 
-    spark.sql("INSERT INTO default.sessioncattest VALUES (1,1,1)");
+    sql("INSERT INTO default.sessioncattest VALUES (1,1,1)");
 
     String location = table.table().location().replaceFirst("file:", "");
     String trashFile = randomName("/data/trashfile");
@@ -180,13 +180,13 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .deleteOrphanFiles(table.table())
             .olderThan(System.currentTimeMillis() + 1000)
             .execute();
-    assertThat(StreamSupport.stream(results.orphanFileLocations().spliterator(), false))
+    assertThat(results.orphanFileLocations())
         .as("trash file should be removed")
-        .anyMatch(file -> file.contains("file:" + location + trashFile));
+        .contains("file:" + location + trashFile);
   }
 
   @AfterEach
-  public void resetSparkSessionCatalog() throws Exception {
+  public void resetSparkSessionCatalog() {
     spark.conf().unset("spark.sql.catalog.spark_catalog");
     spark.conf().unset("spark.sql.catalog.spark_catalog.type");
     spark.conf().unset("spark.sql.catalog.spark_catalog.warehouse");

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -658,7 +658,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveMinSequenceNumberInPartition(table, "data_file.partition.c1 == 1", 3);
 
     shouldHaveSnapshots(table, 5);
-    assertThat(table.currentSnapshot().summary().get("total-position-deletes")).isEqualTo("0");
+    assertThat(table.currentSnapshot().summary()).containsEntry("total-position-deletes", "0");
     assertEquals("Rows must match", expectedRecords, currentData());
   }
 
@@ -1894,7 +1894,7 @@ public class TestRewriteDataFilesAction extends TestBase {
             .execute();
 
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-    assertThat(currentData().size()).isEqualTo(count);
+    assertThat(currentData()).hasSize((int) count);
     shouldRewriteDataFilesWithPartitionSpec(table, outputSpecId);
   }
 
@@ -1917,7 +1917,7 @@ public class TestRewriteDataFilesAction extends TestBase {
             .execute();
 
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-    assertThat(currentData().size()).isEqualTo(count);
+    assertThat(currentData()).hasSize((int) count);
     shouldRewriteDataFilesWithPartitionSpec(table, outputSpecId);
   }
 
@@ -1956,7 +1956,7 @@ public class TestRewriteDataFilesAction extends TestBase {
             .execute();
 
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-    assertThat(currentData().size()).isEqualTo(count);
+    assertThat(currentData()).hasSize((int) count);
     shouldRewriteDataFilesWithPartitionSpec(table, outputSpecId);
   }
 
@@ -1979,7 +1979,7 @@ public class TestRewriteDataFilesAction extends TestBase {
             .execute();
 
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-    assertThat(currentData().size()).isEqualTo(count);
+    assertThat(currentData()).hasSize((int) count);
     shouldRewriteDataFilesWithPartitionSpec(table, outputSpecId);
   }
 
@@ -2049,10 +2049,9 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   protected void shouldHaveSnapshots(Table table, int expectedSnapshots) {
     table.refresh();
-    int actualSnapshots = Iterables.size(table.snapshots());
-    assertThat(actualSnapshots)
+    assertThat(table.snapshots())
         .as("Table did not have the expected number of snapshots")
-        .isEqualTo(expectedSnapshots);
+        .hasSize(expectedSnapshots);
   }
 
   protected void shouldHaveNoOrphans(Table table) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -163,7 +163,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @BeforeEach
-  public void setupTableLocation() throws Exception {
+  public void setupTableLocation() {
     this.tableLocation = tableDir.toURI().toString();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -400,7 +400,6 @@ public class TestRewriteManifestsAction extends TestBase {
     table.refresh();
 
     List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
-
     assertThat(newManifests).as("Should have 2 manifests after rewrite").hasSize(2);
 
     assertThat(newManifests.get(0).existingFilesCount()).isEqualTo(4);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +43,7 @@ import org.apache.iceberg.Files;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionSpec;
@@ -86,8 +86,9 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
 
   private static final String TABLE_NAME = "test_table";
@@ -117,8 +118,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
       }
     };
   }
-
-  @TempDir private Path temp;
 
   @Parameter(index = 3)
   private FileFormat format;
@@ -1117,7 +1116,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
 
   private String name(Table table) {
     String[] splits = table.name().split("\\.");
-
     assertThat(splits).hasSize(3);
     return String.format("%s.%s", splits[1], splits[2]);
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -150,7 +150,9 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> projected.get(0))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -136,6 +136,7 @@ public abstract class TestReadProjection {
   }
 
   @TestTemplate
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testEmptyProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -150,9 +151,8 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("out of bounds");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @TestTemplate


### PR DESCRIPTION
### Description
* Added regex to check usage of `assertThatThrownBy` and `assertThatExceptionOfType` need to include check on the error message content.
* Resolve all current files that didn't include error message check and causing checkstyle failures.
```
assertThatExceptionOfType\((?:(?!\.withMessage\w*\().)*?isThrownBy\((?:(?!\.withMessage\w*\().)*?;
```
The regex will flag when a code block starts with `assertThatExceptionOfType`, ends with `;`, and includes `isThrownBy` in-between, but didn't have `withMessageXXX(...` before or after the `isThrownBy`

Examples that will get flagged:
```
assertThatExceptionOfType(NotFoundException.class).isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file"));

assertThatExceptionOfType(NotFoundException.class)
    .isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file"));
```

Examples that will not get flagged:
```
assertThatExceptionOfType(NotFoundException.class).isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file")).hasMessage("123");

assertThatExceptionOfType(NotFoundException.class)
    .isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file"))
    .hasMessage("123");
```

Closes #7040