### PR TITLE
Build: Enforce error message check on Exception assertions

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -93,6 +93,18 @@
         <property name="message" value="assertThatThrownBy() should be statically imported from org.assertj.core.api.Assertions"/>
     </module>
     <module name="RegexpMultiline">
+        <property name="id" value="AssertThatThrownByWithMessageCheck"/>
+        <property name="matchAcrossLines" value="true"/>
+        <property name="format" value="assertThatThrownBy\((?:(?!\.hasMessage\w*\().)*?isInstanceOf\((?:(?!\.hasMessage\w*\().)*?;"/>
+        <property name="message" value="assertThatThrownBy must include a message check like .hasMessageContaining(...)"/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="id" value="AssertThatExceptionOfTypeWithMessageCheck"/>
+        <property name="matchAcrossLines" value="true"/>
+        <property name="format" value="assertThatExceptionOfType\((?:(?!\.withMessage\w*\().)*?isThrownBy\((?:(?!\.withMessage\w*\().)*?;"/>
+        <property name="message" value="assertThatExceptionOfType must include a message check like .withMessageContaining(...)"/>
+    </module>
+    <module name="RegexpMultiline">
         <property name="format" value="^\s*import\s+\Qorg.assertj.core.api.Assertions;\E" />
         <property name="message" value="org.assertj.core.api.Assertions should only be used with static imports" />
     </module>

--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -97,14 +97,14 @@
         <property name="fileExtensions" value="java"/>
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="assertThatThrownBy\((?:(?!\.hasMessage\w*\().)*?isInstanceOf\((?:(?!\.hasMessage\w*\().)*?;"/>
-        <property name="message" value="assertThatThrownBy must include a message check like .hasMessageContaining(...)"/>
+        <property name="message" value="assertThatThrownBy must include a message check like .hasMessage(...)"/>
     </module>
     <module name="RegexpMultiline">
         <property name="id" value="AssertThatExceptionOfTypeWithMessageCheck"/>
         <property name="fileExtensions" value="java"/>
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="assertThatExceptionOfType\((?:(?!\.withMessage\w*\().)*?isThrownBy\((?:(?!\.withMessage\w*\().)*?;"/>
-        <property name="message" value="assertThatExceptionOfType must include a message check like .withMessageContaining(...)"/>
+        <property name="message" value="assertThatExceptionOfType must include a message check like .withMessage(...)"/>
     </module>
     <module name="RegexpMultiline">
         <property name="format" value="^\s*import\s+\Qorg.assertj.core.api.Assertions;\E" />

--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -94,12 +94,14 @@
     </module>
     <module name="RegexpMultiline">
         <property name="id" value="AssertThatThrownByWithMessageCheck"/>
+        <property name="fileExtensions" value="java"/>
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="assertThatThrownBy\((?:(?!\.hasMessage\w*\().)*?isInstanceOf\((?:(?!\.hasMessage\w*\().)*?;"/>
         <property name="message" value="assertThatThrownBy must include a message check like .hasMessageContaining(...)"/>
     </module>
     <module name="RegexpMultiline">
         <property name="id" value="AssertThatExceptionOfTypeWithMessageCheck"/>
