### PR TITLE
Spark, API: Enhance hashing efficiency by operating on raw UTF-8 bytes

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
@@ -67,6 +67,10 @@ public class BucketUtil {
     return MURMUR3.hashString(value, StandardCharsets.UTF_8).asInt();
   }
 
+  public static int hash(byte[] value) {
+    return MURMUR3.hashBytes(value).asInt();
+  }
+
   public static int hash(ByteBuffer value) {
     if (value.hasArray()) {
       return MURMUR3

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -222,6 +222,11 @@ public class BucketFunction implements UnboundFunction {
       return BucketUtil.hash(value);
     }
 
+    // Visible for testing
+    public static int hash(String value) {
+      return BucketUtil.hash(value);
+    }
+
     @Override
     public DataType[] inputTypes() {
       return new DataType[] {DataTypes.IntegerType, DataTypes.StringType};

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -214,12 +214,11 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      // TODO - We can probably hash the bytes directly given they're already UTF-8 input.
-      return apply(numBuckets, hash(value.toString()));
+      return apply(numBuckets, hash(value.getBytes()));
     }
 
     // Visible for testing
-    public static int hash(String value) {
+    public static int hash(byte[] value) {
       return BucketUtil.hash(value);
     }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -82,7 +82,7 @@ public class TestSparkBucketFunction extends SparkTestBaseWithCatalog {
     Assert.assertEquals(
         "Spec example: hash(\"iceberg\") = 1210000089",
         1210000089,
-        new BucketFunction.BucketString().hash("iceberg".getBytes(StandardCharsets.UTF_8)));
+        new BucketFunction.BucketString().hash("iceberg"));
 
     Assert.assertEquals(
         "Verify that the hash string and hash raw bytes produce the same result",

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -82,7 +82,7 @@ public class TestSparkBucketFunction extends SparkTestBaseWithCatalog {
     Assert.assertEquals(
         "Spec example: hash(\"iceberg\") = 1210000089",
         1210000089,
-        new BucketFunction.BucketString().hash("iceberg"));
+        new BucketFunction.BucketString().hash("iceberg".getBytes(StandardCharsets.UTF_8)));
 
     ByteBuffer bytes = ByteBuffer.wrap(new byte[] {0, 1, 2, 3});
     Assert.assertEquals(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -84,6 +84,11 @@ public class TestSparkBucketFunction extends SparkTestBaseWithCatalog {
         1210000089,
         new BucketFunction.BucketString().hash("iceberg".getBytes(StandardCharsets.UTF_8)));
 
+    Assert.assertEquals(
+        "Verify that the hash string and hash raw bytes produce the same result",
+        new BucketFunction.BucketString().hash("iceberg"),
+        new BucketFunction.BucketString().hash("iceberg".getBytes(StandardCharsets.UTF_8)));
+
     ByteBuffer bytes = ByteBuffer.wrap(new byte[] {0, 1, 2, 3});
     Assert.assertEquals(
         "Spec example: hash([00 01 02 03]) = -188683207",

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -222,6 +222,11 @@ public class BucketFunction implements UnboundFunction {
       return BucketUtil.hash(value);
     }
 
+    // Visible for testing
+    public static int hash(String value) {
+      return BucketUtil.hash(value);
+    }
+
     @Override
     public DataType[] inputTypes() {
       return new DataType[] {DataTypes.IntegerType, DataTypes.StringType};

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -214,12 +214,11 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      // TODO - We can probably hash the bytes directly given they're already UTF-8 input.
-      return apply(numBuckets, hash(value.toString()));
+      return apply(numBuckets, hash(value.getBytes()));
     }
 
     // Visible for testing
-    public static int hash(String value) {
+    public static int hash(byte[] value) {
       return BucketUtil.hash(value);
     }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -78,6 +78,10 @@ public class TestSparkBucketFunction extends TestBaseWithCatalog {
         .as("Spec example: hash(\"iceberg\") = 1210000089")
         .isEqualTo(1210000089);
 
+    assertThat(new BucketFunction.BucketString().hash("iceberg".getBytes(StandardCharsets.UTF_8)))
+        .as("Verify that the hash string and hash raw bytes produce the same result")
+        .isEqualTo(new BucketFunction.BucketString().hash("iceberg"));
+
     ByteBuffer bytes = ByteBuffer.wrap(new byte[] {0, 1, 2, 3});
     assertThat(new BucketFunction.BucketBinary().hash(bytes))
         .as("Spec example: hash([00 01 02 03]) = -188683207")

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -74,7 +74,7 @@ public class TestSparkBucketFunction extends TestBaseWithCatalog {
         .as("Spec example: hash(2017-11-16T22:31:08) = -2047944441")
         .isEqualTo(-2047944441);
 
-    assertThat(new BucketFunction.BucketString().hash("iceberg".getBytes(StandardCharsets.UTF_8)))
+    assertThat(new BucketFunction.BucketString().hash("iceberg"))
         .as("Spec example: hash(\"iceberg\") = 1210000089")
         .isEqualTo(1210000089);
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -74,7 +74,7 @@ public class TestSparkBucketFunction extends TestBaseWithCatalog {
         .as("Spec example: hash(2017-11-16T22:31:08) = -2047944441")
         .isEqualTo(-2047944441);
 
-    assertThat(new BucketFunction.BucketString().hash("iceberg"))
+    assertThat(new BucketFunction.BucketString().hash("iceberg".getBytes(StandardCharsets.UTF_8)))
         .as("Spec example: hash(\"iceberg\") = 1210000089")
         .isEqualTo(1210000089);
 


### PR DESCRIPTION
This change removes unnecessary `toString()` conversions by directly processing UTF-8 bytes, improving efficiency and reducing memory allocations.