### PR TITLE
Core: Add update event for rewrite manifests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -192,7 +192,7 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
 
   @Override
   public RewriteManifests rewriteManifests() {
-    return new BaseRewriteManifests(ops).reportWith(reporter);
+    return new BaseRewriteManifests(name, ops).reportWith(reporter);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -196,7 +196,8 @@ public class BaseTransaction implements Transaction {
   @Override
   public RewriteManifests rewriteManifests() {
     checkLastOperationCommitted("RewriteManifests");
-    RewriteManifests rewrite = new BaseRewriteManifests(transactionOps).reportWith(reporter);
+    RewriteManifests rewrite =
+        new BaseRewriteManifests(tableName, transactionOps).reportWith(reporter);
     rewrite.deleteWith(enqueueDelete);
     updates.add(rewrite);
     return rewrite;

--- a/core/src/test/java/org/apache/iceberg/TestCommitReporting.java
+++ b/core/src/test/java/org/apache/iceberg/TestCommitReporting.java
@@ -196,14 +196,9 @@ public class TestCommitReporting extends TestBase {
 
     CommitReport report = reporter.lastCommitReport();
     assertThat(report).isNotNull();
-    assertThat(report.operation()).isEqualTo("append");
-    assertThat(report.snapshotId()).isEqualTo(2L);
-    assertThat(report.sequenceNumber()).isEqualTo(2L);
+    assertThat(report.operation()).isEqualTo("replace");
+    assertThat(report.snapshotId()).isEqualTo(3L);
+    assertThat(report.sequenceNumber()).isEqualTo(3L);
     assertThat(report.tableName()).isEqualTo(tableName);
-
-    CommitMetricsResult metrics = report.commitMetrics();
-    assertThat(metrics.addedDataFiles().value()).isEqualTo(1L);
-    assertThat(metrics.addedRecords().value()).isEqualTo(1L);
-    assertThat(metrics.addedFilesSizeInBytes().value()).isEqualTo(10L);
   }
 }


### PR DESCRIPTION
The rewrite manifests snapshot producer is the only one that does not generate an update event, thus listeners are not notified when a rewrite manifest occurs. This PR adds an update event for rewrite manifests.