### PR TITLE
API, Core: Geospatial bounds and spatial predicates

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/BoundGeospatialPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundGeospatialPredicate.java
@@ -36,7 +36,10 @@ public class BoundGeospatialPredicate extends BoundPredicate<ByteBuffer> {
 
   @Override
   public boolean test(ByteBuffer value) {
-    return true;
+    throw new UnsupportedOperationException(
+        "Evaluation of spatial predicate \""
+            + op()
+            + "\" against geometry/geography value is not implemented.");
   }
 
   @Override
@@ -56,13 +59,14 @@ public class BoundGeospatialPredicate extends BoundPredicate<ByteBuffer> {
 
   @Override
   public boolean isEquivalentTo(Expression expr) {
-    if (expr instanceof BoundGeospatialPredicate) {
-      BoundGeospatialPredicate other = (BoundGeospatialPredicate) expr;
-      return op() == other.op()
-          && term().isEquivalentTo(other.term())
-          && literal.value().equals(other.literal.value());
+    if (!(expr instanceof BoundGeospatialPredicate)) {
+      return false;
     }
-    return false;
+
+    BoundGeospatialPredicate other = (BoundGeospatialPredicate) expr;
+    return op() == other.op()
+        && term().isEquivalentTo(other.term())
+        && literal.value().equals(other.literal.value());
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundGeospatialPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundGeospatialPredicate.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import java.nio.ByteBuffer;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
+
+public class BoundGeospatialPredicate extends BoundPredicate<ByteBuffer> {
+  private final Literal<GeospatialBoundingBox> literal;
+
+  BoundGeospatialPredicate(
+      Operation op, BoundTerm<ByteBuffer> term, Literal<GeospatialBoundingBox> literal) {
+    super(op, term);
+    this.literal = literal;
+  }
+
+  public Literal<GeospatialBoundingBox> literal() {
+    return literal;
+  }
+
+  @Override
+  public boolean test(ByteBuffer value) {
+    return true;
+  }
+
+  @Override
+  public boolean isGeospatialPredicate() {
+    return true;
+  }
+
+  @Override
+  public BoundGeospatialPredicate asGeospatialPredicate() {
+    return this;
+  }
+
+  @Override
+  public Expression negate() {
+    return new BoundGeospatialPredicate(op().negate(), term(), literal);
+  }
+
+  @Override
+  public boolean isEquivalentTo(Expression expr) {
+    if (expr instanceof BoundGeospatialPredicate) {
+      BoundGeospatialPredicate other = (BoundGeospatialPredicate) expr;
+      return op() == other.op()
+          && term().isEquivalentTo(other.term())
+          && literal.value().equals(other.literal.value());
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    switch (op()) {
+      case ST_INTERSECTS:
+        return term().toString() + " stIntersects " + literal.value();
+      case ST_DISJOINT:
+        return term().toString() + " stDisjoint " + literal.value();
+      default:
+        return "Invalid geospatial predicate: operation = " + op();
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundGeospatialPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundGeospatialPredicate.java
@@ -19,18 +19,17 @@
 package org.apache.iceberg.expressions;
 
 import java.nio.ByteBuffer;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
+import org.apache.iceberg.geospatial.BoundingBox;
 
 public class BoundGeospatialPredicate extends BoundPredicate<ByteBuffer> {
-  private final Literal<GeospatialBoundingBox> literal;
+  private final Literal<BoundingBox> literal;
 
-  BoundGeospatialPredicate(
-      Operation op, BoundTerm<ByteBuffer> term, Literal<GeospatialBoundingBox> literal) {
+  BoundGeospatialPredicate(Operation op, BoundTerm<ByteBuffer> term, Literal<BoundingBox> literal) {
     super(op, term);
     this.literal = literal;
   }
 
-  public Literal<GeospatialBoundingBox> literal() {
+  public Literal<BoundingBox> literal() {
     return literal;
   }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundPredicate.java
@@ -65,4 +65,12 @@ public abstract class BoundPredicate<T> extends Predicate<T, BoundTerm<T>>
   public BoundSetPredicate<T> asSetPredicate() {
     throw new IllegalStateException("Not a set predicate: " + this);
   }
+
+  public boolean isGeospatialPredicate() {
+    return false;
+  }
+
+  public BoundGeospatialPredicate asGeospatialPredicate() {
+    throw new IllegalStateException("Not a geospatial predicate: " + this);
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -160,16 +160,14 @@ public class Evaluator implements Serializable {
 
     @Override
     public <T> Boolean stIntersects(Bound<T> valueExpr, Literal<GeospatialBoundingBox> literal) {
-      // We don't know how to evaluate ST_Intersects, so we return true to be safe.
-      // Reading data using GenericReader with spaital filters will yield false positives.
-      return true;
+      throw new UnsupportedOperationException(
+          "Evaluation of stIntersects against geometry/geography value is not implemented.");
     }
 
     @Override
     public <T> Boolean stDisjoint(Bound<T> valueExpr, Literal<GeospatialBoundingBox> literal) {
-      // We don't know how to evaluate ST_Disjoint, so we return true to be safe.
-      // Reading data using GenericReader with spaital filters will yield false positives.
-      return true;
+      throw new UnsupportedOperationException(
+          "Evaluation of stDisjoint against geometry/geography value is not implemented.");
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.Set;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundVisitor;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.NaNUtil;
 
@@ -155,6 +156,20 @@ public class Evaluator implements Serializable {
     @Override
     public <T> Boolean notStartsWith(Bound<T> valueExpr, Literal<T> lit) {
       return !startsWith(valueExpr, lit);
+    }
+
+    @Override
+    public <T> Boolean stIntersects(Bound<T> valueExpr, Literal<GeospatialBoundingBox> literal) {
+      // We don't know how to evaluate ST_Intersects, so we return true to be safe.
+      // Reading data using GenericReader with spaital filters will yield false positives.
+      return true;
+    }
+
+    @Override
+    public <T> Boolean stDisjoint(Bound<T> valueExpr, Literal<GeospatialBoundingBox> literal) {
+      // We don't know how to evaluate ST_Disjoint, so we return true to be safe.
+      // Reading data using GenericReader with spaital filters will yield false positives.
+      return true;
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -23,7 +23,7 @@ import java.util.Comparator;
 import java.util.Set;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundVisitor;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.NaNUtil;
 
@@ -159,13 +159,13 @@ public class Evaluator implements Serializable {
     }
 
     @Override
-    public <T> Boolean stIntersects(Bound<T> valueExpr, Literal<GeospatialBoundingBox> literal) {
+    public <T> Boolean stIntersects(Bound<T> valueExpr, Literal<BoundingBox> literal) {
       throw new UnsupportedOperationException(
           "Evaluation of stIntersects against geometry/geography value is not implemented.");
     }
 
     @Override
-    public <T> Boolean stDisjoint(Bound<T> valueExpr, Literal<GeospatialBoundingBox> literal) {
+    public <T> Boolean stDisjoint(Bound<T> valueExpr, Literal<BoundingBox> literal) {
       throw new UnsupportedOperationException(
           "Evaluation of stDisjoint against geometry/geography value is not implemented.");
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expression.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expression.java
@@ -44,6 +44,8 @@ public interface Expression extends Serializable {
     OR,
     STARTS_WITH,
     NOT_STARTS_WITH,
+    ST_INTERSECTS,
+    ST_DISJOINT,
     COUNT,
     COUNT_STAR,
     MAX,
@@ -90,6 +92,10 @@ public interface Expression extends Serializable {
           return Operation.NOT_STARTS_WITH;
         case NOT_STARTS_WITH:
           return Operation.STARTS_WITH;
+        case ST_INTERSECTS:
+          return Operation.ST_DISJOINT;
+        case ST_DISJOINT:
+          return Operation.ST_INTERSECTS;
         default:
           throw new IllegalArgumentException("No negation for operation: " + this);
       }

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.transforms.Transforms;
@@ -315,7 +315,7 @@ public class ExpressionUtil {
       } else if (pred.isGeospatialPredicate()) {
         BoundGeospatialPredicate bound = (BoundGeospatialPredicate) pred;
         return Expressions.geospatialPredicate(
-            pred.op(), unbind(bound.term()), GeospatialBoundingBox.SANITIZED);
+            pred.op(), unbind(bound.term()), BoundingBox.empty());
       }
 
       throw new UnsupportedOperationException("Cannot sanitize bound predicate type: " + pred.op());
@@ -344,7 +344,7 @@ public class ExpressionUtil {
         case ST_INTERSECTS:
         case ST_DISJOINT:
           return Expressions.geospatialPredicate(
-              pred.op(), (UnboundTerm<ByteBuffer>) pred.term(), GeospatialBoundingBox.SANITIZED);
+              pred.op(), (UnboundTerm<ByteBuffer>) pred.term(), BoundingBox.empty());
         case IN:
         case NOT_IN:
           Iterable<T> iter =
@@ -496,9 +496,9 @@ public class ExpressionUtil {
         case NOT_STARTS_WITH:
           return term + " NOT STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
         case ST_INTERSECTS:
-          return term + " ST_INTERSECTS WITH " + GeospatialBoundingBox.SANITIZED;
+          return term + " ST_INTERSECTS WITH (bounding-box)";
         case ST_DISJOINT:
-          return term + " ST_DISJOINT WITH " + GeospatialBoundingBox.SANITIZED;
+          return term + " ST_DISJOINT WITH (bounding-box)";
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.transforms.Transforms;
@@ -310,6 +312,10 @@ public class ExpressionUtil {
                     .map(lit -> (T) sanitize(bound.term().type(), lit, now, today))
                     .iterator();
         return new UnboundPredicate<>(pred.op(), unbind(pred.term()), iter);
+      } else if (pred.isGeospatialPredicate()) {
+        BoundGeospatialPredicate bound = (BoundGeospatialPredicate) pred;
+        return Expressions.geospatialPredicate(
+            pred.op(), unbind(bound.term()), GeospatialBoundingBox.SANITIZED);
       }
 
       throw new UnsupportedOperationException("Cannot sanitize bound predicate type: " + pred.op());
@@ -335,6 +341,10 @@ public class ExpressionUtil {
         case NOT_STARTS_WITH:
           return new UnboundPredicate<>(
               pred.op(), pred.term(), (T) sanitize(pred.literal(), now, today));
+        case ST_INTERSECTS:
+        case ST_DISJOINT:
+          return Expressions.geospatialPredicate(
+              pred.op(), (UnboundTerm<ByteBuffer>) pred.term(), GeospatialBoundingBox.SANITIZED);
         case IN:
         case NOT_IN:
           Iterable<T> iter =
@@ -485,6 +495,10 @@ public class ExpressionUtil {
           return term + " STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
         case NOT_STARTS_WITH:
           return term + " NOT STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
+        case ST_INTERSECTS:
+          return term + " ST_INTERSECTS WITH " + GeospatialBoundingBox.SANITIZED;
+        case ST_DISJOINT:
+          return term + " ST_DISJOINT WITH " + GeospatialBoundingBox.SANITIZED;
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.expressions;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
+import org.apache.iceberg.geospatial.BoundingBox;
 
 /** Utils for traversing {@link Expression expressions}. */
 public class ExpressionVisitors {
@@ -127,12 +127,12 @@ public class ExpressionVisitors {
           "notStartsWith expression is not supported by the visitor");
     }
 
-    public <T> R stIntersects(BoundReference<T> ref, Literal<GeospatialBoundingBox> lit) {
+    public <T> R stIntersects(BoundReference<T> ref, Literal<BoundingBox> lit) {
       throw new UnsupportedOperationException(
           "stIntersects expression is not supported by the visitor");
     }
 
-    public <T> R stDisjoint(BoundReference<T> ref, Literal<GeospatialBoundingBox> lit) {
+    public <T> R stDisjoint(BoundReference<T> ref, Literal<BoundingBox> lit) {
       throw new UnsupportedOperationException(
           "stDisjoint expression is not supported by the visitor");
     }
@@ -290,11 +290,11 @@ public class ExpressionVisitors {
       throw new UnsupportedOperationException("Unsupported operation.");
     }
 
-    public <T> R stIntersects(Bound<T> term, Literal<GeospatialBoundingBox> literal) {
+    public <T> R stIntersects(Bound<T> term, Literal<BoundingBox> literal) {
       throw new UnsupportedOperationException("ST_INTERSECTS is not supported by the visitor");
     }
 
-    public <T> R stDisjoint(Bound<T> term, Literal<GeospatialBoundingBox> literal) {
+    public <T> R stDisjoint(Bound<T> term, Literal<BoundingBox> literal) {
       throw new UnsupportedOperationException("ST_DISJOINT is not supported by the visitor");
     }
 
@@ -602,11 +602,11 @@ public class ExpressionVisitors {
       return null;
     }
 
-    public <T> R stIntersects(BoundTerm<T> term, Literal<GeospatialBoundingBox> lit) {
+    public <T> R stIntersects(BoundTerm<T> term, Literal<BoundingBox> lit) {
       return null;
     }
 
-    public <T> R stDisjoint(BoundTerm<T> term, Literal<GeospatialBoundingBox> lit) {
+    public <T> R stDisjoint(BoundTerm<T> term, Literal<BoundingBox> lit) {
       return null;
     }
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.expressions;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 
 /** Utils for traversing {@link Expression expressions}. */
 public class ExpressionVisitors {
@@ -126,6 +127,16 @@ public class ExpressionVisitors {
           "notStartsWith expression is not supported by the visitor");
     }
 
+    public <T> R stIntersects(BoundReference<T> ref, Literal<GeospatialBoundingBox> lit) {
+      throw new UnsupportedOperationException(
+          "stIntersects expression is not supported by the visitor");
+    }
+
+    public <T> R stDisjoint(BoundReference<T> ref, Literal<GeospatialBoundingBox> lit) {
+      throw new UnsupportedOperationException(
+          "stDisjoint expression is not supported by the visitor");
+    }
+
     /**
      * Handle a non-reference value in this visitor.
      *
@@ -195,6 +206,19 @@ public class ExpressionVisitors {
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundSetPredicate: " + pred.op());
+        }
+
+      } else if (pred.isGeospatialPredicate()) {
+        switch (pred.op()) {
+          case ST_INTERSECTS:
+            return stIntersects(
+                (BoundReference<T>) pred.term(), pred.asGeospatialPredicate().literal());
+          case ST_DISJOINT:
+            return stDisjoint(
+                (BoundReference<T>) pred.term(), pred.asGeospatialPredicate().literal());
+          default:
+            throw new IllegalStateException(
+                "Invalid operation for BoundGeospatialPredicate: " + pred.op());
         }
       }
 
@@ -266,6 +290,14 @@ public class ExpressionVisitors {
       throw new UnsupportedOperationException("Unsupported operation.");
     }
 
+    public <T> R stIntersects(Bound<T> term, Literal<GeospatialBoundingBox> literal) {
+      throw new UnsupportedOperationException("ST_INTERSECTS is not supported by the visitor");
+    }
+
+    public <T> R stDisjoint(Bound<T> term, Literal<GeospatialBoundingBox> literal) {
+      throw new UnsupportedOperationException("ST_DISJOINT is not supported by the visitor");
+    }
+
     @Override
     public <T> R predicate(BoundPredicate<T> pred) {
       if (pred.isLiteralPredicate()) {
@@ -317,8 +349,15 @@ public class ExpressionVisitors {
             throw new IllegalStateException(
                 "Invalid operation for BoundSetPredicate: " + pred.op());
         }
-      }
 
+      } else if (pred.isGeospatialPredicate()) {
+        switch (pred.op()) {
+          case ST_INTERSECTS:
+            return stIntersects(pred.term(), pred.asGeospatialPredicate().literal());
+          case ST_DISJOINT:
+            return stDisjoint(pred.term(), pred.asGeospatialPredicate().literal());
+        }
+      }
       throw new IllegalStateException("Unsupported bound predicate: " + pred.getClass().getName());
     }
 
@@ -495,6 +534,13 @@ public class ExpressionVisitors {
             throw new IllegalStateException(
                 "Invalid operation for BoundSetPredicate: " + pred.op());
         }
+      } else if (pred.isGeospatialPredicate()) {
+        switch (pred.op()) {
+          case ST_INTERSECTS:
+            return stIntersects(pred.term(), pred.asGeospatialPredicate().literal());
+          case ST_DISJOINT:
+            return stDisjoint(pred.term(), pred.asGeospatialPredicate().literal());
+        }
       }
 
       throw new IllegalStateException("Unsupported bound predicate: " + pred.getClass().getName());
@@ -553,6 +599,14 @@ public class ExpressionVisitors {
     }
 
     public <T> R notStartsWith(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R stIntersects(BoundTerm<T> term, Literal<GeospatialBoundingBox> lit) {
+      return null;
+    }
+
+    public <T> R stDisjoint(BoundTerm<T> term, Literal<GeospatialBoundingBox> lit) {
       return null;
     }
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -18,8 +18,10 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.nio.ByteBuffer;
 import java.util.stream.Stream;
 import org.apache.iceberg.expressions.Expression.Operation;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.transforms.Transform;
@@ -202,6 +204,45 @@ public class Expressions {
     return new UnboundPredicate<>(Expression.Operation.NOT_STARTS_WITH, expr, value);
   }
 
+  public static UnboundPredicate<ByteBuffer> stIntersects(
+      String name, GeospatialBoundingBox value) {
+    return geospatialPredicate(Operation.ST_INTERSECTS, name, value);
+  }
+
+  public static UnboundPredicate<ByteBuffer> stIntersects(
+      String name, ByteBuffer min, ByteBuffer max) {
+    return geospatialPredicate(Operation.ST_INTERSECTS, name, min, max);
+  }
+
+  public static UnboundPredicate<ByteBuffer> stIntersects(
+      UnboundTerm<ByteBuffer> expr, GeospatialBoundingBox value) {
+    return geospatialPredicate(Operation.ST_INTERSECTS, expr, value);
+  }
+
+  public static UnboundPredicate<ByteBuffer> stIntersects(
+      UnboundTerm<ByteBuffer> expr, ByteBuffer min, ByteBuffer max) {
+    return geospatialPredicate(Operation.ST_INTERSECTS, expr, min, max);
+  }
+
+  public static UnboundPredicate<ByteBuffer> stDisjoint(String name, GeospatialBoundingBox value) {
+    return geospatialPredicate(Operation.ST_DISJOINT, name, value);
+  }
+
+  public static UnboundPredicate<ByteBuffer> stDisjoint(
+      String name, ByteBuffer min, ByteBuffer max) {
+    return geospatialPredicate(Operation.ST_DISJOINT, name, min, max);
+  }
+
+  public static UnboundPredicate<ByteBuffer> stDisjoint(
+      UnboundTerm<ByteBuffer> expr, GeospatialBoundingBox value) {
+    return geospatialPredicate(Operation.ST_DISJOINT, expr, value);
+  }
+
+  public static UnboundPredicate<ByteBuffer> stDisjoint(
+      UnboundTerm<ByteBuffer> expr, ByteBuffer min, ByteBuffer max) {
+    return geospatialPredicate(Operation.ST_DISJOINT, expr, min, max);
+  }
+
   public static <T> UnboundPredicate<T> in(String name, T... values) {
     return predicate(Operation.IN, name, Lists.newArrayList(values));
   }
@@ -278,6 +319,27 @@ public class Expressions {
 
   public static <T> UnboundPredicate<T> predicate(Operation op, UnboundTerm<T> expr) {
     return new UnboundPredicate<>(op, expr);
+  }
+
+  public static UnboundPredicate<ByteBuffer> geospatialPredicate(
+      Operation op, String name, GeospatialBoundingBox value) {
+    return geospatialPredicate(
+        op, ref(name), value.min().toByteBuffer(), value.max().toByteBuffer());
+  }
+
+  public static UnboundPredicate<ByteBuffer> geospatialPredicate(
+      Operation op, UnboundTerm<ByteBuffer> expr, GeospatialBoundingBox value) {
+    return geospatialPredicate(op, expr, value.min().toByteBuffer(), value.max().toByteBuffer());
+  }
+
+  public static UnboundPredicate<ByteBuffer> geospatialPredicate(
+      Operation op, String name, ByteBuffer min, ByteBuffer max) {
+    return geospatialPredicate(op, ref(name), min, max);
+  }
+
+  public static UnboundPredicate<ByteBuffer> geospatialPredicate(
+      Operation op, UnboundTerm<ByteBuffer> expr, ByteBuffer min, ByteBuffer max) {
+    return new UnboundPredicate<>(op, expr, Lists.newArrayList(min, max));
   }
 
   public static True alwaysTrue() {

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.expressions;
 import java.nio.ByteBuffer;
 import java.util.stream.Stream;
 import org.apache.iceberg.expressions.Expression.Operation;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.transforms.Transform;
@@ -204,8 +204,7 @@ public class Expressions {
     return new UnboundPredicate<>(Expression.Operation.NOT_STARTS_WITH, expr, value);
   }
 
-  public static UnboundPredicate<ByteBuffer> stIntersects(
-      String name, GeospatialBoundingBox value) {
+  public static UnboundPredicate<ByteBuffer> stIntersects(String name, BoundingBox value) {
     return geospatialPredicate(Operation.ST_INTERSECTS, name, value);
   }
 
@@ -215,7 +214,7 @@ public class Expressions {
   }
 
   public static UnboundPredicate<ByteBuffer> stIntersects(
-      UnboundTerm<ByteBuffer> expr, GeospatialBoundingBox value) {
+      UnboundTerm<ByteBuffer> expr, BoundingBox value) {
     return geospatialPredicate(Operation.ST_INTERSECTS, expr, value);
   }
 
@@ -224,7 +223,7 @@ public class Expressions {
     return geospatialPredicate(Operation.ST_INTERSECTS, expr, min, max);
   }
 
-  public static UnboundPredicate<ByteBuffer> stDisjoint(String name, GeospatialBoundingBox value) {
+  public static UnboundPredicate<ByteBuffer> stDisjoint(String name, BoundingBox value) {
     return geospatialPredicate(Operation.ST_DISJOINT, name, value);
   }
 
@@ -234,7 +233,7 @@ public class Expressions {
   }
 
   public static UnboundPredicate<ByteBuffer> stDisjoint(
-      UnboundTerm<ByteBuffer> expr, GeospatialBoundingBox value) {
+      UnboundTerm<ByteBuffer> expr, BoundingBox value) {
     return geospatialPredicate(Operation.ST_DISJOINT, expr, value);
   }
 
@@ -322,13 +321,13 @@ public class Expressions {
   }
 
   public static UnboundPredicate<ByteBuffer> geospatialPredicate(
-      Operation op, String name, GeospatialBoundingBox value) {
+      Operation op, String name, BoundingBox value) {
     return geospatialPredicate(
         op, ref(name), value.min().toByteBuffer(), value.max().toByteBuffer());
   }
 
   public static UnboundPredicate<ByteBuffer> geospatialPredicate(
-      Operation op, UnboundTerm<ByteBuffer> expr, GeospatialBoundingBox value) {
+      Operation op, UnboundTerm<ByteBuffer> expr, BoundingBox value) {
     return geospatialPredicate(op, expr, value.min().toByteBuffer(), value.max().toByteBuffer());
   }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialPredicateEvaluators;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.types.Comparators;
@@ -474,7 +474,7 @@ public class InclusiveMetricsEvaluator {
     }
 
     @Override
-    public <T> Boolean stIntersects(Bound<T> term, Literal<GeospatialBoundingBox> lit) {
+    public <T> Boolean stIntersects(Bound<T> term, Literal<BoundingBox> lit) {
       T lower = lowerBound(term);
       T upper = upperBound(term);
 
@@ -483,9 +483,8 @@ public class InclusiveMetricsEvaluator {
       }
 
       if (lit.value() != null && lower instanceof ByteBuffer && upper instanceof ByteBuffer) {
-        GeospatialBoundingBox dataBox =
-            GeospatialBoundingBox.fromByteBuffers((ByteBuffer) lower, (ByteBuffer) upper);
-        GeospatialBoundingBox queryBox = lit.value();
+        BoundingBox dataBox = BoundingBox.fromByteBuffers((ByteBuffer) lower, (ByteBuffer) upper);
+        BoundingBox queryBox = lit.value();
 
         // If the data box and query box doesn't intersect, no records can match
         GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
@@ -499,7 +498,7 @@ public class InclusiveMetricsEvaluator {
     }
 
     @Override
-    public <T> Boolean stDisjoint(Bound<T> term, Literal<GeospatialBoundingBox> lit) {
+    public <T> Boolean stDisjoint(Bound<T> term, Literal<BoundingBox> lit) {
       return ROWS_MIGHT_MATCH;
     }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -479,16 +479,15 @@ public class InclusiveMetricsEvaluator {
       T upper = upperBound(term);
 
       if (lower == null || upper == null) {
-        return ROWS_MIGHT_MATCH; // no information
+        return ROWS_MIGHT_MATCH;
       }
 
       if (lit.value() != null && lower instanceof ByteBuffer && upper instanceof ByteBuffer) {
-        // Construct a bounding box from the min/max bounds
         GeospatialBoundingBox dataBox =
-            GeospatialBoundingBox.create((ByteBuffer) lower, (ByteBuffer) upper);
+            GeospatialBoundingBox.fromByteBuffers((ByteBuffer) lower, (ByteBuffer) upper);
         GeospatialBoundingBox queryBox = lit.value();
 
-        // If the data box and query box don't intersect, no records can match
+        // If the data box and query box doesn't intersect, no records can match
         GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
             GeospatialPredicateEvaluators.create(term.ref().type());
         if (!evaluator.intersects(dataBox, queryBox)) {

--- a/api/src/main/java/org/apache/iceberg/expressions/Literal.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literal.java
@@ -23,7 +23,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.UUID;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.types.Type;
 
 /**
@@ -72,7 +72,7 @@ public interface Literal<T> extends Serializable {
     return new Literals.DecimalLiteral(value);
   }
 
-  static Literal<GeospatialBoundingBox> of(GeospatialBoundingBox value) {
+  static Literal<BoundingBox> of(BoundingBox value) {
     return new Literals.GeospatialBoundingBoxLiteral(value);
   }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/Literal.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literal.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.UUID;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Type;
 
 /**
@@ -69,6 +70,10 @@ public interface Literal<T> extends Serializable {
 
   static Literal<BigDecimal> of(BigDecimal value) {
     return new Literals.DecimalLiteral(value);
+  }
+
+  static Literal<GeospatialBoundingBox> of(GeospatialBoundingBox value) {
+    return new Literals.GeospatialBoundingBoxLiteral(value);
   }
 
   /** Returns the value wrapped by this literal. */

--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -32,7 +32,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.UUID;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.types.Comparators;
@@ -81,8 +81,8 @@ class Literals {
       return (Literal<T>) new Literals.BinaryLiteral((ByteBuffer) value);
     } else if (value instanceof BigDecimal) {
       return (Literal<T>) new Literals.DecimalLiteral((BigDecimal) value);
-    } else if (value instanceof GeospatialBoundingBox) {
-      return (Literal<T>) new Literals.GeospatialBoundingBoxLiteral((GeospatialBoundingBox) value);
+    } else if (value instanceof BoundingBox) {
+      return (Literal<T>) new Literals.GeospatialBoundingBoxLiteral((BoundingBox) value);
     }
 
     throw new IllegalArgumentException(
@@ -691,18 +691,18 @@ class Literals {
     }
   }
 
-  static class GeospatialBoundingBoxLiteral implements Literal<GeospatialBoundingBox> {
-    private static final Comparator<GeospatialBoundingBox> CMP =
-        Comparators.<GeospatialBoundingBox>nullsFirst().thenComparing(Comparator.naturalOrder());
+  static class GeospatialBoundingBoxLiteral implements Literal<BoundingBox> {
+    private static final Comparator<BoundingBox> CMP =
+        Comparators.<BoundingBox>nullsFirst().thenComparing(Comparator.naturalOrder());
 
-    private final GeospatialBoundingBox value;
+    private final BoundingBox value;
 
-    GeospatialBoundingBoxLiteral(GeospatialBoundingBox value) {
+    GeospatialBoundingBoxLiteral(BoundingBox value) {
       this.value = value;
     }
 
     @Override
-    public GeospatialBoundingBox value() {
+    public BoundingBox value() {
       return value;
     }
 
@@ -712,7 +712,7 @@ class Literals {
     }
 
     @Override
-    public Comparator<GeospatialBoundingBox> comparator() {
+    public Comparator<BoundingBox> comparator() {
       return CMP;
     }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -32,6 +32,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.UUID;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.types.Comparators;
@@ -80,6 +81,8 @@ class Literals {
       return (Literal<T>) new Literals.BinaryLiteral((ByteBuffer) value);
     } else if (value instanceof BigDecimal) {
       return (Literal<T>) new Literals.DecimalLiteral((BigDecimal) value);
+    } else if (value instanceof GeospatialBoundingBox) {
+      return (Literal<T>) new Literals.GeospatialBoundingBoxLiteral((GeospatialBoundingBox) value);
     }
 
     throw new IllegalArgumentException(
@@ -685,6 +688,37 @@ class Literals {
     public String toString() {
       byte[] bytes = ByteBuffers.toByteArray(value());
       return "X'" + BaseEncoding.base16().encode(bytes) + "'";
+    }
+  }
+
+  static class GeospatialBoundingBoxLiteral implements Literal<GeospatialBoundingBox> {
+    private static final Comparator<GeospatialBoundingBox> CMP =
+        Comparators.<GeospatialBoundingBox>nullsFirst().thenComparing(Comparator.naturalOrder());
+
+    private final GeospatialBoundingBox value;
+
+    GeospatialBoundingBoxLiteral(GeospatialBoundingBox value) {
+      this.value = value;
+    }
+
+    @Override
+    public GeospatialBoundingBox value() {
+      return value;
+    }
+
+    @Override
+    public <T> Literal<T> to(Type type) {
+      return null;
+    }
+
+    @Override
+    public Comparator<GeospatialBoundingBox> comparator() {
+      return CMP;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value());
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.NaNUtil;
@@ -469,6 +470,16 @@ public class StrictMetricsEvaluator {
     public <T> Boolean notStartsWith(BoundReference<T> ref, Literal<T> lit) {
       // TODO: Handle cases that definitely cannot match, such as notStartsWith("x") when the bounds
       // are ["a", "b"].
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean stIntersects(BoundReference<T> ref, Literal<GeospatialBoundingBox> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean stDisjoint(BoundReference<T> ref, Literal<GeospatialBoundingBox> lit) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -29,7 +29,7 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.NaNUtil;
@@ -474,12 +474,12 @@ public class StrictMetricsEvaluator {
     }
 
     @Override
-    public <T> Boolean stIntersects(BoundReference<T> ref, Literal<GeospatialBoundingBox> lit) {
+    public <T> Boolean stIntersects(BoundReference<T> ref, Literal<BoundingBox> lit) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
     @Override
-    public <T> Boolean stDisjoint(BoundReference<T> ref, Literal<GeospatialBoundingBox> lit) {
+    public <T> Boolean stDisjoint(BoundReference<T> ref, Literal<BoundingBox> lit) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -282,7 +282,7 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
     return new BoundGeospatialPredicate(
         op(),
         (BoundTerm<ByteBuffer>) boundTerm,
-        Literals.from(GeospatialBoundingBox.fromByteBuffers(min.value(), max.value())));
+        Literals.from(BoundingBox.fromByteBuffers(min.value(), max.value())));
   }
 
   @Override
@@ -319,7 +319,7 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
         String opName = op() == Operation.ST_INTERSECTS ? " stIntersects " : " stDisjoint ";
         return term()
             + opName
-            + GeospatialBoundingBox.fromByteBuffers(minLiteral.value(), maxLiteral.value());
+            + BoundingBox.fromByteBuffers(minLiteral.value(), maxLiteral.value());
       case IN:
         return term() + " in (" + COMMA.join(literals()) + ")";
       case NOT_IN:

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
@@ -282,7 +282,7 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
     return new BoundGeospatialPredicate(
         op(),
         (BoundTerm<ByteBuffer>) boundTerm,
-        Literals.from(GeospatialBoundingBox.create(min.value(), max.value())));
+        Literals.from(GeospatialBoundingBox.fromByteBuffers(min.value(), max.value())));
   }
 
   @Override
@@ -319,7 +319,7 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
         String opName = op() == Operation.ST_INTERSECTS ? " stIntersects " : " stDisjoint ";
         return term()
             + opName
-            + GeospatialBoundingBox.create(minLiteral.value(), maxLiteral.value());
+            + GeospatialBoundingBox.fromByteBuffers(minLiteral.value(), maxLiteral.value());
       case IN:
         return term() + " in (" + COMMA.join(literals()) + ")";
       case NOT_IN:

--- a/api/src/main/java/org/apache/iceberg/geospatial/BoundingBox.java
+++ b/api/src/main/java/org/apache/iceberg/geospatial/BoundingBox.java
@@ -29,31 +29,37 @@ import java.util.Objects;
  * minimum and maximum coordinates that define the box's corners. This provides a simple
  * approximation of a more complex geometry for efficient filtering and data skipping.
  */
-public class GeospatialBoundingBox implements Serializable, Comparable<GeospatialBoundingBox> {
-  public static final GeospatialBoundingBox SANITIZED =
-      new GeospatialBoundingBox(
-          GeospatialBound.createXY(Double.NaN, Double.NaN),
-          GeospatialBound.createXY(Double.NaN, Double.NaN));
-
-  private final GeospatialBound min;
-  private final GeospatialBound max;
-
+public class BoundingBox implements Serializable, Comparable<BoundingBox> {
   /**
-   * Create a {@link GeospatialBoundingBox} object from buffers containing min and max bounds
+   * Create a {@link BoundingBox} object from buffers containing min and max bounds
    *
    * @param min the serialized minimum bound
    * @param max the serialized maximum bound
-   * @return a GeospatialBoundingBox instance
+   * @return a BoundingBox instance
    */
-  public static GeospatialBoundingBox fromByteBuffers(ByteBuffer min, ByteBuffer max) {
-    return new GeospatialBoundingBox(
+  public static BoundingBox fromByteBuffers(ByteBuffer min, ByteBuffer max) {
+    return new BoundingBox(
         GeospatialBound.fromByteBuffer(min), GeospatialBound.fromByteBuffer(max));
   }
 
-  public GeospatialBoundingBox(GeospatialBound min, GeospatialBound max) {
+  /**
+   * Create an empty bounding box
+   *
+   * @return an empty bounding box
+   */
+  public static BoundingBox empty() {
+    return new BoundingBox(
+        GeospatialBound.createXY(Double.NaN, Double.NaN),
+        GeospatialBound.createXY(Double.NaN, Double.NaN));
+  }
+
+  public BoundingBox(GeospatialBound min, GeospatialBound max) {
     this.min = min;
     this.max = max;
   }
+
+  private final GeospatialBound min;
+  private final GeospatialBound max;
 
   /**
    * Get the minimum corner of the bounding box.
@@ -77,11 +83,11 @@ public class GeospatialBoundingBox implements Serializable, Comparable<Geospatia
   public boolean equals(Object other) {
     if (this == other) {
       return true;
-    } else if (!(other instanceof GeospatialBoundingBox)) {
+    } else if (!(other instanceof BoundingBox)) {
       return false;
     }
 
-    GeospatialBoundingBox that = (GeospatialBoundingBox) other;
+    BoundingBox that = (BoundingBox) other;
     return Objects.equals(min, that.min) && Objects.equals(max, that.max);
   }
 
@@ -92,15 +98,11 @@ public class GeospatialBoundingBox implements Serializable, Comparable<Geospatia
 
   @Override
   public String toString() {
-    if (SANITIZED.equals(this)) {
-      return "BoundingBox{sanitized}";
-    }
-
     return "BoundingBox{min=" + min.simpleString() + ", max=" + max.simpleString() + '}';
   }
 
   @Override
-  public int compareTo(GeospatialBoundingBox other) {
+  public int compareTo(BoundingBox other) {
     int minComparison = min.compareTo(other.min);
     if (minComparison != 0) {
       return minComparison;

--- a/api/src/main/java/org/apache/iceberg/geospatial/GeospatialBound.java
+++ b/api/src/main/java/org/apache/iceberg/geospatial/GeospatialBound.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.geospatial;
+
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Comparator;
+import java.util.Objects;
+
+/**
+ * Represents a geospatial bound (minimum or maximum) for Iceberg tables.
+ *
+ * <p>According to the <a href="https://iceberg.apache.org/spec/#bound-serialization">Bound
+ * serialization section of Iceberg Table spec</a>, geospatial bounds are serialized differently
+ * from the regular WKB representation. Geometry and geography bounds are single point encoded as a
+ * concatenation of 8-byte little-endian IEEE 754 coordinate values in the order X, Y, Z (optional),
+ * M (optional).
+ *
+ * <p>The encoding varies based on which coordinates are present:
+ *
+ * <ul>
+ *   <li>x:y (2 doubles) when both z and m are unset
+ *   <li>x:y:z (3 doubles) when only m is unset
+ *   <li>x:y:NaN:m (4 doubles) when only z is unset
+ *   <li>x:y:z:m (4 doubles) when all coordinates are set
+ * </ul>
+ *
+ * <p>This class represents a lower or upper geospatial bound and handles serialization and
+ * deserialization of these bounds to/from byte arrays, conforming to the Iceberg specification.
+ */
+public class GeospatialBound implements Serializable, Comparable<GeospatialBound> {
+  private final double x;
+  private final double y;
+  private final double z;
+  private final double m;
+
+  /** Private constructor - use factory methods instead. */
+  private GeospatialBound(double x, double y, double z, double m) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+    this.m = m;
+  }
+
+  /**
+   * Creates a GeospatialBound with X and Y coordinates only.
+   *
+   * @param x the X coordinate (longitude/easting)
+   * @param y the Y coordinate (latitude/northing)
+   * @return a GeospatialBound with XY coordinates
+   */
+  public static GeospatialBound createXY(double x, double y) {
+    return new GeospatialBound(x, y, Double.NaN, Double.NaN);
+  }
+
+  /**
+   * Creates a GeospatialBound with X, Y, and Z coordinates, with no M value.
+   *
+   * @param x the X coordinate (longitude/easting)
+   * @param y the Y coordinate (latitude/northing)
+   * @param z the Z coordinate (elevation)
+   * @return a GeospatialBound with XYZ coordinates
+   */
+  public static GeospatialBound createXYZ(double x, double y, double z) {
+    return new GeospatialBound(x, y, z, Double.NaN);
+  }
+
+  /**
+   * Creates a GeospatialBound with X, Y, Z, and M coordinates.
+   *
+   * @param x the X coordinate (longitude/easting)
+   * @param y the Y coordinate (latitude/northing)
+   * @param z the Z coordinate (elevation)
+   * @param m the M value (measure)
+   * @return a GeospatialBound with XYZM coordinates
+   */
+  public static GeospatialBound createXYZM(double x, double y, double z, double m) {
+    return new GeospatialBound(x, y, z, m);
+  }
+
+  /**
+   * Creates a GeospatialBound with X, Y, and M values, with no Z coordinate.
+   *
+   * @param x the X coordinate (longitude/easting)
+   * @param y the Y coordinate (latitude/northing)
+   * @param m the M value (measure)
+   * @return a GeospatialBound with XYM coordinates
+   */
+  public static GeospatialBound createXYM(double x, double y, double m) {
+    return new GeospatialBound(x, y, Double.NaN, m);
+  }
+
+  /**
+   * Get the X coordinate (longitude/easting).
+   *
+   * @return X coordinate value
+   */
+  public double x() {
+    return x;
+  }
+
+  /**
+   * Get the Y coordinate (latitude/northing).
+   *
+   * @return Y coordinate value
+   */
+  public double y() {
+    return y;
+  }
+
+  /**
+   * Get the Z coordinate (typically elevation).
+   *
+   * @return Z coordinate value or NaN if not set
+   */
+  public double z() {
+    return z;
+  }
+
+  /**
+   * Get the M value (measure).
+   *
+   * @return M value or NaN if not set
+   */
+  public double m() {
+    return m;
+  }
+
+  /**
+   * Check if this bound has a defined Z coordinate.
+   *
+   * @return true if Z is not NaN
+   */
+  public boolean hasZ() {
+    return !Double.isNaN(z);
+  }
+
+  /**
+   * Check if this bound has a defined M value.
+   *
+   * @return true if M is not NaN
+   */
+  public boolean hasM() {
+    return !Double.isNaN(m);
+  }
+
+  /**
+   * Serializes this geospatial bound to a byte buffer according to Iceberg spec.
+   *
+   * <p>Following the Iceberg spec, the bound is serialized based on which coordinates are set: -
+   * x:y (2 doubles) when both z and m are unset - x:y:z (3 doubles) when only m is unset -
+   * x:y:NaN:m (4 doubles) when only z is unset - x:y:z:m (4 doubles) when all coordinates are set
+   *
+   * @return A ByteBuffer containing the serialized geospatial bound
+   */
+  public ByteBuffer toByteBuffer() {
+    // Calculate size based on which coordinates are present
+    int size;
+    if (!hasZ() && !hasM()) {
+      // Just x and y
+      size = 2 * Double.BYTES;
+    } else if (hasZ() && !hasM()) {
+      // x, y, and z (no m)
+      size = 3 * Double.BYTES;
+    } else {
+      // x, y, z (or NaN), and m
+      size = 4 * Double.BYTES;
+    }
+
+    ByteBuffer buffer = ByteBuffer.allocate(size).order(ByteOrder.LITTLE_ENDIAN);
+    buffer.putDouble(x);
+    buffer.putDouble(y);
+
+    if (hasZ() || hasM()) {
+      // If we have z or m or both, we need to include z (could be NaN)
+      buffer.putDouble(z);
+    }
+
+    if (hasM()) {
+      // If we have m, include it
+      buffer.putDouble(m);
+    }
+
+    buffer.flip();
+    return buffer;
+  }
+
+  /**
+   * Parses a geospatial bound from a byte buffer according to Iceberg spec.
+   *
+   * <p>Based on the buffer size, this method determines which coordinates are present: - 16 bytes
+   * (2 doubles): x and y only - 24 bytes (3 doubles): x, y, and z - 32 bytes (4 doubles): x, y, z
+   * (might be NaN), and m
+   *
+   * @param buffer the ByteBuffer containing the serialized geospatial bound
+   * @return a GeospatialBound object representing the parsed bound
+   * @throws IllegalArgumentException if the buffer has an invalid size
+   */
+  public static GeospatialBound fromByteBuffer(ByteBuffer buffer) {
+    // Create a duplicate to avoid modifying the original buffer's position and byte order
+    ByteBuffer tmp = buffer.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+
+    int size = tmp.remaining();
+
+    if (size == 2 * Double.BYTES) {
+      // x:y format (2 doubles)
+      double coordX = tmp.getDouble();
+      double coordY = tmp.getDouble();
+      return createXY(coordX, coordY);
+    } else if (size == 3 * Double.BYTES) {
+      // x:y:z format (3 doubles)
+      double coordX = tmp.getDouble();
+      double coordY = tmp.getDouble();
+      double coordZ = tmp.getDouble();
+      return createXYZ(coordX, coordY, coordZ);
+    } else if (size == 4 * Double.BYTES) {
+      // x:y:z:m format (4 doubles) - z might be NaN
+      double coordX = tmp.getDouble();
+      double coordY = tmp.getDouble();
+      double coordZ = tmp.getDouble();
+      double coordM = tmp.getDouble();
+      return new GeospatialBound(coordX, coordY, coordZ, coordM);
+    } else {
+      throw new IllegalArgumentException(
+          "Invalid buffer size for GeospatialBound: expected 16, 24, or 32 bytes, got " + size);
+    }
+  }
+
+  /**
+   * Parses a geospatial bound from a byte array according to Iceberg spec.
+   *
+   * @param bytes the byte array containing the serialized geospatial bound
+   * @return a GeospatialBound object representing the parsed bound
+   * @throws IllegalArgumentException if the byte array has an invalid length
+   */
+  public static GeospatialBound fromByteArray(byte[] bytes) {
+    int length = bytes.length;
+    if (length != 2 * Double.BYTES && length != 3 * Double.BYTES && length != 4 * Double.BYTES) {
+      throw new IllegalArgumentException(
+          "Invalid byte array length for GeospatialBound: expected 16, 24, or 32 bytes, got "
+              + length);
+    }
+    return fromByteBuffer(ByteBuffer.wrap(bytes));
+  }
+
+  @Override
+  public String toString() {
+    return "GeospatialBound(" + simpleString() + ")";
+  }
+
+  public String simpleString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("x=").append(x).append(", y=").append(y);
+
+    if (hasZ()) {
+      sb.append(", z=").append(z);
+    }
+
+    if (hasM()) {
+      sb.append(", m=").append(m);
+    }
+
+    return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    GeospatialBound that = (GeospatialBound) o;
+
+    return Double.compare(that.x, x) == 0
+        && Double.compare(that.y, y) == 0
+        && Double.compare(that.z, z) == 0
+        && Double.compare(that.m, m) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(GeospatialBound.class, x, y, z, m);
+  }
+
+  @Override
+  public int compareTo(GeospatialBound o) {
+    return Comparator.comparingDouble(GeospatialBound::x)
+        .thenComparingDouble(GeospatialBound::y)
+        .thenComparingDouble(GeospatialBound::z)
+        .thenComparingDouble(GeospatialBound::m)
+        .compare(this, o);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/geospatial/GeospatialBoundingBox.java
+++ b/api/src/main/java/org/apache/iceberg/geospatial/GeospatialBoundingBox.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.geospatial;
+
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * Represents a geospatial bounding box composed of minimum and maximum bounds.
+ *
+ * <p>A bounding box (also called a Minimum Bounding Rectangle or MBR) is defined by two points: the
+ * minimum and maximum coordinates that define the box's corners. This provides a simple
+ * approximation of a more complex geometry for efficient filtering and data skipping.
+ */
+public class GeospatialBoundingBox implements Serializable, Comparable<GeospatialBoundingBox> {
+  private final GeospatialBound min;
+  private final GeospatialBound max;
+
+  public static final GeospatialBoundingBox SANITIZED =
+      new GeospatialBoundingBox(
+          GeospatialBound.createXY(Double.NaN, Double.NaN),
+          GeospatialBound.createXY(Double.NaN, Double.NaN));
+
+  /**
+   * Create an appropriate GeospatialBoundingBox according to the geospatial type.
+   *
+   * @param min the serialized minimum bound
+   * @param max the serialized maximum bound
+   * @return a GeospatialBoundingBox instance
+   */
+  public static GeospatialBoundingBox create(ByteBuffer min, ByteBuffer max) {
+    return new GeospatialBoundingBox(
+        GeospatialBound.fromByteBuffer(min), GeospatialBound.fromByteBuffer(max));
+  }
+
+  public GeospatialBoundingBox(GeospatialBound min, GeospatialBound max) {
+    this.min = min;
+    this.max = max;
+  }
+
+  /**
+   * Get the minimum corner of the bounding box.
+   *
+   * @return the minimum bound
+   */
+  public GeospatialBound min() {
+    return min;
+  }
+
+  /**
+   * Get the maximum corner of the bounding box.
+   *
+   * @return the maximum bound
+   */
+  public GeospatialBound max() {
+    return max;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GeospatialBoundingBox that = (GeospatialBoundingBox) o;
+    return Objects.equals(min, that.min) && Objects.equals(max, that.max);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(min, max);
+  }
+
+  @Override
+  public String toString() {
+    if (SANITIZED.equals(this)) {
+      return "BoundingBox{sanitized}";
+    }
+    return "BoundingBox{min=" + min.simpleString() + ", max=" + max.simpleString() + '}';
+  }
+
+  @Override
+  public int compareTo(GeospatialBoundingBox o) {
+    int minComparison = min.compareTo(o.min);
+    if (minComparison != 0) {
+      return minComparison;
+    }
+    return max.compareTo(o.max);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/geospatial/GeospatialBoundingBox.java
+++ b/api/src/main/java/org/apache/iceberg/geospatial/GeospatialBoundingBox.java
@@ -30,22 +30,22 @@ import java.util.Objects;
  * approximation of a more complex geometry for efficient filtering and data skipping.
  */
 public class GeospatialBoundingBox implements Serializable, Comparable<GeospatialBoundingBox> {
-  private final GeospatialBound min;
-  private final GeospatialBound max;
-
   public static final GeospatialBoundingBox SANITIZED =
       new GeospatialBoundingBox(
           GeospatialBound.createXY(Double.NaN, Double.NaN),
           GeospatialBound.createXY(Double.NaN, Double.NaN));
 
+  private final GeospatialBound min;
+  private final GeospatialBound max;
+
   /**
-   * Create an appropriate GeospatialBoundingBox according to the geospatial type.
+   * Create a {@link GeospatialBoundingBox} object from buffers containing min and max bounds
    *
    * @param min the serialized minimum bound
    * @param max the serialized maximum bound
    * @return a GeospatialBoundingBox instance
    */
-  public static GeospatialBoundingBox create(ByteBuffer min, ByteBuffer max) {
+  public static GeospatialBoundingBox fromByteBuffers(ByteBuffer min, ByteBuffer max) {
     return new GeospatialBoundingBox(
         GeospatialBound.fromByteBuffer(min), GeospatialBound.fromByteBuffer(max));
   }
@@ -74,10 +74,14 @@ public class GeospatialBoundingBox implements Serializable, Comparable<Geospatia
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    GeospatialBoundingBox that = (GeospatialBoundingBox) o;
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (!(other instanceof GeospatialBoundingBox)) {
+      return false;
+    }
+
+    GeospatialBoundingBox that = (GeospatialBoundingBox) other;
     return Objects.equals(min, that.min) && Objects.equals(max, that.max);
   }
 
@@ -91,15 +95,17 @@ public class GeospatialBoundingBox implements Serializable, Comparable<Geospatia
     if (SANITIZED.equals(this)) {
       return "BoundingBox{sanitized}";
     }
+
     return "BoundingBox{min=" + min.simpleString() + ", max=" + max.simpleString() + '}';
   }
 
   @Override
-  public int compareTo(GeospatialBoundingBox o) {
-    int minComparison = min.compareTo(o.min);
+  public int compareTo(GeospatialBoundingBox other) {
+    int minComparison = min.compareTo(other.min);
     if (minComparison != 0) {
       return minComparison;
     }
-    return max.compareTo(o.max);
+
+    return max.compareTo(other.max);
   }
 }

--- a/api/src/main/java/org/apache/iceberg/geospatial/GeospatialPredicateEvaluators.java
+++ b/api/src/main/java/org/apache/iceberg/geospatial/GeospatialPredicateEvaluators.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.geospatial;
+
+import org.apache.iceberg.types.Type;
+
+public class GeospatialPredicateEvaluators {
+
+  public interface GeospatialPredicateEvaluator {
+    /**
+     * Test whether this bounding box intersects with another.
+     *
+     * @param a the first bounding box
+     * @param b the second bounding box
+     * @return true if this box intersects the other box
+     */
+    boolean intersects(GeospatialBoundingBox a, GeospatialBoundingBox b);
+  }
+
+  public static GeospatialPredicateEvaluator create(Type type) {
+    switch (type.typeId()) {
+      case GEOMETRY:
+        return new GeometryEvaluator();
+      case GEOGRAPHY:
+        return new GeographyEvaluator();
+      default:
+        throw new UnsupportedOperationException(
+            "Unsupported type for GeospatialBoundingBox: " + type);
+    }
+  }
+
+  static class GeometryEvaluator implements GeospatialPredicateEvaluator {
+    @Override
+    public boolean intersects(GeospatialBoundingBox a, GeospatialBoundingBox b) {
+      return intersectsWithWrapAround(a, b);
+    }
+
+    static boolean intersectsWithWrapAround(GeospatialBoundingBox a, GeospatialBoundingBox b) {
+      // Let's check y first, and if y does not intersect, we can return false
+      if (a.min().y() > b.max().y() || a.max().y() < b.min().y()) {
+        return false;
+      }
+
+      // Now check x, need to take wrap-around into account
+      if (a.min().x() <= a.max().x() && b.min().x() <= b.max().x()) {
+        // No wrap-around
+        return a.min().x() <= b.max().x() && a.max().x() >= b.min().x();
+      } else if (a.min().x() > a.max().x() && b.min().x() <= b.max().x()) {
+        // a wraps around the antimeridian, b does not
+        return a.min().x() <= b.max().x() || a.max().x() >= b.min().x();
+      } else if (a.min().x() <= a.max().x() && b.min().x() > b.max().x()) {
+        // b wraps around the antimeridian, a does not
+        return intersectsWithWrapAround(b, a);
+      } else {
+        // Both wrap around the antimeridian, they must intersect
+        return true;
+      }
+    }
+  }
+
+  static class GeographyEvaluator implements GeospatialPredicateEvaluator {
+    @Override
+    public boolean intersects(GeospatialBoundingBox a, GeospatialBoundingBox b) {
+      validateBoundingBox(a);
+      validateBoundingBox(b);
+      return GeometryEvaluator.intersectsWithWrapAround(a, b);
+    }
+
+    private void validateBoundingBox(GeospatialBoundingBox box) {
+      if (box.min().y() < -90 || box.max().y() > 90) {
+        throw new IllegalArgumentException("Latitude out of range: " + box);
+      }
+      if (box.min().x() < -180
+          || box.min().x() > 180
+          || box.max().x() < -180
+          || box.max().x() > 180) {
+        throw new IllegalArgumentException("Longitude out of range: " + box);
+      }
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -122,14 +122,13 @@ public class Conversions {
         // There are 2 representations of geometry and geography in iceberg:
         //
         // 1. Well-known binary (WKB) format for general storage and processing
-        // 2. For bound values (partition and sort keys), points are encoded as 4 little-endian
+        // 2. For bound values (partition and sort keys), points are encoded as little-endian
         // doubles:
         //    X (longitude/easting), Y (latitude/northing), Z (optional elevation), and M (optional
         // measure)
         //
         // No matter what representation is used, geospatial values are always represented as byte
-        // buffers,
-        // so we can just return the value as is.
+        // buffers, so we can just return the value as is.
         return (ByteBuffer) value;
       default:
         throw new UnsupportedOperationException("Cannot serialize type: " + typeId);
@@ -193,8 +192,8 @@ public class Conversions {
         return new BigDecimal(new BigInteger(unscaledBytes), decimal.scale());
       case GEOMETRY:
       case GEOGRAPHY:
-        // GEOMETRY and GEOGRAPHY types are handled by passing through the byte buffer. Please
-        // refer to the comment in toByteBuffer for more details.
+        // GEOMETRY and GEOGRAPHY values are represented as byte buffers. Please refer to the
+        // comment in toByteBuffer for more details.
         return tmp;
       default:
         throw new UnsupportedOperationException("Cannot deserialize type: " + type);

--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -117,6 +117,20 @@ public class Conversions {
         return (ByteBuffer) value;
       case DECIMAL:
         return ByteBuffer.wrap(((BigDecimal) value).unscaledValue().toByteArray());
+      case GEOMETRY:
+      case GEOGRAPHY:
+        // There are 2 representations of geometry and geography in iceberg:
+        //
+        // 1. Well-known binary (WKB) format for general storage and processing
+        // 2. For bound values (partition and sort keys), points are encoded as 4 little-endian
+        // doubles:
+        //    X (longitude/easting), Y (latitude/northing), Z (optional elevation), and M (optional
+        // measure)
+        //
+        // No matter what representation is used, geospatial values are always represented as byte
+        // buffers,
+        // so we can just return the value as is.
+        return (ByteBuffer) value;
       default:
         throw new UnsupportedOperationException("Cannot serialize type: " + typeId);
     }
@@ -177,6 +191,11 @@ public class Conversions {
         byte[] unscaledBytes = new byte[buffer.remaining()];
         tmp.get(unscaledBytes);
         return new BigDecimal(new BigInteger(unscaledBytes), decimal.scale());
+      case GEOMETRY:
+      case GEOGRAPHY:
+        // GEOMETRY and GEOGRAPHY types are handled by passing through the byte buffer. Please
+        // refer to the comment in toByteBuffer for more details.
+        return tmp;
       default:
         throw new UnsupportedOperationException("Cannot deserialize type: " + type);
     }

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -81,7 +81,6 @@ public class Types {
     Matcher geometry = GEOMETRY_PARAMETERS.matcher(typeString);
     if (geometry.matches()) {
       String crs = geometry.group(1);
-      Preconditions.checkArgument(!crs.contains(","), "Invalid CRS: %s", crs);
       return GeometryType.of(crs);
     }
 
@@ -599,7 +598,7 @@ public class Types {
     }
 
     public String crs() {
-      return crs;
+      return crs != null ? crs : DEFAULT_CRS;
     }
 
     @Override
@@ -631,6 +630,7 @@ public class Types {
 
   public static class GeographyType extends PrimitiveType {
     public static final String DEFAULT_CRS = "OGC:CRS84";
+    public static final EdgeAlgorithm DEFAULT_ALGORITHM = EdgeAlgorithm.SPHERICAL;
 
     public static GeographyType crs84() {
       return new GeographyType();
@@ -664,11 +664,11 @@ public class Types {
     }
 
     public String crs() {
-      return crs;
+      return crs != null ? crs : DEFAULT_CRS;
     }
 
     public EdgeAlgorithm algorithm() {
-      return algorithm;
+      return algorithm != null ? algorithm : DEFAULT_ALGORITHM;
     }
 
     @Override

--- a/api/src/test/java/org/apache/iceberg/expressions/TestBoundGeospatialPredicate.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestBoundGeospatialPredicate.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.util.stream.Stream;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TestBoundGeospatialPredicate {
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "point", Types.GeometryType.crs84()),
+          required(2, "geography", Types.GeographyType.crs84()),
+          required(3, "point2", Types.GeometryType.crs84()),
+          required(4, "geography2", Types.GeographyType.crs84()));
+
+  private static Stream<Arguments> geospatialOperators() {
+    return Stream.of(
+        Arguments.of(Expression.Operation.ST_INTERSECTS, "point", 1),
+        Arguments.of(Expression.Operation.ST_DISJOINT, "geography", 2));
+  }
+
+  @ParameterizedTest
+  @MethodSource("geospatialOperators")
+  public void testGeospatialPredicateBinding(
+      Expression.Operation op, String fieldName, int fieldId) {
+    // Create a bounding box for testing
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    // Create an unbound predicate based on the operation
+    UnboundPredicate<ByteBuffer> unbound = Expressions.geospatialPredicate(op, fieldName, bbox);
+
+    // Bind the predicate to the schema
+    Expression bound = unbound.bind(SCHEMA.asStruct());
+
+    // Verify the bound predicate is a BoundGeospatialPredicate
+    assertThat(bound).isInstanceOf(BoundGeospatialPredicate.class);
+    BoundGeospatialPredicate predicate = (BoundGeospatialPredicate) bound;
+
+    // Verify the operation matches the expected operation
+    assertThat(predicate.op()).isEqualTo(op);
+
+    // Verify the term references the correct field
+    assertThat(predicate.term().ref().fieldId()).isEqualTo(fieldId);
+
+    // Verify the literal value is correct
+    assertThat(predicate.literal().value()).isEqualTo(bbox);
+
+    // Verify the predicate is identified as a geospatial predicate
+    assertThat(predicate.isGeospatialPredicate()).isTrue();
+
+    // Only check asGeospatialPredicate for ST_INTERSECTS to maintain original test behavior
+    if (op == Expression.Operation.ST_INTERSECTS) {
+      assertThat(predicate.asGeospatialPredicate()).isSameAs(predicate);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("geospatialOperators")
+  public void testNegation(Expression.Operation op, String fieldName, int fieldId) {
+    // Create a bounding box for testing
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    // Create an unbound predicate based on the operation
+    UnboundPredicate<ByteBuffer> unbound = Expressions.geospatialPredicate(op, fieldName, bbox);
+
+    // Bind the predicate to the schema
+    Expression bound = unbound.bind(SCHEMA.asStruct());
+    BoundGeospatialPredicate predicate = (BoundGeospatialPredicate) bound;
+
+    // Negate the predicate
+    Expression negated = predicate.negate();
+
+    // Verify the negated predicate is a BoundGeospatialPredicate
+    assertThat(negated).isInstanceOf(BoundGeospatialPredicate.class);
+    BoundGeospatialPredicate negatedPredicate = (BoundGeospatialPredicate) negated;
+
+    // Verify the operation is the opposite of the original
+    Expression.Operation expectedNegatedOp =
+        (op == Expression.Operation.ST_INTERSECTS)
+            ? Expression.Operation.ST_DISJOINT
+            : Expression.Operation.ST_INTERSECTS;
+    assertThat(negatedPredicate.op()).isEqualTo(expectedNegatedOp);
+
+    // Verify the term and literal are unchanged
+    assertThat(negatedPredicate.term()).isEqualTo(predicate.term());
+    assertThat(negatedPredicate.literal().value()).isEqualTo(predicate.literal().value());
+
+    // Test double negation
+    Expression doubleNegated = negatedPredicate.negate();
+    assertThat(doubleNegated).isInstanceOf(BoundGeospatialPredicate.class);
+    BoundGeospatialPredicate doubleNegatedPredicate = (BoundGeospatialPredicate) doubleNegated;
+
+    // Verify the operation is back to the original
+    assertThat(doubleNegatedPredicate.op()).isEqualTo(op);
+  }
+
+  @ParameterizedTest
+  @MethodSource("geospatialOperators")
+  public void testEquivalence(Expression.Operation op, String fieldName, int fieldId) {
+    // Create two identical bounding boxes
+    GeospatialBound min1 = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max1 = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox1 = new GeospatialBoundingBox(min1, max1);
+    GeospatialBound min2 = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max2 = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox2 = new GeospatialBoundingBox(min2, max2);
+
+    // Create a different bounding box
+    GeospatialBound min3 = GeospatialBound.createXY(5.0, 6.0);
+    GeospatialBound max3 = GeospatialBound.createXY(7.0, 8.0);
+    GeospatialBoundingBox bbox3 = new GeospatialBoundingBox(min3, max3);
+
+    // Create the main predicate with the current operation
+    UnboundPredicate<ByteBuffer> unbound1 = Expressions.geospatialPredicate(op, fieldName, bbox1);
+    Expression bound1 = unbound1.bind(SCHEMA.asStruct());
+    BoundGeospatialPredicate predicate1 = (BoundGeospatialPredicate) bound1;
+
+    // Create a predicate with the same operation and same bounding box
+    UnboundPredicate<ByteBuffer> unbound2 = Expressions.geospatialPredicate(op, fieldName, bbox2);
+    Expression bound2 = unbound2.bind(SCHEMA.asStruct());
+    BoundGeospatialPredicate predicate2 = (BoundGeospatialPredicate) bound2;
+
+    // Create a predicate with the same operation but different bounding box
+    UnboundPredicate<ByteBuffer> unbound3 = Expressions.geospatialPredicate(op, fieldName, bbox3);
+    Expression bound3 = unbound3.bind(SCHEMA.asStruct());
+    BoundGeospatialPredicate predicate3 = (BoundGeospatialPredicate) bound3;
+
+    // Create a predicate with the opposite operation and same bounding box
+    UnboundPredicate<ByteBuffer> unbound4 =
+        Expressions.geospatialPredicate(op.negate(), fieldName, bbox1);
+    Expression bound4 = unbound4.bind(SCHEMA.asStruct());
+    BoundGeospatialPredicate predicate4 = (BoundGeospatialPredicate) bound4;
+
+    // Create a predicate with the same operation and the same bounding box, but different field
+    // name
+    UnboundPredicate<ByteBuffer> unbound5 = Expressions.geospatialPredicate(op, "point2", bbox1);
+    Expression bound5 = unbound5.bind(SCHEMA.asStruct());
+    BoundGeospatialPredicate predicate5 = (BoundGeospatialPredicate) bound5;
+
+    UnboundPredicate<ByteBuffer> unbound6 =
+        Expressions.geospatialPredicate(op, "geography2", bbox1);
+    Expression bound6 = unbound6.bind(SCHEMA.asStruct());
+    BoundGeospatialPredicate predicate6 = (BoundGeospatialPredicate) bound6;
+
+    // Test equivalence
+    assertThat(predicate1.isEquivalentTo(predicate2)).isTrue();
+    assertThat(predicate2.isEquivalentTo(predicate1)).isTrue();
+
+    // Different bounding box
+    assertThat(predicate1.isEquivalentTo(predicate3)).isFalse();
+
+    // Different operation
+    assertThat(predicate1.isEquivalentTo(predicate4)).isFalse();
+
+    // Different field name
+    assertThat(predicate1.isEquivalentTo(predicate5)).isFalse();
+    assertThat(predicate1.isEquivalentTo(predicate6)).isFalse();
+
+    // Not a geospatial predicate
+    assertThat(predicate1.isEquivalentTo(Expressions.alwaysTrue())).isFalse();
+  }
+
+  @ParameterizedTest
+  @MethodSource("geospatialOperators")
+  public void testToString(Expression.Operation op, String fieldName, int fieldId) {
+    // Create a bounding box for testing
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    // Create an unbound predicate based on the operation
+    UnboundPredicate<ByteBuffer> unbound = Expressions.geospatialPredicate(op, fieldName, bbox);
+
+    // Bind the predicate to the schema
+    Expression bound = unbound.bind(SCHEMA.asStruct());
+    BoundGeospatialPredicate predicate = (BoundGeospatialPredicate) bound;
+
+    // Verify toString output contains the operation name
+    String expectedOpString =
+        (op == Expression.Operation.ST_INTERSECTS) ? "stIntersects" : "stDisjoint";
+    assertThat(predicate.toString()).contains(expectedOpString);
+
+    // Verify toString output contains the field ID
+    assertThat(predicate.toString()).contains("id=" + fieldId);
+  }
+
+  @ParameterizedTest
+  @MethodSource("geospatialOperators")
+  public void testWithComplexBoundingBox(Expression.Operation op, String fieldName, int fieldId) {
+    // Create a bounding box with Z and M coordinates
+    GeospatialBound min = GeospatialBound.createXYZM(1.0, 2.0, 3.0, 4.0);
+    GeospatialBound max = GeospatialBound.createXYZM(5.0, 6.0, 7.0, 8.0);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    // Create an unbound predicate based on the operation
+    UnboundPredicate<ByteBuffer> unbound = Expressions.geospatialPredicate(op, fieldName, bbox);
+
+    // Bind the predicate to the schema
+    Expression bound = unbound.bind(SCHEMA.asStruct());
+    BoundGeospatialPredicate predicate = (BoundGeospatialPredicate) bound;
+
+    // Verify the operation matches the expected operation
+    assertThat(predicate.op()).isEqualTo(op);
+
+    // Verify the term references the correct field
+    assertThat(predicate.term().ref().fieldId()).isEqualTo(fieldId);
+
+    // Verify the literal value is correct
+    assertThat(predicate.literal().value()).isEqualTo(bbox);
+
+    // Verify Z and M coordinates are preserved
+    GeospatialBoundingBox boundingBox = predicate.literal().value();
+    assertThat(boundingBox.min().hasZ()).isTrue();
+    assertThat(boundingBox.min().hasM()).isTrue();
+    assertThat(boundingBox.min().z()).isEqualTo(3.0);
+    assertThat(boundingBox.min().m()).isEqualTo(4.0);
+    assertThat(boundingBox.max().hasZ()).isTrue();
+    assertThat(boundingBox.max().hasM()).isTrue();
+    assertThat(boundingBox.max().z()).isEqualTo(7.0);
+    assertThat(boundingBox.max().m()).isEqualTo(8.0);
+  }
+
+  @ParameterizedTest
+  @MethodSource("geospatialOperators")
+  public void testWithSpecialValues(Expression.Operation op, String fieldName, int fieldId) {
+    // Create a bounding box with NaN and infinity values
+    GeospatialBound min = GeospatialBound.createXY(Double.NEGATIVE_INFINITY, Double.NaN);
+    GeospatialBound max = GeospatialBound.createXY(Double.POSITIVE_INFINITY, Double.NaN);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    // Create an unbound predicate based on the operation
+    UnboundPredicate<ByteBuffer> unbound = Expressions.geospatialPredicate(op, fieldName, bbox);
+
+    // Bind the predicate to the schema
+    Expression bound = unbound.bind(SCHEMA.asStruct());
+    BoundGeospatialPredicate predicate = (BoundGeospatialPredicate) bound;
+
+    // Verify the operation matches the expected operation
+    assertThat(predicate.op()).isEqualTo(op);
+
+    // Verify the term references the correct field
+    assertThat(predicate.term().ref().fieldId()).isEqualTo(fieldId);
+
+    // Verify the literal value is correct
+    assertThat(predicate.literal().value()).isEqualTo(bbox);
+
+    // Verify special values are preserved
+    GeospatialBoundingBox boundingBox = predicate.literal().value();
+    assertThat(boundingBox.min().x()).isEqualTo(Double.NEGATIVE_INFINITY);
+    assertThat(Double.isNaN(boundingBox.min().y())).isTrue();
+    assertThat(boundingBox.max().x()).isEqualTo(Double.POSITIVE_INFINITY);
+    assertThat(Double.isNaN(boundingBox.max().y())).isTrue();
+  }
+
+  @ParameterizedTest
+  @MethodSource("geospatialOperators")
+  public void testSanitizedBoundingBox(Expression.Operation op, String fieldName, int fieldId) {
+    // Use the sanitized bounding box
+    GeospatialBoundingBox bbox = GeospatialBoundingBox.SANITIZED;
+
+    // Create an unbound predicate based on the operation
+    UnboundPredicate<ByteBuffer> unbound = Expressions.geospatialPredicate(op, fieldName, bbox);
+
+    // Bind the predicate to the schema
+    Expression bound = unbound.bind(SCHEMA.asStruct());
+    BoundGeospatialPredicate predicate = (BoundGeospatialPredicate) bound;
+
+    // Verify the operation matches the expected operation
+    assertThat(predicate.op()).isEqualTo(op);
+
+    // Verify the term references the correct field
+    assertThat(predicate.term().ref().fieldId()).isEqualTo(fieldId);
+
+    // Verify the literal value is the sanitized bounding box
+    assertThat(predicate.literal().value()).isEqualTo(GeospatialBoundingBox.SANITIZED);
+    assertThat(predicate.literal().value().toString()).isEqualTo("BoundingBox{sanitized}");
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/expressions/TestBoundGeospatialPredicate.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestBoundGeospatialPredicate.java
@@ -24,8 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.ByteBuffer;
 import java.util.stream.Stream;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialBound;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -52,7 +52,7 @@ public class TestBoundGeospatialPredicate {
     // Create a bounding box for testing
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     // Create an unbound predicate based on the operation
     UnboundPredicate<ByteBuffer> unbound = Expressions.geospatialPredicate(op, fieldName, bbox);
@@ -88,7 +88,7 @@ public class TestBoundGeospatialPredicate {
     // Create a bounding box for testing
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     // Create an unbound predicate based on the operation
     UnboundPredicate<ByteBuffer> unbound = Expressions.geospatialPredicate(op, fieldName, bbox);
@@ -130,15 +130,15 @@ public class TestBoundGeospatialPredicate {
     // Create two identical bounding boxes
     GeospatialBound min1 = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max1 = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox bbox1 = new BoundingBox(min1, max1);
     GeospatialBound min2 = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max2 = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox bbox2 = new BoundingBox(min2, max2);
 
     // Create a different bounding box
     GeospatialBound min3 = GeospatialBound.createXY(5.0, 6.0);
     GeospatialBound max3 = GeospatialBound.createXY(7.0, 8.0);
-    GeospatialBoundingBox bbox3 = new GeospatialBoundingBox(min3, max3);
+    BoundingBox bbox3 = new BoundingBox(min3, max3);
 
     // Create the main predicate with the current operation
     UnboundPredicate<ByteBuffer> unbound1 = Expressions.geospatialPredicate(op, fieldName, bbox1);
@@ -196,7 +196,7 @@ public class TestBoundGeospatialPredicate {
     // Create a bounding box for testing
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     // Create an unbound predicate based on the operation
     UnboundPredicate<ByteBuffer> unbound = Expressions.geospatialPredicate(op, fieldName, bbox);
@@ -220,7 +220,7 @@ public class TestBoundGeospatialPredicate {
     // Create a bounding box with Z and M coordinates
     GeospatialBound min = GeospatialBound.createXYZM(1.0, 2.0, 3.0, 4.0);
     GeospatialBound max = GeospatialBound.createXYZM(5.0, 6.0, 7.0, 8.0);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     // Create an unbound predicate based on the operation
     UnboundPredicate<ByteBuffer> unbound = Expressions.geospatialPredicate(op, fieldName, bbox);
@@ -239,7 +239,7 @@ public class TestBoundGeospatialPredicate {
     assertThat(predicate.literal().value()).isEqualTo(bbox);
 
     // Verify Z and M coordinates are preserved
-    GeospatialBoundingBox boundingBox = predicate.literal().value();
+    BoundingBox boundingBox = predicate.literal().value();
     assertThat(boundingBox.min().hasZ()).isTrue();
     assertThat(boundingBox.min().hasM()).isTrue();
     assertThat(boundingBox.min().z()).isEqualTo(3.0);
@@ -256,7 +256,7 @@ public class TestBoundGeospatialPredicate {
     // Create a bounding box with NaN and infinity values
     GeospatialBound min = GeospatialBound.createXY(Double.NEGATIVE_INFINITY, Double.NaN);
     GeospatialBound max = GeospatialBound.createXY(Double.POSITIVE_INFINITY, Double.NaN);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     // Create an unbound predicate based on the operation
     UnboundPredicate<ByteBuffer> unbound = Expressions.geospatialPredicate(op, fieldName, bbox);
@@ -275,34 +275,10 @@ public class TestBoundGeospatialPredicate {
     assertThat(predicate.literal().value()).isEqualTo(bbox);
 
     // Verify special values are preserved
-    GeospatialBoundingBox boundingBox = predicate.literal().value();
+    BoundingBox boundingBox = predicate.literal().value();
     assertThat(boundingBox.min().x()).isEqualTo(Double.NEGATIVE_INFINITY);
     assertThat(Double.isNaN(boundingBox.min().y())).isTrue();
     assertThat(boundingBox.max().x()).isEqualTo(Double.POSITIVE_INFINITY);
     assertThat(Double.isNaN(boundingBox.max().y())).isTrue();
-  }
-
-  @ParameterizedTest
-  @MethodSource("geospatialOperators")
-  public void testSanitizedBoundingBox(Expression.Operation op, String fieldName, int fieldId) {
-    // Use the sanitized bounding box
-    GeospatialBoundingBox bbox = GeospatialBoundingBox.SANITIZED;
-
-    // Create an unbound predicate based on the operation
-    UnboundPredicate<ByteBuffer> unbound = Expressions.geospatialPredicate(op, fieldName, bbox);
-
-    // Bind the predicate to the schema
-    Expression bound = unbound.bind(SCHEMA.asStruct());
-    BoundGeospatialPredicate predicate = (BoundGeospatialPredicate) bound;
-
-    // Verify the operation matches the expected operation
-    assertThat(predicate.op()).isEqualTo(op);
-
-    // Verify the term references the correct field
-    assertThat(predicate.term().ref().fieldId()).isEqualTo(fieldId);
-
-    // Verify the literal value is the sanitized bounding box
-    assertThat(predicate.literal().value()).isEqualTo(GeospatialBoundingBox.SANITIZED);
-    assertThat(predicate.literal().value().toString()).isEqualTo("BoundingBox{sanitized}");
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
@@ -51,8 +51,8 @@ import java.util.stream.Stream;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialBound;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 import org.junit.jupiter.api.Test;
@@ -833,9 +833,8 @@ public class TestEvaluator {
             required(1, "geom", Types.GeometryType.crs84()),
             required(2, "geog", Types.GeographyType.crs84()));
 
-    GeospatialBoundingBox bbox =
-        new GeospatialBoundingBox(
-            GeospatialBound.createXY(1.0, 2.0), GeospatialBound.createXY(3.0, 4.0));
+    BoundingBox bbox =
+        new BoundingBox(GeospatialBound.createXY(1.0, 2.0), GeospatialBound.createXY(3.0, 4.0));
 
     // Create a WKB point at (2, 3)
     ByteBuffer wkb =

--- a/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
@@ -840,34 +840,13 @@ public class TestEvaluator {
     // Create a WKB point at (2, 3)
     ByteBuffer wkb =
         ByteBuffer.wrap(
-            new byte[] {
-              1, // little endian byte order
-              1,
-              0,
-              0,
-              0, // type: Point (1)
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              64, // X coordinate: 2.0 in IEEE 754
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              8,
-              64 // Y coordinate: 3.0 in IEEE 754
-            });
+            new byte[] {1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 8, 64});
 
     Evaluator evaluator =
         new Evaluator(geoStruct, Expressions.geospatialPredicate(operation, columnName, bbox));
-    assertThat(evaluator.eval(TestHelpers.Row.of(wkb, wkb)))
-        .as("Geospatial predicates always evaluate to true")
-        .isTrue();
+    assertThatThrownBy(() -> evaluator.eval(TestHelpers.Row.of(wkb, wkb)))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageMatching(
+            "Evaluation of \\w+ against geometry/geography value is not implemented.");
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
@@ -40,8 +40,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialBound;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 import org.junit.jupiter.api.Test;
@@ -431,7 +431,7 @@ public class TestExpressionBinding {
     // Create a bounding box for testing
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     Expression expr =
         Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "point", bbox);
@@ -451,7 +451,7 @@ public class TestExpressionBinding {
     // Create a bounding box for testing
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     Expression expr =
         Expressions.geospatialPredicate(Expression.Operation.ST_DISJOINT, "geography", bbox);
@@ -471,7 +471,7 @@ public class TestExpressionBinding {
     // Create a bounding box for testing
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     // Test with a field that doesn't exist
     Expression expr =

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
@@ -40,6 +40,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 import org.junit.jupiter.api.Test;
@@ -55,7 +57,9 @@ public class TestExpressionBinding {
           required(3, "data", Types.StringType.get()),
           required(4, "var", Types.VariantType.get()),
           optional(5, "nullable", Types.IntegerType.get()),
-          optional(6, "always_null", Types.UnknownType.get()));
+          optional(6, "always_null", Types.UnknownType.get()),
+          required(7, "point", Types.GeometryType.crs84()),
+          required(8, "geography", Types.GeographyType.crs84()));
 
   @Test
   public void testMissingReference() {
@@ -420,5 +424,67 @@ public class TestExpressionBinding {
     BoundPredicate<?> pred = TestHelpers.assertAndUnwrap(bound);
     assertThat(pred.term()).as("Should use a BoundExtract").isInstanceOf(BoundExtract.class);
     assertThat(pred.term().type()).isEqualTo(Types.fromPrimitiveString(typeName));
+  }
+
+  @Test
+  public void testStIntersects() {
+    // Create a bounding box for testing
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    Expression expr =
+        Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "point", bbox);
+    Expression bound = Binder.bind(STRUCT, expr);
+
+    TestHelpers.assertAllReferencesBound("BoundGeospatialPredicate", bound);
+    BoundPredicate<?> pred = TestHelpers.assertAndUnwrap(bound);
+    assertThat(pred.op()).isEqualTo(Expression.Operation.ST_INTERSECTS);
+    assertThat(pred.term().ref().fieldId()).as("Should bind point correctly").isEqualTo(7);
+    assertThat(bound).isInstanceOf(BoundGeospatialPredicate.class);
+    BoundGeospatialPredicate predicate = (BoundGeospatialPredicate) bound;
+    assertThat(predicate.literal().value()).isEqualTo(bbox);
+  }
+
+  @Test
+  public void testStDisjoint() {
+    // Create a bounding box for testing
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    Expression expr =
+        Expressions.geospatialPredicate(Expression.Operation.ST_DISJOINT, "geography", bbox);
+    Expression bound = Binder.bind(STRUCT, expr);
+
+    TestHelpers.assertAllReferencesBound("BoundGeospatialPredicate", bound);
+    BoundPredicate<?> pred = TestHelpers.assertAndUnwrap(bound);
+    assertThat(pred.op()).isEqualTo(Expression.Operation.ST_DISJOINT);
+    assertThat(pred.term().ref().fieldId()).as("Should bind geography correctly").isEqualTo(8);
+    assertThat(bound).isInstanceOf(BoundGeospatialPredicate.class);
+    BoundGeospatialPredicate predicate = (BoundGeospatialPredicate) bound;
+    assertThat(predicate.literal().value()).isEqualTo(bbox);
+  }
+
+  @Test
+  public void testGeospatialPredicateWithInvalidField() {
+    // Create a bounding box for testing
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    // Test with a field that doesn't exist
+    Expression expr =
+        Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "nonexistent", bbox);
+    assertThatThrownBy(() -> Binder.bind(STRUCT, expr))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot find field 'nonexistent' in struct");
+
+    // Test with a field that is not a geometry or geography type
+    Expression expr2 =
+        Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "x", bbox);
+    assertThatThrownBy(() -> Binder.bind(STRUCT, expr2))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot bind geospatial operation to non-geospatial type");
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
@@ -48,8 +48,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.Callable;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialBound;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
@@ -234,7 +234,7 @@ public class TestExpressionHelpers {
     // Create a bounding box for testing
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     // Test pairs of expressions: (rewritten pred, original pred)
     Expression[][] expressions =

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
@@ -48,6 +48,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.Callable;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
@@ -219,6 +221,73 @@ public class TestExpressionHelpers {
     assertInvalidateNaNThrows(() -> notIn(self("a"), 1.0D, 2.0D, Double.NaN));
 
     assertInvalidateNaNThrows(() -> predicate(Expression.Operation.EQ, "a", Double.NaN));
+  }
+
+  @Test
+  public void testRewriteNotForGeospatialPredicates() {
+    // Create a schema with geometry and geography fields
+    StructType struct =
+        StructType.of(
+            NestedField.optional(1, "geom", Types.GeometryType.crs84()),
+            NestedField.optional(2, "geog", Types.GeographyType.crs84()));
+
+    // Create a bounding box for testing
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    // Test pairs of expressions: (rewritten pred, original pred)
+    Expression[][] expressions =
+        new Expression[][] {
+          // ST_INTERSECTS and its negation (ST_DISJOINT)
+          {
+            Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "geom", bbox),
+            Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "geom", bbox)
+          },
+          {
+            Expressions.geospatialPredicate(Expression.Operation.ST_DISJOINT, "geom", bbox),
+            not(Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "geom", bbox))
+          },
+          {
+            Expressions.geospatialPredicate(Expression.Operation.ST_DISJOINT, "geom", bbox),
+            Expressions.geospatialPredicate(Expression.Operation.ST_DISJOINT, "geom", bbox)
+          },
+          {
+            Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "geom", bbox),
+            not(Expressions.geospatialPredicate(Expression.Operation.ST_DISJOINT, "geom", bbox))
+          },
+          // Same tests with geography type
+          {
+            Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "geog", bbox),
+            Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "geog", bbox)
+          },
+          {
+            Expressions.geospatialPredicate(Expression.Operation.ST_DISJOINT, "geog", bbox),
+            not(Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "geog", bbox))
+          },
+          {
+            Expressions.geospatialPredicate(Expression.Operation.ST_DISJOINT, "geog", bbox),
+            Expressions.geospatialPredicate(Expression.Operation.ST_DISJOINT, "geog", bbox)
+          },
+          {
+            Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "geog", bbox),
+            not(Expressions.geospatialPredicate(Expression.Operation.ST_DISJOINT, "geog", bbox))
+          }
+        };
+
+    for (Expression[] pair : expressions) {
+      // unbound rewrite
+      assertThat(rewriteNot(pair[1]))
+          .as(String.format("rewriteNot(%s) should be %s", pair[1], pair[0]))
+          .hasToString(pair[0].toString());
+
+      // bound rewrite
+      Expression expectedBound = Binder.bind(struct, pair[0]);
+      Expression toRewriteBound = Binder.bind(struct, pair[1]);
+      assertThat(rewriteNot(toRewriteBound))
+          .as(String.format("rewriteNot(%s) should be %s", toRewriteBound, expectedBound))
+          .hasToString(expectedBound.toString());
+    }
   }
 
   private void assertInvalidateNaNThrows(Callable<UnboundPredicate<Double>> callable) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionSerialization.java
@@ -24,6 +24,8 @@ import java.util.Collection;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.expressions.Expression.Operation;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +35,9 @@ public class TestExpressionSerialization {
     Schema schema =
         new Schema(
             Types.NestedField.optional(34, "a", Types.IntegerType.get()),
-            Types.NestedField.required(35, "s", Types.StringType.get()));
+            Types.NestedField.required(35, "s", Types.StringType.get()),
+            Types.NestedField.required(36, "point", Types.GeometryType.crs84()),
+            Types.NestedField.required(37, "geography", Types.GeographyType.crs84()));
 
     Expression[] expressions =
         new Expression[] {
@@ -61,7 +65,26 @@ public class TestExpressionSerialization {
           Expressions.notIn("s", "abc", "xyz").bind(schema.asStruct()),
           Expressions.isNull("a").bind(schema.asStruct()),
           Expressions.startsWith("s", "abc").bind(schema.asStruct()),
-          Expressions.notStartsWith("s", "xyz").bind(schema.asStruct())
+          Expressions.notStartsWith("s", "xyz").bind(schema.asStruct()),
+          Expressions.notStartsWith("s", "xyz").bind(schema.asStruct()),
+          Expressions.stIntersects(
+              "point",
+              new GeospatialBoundingBox(
+                  GeospatialBound.createXY(1.0, 2.0), GeospatialBound.createXY(3.0, 4.0))),
+          Expressions.stDisjoint(
+              "geography",
+              new GeospatialBoundingBox(
+                  GeospatialBound.createXY(5.0, 6.0), GeospatialBound.createXY(7.0, 8.0))),
+          Expressions.stIntersects(
+                  "point",
+                  new GeospatialBoundingBox(
+                      GeospatialBound.createXY(1.0, 2.0), GeospatialBound.createXY(3.0, 4.0)))
+              .bind(schema.asStruct()),
+          Expressions.stDisjoint(
+                  "geography",
+                  new GeospatialBoundingBox(
+                      GeospatialBound.createXY(5.0, 6.0), GeospatialBound.createXY(7.0, 8.0)))
+              .bind(schema.asStruct())
         };
 
     for (Expression expression : expressions) {
@@ -149,12 +172,19 @@ public class TestExpressionSerialization {
     if (left instanceof UnboundPredicate) {
       UnboundPredicate lpred = (UnboundPredicate) left;
       UnboundPredicate rpred = (UnboundPredicate) right;
-      if (left.op() == Operation.IN || left.op() == Operation.NOT_IN) {
+      if (left.op() == Operation.IN
+          || left.op() == Operation.NOT_IN
+          || left.op() == Operation.ST_INTERSECTS
+          || left.op() == Operation.ST_DISJOINT) {
         return equals(lpred.literals(), rpred.literals());
       }
       return lpred.literal().comparator().compare(lpred.literal().value(), rpred.literal().value())
           == 0;
 
+    } else if (left instanceof BoundGeospatialPredicate) {
+      BoundGeospatialPredicate lpred = (BoundGeospatialPredicate) left;
+      BoundGeospatialPredicate rpred = (BoundGeospatialPredicate) right;
+      return lpred.isEquivalentTo(rpred);
     } else if (left instanceof BoundPredicate) {
       BoundPredicate lpred = (BoundPredicate) left;
       BoundPredicate rpred = (BoundPredicate) right;
@@ -172,7 +202,6 @@ public class TestExpressionSerialization {
       } else {
         return lpred.isUnaryPredicate() && rpred.isUnaryPredicate();
       }
-
     } else {
       throw new UnsupportedOperationException(
           String.format("Predicate equality check for %s is not supported", left.getClass()));

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionSerialization.java
@@ -24,8 +24,8 @@ import java.util.Collection;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.expressions.Expression.Operation;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialBound;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
@@ -69,20 +69,20 @@ public class TestExpressionSerialization {
           Expressions.notStartsWith("s", "xyz").bind(schema.asStruct()),
           Expressions.stIntersects(
               "point",
-              new GeospatialBoundingBox(
+              new BoundingBox(
                   GeospatialBound.createXY(1.0, 2.0), GeospatialBound.createXY(3.0, 4.0))),
           Expressions.stDisjoint(
               "geography",
-              new GeospatialBoundingBox(
+              new BoundingBox(
                   GeospatialBound.createXY(5.0, 6.0), GeospatialBound.createXY(7.0, 8.0))),
           Expressions.stIntersects(
                   "point",
-                  new GeospatialBoundingBox(
+                  new BoundingBox(
                       GeospatialBound.createXY(1.0, 2.0), GeospatialBound.createXY(3.0, 4.0)))
               .bind(schema.asStruct()),
           Expressions.stDisjoint(
                   "geography",
-                  new GeospatialBoundingBox(
+                  new BoundingBox(
                       GeospatialBound.createXY(5.0, 6.0), GeospatialBound.createXY(7.0, 8.0)))
               .bind(schema.asStruct())
         };

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionSerialization.java
@@ -185,6 +185,7 @@ public class TestExpressionSerialization {
       BoundGeospatialPredicate lpred = (BoundGeospatialPredicate) left;
       BoundGeospatialPredicate rpred = (BoundGeospatialPredicate) right;
       return lpred.isEquivalentTo(rpred);
+
     } else if (left instanceof BoundPredicate) {
       BoundPredicate lpred = (BoundPredicate) left;
       BoundPredicate rpred = (BoundPredicate) right;
@@ -202,6 +203,7 @@ public class TestExpressionSerialization {
       } else {
         return lpred.isUnaryPredicate() && rpred.isUnaryPredicate();
       }
+
     } else {
       throw new UnsupportedOperationException(
           String.format("Predicate equality check for %s is not supported", left.getClass()));

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.expressions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -28,12 +29,18 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestExpressionUtil {
   private static final Schema SCHEMA =
@@ -1048,6 +1055,48 @@ public class TestExpressionUtil {
                 true))
         .as("Should not select partitions, on hour not day boundary")
         .isFalse();
+  }
+
+  private static Stream<Arguments> geospatialPredicateParameters() {
+    return Stream.of(
+        Arguments.of(Expression.Operation.ST_INTERSECTS, "geom"),
+        Arguments.of(Expression.Operation.ST_INTERSECTS, "geog"),
+        Arguments.of(Expression.Operation.ST_DISJOINT, "geom"),
+        Arguments.of(Expression.Operation.ST_DISJOINT, "geog"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("geospatialPredicateParameters")
+  public void testSanitizeGeospatialPredicates(Expression.Operation operation, String columnName) {
+    // Create a schema with geometry and geography fields
+    Schema geoSchema =
+        new Schema(
+            Types.NestedField.required(1, "geom", Types.GeometryType.crs84()),
+            Types.NestedField.required(2, "geog", Types.GeographyType.crs84()));
+    Types.StructType geoStruct = geoSchema.asStruct();
+
+    // Create a bounding box for testing
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    UnboundPredicate<ByteBuffer> geoPredicate =
+        Expressions.geospatialPredicate(operation, columnName, bbox);
+    Expression predicateSanitized =
+        Expressions.geospatialPredicate(operation, columnName, GeospatialBoundingBox.SANITIZED);
+    assertEquals(predicateSanitized, ExpressionUtil.sanitize(geoPredicate));
+    assertEquals(predicateSanitized, ExpressionUtil.sanitize(geoStruct, geoPredicate, true));
+
+    String opString = operation.name();
+    String expectedSanitizedString = columnName + " " + opString + " WITH BoundingBox{sanitized}";
+
+    assertThat(ExpressionUtil.toSanitizedString(geoPredicate))
+        .as("Sanitized string should be identical for geospatial predicates")
+        .isEqualTo(expectedSanitizedString);
+
+    assertThat(ExpressionUtil.toSanitizedString(geoStruct, geoPredicate, true))
+        .as("Sanitized string should be identical for geospatial predicates")
+        .isEqualTo(expectedSanitizedString);
   }
 
   private void assertEquals(Expression expected, Expression actual) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -32,8 +32,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialBound;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
@@ -1078,17 +1078,17 @@ public class TestExpressionUtil {
     // Create a bounding box for testing
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     UnboundPredicate<ByteBuffer> geoPredicate =
         Expressions.geospatialPredicate(operation, columnName, bbox);
     Expression predicateSanitized =
-        Expressions.geospatialPredicate(operation, columnName, GeospatialBoundingBox.SANITIZED);
+        Expressions.geospatialPredicate(operation, columnName, BoundingBox.empty());
     assertEquals(predicateSanitized, ExpressionUtil.sanitize(geoPredicate));
     assertEquals(predicateSanitized, ExpressionUtil.sanitize(geoStruct, geoPredicate, true));
 
     String opString = operation.name();
-    String expectedSanitizedString = columnName + " " + opString + " WITH BoundingBox{sanitized}";
+    String expectedSanitizedString = columnName + " " + opString + " WITH (bounding-box)";
 
     assertThat(ExpressionUtil.toSanitizedString(geoPredicate))
         .as("Sanitized string should be identical for geospatial predicates")

--- a/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluator.java
@@ -49,8 +49,8 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.TestHelpers.TestDataFile;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialBound;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
@@ -913,7 +913,7 @@ public class TestInclusiveMetricsEvaluator {
                 SCHEMA,
                 stIntersects(
                     "geom",
-                    new GeospatialBoundingBox(
+                    new BoundingBox(
                         GeospatialBound.createXY(0, 0), GeospatialBound.createXY(3, 4))))
             .eval(FILE_6);
     assertThat(shouldRead).as("Should read: query window intersects the boundary").isTrue();
@@ -923,7 +923,7 @@ public class TestInclusiveMetricsEvaluator {
                 SCHEMA,
                 stIntersects(
                     "geom",
-                    new GeospatialBoundingBox(
+                    new BoundingBox(
                         GeospatialBound.createXY(0, 0), GeospatialBound.createXY(0.5, 2))))
             .eval(FILE_6);
     assertThat(shouldRead)
@@ -935,7 +935,7 @@ public class TestInclusiveMetricsEvaluator {
                 SCHEMA,
                 stIntersects(
                     "geom",
-                    new GeospatialBoundingBox(
+                    new BoundingBox(
                         GeospatialBound.createXY(0, 0), GeospatialBound.createXY(0.5, 2))))
             .eval(FILE);
     assertThat(shouldRead).as("Should read: stats is missing").isTrue();
@@ -948,7 +948,7 @@ public class TestInclusiveMetricsEvaluator {
                 SCHEMA,
                 stDisjoint(
                     "geom",
-                    new GeospatialBoundingBox(
+                    new BoundingBox(
                         GeospatialBound.createXY(0, 0), GeospatialBound.createXY(3, 4))))
             .eval(FILE_6);
     assertThat(shouldRead).as("Should read: always read no matter if it's disjoint").isTrue();
@@ -958,7 +958,7 @@ public class TestInclusiveMetricsEvaluator {
                 SCHEMA,
                 stDisjoint(
                     "geom",
-                    new GeospatialBoundingBox(
+                    new BoundingBox(
                         GeospatialBound.createXY(0, 0), GeospatialBound.createXY(0.5, 2))))
             .eval(FILE);
     assertThat(shouldRead).as("Should read: stats is missing").isTrue();

--- a/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluator.java
@@ -34,6 +34,8 @@ import static org.apache.iceberg.expressions.Expressions.notNaN;
 import static org.apache.iceberg.expressions.Expressions.notNull;
 import static org.apache.iceberg.expressions.Expressions.notStartsWith;
 import static org.apache.iceberg.expressions.Expressions.or;
+import static org.apache.iceberg.expressions.Expressions.stDisjoint;
+import static org.apache.iceberg.expressions.Expressions.stIntersects;
 import static org.apache.iceberg.expressions.Expressions.startsWith;
 import static org.apache.iceberg.types.Conversions.toByteBuffer;
 import static org.apache.iceberg.types.Types.NestedField.optional;
@@ -47,6 +49,8 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.TestHelpers.TestDataFile;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
@@ -71,7 +75,11 @@ public class TestInclusiveMetricsEvaluator {
           optional(11, "all_nans_v1_stats", Types.FloatType.get()),
           optional(12, "nan_and_null_only", Types.DoubleType.get()),
           optional(13, "no_nan_stats", Types.DoubleType.get()),
-          optional(14, "some_empty", Types.StringType.get()));
+          optional(14, "some_empty", Types.StringType.get()),
+          optional(15, "geom", Types.GeometryType.crs84()),
+          optional(16, "all_nulls_geom", Types.GeometryType.crs84()),
+          optional(17, "geog", Types.GeographyType.crs84()),
+          optional(18, "all_nulls_geog", Types.GeographyType.crs84()));
 
   private static final int INT_MIN_VALUE = 30;
   private static final int INT_MAX_VALUE = 79;
@@ -186,6 +194,40 @@ public class TestInclusiveMetricsEvaluator {
           ImmutableMap.of(3, toByteBuffer(StringType.get(), "abc")),
           // upper bounds
           ImmutableMap.of(3, toByteBuffer(StringType.get(), "abcdefghi")));
+
+  private static final DataFile FILE_6 =
+      new TestDataFile(
+          "file_6.avro",
+          Row.of(),
+          50,
+          // any value counts, including nulls
+          ImmutableMap.<Integer, Long>builder()
+              .put(15, 20L)
+              .put(16, 20L)
+              .put(17, 20L)
+              .put(18, 20L)
+              .buildOrThrow(),
+          // null value counts
+          ImmutableMap.<Integer, Long>builder()
+              .put(15, 2L)
+              .put(16, 20L)
+              .put(17, 2L)
+              .put(18, 20L)
+              .buildOrThrow(),
+          // nan value counts
+          null,
+          // lower bounds
+          ImmutableMap.of(
+              15,
+              GeospatialBound.createXY(1, 2).toByteBuffer(),
+              17,
+              GeospatialBound.createXY(1, 2).toByteBuffer()),
+          // upper bounds
+          ImmutableMap.of(
+              15,
+              GeospatialBound.createXY(10, 20).toByteBuffer(),
+              17,
+              GeospatialBound.createXY(10, 20).toByteBuffer()));
 
   @Test
   public void testAllNulls() {
@@ -862,5 +904,63 @@ public class TestInclusiveMetricsEvaluator {
 
     shouldRead = new InclusiveMetricsEvaluator(SCHEMA, notIn("no_nulls", "abc", "def")).eval(FILE);
     assertThat(shouldRead).as("Should read: notIn on no nulls column").isTrue();
+  }
+
+  @Test
+  public void testStIntersects() {
+    boolean shouldRead =
+        new InclusiveMetricsEvaluator(
+                SCHEMA,
+                stIntersects(
+                    "geom",
+                    new GeospatialBoundingBox(
+                        GeospatialBound.createXY(0, 0), GeospatialBound.createXY(3, 4))))
+            .eval(FILE_6);
+    assertThat(shouldRead).as("Should read: query window intersects the boundary").isTrue();
+
+    shouldRead =
+        new InclusiveMetricsEvaluator(
+                SCHEMA,
+                stIntersects(
+                    "geom",
+                    new GeospatialBoundingBox(
+                        GeospatialBound.createXY(0, 0), GeospatialBound.createXY(0.5, 2))))
+            .eval(FILE_6);
+    assertThat(shouldRead)
+        .as("Should skip: query window does not intersect with the boundary")
+        .isFalse();
+
+    shouldRead =
+        new InclusiveMetricsEvaluator(
+                SCHEMA,
+                stIntersects(
+                    "geom",
+                    new GeospatialBoundingBox(
+                        GeospatialBound.createXY(0, 0), GeospatialBound.createXY(0.5, 2))))
+            .eval(FILE);
+    assertThat(shouldRead).as("Should read: stats is missing").isTrue();
+  }
+
+  @Test
+  public void testStDisjoint() {
+    boolean shouldRead =
+        new InclusiveMetricsEvaluator(
+                SCHEMA,
+                stDisjoint(
+                    "geom",
+                    new GeospatialBoundingBox(
+                        GeospatialBound.createXY(0, 0), GeospatialBound.createXY(3, 4))))
+            .eval(FILE_6);
+    assertThat(shouldRead).as("Should read: always read no matter if it's disjoint").isTrue();
+
+    shouldRead =
+        new InclusiveMetricsEvaluator(
+                SCHEMA,
+                stDisjoint(
+                    "geom",
+                    new GeospatialBoundingBox(
+                        GeospatialBound.createXY(0, 0), GeospatialBound.createXY(0.5, 2))))
+            .eval(FILE);
+    assertThat(shouldRead).as("Should read: stats is missing").isTrue();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestLiteralSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestLiteralSerialization.java
@@ -23,8 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import java.util.UUID;
 import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialBound;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +50,7 @@ public class TestLiteralSerialization {
           Literal.of(new byte[] {3, 4, 5, 6}).to(Types.BinaryType.get()),
           Literal.of(new BigDecimal("122.50")),
           Literal.of(
-              new GeospatialBoundingBox(
+              new BoundingBox(
                   GeospatialBound.createXY(1.0, 2.0), GeospatialBound.createXY(3.0, 4.0)))
         };
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestLiteralSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestLiteralSerialization.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import java.util.UUID;
 import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
@@ -47,6 +49,9 @@ public class TestLiteralSerialization {
           Literal.of(new byte[] {1, 2, 3}).to(Types.FixedType.ofLength(3)),
           Literal.of(new byte[] {3, 4, 5, 6}).to(Types.BinaryType.get()),
           Literal.of(new BigDecimal("122.50")),
+          Literal.of(
+              new GeospatialBoundingBox(
+                  GeospatialBound.createXY(1.0, 2.0), GeospatialBound.createXY(3.0, 4.0)))
         };
 
     for (Literal<?> lit : literals) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestMiscLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestMiscLiteralConversions.java
@@ -25,6 +25,8 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -302,7 +304,9 @@ public class TestMiscLiteralConversions {
         Types.FloatType.get(),
         Types.DoubleType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.GeometryType.crs84(),
+        Types.GeographyType.crs84());
   }
 
   @Test
@@ -344,7 +348,9 @@ public class TestMiscLiteralConversions {
         Types.DecimalType.of(9, 2),
         Types.StringType.get(),
         Types.UUIDType.get(),
-        Types.FixedType.ofLength(1));
+        Types.FixedType.ofLength(1),
+        Types.GeometryType.crs84(),
+        Types.GeographyType.crs84());
   }
 
   @Test
@@ -365,7 +371,35 @@ public class TestMiscLiteralConversions {
         Types.DecimalType.of(9, 2),
         Types.StringType.get(),
         Types.UUIDType.get(),
-        Types.FixedType.ofLength(1));
+        Types.FixedType.ofLength(1),
+        Types.GeometryType.crs84(),
+        Types.GeographyType.crs84());
+  }
+
+  @Test
+  public void testInvalidGeospatialBoundingBoxConversions() {
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    Literal<GeospatialBoundingBox> geoBoundingBoxLiteral =
+        Literal.of(new GeospatialBoundingBox(min, max));
+
+    // Test that geospatial bounding box literals cannot be converted to other types
+    testInvalidConversions(
+        geoBoundingBoxLiteral,
+        Types.BooleanType.get(),
+        Types.IntegerType.get(),
+        Types.LongType.get(),
+        Types.FloatType.get(),
+        Types.DoubleType.get(),
+        Types.DateType.get(),
+        Types.TimeType.get(),
+        Types.DecimalType.of(9, 2),
+        Types.StringType.get(),
+        Types.UUIDType.get(),
+        Types.BinaryType.get(),
+        Types.FixedType.ofLength(1),
+        Types.GeometryType.crs84(),
+        Types.GeographyType.crs84());
   }
 
   private void testInvalidConversions(Literal<?> lit, Type... invalidTypes) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestMiscLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestMiscLiteralConversions.java
@@ -25,8 +25,8 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialBound;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -380,8 +380,7 @@ public class TestMiscLiteralConversions {
   public void testInvalidGeospatialBoundingBoxConversions() {
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    Literal<GeospatialBoundingBox> geoBoundingBoxLiteral =
-        Literal.of(new GeospatialBoundingBox(min, max));
+    Literal<BoundingBox> geoBoundingBoxLiteral = Literal.of(new BoundingBox(min, max));
 
     // Test that geospatial bounding box literals cannot be converted to other types
     testInvalidConversions(

--- a/api/src/test/java/org/apache/iceberg/expressions/TestPredicateBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestPredicateBinding.java
@@ -41,10 +41,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 import org.junit.jupiter.api.Test;
@@ -647,5 +650,90 @@ public class TestPredicateBinding {
     assertThat(expr)
         .as("Should change NOT_IN to alwaysTrue expression")
         .isEqualTo(Expressions.alwaysTrue());
+  }
+
+  @Test
+  public void testGeospatialPredicateBinding() {
+    StructType struct =
+        StructType.of(
+            required(20, "geom", Types.GeometryType.crs84()),
+            required(21, "geog", Types.GeographyType.crs84()));
+
+    // Create a bounding box for testing
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    // Test ST_INTERSECTS with geometry
+    UnboundPredicate<ByteBuffer> stIntersectsGeom =
+        Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "geom", bbox);
+    Expression boundStIntersectsGeom = stIntersectsGeom.bind(struct);
+    assertThat(boundStIntersectsGeom).isInstanceOf(BoundGeospatialPredicate.class);
+    BoundGeospatialPredicate boundGeomPred = (BoundGeospatialPredicate) boundStIntersectsGeom;
+    assertThat(boundGeomPred.op()).isEqualTo(Expression.Operation.ST_INTERSECTS);
+    assertThat(boundGeomPred.term().ref().fieldId()).isEqualTo(20);
+    assertThat(boundGeomPred.literal().value()).isEqualTo(bbox);
+
+    // Test ST_DISJOINT with geometry
+    UnboundPredicate<ByteBuffer> stDisjointGeom =
+        Expressions.geospatialPredicate(Expression.Operation.ST_DISJOINT, "geom", bbox);
+    Expression boundStDisjointGeom = stDisjointGeom.bind(struct);
+    assertThat(boundStDisjointGeom).isInstanceOf(BoundGeospatialPredicate.class);
+    BoundGeospatialPredicate boundDisjointGeomPred = (BoundGeospatialPredicate) boundStDisjointGeom;
+    assertThat(boundDisjointGeomPred.op()).isEqualTo(Expression.Operation.ST_DISJOINT);
+    assertThat(boundDisjointGeomPred.term().ref().fieldId()).isEqualTo(20);
+    assertThat(boundDisjointGeomPred.literal().value()).isEqualTo(bbox);
+
+    // Test ST_INTERSECTS with geography
+    UnboundPredicate<ByteBuffer> stIntersectsGeog =
+        Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "geog", bbox);
+    Expression boundStIntersectsGeog = stIntersectsGeog.bind(struct);
+    assertThat(boundStIntersectsGeog).isInstanceOf(BoundGeospatialPredicate.class);
+    BoundGeospatialPredicate boundGeogPred = (BoundGeospatialPredicate) boundStIntersectsGeog;
+    assertThat(boundGeogPred.op()).isEqualTo(Expression.Operation.ST_INTERSECTS);
+    assertThat(boundGeogPred.term().ref().fieldId()).isEqualTo(21);
+    assertThat(boundGeogPred.literal().value()).isEqualTo(bbox);
+
+    // Test ST_DISJOINT with geography
+    UnboundPredicate<ByteBuffer> stDisjointGeog =
+        Expressions.geospatialPredicate(Expression.Operation.ST_DISJOINT, "geog", bbox);
+    Expression boundStDisjointGeog = stDisjointGeog.bind(struct);
+    assertThat(boundStDisjointGeog).isInstanceOf(BoundGeospatialPredicate.class);
+    BoundGeospatialPredicate boundDisjointGeogPred = (BoundGeospatialPredicate) boundStDisjointGeog;
+    assertThat(boundDisjointGeogPred.op()).isEqualTo(Expression.Operation.ST_DISJOINT);
+    assertThat(boundDisjointGeogPred.term().ref().fieldId()).isEqualTo(21);
+    assertThat(boundDisjointGeogPred.literal().value()).isEqualTo(bbox);
+  }
+
+  @Test
+  public void testMissingFieldGeospatialPredicate() {
+    StructType struct = StructType.of(required(22, "x", Types.IntegerType.get()));
+
+    // Create a bounding box for testing
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    UnboundPredicate<ByteBuffer> unbound =
+        Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "missing", bbox);
+    assertThatThrownBy(() -> unbound.bind(struct))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot find field 'missing' in struct:");
+  }
+
+  @Test
+  public void testInvalidTypeGeospatialPredicate() {
+    StructType struct = StructType.of(required(23, "x", Types.IntegerType.get()));
+
+    // Create a bounding box for testing
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+
+    UnboundPredicate<ByteBuffer> unbound =
+        Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "x", bbox);
+    assertThatThrownBy(() -> unbound.bind(struct))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot bind geospatial operation to non-geospatial type:");
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestPredicateBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestPredicateBinding.java
@@ -46,8 +46,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialBound;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 import org.junit.jupiter.api.Test;
@@ -662,7 +662,7 @@ public class TestPredicateBinding {
     // Create a bounding box for testing
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     // Test ST_INTERSECTS with geometry
     UnboundPredicate<ByteBuffer> stIntersectsGeom =
@@ -712,7 +712,7 @@ public class TestPredicateBinding {
     // Create a bounding box for testing
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     UnboundPredicate<ByteBuffer> unbound =
         Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "missing", bbox);
@@ -728,7 +728,7 @@ public class TestPredicateBinding {
     // Create a bounding box for testing
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox bbox = new GeospatialBoundingBox(min, max);
+    BoundingBox bbox = new BoundingBox(min, max);
 
     UnboundPredicate<ByteBuffer> unbound =
         Expressions.geospatialPredicate(Expression.Operation.ST_INTERSECTS, "x", bbox);

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -46,8 +46,8 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.TestHelpers.TestDataFile;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialBound;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.IntegerType;
@@ -737,7 +737,7 @@ public class TestStrictMetricsEvaluator {
                 geospatialPredicate(
                     operation,
                     columnName,
-                    new GeospatialBoundingBox(
+                    new BoundingBox(
                         GeospatialBound.createXY(1, 2), GeospatialBound.createXY(2, 3))))
             .eval(FILE_4);
     assertThat(shouldRead).as("Geospatial predicate should never match").isFalse();

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.expressions;
 
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.equal;
+import static org.apache.iceberg.expressions.Expressions.geospatialPredicate;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.in;
@@ -39,16 +40,22 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.stream.Stream;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.TestHelpers.TestDataFile;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.types.Types.StringType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestStrictMetricsEvaluator {
   private static final Schema SCHEMA =
@@ -73,7 +80,9 @@ public class TestStrictMetricsEvaluator {
               Types.StructType.of(
                   Types.NestedField.optional(16, "nested_col_no_stats", Types.IntegerType.get()),
                   Types.NestedField.optional(
-                      17, "nested_col_with_stats", Types.IntegerType.get()))));
+                      17, "nested_col_with_stats", Types.IntegerType.get()))),
+          optional(18, "geom", Types.GeometryType.crs84()),
+          optional(19, "geog", Types.GeographyType.crs84()));
 
   private static final int INT_MIN_VALUE = 30;
   private static final int INT_MAX_VALUE = 79;
@@ -171,6 +180,32 @@ public class TestStrictMetricsEvaluator {
           ImmutableMap.of(5, toByteBuffer(StringType.get(), "bbb")),
           // upper bounds
           ImmutableMap.of(5, toByteBuffer(StringType.get(), "bbb")));
+
+  private static final DataFile FILE_4 =
+      new TestDataFile(
+          "file_4.avro",
+          Row.of(),
+          50,
+          // any value counts, including nulls
+          ImmutableMap.of(
+              1, 50L,
+              18, 50L,
+              19, 50L),
+          // null value counts
+          ImmutableMap.of(
+              1, 0L,
+              18, 0L,
+              19, 0L),
+          // nan value counts
+          null,
+          // lower bounds
+          ImmutableMap.of(
+              18, GeospatialBound.createXY(1, 2).toByteBuffer(),
+              19, GeospatialBound.createXY(1, 2).toByteBuffer()),
+          // upper bounds
+          ImmutableMap.of(
+              18, GeospatialBound.createXY(10, 20).toByteBuffer(),
+              19, GeospatialBound.createXY(10, 20).toByteBuffer()));
 
   @Test
   public void testAllNulls() {
@@ -683,5 +718,28 @@ public class TestStrictMetricsEvaluator {
     shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notNull("struct.nested_col_with_stats")).eval(FILE);
     assertThat(shouldRead).as("notNull nested column should not match").isFalse();
+  }
+
+  private static Stream<Arguments> geospatialPredicateParameters() {
+    return Stream.of(
+        Arguments.of(Expression.Operation.ST_INTERSECTS, "geom"),
+        Arguments.of(Expression.Operation.ST_INTERSECTS, "geog"),
+        Arguments.of(Expression.Operation.ST_DISJOINT, "geom"),
+        Arguments.of(Expression.Operation.ST_DISJOINT, "geog"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("geospatialPredicateParameters")
+  public void testGeospatialPredicates(Expression.Operation operation, String columnName) {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(
+                SCHEMA,
+                geospatialPredicate(
+                    operation,
+                    columnName,
+                    new GeospatialBoundingBox(
+                        GeospatialBound.createXY(1, 2), GeospatialBound.createXY(2, 3))))
+            .eval(FILE_4);
+    assertThat(shouldRead).as("Geospatial predicate should never match").isFalse();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/geospatial/TestBoundingBox.java
+++ b/api/src/test/java/org/apache/iceberg/geospatial/TestBoundingBox.java
@@ -24,14 +24,14 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import org.junit.jupiter.api.Test;
 
-public class TestGeospatialBoundingBox {
+public class TestBoundingBox {
 
   @Test
   public void testConstructorAndAccessors() {
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
 
-    GeospatialBoundingBox box = new GeospatialBoundingBox(min, max);
+    BoundingBox box = new BoundingBox(min, max);
 
     assertThat(box.min()).isEqualTo(min);
     assertThat(box.max()).isEqualTo(max);
@@ -54,29 +54,56 @@ public class TestGeospatialBoundingBox {
     maxBuffer.putDouble(0, 3.0); // x
     maxBuffer.putDouble(8, 4.0); // y
 
-    GeospatialBoundingBox box = GeospatialBoundingBox.fromByteBuffers(minBuffer, maxBuffer);
+    BoundingBox box = BoundingBox.fromByteBuffers(minBuffer, maxBuffer);
 
     assertThat(box.min().x()).isEqualTo(1.0);
     assertThat(box.min().y()).isEqualTo(2.0);
     assertThat(box.max().x()).isEqualTo(3.0);
     assertThat(box.max().y()).isEqualTo(4.0);
+    assertThat(minBuffer.order()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+    assertThat(maxBuffer.order()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  @Test
+  public void testCreateFromBigEndianByteBuffers() {
+    // Create byte buffers for XY bounds
+    ByteBuffer minBuffer = ByteBuffer.allocate(16);
+    minBuffer.order(ByteOrder.LITTLE_ENDIAN);
+    minBuffer.putDouble(0, 10.0); // x
+    minBuffer.putDouble(8, 20.0); // y
+    minBuffer.order(ByteOrder.BIG_ENDIAN);
+
+    ByteBuffer maxBuffer = ByteBuffer.allocate(16);
+    maxBuffer.order(ByteOrder.LITTLE_ENDIAN);
+    maxBuffer.putDouble(0, 30.0); // x
+    maxBuffer.putDouble(8, 40.0); // y
+    maxBuffer.order(ByteOrder.BIG_ENDIAN);
+
+    BoundingBox box = BoundingBox.fromByteBuffers(minBuffer, maxBuffer);
+
+    assertThat(box.min().x()).isEqualTo(10.0);
+    assertThat(box.min().y()).isEqualTo(20.0);
+    assertThat(box.max().x()).isEqualTo(30.0);
+    assertThat(box.max().y()).isEqualTo(40.0);
+    assertThat(minBuffer.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
+    assertThat(maxBuffer.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
   }
 
   @Test
   public void testEqualsAndHashCode() {
     GeospatialBound min1 = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max1 = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     // Same values
     GeospatialBound min2 = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max2 = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     // Different values
     GeospatialBound min3 = GeospatialBound.createXY(0.0, 0.0);
     GeospatialBound max3 = GeospatialBound.createXY(10.0, 10.0);
-    GeospatialBoundingBox box3 = new GeospatialBoundingBox(min3, max3);
+    BoundingBox box3 = new BoundingBox(min3, max3);
 
     // Test equals
     assertThat(box1).isEqualTo(box2);
@@ -93,21 +120,7 @@ public class TestGeospatialBoundingBox {
   public void testToString() {
     GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
     GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
-    GeospatialBoundingBox box = new GeospatialBoundingBox(min, max);
+    BoundingBox box = new BoundingBox(min, max);
     assertThat(box.toString()).isEqualTo("BoundingBox{min=x=1.0, y=2.0, max=x=3.0, y=4.0}");
-  }
-
-  @Test
-  public void testSanitized() {
-    GeospatialBoundingBox box = GeospatialBoundingBox.SANITIZED;
-    GeospatialBoundingBox box2 =
-        GeospatialBoundingBox.fromByteBuffers(box.min().toByteBuffer(), box.max().toByteBuffer());
-    assertThat(box).isEqualTo(box2);
-    assertThat(box.toString()).isEqualTo("BoundingBox{sanitized}");
-    assertThat(box2.toString()).isEqualTo("BoundingBox{sanitized}");
-    GeospatialBound min3 = GeospatialBound.createXY(0.0, 0.0);
-    GeospatialBound max3 = GeospatialBound.createXY(10.0, 10.0);
-    GeospatialBoundingBox box3 = new GeospatialBoundingBox(min3, max3);
-    assertThat(box).isNotEqualTo(box3);
   }
 }

--- a/api/src/test/java/org/apache/iceberg/geospatial/TestGeospatialBound.java
+++ b/api/src/test/java/org/apache/iceberg/geospatial/TestGeospatialBound.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.geospatial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import org.apache.iceberg.util.ByteBuffers;
+import org.junit.jupiter.api.Test;
+
+public class TestGeospatialBound {
+
+  @Test
+  public void testCreateXY() {
+    GeospatialBound bound = GeospatialBound.createXY(1.0, 2.0);
+    assertThat(bound.x()).isEqualTo(1.0);
+    assertThat(bound.y()).isEqualTo(2.0);
+    assertThat(bound.hasZ()).isFalse();
+    assertThat(bound.hasM()).isFalse();
+    assertThat(Double.isNaN(bound.z())).isTrue();
+    assertThat(Double.isNaN(bound.m())).isTrue();
+  }
+
+  @Test
+  public void testCreateXYZ() {
+    GeospatialBound bound = GeospatialBound.createXYZ(1.0, 2.0, 3.0);
+    assertThat(bound.x()).isEqualTo(1.0);
+    assertThat(bound.y()).isEqualTo(2.0);
+    assertThat(bound.z()).isEqualTo(3.0);
+    assertThat(bound.hasZ()).isTrue();
+    assertThat(bound.hasM()).isFalse();
+    assertThat(Double.isNaN(bound.m())).isTrue();
+  }
+
+  @Test
+  public void testCreateXYM() {
+    GeospatialBound bound = GeospatialBound.createXYM(1.0, 2.0, 4.0);
+    assertThat(bound.x()).isEqualTo(1.0);
+    assertThat(bound.y()).isEqualTo(2.0);
+    assertThat(bound.m()).isEqualTo(4.0);
+    assertThat(bound.hasZ()).isFalse();
+    assertThat(bound.hasM()).isTrue();
+    assertThat(Double.isNaN(bound.z())).isTrue();
+  }
+
+  @Test
+  public void testCreateXYZM() {
+    GeospatialBound bound = GeospatialBound.createXYZM(1.0, 2.0, 3.0, 4.0);
+    assertThat(bound.x()).isEqualTo(1.0);
+    assertThat(bound.y()).isEqualTo(2.0);
+    assertThat(bound.z()).isEqualTo(3.0);
+    assertThat(bound.m()).isEqualTo(4.0);
+    assertThat(bound.hasZ()).isTrue();
+    assertThat(bound.hasM()).isTrue();
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    GeospatialBound xy1 = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound xy2 = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound xy3 = GeospatialBound.createXY(2.0, 1.0);
+    assertThat(xy1).isEqualTo(xy2);
+    assertThat(xy1.hashCode()).isEqualTo(xy2.hashCode());
+    assertThat(xy1).isNotEqualTo(xy3);
+
+    GeospatialBound xyz1 = GeospatialBound.createXYZ(1.0, 2.0, 3.0);
+    GeospatialBound xyz2 = GeospatialBound.createXYZ(1.0, 2.0, 3.0);
+    GeospatialBound xyz3 = GeospatialBound.createXYZ(1.0, 2.0, 4.0);
+    assertThat(xyz1).isEqualTo(xyz2);
+    assertThat(xyz1.hashCode()).isEqualTo(xyz2.hashCode());
+    assertThat(xyz1).isNotEqualTo(xyz3);
+    assertThat(xyz1).isNotEqualTo(xy1);
+
+    GeospatialBound xym1 = GeospatialBound.createXYM(1.0, 2.0, 4.0);
+    GeospatialBound xym2 = GeospatialBound.createXYM(1.0, 2.0, 4.0);
+    GeospatialBound xym3 = GeospatialBound.createXYM(1.0, 2.0, 5.0);
+    assertThat(xym1).isEqualTo(xym2);
+    assertThat(xym1.hashCode()).isEqualTo(xym2.hashCode());
+    assertThat(xym1).isNotEqualTo(xym3);
+    assertThat(xym1).isNotEqualTo(xy1);
+
+    GeospatialBound xyzm1 = GeospatialBound.createXYZM(1.0, 2.0, 3.0, 4.0);
+    GeospatialBound xyzm2 = GeospatialBound.createXYZM(1.0, 2.0, 3.0, 4.0);
+    GeospatialBound xyzm3 = GeospatialBound.createXYZM(1.0, 2.0, 3.0, 5.0);
+    assertThat(xyzm1).isEqualTo(xyzm2);
+    assertThat(xyzm1.hashCode()).isEqualTo(xyzm2.hashCode());
+    assertThat(xyzm1).isNotEqualTo(xyzm3);
+    assertThat(xyzm1).isNotEqualTo(xyz1);
+  }
+
+  @Test
+  public void testCompareTo() {
+    GeospatialBound xy1 = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound xy2 = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound xy3 = GeospatialBound.createXY(1.0, 3.0);
+    assertThat(xy1.compareTo(xy2)).isEqualTo(0);
+    assertThat(xy1.compareTo(xy3)).isLessThan(0);
+    assertThat(xy3.compareTo(xy1)).isGreaterThan(0);
+
+    GeospatialBound xyz1 = GeospatialBound.createXYZ(1.0, 2.0, 3.0);
+    GeospatialBound xyz2 = GeospatialBound.createXYZ(1.0, 2.0, 3.0);
+    GeospatialBound xyz3 = GeospatialBound.createXYZ(1.0, 2.0, 4.0);
+    assertThat(xyz1.compareTo(xyz2)).isEqualTo(0);
+    assertThat(xyz1.compareTo(xyz3)).isLessThan(0);
+    assertThat(xyz3.compareTo(xyz1)).isGreaterThan(0);
+
+    GeospatialBound xym1 = GeospatialBound.createXYM(1.0, 2.0, 4.0);
+    GeospatialBound xym2 = GeospatialBound.createXYM(1.0, 2.0, 4.0);
+    GeospatialBound xym3 = GeospatialBound.createXYM(1.0, 2.0, 5.0);
+    assertThat(xym1.compareTo(xym2)).isEqualTo(0);
+    assertThat(xym1.compareTo(xym3)).isLessThan(0);
+    assertThat(xym3.compareTo(xym1)).isGreaterThan(0);
+
+    GeospatialBound xyzm1 = GeospatialBound.createXYZM(1.0, 2.0, 3.0, 4.0);
+    GeospatialBound xyzm2 = GeospatialBound.createXYZM(1.0, 2.0, 3.0, 4.0);
+    GeospatialBound xyzm3 = GeospatialBound.createXYZM(1.0, 2.0, 3.0, 5.0);
+    assertThat(xyzm1.compareTo(xyzm2)).isEqualTo(0);
+    assertThat(xyzm1.compareTo(xyzm3)).isLessThan(0);
+    assertThat(xyzm3.compareTo(xyzm1)).isGreaterThan(0);
+  }
+
+  @Test
+  public void testToString() {
+    GeospatialBound xy = GeospatialBound.createXY(1.0, 2.0);
+    assertThat(xy.toString()).isEqualTo("GeospatialBound(x=1.0, y=2.0)");
+
+    GeospatialBound xyz = GeospatialBound.createXYZ(1.0, 2.0, 3.0);
+    assertThat(xyz.toString()).isEqualTo("GeospatialBound(x=1.0, y=2.0, z=3.0)");
+
+    GeospatialBound xym = GeospatialBound.createXYM(1.0, 2.0, 4.0);
+    assertThat(xym.toString()).isEqualTo("GeospatialBound(x=1.0, y=2.0, m=4.0)");
+
+    GeospatialBound xyzm = GeospatialBound.createXYZM(1.0, 2.0, 3.0, 4.0);
+    assertThat(xyzm.toString()).isEqualTo("GeospatialBound(x=1.0, y=2.0, z=3.0, m=4.0)");
+  }
+
+  @Test
+  public void testSimpleString() {
+    GeospatialBound xy = GeospatialBound.createXY(1.0, 2.0);
+    assertThat(xy.simpleString()).isEqualTo("x=1.0, y=2.0");
+
+    GeospatialBound xyz = GeospatialBound.createXYZ(1.0, 2.0, 3.0);
+    assertThat(xyz.simpleString()).isEqualTo("x=1.0, y=2.0, z=3.0");
+
+    GeospatialBound xym = GeospatialBound.createXYM(1.0, 2.0, 4.0);
+    assertThat(xym.simpleString()).isEqualTo("x=1.0, y=2.0, m=4.0");
+
+    GeospatialBound xyzm = GeospatialBound.createXYZM(1.0, 2.0, 3.0, 4.0);
+    assertThat(xyzm.simpleString()).isEqualTo("x=1.0, y=2.0, z=3.0, m=4.0");
+  }
+
+  @Test
+  public void testSerde() {
+    // Test XY format (16 bytes: x:y)
+    // These bytes represent x=10.0, y=13.0
+    byte[] xyBytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 36, 64, // 10.0 in little-endian IEEE 754
+          0, 0, 0, 0, 0, 0, 42, 64 // 13.0 in little-endian IEEE 754
+        };
+    GeospatialBound xy = GeospatialBound.fromByteArray(xyBytes);
+    assertThat(xy.x()).isEqualTo(10.0);
+    assertThat(xy.y()).isEqualTo(13.0);
+    assertThat(xy.hasZ()).isFalse();
+    assertThat(xy.hasM()).isFalse();
+    assertThat(ByteBuffers.toByteArray(xy.toByteBuffer())).isEqualTo(xyBytes);
+
+    // Test XYZ format (24 bytes: x:y:z)
+    // These bytes represent x=10.0, y=13.0, z=15.0
+    byte[] xyzBytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 36, 64, // 10.0 in little-endian IEEE 754
+          0, 0, 0, 0, 0, 0, 42, 64, // 13.0 in little-endian IEEE 754
+          0, 0, 0, 0, 0, 0, 46, 64 // 15.0 in little-endian IEEE 754
+        };
+    GeospatialBound xyz = GeospatialBound.fromByteArray(xyzBytes);
+    assertThat(xyz.x()).isEqualTo(10.0);
+    assertThat(xyz.y()).isEqualTo(13.0);
+    assertThat(xyz.z()).isEqualTo(15.0);
+    assertThat(xyz.hasZ()).isTrue();
+    assertThat(xyz.hasM()).isFalse();
+    assertThat(ByteBuffers.toByteArray(xyz.toByteBuffer())).isEqualTo(xyzBytes);
+    // Test XYM format (32 bytes: x:y:NaN:m)
+    // These bytes represent x=10.0, y=13.0, z=NaN, m=20.0
+    byte[] xymBytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 36, 64, // 10.0 in little-endian IEEE 754
+          0, 0, 0, 0, 0, 0, 42, 64, // 13.0 in little-endian IEEE 754
+          0, 0, 0, 0, 0, 0, (byte) 248, 127, // NaN in little-endian IEEE 754
+          0, 0, 0, 0, 0, 0, 52, 64 // 20.0 in little-endian IEEE 754
+        };
+    GeospatialBound xym = GeospatialBound.fromByteArray(xymBytes);
+    assertThat(xym.x()).isEqualTo(10.0);
+    assertThat(xym.y()).isEqualTo(13.0);
+    assertThat(Double.isNaN(xym.z())).isTrue();
+    assertThat(xym.m()).isEqualTo(20.0);
+    assertThat(xym.hasZ()).isFalse();
+    assertThat(xym.hasM()).isTrue();
+    assertThat(ByteBuffers.toByteArray(xym.toByteBuffer())).isEqualTo(xymBytes);
+
+    // Test XYZM format (32 bytes: x:y:z:m)
+    // These bytes represent x=10.0, y=13.0, z=15.0, m=20.0
+    byte[] xyzmBytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 36, 64, // 10.0 in little-endian IEEE 754
+          0, 0, 0, 0, 0, 0, 42, 64, // 13.0 in little-endian IEEE 754
+          0, 0, 0, 0, 0, 0, 46, 64, // 15.0 in little-endian IEEE 754
+          0, 0, 0, 0, 0, 0, 52, 64 // 20.0 in little-endian IEEE 754
+        };
+    GeospatialBound xyzm = GeospatialBound.fromByteArray(xyzmBytes);
+    assertThat(xyzm.x()).isEqualTo(10.0);
+    assertThat(xyzm.y()).isEqualTo(13.0);
+    assertThat(xyzm.z()).isEqualTo(15.0);
+    assertThat(xyzm.m()).isEqualTo(20.0);
+    assertThat(xyzm.hasZ()).isTrue();
+    assertThat(xyzm.hasM()).isTrue();
+    assertThat(ByteBuffers.toByteArray(xyzm.toByteBuffer())).isEqualTo(xyzmBytes);
+  }
+
+  private GeospatialBound roundTripSerDe(GeospatialBound original) {
+    ByteBuffer buffer = original.toByteBuffer();
+    return GeospatialBound.fromByteBuffer(buffer);
+  }
+
+  @Test
+  public void testRoundTripSerDe() {
+    // Test XY serialization
+    GeospatialBound xy = GeospatialBound.createXY(1.1, 2.2);
+    assertThat(roundTripSerDe(xy)).isEqualTo(xy);
+
+    // Test XYZ serialization
+    GeospatialBound xyz = GeospatialBound.createXYZ(1.1, 2.2, 3.3);
+    assertThat(roundTripSerDe(xyz)).isEqualTo(xyz);
+
+    // Test XYM serialization
+    GeospatialBound xym = GeospatialBound.createXYM(1.1, 2.2, 4.4);
+    assertThat(roundTripSerDe(xym)).isEqualTo(xym);
+
+    // Test XYZM serialization
+    GeospatialBound xyzm = GeospatialBound.createXYZM(1.1, 2.2, 3.3, 4.4);
+    assertThat(roundTripSerDe(xyzm)).isEqualTo(xyzm);
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/geospatial/TestGeospatialBoundingBox.java
+++ b/api/src/test/java/org/apache/iceberg/geospatial/TestGeospatialBoundingBox.java
@@ -54,7 +54,7 @@ public class TestGeospatialBoundingBox {
     maxBuffer.putDouble(0, 3.0); // x
     maxBuffer.putDouble(8, 4.0); // y
 
-    GeospatialBoundingBox box = GeospatialBoundingBox.create(minBuffer, maxBuffer);
+    GeospatialBoundingBox box = GeospatialBoundingBox.fromByteBuffers(minBuffer, maxBuffer);
 
     assertThat(box.min().x()).isEqualTo(1.0);
     assertThat(box.min().y()).isEqualTo(2.0);
@@ -101,7 +101,7 @@ public class TestGeospatialBoundingBox {
   public void testSanitized() {
     GeospatialBoundingBox box = GeospatialBoundingBox.SANITIZED;
     GeospatialBoundingBox box2 =
-        GeospatialBoundingBox.create(box.min().toByteBuffer(), box.max().toByteBuffer());
+        GeospatialBoundingBox.fromByteBuffers(box.min().toByteBuffer(), box.max().toByteBuffer());
     assertThat(box).isEqualTo(box2);
     assertThat(box.toString()).isEqualTo("BoundingBox{sanitized}");
     assertThat(box2.toString()).isEqualTo("BoundingBox{sanitized}");

--- a/api/src/test/java/org/apache/iceberg/geospatial/TestGeospatialBoundingBox.java
+++ b/api/src/test/java/org/apache/iceberg/geospatial/TestGeospatialBoundingBox.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.geospatial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.junit.jupiter.api.Test;
+
+public class TestGeospatialBoundingBox {
+
+  @Test
+  public void testConstructorAndAccessors() {
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+
+    GeospatialBoundingBox box = new GeospatialBoundingBox(min, max);
+
+    assertThat(box.min()).isEqualTo(min);
+    assertThat(box.max()).isEqualTo(max);
+    assertThat(box.min().x()).isEqualTo(1.0);
+    assertThat(box.min().y()).isEqualTo(2.0);
+    assertThat(box.max().x()).isEqualTo(3.0);
+    assertThat(box.max().y()).isEqualTo(4.0);
+  }
+
+  @Test
+  public void testCreateFromByteBuffers() {
+    // Create byte buffers for XY bounds
+    ByteBuffer minBuffer = ByteBuffer.allocate(16);
+    minBuffer.order(ByteOrder.LITTLE_ENDIAN);
+    minBuffer.putDouble(0, 1.0); // x
+    minBuffer.putDouble(8, 2.0); // y
+
+    ByteBuffer maxBuffer = ByteBuffer.allocate(16);
+    maxBuffer.order(ByteOrder.LITTLE_ENDIAN);
+    maxBuffer.putDouble(0, 3.0); // x
+    maxBuffer.putDouble(8, 4.0); // y
+
+    GeospatialBoundingBox box = GeospatialBoundingBox.create(minBuffer, maxBuffer);
+
+    assertThat(box.min().x()).isEqualTo(1.0);
+    assertThat(box.min().y()).isEqualTo(2.0);
+    assertThat(box.max().x()).isEqualTo(3.0);
+    assertThat(box.max().y()).isEqualTo(4.0);
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    GeospatialBound min1 = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max1 = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    // Same values
+    GeospatialBound min2 = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max2 = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    // Different values
+    GeospatialBound min3 = GeospatialBound.createXY(0.0, 0.0);
+    GeospatialBound max3 = GeospatialBound.createXY(10.0, 10.0);
+    GeospatialBoundingBox box3 = new GeospatialBoundingBox(min3, max3);
+
+    // Test equals
+    assertThat(box1).isEqualTo(box2);
+    assertThat(box1).isNotEqualTo(box3);
+    assertThat(box1).isNotEqualTo(null);
+    assertThat(box1).isNotEqualTo("not a box");
+
+    // Test hashCode
+    assertThat(box1.hashCode()).isEqualTo(box2.hashCode());
+    assertThat(box1.hashCode()).isNotEqualTo(box3.hashCode());
+  }
+
+  @Test
+  public void testToString() {
+    GeospatialBound min = GeospatialBound.createXY(1.0, 2.0);
+    GeospatialBound max = GeospatialBound.createXY(3.0, 4.0);
+    GeospatialBoundingBox box = new GeospatialBoundingBox(min, max);
+    assertThat(box.toString()).isEqualTo("BoundingBox{min=x=1.0, y=2.0, max=x=3.0, y=4.0}");
+  }
+
+  @Test
+  public void testSanitized() {
+    GeospatialBoundingBox box = GeospatialBoundingBox.SANITIZED;
+    GeospatialBoundingBox box2 =
+        GeospatialBoundingBox.create(box.min().toByteBuffer(), box.max().toByteBuffer());
+    assertThat(box).isEqualTo(box2);
+    assertThat(box.toString()).isEqualTo("BoundingBox{sanitized}");
+    assertThat(box2.toString()).isEqualTo("BoundingBox{sanitized}");
+    GeospatialBound min3 = GeospatialBound.createXY(0.0, 0.0);
+    GeospatialBound max3 = GeospatialBound.createXY(10.0, 10.0);
+    GeospatialBoundingBox box3 = new GeospatialBoundingBox(min3, max3);
+    assertThat(box).isNotEqualTo(box3);
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/geospatial/TestGeospatialPredicateEvaluators.java
+++ b/api/src/test/java/org/apache/iceberg/geospatial/TestGeospatialPredicateEvaluators.java
@@ -1,0 +1,430 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.geospatial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.iceberg.types.EdgeAlgorithm;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestGeospatialPredicateEvaluators {
+
+  @Test
+  public void testGeometryType() {
+    Type geometryType = Types.GeometryType.crs84();
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geometryType);
+
+    assertThat(evaluator).isInstanceOf(GeospatialPredicateEvaluators.GeometryEvaluator.class);
+  }
+
+  @Test
+  public void testOverlappingBoxesIntersect() {
+    Type geometryType = Types.GeometryType.crs84();
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geometryType);
+
+    GeospatialBound min1 = GeospatialBound.createXY(0.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXY(5.0, 5.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    GeospatialBound min2 = GeospatialBound.createXY(3.0, 3.0);
+    GeospatialBound max2 = GeospatialBound.createXY(8.0, 8.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    assertThat(evaluator.intersects(box1, box2)).isTrue();
+    assertThat(evaluator.intersects(box2, box1)).isTrue();
+  }
+
+  @Test
+  public void testNonOverlappingBoxesDontIntersect() {
+    Type geometryType = Types.GeometryType.crs84();
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geometryType);
+
+    GeospatialBound min1 = GeospatialBound.createXY(0.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXY(2.0, 2.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    GeospatialBound min2 = GeospatialBound.createXY(3.0, 3.0);
+    GeospatialBound max2 = GeospatialBound.createXY(5.0, 5.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    assertThat(evaluator.intersects(box1, box2)).isFalse();
+    assertThat(evaluator.intersects(box2, box1)).isFalse();
+  }
+
+  @Test
+  public void testBoxesTouchingAtCornerIntersect() {
+    Type geometryType = Types.GeometryType.crs84();
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geometryType);
+
+    GeospatialBound min1 = GeospatialBound.createXY(0.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXY(2.0, 2.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    GeospatialBound min2 = GeospatialBound.createXY(2.0, 2.0);
+    GeospatialBound max2 = GeospatialBound.createXY(4.0, 4.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    assertThat(evaluator.intersects(box1, box2)).isTrue();
+    assertThat(evaluator.intersects(box2, box1)).isTrue();
+  }
+
+  @Test
+  public void testBoxesTouchingAtEdgeIntersect() {
+    Type geometryType = Types.GeometryType.crs84();
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geometryType);
+
+    GeospatialBound min1 = GeospatialBound.createXY(0.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXY(2.0, 2.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    GeospatialBound min2 = GeospatialBound.createXY(2.0, 0.0);
+    GeospatialBound max2 = GeospatialBound.createXY(4.0, 2.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    assertThat(evaluator.intersects(box1, box2)).isTrue();
+    assertThat(evaluator.intersects(box2, box1)).isTrue();
+  }
+
+  @Test
+  public void testBoxContainedWithinAnotherIntersects() {
+    Type geometryType = Types.GeometryType.crs84();
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geometryType);
+
+    GeospatialBound min1 = GeospatialBound.createXY(0.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXY(10.0, 10.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    GeospatialBound min2 = GeospatialBound.createXY(2.0, 2.0);
+    GeospatialBound max2 = GeospatialBound.createXY(5.0, 5.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    assertThat(evaluator.intersects(box1, box2)).isTrue();
+    assertThat(evaluator.intersects(box2, box1)).isTrue();
+  }
+
+  @Test
+  public void testBoxesWithZCoordinate() {
+    Type geometryType = Types.GeometryType.crs84();
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geometryType);
+
+    // Two boxes with Z coordinates that overlap in X and Y but not in Z
+    // Note: The current implementation only checks X and Y coordinates
+    GeospatialBound min1 = GeospatialBound.createXYZ(0.0, 0.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXYZ(2.0, 2.0, 1.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    GeospatialBound min2 = GeospatialBound.createXYZ(1.0, 1.0, 2.0);
+    GeospatialBound max2 = GeospatialBound.createXYZ(3.0, 3.0, 3.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    // They should intersect because the current implementation only checks X and Y
+    assertThat(evaluator.intersects(box1, box2)).isTrue();
+    assertThat(evaluator.intersects(box2, box1)).isTrue();
+  }
+
+  @Test
+  public void testBoxesWithMCoordinate() {
+    Type geometryType = Types.GeometryType.crs84();
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geometryType);
+
+    // Two boxes with M coordinates that overlap in X and Y but not in M
+    // Note: The current implementation only checks X and Y coordinates
+    GeospatialBound min1 = GeospatialBound.createXYM(0.0, 0.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXYM(2.0, 2.0, 1.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    GeospatialBound min2 = GeospatialBound.createXYM(1.0, 1.0, 2.0);
+    GeospatialBound max2 = GeospatialBound.createXYM(3.0, 3.0, 3.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    // They should intersect because the current implementation only checks X and Y
+    assertThat(evaluator.intersects(box1, box2)).isTrue();
+    assertThat(evaluator.intersects(box2, box1)).isTrue();
+  }
+
+  @Test
+  public void testGeometryWrapAroundOnA() {
+    Type geometryType = Types.GeometryType.crs84();
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geometryType);
+
+    // First box wraps around antimeridian (min.x > max.x), second doesn't
+    GeospatialBound min1 = GeospatialBound.createXY(170.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXY(-170.0, 10.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    // Box that overlaps with the part after the wrap around
+    GeospatialBound min2 = GeospatialBound.createXY(-175.0, 5.0);
+    GeospatialBound max2 = GeospatialBound.createXY(-160.0, 15.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    assertThat(evaluator.intersects(box1, box2)).isTrue();
+    assertThat(evaluator.intersects(box2, box1)).isTrue();
+
+    // Box that overlaps with the part before the wrap around
+    GeospatialBound min3 = GeospatialBound.createXY(160.0, 5.0);
+    GeospatialBound max3 = GeospatialBound.createXY(175.0, 15.0);
+    GeospatialBoundingBox box3 = new GeospatialBoundingBox(min3, max3);
+
+    assertThat(evaluator.intersects(box1, box3)).isTrue();
+    assertThat(evaluator.intersects(box3, box1)).isTrue();
+
+    // Box that doesn't overlap with either part
+    GeospatialBound min4 = GeospatialBound.createXY(-150.0, 20.0);
+    GeospatialBound max4 = GeospatialBound.createXY(-140.0, 30.0);
+    GeospatialBoundingBox box4 = new GeospatialBoundingBox(min4, max4);
+
+    assertThat(evaluator.intersects(box1, box4)).isFalse();
+    assertThat(evaluator.intersects(box4, box1)).isFalse();
+  }
+
+  @Test
+  public void testGeometryWrapAroundOnB() {
+    Type geometryType = Types.GeometryType.crs84();
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geometryType);
+
+    // First box doesn't wrap around, second does (min.x > max.x)
+    GeospatialBound min1 = GeospatialBound.createXY(-175.0, 5.0);
+    GeospatialBound max1 = GeospatialBound.createXY(-160.0, 15.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    GeospatialBound min2 = GeospatialBound.createXY(170.0, 0.0);
+    GeospatialBound max2 = GeospatialBound.createXY(-170.0, 10.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    assertThat(evaluator.intersects(box1, box2)).isTrue();
+    assertThat(evaluator.intersects(box2, box1)).isTrue();
+  }
+
+  @Test
+  public void testBothGeometryWrappingAround() {
+    Type geometryType = Types.GeometryType.crs84();
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geometryType);
+
+    // Both boxes wrap around (min.x > max.x)
+    GeospatialBound min1 = GeospatialBound.createXY(170.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXY(-170.0, 10.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    GeospatialBound min2 = GeospatialBound.createXY(160.0, 5.0);
+    GeospatialBound max2 = GeospatialBound.createXY(-160.0, 15.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    // When both wrap around, they must intersect
+    assertThat(evaluator.intersects(box1, box2)).isTrue();
+    assertThat(evaluator.intersects(box2, box1)).isTrue();
+  }
+
+  @Test
+  public void testBasicGeographyCases() {
+    Type geographyType = Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL);
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geographyType);
+
+    // Two overlapping boxes
+    GeospatialBound min1 = GeospatialBound.createXY(0.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXY(10.0, 10.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    GeospatialBound min2 = GeospatialBound.createXY(5.0, 5.0);
+    GeospatialBound max2 = GeospatialBound.createXY(15.0, 15.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    assertThat(evaluator.intersects(box1, box2)).isTrue();
+    assertThat(evaluator.intersects(box2, box1)).isTrue();
+
+    // Non-overlapping boxes
+    GeospatialBound min3 = GeospatialBound.createXY(20.0, 20.0);
+    GeospatialBound max3 = GeospatialBound.createXY(30.0, 30.0);
+    GeospatialBoundingBox box3 = new GeospatialBoundingBox(min3, max3);
+
+    assertThat(evaluator.intersects(box1, box3)).isFalse();
+    assertThat(evaluator.intersects(box3, box1)).isFalse();
+
+    // Boxes at extreme valid latitudes
+    GeospatialBound min4 = GeospatialBound.createXY(-10.0, -90.0);
+    GeospatialBound max4 = GeospatialBound.createXY(10.0, -80.0);
+    GeospatialBoundingBox box4 = new GeospatialBoundingBox(min4, max4);
+
+    GeospatialBound min5 = GeospatialBound.createXY(-5.0, 80.0);
+    GeospatialBound max5 = GeospatialBound.createXY(15.0, 90.0);
+    GeospatialBoundingBox box5 = new GeospatialBoundingBox(min5, max5);
+
+    assertThat(evaluator.intersects(box4, box5)).isFalse();
+    assertThat(evaluator.intersects(box5, box4)).isFalse();
+  }
+
+  @Test
+  public void testGeographyWrapAround() {
+    Type geographyType = Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL);
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geographyType);
+
+    // Box that wraps around the antimeridian
+    GeospatialBound min1 = GeospatialBound.createXY(170.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXY(-170.0, 10.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    // Box that overlaps with the part after the wrap around
+    GeospatialBound min2 = GeospatialBound.createXY(-175.0, 5.0);
+    GeospatialBound max2 = GeospatialBound.createXY(-160.0, 15.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    assertThat(evaluator.intersects(box1, box2)).isTrue();
+    assertThat(evaluator.intersects(box2, box1)).isTrue();
+  }
+
+  @Test
+  public void testInvalidGeographyLatitude() {
+    Type geographyType = Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL);
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geographyType);
+
+    // Box with latitude below -90
+    GeospatialBound min1 = GeospatialBound.createXY(0.0, -91.0);
+    GeospatialBound max1 = GeospatialBound.createXY(10.0, 0.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    // Box with latitude above 90
+    GeospatialBound min2 = GeospatialBound.createXY(0.0, 0.0);
+    GeospatialBound max2 = GeospatialBound.createXY(10.0, 91.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    GeospatialBound validMin = GeospatialBound.createXY(0.0, 0.0);
+    GeospatialBound validMax = GeospatialBound.createXY(10.0, 10.0);
+    GeospatialBoundingBox validBox = new GeospatialBoundingBox(validMin, validMax);
+
+    assertThatThrownBy(() -> evaluator.intersects(box1, validBox))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Latitude out of range");
+
+    assertThatThrownBy(() -> evaluator.intersects(validBox, box1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Latitude out of range");
+
+    assertThatThrownBy(() -> evaluator.intersects(box2, validBox))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Latitude out of range");
+
+    assertThatThrownBy(() -> evaluator.intersects(validBox, box2))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Latitude out of range");
+  }
+
+  @Test
+  public void testInvalidGeographyLongitude() {
+    Type geographyType = Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL);
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geographyType);
+
+    // Box with longitude below -180
+    GeospatialBound min1 = GeospatialBound.createXY(-181.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXY(0.0, 10.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    // Box with longitude above 180
+    GeospatialBound min2 = GeospatialBound.createXY(0.0, 0.0);
+    GeospatialBound max2 = GeospatialBound.createXY(181.0, 10.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    GeospatialBound validMin = GeospatialBound.createXY(0.0, 0.0);
+    GeospatialBound validMax = GeospatialBound.createXY(10.0, 10.0);
+    GeospatialBoundingBox validBox = new GeospatialBoundingBox(validMin, validMax);
+
+    assertThatThrownBy(() -> evaluator.intersects(box1, validBox))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Longitude out of range");
+
+    assertThatThrownBy(() -> evaluator.intersects(validBox, box1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Longitude out of range");
+
+    assertThatThrownBy(() -> evaluator.intersects(box2, validBox))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Longitude out of range");
+
+    assertThatThrownBy(() -> evaluator.intersects(validBox, box2))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Longitude out of range");
+  }
+
+  @Test
+  public void testExtremeLongitudeBoundaries() {
+    // Tests valid boxes at the extreme boundaries of longitude
+    Type geographyType = Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL);
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geographyType);
+
+    // Box at -180 longitude
+    GeospatialBound min1 = GeospatialBound.createXY(-180.0, 0.0);
+    GeospatialBound max1 = GeospatialBound.createXY(-170.0, 10.0);
+    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+
+    // Box at 180 longitude
+    GeospatialBound min2 = GeospatialBound.createXY(170.0, 0.0);
+    GeospatialBound max2 = GeospatialBound.createXY(180.0, 10.0);
+    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+
+    // These boxes should not intersect
+    assertThat(evaluator.intersects(box1, box2)).isFalse();
+    assertThat(evaluator.intersects(box2, box1)).isFalse();
+
+    // Box that wraps around the antimeridian, touching -180 and 180
+    GeospatialBound min3 = GeospatialBound.createXY(180.0, 0.0);
+    GeospatialBound max3 = GeospatialBound.createXY(-180.0, 10.0);
+    GeospatialBoundingBox box3 = new GeospatialBoundingBox(min3, max3);
+
+    // This should intersect with both boxes at the extreme edges
+    assertThat(evaluator.intersects(box1, box3)).isTrue();
+    assertThat(evaluator.intersects(box3, box1)).isTrue();
+    assertThat(evaluator.intersects(box2, box3)).isTrue();
+    assertThat(evaluator.intersects(box3, box2)).isTrue();
+  }
+
+  @Test
+  public void testSphericalGeographyType() {
+    Type geographyType = Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL);
+    GeospatialPredicateEvaluators.GeospatialPredicateEvaluator evaluator =
+        GeospatialPredicateEvaluators.create(geographyType);
+
+    assertThat(evaluator).isInstanceOf(GeospatialPredicateEvaluators.GeographyEvaluator.class);
+  }
+
+  @Test
+  public void testUnsupportedType() {
+    Type stringType = Types.StringType.get();
+
+    assertThatThrownBy(() -> GeospatialPredicateEvaluators.create(stringType))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("Unsupported type for GeospatialBoundingBox");
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/geospatial/TestGeospatialPredicateEvaluators.java
+++ b/api/src/test/java/org/apache/iceberg/geospatial/TestGeospatialPredicateEvaluators.java
@@ -45,11 +45,11 @@ public class TestGeospatialPredicateEvaluators {
 
     GeospatialBound min1 = GeospatialBound.createXY(0.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXY(5.0, 5.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     GeospatialBound min2 = GeospatialBound.createXY(3.0, 3.0);
     GeospatialBound max2 = GeospatialBound.createXY(8.0, 8.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     assertThat(evaluator.intersects(box1, box2)).isTrue();
     assertThat(evaluator.intersects(box2, box1)).isTrue();
@@ -63,11 +63,11 @@ public class TestGeospatialPredicateEvaluators {
 
     GeospatialBound min1 = GeospatialBound.createXY(0.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXY(2.0, 2.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     GeospatialBound min2 = GeospatialBound.createXY(3.0, 3.0);
     GeospatialBound max2 = GeospatialBound.createXY(5.0, 5.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     assertThat(evaluator.intersects(box1, box2)).isFalse();
     assertThat(evaluator.intersects(box2, box1)).isFalse();
@@ -81,11 +81,11 @@ public class TestGeospatialPredicateEvaluators {
 
     GeospatialBound min1 = GeospatialBound.createXY(0.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXY(2.0, 2.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     GeospatialBound min2 = GeospatialBound.createXY(2.0, 2.0);
     GeospatialBound max2 = GeospatialBound.createXY(4.0, 4.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     assertThat(evaluator.intersects(box1, box2)).isTrue();
     assertThat(evaluator.intersects(box2, box1)).isTrue();
@@ -99,11 +99,11 @@ public class TestGeospatialPredicateEvaluators {
 
     GeospatialBound min1 = GeospatialBound.createXY(0.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXY(2.0, 2.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     GeospatialBound min2 = GeospatialBound.createXY(2.0, 0.0);
     GeospatialBound max2 = GeospatialBound.createXY(4.0, 2.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     assertThat(evaluator.intersects(box1, box2)).isTrue();
     assertThat(evaluator.intersects(box2, box1)).isTrue();
@@ -117,11 +117,11 @@ public class TestGeospatialPredicateEvaluators {
 
     GeospatialBound min1 = GeospatialBound.createXY(0.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXY(10.0, 10.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     GeospatialBound min2 = GeospatialBound.createXY(2.0, 2.0);
     GeospatialBound max2 = GeospatialBound.createXY(5.0, 5.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     assertThat(evaluator.intersects(box1, box2)).isTrue();
     assertThat(evaluator.intersects(box2, box1)).isTrue();
@@ -137,11 +137,11 @@ public class TestGeospatialPredicateEvaluators {
     // Note: The current implementation only checks X and Y coordinates
     GeospatialBound min1 = GeospatialBound.createXYZ(0.0, 0.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXYZ(2.0, 2.0, 1.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     GeospatialBound min2 = GeospatialBound.createXYZ(1.0, 1.0, 2.0);
     GeospatialBound max2 = GeospatialBound.createXYZ(3.0, 3.0, 3.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     // They should intersect because the current implementation only checks X and Y
     assertThat(evaluator.intersects(box1, box2)).isTrue();
@@ -158,11 +158,11 @@ public class TestGeospatialPredicateEvaluators {
     // Note: The current implementation only checks X and Y coordinates
     GeospatialBound min1 = GeospatialBound.createXYM(0.0, 0.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXYM(2.0, 2.0, 1.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     GeospatialBound min2 = GeospatialBound.createXYM(1.0, 1.0, 2.0);
     GeospatialBound max2 = GeospatialBound.createXYM(3.0, 3.0, 3.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     // They should intersect because the current implementation only checks X and Y
     assertThat(evaluator.intersects(box1, box2)).isTrue();
@@ -178,12 +178,12 @@ public class TestGeospatialPredicateEvaluators {
     // First box wraps around antimeridian (min.x > max.x), second doesn't
     GeospatialBound min1 = GeospatialBound.createXY(170.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXY(-170.0, 10.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     // Box that overlaps with the part after the wrap around
     GeospatialBound min2 = GeospatialBound.createXY(-175.0, 5.0);
     GeospatialBound max2 = GeospatialBound.createXY(-160.0, 15.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     assertThat(evaluator.intersects(box1, box2)).isTrue();
     assertThat(evaluator.intersects(box2, box1)).isTrue();
@@ -191,7 +191,7 @@ public class TestGeospatialPredicateEvaluators {
     // Box that overlaps with the part before the wrap around
     GeospatialBound min3 = GeospatialBound.createXY(160.0, 5.0);
     GeospatialBound max3 = GeospatialBound.createXY(175.0, 15.0);
-    GeospatialBoundingBox box3 = new GeospatialBoundingBox(min3, max3);
+    BoundingBox box3 = new BoundingBox(min3, max3);
 
     assertThat(evaluator.intersects(box1, box3)).isTrue();
     assertThat(evaluator.intersects(box3, box1)).isTrue();
@@ -199,7 +199,7 @@ public class TestGeospatialPredicateEvaluators {
     // Box that doesn't overlap with either part
     GeospatialBound min4 = GeospatialBound.createXY(-150.0, 20.0);
     GeospatialBound max4 = GeospatialBound.createXY(-140.0, 30.0);
-    GeospatialBoundingBox box4 = new GeospatialBoundingBox(min4, max4);
+    BoundingBox box4 = new BoundingBox(min4, max4);
 
     assertThat(evaluator.intersects(box1, box4)).isFalse();
     assertThat(evaluator.intersects(box4, box1)).isFalse();
@@ -214,11 +214,11 @@ public class TestGeospatialPredicateEvaluators {
     // First box doesn't wrap around, second does (min.x > max.x)
     GeospatialBound min1 = GeospatialBound.createXY(-175.0, 5.0);
     GeospatialBound max1 = GeospatialBound.createXY(-160.0, 15.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     GeospatialBound min2 = GeospatialBound.createXY(170.0, 0.0);
     GeospatialBound max2 = GeospatialBound.createXY(-170.0, 10.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     assertThat(evaluator.intersects(box1, box2)).isTrue();
     assertThat(evaluator.intersects(box2, box1)).isTrue();
@@ -233,11 +233,11 @@ public class TestGeospatialPredicateEvaluators {
     // Both boxes wrap around (min.x > max.x)
     GeospatialBound min1 = GeospatialBound.createXY(170.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXY(-170.0, 10.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     GeospatialBound min2 = GeospatialBound.createXY(160.0, 5.0);
     GeospatialBound max2 = GeospatialBound.createXY(-160.0, 15.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     // When both wrap around, they must intersect
     assertThat(evaluator.intersects(box1, box2)).isTrue();
@@ -253,11 +253,11 @@ public class TestGeospatialPredicateEvaluators {
     // Two overlapping boxes
     GeospatialBound min1 = GeospatialBound.createXY(0.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXY(10.0, 10.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     GeospatialBound min2 = GeospatialBound.createXY(5.0, 5.0);
     GeospatialBound max2 = GeospatialBound.createXY(15.0, 15.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     assertThat(evaluator.intersects(box1, box2)).isTrue();
     assertThat(evaluator.intersects(box2, box1)).isTrue();
@@ -265,7 +265,7 @@ public class TestGeospatialPredicateEvaluators {
     // Non-overlapping boxes
     GeospatialBound min3 = GeospatialBound.createXY(20.0, 20.0);
     GeospatialBound max3 = GeospatialBound.createXY(30.0, 30.0);
-    GeospatialBoundingBox box3 = new GeospatialBoundingBox(min3, max3);
+    BoundingBox box3 = new BoundingBox(min3, max3);
 
     assertThat(evaluator.intersects(box1, box3)).isFalse();
     assertThat(evaluator.intersects(box3, box1)).isFalse();
@@ -273,11 +273,11 @@ public class TestGeospatialPredicateEvaluators {
     // Boxes at extreme valid latitudes
     GeospatialBound min4 = GeospatialBound.createXY(-10.0, -90.0);
     GeospatialBound max4 = GeospatialBound.createXY(10.0, -80.0);
-    GeospatialBoundingBox box4 = new GeospatialBoundingBox(min4, max4);
+    BoundingBox box4 = new BoundingBox(min4, max4);
 
     GeospatialBound min5 = GeospatialBound.createXY(-5.0, 80.0);
     GeospatialBound max5 = GeospatialBound.createXY(15.0, 90.0);
-    GeospatialBoundingBox box5 = new GeospatialBoundingBox(min5, max5);
+    BoundingBox box5 = new BoundingBox(min5, max5);
 
     assertThat(evaluator.intersects(box4, box5)).isFalse();
     assertThat(evaluator.intersects(box5, box4)).isFalse();
@@ -292,12 +292,12 @@ public class TestGeospatialPredicateEvaluators {
     // Box that wraps around the antimeridian
     GeospatialBound min1 = GeospatialBound.createXY(170.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXY(-170.0, 10.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     // Box that overlaps with the part after the wrap around
     GeospatialBound min2 = GeospatialBound.createXY(-175.0, 5.0);
     GeospatialBound max2 = GeospatialBound.createXY(-160.0, 15.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     assertThat(evaluator.intersects(box1, box2)).isTrue();
     assertThat(evaluator.intersects(box2, box1)).isTrue();
@@ -312,16 +312,16 @@ public class TestGeospatialPredicateEvaluators {
     // Box with latitude below -90
     GeospatialBound min1 = GeospatialBound.createXY(0.0, -91.0);
     GeospatialBound max1 = GeospatialBound.createXY(10.0, 0.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     // Box with latitude above 90
     GeospatialBound min2 = GeospatialBound.createXY(0.0, 0.0);
     GeospatialBound max2 = GeospatialBound.createXY(10.0, 91.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     GeospatialBound validMin = GeospatialBound.createXY(0.0, 0.0);
     GeospatialBound validMax = GeospatialBound.createXY(10.0, 10.0);
-    GeospatialBoundingBox validBox = new GeospatialBoundingBox(validMin, validMax);
+    BoundingBox validBox = new BoundingBox(validMin, validMax);
 
     assertThatThrownBy(() -> evaluator.intersects(box1, validBox))
         .isInstanceOf(IllegalArgumentException.class)
@@ -349,16 +349,16 @@ public class TestGeospatialPredicateEvaluators {
     // Box with longitude below -180
     GeospatialBound min1 = GeospatialBound.createXY(-181.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXY(0.0, 10.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     // Box with longitude above 180
     GeospatialBound min2 = GeospatialBound.createXY(0.0, 0.0);
     GeospatialBound max2 = GeospatialBound.createXY(181.0, 10.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     GeospatialBound validMin = GeospatialBound.createXY(0.0, 0.0);
     GeospatialBound validMax = GeospatialBound.createXY(10.0, 10.0);
-    GeospatialBoundingBox validBox = new GeospatialBoundingBox(validMin, validMax);
+    BoundingBox validBox = new BoundingBox(validMin, validMax);
 
     assertThatThrownBy(() -> evaluator.intersects(box1, validBox))
         .isInstanceOf(IllegalArgumentException.class)
@@ -387,12 +387,12 @@ public class TestGeospatialPredicateEvaluators {
     // Box at -180 longitude
     GeospatialBound min1 = GeospatialBound.createXY(-180.0, 0.0);
     GeospatialBound max1 = GeospatialBound.createXY(-170.0, 10.0);
-    GeospatialBoundingBox box1 = new GeospatialBoundingBox(min1, max1);
+    BoundingBox box1 = new BoundingBox(min1, max1);
 
     // Box at 180 longitude
     GeospatialBound min2 = GeospatialBound.createXY(170.0, 0.0);
     GeospatialBound max2 = GeospatialBound.createXY(180.0, 10.0);
-    GeospatialBoundingBox box2 = new GeospatialBoundingBox(min2, max2);
+    BoundingBox box2 = new BoundingBox(min2, max2);
 
     // These boxes should not intersect
     assertThat(evaluator.intersects(box1, box2)).isFalse();
@@ -401,7 +401,7 @@ public class TestGeospatialPredicateEvaluators {
     // Box that wraps around the antimeridian, touching -180 and 180
     GeospatialBound min3 = GeospatialBound.createXY(180.0, 0.0);
     GeospatialBound max3 = GeospatialBound.createXY(-180.0, 10.0);
-    GeospatialBoundingBox box3 = new GeospatialBoundingBox(min3, max3);
+    BoundingBox box3 = new BoundingBox(min3, max3);
 
     // This should intersect with both boxes at the extreme edges
     assertThat(evaluator.intersects(box1, box3)).isTrue();
@@ -425,6 +425,6 @@ public class TestGeospatialPredicateEvaluators {
 
     assertThatThrownBy(() -> GeospatialPredicateEvaluators.create(stringType))
         .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("Unsupported type for GeospatialBoundingBox");
+        .hasMessageContaining("Unsupported type for BoundingBox");
   }
 }

--- a/api/src/test/java/org/apache/iceberg/types/TestConversions.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestConversions.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test;
 public class TestConversions {
 
   @Test
+  @SuppressWarnings("MethodLength")
   public void testByteBufferConversions() {
     // booleans are stored as 0x00 for 'false' and a non-zero byte for 'true'
     assertConversion(false, BooleanType.get(), new byte[] {0x00});

--- a/api/src/test/java/org/apache/iceberg/types/TestConversions.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestConversions.java
@@ -189,6 +189,13 @@ public class TestConversions {
     assertConversion(new BigDecimal("0.011"), DecimalType.of(10, 3), new byte[] {11});
     assertThat(Literal.of(new BigDecimal("0.011")).toByteBuffer().array())
         .isEqualTo(new byte[] {11});
+
+    // geospatial bounds were kept as-is
+    // this is a geospatial bound with x = 10.0, y = 20.0
+    byte[] geospatialBound = new byte[] {0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 52, 64};
+    assertConversion(ByteBuffer.wrap(geospatialBound), Types.GeometryType.crs84(), geospatialBound);
+    assertConversion(
+        ByteBuffer.wrap(geospatialBound), Types.GeographyType.crs84(), geospatialBound);
   }
 
   private <T> void assertConversion(T value, Type type, byte[] expectedBinary) {

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -98,6 +98,8 @@ public class TestTypes {
 
     assertThat(Types.fromPrimitiveString("geometry")).isEqualTo(Types.GeometryType.crs84());
     assertThat(Types.fromPrimitiveString("Geometry")).isEqualTo(Types.GeometryType.crs84());
+    assertThat(((Types.GeometryType) Types.fromPrimitiveString("geometry")).crs())
+        .isEqualTo(Types.GeometryType.DEFAULT_CRS);
     assertThat(Types.fromPrimitiveString("geometry(srid:3857)"))
         .isEqualTo(Types.GeometryType.of("srid:3857"));
     assertThat(Types.fromPrimitiveString("geometry( srid:3857 )"))
@@ -113,12 +115,13 @@ public class TestTypes {
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> Types.fromPrimitiveString("geometry( )"))
         .withMessageContaining("Invalid CRS: (empty string)");
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> Types.fromPrimitiveString("geometry(srid:123,456)"))
-        .withMessageContaining("Invalid CRS: srid:123,456");
 
     assertThat(Types.fromPrimitiveString("geography")).isEqualTo(Types.GeographyType.crs84());
     assertThat(Types.fromPrimitiveString("Geography")).isEqualTo(Types.GeographyType.crs84());
+    assertThat(((Types.GeographyType) Types.fromPrimitiveString("geography")).crs())
+        .isEqualTo(Types.GeographyType.DEFAULT_CRS);
+    assertThat(((Types.GeographyType) Types.fromPrimitiveString("geography")).algorithm())
+        .isEqualTo(Types.GeographyType.DEFAULT_ALGORITHM);
     assertThat(Types.fromPrimitiveString("geography(srid:4269)"))
         .isEqualTo(Types.GeographyType.of("srid:4269"));
     assertThat(Types.fromPrimitiveString("geography(srid: 4269)"))

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -202,7 +202,8 @@ public class ExpressionParser {
                 gen.writeFieldName(VALUE);
                 Literal<ByteBuffer> min = pred.literals().get(0).to(Types.BinaryType.get());
                 Literal<ByteBuffer> max = pred.literals().get(1).to(Types.BinaryType.get());
-                GeospatialBoundingBox bbox = GeospatialBoundingBox.create(min.value(), max.value());
+                GeospatialBoundingBox bbox =
+                    GeospatialBoundingBox.fromByteBuffers(min.value(), max.value());
                 geospatialBoundingBox(bbox);
               } else {
                 gen.writeFieldName(VALUE);
@@ -356,7 +357,6 @@ public class ExpressionParser {
         return Expressions.or(
             fromJson(JsonUtil.get(LEFT, json), schema),
             fromJson(JsonUtil.get(RIGHT, json), schema));
-
       case ST_INTERSECTS:
       case ST_DISJOINT:
         return geospatialPredicateFromJson(op, json);

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -31,6 +31,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SingleValueParser;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -167,6 +169,9 @@ public class ExpressionParser {
                 SingleValueParser.toJson(pred.term().type(), value, gen);
               }
               gen.writeEndArray();
+            } else if (pred.isGeospatialPredicate()) {
+              gen.writeFieldName(VALUE);
+              geospatialBoundingBox(pred.asGeospatialPredicate().literal().value());
             }
 
             gen.writeEndObject();
@@ -192,6 +197,13 @@ public class ExpressionParser {
                 }
                 gen.writeEndArray();
 
+              } else if (pred.op() == Expression.Operation.ST_INTERSECTS
+                  || pred.op() == Expression.Operation.ST_DISJOINT) {
+                gen.writeFieldName(VALUE);
+                Literal<ByteBuffer> min = pred.literals().get(0).to(Types.BinaryType.get());
+                Literal<ByteBuffer> max = pred.literals().get(1).to(Types.BinaryType.get());
+                GeospatialBoundingBox bbox = GeospatialBoundingBox.create(min.value(), max.value());
+                geospatialBoundingBox(bbox);
               } else {
                 gen.writeFieldName(VALUE);
                 unboundLiteral(pred.literal().value());
@@ -227,6 +239,44 @@ public class ExpressionParser {
         SingleValueParser.toJson(
             Types.DecimalType.of(decimal.precision(), decimal.scale()), decimal, gen);
       }
+    }
+
+    private void geospatialBoundingBox(GeospatialBoundingBox value) throws IOException {
+      gen.writeStartObject();
+
+      // Write x coordinate
+      gen.writeFieldName("x");
+      gen.writeStartObject();
+      gen.writeNumberField("min", value.min().x());
+      gen.writeNumberField("max", value.max().x());
+      gen.writeEndObject();
+
+      // Write y coordinate
+      gen.writeFieldName("y");
+      gen.writeStartObject();
+      gen.writeNumberField("min", value.min().y());
+      gen.writeNumberField("max", value.max().y());
+      gen.writeEndObject();
+
+      // Write z coordinate if present
+      if (value.min().hasZ() || value.max().hasZ()) {
+        gen.writeFieldName("z");
+        gen.writeStartObject();
+        gen.writeNumberField("min", value.min().z());
+        gen.writeNumberField("max", value.max().z());
+        gen.writeEndObject();
+      }
+
+      // Write m coordinate if present
+      if (value.min().hasM() || value.max().hasM()) {
+        gen.writeFieldName("m");
+        gen.writeStartObject();
+        gen.writeNumberField("min", value.min().m());
+        gen.writeNumberField("max", value.max().m());
+        gen.writeEndObject();
+      }
+
+      gen.writeEndObject();
     }
 
     private String operationType(Expression.Operation op) {
@@ -306,6 +356,10 @@ public class ExpressionParser {
         return Expressions.or(
             fromJson(JsonUtil.get(LEFT, json), schema),
             fromJson(JsonUtil.get(RIGHT, json), schema));
+
+      case ST_INTERSECTS:
+      case ST_DISJOINT:
+        return geospatialPredicateFromJson(op, json);
     }
 
     return predicateFromJson(op, json, schema);
@@ -374,6 +428,15 @@ public class ExpressionParser {
     }
   }
 
+  private static Expression geospatialPredicateFromJson(Expression.Operation op, JsonNode node) {
+    UnboundTerm<ByteBuffer> term = term(JsonUtil.get(TERM, node));
+    Preconditions.checkArgument(node.has(VALUE), "Cannot parse %s predicate: missing value", op);
+    Preconditions.checkArgument(
+        !node.has(VALUES), "Cannot parse %s predicate: has invalid values field", op);
+    GeospatialBoundingBox geospatialBoundingBox = geospatialBoundingBox(JsonUtil.get(VALUE, node));
+    return Expressions.geospatialPredicate(op, term, geospatialBoundingBox);
+  }
+
   private static <T> T literal(JsonNode valueNode, Function<JsonNode, T> toValue) {
     if (valueNode.isObject() && valueNode.has(TYPE)) {
       String type = JsonUtil.getString(TYPE, valueNode);
@@ -384,6 +447,51 @@ public class ExpressionParser {
 
     // the node is a directly embedded literal value
     return toValue.apply(valueNode);
+  }
+
+  private static GeospatialBoundingBox geospatialBoundingBox(JsonNode valueNode) {
+    // X and Y coordinates are required
+    double xMin = valueNode.get("x").get("min").asDouble();
+    double xMax = valueNode.get("x").get("max").asDouble();
+    double yMin = valueNode.get("y").get("min").asDouble();
+    double yMax = valueNode.get("y").get("max").asDouble();
+
+    // Create GeospatialBound objects for min and max
+    GeospatialBound minBound;
+    GeospatialBound maxBound;
+
+    // Check if Z coordinate exists
+    boolean hasZ = valueNode.has("z");
+    // Check if M coordinate exists
+    boolean hasM = valueNode.has("m");
+
+    if (hasZ && hasM) {
+      // Both Z and M present
+      double zMin = valueNode.get("z").get("min").asDouble();
+      double zMax = valueNode.get("z").get("max").asDouble();
+      double mMin = valueNode.get("m").get("min").asDouble();
+      double mMax = valueNode.get("m").get("max").asDouble();
+      minBound = GeospatialBound.createXYZM(xMin, yMin, zMin, mMin);
+      maxBound = GeospatialBound.createXYZM(xMax, yMax, zMax, mMax);
+    } else if (hasZ) {
+      // Only Z present, no M
+      double zMin = valueNode.get("z").get("min").asDouble();
+      double zMax = valueNode.get("z").get("max").asDouble();
+      minBound = GeospatialBound.createXYZ(xMin, yMin, zMin);
+      maxBound = GeospatialBound.createXYZ(xMax, yMax, zMax);
+    } else if (hasM) {
+      // Only M present, no Z
+      double mMin = valueNode.get("m").get("min").asDouble();
+      double mMax = valueNode.get("m").get("max").asDouble();
+      minBound = GeospatialBound.createXYM(xMin, yMin, mMin);
+      maxBound = GeospatialBound.createXYM(xMax, yMax, mMax);
+    } else {
+      // Only X and Y present
+      minBound = GeospatialBound.createXY(xMin, yMin);
+      maxBound = GeospatialBound.createXY(xMax, yMax);
+    }
+
+    return new GeospatialBoundingBox(minBound, maxBound);
   }
 
   private static Object asObject(JsonNode node) {

--- a/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
@@ -28,8 +28,8 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.geospatial.BoundingBox;
 import org.apache.iceberg.geospatial.GeospatialBound;
-import org.apache.iceberg.geospatial.GeospatialBoundingBox;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
@@ -101,19 +101,18 @@ public class TestExpressionParser {
           Expressions.not(Expressions.in("l", 1, 2, 3, 4)),
           Expressions.stIntersects(
               "geom",
-              new GeospatialBoundingBox(
-                  GeospatialBound.createXY(1, 2), GeospatialBound.createXY(3, 4))),
+              new BoundingBox(GeospatialBound.createXY(1, 2), GeospatialBound.createXY(3, 4))),
           Expressions.stDisjoint(
               "geom",
-              new GeospatialBoundingBox(
+              new BoundingBox(
                   GeospatialBound.createXYM(1, 2, 3), GeospatialBound.createXYM(3, 4, 5))),
           Expressions.stIntersects(
               "geog",
-              new GeospatialBoundingBox(
+              new BoundingBox(
                   GeospatialBound.createXYZ(1, 2, 3), GeospatialBound.createXYZ(3, 4, 5))),
           Expressions.stDisjoint(
               "geog",
-              new GeospatialBoundingBox(
+              new BoundingBox(
                   GeospatialBound.createXYZM(1, 2, 3, 4), GeospatialBound.createXYZM(3, 4, 5, 6)))
         };
 
@@ -586,8 +585,7 @@ public class TestExpressionParser {
     Expression expression =
         Expressions.stIntersects(
             "column-name",
-            new GeospatialBoundingBox(
-                GeospatialBound.createXY(1, 2), GeospatialBound.createXY(3, 4)));
+            new BoundingBox(GeospatialBound.createXY(1, 2), GeospatialBound.createXY(3, 4)));
     assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
     assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
         .isEqualTo(expected);
@@ -615,7 +613,7 @@ public class TestExpressionParser {
     expression =
         Expressions.stIntersects(
             "column-name",
-            new GeospatialBoundingBox(
+            new BoundingBox(
                 GeospatialBound.createXYM(1, 2, 3), GeospatialBound.createXYM(3, 4, 5)));
     assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
     assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
@@ -644,7 +642,7 @@ public class TestExpressionParser {
     expression =
         Expressions.stIntersects(
             "column-name",
-            new GeospatialBoundingBox(
+            new BoundingBox(
                 GeospatialBound.createXYZ(1, 2, 3), GeospatialBound.createXYZ(3, 4, 5)));
     assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
     assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
@@ -677,7 +675,7 @@ public class TestExpressionParser {
     expression =
         Expressions.stIntersects(
             "column-name",
-            new GeospatialBoundingBox(
+            new BoundingBox(
                 GeospatialBound.createXYZM(1, 2, 3, 4), GeospatialBound.createXYZM(3, 4, 5, 6)));
     assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
     assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))


### PR DESCRIPTION
This PR adds support for parsing and serializing geospatial bounds, partially implementing the iceberg geo spec:  https://github.com/apache/iceberg/pull/10981. It also resolved remaining review comments in https://github.com/apache/iceberg/pull/12346.

2 spatial predicates were added to operate on geospatial bounds:

* `ST_INTERSECTS`: Test if 2 geospatial bounds intersects with each other
* `ST_DISJOINT`: The negation of `ST_INTERSECTS`.

A new subclass of `BoundPredicate` named `BoundGeospatialPredicate` was added to represent bound geospatial predicates. `BoundGeospatialPredicate` do not support evaluating on WKB encoded geometry/geography values, handling of geospatial predicates were implemented by expression visitors to support metrics evaluation on geospatial bounds.

I can divide geospatial bound classes and spatial predicates into 2 PRs, but I'd like to know if my approach of adding geospatial predicates is OK before proceeding.