### PR TITLE
Spark 3.4: Migrate SparkRowLevelOperationsTestBase related tests to JUnit 5

### DIFF
--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -184,6 +184,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
 
     testImplementation libs.avro.avro
     testImplementation libs.parquet.hadoop
+    testImplementation libs.awaitility
     testImplementation libs.junit.vintage.engine
     testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -48,11 +48,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PlanningMode;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
@@ -74,44 +78,33 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.execution.SparkPlan;
-import org.junit.Assert;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase {
 
   private static final Random RANDOM = ThreadLocalRandom.current();
 
-  protected final String fileFormat;
-  protected final boolean vectorized;
-  protected final String distributionMode;
-  protected final boolean fanoutEnabled;
-  protected final String branch;
-  protected final PlanningMode planningMode;
-  protected final int formatVersion;
+  @Parameter(index = 3)
+  protected FileFormat fileFormat;
 
-  public SparkRowLevelOperationsTestBase(
-      String catalogName,
-      String implementation,
-      Map<String, String> config,
-      String fileFormat,
-      boolean vectorized,
-      String distributionMode,
-      boolean fanoutEnabled,
-      String branch,
-      PlanningMode planningMode,
-      int formatVersion) {
-    super(catalogName, implementation, config);
-    this.fileFormat = fileFormat;
-    this.vectorized = vectorized;
-    this.distributionMode = distributionMode;
-    this.fanoutEnabled = fanoutEnabled;
-    this.branch = branch;
-    this.planningMode = planningMode;
-    this.formatVersion = formatVersion;
-  }
+  @Parameter(index = 4)
+  protected boolean vectorized;
+
+  @Parameter(index = 5)
+  protected String distributionMode;
+
+  @Parameter(index = 6)
+  protected boolean fanoutEnabled;
+
+  @Parameter(index = 7)
+  protected String branch;
+
+  @Parameter(index = 8)
+  protected PlanningMode planningMode;
+
+  @Parameter(index = 9)
+  protected int formatVersion;
 
   @Parameters(
       name =
@@ -126,7 +119,7 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
         ImmutableMap.of(
             "type", "hive",
             "default-namespace", "default"),
-        "orc",
+        FileFormat.ORC,
         true,
         WRITE_DISTRIBUTION_MODE_NONE,
         true,
@@ -140,7 +133,7 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
         ImmutableMap.of(
             "type", "hive",
             "default-namespace", "default"),
-        "parquet",
+        FileFormat.PARQUET,
         true,
         WRITE_DISTRIBUTION_MODE_NONE,
         false,
@@ -152,7 +145,7 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
         "testhadoop",
         SparkCatalog.class.getName(),
         ImmutableMap.of("type", "hadoop"),
-        "parquet",
+        FileFormat.PARQUET,
         RANDOM.nextBoolean(),
         WRITE_DISTRIBUTION_MODE_HASH,
         true,
@@ -171,7 +164,7 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
             "cache-enabled",
                 "false" // Spark will delete tables using v1, leaving the cache out of sync
             ),
-        "avro",
+        FileFormat.AVRO,
         false,
         WRITE_DISTRIBUTION_MODE_RANGE,
         false,
@@ -183,7 +176,7 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
         "testhadoop",
         SparkCatalog.class.getName(),
         ImmutableMap.of("type", "hadoop"),
-        "parquet",
+        FileFormat.PARQUET,
         RANDOM.nextBoolean(),
         WRITE_DISTRIBUTION_MODE_HASH,
         true,
@@ -206,7 +199,7 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
             "cache-enabled",
             "false" // Spark will delete tables using v1, leaving the cache out of sync
             ),
-        "avro",
+        FileFormat.AVRO,
         false,
         WRITE_DISTRIBUTION_MODE_RANGE,
         false,
@@ -237,18 +230,18 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
         formatVersion);
 
     switch (fileFormat) {
-      case "parquet":
+      case PARQUET:
         sql(
             "ALTER TABLE %s SET TBLPROPERTIES('%s' '%b')",
             tableName, PARQUET_VECTORIZATION_ENABLED, vectorized);
         break;
-      case "orc":
+      case ORC:
         sql(
             "ALTER TABLE %s SET TBLPROPERTIES('%s' '%b')",
             tableName, ORC_VECTORIZATION_ENABLED, vectorized);
         break;
-      case "avro":
-        Assert.assertFalse(vectorized);
+      case AVRO:
+        assertThat(vectorized).isFalse();
         break;
     }
 
