### PR TITLE
CORE: Inject OAuth2 Token from TableSession

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -416,7 +416,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
         authManager.tableSession(finalIdentifier, tableConf, contextualSession);
     TableMetadata tableMetadata;
 
-    if (tableSession instanceof OAuth2Util.AuthSession){
+    if (tableSession instanceof OAuth2Util.AuthSession) {
       tableConf.put(OAuth2Properties.TOKEN, ((OAuth2Util.AuthSession) tableSession).token());
     }
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -65,6 +65,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.rest.auth.AuthManager;
 import org.apache.iceberg.rest.auth.AuthManagers;
 import org.apache.iceberg.rest.auth.AuthSession;
+import org.apache.iceberg.rest.auth.OAuth2Properties;
+import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -413,6 +415,10 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     AuthSession tableSession =
         authManager.tableSession(finalIdentifier, tableConf, contextualSession);
     TableMetadata tableMetadata;
+
+    if (tableSession instanceof OAuth2Util.AuthSession){
+      tableConf.put(OAuth2Properties.TOKEN, ((OAuth2Util.AuthSession) tableSession).token());
+    }
 
     if (snapshotMode == SnapshotMode.REFS) {
       tableMetadata =


### PR DESCRIPTION
Originally, we are expecting `loadTable` from the REST Service to return `token` as part of the config in `LoadTableResponse`. The token should have access to the table the application is interacting with.

In this PR, I am proposing to inject the token from `tableSession` that's created within `RestSessionCatalog.loadTable`. This make sense since `RestSessionCatalog` already make a request to the REST service for a token that is dedicated to interact with the table. We can use it to interact with the server instead of getting another one from the endpoint.