+        <property name="fileExtensions" value="java"/>
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="assertThatExceptionOfType\((?:(?!\.withMessage\w*\().)*?isThrownBy\((?:(?!\.withMessage\w*\().)*?;"/>
         <property name="message" value="assertThatExceptionOfType must include a message check like .withMessageContaining(...)"/>

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/TestLocalAliyunOSS.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/TestLocalAliyunOSS.java
@@ -52,6 +52,7 @@ public class TestLocalAliyunOSS {
   private final String bucketName = OSS_TEST_EXTENSION.testBucketName();
   private final Random random = new Random(1);
 
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   private static void assertThrows(Runnable runnable, String expectedErrorCode) {
     assertThatThrownBy(runnable::run)
         .isInstanceOf(OSSException.class)

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
@@ -381,7 +381,8 @@ public class TestExpressionBinding {
   @FieldSource("UNSUPPORTED_PATHS")
   public void testExtractBindingWithInvalidPath(String path) {
     assertThatThrownBy(() -> Binder.bind(STRUCT, lessThan(extract("var", path, "long"), 100)))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageMatching("(Unsupported|Invalid) path.*");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/expressions/TestPathParsing.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestPathParsing.java
@@ -66,6 +66,8 @@ public class TestPathParsing {
   @ParameterizedTest
   @FieldSource("INVALID_PATHS")
   public void testExtractBindingWithInvalidPath(String path) {
-    assertThatThrownBy(() -> PathUtil.parse(path)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> PathUtil.parse(path))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageMatching("(Unsupported|Invalid) path.*");
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestTimestampLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestTimestampLiteralConversions.java
@@ -165,12 +165,14 @@ public class TestTimestampLiteralConversions {
 
     assertThatThrownBy(() -> isoTimestampNanosWithZoneOffset.to(Types.TimestampType.withoutZone()))
         .as("Should not convert timestamp with offset to a timestamp without zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThatThrownBy(
             () -> isoTimestampNanosWithZoneOffset.to(Types.TimestampNanoType.withoutZone()))
         .as("Should not convert timestamp with offset to a timestamp without zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThat(isoTimestampNanosWithZoneOffset.to(Types.TimestampType.withZone()).value())
         .isEqualTo(1510842668000000L);
@@ -186,12 +188,14 @@ public class TestTimestampLiteralConversions {
 
     assertThatThrownBy(() -> isoTimestampMicrosWithZoneOffset.to(Types.TimestampType.withoutZone()))
         .as("Should not convert timestamp with offset to a timestamp without zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThatThrownBy(
             () -> isoTimestampMicrosWithZoneOffset.to(Types.TimestampNanoType.withoutZone()))
         .as("Should not convert timestamp with offset to a timestamp without zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThat(isoTimestampMicrosWithZoneOffset.to(Types.TimestampType.withZone()).value())
         .isEqualTo(1510842668000001L);
@@ -207,12 +211,14 @@ public class TestTimestampLiteralConversions {
 
     assertThatThrownBy(() -> isoTimestampNanosWithoutZoneOffset.to(Types.TimestampType.withZone()))
         .as("Should not convert timestamp without offset to a timestamp with zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThatThrownBy(
             () -> isoTimestampNanosWithoutZoneOffset.to(Types.TimestampNanoType.withZone()))
         .as("Should not convert timestamp without offset to a timestamp with zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThat(isoTimestampNanosWithoutZoneOffset.to(Types.TimestampType.withoutZone()).value())
         .isEqualTo(1510842668000000L);
@@ -228,12 +234,14 @@ public class TestTimestampLiteralConversions {
 
     assertThatThrownBy(() -> isoTimestampMicrosWithoutZoneOffset.to(Types.TimestampType.withZone()))
         .as("Should not convert timestamp without offset to a timestamp with zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThatThrownBy(
             () -> isoTimestampMicrosWithoutZoneOffset.to(Types.TimestampNanoType.withZone()))
         .as("Should not convert timestamp without offset to a timestamp with zone")
-        .isInstanceOf(DateTimeParseException.class);
+        .isInstanceOf(DateTimeParseException.class)
+        .hasMessageContaining("could not be parsed");
 
     assertThat(isoTimestampMicrosWithoutZoneOffset.to(Types.TimestampType.withoutZone()).value())
         .isEqualTo(1510842668000001L);

--- a/api/src/test/java/org/apache/iceberg/io/TestCloseableGroup.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestCloseableGroup.java
@@ -92,7 +92,9 @@ public class TestCloseableGroup {
     closeableGroup.addCloseable(closeable2);
     closeableGroup.addCloseable(closeable3);
 
-    assertThatThrownBy(closeableGroup::close).isEqualTo(ioException);
+    assertThatThrownBy(closeableGroup::close)
+        .hasMessage(ioException.getMessage())
+        .isEqualTo(ioException);
     Mockito.verify(closeable1).close();
     Mockito.verify(closeable2).close();
     Mockito.verifyNoInteractions(closeable3);
@@ -112,7 +114,9 @@ public class TestCloseableGroup {
     closeableGroup.addCloseable(closeable2);
     closeableGroup.addCloseable(closeable3);
 
-    assertThatThrownBy(closeableGroup::close).isEqualTo(ioException);
+    assertThatThrownBy(closeableGroup::close)
+        .hasMessage(ioException.getMessage())
+        .isEqualTo(ioException);
     Mockito.verify(closeable1).close();
     Mockito.verify(closeable2).close();
     Mockito.verifyNoInteractions(closeable3);
@@ -129,6 +133,7 @@ public class TestCloseableGroup {
 
     assertThatThrownBy(closeableGroup::close)
         .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining(generalException.getMessage())
         .hasRootCause(generalException);
   }
 

--- a/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
@@ -92,7 +92,9 @@ public class TestCloseableIterable {
     CloseableIterable<Integer> concat5 =
         CloseableIterable.concat(Lists.newArrayList(empty, empty, empty));
 
-    assertThatThrownBy(() -> Iterables.getLast(concat5)).isInstanceOf(NoSuchElementException.class);
+    assertThatThrownBy(() -> Iterables.getLast(concat5))
+        .isInstanceOf(NoSuchElementException.class)
+        .hasMessage(null);
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
@@ -52,6 +52,7 @@ public class TestExceptionUtil {
                     },
                     CustomCheckedException.class))
         .isInstanceOf(CustomCheckedException.class)
+        .hasMessage(exc.getMessage())
         .isEqualTo(exc)
         .extracting(e -> Arrays.asList(e.getSuppressed()))
         .asInstanceOf(InstanceOfAssertFactories.LIST)
@@ -81,6 +82,7 @@ public class TestExceptionUtil {
                     CustomCheckedException.class,
                     IOException.class))
         .isInstanceOf(CustomCheckedException.class)
+        .hasMessage(exc.getMessage())
         .isEqualTo(exc)
         .extracting(e -> Arrays.asList(e.getSuppressed()))
         .asInstanceOf(InstanceOfAssertFactories.LIST)
@@ -111,6 +113,7 @@ public class TestExceptionUtil {
                     IOException.class,
                     ClassNotFoundException.class))
         .isInstanceOf(CustomCheckedException.class)
+        .hasMessage(exc.getMessage())
         .isEqualTo(exc)
         .extracting(e -> Arrays.asList(e.getSuppressed()))
         .asInstanceOf(InstanceOfAssertFactories.LIST)
@@ -136,6 +139,7 @@ public class TestExceptionUtil {
                       throw suppressedTwo;
                     }))
         .isInstanceOf(RuntimeException.class)
+        .hasMessage(exc.getMessage())
         .isEqualTo(exc)
         .extracting(e -> Arrays.asList(e.getSuppressed()))
         .asInstanceOf(InstanceOfAssertFactories.LIST)

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedMetadata.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedMetadata.java
@@ -39,7 +39,9 @@ public class TestSerializedMetadata {
 
     assertThat(metadata.isSorted()).isFalse();
     assertThat(metadata.dictionarySize()).isEqualTo(0);
-    assertThatThrownBy(() -> metadata.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> metadata.get(0))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test
@@ -109,7 +111,9 @@ public class TestSerializedMetadata {
     assertThat(metadata.get(2)).isEqualTo("c");
     assertThat(metadata.get(3)).isEqualTo("d");
     assertThat(metadata.get(4)).isEqualTo("e");
-    assertThatThrownBy(() -> metadata.get(5)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> metadata.get(5))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test
@@ -125,7 +129,9 @@ public class TestSerializedMetadata {
     assertThat(metadata.get(2)).isEqualTo("xyz");
     assertThat(metadata.get(3)).isEqualTo("d");
     assertThat(metadata.get(4)).isEqualTo("e");
-    assertThatThrownBy(() -> metadata.get(5)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> metadata.get(5))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test
@@ -142,7 +148,9 @@ public class TestSerializedMetadata {
     assertThat(metadata.get(2)).isEqualTo("xyz");
     assertThat(metadata.get(3)).isEqualTo("d");
     assertThat(metadata.get(4)).isEqualTo("e");
-    assertThatThrownBy(() -> metadata.get(5)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> metadata.get(5))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test
@@ -229,7 +237,8 @@ public class TestSerializedMetadata {
   @Test
   public void testMissingLength() {
     assertThatThrownBy(() -> SerializedMetadata.from(new byte[] {0x01}))
-        .isInstanceOf(IndexOutOfBoundsException.class);
+        .isInstanceOf(IndexOutOfBoundsException.class)
+        .hasMessage(null);
   }
 
   @Test
@@ -237,6 +246,7 @@ public class TestSerializedMetadata {
     // missing the 4th length byte
     assertThatThrownBy(
             () -> SerializedMetadata.from(new byte[] {(byte) 0b11010001, 0x00, 0x00, 0x00}))
-        .isInstanceOf(IndexOutOfBoundsException.class);
+        .isInstanceOf(IndexOutOfBoundsException.class)
+        .hasMessage(null);
   }
 }

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedMetadata.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedMetadata.java
@@ -235,18 +235,20 @@ public class TestSerializedMetadata {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testMissingLength() {
+    // no check on the underlying error msg as it might be missing based on the JDK version
     assertThatThrownBy(() -> SerializedMetadata.from(new byte[] {0x01}))
-        .isInstanceOf(IndexOutOfBoundsException.class)
-        .hasMessage(null);
+        .isInstanceOf(IndexOutOfBoundsException.class);
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testLengthTooShort() {
     // missing the 4th length byte
+    // no check on the underlying error msg as it might be missing based on the JDK version
     assertThatThrownBy(
             () -> SerializedMetadata.from(new byte[] {(byte) 0b11010001, 0x00, 0x00, 0x00}))
-        .isInstanceOf(IndexOutOfBoundsException.class)
-        .hasMessage(null);
+        .isInstanceOf(IndexOutOfBoundsException.class);
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
@@ -136,7 +136,7 @@ public class TestAssumeRoleAwsClientFactory {
                 glueCatalog.createNamespace(
                     Namespace.of("denied_" + UUID.randomUUID().toString().replace("-", ""))))
         .isInstanceOf(AccessDeniedException.class)
-        .hasMessageContaining("Access denied");
+        .hasMessageContaining("not authorized to perform: glue:CreateDatabase");
 
     Namespace namespace = Namespace.of("allowed_" + UUID.randomUUID().toString().replace("-", ""));
     try {
@@ -181,7 +181,7 @@ public class TestAssumeRoleAwsClientFactory {
                     .newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/denied/file")
                     .exists())
         .isInstanceOf(S3Exception.class)
-        .hasMessageContaining("s3 exception")
+        .hasMessageContaining("Forbidden")
         .asInstanceOf(InstanceOfAssertFactories.type(S3Exception.class))
         .extracting(SdkServiceException::statusCode)
         .isEqualTo(403);

--- a/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
@@ -135,7 +135,8 @@ public class TestAssumeRoleAwsClientFactory {
             () ->
                 glueCatalog.createNamespace(
                     Namespace.of("denied_" + UUID.randomUUID().toString().replace("-", ""))))
-        .isInstanceOf(AccessDeniedException.class);
+        .isInstanceOf(AccessDeniedException.class)
+        .hasMessageContaining("Access denied");
 
     Namespace namespace = Namespace.of("allowed_" + UUID.randomUUID().toString().replace("-", ""));
     try {
@@ -180,6 +181,7 @@ public class TestAssumeRoleAwsClientFactory {
                     .newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/denied/file")
                     .exists())
         .isInstanceOf(S3Exception.class)
+        .hasMessageContaining("s3 exception")
         .asInstanceOf(InstanceOfAssertFactories.type(S3Exception.class))
         .extracting(SdkServiceException::statusCode)
         .isEqualTo(403);

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -713,7 +713,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
     Table table = glueCatalog.loadTable(identifier);
     String metadataLocation = ((BaseTable) table).operations().current().metadataFileLocation();
     assertThatThrownBy(() -> glueCatalog.registerTable(identifier, metadataLocation))
-        .isInstanceOf(AlreadyExistsException.class);
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("Already exists");
     assertThat(glueCatalog.dropTable(identifier, true)).isTrue();
     assertThat(glueCatalog.dropNamespace(Namespace.of(namespace))).isTrue();
   }

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -714,7 +714,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
     String metadataLocation = ((BaseTable) table).operations().current().metadataFileLocation();
     assertThatThrownBy(() -> glueCatalog.registerTable(identifier, metadataLocation))
         .isInstanceOf(AlreadyExistsException.class)
-        .hasMessageContaining("Already exists");
+        .hasMessageContaining("Table already exists");
     assertThat(glueCatalog.dropTable(identifier, true)).isTrue();
     assertThat(glueCatalog.dropNamespace(Namespace.of(namespace))).isTrue();
   }

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
@@ -152,7 +152,7 @@ public class TestLakeFormationAwsClientFactory {
     try {
       assertThatThrownBy(() -> glueCatalog.createNamespace(deniedNamespace))
           .isInstanceOf(AccessDeniedException.class)
-          .hasMessageContaining("Access denied");
+          .hasMessageContaining("not authorized to perform: glue:CreateDatabase");
     } catch (AssertionError e) {
       glueCatalog.dropNamespace(deniedNamespace);
       throw e;

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
@@ -151,7 +151,8 @@ public class TestLakeFormationAwsClientFactory {
         Namespace.of("denied_" + UUID.randomUUID().toString().replace("-", ""));
     try {
       assertThatThrownBy(() -> glueCatalog.createNamespace(deniedNamespace))
-          .isInstanceOf(AccessDeniedException.class);
+          .isInstanceOf(AccessDeniedException.class)
+          .hasMessageContaining("Access denied");
     } catch (AssertionError e) {
       glueCatalog.dropNamespace(deniedNamespace);
       throw e;

--- a/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
@@ -591,7 +591,9 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(group.filter(5)).isEqualTo(new DeleteFile[] {});
 
     // it should not be possible to add more elements upon indexing
-    assertThatThrownBy(() -> group.add(file1)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> group.add(file1))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Can't add files upon indexing");
   }
 
   @TestTemplate
@@ -625,7 +627,9 @@ public abstract class DeleteFileIndexTestBase<
     assertThat(group.filter(4, FILE_A)).isEqualTo(new DeleteFile[] {});
 
     // it should not be possible to add more elements upon indexing
-    assertThatThrownBy(() -> group.add(SPEC, file1)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> group.add(SPEC, file1))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Can't add files upon indexing");
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestClientPoolImpl.java
+++ b/core/src/test/java/org/apache/iceberg/TestClientPoolImpl.java
@@ -52,7 +52,8 @@ public class TestClientPoolImpl {
         new MockClientPoolImpl(2, RetryableException.class, true, maxRetries)) {
       assertThatThrownBy(
               () -> mockClientPool.run(client -> client.succeedAfter(succeedAfterAttempts)))
-          .isInstanceOf(RetryableException.class);
+          .isInstanceOf(RetryableException.class)
+          .hasMessage(null);
       assertThat(mockClientPool.reconnectionAttempts()).isEqualTo(maxRetries);
     }
   }
@@ -62,7 +63,8 @@ public class TestClientPoolImpl {
     try (MockClientPoolImpl mockClientPool =
         new MockClientPoolImpl(2, RetryableException.class, true, 3)) {
       assertThatThrownBy(() -> mockClientPool.run(MockClient::failWithNonRetryable, true))
-          .isInstanceOf(NonRetryableException.class);
+          .isInstanceOf(NonRetryableException.class)
+          .hasMessage(null);
       assertThat(mockClientPool.reconnectionAttempts()).isEqualTo(0);
     }
   }
@@ -72,7 +74,8 @@ public class TestClientPoolImpl {
     try (MockClientPoolImpl mockClientPool =
         new MockClientPoolImpl(2, RetryableException.class, false, 3)) {
       assertThatThrownBy(() -> mockClientPool.run(client -> client.succeedAfter(3)))
-          .isInstanceOf(RetryableException.class);
+          .isInstanceOf(RetryableException.class)
+          .hasMessage(null);
       assertThat(mockClientPool.reconnectionAttempts()).isEqualTo(0);
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
@@ -273,10 +273,10 @@ public class TestManifestReaderStats extends TestBase {
         .isEqualTo(FILE_PATH); // always select file path in all test cases
   }
 
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   private void assertNullRecordCount(DataFile dataFile) {
     // record count is a primitive type, accessing null record count will throw NPE
-    assertThatThrownBy(dataFile::recordCount)
-        .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("\"this.recordCount\" is null");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(dataFile::recordCount).isInstanceOf(NullPointerException.class);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
@@ -221,32 +221,38 @@ public class TestManifestReaderStats extends TestBase {
 
     if (dataFile.valueCounts() != null) {
       assertThatThrownBy(() -> dataFile.valueCounts().clear(), "Should not be modifiable")
-          .isInstanceOf(UnsupportedOperationException.class);
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(null);
     }
 
     if (dataFile.nullValueCounts() != null) {
       assertThatThrownBy(() -> dataFile.nullValueCounts().clear(), "Should not be modifiable")
-          .isInstanceOf(UnsupportedOperationException.class);
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(null);
     }
 
     if (dataFile.nanValueCounts() != null) {
       assertThatThrownBy(() -> dataFile.nanValueCounts().clear(), "Should not be modifiable")
-          .isInstanceOf(UnsupportedOperationException.class);
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(null);
     }
 
     if (dataFile.upperBounds() != null) {
       assertThatThrownBy(() -> dataFile.upperBounds().clear(), "Should not be modifiable")
-          .isInstanceOf(UnsupportedOperationException.class);
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(null);
     }
 
     if (dataFile.lowerBounds() != null) {
       assertThatThrownBy(() -> dataFile.lowerBounds().clear(), "Should not be modifiable")
-          .isInstanceOf(UnsupportedOperationException.class);
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(null);
     }
 
     if (dataFile.columnSizes() != null) {
       assertThatThrownBy(() -> dataFile.columnSizes().clear(), "Should not be modifiable")
-          .isInstanceOf(UnsupportedOperationException.class);
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(null);
     }
 
     assertThat(dataFile.location())
@@ -269,6 +275,8 @@ public class TestManifestReaderStats extends TestBase {
 
   private void assertNullRecordCount(DataFile dataFile) {
     // record count is a primitive type, accessing null record count will throw NPE
-    assertThatThrownBy(dataFile::recordCount).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(dataFile::recordCount)
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("\"this.recordCount\" is null");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
@@ -133,6 +133,7 @@ public abstract class TestReadProjection {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testEmptyProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -147,9 +148,8 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("out of bounds");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
@@ -147,7 +147,9 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> projected.get(0))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -381,7 +381,8 @@ public class TestHadoopCommits extends HadoopTableTestBase {
     // inject the mockFS into the TableOperations
     doReturn(mockFs).when(spyOps).getFileSystem(any(), any());
     assertThatThrownBy(() -> spyOps.commit(tops.current(), meta1))
-        .isInstanceOf(CommitFailedException.class);
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("Cannot commit changes based on stale table metadata");
 
     // Verifies that there is no temporary metadata.json files left on rename failures.
     Set<String> actual =

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
@@ -57,14 +57,16 @@ public class TestInMemoryFileIO {
   public void testNewInputFileNotFound() {
     InMemoryFileIO fileIO = new InMemoryFileIO();
     assertThatExceptionOfType(NotFoundException.class)
-        .isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file"));
+        .isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file"))
+        .withMessageContaining("No in-memory file found");
   }
 
   @Test
   public void testDeleteFileNotFound() {
     InMemoryFileIO fileIO = new InMemoryFileIO();
     assertThatExceptionOfType(NotFoundException.class)
-        .isThrownBy(() -> fileIO.deleteFile("s3://nonexistent/file"));
+        .isThrownBy(() -> fileIO.deleteFile("s3://nonexistent/file"))
+        .withMessageContaining("No in-memory file found");
   }
 
   @Test
@@ -73,7 +75,8 @@ public class TestInMemoryFileIO {
     InMemoryFileIO fileIO = new InMemoryFileIO();
     fileIO.addFile(location, "hello world".getBytes());
     assertThatExceptionOfType(AlreadyExistsException.class)
-        .isThrownBy(() -> fileIO.newOutputFile(location).create());
+        .isThrownBy(() -> fileIO.newOutputFile(location).create())
+        .withMessage("Already exists");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -2273,7 +2273,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         .when(adapter)
         .execute(reqMatcher(HTTPMethod.POST), any(), any(), any());
     assertThatThrownBy(() -> catalog.loadTable(TABLE).newFastAppend().appendFile(file).commit())
-        .isInstanceOf(NotAuthorizedException.class);
+        .isInstanceOf(NotAuthorizedException.class)
+        .hasMessage("not authorized");
 
     // Extract the UpdateTableRequest to determine the path of the manifest list that should be
     // cleaned up
@@ -2288,7 +2289,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                   (MetadataUpdate.AddSnapshot) body.updates().get(0);
               assertThatThrownBy(
                       () -> table.io().newInputFile(addSnapshot.snapshot().manifestListLocation()))
-                  .isInstanceOf(NotFoundException.class);
+                  .isInstanceOf(NotFoundException.class)
+                  .hasMessageContaining("No in-memory file found");
             });
   }
 
@@ -2308,7 +2310,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         .when(adapter)
         .execute(reqMatcher(HTTPMethod.POST), any(), any(), any());
     assertThatThrownBy(() -> catalog.loadTable(TABLE).newFastAppend().appendFile(FILE_A).commit())
-        .isInstanceOf(ServiceFailureException.class);
+        .isInstanceOf(ServiceFailureException.class)
+        .hasMessage("some service failure");
 
     // Extract the UpdateTableRequest to determine the path of the manifest list that should still
     // exist even though the commit failed
@@ -2344,7 +2347,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Transaction createTableTransaction = catalog.newCreateTableTransaction(newTable, SCHEMA);
     createTableTransaction.newAppend().appendFile(FILE_A).commit();
     assertThatThrownBy(createTableTransaction::commitTransaction)
-        .isInstanceOf(NotAuthorizedException.class);
+        .isInstanceOf(NotAuthorizedException.class)
+        .hasMessage("not authorized");
 
     assertThat(allRequests(adapter))
         .anySatisfy(
@@ -2367,7 +2371,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                               .loadTable(TABLE)
                               .io()
                               .newInputFile(addSnapshot.snapshot().manifestListLocation()))
-                  .isInstanceOf(NotFoundException.class);
+                  .isInstanceOf(NotFoundException.class)
+                  .hasMessageContaining("No in-memory file found");
             });
   }
 
@@ -2389,7 +2394,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Transaction createTableTransaction = catalog.newCreateTableTransaction(newTable, SCHEMA);
     createTableTransaction.newAppend().appendFile(FILE_A).commit();
     assertThatThrownBy(createTableTransaction::commitTransaction)
-        .isInstanceOf(ServiceFailureException.class);
+        .isInstanceOf(ServiceFailureException.class)
+        .hasMessage("some service failure");
 
     assertThat(allRequests(adapter))
         .anySatisfy(
@@ -2429,7 +2435,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Transaction replaceTableTransaction = catalog.newReplaceTableTransaction(TABLE, SCHEMA, false);
     replaceTableTransaction.newAppend().appendFile(FILE_A).commit();
     assertThatThrownBy(replaceTableTransaction::commitTransaction)
-        .isInstanceOf(NotAuthorizedException.class);
+        .isInstanceOf(NotAuthorizedException.class)
+        .hasMessage("not authorized");
 
     assertThat(allRequests(adapter))
         .anySatisfy(
@@ -2449,7 +2456,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
               String manifestListLocation = addSnapshot.snapshot().manifestListLocation();
               assertThatThrownBy(
                       () -> catalog.loadTable(TABLE).io().newInputFile(manifestListLocation))
-                  .isInstanceOf(NotFoundException.class);
+                  .isInstanceOf(NotFoundException.class)
+                  .hasMessageContaining("No in-memory file found");
             });
   }
 
@@ -2470,7 +2478,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Transaction replaceTableTransaction = catalog.newReplaceTableTransaction(TABLE, SCHEMA, false);
     replaceTableTransaction.newAppend().appendFile(FILE_A).commit();
     assertThatThrownBy(replaceTableTransaction::commitTransaction)
-        .isInstanceOf(ServiceFailureException.class);
+        .isInstanceOf(ServiceFailureException.class)
+        .hasMessage("some service failure");
 
     assertThat(allRequests(adapter))
         .anySatisfy(

--- a/core/src/test/java/org/apache/iceberg/util/TestPartitionMap.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestPartitionMap.java
@@ -233,9 +233,15 @@ public class TestPartitionMap {
   @Test
   public void testNullKey() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
-    assertThatThrownBy(() -> map.put(null, "value")).isInstanceOf(NullPointerException.class);
-    assertThatThrownBy(() -> map.get(null)).isInstanceOf(NullPointerException.class);
-    assertThatThrownBy(() -> map.remove(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> map.put(null, "value"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("\"key\" is null");
+    assertThatThrownBy(() -> map.get(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("does not support null keys");
+    assertThatThrownBy(() -> map.remove(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("does not support null keys");
   }
 
   @Test
@@ -253,15 +259,20 @@ public class TestPartitionMap {
     map.put(BY_DATA_SPEC.specId(), Row.of("bbb"), "v2");
 
     assertThatThrownBy(() -> map.keySet().add(Pair.of(1, null)))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
     assertThatThrownBy(() -> map.values().add("other"))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
     assertThatThrownBy(() -> map.entrySet().add(null))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
     assertThatThrownBy(() -> map.entrySet().iterator().next().setValue("other"))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot set value");
     assertThatThrownBy(() -> map.entrySet().iterator().remove())
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/util/TestPartitionMap.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestPartitionMap.java
@@ -231,17 +231,13 @@ public class TestPartitionMap {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testNullKey() {
+    // no check on the underlying error msg as it might be missing based on the JDK version
     PartitionMap<String> map = PartitionMap.create(SPECS);
-    assertThatThrownBy(() -> map.put(null, "value"))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("\"key\" is null");
-    assertThatThrownBy(() -> map.get(null))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("does not support null keys");
-    assertThatThrownBy(() -> map.remove(null))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("does not support null keys");
+    assertThatThrownBy(() -> map.put(null, "value")).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> map.get(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> map.remove(null)).isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/data/src/test/java/org/apache/iceberg/data/TestReadProjection.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestReadProjection.java
@@ -195,7 +195,9 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> projected.get(0))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test

--- a/data/src/test/java/org/apache/iceberg/data/TestReadProjection.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestReadProjection.java
@@ -181,6 +181,7 @@ public abstract class TestReadProjection {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testEmptyProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -195,9 +196,8 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("out of bounds");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @Test

--- a/data/src/test/java/org/apache/iceberg/io/TestGenericSortedPosDeleteWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestGenericSortedPosDeleteWriter.java
@@ -168,6 +168,7 @@ public class TestGenericSortedPosDeleteWriter extends TestBase {
   }
 
   @TestTemplate
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testSortedPosDeleteWithSchemaAndNullRow() throws IOException {
     List<Record> rowSet =
         Lists.newArrayList(createRow(0, "aaa"), createRow(1, "bbb"), createRow(2, "ccc"));

--- a/dell/src/test/java/org/apache/iceberg/dell/mock/ecs/TestExceptionCode.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/mock/ecs/TestExceptionCode.java
@@ -68,6 +68,7 @@ public class TestExceptionCode {
         });
   }
 
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void assertS3Exception(String message, int httpCode, String errorCode, Runnable task) {
     assertThatThrownBy(task::run)
         .isInstanceOf(S3Exception.class)

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -427,6 +427,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // validation.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (dt INTEGER)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot change column type: dt: string -> int");
   }
@@ -557,6 +558,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // because Iceberg's SchemaUpdate does not allow incompatible changes.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (PRIMARY KEY (col1) NOT ENFORCED)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot add field col1 as an identifier field: not a required field");
 
@@ -564,12 +566,14 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // because Iceberg's SchemaUpdate does not allow incompatible changes.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (PRIMARY KEY (id, col1) NOT ENFORCED)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot add field col1 as an identifier field: not a required field");
 
     // Dropping constraints is not supported yet
     assertThatThrownBy(() -> sql("ALTER TABLE tl DROP PRIMARY KEY"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(UnsupportedOperationException.class)
         .hasRootCauseMessage("Unsupported table change: DropConstraint.");
   }

--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -434,7 +434,8 @@ public class TestRewriteDataFilesAction extends CatalogTestBase {
                     .useStartingSequenceNumber(false)
                     .execute(),
             "Rewrite using new sequence number should fail")
-        .isInstanceOf(ValidationException.class);
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot commit, found new delete for replaced data file");
 
     // Rewrite using the starting sequence number should succeed
     RewriteDataFilesActionResult result =

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -427,6 +427,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // validation.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (dt INTEGER)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot change column type: dt: string -> int");
   }
@@ -557,6 +558,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // because Iceberg's SchemaUpdate does not allow incompatible changes.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (PRIMARY KEY (col1) NOT ENFORCED)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot add field col1 as an identifier field: not a required field");
 
@@ -564,12 +566,14 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // because Iceberg's SchemaUpdate does not allow incompatible changes.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (PRIMARY KEY (id, col1) NOT ENFORCED)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot add field col1 as an identifier field: not a required field");
 
     // Dropping constraints is not supported yet
     assertThatThrownBy(() -> sql("ALTER TABLE tl DROP PRIMARY KEY"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(UnsupportedOperationException.class)
         .hasRootCauseMessage("Unsupported table change: DropConstraint.");
   }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -434,7 +434,8 @@ public class TestRewriteDataFilesAction extends CatalogTestBase {
                     .useStartingSequenceNumber(false)
                     .execute(),
             "Rewrite using new sequence number should fail")
-        .isInstanceOf(ValidationException.class);
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot commit, found new delete for replaced data file");
 
     // Rewrite using the starting sequence number should succeed
     RewriteDataFilesActionResult result =

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -461,6 +461,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // validation.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (dt INTEGER)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot change column type: dt: string -> int");
   }
@@ -591,6 +592,7 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // because Iceberg's SchemaUpdate does not allow incompatible changes.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (PRIMARY KEY (col1) NOT ENFORCED)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot add field col1 as an identifier field: not a required field");
 
@@ -598,12 +600,14 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // because Iceberg's SchemaUpdate does not allow incompatible changes.
     assertThatThrownBy(() -> sql("ALTER TABLE tl MODIFY (PRIMARY KEY (id, col1) NOT ENFORCED)"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Cannot add field col1 as an identifier field: not a required field");
 
     // Dropping constraints is not supported yet
     assertThatThrownBy(() -> sql("ALTER TABLE tl DROP PRIMARY KEY"))
         .isInstanceOf(TableException.class)
+        .hasMessageContaining("Could not execute AlterTable")
         .hasRootCauseInstanceOf(UnsupportedOperationException.class)
         .hasRootCauseMessage("Unsupported table change: DropConstraint.");
   }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -441,7 +441,8 @@ public class TestRewriteDataFilesAction extends CatalogTestBase {
                     .useStartingSequenceNumber(false)
                     .execute(),
             "Rewrite using new sequence number should fail")
-        .isInstanceOf(ValidationException.class);
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot commit, found new delete for replaced data file");
 
     // Rewrite using the starting sequence number should succeed
     RewriteDataFilesActionResult result =

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSInputStreamTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSInputStreamTest.java
@@ -166,7 +166,9 @@ public class GCSInputStreamTest {
     SeekableInputStream closed =
         new GCSInputStream(storage, blobId, null, gcpProperties, MetricsContext.nullMetrics());
     closed.close();
-    assertThatThrownBy(() -> closed.seek(0)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> closed.seek(0))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("already closed");
   }
 
   @Test

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -442,7 +442,8 @@ public class TestHiveCommits extends HiveTableBaseTest {
     }
 
     assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
-        .isInstanceOf(OutOfMemoryError.class);
+        .isInstanceOf(OutOfMemoryError.class)
+        .hasMessage(null);
 
     ops.refresh();
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
@@ -479,7 +479,8 @@ public class TestHiveViewCommits {
     }
 
     assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
-        .isInstanceOf(OutOfMemoryError.class);
+        .isInstanceOf(OutOfMemoryError.class)
+        .hasMessage(null);
 
     ops.refresh();
 

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/JsonToMapTransformTest.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/JsonToMapTransformTest.java
@@ -84,7 +84,9 @@ public class JsonToMapTransformTest extends FileLoads {
               offset,
               timestamp,
               TimestampType.CREATE_TIME);
-      assertThatThrownBy(() -> smt.apply(record)).isInstanceOf(JsonToMapException.class);
+      assertThatThrownBy(() -> smt.apply(record))
+          .isInstanceOf(JsonToMapException.class)
+          .hasMessageContaining("not valid json");
     }
   }
 
@@ -103,7 +105,9 @@ public class JsonToMapTransformTest extends FileLoads {
               offset,
               timestamp,
               TimestampType.CREATE_TIME);
-      assertThatThrownBy(() -> smt.apply(record)).isInstanceOf(JsonToMapException.class);
+      assertThatThrownBy(() -> smt.apply(record))
+          .isInstanceOf(JsonToMapException.class)
+          .hasMessageContaining("not valid json");
     }
   }
 

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/JsonToMapUtilsTest.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/JsonToMapUtilsTest.java
@@ -124,7 +124,8 @@ class JsonToMapUtilsTest extends FileLoads {
   public void primitiveBasedOnSchemaThrows() {
     assertThatThrownBy(
             () -> JsonToMapUtils.extractValue(objNode.get("string"), Schema.Type.STRUCT, ""))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Unexpected type STRUCT for field");
   }
 
   @Test
@@ -327,9 +328,17 @@ class JsonToMapUtilsTest extends FileLoads {
     assertThat(result.get("empty_string")).isEqualTo("");
 
     // assert empty fields don't show up on the struct
-    assertThatThrownBy(() -> result.get("null")).isInstanceOf(RuntimeException.class);
-    assertThatThrownBy(() -> result.get("empty_obj")).isInstanceOf(RuntimeException.class);
-    assertThatThrownBy(() -> result.get("empty_arr")).isInstanceOf(RuntimeException.class);
-    assertThatThrownBy(() -> result.get("empty_arr_arr")).isInstanceOf(RuntimeException.class);
+    assertThatThrownBy(() -> result.get("null"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a valid field name");
+    assertThatThrownBy(() -> result.get("empty_obj"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a valid field name");
+    assertThatThrownBy(() -> result.get("empty_arr"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a valid field name");
+    assertThatThrownBy(() -> result.get("empty_arr_arr"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a valid field name");
   }
 }

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/JsonToMapUtilsTest.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/JsonToMapUtilsTest.java
@@ -125,7 +125,7 @@ class JsonToMapUtilsTest extends FileLoads {
     assertThatThrownBy(
             () -> JsonToMapUtils.extractValue(objNode.get("string"), Schema.Type.STRUCT, ""))
         .isInstanceOf(RuntimeException.class)
-        .hasMessage("Unexpected type STRUCT for field");
+        .hasMessageContaining("Unexpected type STRUCT for field");
   }
 
   @Test

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/KafkaMetadataTransformTest.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/KafkaMetadataTransformTest.java
@@ -83,8 +83,12 @@ public class KafkaMetadataTransformTest {
             TimestampType.CREATE_TIME);
     try (KafkaMetadataTransform smt = new KafkaMetadataTransform()) {
       smt.configure(ImmutableMap.of());
-      assertThatThrownBy(() -> smt.apply(recordNotMap)).isInstanceOf(RuntimeException.class);
-      assertThatThrownBy(() -> smt.apply(recordNotStruct)).isInstanceOf(RuntimeException.class);
+      assertThatThrownBy(() -> smt.apply(recordNotMap))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Only Map objects supported in absence of schema");
+      assertThatThrownBy(() -> smt.apply(recordNotStruct))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Only Struct objects supported");
     }
   }
 
@@ -186,7 +190,8 @@ public class KafkaMetadataTransformTest {
               () -> {
                 smt.configure(ImmutableMap.of("external_field", "external,*,,,value"));
               })
-          .isInstanceOf(RuntimeException.class);
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Could not parse external,*,,,value");
     }
   }
 

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/MongoDebeziumTransformTest.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/MongoDebeziumTransformTest.java
@@ -563,6 +563,8 @@ public class MongoDebeziumTransformTest {
             TimestampType.CREATE_TIME);
 
     MongoDebeziumTransform smt = getTransformer("array");
-    assertThatThrownBy(() -> smt.apply(record)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> smt.apply(record))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("malformed record topic");
   }
 }

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/debezium/connector/mongodb/transforms/MongoArrayConverterTest.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/debezium/connector/mongodb/transforms/MongoArrayConverterTest.java
@@ -113,7 +113,8 @@ public class MongoArrayConverterTest {
                 converter.addFieldSchema(entry, builder);
               }
             })
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a homogenous array");
   }
 
   @Test
@@ -127,7 +128,8 @@ public class MongoArrayConverterTest {
                 converter.addFieldSchema(entry, builder);
               }
             })
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not the same type for all documents in the array");
   }
 
   @Test

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -494,7 +494,8 @@ public class TestNessieTable extends BaseTestIceberg {
             () ->
                 catalog.registerTable(
                     TABLE_IDENTIFIER, "file:" + metadataVersionFiles.get(0) + "invalidName"))
-        .isInstanceOf(NotFoundException.class);
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Failed to open input stream for file");
     // Case 5: null identifier
     assertThatThrownBy(
             () ->

--- a/orc/src/test/java/org/apache/iceberg/orc/TestORCFileIOProxies.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestORCFileIOProxies.java
@@ -45,7 +45,8 @@ public class TestORCFileIOProxies {
 
     // Cannot use the filesystem for any other operation
     assertThatThrownBy(() -> ifs.getFileStatus(new Path(localFile.location())))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
 
     // Cannot use the filesystem for any other path
     assertThatThrownBy(() -> ifs.open(new Path("/tmp/dummy")))
@@ -67,7 +68,8 @@ public class TestORCFileIOProxies {
     }
     // No other operation is supported
     assertThatThrownBy(() -> ofs.open(new Path(outputFile.location())))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
     // No other path is supported
     assertThatThrownBy(() -> ofs.create(new Path("/tmp/dummy")))
         .isInstanceOf(IllegalArgumentException.class)

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -76,6 +76,7 @@ public class TestCallStatementParser {
   @Test
   public void testDelegateUnsupportedProcedure() {
     assertThatThrownBy(() -> parser.parsePlan("CALL cat.d.t()"))
+        .hasMessageContaining("Syntax error")
         .isInstanceOf(ParseException.class)
         .satisfies(
             exception -> {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
@@ -177,6 +177,7 @@ public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.cherrypick_snapshot('n', 't', 1L)", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -177,6 +177,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.expire_snapshots('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
@@ -178,6 +178,7 @@ public class TestFastForwardBranchProcedure extends SparkExtensionsTestBase {
             () ->
                 sql("CALL %s.custom.fast_forward('test_table', 'main', 'newBranch')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestPublishChangesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestPublishChangesProcedure.java
@@ -175,6 +175,7 @@ public class TestPublishChangesProcedure extends SparkExtensionsTestBase {
     assertThatThrownBy(
             () -> sql("CALL %s.custom.publish_changes('n', 't', 'not_valid')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -264,6 +264,7 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.remove_orphan_files('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -720,6 +720,7 @@ public class TestRewriteDataFilesProcedure extends SparkExtensionsTestBase {
         .hasMessage("Named and positional arguments cannot be mixed");
 
     assertThatThrownBy(() -> sql("CALL %s.custom.rewrite_data_files('n', 't')", catalogName))
+        .hasMessageContaining("Syntax error")
         .isInstanceOf(ParseException.class)
         .satisfies(
             exception -> {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -283,6 +283,7 @@ public class TestRewriteManifestsProcedure extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.rewrite_manifests('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
@@ -260,6 +260,7 @@ public class TestRollbackToSnapshotProcedure extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.rollback_to_snapshot('n', 't', 1L)", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
@@ -303,6 +303,7 @@ public class TestRollbackToTimestampProcedure extends SparkExtensionsTestBase {
     assertThatThrownBy(
             () -> sql("CALL %s.custom.rollback_to_timestamp('n', 't', %s)", catalogName, timestamp))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
@@ -208,6 +208,7 @@ public class TestSetCurrentSnapshotProcedure extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.set_current_snapshot('n', 't', 1L)", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -141,7 +141,9 @@ public abstract class TestReadProjection {
 
     Assert.assertNotNull("Should read a non-null record", projected);
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> projected.get(0))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -127,6 +127,7 @@ public abstract class TestReadProjection {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testEmptyProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -141,9 +142,8 @@ public abstract class TestReadProjection {
 
     Assert.assertNotNull("Should read a non-null record", projected);
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("out of bounds");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @Test

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -72,6 +72,7 @@ public class TestCallStatementParser {
   public void testDelegateUnsupportedProcedure() {
     assertThatThrownBy(() -> parser.parsePlan("CALL cat.d.t()"))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
@@ -171,6 +171,7 @@ public class TestCherrypickSnapshotProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.cherrypick_snapshot('n', 't', 1L)", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -170,6 +170,7 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.expire_snapshots('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
@@ -172,6 +172,7 @@ public class TestFastForwardBranchProcedure extends ExtensionsTestBase {
             () ->
                 sql("CALL %s.custom.fast_forward('test_table', 'main', 'newBranch')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestPublishChangesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestPublishChangesProcedure.java
@@ -169,6 +169,7 @@ public class TestPublishChangesProcedure extends ExtensionsTestBase {
     assertThatThrownBy(
             () -> sql("CALL %s.custom.publish_changes('n', 't', 'not_valid')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -252,6 +252,7 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.remove_orphan_files('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -721,6 +721,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.rewrite_data_files('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -294,6 +294,7 @@ public class TestRewriteManifestsProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.rewrite_manifests('n', 't')", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
@@ -256,6 +256,7 @@ public class TestRollbackToSnapshotProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.rollback_to_snapshot('n', 't', 1L)", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
@@ -297,6 +297,7 @@ public class TestRollbackToTimestampProcedure extends ExtensionsTestBase {
     assertThatThrownBy(
             () -> sql("CALL %s.custom.rollback_to_timestamp('n', 't', %s)", catalogName, timestamp))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
@@ -205,6 +205,7 @@ public class TestSetCurrentSnapshotProcedure extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CALL %s.custom.set_current_snapshot('n', 't', 1L)", catalogName))
         .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error")
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -150,7 +150,9 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> projected.get(0))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("out of bounds");
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -136,6 +136,7 @@ public abstract class TestReadProjection {
   }
 
   @TestTemplate
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testEmptyProjection() throws Exception {
     Schema schema =
         new Schema(
@@ -150,9 +151,8 @@ public abstract class TestReadProjection {
 
     assertThat(projected).as("Should read a non-null record").isNotNull();
     // this is expected because there are no values
-    assertThatThrownBy(() -> projected.get(0))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("out of bounds");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(() -> projected.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @TestTemplate


### PR DESCRIPTION
### Description
* Added regex to check usage of `assertThatThrownBy` and `assertThatExceptionOfType` need to include check on the error message content.
* Resolve all current files that didn't include error message check and causing checkstyle failures.
```
assertThatExceptionOfType\((?:(?!\.withMessage\w*\().)*?isThrownBy\((?:(?!\.withMessage\w*\().)*?;
```
The regex will flag when a code block starts with `assertThatExceptionOfType`, ends with `;`, and includes `isThrownBy` in-between, but didn't have `withMessageXXX(...` before or after the `isThrownBy`

Examples that will get flagged:
```
assertThatExceptionOfType(NotFoundException.class).isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file"));

assertThatExceptionOfType(NotFoundException.class)
    .isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file"));
```

Examples that will not get flagged:
```
assertThatExceptionOfType(NotFoundException.class).isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file")).hasMessage("123");

assertThatExceptionOfType(NotFoundException.class)
    .isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file"))
    .hasMessage("123");
```

Closes #7040