@@ -354,7 +347,7 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
       String deletedDataFiles,
       String addedDeleteFiles,
       String addedDataFiles) {
-    Assert.assertEquals("Operation must match", operation, snapshot.operation());
+    assertThat(snapshot.operation()).as("Operation must match").isEqualTo(operation);
     validateProperty(snapshot, CHANGED_PARTITION_COUNT_PROP, changedPartitionCount);
     validateProperty(snapshot, DELETED_FILES_PROP, deletedDataFiles);
     validateProperty(snapshot, ADDED_DELETE_FILES_PROP, addedDeleteFiles);
@@ -367,14 +360,15 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
 
   protected void validateProperty(Snapshot snapshot, String property, Set<String> expectedValues) {
     String actual = snapshot.summary().get(property);
-    Assert.assertTrue(
-        "Snapshot property "
-            + property
-            + " has unexpected value, actual = "
-            + actual
-            + ", expected one of : "
-            + String.join(",", expectedValues),
-        expectedValues.contains(actual));
+    assertThat(actual)
+        .as(
+            "Snapshot property "
+                + property
+                + " has unexpected value, actual = "
+                + actual
+                + ", expected one of : "
+                + String.join(",", expectedValues))
+        .isIn(expectedValues);
   }
 
   protected void validateProperty(Snapshot snapshot, String property, String expectedValue) {
@@ -397,7 +391,9 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
 
   protected DataFile writeDataFile(Table table, List<GenericRecord> records) {
     try {
-      OutputFile file = Files.localOutput(temp.newFile());
+      OutputFile file =
+          Files.localOutput(
+              temp.resolve(fileFormat.addExtension(UUID.randomUUID().toString())).toFile());
 
       DataWriter<GenericRecord> dataWriter =
           Parquet.writeData(file)
@@ -443,7 +439,7 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
   }
 
   private boolean isParquet() {
-    return fileFormat.equalsIgnoreCase(FileFormat.PARQUET.name());
+    return fileFormat.equals(FileFormat.PARQUET);
   }
 
   private boolean isCopyOnWrite() {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -19,9 +19,14 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -33,15 +38,20 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.PlanningMode;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkSQLProperties;
@@ -49,35 +59,12 @@ import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestCopyOnWriteDelete extends TestDelete {
-
-  public TestCopyOnWriteDelete(
-      String catalogName,
-      String implementation,
-      Map<String, String> config,
-      String fileFormat,
-      Boolean vectorized,
-      String distributionMode,
-      boolean fanoutEnabled,
-      String branch,
-      PlanningMode planningMode,
-      int formatVersion) {
-    super(
-        catalogName,
-        implementation,
-        config,
-        fileFormat,
-        vectorized,
-        distributionMode,
-        fanoutEnabled,
-        branch,
-        planningMode,
-        formatVersion);
-  }
 
   @Override
   protected Map<String, String> extraTableProperties() {
@@ -85,11 +72,11 @@ public class TestCopyOnWriteDelete extends TestDelete {
         TableProperties.DELETE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
   }
 
-  @Test
+  @TestTemplate
   public synchronized void testDeleteWithConcurrentTableRefresh() throws Exception {
     // this test can only be run with Hive tables as it requires a reliable lock
     // also, the table cache must be enabled so that the same table instance can be reused
-    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+    assumeThat(catalogName).isEqualToIgnoringCase("testhive");
 
     createAndInitUnpartitionedTable();
     createOrReplaceView("deleted_id", Collections.singletonList(1), Encoders.INT());
@@ -115,9 +102,11 @@ public class TestCopyOnWriteDelete extends TestDelete {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> barrier.get() >= currentNumOperations * 2);
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", commitTarget());
 
@@ -134,9 +123,11 @@ public class TestCopyOnWriteDelete extends TestDelete {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> !shouldAppend.get() || barrier.get() >= currentNumOperations * 2);
 
                 if (!shouldAppend.get()) {
                   return;
@@ -150,7 +141,6 @@ public class TestCopyOnWriteDelete extends TestDelete {
                   }
 
                   appendFiles.commit();
-                  sleep(10);
                 }
 
                 barrier.incrementAndGet();
@@ -169,10 +159,10 @@ public class TestCopyOnWriteDelete extends TestDelete {
     }
 
     executorService.shutdown();
-    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    assertThat(executorService.awaitTermination(2, TimeUnit.MINUTES)).as("Timeout").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testRuntimeFilteringWithPreservedDataGrouping() throws NoSuchTableException {
     createAndInitPartitionedTable();
 
@@ -190,7 +180,7 @@ public class TestCopyOnWriteDelete extends TestDelete {
     withSQLConf(sqlConf, () -> sql("DELETE FROM %s WHERE id = 2", commitTarget()));
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 3 snapshots", 3, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 3 snapshots").hasSize(3);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
     validateCopyOnWrite(currentSnapshot, "1", "1", "1");
@@ -199,5 +189,39 @@ public class TestCopyOnWriteDelete extends TestDelete {
         "Should have expected rows",
         ImmutableList.of(row(1, "hardware"), row(1, "hr"), row(3, "hr")),
         sql("SELECT * FROM %s ORDER BY id, dep", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testEqualityDeletePreservation() throws NoSuchTableException, IOException {
+    createAndInitPartitionedTable();
+    append(tableName, new Employee(1, "hr"), new Employee(2, "hr"), new Employee(3, "hr"));
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    OutputFile out = Files.localOutput(File.createTempFile("junit", null, temp.toFile()));
+    Schema deleteSchema = table.schema().select("id");
+    GenericRecord deleteRecord = GenericRecord.create(deleteSchema);
+    DeleteFile eqDelete =
+        FileHelpers.writeDeleteFile(
+            table,
+            out,
+            TestHelpers.Row.of("hr"),
+            List.of(deleteRecord.copy("id", 2)),
+            deleteSchema);
+
+    table.newRowDelta().addDeletes(eqDelete).commit();
+
+    sql("REFRESH TABLE %s", tableName);
+
+    assertEquals(
+        "Equality delete should remove row with id 2",
+        ImmutableList.of(row(1, "hr"), row(3, "hr")),
+        sql("SELECT * FROM %s ORDER BY id, dep", tableName));
+
+    sql("DELETE FROM %s WHERE id = 3", tableName);
+
+    assertEquals(
+        "COW Delete should remove row with id 3",
+        ImmutableList.of(row(1, "hr")),
+        sql("SELECT * FROM %s ORDER BY id, dep", tableName));
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.MERGE_ISOLATION_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.Collections;
 import java.util.Map;
@@ -32,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.PlanningMode;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
@@ -40,42 +42,17 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.internal.SQLConf;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestCopyOnWriteMerge extends TestMerge {
-
-  public TestCopyOnWriteMerge(
-      String catalogName,
-      String implementation,
-      Map<String, String> config,
-      String fileFormat,
-      boolean vectorized,
-      String distributionMode,
-      boolean fanoutEnabled,
-      String branch,
-      PlanningMode planningMode,
-      int formatVersion) {
-    super(
-        catalogName,
-        implementation,
-        config,
-        fileFormat,
-        vectorized,
-        distributionMode,
-        fanoutEnabled,
-        branch,
-        planningMode,
-        formatVersion);
-  }
 
   @Override
   protected Map<String, String> extraTableProperties() {
@@ -83,11 +60,11 @@ public class TestCopyOnWriteMerge extends TestMerge {
         TableProperties.MERGE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
   }
 
-  @Test
+  @TestTemplate
   public synchronized void testMergeWithConcurrentTableRefresh() throws Exception {
     // this test can only be run with Hive tables as it requires a reliable lock
     // also, the table cache must be enabled so that the same table instance can be reused
-    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+    assumeThat(catalogName).isEqualToIgnoringCase("testhive");
 
     createAndInitTable("id INT, dep STRING");
     createOrReplaceView("source", Collections.singletonList(1), Encoders.INT());
@@ -167,10 +144,10 @@ public class TestCopyOnWriteMerge extends TestMerge {
     }
 
     executorService.shutdown();
-    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    assertThat(executorService.awaitTermination(2, TimeUnit.MINUTES)).as("Timeout").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testRuntimeFilteringWithReportedPartitioning() {
     createAndInitTable("id INT, dep STRING");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -201,7 +178,7 @@ public class TestCopyOnWriteMerge extends TestMerge {
                 commitTarget()));
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 3 snapshots", 3, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 3 snapshots").hasSize(3);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
     validateCopyOnWrite(currentSnapshot, "1", "1", "1");

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -51,8 +51,9 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ManifestFile;
-import org.apache.iceberg.PlanningMode;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotRef;
@@ -63,7 +64,6 @@ import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.spark.Spark3Util;
@@ -82,44 +82,21 @@ import org.apache.spark.sql.catalyst.plans.logical.RowLevelWrite;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.execution.datasources.v2.OptimizeMetadataOnlyDeleteFromTable;
 import org.apache.spark.sql.internal.SQLConf;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
-  public TestDelete(
-      String catalogName,
-      String implementation,
-      Map<String, String> config,
-      String fileFormat,
-      Boolean vectorized,
-      String distributionMode,
-      boolean fanoutEnabled,
-      String branch,
-      PlanningMode planningMode,
-      int formatVersion) {
-    super(
-        catalogName,
-        implementation,
-        config,
-        fileFormat,
-        vectorized,
-        distributionMode,
-        fanoutEnabled,
-        branch,
-        planningMode,
-        formatVersion);
-  }
-
-  @BeforeClass
+  @BeforeAll
   public static void setupSparkConf() {
     spark.conf().set("spark.sql.shuffle.partitions", "4");
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS deleted_id");
@@ -127,7 +104,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("DROP TABLE IF EXISTS parquet_table");
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithVectorizedReads() throws NoSuchTableException {
     assumeThat(supportsVectorization()).isTrue();
 
@@ -142,7 +119,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     assertAllBatchScansVectorized(plan);
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 3 snapshots", 3, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 3 snapshots").hasSize(3);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
     if (mode(table) == COPY_ON_WRITE) {
@@ -157,7 +134,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testCoalesceDelete() throws Exception {
     createAndInitUnpartitionedTable();
 
@@ -217,11 +194,12 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
       validateProperty(snapshot, SnapshotSummary.ADDED_DELETE_FILES_PROP, "1");
     }
 
-    Assert.assertEquals(
-        "Row count must match", 200L, scalarSql("SELECT COUNT(*) FROM %s", commitTarget()));
+    assertThat(scalarSql("SELECT COUNT(*) FROM %s", commitTarget()))
+        .as("Row count must match")
+        .isEqualTo(200L);
   }
 
-  @Test
+  @TestTemplate
   public void testSkewDelete() throws Exception {
     createAndInitPartitionedTable();
 
@@ -279,11 +257,12 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
       validateProperty(snapshot, SnapshotSummary.ADDED_DELETE_FILES_PROP, "4");
     }
 
-    Assert.assertEquals(
-        "Row count must match", 200L, scalarSql("SELECT COUNT(*) FROM %s", commitTarget()));
+    assertThat(scalarSql("SELECT COUNT(*) FROM %s", commitTarget()))
+        .as("Row count must match")
+        .isEqualTo(200L);
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithoutScanningTable() throws Exception {
     createAndInitPartitionedTable();
 
@@ -318,9 +297,11 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteFileThenMetadataDelete() throws Exception {
-    Assume.assumeFalse("Avro does not support metadata delete", fileFormat.equals("avro"));
+    assumeThat(fileFormat)
+        .as("Avro does not support metadata delete")
+        .isNotEqualTo(FileFormat.AVRO);
     createAndInitUnpartitionedTable();
     createBranchIfNeeded();
     sql("INSERT INTO TABLE %s VALUES (1, 'hr'), (2, 'hardware'), (null, 'hr')", commitTarget());
@@ -335,8 +316,9 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("DELETE FROM %s AS t WHERE t.id = 1", commitTarget());
 
     List<DataFile> dataFilesAfter = TestHelpers.dataFiles(table, branch);
-    Assert.assertTrue(
-        "Data file should have been removed", dataFilesBefore.size() > dataFilesAfter.size());
+    assertThat(dataFilesAfter)
+        .as("Data file should have been removed")
+        .hasSizeLessThan(dataFilesBefore.size());
 
     assertEquals(
         "Should have expected rows",
@@ -344,7 +326,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithPartitionedTable() throws Exception {
     createAndInitPartitionedTable();
 
@@ -360,8 +342,9 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
     List<Row> rowLevelDeletePartitions =
         spark.sql("SELECT * FROM " + tableName + ".partitions ").collectAsList();
-    Assert.assertEquals(
-        "row level delete does not reduce number of partition", 2, rowLevelDeletePartitions.size());
+    assertThat(rowLevelDeletePartitions)
+        .as("row level delete does not reduce number of partition")
+        .hasSize(2);
 
     // partition aligned delete
     sql("DELETE FROM %s WHERE dep = 'hr'", tableName);
@@ -372,11 +355,10 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
     List<Row> actualPartitions =
         spark.sql("SELECT * FROM " + tableName + ".partitions ").collectAsList();
-    Assert.assertEquals(
-        "partition aligned delete results in 1 partition", 1, actualPartitions.size());
+    assertThat(actualPartitions).as("partition aligned delete results in 1 partition").hasSize(1);
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithFalseCondition() {
     createAndInitUnpartitionedTable();
 
@@ -386,7 +368,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("DELETE FROM %s WHERE id = 1 AND id > 20", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 2 snapshots", 2, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 2 snapshots").hasSize(2);
 
     assertEquals(
         "Should have expected rows",
@@ -394,16 +376,16 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteFromEmptyTable() {
-    Assume.assumeFalse("Custom branch does not exist for empty table", "test".equals(branch));
+    assumeThat(branch).as("Custom branch does not exist for empty table").isNotEqualTo("test");
     createAndInitUnpartitionedTable();
 
     sql("DELETE FROM %s WHERE id IN (1)", commitTarget());
     sql("DELETE FROM %s WHERE dep = 'hr'", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 2 snapshots", 2, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 2 snapshots").hasSize(2);
 
     assertEquals(
         "Should have expected rows",
@@ -411,9 +393,9 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteFromNonExistingCustomBranch() {
-    Assume.assumeTrue("Test only applicable to custom branch", "test".equals(branch));
+    assumeThat(branch).as("Test only applicable to custom branch").isEqualTo("test");
     createAndInitUnpartitionedTable();
 
     assertThatThrownBy(() -> sql("DELETE FROM %s WHERE id IN (1)", commitTarget()))
@@ -421,7 +403,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         .hasMessage("Cannot use branch (does not exist): test");
   }
 
-  @Test
+  @TestTemplate
   public void testExplain() {
     createAndInitUnpartitionedTable();
 
@@ -433,7 +415,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("EXPLAIN DELETE FROM %s WHERE true", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 1 snapshot", 1, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 1 snapshot").hasSize(1);
 
     assertEquals(
         "Should have expected rows",
@@ -441,7 +423,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", commitTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithAlias() {
     createAndInitUnpartitionedTable();
 
@@ -456,7 +438,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithDynamicFileFiltering() throws NoSuchTableException {
     createAndInitPartitionedTable();
 
@@ -467,7 +449,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("DELETE FROM %s WHERE id = 2", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 3 snapshots", 3, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 3 snapshots").hasSize(3);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
     if (mode(table) == COPY_ON_WRITE) {
@@ -482,7 +464,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id, dep", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteNonExistingRecords() {
     createAndInitPartitionedTable();
 
@@ -492,11 +474,11 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("DELETE FROM %s AS t WHERE t.id > 10", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 2 snapshots", 2, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 2 snapshots").hasSize(2);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
 
-    if (fileFormat.equals("orc") || fileFormat.equals("parquet")) {
+    if (fileFormat.equals(FileFormat.ORC) || fileFormat.equals(FileFormat.PARQUET)) {
       validateDelete(currentSnapshot, "0", null);
     } else {
       if (mode(table) == COPY_ON_WRITE) {
@@ -512,7 +494,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void deleteSingleRecordProducesDeleteOperation() throws NoSuchTableException {
     createAndInitPartitionedTable();
     append(tableName, new Employee(1, "eng"), new Employee(2, "eng"), new Employee(3, "eng"));
@@ -538,7 +520,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         .containsExactlyInAnyOrder(row(1, "eng"), row(3, "eng"));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithoutCondition() {
     createAndInitPartitionedTable();
 
@@ -550,7 +532,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("DELETE FROM %s", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 4 snapshots", 4, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 4 snapshots").hasSize(4);
 
     // should be a delete instead of an overwrite as it is done through a metadata operation
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
@@ -560,7 +542,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         "Should have expected rows", ImmutableList.of(), sql("SELECT * FROM %s", commitTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteUsingMetadataWithComplexCondition() {
     createAndInitPartitionedTable();
 
@@ -574,7 +556,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 4 snapshots", 4, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 4 snapshots").hasSize(4);
 
     // should be a delete instead of an overwrite as it is done through a metadata operation
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
@@ -586,7 +568,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithArbitraryPartitionPredicates() {
     createAndInitPartitionedTable();
 
@@ -599,7 +581,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("DELETE FROM %s WHERE id = 10 OR dep LIKE '%%ware'", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 4 snapshots", 4, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 4 snapshots").hasSize(4);
 
     // should be a "delete" instead of an "overwrite" as only data files have been removed (COW) /
     // delete files have been added (MOR)
@@ -617,7 +599,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithNonDeterministicCondition() {
     createAndInitPartitionedTable();
 
@@ -629,7 +611,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         .hasMessageStartingWith("nondeterministic expressions are only allowed");
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithFoldableConditions() {
     createAndInitPartitionedTable();
 
@@ -665,10 +647,10 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 2 snapshots", 2, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 2 snapshots").hasSize(2);
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithNullConditions() {
     createAndInitPartitionedTable();
 
@@ -700,13 +682,13 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 3 snapshots", 3, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 3 snapshots").hasSize(3);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
     validateDelete(currentSnapshot, "1", "1");
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithInAndNotInConditions() {
     createAndInitUnpartitionedTable();
 
@@ -732,9 +714,9 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithMultipleRowGroupsParquet() throws NoSuchTableException {
-    Assume.assumeTrue(fileFormat.equalsIgnoreCase("parquet"));
+    assumeThat(fileFormat).isEqualTo(FileFormat.PARQUET);
 
     createAndInitPartitionedTable();
 
@@ -755,15 +737,15 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     df.coalesce(1).writeTo(tableName).append();
     createBranchIfNeeded();
 
-    Assert.assertEquals(200, spark.table(commitTarget()).count());
+    assertThat(spark.table(commitTarget()).count()).isEqualTo(200);
 
     // delete a record from one of two row groups and copy over the second one
     sql("DELETE FROM %s WHERE id IN (200, 201)", commitTarget());
 
-    Assert.assertEquals(199, spark.table(commitTarget()).count());
+    assertThat(spark.table(commitTarget()).count()).isEqualTo(199);
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithConditionOnNestedColumn() {
     createAndInitNestedColumnsTable();
 
@@ -782,7 +764,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         "Should have expected rows", ImmutableList.of(), sql("SELECT id FROM %s", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithInSubquery() throws NoSuchTableException {
     createAndInitUnpartitionedTable();
 
@@ -829,7 +811,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithMultiColumnInSubquery() throws NoSuchTableException {
     createAndInitUnpartitionedTable();
 
@@ -847,7 +829,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithNotInSubquery() throws NoSuchTableException {
     createAndInitUnpartitionedTable();
 
@@ -907,9 +889,9 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteOnNonIcebergTableNotSupported() {
-    Assume.assumeTrue(catalogName.equalsIgnoreCase("spark_catalog"));
+    assumeThat(catalogName).isEqualToIgnoringCase("spark_catalog");
 
     sql("CREATE TABLE parquet_table (c1 INT, c2 INT) USING parquet");
 
@@ -918,7 +900,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         .hasMessageContaining("does not support DELETE");
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithExistSubquery() throws NoSuchTableException {
     createAndInitUnpartitionedTable();
 
@@ -963,7 +945,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithNotExistsSubquery() throws NoSuchTableException {
     createAndInitUnpartitionedTable();
 
@@ -999,7 +981,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithScalarSubquery() throws NoSuchTableException {
     createAndInitUnpartitionedTable();
 
@@ -1020,7 +1002,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteThatRequiresGroupingBeforeWrite() throws NoSuchTableException {
     createAndInitPartitionedTable();
 
@@ -1038,20 +1020,21 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
       spark.conf().set("spark.sql.shuffle.partitions", "1");
 
       sql("DELETE FROM %s t WHERE id IN (SELECT * FROM deleted_id)", commitTarget());
-      Assert.assertEquals(
-          "Should have expected num of rows", 8L, spark.table(commitTarget()).count());
+      assertThat(spark.table(commitTarget()).count())
+          .as("Should have expected num of rows")
+          .isEqualTo(8L);
     } finally {
       spark.conf().set("spark.sql.shuffle.partitions", originalNumOfShufflePartitions);
     }
   }
 
-  @Test
+  @TestTemplate
   public synchronized void testDeleteWithSerializableIsolation() throws InterruptedException {
     // cannot run tests with concurrency for Hadoop tables without atomic renames
-    Assume.assumeFalse(catalogName.equalsIgnoreCase("testhadoop"));
+    assumeThat(catalogName).isNotEqualToIgnoringCase("testhadoop");
     // if caching is off, the table is eagerly refreshed during runtime filtering
     // this can cause a validation exception as concurrent changes would be visible
-    Assume.assumeTrue(cachingCatalogEnabled());
+    assumeThat(cachingCatalogEnabled()).isTrue();
 
     createAndInitUnpartitionedTable();
     createOrReplaceView("deleted_id", Collections.singletonList(1), Encoders.INT());
@@ -1075,9 +1058,11 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> barrier.get() >= currentNumOperations * 2);
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", commitTarget());
 
@@ -1097,9 +1082,11 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> !shouldAppend.get() || barrier.get() >= currentNumOperations * 2);
 
                 if (!shouldAppend.get()) {
                   return;
@@ -1113,7 +1100,6 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                   }
 
                   appendFiles.commit();
-                  sleep(10);
                 }
 
                 barrier.incrementAndGet();
@@ -1132,17 +1118,17 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     }
 
     executorService.shutdown();
-    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    assertThat(executorService.awaitTermination(2, TimeUnit.MINUTES)).as("Timeout").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public synchronized void testDeleteWithSnapshotIsolation()
       throws InterruptedException, ExecutionException {
     // cannot run tests with concurrency for Hadoop tables without atomic renames
-    Assume.assumeFalse(catalogName.equalsIgnoreCase("testhadoop"));
+    assumeThat(catalogName).isNotEqualToIgnoringCase("testhadoop");
     // if caching is off, the table is eagerly refreshed during runtime filtering
     // this can cause a validation exception as concurrent changes would be visible
-    Assume.assumeTrue(cachingCatalogEnabled());
+    assumeThat(cachingCatalogEnabled()).isTrue();
 
     createAndInitUnpartitionedTable();
     createOrReplaceView("deleted_id", Collections.singletonList(1), Encoders.INT());
@@ -1166,9 +1152,11 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> barrier.get() >= currentNumOperations * 2);
 
                 sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", commitTarget());
 
@@ -1188,9 +1176,11 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> !shouldAppend.get() || barrier.get() >= currentNumOperations * 2);
 
                 if (!shouldAppend.get()) {
                   return;
@@ -1204,7 +1194,6 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                   }
 
                   appendFiles.commit();
-                  sleep(10);
                 }
 
                 barrier.incrementAndGet();
@@ -1219,10 +1208,10 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     }
 
     executorService.shutdown();
-    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    assertThat(executorService.awaitTermination(2, TimeUnit.MINUTES)).as("Timeout").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteRefreshesRelationCache() throws NoSuchTableException {
     createAndInitPartitionedTable();
 
@@ -1243,7 +1232,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("DELETE FROM %s WHERE id = 1", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 3 snapshots", 3, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 3 snapshots").hasSize(3);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
     if (mode(table) == COPY_ON_WRITE) {
@@ -1264,7 +1253,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     spark.sql("UNCACHE TABLE tmp");
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteWithMultipleSpecs() {
     createAndInitTable("id INT, dep STRING, category STRING");
 
@@ -1290,7 +1279,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("DELETE FROM %s WHERE id IN (1, 3, 5, 7)", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 5 snapshots", 5, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 5 snapshots").hasSize(5);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
     if (mode(table) == COPY_ON_WRITE) {
@@ -1307,9 +1296,9 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteToWapBranch() throws NoSuchTableException {
-    Assume.assumeTrue("WAP branch only works for table identifier without branch", branch == null);
+    assumeThat(branch).as("WAP branch only works for table identifier without branch").isNull();
 
     createAndInitPartitionedTable();
     sql(
@@ -1321,40 +1310,36 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, "wap"),
         () -> {
           sql("DELETE FROM %s t WHERE id=0", tableName);
-          Assert.assertEquals(
-              "Should have expected num of rows when reading table",
-              2L,
-              spark.table(tableName).count());
-          Assert.assertEquals(
-              "Should have expected num of rows when reading WAP branch",
-              2L,
-              spark.table(tableName + ".branch_wap").count());
-          Assert.assertEquals(
-              "Should not modify main branch", 3L, spark.table(tableName + ".branch_main").count());
+          assertThat(spark.table(tableName).count())
+              .as("Should have expected num of rows when reading table")
+              .isEqualTo(2L);
+          assertThat(spark.table(tableName + ".branch_wap").count())
+              .as("Should have expected num of rows when reading WAP branch")
+              .isEqualTo(2L);
+          assertThat(spark.table(tableName + ".branch_main").count())
+              .as("Should not modify main branch")
+              .isEqualTo(3L);
         });
 
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, "wap"),
         () -> {
           sql("DELETE FROM %s t WHERE id=1", tableName);
-          Assert.assertEquals(
-              "Should have expected num of rows when reading table with multiple writes",
-              1L,
-              spark.table(tableName).count());
-          Assert.assertEquals(
-              "Should have expected num of rows when reading WAP branch with multiple writes",
-              1L,
-              spark.table(tableName + ".branch_wap").count());
-          Assert.assertEquals(
-              "Should not modify main branch with multiple writes",
-              3L,
-              spark.table(tableName + ".branch_main").count());
+          assertThat(spark.table(tableName).count())
+              .as("Should have expected num of rows when reading table with multiple writes")
+              .isEqualTo(1L);
+          assertThat(spark.table(tableName + ".branch_wap").count())
+              .as("Should have expected num of rows when reading WAP branch with multiple writes")
+              .isEqualTo(1L);
+          assertThat(spark.table(tableName + ".branch_main").count())
+              .as("Should not modify main branch with multiple writes")
+              .isEqualTo(3L);
         });
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteToWapBranchWithTableBranchIdentifier() throws NoSuchTableException {
-    Assume.assumeTrue("Test must have branch name part in table identifier", branch != null);
+    assumeThat(branch).as("Test must have branch name part in table identifier").isNotNull();
 
     createAndInitPartitionedTable();
     sql(
@@ -1374,7 +1359,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
                         branch)));
   }
 
-  @Test
+  @TestTemplate
   public void testDeleteToCustomWapBranchWithoutWhereClause() throws NoSuchTableException {
     assumeThat(branch)
         .as("Run only if custom WAP branch is not main")
@@ -1408,6 +1393,28 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
               .as("Should not modify main branch")
               .isEqualTo(3L);
         });
+  }
+
+  @TestTemplate
+  public void testDeleteWithFilterOnNestedColumn() {
+    createAndInitNestedColumnsTable();
+
+    sql("INSERT INTO TABLE %s VALUES (1, named_struct(\"c1\", 3, \"c2\", \"v1\"))", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, named_struct(\"c1\", 2, \"c2\", \"v2\"))", tableName);
+
+    sql("DELETE FROM %s WHERE complex.c1 > 3", tableName);
+    assertEquals(
+        "Should have expected rows",
+        ImmutableList.of(row(1), row(2)),
+        sql("SELECT id FROM %s order by id", tableName));
+
+    sql("DELETE FROM %s WHERE complex.c1 = 3", tableName);
+    assertEquals(
+        "Should have expected rows", ImmutableList.of(row(2)), sql("SELECT id FROM %s", tableName));
+
+    sql("DELETE FROM %s t WHERE t.complex.c1 = 2", tableName);
+    assertEquals(
+        "Should have expected rows", ImmutableList.of(), sql("SELECT id FROM %s", tableName));
   }
 
   // TODO: multiple stripes for ORC

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -48,7 +48,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DistributionMode;
-import org.apache.iceberg.PlanningMode;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
@@ -70,50 +71,27 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.internal.SQLConf;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
 
-  public TestMerge(
-      String catalogName,
-      String implementation,
-      Map<String, String> config,
-      String fileFormat,
-      boolean vectorized,
-      String distributionMode,
-      boolean fanoutEnabled,
-      String branch,
-      PlanningMode planningMode,
-      int formatVersion) {
-    super(
-        catalogName,
-        implementation,
-        config,
-        fileFormat,
-        vectorized,
-        distributionMode,
-        fanoutEnabled,
-        branch,
-        planningMode,
-        formatVersion);
-  }
-
-  @BeforeClass
+  @BeforeAll
   public static void setupSparkConf() {
     spark.conf().set("spark.sql.shuffle.partitions", "4");
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS source");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithVectorizedReads() {
     assumeThat(supportsVectorization()).isTrue();
 
@@ -155,7 +133,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testCoalesceMerge() {
     createAndInitTable("id INT, salary INT, dep STRING");
 
@@ -221,13 +199,12 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
       validateProperty(currentSnapshot, SnapshotSummary.ADDED_DELETE_FILES_PROP, "1");
     }
 
-    Assert.assertEquals(
-        "Row count must match",
-        400L,
-        scalarSql("SELECT COUNT(*) FROM %s WHERE salary = -1", commitTarget()));
+    assertThat(scalarSql("SELECT COUNT(*) FROM %s WHERE salary = -1", commitTarget()))
+        .as("Row count must match")
+        .isEqualTo(400L);
   }
 
-  @Test
+  @TestTemplate
   public void testSkewMerge() {
     createAndInitTable("id INT, salary INT, dep STRING");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -297,13 +274,12 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
       validateProperty(currentSnapshot, SnapshotSummary.ADDED_DELETE_FILES_PROP, "4");
     }
 
-    Assert.assertEquals(
-        "Row count must match",
-        400L,
-        scalarSql("SELECT COUNT(*) FROM %s WHERE salary = -1", commitTarget()));
+    assertThat(scalarSql("SELECT COUNT(*) FROM %s WHERE salary = -1", commitTarget()))
+        .as("Row count must match")
+        .isEqualTo(400L);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeConditionSplitIntoTargetPredicateAndJoinCondition() {
     createAndInitTable(
         "id INT, salary INT, dep STRING, sub_dep STRING",
@@ -352,7 +328,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithStaticPredicatePushDown() {
     createAndInitTable("id BIGINT, dep STRING");
 
@@ -369,7 +345,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
 
     Snapshot snapshot = SnapshotUtil.latestSnapshot(table, branch);
     String dataFilesCount = snapshot.summary().get(SnapshotSummary.TOTAL_DATA_FILES_PROP);
-    Assert.assertEquals("Must have 2 files before MERGE", "2", dataFilesCount);
+    assertThat(dataFilesCount).as("Must have 2 files before MERGE").isEqualTo("2");
 
     createOrReplaceView(
         "source", "{ \"id\": 1, \"dep\": \"finance\" }\n" + "{ \"id\": 2, \"dep\": \"hardware\" }");
@@ -405,9 +381,9 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id, dep", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeIntoEmptyTargetInsertAllNonMatchingRows() {
-    Assume.assumeFalse("Custom branch does not exist for empty table", "test".equals(branch));
+    assumeThat(branch).as("Custom branch does not exist for empty table").isNotEqualTo("test");
     createAndInitTable("id INT, dep STRING");
 
     createOrReplaceView(
@@ -436,9 +412,9 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeIntoEmptyTargetInsertOnlyMatchingRows() {
-    Assume.assumeFalse("Custom branch does not exist for empty table", "test".equals(branch));
+    assumeThat(branch).as("Custom branch does not exist for empty table").isNotEqualTo("test");
     createAndInitTable("id INT, dep STRING");
 
     createOrReplaceView(
@@ -466,7 +442,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithOnlyUpdateClause() {
     createAndInitTable(
         "id INT, dep STRING",
@@ -497,7 +473,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithOnlyUpdateClauseAndNullValues() {
     createAndInitTable(
         "id INT, dep STRING",
@@ -530,7 +506,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithOnlyUpdateNullUnmatchedValues() {
     createAndInitTable(
         "id INT, value INT", "{ \"id\": 1, \"value\": 2 }\n" + "{ \"id\": 6, \"value\": null }");
@@ -556,7 +532,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithOnlyUpdateSingleFieldNullUnmatchedValues() {
     createAndInitTable(
         "id INT, value INT", "{ \"id\": 1, \"value\": 2 }\n" + "{ \"id\": 6, \"value\": null }");
@@ -582,7 +558,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithOnlyDeleteNullUnmatchedValues() {
     createAndInitTable(
         "id INT, value INT", "{ \"id\": 1, \"value\": 2 }\n" + "{ \"id\": 6, \"value\": null }");
@@ -602,7 +578,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithOnlyDeleteClause() {
     createAndInitTable(
         "id INT, dep STRING",
@@ -632,8 +608,8 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
-  public void testMergeWithAllCauses() {
+  @TestTemplate
+  public void testMergeWithAllClauses() {
     createAndInitTable(
         "id INT, dep STRING",
         "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n" + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
@@ -667,7 +643,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithAllCausesWithExplicitColumnSpecification() {
     createAndInitTable(
         "id INT, dep STRING",
@@ -702,7 +678,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithSourceCTE() {
     createAndInitTable(
         "id INT, dep STRING",
@@ -738,7 +714,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithSourceFromSetOps() {
     createAndInitTable(
         "id INT, dep STRING",
@@ -778,7 +754,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithOneMatchingBranchButMultipleSourceRowsForTargetRow() {
     createAndInitTable(
         "id INT, dep STRING",
@@ -813,7 +789,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithMultipleUpdatesForTargetRowSmallTargetLargeSource() {
     createAndInitTable(
         "id INT, dep STRING",
@@ -850,7 +826,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void
       testMergeWithMultipleUpdatesForTargetRowSmallTargetLargeSourceEnabledHashShuffleJoin() {
     createAndInitTable(
@@ -892,7 +868,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithMultipleUpdatesForTargetRowSmallTargetLargeSourceNoEqualityCondition() {
     createAndInitTable("id INT, dep STRING", "{ \"id\": 1, \"dep\": \"emp-id-one\" }");
 
@@ -931,7 +907,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithMultipleUpdatesForTargetRowSmallTargetLargeSourceNoNotMatchedActions() {
     createAndInitTable(
         "id INT, dep STRING",
@@ -966,7 +942,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void
       testMergeWithMultipleUpdatesForTargetRowSmallTargetLargeSourceNoNotMatchedActionsNoEqualityCondition() {
     createAndInitTable("id INT, dep STRING", "{ \"id\": 1, \"dep\": \"emp-id-one\" }");
@@ -1000,7 +976,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithMultipleUpdatesForTargetRow() {
     createAndInitTable(
         "id INT, dep STRING",
@@ -1038,7 +1014,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithUnconditionalDelete() {
     createAndInitTable(
         "id INT, dep STRING",
@@ -1071,7 +1047,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithSingleConditionalDelete() {
     createAndInitTable(
         "id INT, dep STRING",
@@ -1107,7 +1083,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithIdentityTransform() {
     for (DistributionMode mode : DistributionMode.values()) {
       createAndInitTable("id INT, dep STRING");
@@ -1153,7 +1129,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithDaysTransform() {
     for (DistributionMode mode : DistributionMode.values()) {
       createAndInitTable("id INT, ts TIMESTAMP");
@@ -1201,7 +1177,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithBucketTransform() {
     for (DistributionMode mode : DistributionMode.values()) {
       createAndInitTable("id INT, dep STRING");
@@ -1247,7 +1223,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithTruncateTransform() {
     for (DistributionMode mode : DistributionMode.values()) {
       createAndInitTable("id INT, dep STRING");
@@ -1293,7 +1269,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testMergeIntoPartitionedAndOrderedTable() {
     for (DistributionMode mode : DistributionMode.values()) {
       createAndInitTable("id INT, dep STRING");
@@ -1340,7 +1316,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testSelfMerge() {
     createAndInitTable(
         "id INT, v STRING", "{ \"id\": 1, \"v\": \"v1\" }\n" + "{ \"id\": 2, \"v\": \"v2\" }");
@@ -1363,7 +1339,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         "Output should match", expectedRows, sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testSelfMergeWithCaching() {
     createAndInitTable(
         "id INT, v STRING", "{ \"id\": 1, \"v\": \"v1\" }\n" + "{ \"id\": 2, \"v\": \"v2\" }");
@@ -1388,7 +1364,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         "Output should match", expectedRows, sql("SELECT * FROM %s ORDER BY id", commitTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithSourceAsSelfSubquery() {
     createAndInitTable(
         "id INT, v STRING", "{ \"id\": 1, \"v\": \"v1\" }\n" + "{ \"id\": 2, \"v\": \"v2\" }");
@@ -1413,13 +1389,13 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         "Output should match", expectedRows, sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public synchronized void testMergeWithSerializableIsolation() throws InterruptedException {
     // cannot run tests with concurrency for Hadoop tables without atomic renames
-    Assume.assumeFalse(catalogName.equalsIgnoreCase("testhadoop"));
+    assumeThat(catalogName).isNotEqualToIgnoringCase("testhadoop");
     // if caching is off, the table is eagerly refreshed during runtime filtering
     // this can cause a validation exception as concurrent changes would be visible
-    Assume.assumeTrue(cachingCatalogEnabled());
+    assumeThat(cachingCatalogEnabled()).isTrue();
 
     createAndInitTable("id INT, dep STRING");
     createOrReplaceView("source", Collections.singletonList(1), Encoders.INT());
@@ -1443,9 +1419,11 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> barrier.get() >= currentNumOperations * 2);
 
                 sql(
                     "MERGE INTO %s t USING source s "
@@ -1470,9 +1448,11 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> !shouldAppend.get() || barrier.get() >= currentNumOperations * 2);
 
                 if (!shouldAppend.get()) {
                   return;
@@ -1485,7 +1465,6 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
                     appendFiles.toBranch(branch);
                   }
                   appendFiles.commit();
-                  sleep(10);
                 }
 
                 barrier.incrementAndGet();
@@ -1504,17 +1483,17 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     }
 
     executorService.shutdown();
-    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    assertThat(executorService.awaitTermination(2, TimeUnit.MINUTES)).as("Timeout").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public synchronized void testMergeWithSnapshotIsolation()
       throws InterruptedException, ExecutionException {
     // cannot run tests with concurrency for Hadoop tables without atomic renames
-    Assume.assumeFalse(catalogName.equalsIgnoreCase("testhadoop"));
+    assumeThat(catalogName).isNotEqualToIgnoringCase("testhadoop");
     // if caching is off, the table is eagerly refreshed during runtime filtering
     // this can cause a validation exception as concurrent changes would be visible
-    Assume.assumeTrue(cachingCatalogEnabled());
+    assumeThat(cachingCatalogEnabled()).isTrue();
 
     createAndInitTable("id INT, dep STRING");
     createOrReplaceView("source", Collections.singletonList(1), Encoders.INT());
@@ -1538,9 +1517,11 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> barrier.get() >= currentNumOperations * 2);
 
                 sql(
                     "MERGE INTO %s t USING source s "
@@ -1565,9 +1546,11 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> !shouldAppend.get() || barrier.get() >= currentNumOperations * 2);
 
                 if (!shouldAppend.get()) {
                   return;
@@ -1581,7 +1564,6 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
                   }
 
                   appendFiles.commit();
-                  sleep(10);
                 }
 
                 barrier.incrementAndGet();
@@ -1596,10 +1578,10 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     }
 
     executorService.shutdown();
-    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    assertThat(executorService.awaitTermination(2, TimeUnit.MINUTES)).as("Timeout").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithExtraColumnsInSource() {
     createAndInitTable(
         "id INT, v STRING", "{ \"id\": 1, \"v\": \"v1\" }\n" + "{ \"id\": 2, \"v\": \"v2\" }");
@@ -1629,7 +1611,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         "Output should match", expectedRows, sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithNullsInTargetAndSource() {
     createAndInitTable(
         "id INT, v STRING", "{ \"id\": null, \"v\": \"v1\" }\n" + "{ \"id\": 2, \"v\": \"v2\" }");
@@ -1657,7 +1639,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         "Output should match", expectedRows, sql("SELECT * FROM %s ORDER BY v", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithNullSafeEquals() {
     createAndInitTable(
         "id INT, v STRING", "{ \"id\": null, \"v\": \"v1\" }\n" + "{ \"id\": 2, \"v\": \"v2\" }");
@@ -1684,7 +1666,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         "Output should match", expectedRows, sql("SELECT * FROM %s ORDER BY v", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithNullCondition() {
     createAndInitTable(
         "id INT, v STRING", "{ \"id\": null, \"v\": \"v1\" }\n" + "{ \"id\": 2, \"v\": \"v2\" }");
@@ -1712,7 +1694,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         "Output should match", expectedRows, sql("SELECT * FROM %s ORDER BY v", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithNullActionConditions() {
     createAndInitTable(
         "id INT, v STRING", "{ \"id\": 1, \"v\": \"v1\" }\n" + "{ \"id\": 2, \"v\": \"v2\" }");
@@ -1763,7 +1745,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         "Output should match", expectedRows2, sql("SELECT * FROM %s ORDER BY v", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithMultipleMatchingActions() {
     createAndInitTable(
         "id INT, v STRING", "{ \"id\": 1, \"v\": \"v1\" }\n" + "{ \"id\": 2, \"v\": \"v2\" }");
@@ -1792,9 +1774,9 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         "Output should match", expectedRows, sql("SELECT * FROM %s ORDER BY v", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithMultipleRowGroupsParquet() throws NoSuchTableException {
-    Assume.assumeTrue(fileFormat.equalsIgnoreCase("parquet"));
+    assumeThat(fileFormat).isEqualTo(FileFormat.PARQUET);
 
     createAndInitTable("id INT, dep STRING");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -1818,7 +1800,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     df.coalesce(1).writeTo(tableName).append();
     createBranchIfNeeded();
 
-    Assert.assertEquals(200, spark.table(commitTarget()).count());
+    assertThat(spark.table(commitTarget()).count()).isEqualTo(200);
 
     // update a record from one of two row groups and copy over the second one
     sql(
@@ -1828,10 +1810,10 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
             + "  UPDATE SET dep = 'x'",
         commitTarget());
 
-    Assert.assertEquals(200, spark.table(commitTarget()).count());
+    assertThat(spark.table(commitTarget()).count()).isEqualTo(200);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeInsertOnly() {
     createAndInitTable(
         "id STRING, v STRING",
@@ -1863,7 +1845,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         "Output should match", expectedRows, sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeInsertOnlyWithCondition() {
     createAndInitTable("id INTEGER, v INTEGER", "{ \"id\": 1, \"v\": 1 }");
     createOrReplaceView(
@@ -1889,7 +1871,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         "Output should match", expectedRows, sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeAlignsUpdateAndInsertActions() {
     createAndInitTable("id INT, a INT, b STRING", "{ \"id\": 1, \"a\": 2, \"b\": \"str\" }");
     createOrReplaceView(
@@ -1912,7 +1894,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeMixedCaseAlignsUpdateAndInsertActions() {
     createAndInitTable("id INT, a INT, b STRING", "{ \"id\": 1, \"a\": 2, \"b\": \"str\" }");
     createOrReplaceView(
@@ -1944,7 +1926,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s WHERE b = 'new_str_2'ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeUpdatesNestedStructFields() {
     createAndInitTable(
         "id INT, s STRUCT<c1:INT,c2:STRUCT<a:ARRAY<INT>,m:MAP<STRING, STRING>>>",
@@ -1991,7 +1973,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithInferredCasts() {
     createAndInitTable("id INT, s STRING", "{ \"id\": 1, \"s\": \"value\" }");
     createOrReplaceView("source", "{ \"id\": 1, \"c1\": -2}");
@@ -2010,7 +1992,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeModifiesNullStruct() {
     createAndInitTable("id INT, s STRUCT<n1:INT,n2:INT>", "{ \"id\": 1, \"s\": null }");
     createOrReplaceView("source", "{ \"id\": 1, \"n1\": -10 }");
@@ -2028,7 +2010,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeRefreshesRelationCache() {
     createAndInitTable("id INT, name STRING", "{ \"id\": 1, \"name\": \"n1\" }");
     createOrReplaceView("source", "{ \"id\": 1, \"name\": \"n2\" }");
@@ -2054,7 +2036,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     spark.sql("UNCACHE TABLE tmp");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithMultipleNotMatchedActions() {
     createAndInitTable("id INT, dep STRING", "{ \"id\": 0, \"dep\": \"emp-id-0\" }");
 
@@ -2087,7 +2069,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithMultipleConditionalNotMatchedActions() {
     createAndInitTable("id INT, dep STRING", "{ \"id\": 0, \"dep\": \"emp-id-0\" }");
 
@@ -2119,7 +2101,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeResolvesColumnsByName() {
     createAndInitTable(
         "id INT, badge INT, dep STRING",
@@ -2154,7 +2136,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT id, badge, dep FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeShouldResolveWhenThereAreNoUnresolvedExpressionsOrColumns() {
     // ensures that MERGE INTO will resolve into the correct action even if no columns
     // or otherwise unresolved expressions exist in the query (testing SPARK-34962)
@@ -2189,7 +2171,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithTableWithNonNullableColumn() {
     createAndInitTable(
         "id INT NOT NULL, dep STRING",
@@ -2223,7 +2205,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithNonExistingColumns() {
     createAndInitTable(
         "id INT, c STRUCT<n1:INT,n2:STRUCT<dn1:INT,dn2:INT>>",
@@ -2266,7 +2248,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         .hasMessageContaining("cannot resolve invalid_col in MERGE command");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithInvalidColumnsInInsert() {
     createAndInitTable(
         "id INT, c STRUCT<n1:INT,n2:STRUCT<dn1:INT,dn2:INT>>",
@@ -2311,7 +2293,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         .hasMessageContaining("must provide values for all columns of the target table");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithInvalidUpdates() {
     createAndInitTable(
         "id INT, a ARRAY<STRUCT<c1:INT,c2:INT>>, m MAP<STRING,STRING>",
@@ -2341,7 +2323,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         .hasMessageContaining("Updating nested fields is only supported for structs");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithConflictingUpdates() {
     createAndInitTable(
         "id INT, c STRUCT<n1:INT,n2:STRUCT<dn1:INT,dn2:INT>>",
@@ -2382,7 +2364,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         .hasMessageContaining("Updates are in conflict");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithInvalidAssignments() {
     createAndInitTable(
         "id INT NOT NULL, s STRUCT<n1:INT NOT NULL,n2:STRUCT<dn1:INT,dn2:INT>> NOT NULL",
@@ -2454,7 +2436,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithNonDeterministicConditions() {
     createAndInitTable(
         "id INT, c STRUCT<n1:INT,n2:STRUCT<dn1:INT,dn2:INT>>",
@@ -2510,7 +2492,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
             "Non-deterministic functions are not supported in INSERT conditions of MERGE operations");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithAggregateExpressions() {
     createAndInitTable(
         "id INT, c STRUCT<n1:INT,n2:STRUCT<dn1:INT,dn2:INT>>",
@@ -2566,7 +2548,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
             "Agg functions are not supported in INSERT conditions of MERGE operations");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithSubqueriesInConditions() {
     createAndInitTable(
         "id INT, c STRUCT<n1:INT,n2:STRUCT<dn1:INT,dn2:INT>>",
@@ -2622,7 +2604,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
             "Subqueries are not supported in conditions of MERGE operations. Found a subquery in the INSERT condition");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithTargetColumnsInInsertConditions() {
     createAndInitTable("id INT, c2 INT", "{ \"id\": 1, \"c2\": 2 }");
     createOrReplaceView("source", "{ \"id\": 1, \"value\": 11 }");
@@ -2639,7 +2621,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         .hasMessageContaining("Cannot resolve [c2] in INSERT condition of MERGE operation");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithNonIcebergTargetTableNotSupported() {
     createOrReplaceView("target", "{ \"c1\": -100, \"c2\": -200 }");
     createOrReplaceView("source", "{ \"c1\": -100, \"c2\": -200 }");
@@ -2659,7 +2641,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
    * Tests a merge where both the source and target are evaluated to be partitioned by
    * SingePartition at planning time but DynamicFileFilterExec will return an empty target.
    */
-  @Test
+  @TestTemplate
   public void testMergeSinglePartitionPartitioning() {
     // This table will only have a single file and a single partition
     createAndInitTable("id INT", "{\"id\": -1}");
@@ -2680,9 +2662,9 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     assertEquals("Should correctly add the non-matching rows", expectedRows, result);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeEmptyTable() {
-    Assume.assumeFalse("Custom branch does not exist for empty table", "test".equals(branch));
+    assumeThat(branch).as("Custom branch does not exist for empty table").isNotEqualTo("test");
     // This table will only have a single file and a single partition
     createAndInitTable("id INT", null);
 
@@ -2701,9 +2683,9 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     assertEquals("Should correctly add the non-matching rows", expectedRows, result);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeNonExistingBranch() {
-    Assume.assumeTrue("Test only applicable to custom branch", "test".equals(branch));
+    assumeThat(branch).as("Test only applicable to custom branch").isEqualTo("test");
     createAndInitTable("id INT", null);
 
     // Coalesce forces our source into a SinglePartition distribution
@@ -2719,9 +2701,9 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         .hasMessage("Cannot use branch (does not exist): test");
   }
 
-  @Test
+  @TestTemplate
   public void testMergeToWapBranch() {
-    Assume.assumeTrue("WAP branch only works for table identifier without branch", branch == null);
+    assumeThat(branch).as("WAP branch only works for table identifier without branch").isNull();
 
     createAndInitTable("id INT", "{\"id\": -1}");
     ImmutableList<Object[]> originalRows = ImmutableList.of(row(-1));
@@ -2780,9 +2762,9 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testMergeToWapBranchWithTableBranchIdentifier() {
-    Assume.assumeTrue("Test must have branch name part in table identifier", branch != null);
+    assumeThat(branch).as("Test must have branch name part in table identifier").isNotNull();
 
     createAndInitTable("id INT", "{\"id\": -1}");
     sql(

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadMerge.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadMerge.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.PlanningMode;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
@@ -40,33 +40,11 @@ import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.Encoders;
-import org.junit.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestMergeOnReadMerge extends TestMerge {
-
-  public TestMergeOnReadMerge(
-      String catalogName,
-      String implementation,
-      Map<String, String> config,
-      String fileFormat,
-      boolean vectorized,
-      String distributionMode,
-      boolean fanoutEnabled,
-      String branch,
-      PlanningMode planningMode,
-      int formatVersion) {
-    super(
-        catalogName,
-        implementation,
-        config,
-        fileFormat,
-        vectorized,
-        distributionMode,
-        fanoutEnabled,
-        branch,
-        planningMode,
-        formatVersion);
-  }
 
   @Override
   protected Map<String, String> extraTableProperties() {
@@ -74,19 +52,19 @@ public class TestMergeOnReadMerge extends TestMerge {
         TableProperties.MERGE_MODE, RowLevelOperationMode.MERGE_ON_READ.modeName());
   }
 
-  @Test
+  @TestTemplate
   public void testMergeDeleteFileGranularity() {
     assumeThat(formatVersion).isEqualTo(2);
     checkMergeDeleteGranularity(DeleteGranularity.FILE);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeDeletePartitionGranularity() {
     assumeThat(formatVersion).isEqualTo(2);
     checkMergeDeleteGranularity(DeleteGranularity.PARTITION);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeWithDVAndHistoricalPositionDeletes() {
     assumeThat(formatVersion).isEqualTo(2);
     createTableWithDeleteGranularity(

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadUpdate.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadUpdate.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.PlanningMode;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
@@ -38,33 +38,11 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.SnapshotUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestMergeOnReadUpdate extends TestUpdate {
-
-  public TestMergeOnReadUpdate(
-      String catalogName,
-      String implementation,
-      Map<String, String> config,
-      String fileFormat,
-      boolean vectorized,
-      String distributionMode,
-      boolean fanoutEnabled,
-      String branch,
-      PlanningMode planningMode,
-      int formatVersion) {
-    super(
-        catalogName,
-        implementation,
-        config,
-        fileFormat,
-        vectorized,
-        distributionMode,
-        fanoutEnabled,
-        branch,
-        planningMode,
-        formatVersion);
-  }
 
   @Override
   protected Map<String, String> extraTableProperties() {
@@ -72,19 +50,19 @@ public class TestMergeOnReadUpdate extends TestUpdate {
         TableProperties.UPDATE_MODE, RowLevelOperationMode.MERGE_ON_READ.modeName());
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateFileGranularity() {
     assumeThat(formatVersion).isEqualTo(2);
     checkUpdateFileGranularity(DeleteGranularity.FILE);
   }
 
-  @Test
+  @TestTemplate
   public void testUpdatePartitionGranularity() {
     assumeThat(formatVersion).isEqualTo(2);
     checkUpdateFileGranularity(DeleteGranularity.PARTITION);
   }
 
-  @Test
+  @TestTemplate
   public void testPositionDeletesAreMaintainedDuringUpdate() {
     // Range distribution will produce partition scoped deletes which will not be cleaned up
     assumeThat(distributionMode).isNotEqualToIgnoringCase("range");
@@ -111,7 +89,7 @@ public class TestMergeOnReadUpdate extends TestUpdate {
         sql("SELECT * FROM %s ORDER BY dep ASC, id ASC", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUnpartitionedPositionDeletesAreMaintainedDuringUpdate() {
     assumeThat(formatVersion).isEqualTo(2);
     // Range distribution will produce partition scoped deletes which will not be cleaned up
@@ -159,7 +137,7 @@ public class TestMergeOnReadUpdate extends TestUpdate {
         sql("SELECT * FROM %s ORDER BY dep ASC, id ASC", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithDVAndHistoricalPositionDeletes() {
     assumeThat(formatVersion).isEqualTo(2);
     createTableWithDeleteGranularity(

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -50,7 +50,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DistributionMode;
-import org.apache.iceberg.PlanningMode;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
@@ -73,44 +74,21 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.internal.SQLConf;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
 
-  public TestUpdate(
-      String catalogName,
-      String implementation,
-      Map<String, String> config,
-      String fileFormat,
-      boolean vectorized,
-      String distributionMode,
-      boolean fanoutEnabled,
-      String branch,
-      PlanningMode planningMode,
-      int formatVersion) {
-    super(
-        catalogName,
-        implementation,
-        config,
-        fileFormat,
-        vectorized,
-        distributionMode,
-        fanoutEnabled,
-        branch,
-        planningMode,
-        formatVersion);
-  }
-
-  @BeforeClass
+  @BeforeAll
   public static void setupSparkConf() {
     spark.conf().set("spark.sql.shuffle.partitions", "4");
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS updated_id");
@@ -118,7 +96,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("DROP TABLE IF EXISTS deleted_employee");
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithVectorizedReads() {
     assumeThat(supportsVectorization()).isTrue();
 
@@ -137,7 +115,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testCoalesceUpdate() {
     createAndInitTable("id INT, dep STRING");
 
@@ -197,13 +175,12 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
       validateProperty(snapshot, SnapshotSummary.ADDED_DELETE_FILES_PROP, "1");
     }
 
-    Assert.assertEquals(
-        "Row count must match",
-        200L,
-        scalarSql("SELECT COUNT(*) FROM %s WHERE id = -1", commitTarget()));
+    assertThat(scalarSql("SELECT COUNT(*) FROM %s WHERE id = -1", commitTarget()))
+        .as("Row count must match")
+        .isEqualTo(200L);
   }
 
-  @Test
+  @TestTemplate
   public void testSkewUpdate() {
     createAndInitTable("id INT, dep STRING");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -262,13 +239,12 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
       validateProperty(snapshot, SnapshotSummary.ADDED_DELETE_FILES_PROP, "4");
     }
 
-    Assert.assertEquals(
-        "Row count must match",
-        200L,
-        scalarSql("SELECT COUNT(*) FROM %s WHERE id = -1", commitTarget()));
+    assertThat(scalarSql("SELECT COUNT(*) FROM %s WHERE id = -1", commitTarget()))
+        .as("Row count must match")
+        .isEqualTo(200L);
   }
 
-  @Test
+  @TestTemplate
   public void testExplain() {
     createAndInitTable("id INT, dep STRING");
 
@@ -280,7 +256,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("EXPLAIN UPDATE %s SET dep = 'invalid' WHERE true", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 1 snapshot", 1, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 1 snapshot").hasSize(1);
 
     assertEquals(
         "Should have expected rows",
@@ -288,16 +264,16 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateEmptyTable() {
-    Assume.assumeFalse("Custom branch does not exist for empty table", "test".equals(branch));
+    assumeThat(branch).as("Custom branch does not exist for empty table").isNotEqualTo("test");
     createAndInitTable("id INT, dep STRING");
 
     sql("UPDATE %s SET dep = 'invalid' WHERE id IN (1)", commitTarget());
     sql("UPDATE %s SET id = -1 WHERE dep = 'hr'", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 2 snapshots", 2, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 2 snapshots").hasSize(2);
 
     assertEquals(
         "Should have expected rows",
@@ -305,9 +281,9 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateNonExistingCustomBranch() {
-    Assume.assumeTrue("Test only applicable to custom branch", "test".equals(branch));
+    assumeThat(branch).as("Test only applicable to custom branch").isEqualTo("test");
     createAndInitTable("id INT, dep STRING");
 
     assertThatThrownBy(() -> sql("UPDATE %s SET dep = 'invalid' WHERE id IN (1)", commitTarget()))
@@ -315,7 +291,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         .hasMessage("Cannot use branch (does not exist): test");
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithAlias() {
     createAndInitTable("id INT, dep STRING", "{ \"id\": 1, \"dep\": \"a\" }");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -323,7 +299,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("UPDATE %s AS t SET t.dep = 'invalid'", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 2 snapshots", 2, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 2 snapshots").hasSize(2);
 
     assertEquals(
         "Should have expected rows",
@@ -331,7 +307,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateAlignsAssignments() {
     createAndInitTable("id INT, c1 INT, c2 INT");
 
@@ -346,7 +322,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithUnsupportedPartitionPredicate() {
     createAndInitTable("id INT, dep STRING");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -362,7 +338,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithDynamicFileFiltering() {
     createAndInitTable("id INT, dep STRING");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -376,7 +352,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("UPDATE %s SET id = cast('-1' AS INT) WHERE id = 2", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 3 snapshots", 3, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 3 snapshots").hasSize(3);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
     if (mode(table) == COPY_ON_WRITE) {
@@ -391,7 +367,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id, dep", commitTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateNonExistingRecords() {
     createAndInitTable("id INT, dep STRING");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -402,7 +378,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("UPDATE %s SET id = -1 WHERE id > 10", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 2 snapshots", 2, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 2 snapshots").hasSize(2);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
     if (mode(table) == COPY_ON_WRITE) {
@@ -417,7 +393,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithoutCondition() {
     createAndInitTable("id INT, dep STRING");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -439,13 +415,13 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         });
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 4 snapshots", 4, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 4 snapshots").hasSize(4);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
 
-    Assert.assertEquals("Operation must match", OVERWRITE, currentSnapshot.operation());
+    assertThat(currentSnapshot.operation()).as("Operation must match").isEqualTo(OVERWRITE);
     if (mode(table) == COPY_ON_WRITE) {
-      Assert.assertEquals("Operation must match", OVERWRITE, currentSnapshot.operation());
+      assertThat(currentSnapshot.operation()).as("Operation must match").isEqualTo(OVERWRITE);
       validateProperty(currentSnapshot, CHANGED_PARTITION_COUNT_PROP, "2");
       validateProperty(currentSnapshot, DELETED_FILES_PROP, "3");
       validateProperty(currentSnapshot, ADDED_FILES_PROP, ImmutableSet.of("2", "3"));
@@ -461,7 +437,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY dep ASC", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithNullConditions() {
     createAndInitTable("id INT, dep STRING");
 
@@ -494,7 +470,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithInAndNotInConditions() {
     createAndInitTable("id INT, dep STRING");
 
@@ -524,9 +500,9 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST, dep", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithMultipleRowGroupsParquet() throws NoSuchTableException {
-    Assume.assumeTrue(fileFormat.equalsIgnoreCase("parquet"));
+    assumeThat(fileFormat).isEqualTo(FileFormat.PARQUET);
 
     createAndInitTable("id INT, dep STRING");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -548,15 +524,15 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     df.coalesce(1).writeTo(tableName).append();
     createBranchIfNeeded();
 
-    Assert.assertEquals(200, spark.table(commitTarget()).count());
+    assertThat(spark.table(commitTarget()).count()).isEqualTo(200);
 
     // update a record from one of two row groups and copy over the second one
     sql("UPDATE %s SET id = -1 WHERE id IN (200, 201)", commitTarget());
 
-    Assert.assertEquals(200, spark.table(commitTarget()).count());
+    assertThat(spark.table(commitTarget()).count()).isEqualTo(200);
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateNestedStructFields() {
     createAndInitTable(
         "id INT, s STRUCT<c1:INT,c2:STRUCT<a:ARRAY<INT>,m:MAP<STRING, STRING>>>",
@@ -589,7 +565,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithUserDefinedDistribution() {
     createAndInitTable("id INT, c2 INT, c3 INT");
     sql("ALTER TABLE %s ADD PARTITION FIELD bucket(8, c3)", tableName);
@@ -626,13 +602,13 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public synchronized void testUpdateWithSerializableIsolation() throws InterruptedException {
     // cannot run tests with concurrency for Hadoop tables without atomic renames
-    Assume.assumeFalse(catalogName.equalsIgnoreCase("testhadoop"));
+    assumeThat(catalogName).isNotEqualToIgnoringCase("testhadoop");
     // if caching is off, the table is eagerly refreshed during runtime filtering
     // this can cause a validation exception as concurrent changes would be visible
-    Assume.assumeTrue(cachingCatalogEnabled());
+    assumeThat(cachingCatalogEnabled()).isTrue();
 
     createAndInitTable("id INT, dep STRING");
 
@@ -655,9 +631,11 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> barrier.get() >= currentNumOperations * 2);
 
                 sql("UPDATE %s SET id = -1 WHERE id = 1", commitTarget());
 
@@ -677,9 +655,11 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> !shouldAppend.get() || barrier.get() >= currentNumOperations * 2);
 
                 if (!shouldAppend.get()) {
                   return;
@@ -693,7 +673,6 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                   }
 
                   appendFiles.commit();
-                  sleep(10);
                 }
 
                 barrier.incrementAndGet();
@@ -712,17 +691,17 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     }
 
     executorService.shutdown();
-    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    assertThat(executorService.awaitTermination(2, TimeUnit.MINUTES)).as("Timeout").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public synchronized void testUpdateWithSnapshotIsolation()
       throws InterruptedException, ExecutionException {
     // cannot run tests with concurrency for Hadoop tables without atomic renames
-    Assume.assumeFalse(catalogName.equalsIgnoreCase("testhadoop"));
+    assumeThat(catalogName).isNotEqualToIgnoringCase("testhadoop");
     // if caching is off, the table is eagerly refreshed during runtime filtering
     // this can cause a validation exception as concurrent changes would be visible
-    Assume.assumeTrue(cachingCatalogEnabled());
+    assumeThat(cachingCatalogEnabled()).isTrue();
 
     createAndInitTable("id INT, dep STRING");
 
@@ -745,9 +724,11 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         executorService.submit(
             () -> {
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> barrier.get() >= currentNumOperations * 2);
 
                 sql("UPDATE %s SET id = -1 WHERE id = 1", tableName);
 
@@ -767,9 +748,11 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
-                  sleep(10);
-                }
+                int currentNumOperations = numOperations;
+                Awaitility.await()
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .until(() -> !shouldAppend.get() || barrier.get() >= currentNumOperations * 2);
 
                 if (!shouldAppend.get()) {
                   return;
@@ -783,7 +766,6 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                   }
 
                   appendFiles.commit();
-                  sleep(10);
                 }
 
                 barrier.incrementAndGet();
@@ -798,10 +780,10 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     }
 
     executorService.shutdown();
-    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    assertThat(executorService.awaitTermination(2, TimeUnit.MINUTES)).as("Timeout").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithInferredCasts() {
     createAndInitTable("id INT, s STRING", "{ \"id\": 1, \"s\": \"value\" }");
 
@@ -813,7 +795,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateModifiesNullStruct() {
     createAndInitTable("id INT, s STRUCT<n1:INT,n2:INT>", "{ \"id\": 1, \"s\": null }");
 
@@ -825,7 +807,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateRefreshesRelationCache() {
     createAndInitTable("id INT, dep STRING");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -850,7 +832,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("UPDATE %s SET id = -1 WHERE id = 1", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 3 snapshots", 3, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 3 snapshots").hasSize(3);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
     if (mode(table) == COPY_ON_WRITE) {
@@ -872,7 +854,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     spark.sql("UNCACHE TABLE tmp");
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithInSubquery() {
     createAndInitTable("id INT, dep STRING");
 
@@ -922,7 +904,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST, dep", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithInSubqueryAndDynamicFileFiltering() {
     createAndInitTable("id INT, dep STRING");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -940,7 +922,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("UPDATE %s SET id = -1 WHERE id IN (SELECT * FROM updated_id)", commitTarget());
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals("Should have 3 snapshots", 3, Iterables.size(table.snapshots()));
+    assertThat(table.snapshots()).as("Should have 3 snapshots").hasSize(3);
 
     Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
     if (mode(table) == COPY_ON_WRITE) {
@@ -955,7 +937,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id, dep", commitTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithSelfSubquery() {
     createAndInitTable("id INT, dep STRING");
 
@@ -991,7 +973,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id, dep", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithMultiColumnInSubquery() {
     createAndInitTable("id INT, dep STRING");
 
@@ -1015,7 +997,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithNotInSubquery() {
     createAndInitTable("id INT, dep STRING");
 
@@ -1053,7 +1035,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST, dep", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithExistSubquery() {
     createAndInitTable("id INT, dep STRING");
 
@@ -1105,7 +1087,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id, dep", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithNotExistsSubquery() {
     createAndInitTable("id INT, dep STRING");
 
@@ -1148,7 +1130,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id, dep", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithScalarSubquery() {
     createAndInitTable("id INT, dep STRING");
 
@@ -1175,7 +1157,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateThatRequiresGroupingBeforeWrite() {
     createAndInitTable("id INT, dep STRING");
     sql("ALTER TABLE %s ADD PARTITION FIELD dep", tableName);
@@ -1213,14 +1195,15 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
       spark.conf().set("spark.sql.shuffle.partitions", "1");
 
       sql("UPDATE %s t SET id = -1 WHERE id IN (SELECT * FROM updated_id)", commitTarget());
-      Assert.assertEquals(
-          "Should have expected num of rows", 12L, spark.table(commitTarget()).count());
+      assertThat(spark.table(commitTarget()).count())
+          .as("Should have expected num of rows")
+          .isEqualTo(12L);
     } finally {
       spark.conf().set("spark.sql.shuffle.partitions", originalNumOfShufflePartitions);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithVectorization() {
     createAndInitTable("id INT, dep STRING");
 
@@ -1243,7 +1226,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateModifyPartitionSourceField() throws NoSuchTableException {
     createAndInitTable("id INT, dep STRING, country STRING");
 
@@ -1283,10 +1266,10 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql(
         "UPDATE %s SET id = -1 WHERE id IN (10, 11, 12, 13, 14, 15, 16, 17, 18, 19)",
         commitTarget());
-    Assert.assertEquals(30L, scalarSql("SELECT count(*) FROM %s WHERE id = -1", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s WHERE id = -1", selectTarget())).isEqualTo(30L);
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithStaticPredicatePushdown() {
     createAndInitTable("id INT, dep STRING");
 
@@ -1303,7 +1286,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
 
     Snapshot snapshot = SnapshotUtil.latestSnapshot(table, branch);
     String dataFilesCount = snapshot.summary().get(SnapshotSummary.TOTAL_DATA_FILES_PROP);
-    Assert.assertEquals("Must have 2 files before UPDATE", "2", dataFilesCount);
+    assertThat(dataFilesCount).as("Must have 2 files before UPDATE").isEqualTo("2");
 
     // remove the data file from the 'hr' partition to ensure it is not scanned
     DataFile dataFile = Iterables.getOnlyElement(snapshot.addedDataFiles(table.io()));
@@ -1317,7 +1300,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithInvalidUpdates() {
     createAndInitTable(
         "id INT, a ARRAY<STRUCT<c1:INT,c2:INT>>, m MAP<STRING,STRING>",
@@ -1332,7 +1315,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         .hasMessageContaining("Updating nested fields is only supported for structs");
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithConflictingAssignments() {
     createAndInitTable(
         "id INT, c STRUCT<n1:INT,n2:STRUCT<dn1:INT,dn2:INT>>", "{ \"id\": 0, \"s\": null }");
@@ -1355,7 +1338,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         .hasMessageStartingWith("Updates are in conflict for these columns");
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithInvalidAssignments() {
     createAndInitTable(
         "id INT NOT NULL, s STRUCT<n1:INT NOT NULL,n2:STRUCT<dn1:INT,dn2:INT>> NOT NULL",
@@ -1393,7 +1376,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithNonDeterministicCondition() {
     createAndInitTable("id INT, dep STRING", "{ \"id\": 1, \"dep\": \"hr\" }");
 
@@ -1404,7 +1387,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
             "nondeterministic expressions are only allowed in Project, Filter, Aggregate or Window");
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateOnNonIcebergTableNotSupported() {
     createOrReplaceView("testtable", "{ \"c1\": -100, \"c2\": -200 }");
 
@@ -1413,9 +1396,9 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         .hasMessage("UPDATE TABLE is not supported temporarily.");
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateToWAPBranch() {
-    Assume.assumeTrue("WAP branch only works for table identifier without branch", branch == null);
+    assumeThat(branch).as("WAP branch only works for table identifier without branch").isNull();
 
     createAndInitTable(
         "id INT, dep STRING", "{ \"id\": 1, \"dep\": \"hr\" }\n" + "{ \"id\": 2, \"dep\": \"a\" }");
@@ -1427,42 +1410,36 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, "wap"),
         () -> {
           sql("UPDATE %s SET dep='hr' WHERE dep='a'", tableName);
-          Assert.assertEquals(
-              "Should have expected num of rows when reading table",
-              2L,
-              sql("SELECT * FROM %s WHERE dep='hr'", tableName).size());
-          Assert.assertEquals(
-              "Should have expected num of rows when reading WAP branch",
-              2L,
-              sql("SELECT * FROM %s.branch_wap WHERE dep='hr'", tableName).size());
-          Assert.assertEquals(
-              "Should not modify main branch",
-              1L,
-              sql("SELECT * FROM %s.branch_main WHERE dep='hr'", tableName).size());
+          assertThat(sql("SELECT * FROM %s WHERE dep='hr'", tableName))
+              .as("Should have expected num of rows when reading table")
+              .hasSize(2);
+          assertThat(sql("SELECT * FROM %s.branch_wap WHERE dep='hr'", tableName))
+              .as("Should have expected num of rows when reading WAP branch")
+              .hasSize(2);
+          assertThat(sql("SELECT * FROM %s.branch_main WHERE dep='hr'", tableName))
+              .as("Should not modify main branch")
+              .hasSize(1);
         });
 
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.WAP_BRANCH, "wap"),
         () -> {
           sql("UPDATE %s SET dep='b' WHERE dep='hr'", tableName);
-          Assert.assertEquals(
-              "Should have expected num of rows when reading table with multiple writes",
-              2L,
-              sql("SELECT * FROM %s WHERE dep='b'", tableName).size());
-          Assert.assertEquals(
-              "Should have expected num of rows when reading WAP branch with multiple writes",
-              2L,
-              sql("SELECT * FROM %s.branch_wap WHERE dep='b'", tableName).size());
-          Assert.assertEquals(
-              "Should not modify main branch with multiple writes",
-              0L,
-              sql("SELECT * FROM %s.branch_main WHERE dep='b'", tableName).size());
+          assertThat(sql("SELECT * FROM %s WHERE dep='b'", tableName))
+              .as("Should have expected num of rows when reading table with multiple writes")
+              .hasSize(2);
+          assertThat(sql("SELECT * FROM %s.branch_wap WHERE dep='b'", tableName))
+              .as("Should have expected num of rows when reading WAP branch with multiple writes")
+              .hasSize(2);
+          assertThat(sql("SELECT * FROM %s.branch_main WHERE dep='b'", tableName))
+              .as("Should not modify main branch with multiple writes")
+              .hasSize(0);
         });
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateToWapBranchWithTableBranchIdentifier() {
-    Assume.assumeTrue("Test must have branch name part in table identifier", branch != null);
+    assumeThat(branch).as("Test must have branch name part in table identifier").isNotNull();
 
     createAndInitTable("id INT, dep STRING", "{ \"id\": 1, \"dep\": \"hr\" }");
     sql(

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
@@ -79,7 +80,9 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
 
   @BeforeAll

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadMerge.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadMerge.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
@@ -40,7 +41,9 @@ import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.Encoders;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestMergeOnReadMerge extends TestMerge {
 
   @Override


### PR DESCRIPTION
*Migrate Spark 3.4 tests based on JUnit 4 to Junit5 with AssertJ style. This is related to https://github.com/apache/iceberg/issues/7160*

This PR migrates `SparkRowLevelOperationsTestBase` related tests in Spark 3.4 into JUnit 5 with AssertJ. The following classes are included in this PR:

- `SparkRowLevelOperationsTestBase`
    - `TestDelete`, and `TestCopyOnWriteDelete`/`TestMergeOnReadDelete`
    - `TestMerge`,  and `TestCopyOnWriteMerge`/`TestMergeOnReadMerge`
    - `TestUpdate`, and  `TestCopyOnWriteUpdate`/`TestMergeOnReadUpdate`